### PR TITLE
Ext 148 add api entrypoints and replace path flags pr2

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import SwaggerUI from 'swagger-ui';
 
 import { NavigationItemContentViewerComponent } from './navigation-item-content-viewer.component';
@@ -24,21 +24,29 @@ import { PortalPageContent } from '../../entities/portal-navigation/portal-page-
 import { RedocService } from '../../services/redoc.service';
 import { AppTestingModule } from '../../testing/app-testing.module';
 
-interface initData {
+interface InitData {
   pageContent: PortalPageContent | null;
+  imports?: TestModuleMetadata['imports'];
+  providers?: TestModuleMetadata['providers'];
+  clearSwaggerUI?: boolean;
 }
 
 describe('NavigationItemContentViewerComponent', () => {
   let fixture: ComponentFixture<NavigationItemContentViewerComponent>;
   let harness: NavigationItemContentViewerHarness;
 
-  const init = async (data: initData) => {
+  const init = async ({ pageContent, imports = [], providers = [], clearSwaggerUI = false }: InitData) => {
     await TestBed.configureTestingModule({
-      imports: [NavigationItemContentViewerComponent],
+      imports: [NavigationItemContentViewerComponent, ...imports],
+      providers,
     }).compileComponents();
 
+    if (clearSwaggerUI) {
+      jest.mocked(SwaggerUI).mockClear();
+    }
+
     fixture = TestBed.createComponent(NavigationItemContentViewerComponent);
-    fixture.componentRef.setInput('pageContent', data.pageContent);
+    fixture.componentRef.setInput('pageContent', pageContent);
 
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, NavigationItemContentViewerHarness);
     fixture.detectChanges();
@@ -67,21 +75,15 @@ describe('NavigationItemContentViewerComponent', () => {
       configuration: { viewer: ViewerEnum.Redoc, try_it_url: 'https://try-it.example.com' },
     };
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [NavigationItemContentViewerComponent],
+      await init({
+        pageContent,
         providers: [
           {
             provide: RedocService,
             useValue: { init: (_content: string | undefined, _options: unknown, _el: unknown) => {} },
           },
         ],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(NavigationItemContentViewerComponent);
-      fixture.componentRef.setInput('pageContent', pageContent);
-
-      harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, NavigationItemContentViewerHarness);
-      fixture.detectChanges();
+      });
     });
     it('should render redoc viewer', async () => {
       const redocViewer = await harness.getRedocViewer();
@@ -90,6 +92,15 @@ describe('NavigationItemContentViewerComponent', () => {
     });
     it('should read Redoc try it URL from snake_case configuration', () => {
       expect(fixture.componentInstance.tryItUrl()).toBe('https://try-it.example.com');
+    });
+    it('should not pass Redoc try it URL when backend resolved server URLs are enabled', () => {
+      fixture.componentRef.setInput('pageContent', {
+        ...pageContent,
+        configuration: { ...pageContent.configuration, context_path_as_server_path: true },
+      });
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.tryItUrl()).toBeUndefined();
     });
     it('should not render markdown viewer', async () => {
       const markdownViewer = await harness.getGMDViewer();
@@ -126,17 +137,7 @@ describe('NavigationItemContentViewerComponent', () => {
     };
 
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [NavigationItemContentViewerComponent, AppTestingModule],
-      }).compileComponents();
-
-      jest.mocked(SwaggerUI).mockClear();
-
-      fixture = TestBed.createComponent(NavigationItemContentViewerComponent);
-      fixture.componentRef.setInput('pageContent', pageContent);
-
-      harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, NavigationItemContentViewerHarness);
-      fixture.detectChanges();
+      await init({ pageContent, imports: [AppTestingModule], clearSwaggerUI: true });
     });
 
     it('should not reinitialize Swagger UI on unchanged change detection cycles', () => {
@@ -153,6 +154,26 @@ describe('NavigationItemContentViewerComponent', () => {
       expect(swaggerViewer).not.toBeNull();
     });
 
+    it('should pass Swagger try it URL when backend server resolution is disabled', () => {
+      fixture.componentRef.setInput('pageContent', {
+        ...pageContent,
+        configuration: { viewer: ViewerEnum.Swagger, try_it_url: 'https://try-it.example.com' },
+      });
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.swaggerPage()?.configuration?.try_it_url).toBe('https://try-it.example.com');
+    });
+
+    it('should not pass Swagger try it URL when backend resolved server URLs are enabled', () => {
+      fixture.componentRef.setInput('pageContent', {
+        ...pageContent,
+        configuration: { viewer: ViewerEnum.Swagger, try_it_url: 'https://try-it.example.com', entrypoints_as_servers: true },
+      });
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.swaggerPage()?.configuration?.try_it_url).toBeUndefined();
+    });
+
     it('should not render redoc viewer', async () => {
       expect(await harness.isShowingRedocContent()).toBe(false);
     });
@@ -165,17 +186,7 @@ describe('NavigationItemContentViewerComponent', () => {
     };
 
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [NavigationItemContentViewerComponent, AppTestingModule],
-      }).compileComponents();
-
-      jest.mocked(SwaggerUI).mockClear();
-
-      fixture = TestBed.createComponent(NavigationItemContentViewerComponent);
-      fixture.componentRef.setInput('pageContent', pageContent);
-
-      harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, NavigationItemContentViewerHarness);
-      fixture.detectChanges();
+      await init({ pageContent, imports: [AppTestingModule], clearSwaggerUI: true });
     });
 
     it('should render swagger viewer', async () => {

--- a/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.ts
@@ -35,7 +35,23 @@ export class NavigationItemContentViewerComponent {
   pageContent = input.required<PortalPageContent | null>();
   protected readonly viewerEnum = ViewerEnum;
 
-  tryItUrl = computed(() => this.pageContent()?.configuration?.try_it_url);
+  private readonly backendResolvedServerUrls = computed(() => {
+    const configuration = this.pageContent()?.configuration;
+    return Boolean(configuration?.entrypoints_as_servers || configuration?.context_path_as_server_path);
+  });
+
+  private readonly pageConfiguration = computed(() => {
+    const configuration = this.pageContent()?.configuration;
+    if (!configuration || !this.backendResolvedServerUrls()) {
+      return configuration;
+    }
+
+    const configurationWithoutTryItUrl = { ...configuration };
+    delete configurationWithoutTryItUrl.try_it_url;
+    return configurationWithoutTryItUrl;
+  });
+
+  tryItUrl = computed(() => this.pageConfiguration()?.try_it_url);
 
   swaggerPage = computed<Page | null>(() => {
     const pageContent = this.pageContent();
@@ -49,7 +65,7 @@ export class NavigationItemContentViewerComponent {
       type: 'SWAGGER',
       order: 0,
       content: pageContent.content,
-      configuration: pageContent.configuration,
+      configuration: this.pageConfiguration(),
     };
   });
 }

--- a/gravitee-apim-portal-webui-next/src/entities/page/page-configuration.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/page/page-configuration.ts
@@ -77,6 +77,14 @@ export interface PageConfiguration {
    */
   use_pkce?: boolean;
   /**
+   * Use API entrypoints as OpenAPI servers.
+   */
+  entrypoints_as_servers?: boolean;
+  /**
+   * Use API context-path as OpenAPI server URL path.
+   */
+  context_path_as_server_path?: boolean;
+  /**
    * The type of viewer for OpenAPI specification. Default is \'Swagger\'
    */
   viewer?: ViewerEnum;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -149,6 +149,7 @@ import io.gravitee.apim.core.portal_listing.use_case.CreateOrUpdatePortalListing
 import io.gravitee.apim.core.portal_listing.use_case.DeletePortalListingUseCase;
 import io.gravitee.apim.core.portal_listing.use_case.GetPortalListingUseCase;
 import io.gravitee.apim.core.portal_listing.use_case.ValidatePortalListingUseCase;
+import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
@@ -1001,6 +1002,11 @@ public class ResourceContextConfiguration {
     @Bean
     public HtmlSanitizer htmlSanitizer(io.gravitee.rest.api.service.sanitizer.HtmlSanitizer delegate) {
         return new HtmlSanitizerImpl(delegate);
+    }
+
+    @Bean
+    public OpenApiContentTransformer openApiContentTransformer() {
+        return mock(OpenApiContentTransformer.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -190,6 +190,7 @@ import io.gravitee.apim.core.portal_listing.domain_service.ValidatePortalListing
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.GraviteePortalPageContentValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiPortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
@@ -1393,6 +1394,11 @@ public class ResourceContextConfiguration {
             portalPageContentCrudService,
             apiCrudService
         );
+    }
+
+    @Bean
+    public OpenApiContentTransformer openApiContentTransformer() {
+        return mock(OpenApiContentTransformer.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -136,6 +136,7 @@ import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
 import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
@@ -1171,6 +1172,11 @@ public class ResourceContextConfiguration {
     @Bean
     public HtmlSanitizer htmlSanitizer(io.gravitee.rest.api.service.sanitizer.HtmlSanitizer delegate) {
         return new HtmlSanitizerImpl(delegate);
+    }
+
+    @Bean
+    public OpenApiContentTransformer openApiContentTransformer() {
+        return mock(OpenApiContentTransformer.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -107,6 +107,8 @@ public interface PortalNavigationItemMapper {
         configuration.setTryItAnonymous(cfg.tryItAnonymous());
         configuration.setTryItUrl(cfg.tryItUrl());
         configuration.setUsePkce(cfg.usePkce());
+        configuration.setEntrypointsAsServers(cfg.entrypointsAsServers());
+        configuration.setContextPathAsServerPath(cfg.contextPathAsServerPath());
         configuration.setViewer(PageConfiguration.ViewerEnum.SWAGGER);
         return configuration;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -7782,6 +7782,14 @@ components:
                     type: boolean
                     description: Enable use of PKCE with authorization code flows in documentation page.
                     default: false
+                entrypoints_as_servers:
+                    type: boolean
+                    description: Use API entrypoints as OpenAPI servers.
+                    default: false
+                context_path_as_server_path:
+                    type: boolean
+                    description: Use API context-path as OpenAPI server URL path.
+                    default: false
                 viewer:
                     type: string
                     description: The type of viewer for OpenAPI specification. Default is 'Swagger'

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
@@ -267,6 +267,59 @@ public class PortalNavigationItemResourceTest extends AbstractResourceTest {
             assertThat(pageConfiguration.getTryItAnonymous()).isTrue();
             assertThat(pageConfiguration.getTryItUrl()).isEqualTo("https://sandbox.example.com");
             assertThat(pageConfiguration.getUsePkce()).isTrue();
+            assertThat(pageConfiguration.getEntrypointsAsServers()).isFalse();
+            assertThat(pageConfiguration.getContextPathAsServerPath()).isFalse();
+        }
+
+        @Test
+        void should_return_openapi_entrypoint_configuration_when_page_found_and_published() {
+            // Given
+            var itemId = PortalNavigationFixtures.randomNavigationId();
+            var contentId = PortalNavigationFixtures.randomPageId();
+            var configuration = new SwaggerUiConfiguration(
+                true,
+                "list",
+                true,
+                12,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                "",
+                true,
+                true,
+                true
+            );
+            var pageContent = PortalPageContentFixtures.anOpenApiPageContent(
+                contentId,
+                ORGANIZATION_ID,
+                ENV_ID,
+                "openapi: 3.0.3\ninfo:\n  title: Test",
+                configuration
+            );
+
+            var publishedPage = PortalNavigationFixtures.page(itemId, "Published Page", PortalArea.TOP_NAVBAR, contentId);
+            publishedPage.setPublished(true);
+            publishedPage.setEnvironmentId(ENV_ID);
+
+            portalNavigationItemsQueryService.initWith(List.of(publishedPage));
+            portalPageContentQueryService.initWith(List.of(pageContent));
+
+            // When
+            Response response = target(itemId.toString()).path("content").request().get();
+
+            // Then
+            assertThat(response.getStatus()).isEqualTo(200);
+            var content = response.readEntity(PortalPageContent.class);
+            assertThat(content.getContent()).isEqualTo("openapi: 3.0.3\ninfo:\n  title: Test");
+            assertThat(content.getType()).isEqualTo(PortalPageContentType.OPENAPI);
+
+            PageConfiguration pageConfiguration = content.getConfiguration();
+            assertThat(pageConfiguration).isNotNull();
+            assertThat(pageConfiguration.getEntrypointsAsServers()).isTrue();
+            assertThat(pageConfiguration.getContextPathAsServerPath()).isTrue();
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -145,6 +145,7 @@ import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
 import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
@@ -204,6 +205,7 @@ import io.gravitee.apim.infra.domain_service.json_patch.JsonMergePatchServiceImp
 import io.gravitee.apim.infra.domain_service.json_patch.JsonPatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.logs_engine.LogNamesPostProcessorImpl;
 import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
+import io.gravitee.apim.infra.domain_service.portal_page.OpenApiContentTransformerImpl;
 import io.gravitee.apim.infra.domain_service.subscription.SubscriptionCRDDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.subscription_form.SubscriptionFormSchemaGeneratorImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
@@ -1123,6 +1125,11 @@ public class ResourceContextConfiguration {
     @Bean
     public HtmlSanitizer htmlSanitizer(io.gravitee.rest.api.service.sanitizer.HtmlSanitizer delegate) {
         return new HtmlSanitizerImpl(delegate);
+    }
+
+    @Bean
+    public OpenApiContentTransformer openApiContentTransformer() {
+        return new OpenApiContentTransformerImpl();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/DefaultContentRenderer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/DefaultContentRenderer.java
@@ -18,29 +18,22 @@ package io.gravitee.apim.core.portal_page.domain_service;
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.portal_page.exception.RendererException;
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
-import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
-import lombok.CustomLog;
 
 @DomainService
 public class DefaultContentRenderer implements ContentRenderer {
 
     @Override
     public boolean appliesTo(PortalPageContent<?> content) {
-        return content instanceof OpenApiPageContent || content instanceof AsyncApiPageContent;
+        return content instanceof AsyncApiPageContent;
     }
 
     @Override
     public RenderedPageContent render(PortalNavigationItem item, PortalPageContent<?> content) {
         return switch (content) {
-            case OpenApiPageContent oapi -> RenderedPageContent.of(
-                oapi.getContent().value(),
-                PortalPageContentType.OPENAPI,
-                oapi.getViewerSettings()
-            );
             case AsyncApiPageContent aapi -> RenderedPageContent.of(aapi.getContent().value(), PortalPageContentType.ASYNCAPI);
             default -> throw new RendererException("Content type not supported: " + content.getType());
         };

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/OpenApiContentRenderer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/OpenApiContentRenderer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.domain_service.ApiExposedEntrypointDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiPathExtractor;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class OpenApiContentRenderer implements ContentRenderer {
+
+    private final PortalNavigationEnclosingApiDomainService enclosingApiDomainService;
+    private final ApiCrudService apiCrudService;
+    private final ApiExposedEntrypointDomainService apiExposedEntrypointDomainService;
+    private final OpenApiContentTransformer openApiContentTransformer;
+
+    @Override
+    public boolean appliesTo(PortalPageContent<?> content) {
+        return content instanceof OpenApiPageContent;
+    }
+
+    @Override
+    public RenderedPageContent render(PortalNavigationItem item, PortalPageContent<?> content) {
+        var openApiPage = (OpenApiPageContent) content;
+        var configuration = openApiPage.getViewerSettings();
+        var rendered = RenderedPageContent.of(openApiPage.getContent().value(), PortalPageContentType.OPENAPI, configuration);
+
+        if (!(configuration instanceof SwaggerUiConfiguration swaggerUiConfiguration)) {
+            return rendered;
+        }
+
+        if (!swaggerUiConfiguration.entrypointsAsServers() && !swaggerUiConfiguration.contextPathAsServerPath()) {
+            return rendered;
+        }
+
+        return RenderedPageContent.of(
+            openApiContentTransformer.transform(
+                rendered.value(),
+                swaggerUiConfiguration,
+                buildApiContext(content, (PortalNavigationPage) item)
+            ),
+            rendered.type(),
+            rendered.configuration()
+        );
+    }
+
+    private Optional<OpenApiContentTransformer.ApiContext> buildApiContext(PortalPageContent<?> content, PortalNavigationPage page) {
+        return enclosingApiDomainService
+            .findEnclosingApiId(content.getEnvironmentId(), page)
+            .flatMap(apiCrudService::findById)
+            .map(api ->
+                new OpenApiContentTransformer.ApiContext(
+                    apiExposedEntrypointDomainService
+                        .get(content.getOrganizationId(), content.getEnvironmentId(), api)
+                        .stream()
+                        .map(entrypoint -> entrypoint.value())
+                        .toList(),
+                    ApiPathExtractor.extractPaths(api)
+                        .stream()
+                        .map(path -> path.getPath())
+                        .findFirst()
+                )
+            );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/OpenApiContentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/OpenApiContentTransformer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
+import java.util.List;
+import java.util.Optional;
+
+public interface OpenApiContentTransformer {
+    String transform(String content, SwaggerUiConfiguration configuration, Optional<ApiContext> apiContext);
+
+    record ApiContext(List<String> entrypoints, Optional<String> contextPath) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal_page/OpenApiContentTransformerImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal_page/OpenApiContentTransformerImpl.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.portal_page;
+
+import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
+import io.gravitee.rest.api.service.impl.swagger.parser.OAIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import lombok.CustomLog;
+import org.springframework.stereotype.Service;
+
+@Service
+@CustomLog
+public class OpenApiContentTransformerImpl implements OpenApiContentTransformer {
+
+    @Override
+    public String transform(String content, SwaggerUiConfiguration configuration, Optional<ApiContext> apiContext) {
+        if (content == null || content.isBlank() || configuration == null) {
+            return content;
+        }
+
+        if (!configuration.entrypointsAsServers() && !configuration.contextPathAsServerPath()) {
+            return content;
+        }
+
+        try {
+            var descriptor = new OAIParser().parse(content);
+            if (descriptor == null || descriptor.getSpecification() == null) {
+                return content;
+            }
+
+            var openApi = descriptor.getSpecification();
+            var transformed = applyTryItUrl(openApi, configuration.tryItUrl());
+            transformed = apiContext.map(context -> applyApiContext(openApi, configuration, context)).orElse(false) || transformed;
+            return transformed ? descriptor.toYaml() : content;
+        } catch (Exception e) {
+            log.warn("Unable to transform OpenAPI content for portal navigation item", e);
+            return content;
+        }
+    }
+
+    private static boolean applyTryItUrl(OpenAPI openApi, String tryItUrl) {
+        if (tryItUrl == null || tryItUrl.isBlank()) {
+            return false;
+        }
+
+        var target = URI.create(tryItUrl);
+        var servers = openApi.getServers();
+        if (servers == null || servers.isEmpty()) {
+            openApi.setServers(List.of(server(target.toString())));
+            return true;
+        }
+
+        servers.forEach(server -> server.setUrl(target.toString()));
+        openApi.setServers(deduplicateByUrl(servers));
+        return true;
+    }
+
+    private static boolean applyApiContext(OpenAPI openApi, SwaggerUiConfiguration configuration, ApiContext apiContext) {
+        var transformed = false;
+        if (configuration.entrypointsAsServers()) {
+            transformed = applyEntrypointsAsServers(openApi, apiContext.entrypoints(), configuration.contextPathAsServerPath());
+        }
+        if (configuration.contextPathAsServerPath()) {
+            transformed = applyContextPathAsServerPath(openApi, apiContext.contextPath()) || transformed;
+        }
+        return transformed;
+    }
+
+    private static boolean applyEntrypointsAsServers(OpenAPI openApi, List<String> entrypoints, boolean keepEntrypointPath) {
+        if (entrypoints == null || entrypoints.isEmpty()) {
+            return false;
+        }
+
+        var servers = entrypoints
+            .stream()
+            .filter(entrypoint -> entrypoint != null && !entrypoint.isBlank())
+            .map(entrypoint -> keepEntrypointPath ? Optional.of(entrypoint) : removePath(entrypoint))
+            .flatMap(Optional::stream)
+            .map(OpenApiContentTransformerImpl::server)
+            .toList();
+
+        if (!servers.isEmpty()) {
+            openApi.setServers(deduplicateByUrl(servers));
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean applyContextPathAsServerPath(OpenAPI openApi, Optional<String> contextPath) {
+        if (contextPath.isEmpty() || contextPath.get().isBlank() || openApi.getServers() == null || openApi.getServers().isEmpty()) {
+            return false;
+        }
+
+        var replaced = false;
+        for (var server : openApi.getServers()) {
+            var replacement = replacePath(server.getUrl(), contextPath.get());
+            if (replacement.isPresent()) {
+                server.setUrl(replacement.get());
+                replaced = true;
+            }
+        }
+
+        if (replaced) {
+            openApi.setServers(deduplicateByUrl(openApi.getServers()));
+        }
+        return replaced;
+    }
+
+    private static Optional<String> removePath(String url) {
+        try {
+            var uri = URI.create(url);
+            return Optional.of(new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), null, null, null).toString());
+        } catch (IllegalArgumentException | URISyntaxException e) {
+            log.warn("Unable to remove path from OpenAPI server URL [{}]", url, e);
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<String> replacePath(String url, String path) {
+        try {
+            var uri = URI.create(url);
+            return Optional.of(
+                new URI(
+                    uri.getScheme(),
+                    uri.getUserInfo(),
+                    uri.getHost(),
+                    uri.getPort(),
+                    normalizePath(path),
+                    uri.getQuery(),
+                    uri.getFragment()
+                ).toString()
+            );
+        } catch (IllegalArgumentException | URISyntaxException e) {
+            log.warn("Unable to replace path in OpenAPI server URL [{}]", url, e);
+            return Optional.empty();
+        }
+    }
+
+    private static String normalizePath(String path) {
+        return path.startsWith("/") ? path : "/" + path;
+    }
+
+    private static Server server(String url) {
+        return new Server().url(url);
+    }
+
+    private static List<Server> deduplicateByUrl(List<Server> servers) {
+        var urls = new LinkedHashSet<String>();
+        return servers
+            .stream()
+            .filter(server -> urls.add(server.getUrl()))
+            .toList();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/OpenApiContentRendererTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/OpenApiContentRendererTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import static fixtures.core.model.PortalNavigationItemFixtures.ENV_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.PortalNavigationItemFixtures;
+import fixtures.core.model.PortalPageContentFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiExposedEntrypointDomainServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.ExposedEntrypoint;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class OpenApiContentRendererTest {
+
+    private static final String ORGANIZATION_ID = PortalPageContentFixtures.ORGANIZATION_ID;
+    private static final String ENVIRONMENT_ID = ENV_ID;
+
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+    private ApiCrudServiceInMemory apiCrudService;
+    private ApiExposedEntrypointDomainServiceInMemory apiExposedEntrypointDomainService;
+    private OpenApiContentTransformerSpy openApiContentTransformer;
+    private OpenApiContentRenderer renderer;
+
+    @BeforeEach
+    void setUp() {
+        navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
+        apiCrudService = new ApiCrudServiceInMemory();
+        apiExposedEntrypointDomainService = new ApiExposedEntrypointDomainServiceInMemory();
+        openApiContentTransformer = new OpenApiContentTransformerSpy();
+        renderer = new OpenApiContentRenderer(
+            new PortalNavigationEnclosingApiDomainService(navigationItemsQueryService),
+            apiCrudService,
+            apiExposedEntrypointDomainService,
+            openApiContentTransformer
+        );
+    }
+
+    @Test
+    void should_render_openapi_page_content_with_viewer_configuration_when_server_resolution_is_disabled() {
+        var contentId = PortalPageContentId.random();
+        var pageId = "00000000-0000-0000-0000-000000000096";
+        var content = "openapi: 3.0.3\ninfo:\n  title: Test";
+        var configuration = configuration(false, false);
+        var page = PortalNavigationItemFixtures.aPage(pageId, "OpenAPI page", null, contentId);
+        page.markAsRoot();
+        var openApiContent = PortalPageContentFixtures.anOpenApiPageContent(
+            contentId,
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            content,
+            configuration
+        );
+
+        var rendered = renderer.render(page, openApiContent);
+
+        assertThat(rendered.value()).isEqualTo(content);
+        assertThat(rendered.type()).isEqualTo(PortalPageContentType.OPENAPI);
+        assertThat(rendered.configuration()).isEqualTo(configuration);
+        assertThat(openApiContentTransformer.calls).isZero();
+    }
+
+    @Test
+    void should_transform_openapi_page_content_with_api_context_when_server_resolution_is_enabled() {
+        var apiTechnicalId = "api-technical-id";
+        var contentId = PortalPageContentId.random();
+        var pageId = "00000000-0000-0000-0000-000000000095";
+        var content = "openapi: 3.0.3\ninfo:\n  title: Test";
+        var configuration = configuration(false, true);
+        var apiNav = PortalNavigationItemFixtures.anApi(PortalNavigationItemFixtures.API1_ID, "API One", null, apiTechnicalId);
+        apiNav.markAsRoot();
+        var pageUnderApi = PortalNavigationItemFixtures.aPage(pageId, "OpenAPI page", apiNav.getId(), contentId);
+        pageUnderApi.updateParent(apiNav);
+        var openApiContent = PortalPageContentFixtures.anOpenApiPageContent(
+            contentId,
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            content,
+            configuration
+        );
+        var api = ApiFixtures.aProxyApiV4().toBuilder().id(apiTechnicalId).environmentId(ENVIRONMENT_ID).build();
+        apiCrudService.initWith(List.of(api));
+        apiExposedEntrypointDomainService.initWith(List.of(new ExposedEntrypoint("https://apis.gravitee.io/http_proxy")));
+        navigationItemsQueryService.initWith(List.of(apiNav, pageUnderApi));
+        openApiContentTransformer.transformedContent = "transformed openapi";
+
+        var rendered = renderer.render(pageUnderApi, openApiContent);
+
+        assertThat(rendered.value()).isEqualTo("transformed openapi");
+        assertThat(openApiContentTransformer.calls).isOne();
+        assertThat(openApiContentTransformer.content).isEqualTo(content);
+        assertThat(openApiContentTransformer.configuration).isEqualTo(configuration);
+        assertThat(openApiContentTransformer.apiContext).isPresent();
+        assertThat(openApiContentTransformer.apiContext.orElseThrow().entrypoints()).containsExactly("https://apis.gravitee.io/http_proxy");
+        assertThat(openApiContentTransformer.apiContext.orElseThrow().contextPath()).contains("/http_proxy/");
+    }
+
+    @Test
+    void should_transform_openapi_page_content_without_api_context_when_page_has_no_api_ancestor() {
+        var contentId = PortalPageContentId.random();
+        var pageId = "00000000-0000-0000-0000-000000000094";
+        var content = "openapi: 3.0.3\ninfo:\n  title: Test";
+        var configuration = configuration(true, true);
+        var page = PortalNavigationItemFixtures.aPage(pageId, "OpenAPI page", null, contentId);
+        page.markAsRoot();
+        var openApiContent = PortalPageContentFixtures.anOpenApiPageContent(
+            contentId,
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            content,
+            configuration
+        );
+        navigationItemsQueryService.initWith(List.of(page));
+        openApiContentTransformer.transformedContent = content;
+
+        var rendered = renderer.render(page, openApiContent);
+
+        assertThat(rendered.value()).isEqualTo(content);
+        assertThat(openApiContentTransformer.calls).isOne();
+        assertThat(openApiContentTransformer.apiContext).isEmpty();
+    }
+
+    private static SwaggerUiConfiguration configuration(boolean entrypointsAsServers, boolean contextPathAsServerPath) {
+        return new SwaggerUiConfiguration(
+            true,
+            "list",
+            true,
+            12,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            "https://sandbox.example.com",
+            true,
+            entrypointsAsServers,
+            contextPathAsServerPath
+        );
+    }
+
+    private static class OpenApiContentTransformerSpy implements OpenApiContentTransformer {
+
+        private String content;
+        private SwaggerUiConfiguration configuration;
+        private Optional<ApiContext> apiContext = Optional.empty();
+        private String transformedContent = "transformed";
+        private int calls;
+
+        @Override
+        public String transform(String content, SwaggerUiConfiguration configuration, Optional<ApiContext> apiContext) {
+            this.content = content;
+            this.configuration = configuration;
+            this.apiContext = apiContext;
+            this.calls++;
+            return transformedContent;
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.when;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import fixtures.core.model.PortalPageContentFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiExposedEntrypointDomainServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
@@ -40,6 +42,8 @@ import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateMod
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.DefaultContentRenderer;
 import io.gravitee.apim.core.portal_page.domain_service.GraviteeMarkdownContentRenderer;
+import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentRenderer;
+import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
@@ -56,6 +60,7 @@ import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -80,6 +85,9 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
     private GetPortalPageContentByNavigationIdUseCase useCase;
     private PortalPageContentQueryServiceInMemory pageContentQueryService;
     private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+    private ApiCrudServiceInMemory apiCrudService;
+    private ApiExposedEntrypointDomainServiceInMemory apiExposedEntrypointDomainService;
+    private OpenApiContentTransformerSpy openApiContentTransformer;
 
     @Mock
     private PortalNavigationTemplatingService portalNavigationTemplatingService;
@@ -94,6 +102,9 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
     void setUp() {
         navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
         pageContentQueryService = new PortalPageContentQueryServiceInMemory();
+        apiCrudService = new ApiCrudServiceInMemory();
+        apiExposedEntrypointDomainService = new ApiExposedEntrypointDomainServiceInMemory();
+        openApiContentTransformer = new OpenApiContentTransformerSpy();
         var apiVisibilityDomainService = new PortalNavigationApiVisibilityDomainService(
             navigationItemsQueryService,
             new ApiPortalMembershipDomainService(
@@ -118,7 +129,16 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
             navigationItemsQueryService,
             pageContentQueryService,
             apiVisibilityDomainService,
-            List.of(gmdRenderer, new DefaultContentRenderer())
+            List.of(
+                gmdRenderer,
+                new OpenApiContentRenderer(
+                    enclosingApiDomainService,
+                    apiCrudService,
+                    apiExposedEntrypointDomainService,
+                    openApiContentTransformer
+                ),
+                new DefaultContentRenderer()
+            )
         );
 
         clearInvocations(portalNavigationTemplatingService);
@@ -235,6 +255,7 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
         assertThat(output.renderedContent().type()).isEqualTo(PortalPageContentType.OPENAPI);
         assertThat(output.renderedContent().value()).isEqualTo(content);
         assertThat(output.renderedContent().configuration()).isEqualTo(configuration);
+        assertThat(openApiContentTransformer.calls).isZero();
     }
 
     @Test
@@ -418,5 +439,23 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(PortalNavigationItemNotFoundException.class)
             .hasMessage("Portal navigation item not found");
+    }
+
+    private static class OpenApiContentTransformerSpy implements OpenApiContentTransformer {
+
+        private String content;
+        private SwaggerUiConfiguration configuration;
+        private Optional<ApiContext> apiContext = Optional.empty();
+        private String transformedContent = "transformed";
+        private int calls;
+
+        @Override
+        public String transform(String content, SwaggerUiConfiguration configuration, Optional<ApiContext> apiContext) {
+            this.content = content;
+            this.configuration = configuration;
+            this.apiContext = apiContext;
+            this.calls++;
+            return transformedContent;
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/portal_page/OpenApiContentTransformerImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/portal_page/OpenApiContentTransformerImplTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.portal_page;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
+import io.gravitee.rest.api.service.impl.swagger.parser.OAIParser;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class OpenApiContentTransformerImplTest {
+
+    private static final String OPENAPI = """
+        openapi: 3.0.3
+        info:
+          title: Test
+          version: 1.0.0
+        servers:
+          - url: https://origin.example.com/base
+        paths: {}
+        """;
+
+    private final OpenApiContentTransformerImpl transformer = new OpenApiContentTransformerImpl();
+
+    @Test
+    void should_keep_content_unchanged_when_server_resolution_flags_are_disabled() {
+        var transformed = transformer.transform(
+            OPENAPI,
+            configuration(false, false, "https://custom.example.com/base"),
+            Optional.of(apiContext(List.of("https://apis.gravitee.io/test"), "/test/"))
+        );
+
+        assertThat(transformed).isEqualTo(OPENAPI);
+    }
+
+    @Test
+    void should_replace_existing_server_path_with_api_context_path() {
+        var transformed = transformer.transform(OPENAPI, configuration(false, true, ""), Optional.of(apiContext(List.of(), "/test/")));
+
+        assertThat(serverUrls(transformed)).containsExactly("https://origin.example.com/test/");
+    }
+
+    @Test
+    void should_use_api_entrypoints_without_paths_as_servers() {
+        var transformed = transformer.transform(
+            OPENAPI,
+            configuration(true, false, ""),
+            Optional.of(apiContext(List.of("https://apis.gravitee.io/test", "https://backup.gravitee.io/test"), "/test/"))
+        );
+
+        assertThat(serverUrls(transformed)).containsExactly("https://apis.gravitee.io", "https://backup.gravitee.io");
+    }
+
+    @Test
+    void should_replace_api_entrypoint_paths_with_context_path_when_context_path_as_server_path_is_enabled() {
+        var transformed = transformer.transform(
+            OPENAPI,
+            configuration(true, true, ""),
+            Optional.of(apiContext(List.of("https://apis.gravitee.io/gateway/echo"), "/test/"))
+        );
+
+        assertThat(serverUrls(transformed)).containsExactly("https://apis.gravitee.io/test/");
+    }
+
+    @Test
+    void should_keep_api_entrypoint_path_when_context_path_as_server_path_is_enabled_without_context_path() {
+        var transformed = transformer.transform(
+            OPENAPI,
+            configuration(true, true, ""),
+            Optional.of(new OpenApiContentTransformer.ApiContext(List.of("https://apis.gravitee.io/gateway/echo"), Optional.empty()))
+        );
+
+        assertThat(serverUrls(transformed)).containsExactly("https://apis.gravitee.io/gateway/echo");
+    }
+
+    @Test
+    void should_apply_try_it_url_without_api_context() {
+        var transformed = transformer.transform(OPENAPI, configuration(false, true, "https://custom.example.com/base"), Optional.empty());
+
+        assertThat(serverUrls(transformed)).containsExactly("https://custom.example.com/base");
+    }
+
+    @Test
+    void should_apply_try_it_url_before_replacing_server_path_with_api_context_path() {
+        var transformed = transformer.transform(
+            OPENAPI,
+            configuration(false, true, "https://custom.example.com/tryit?q=test"),
+            Optional.of(apiContext(List.of(), "/test/"))
+        );
+
+        assertThat(serverUrls(transformed)).containsExactly("https://custom.example.com/test/?q=test");
+    }
+
+    private static SwaggerUiConfiguration configuration(boolean entrypointsAsServers, boolean contextPathAsServerPath, String tryItUrl) {
+        return new SwaggerUiConfiguration(
+            false,
+            "none",
+            false,
+            -1,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            tryItUrl,
+            false,
+            entrypointsAsServers,
+            contextPathAsServerPath
+        );
+    }
+
+    private static OpenApiContentTransformer.ApiContext apiContext(List<String> entrypoints, String contextPath) {
+        return new OpenApiContentTransformer.ApiContext(entrypoints, Optional.of(contextPath));
+    }
+
+    private static List<String> serverUrls(String content) {
+        return new OAIParser()
+            .parse(content)
+            .getSpecification()
+            .getServers()
+            .stream()
+            .map(server -> server.getUrl())
+            .toList();
+    }
+}


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/EXT-148

## Issue

https://gravitee.atlassian.net/browse/EXT-148


## Description

This PR completes Phase 2 of EXT-148 for Developer Portal runtime rendering.

It adds Portal REST read support for the saved OpenAPI Try It server resolution options and applies them when navigation OpenAPI content is rendered. When enabled, the backend resolves API entrypoints and/or API context path from the enclosing API navigation item, transforms the OpenAPI `servers`, and portal-next avoids overriding those backend-resolved servers with the raw `try_it_url`.

## Changes

- Expose `entrypoints_as_servers` and `context_path_as_server_path` in the Portal REST OpenAPI contract.
- Map saved `SwaggerUiConfiguration` flags into Portal REST page configuration responses.
- Add backend OpenAPI content transformer for navigation page content.
- Resolve enclosing API context, API entrypoints, and API context path in `GetPortalPageContentByNavigationIdUseCase`.
- Prevent portal-next Swagger/Redoc navigation rendering from reapplying `try_it_url` when backend-resolved server URLs are enabled.



https://github.com/user-attachments/assets/dfe1f6bc-b3cd-471b-9cc6-7441b9823d76


