### PR TITLE
feat(permissions): add CATALOG scope and AI_CATALOG permission

### DIFF
--- a/gravitee-apim-console-webui/src/entities/role/permission.fixtures.ts
+++ b/gravitee-apim-console-webui/src/entities/role/permission.fixtures.ts
@@ -35,6 +35,7 @@ export function fakePermissionsByScopes(attributes?: Partial<PermissionsByScopes
     ],
     ENVIRONMENT: [
       'AGENT_IDENTITY',
+      'AI_CATALOG',
       'ALERT',
       'AM_CONFIGURATION',
       'API',

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/RoleScope.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/RoleScope.java
@@ -29,4 +29,5 @@ public enum RoleScope {
     INTEGRATION,
     CLUSTER,
     API_PRODUCT,
+    CATALOG,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1905,6 +1905,7 @@ components:
         - INTEGRATION
         - CLUSTER
         - API_PRODUCT
+        - CATALOG
     Member:
       type: object
       properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResource.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.management.rest.resource.AbstractResource;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
+import io.gravitee.rest.api.model.permissions.CatalogPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
 import io.gravitee.rest.api.model.permissions.IntegrationPermission;
@@ -83,6 +84,7 @@ public class RoleScopesResource extends AbstractResource {
             RoleScope.API_PRODUCT.name(),
             stream(ApiProductPermission.values()).map(ApiProductPermission::getName).sorted().collect(toList())
         );
+        roles.put(RoleScope.CATALOG.name(), stream(CatalogPermission.values()).map(CatalogPermission::getName).sorted().collect(toList()));
         return roles;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
@@ -50,6 +50,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
         "ENVIRONMENT",
         List.of(
             "AGENT_IDENTITY",
+            "AI_CATALOG",
             "ALERT",
             "AM_CONFIGURATION",
             "API",
@@ -118,7 +119,9 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
         "INTEGRATION",
         List.of("DEFINITION", "MEMBER"),
         "CLUSTER",
-        List.of("ANALYTICS", "CONFIGURATION", "DEFINITION", "MEMBER")
+        List.of("ANALYTICS", "CONFIGURATION", "DEFINITION", "MEMBER"),
+        "CATALOG",
+        List.of("DEFINITION", "MEMBER")
     );
 
     @Override
@@ -134,7 +137,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
 
         assertAll(
             () -> assertEquals(HttpStatusCode.OK_200, response.getStatus()),
-            () -> assertThat(resultRoleScopes.size()).isEqualTo(7),
+            () -> assertThat(resultRoleScopes.size()).isEqualTo(8),
             () ->
                 assertThat(resultRoleScopes.keySet()).containsExactlyInAnyOrder(
                     "ORGANIZATION",
@@ -143,14 +146,16 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
                     "APPLICATION",
                     "INTEGRATION",
                     "CLUSTER",
-                    "API_PRODUCT"
+                    "API_PRODUCT",
+                    "CATALOG"
                 ),
             () -> assertThat(resultRoleScopes.get("ORGANIZATION")).isEqualTo(EXPECTED_ROLE_SCOPES.get("ORGANIZATION")),
             () -> assertThat(resultRoleScopes.get("ENVIRONMENT")).isEqualTo(EXPECTED_ROLE_SCOPES.get("ENVIRONMENT")),
             () -> assertThat(resultRoleScopes.get("API")).isEqualTo(EXPECTED_ROLE_SCOPES.get("API")),
             () -> assertThat(resultRoleScopes.get("APPLICATION")).isEqualTo(EXPECTED_ROLE_SCOPES.get("APPLICATION")),
             () -> assertThat(resultRoleScopes.get("INTEGRATION")).isEqualTo(EXPECTED_ROLE_SCOPES.get("INTEGRATION")),
-            () -> assertThat(resultRoleScopes.get("CLUSTER")).isEqualTo(EXPECTED_ROLE_SCOPES.get("CLUSTER"))
+            () -> assertThat(resultRoleScopes.get("CLUSTER")).isEqualTo(EXPECTED_ROLE_SCOPES.get("CLUSTER")),
+            () -> assertThat(resultRoleScopes.get("CATALOG")).isEqualTo(EXPECTED_ROLE_SCOPES.get("CATALOG"))
         );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MembershipReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MembershipReferenceType.java
@@ -31,13 +31,22 @@ public enum MembershipReferenceType {
     API(EnumSet.of(RoleScope.API)),
     API_PRODUCT(EnumSet.of(RoleScope.API_PRODUCT)),
     GROUP(
-        EnumSet.of(RoleScope.GROUP, RoleScope.API, RoleScope.API_PRODUCT, RoleScope.APPLICATION, RoleScope.INTEGRATION, RoleScope.CLUSTER)
+        EnumSet.of(
+            RoleScope.GROUP,
+            RoleScope.API,
+            RoleScope.API_PRODUCT,
+            RoleScope.APPLICATION,
+            RoleScope.INTEGRATION,
+            RoleScope.CLUSTER,
+            RoleScope.CATALOG
+        )
     ),
     ENVIRONMENT(EnumSet.allOf(RoleScope.class)),
     ORGANIZATION(EnumSet.allOf(RoleScope.class)),
     PLATFORM(EnumSet.allOf(RoleScope.class)),
     INTEGRATION(EnumSet.allOf(RoleScope.class)),
-    CLUSTER(EnumSet.allOf(RoleScope.class));
+    CLUSTER(EnumSet.allOf(RoleScope.class)),
+    CATALOG(EnumSet.of(RoleScope.CATALOG));
 
     private final EnumSet<RoleScope> roleScopes;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/CatalogPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/CatalogPermission.java
@@ -13,21 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.member.model;
+package io.gravitee.rest.api.model.permissions;
 
-/**
- * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum RoleScope {
-    API,
-    APPLICATION,
-    GROUP,
-    ENVIRONMENT,
-    ORGANIZATION,
-    PLATFORM,
-    INTEGRATION,
-    CLUSTER,
-    API_PRODUCT,
-    CATALOG,
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(enumAsRef = true)
+public enum CatalogPermission implements Permission {
+    DEFINITION("DEFINITION", 1000),
+    MEMBER("MEMBER", 1100);
+
+    final String name;
+    final int mask;
+
+    CatalogPermission(String name, int mask) {
+        this.name = name;
+        this.mask = mask;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int getMask() {
+        return mask;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
@@ -59,7 +59,8 @@ public enum EnvironmentPermission implements Permission {
     AUTHZ_ENTITIES("AUTHZ_ENTITIES", 4700),
     AUTHZ_POLICIES("AUTHZ_POLICIES", 4800),
     AUTHZ_PDP("AUTHZ_PDP", 4900),
-    AUTHZ_SCHEMA("AUTHZ_SCHEMA", 5000);
+    AUTHZ_SCHEMA("AUTHZ_SCHEMA", 5000),
+    AI_CATALOG("AI_CATALOG", 5100);
 
     String name;
     int mask;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/Permission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/Permission.java
@@ -46,6 +46,8 @@ public interface Permission {
                 return ClusterPermission.values();
             case API_PRODUCT:
                 return ApiProductPermission.values();
+            case CATALOG:
+                return CatalogPermission.values();
             default:
                 throw new IllegalArgumentException("[" + scope + "] are not a RolePermission");
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -100,6 +100,7 @@ public enum RolePermission {
     ENVIRONMENT_AUTHZ_POLICIES(RoleScope.ENVIRONMENT, EnvironmentPermission.AUTHZ_POLICIES),
     ENVIRONMENT_AUTHZ_PDP(RoleScope.ENVIRONMENT, EnvironmentPermission.AUTHZ_PDP),
     ENVIRONMENT_AUTHZ_SCHEMA(RoleScope.ENVIRONMENT, EnvironmentPermission.AUTHZ_SCHEMA),
+    ENVIRONMENT_AI_CATALOG(RoleScope.ENVIRONMENT, EnvironmentPermission.AI_CATALOG),
 
     ORGANIZATION_USERS(RoleScope.ORGANIZATION, OrganizationPermission.USER),
     ORGANIZATION_USERS_TOKEN(RoleScope.ORGANIZATION, OrganizationPermission.USER_TOKEN),
@@ -130,7 +131,10 @@ public enum RolePermission {
     API_PRODUCT_PLAN(RoleScope.API_PRODUCT, ApiProductPermission.PLAN),
     API_PRODUCT_SUBSCRIPTION(RoleScope.API_PRODUCT, ApiProductPermission.SUBSCRIPTION),
     API_PRODUCT_NOTIFICATION(RoleScope.API_PRODUCT, ApiProductPermission.NOTIFICATION),
-    API_PRODUCT_MEMBER(RoleScope.API_PRODUCT, ApiProductPermission.MEMBER);
+    API_PRODUCT_MEMBER(RoleScope.API_PRODUCT, ApiProductPermission.MEMBER),
+
+    CATALOG_DEFINITION(RoleScope.CATALOG, CatalogPermission.DEFINITION),
+    CATALOG_MEMBER(RoleScope.CATALOG, CatalogPermission.MEMBER);
 
     final RoleScope scope;
     final Permission permission;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RoleScope.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RoleScope.java
@@ -32,4 +32,5 @@ public enum RoleScope {
     INTEGRATION,
     CLUSTER,
     API_PRODUCT,
+    CATALOG,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-rest/src/main/java/io/gravitee/rest/api/rest/filter/PermissionsFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-rest/src/main/java/io/gravitee/rest/api/rest/filter/PermissionsFilter.java
@@ -53,6 +53,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
     private static final String INTEGRATION_ID_PARAM = "integrationId";
     private static final String CLUSTER_ID_PARAM = "clusterId";
     private static final String API_PRODUCT_ID_PARAM = "apiProductId";
+    private static final String CATALOG_ID_PARAM = "catalogId";
 
     @Context
     protected ResourceInfo resourceInfo;
@@ -89,6 +90,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
             case INTEGRATION -> hasPermission(executionContext, permission, getId(INTEGRATION_ID_PARAM, requestContext));
             case CLUSTER -> hasPermission(executionContext, permission, getId(CLUSTER_ID_PARAM, requestContext));
             case API_PRODUCT -> hasPermission(executionContext, permission, getId(API_PRODUCT_ID_PARAM, requestContext));
+            case CATALOG -> hasPermission(executionContext, permission, getId(CATALOG_ID_PARAM, requestContext));
             case PLATFORM -> false;
         };
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/MembershipReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/MembershipReferenceType.java
@@ -32,7 +32,8 @@ public enum MembershipReferenceType {
     ORGANIZATION(EnumSet.allOf(RoleScope.class)),
     PLATFORM(EnumSet.allOf(RoleScope.class)),
     INTEGRATION(EnumSet.allOf(RoleScope.class)),
-    CLUSTER(EnumSet.allOf(RoleScope.class));
+    CLUSTER(EnumSet.allOf(RoleScope.class)),
+    CATALOG(EnumSet.of(RoleScope.CATALOG));
 
     private final EnumSet<RoleScope> roleScopes;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Role.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Role.java
@@ -50,5 +50,6 @@ public class Role {
         INTEGRATION,
         CLUSTER,
         API_PRODUCT,
+        CATALOG,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.NewRoleEntity;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
+import io.gravitee.rest.api.model.permissions.CatalogPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
 import io.gravitee.rest.api.model.permissions.IntegrationPermission;
@@ -258,6 +259,28 @@ public interface DefaultRoleEntityDefinition {
         Maps.<String, char[]>builder()
             .put(IntegrationPermission.DEFINITION.getName(), new char[] { READ.getId() })
             .put(IntegrationPermission.MEMBER.getName(), new char[] { READ.getId() })
+            .build()
+    );
+
+    NewRoleEntity ROLE_CATALOG_OWNER = new NewRoleEntity(
+        "OWNER",
+        "Catalog Role. Created by Gravitee.io.",
+        CATALOG,
+        false,
+        Maps.<String, char[]>builder()
+            .put(CatalogPermission.DEFINITION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .put(CatalogPermission.MEMBER.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .build()
+    );
+
+    NewRoleEntity ROLE_CATALOG_USER = new NewRoleEntity(
+        "USER",
+        "Default Catalog Role. Created by Gravitee.io.",
+        CATALOG,
+        true,
+        Maps.<String, char[]>builder()
+            .put(CatalogPermission.DEFINITION.getName(), new char[] { READ.getId() })
+            .put(CatalogPermission.MEMBER.getName(), new char[] { READ.getId() })
             .build()
     );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
@@ -51,7 +51,8 @@ public class PermissionServiceImpl extends AbstractService implements Permission
         Pair.of(RoleScope.ENVIRONMENT, MembershipReferenceType.ENVIRONMENT),
         Pair.of(RoleScope.GROUP, MembershipReferenceType.GROUP),
         Pair.of(RoleScope.INTEGRATION, MembershipReferenceType.INTEGRATION),
-        Pair.of(RoleScope.CLUSTER, MembershipReferenceType.CLUSTER)
+        Pair.of(RoleScope.CLUSTER, MembershipReferenceType.CLUSTER),
+        Pair.of(RoleScope.CATALOG, MembershipReferenceType.CATALOG)
     );
 
     @Autowired

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -35,6 +35,8 @@ import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.RO
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_PRODUCT_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_REVIEWER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_APPLICATION_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_CATALOG_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_CATALOG_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_API_PUBLISHER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_EDGE_MANAGER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_FEDERATION_AGENT;
@@ -57,6 +59,7 @@ import io.gravitee.rest.api.model.UpdateRoleEntity;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
+import io.gravitee.rest.api.model.permissions.CatalogPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
 import io.gravitee.rest.api.model.permissions.GroupPermission;
@@ -125,7 +128,9 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
         Map.entry("<API_PRODUCT> OWNER", ROLE_API_PRODUCT_OWNER),
         Map.entry("<API_PRODUCT> USER", ROLE_API_PRODUCT_USER),
         Map.entry("<CLUSTER> USER", CLUSTER_ROLE_USER),
-        Map.entry("<CLUSTER> OWNER", CLUSTER_ROLE_OWNER)
+        Map.entry("<CLUSTER> OWNER", CLUSTER_ROLE_OWNER),
+        Map.entry("<CATALOG> OWNER", ROLE_CATALOG_OWNER),
+        Map.entry("<CATALOG> USER", ROLE_CATALOG_USER)
     );
 
     @Lazy
@@ -609,6 +614,14 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 SystemRole.PRIMARY_OWNER,
                 RoleScope.CLUSTER,
                 ClusterPermission.values(),
+                organizationId
+            );
+            // CATALOG - PRIMARY_OWNER
+            createOrUpdateSystemRole(
+                executionContext,
+                SystemRole.PRIMARY_OWNER,
+                RoleScope.CATALOG,
+                CatalogPermission.values(),
                 organizationId
             );
         } catch (TechnicalManagementException ex) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/DefaultOrganizationAdminRoleInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/DefaultOrganizationAdminRoleInitializer.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade.initializer;
 
+import io.gravitee.rest.api.model.permissions.CatalogPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
 import io.gravitee.rest.api.model.permissions.IntegrationPermission;
@@ -67,6 +68,13 @@ public class DefaultOrganizationAdminRoleInitializer extends OrganizationInitial
             SystemRole.PRIMARY_OWNER,
             RoleScope.CLUSTER,
             ClusterPermission.values(),
+            executionContext.getOrganizationId()
+        );
+        roleService.createOrUpdateSystemRole(
+            executionContext,
+            SystemRole.PRIMARY_OWNER,
+            RoleScope.CATALOG,
+            CatalogPermission.values(),
             executionContext.getOrganizationId()
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/CatalogRolesUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/CatalogRolesUpgrader.java
@@ -58,22 +58,18 @@ public class CatalogRolesUpgrader implements Upgrader {
     }
 
     private void initializeCatalogRoles(ExecutionContext executionContext) {
-        if (shouldCreateCatalogOwnerRole(executionContext)) {
+        if (shouldCreateRole(executionContext, ROLE_CATALOG_OWNER.getName())) {
             log.info("     - <CATALOG> OWNER");
             roleService.create(executionContext, ROLE_CATALOG_OWNER);
         }
-        if (shouldCreateCatalogUserRole(executionContext)) {
+        if (shouldCreateRole(executionContext, ROLE_CATALOG_USER.getName())) {
             log.info("     - <CATALOG> USER");
             roleService.create(executionContext, ROLE_CATALOG_USER);
         }
     }
 
-    private boolean shouldCreateCatalogOwnerRole(final ExecutionContext executionContext) {
-        return roleService.findByScopeAndName(CATALOG, ROLE_CATALOG_OWNER.getName(), executionContext.getOrganizationId()).isEmpty();
-    }
-
-    private boolean shouldCreateCatalogUserRole(final ExecutionContext executionContext) {
-        return roleService.findByScopeAndName(CATALOG, ROLE_CATALOG_USER.getName(), executionContext.getOrganizationId()).isEmpty();
+    private boolean shouldCreateRole(final ExecutionContext executionContext, String roleName) {
+        return roleService.findByScopeAndName(CATALOG, roleName, executionContext.getOrganizationId()).isEmpty();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/CatalogRolesUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/CatalogRolesUpgrader.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.model.permissions.RoleScope.CATALOG;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_CATALOG_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_CATALOG_USER;
+
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+@CustomLog
+public class CatalogRolesUpgrader implements Upgrader {
+
+    private final RoleService roleService;
+
+    private final OrganizationRepository organizationRepository;
+
+    @Autowired
+    public CatalogRolesUpgrader(RoleService roleService, @Lazy OrganizationRepository organizationRepository) {
+        this.roleService = roleService;
+        this.organizationRepository = organizationRepository;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
+            organizationRepository
+                .findAll()
+                .forEach(organization -> {
+                    ExecutionContext executionContext = new ExecutionContext(organization);
+                    initializeCatalogRoles(executionContext);
+                    roleService.createOrUpdateSystemRoles(executionContext, executionContext.getOrganizationId());
+                });
+            return true;
+        });
+    }
+
+    private void initializeCatalogRoles(ExecutionContext executionContext) {
+        if (shouldCreateCatalogOwnerRole(executionContext)) {
+            log.info("     - <CATALOG> OWNER");
+            roleService.create(executionContext, ROLE_CATALOG_OWNER);
+        }
+        if (shouldCreateCatalogUserRole(executionContext)) {
+            log.info("     - <CATALOG> USER");
+            roleService.create(executionContext, ROLE_CATALOG_USER);
+        }
+    }
+
+    private boolean shouldCreateCatalogOwnerRole(final ExecutionContext executionContext) {
+        return roleService.findByScopeAndName(CATALOG, ROLE_CATALOG_OWNER.getName(), executionContext.getOrganizationId()).isEmpty();
+    }
+
+    private boolean shouldCreateCatalogUserRole(final ExecutionContext executionContext) {
+        return roleService.findByScopeAndName(CATALOG, ROLE_CATALOG_USER.getName(), executionContext.getOrganizationId()).isEmpty();
+    }
+
+    @Override
+    public int getOrder() {
+        return UpgraderOrder.CATALOG_ROLES_UPGRADER;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -80,4 +80,5 @@ public class UpgraderOrder {
     public static final int EDGE_ROLES_UPGRADER = 955;
     public static final int GAMMA_IDENTITY_ROLES_UPGRADER = 956;
     public static final int GAMMA_AUTHZ_ROLES_UPGRADER = 957;
+    public static final int CATALOG_ROLES_UPGRADER = 958;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_CreateOrUpdateSystemRolesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_CreateOrUpdateSystemRolesTest.java
@@ -72,14 +72,14 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
 
         roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
 
-        verify(mockRoleRepository, times(8)).findByScopeAndNameAndReferenceIdAndReferenceType(
+        verify(mockRoleRepository, times(9)).findByScopeAndNameAndReferenceIdAndReferenceType(
             any(),
             anyString(),
             eq(REFERENCE_ID),
             eq(REFERENCE_TYPE)
         );
         verify(mockRoleRepository, never()).update(any());
-        verify(mockRoleRepository, times(8)).create(any());
+        verify(mockRoleRepository, times(9)).create(any());
     }
 
     @Test
@@ -124,7 +124,7 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
 
         roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
 
-        verify(mockRoleRepository, times(8)).findByScopeAndNameAndReferenceIdAndReferenceType(
+        verify(mockRoleRepository, times(9)).findByScopeAndNameAndReferenceIdAndReferenceType(
             any(),
             anyString(),
             eq(REFERENCE_ID),
@@ -186,7 +186,7 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
 
         roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
 
-        verify(mockRoleRepository, times(8)).findByScopeAndNameAndReferenceIdAndReferenceType(
+        verify(mockRoleRepository, times(9)).findByScopeAndNameAndReferenceIdAndReferenceType(
             any(),
             anyString(),
             eq(REFERENCE_ID),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/CatalogRolesUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/CatalogRolesUpgraderTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.model.permissions.RoleScope.CATALOG;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_CATALOG_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_CATALOG_USER;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Organization;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
+public class CatalogRolesUpgraderTest {
+
+    @InjectMocks
+    CatalogRolesUpgrader upgrader;
+
+    @Mock
+    RoleService roleService;
+
+    @Mock
+    OrganizationRepository organizationRepository;
+
+    @Test
+    public void upgrade_should_fail_because_of_exception() throws TechnicalException {
+        assertThrows(UpgraderException.class, () -> {
+            when(organizationRepository.findAll()).thenThrow(new RuntimeException());
+            upgrader.upgrade();
+        });
+    }
+
+    @Test
+    public void shouldCreateCatalogRolesWhenNotPresent() throws UpgraderException, TechnicalException {
+        String organizationId = GraviteeContext.getDefaultOrganization();
+        Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(organizationId);
+        when(organizationRepository.findAll()).thenReturn(Set.of(organization));
+
+        ExecutionContext expectedExecutionContext = new ExecutionContext(organization);
+        when(roleService.findByScopeAndName(eq(CATALOG), eq(ROLE_CATALOG_OWNER.getName()), eq(organizationId))).thenReturn(
+            Optional.empty()
+        );
+        when(roleService.findByScopeAndName(eq(CATALOG), eq(ROLE_CATALOG_USER.getName()), eq(organizationId))).thenReturn(Optional.empty());
+
+        upgrader.upgrade();
+
+        verify(roleService).create(expectedExecutionContext, ROLE_CATALOG_OWNER);
+        verify(roleService).create(expectedExecutionContext, ROLE_CATALOG_USER);
+        verify(roleService).createOrUpdateSystemRoles(expectedExecutionContext, organizationId);
+    }
+
+    @Test
+    public void shouldNotCreateCatalogRolesWhenAlreadyPresent() throws UpgraderException, TechnicalException {
+        String organizationId = GraviteeContext.getDefaultOrganization();
+        Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(organizationId);
+        when(organizationRepository.findAll()).thenReturn(Set.of(organization));
+
+        when(roleService.findByScopeAndName(eq(CATALOG), eq(ROLE_CATALOG_OWNER.getName()), eq(organizationId))).thenReturn(
+            Optional.of(new RoleEntity())
+        );
+        when(roleService.findByScopeAndName(eq(CATALOG), eq(ROLE_CATALOG_USER.getName()), eq(organizationId))).thenReturn(
+            Optional.of(new RoleEntity())
+        );
+
+        upgrader.upgrade();
+
+        verify(roleService, never()).create(any(), eq(ROLE_CATALOG_OWNER));
+        verify(roleService, never()).create(any(), eq(ROLE_CATALOG_USER));
+        verify(roleService).createOrUpdateSystemRoles(any(), eq(organizationId));
+    }
+
+    @Test
+    public void test_order() {
+        Assertions.assertEquals(UpgraderOrder.CATALOG_ROLES_UPGRADER, upgrader.getOrder());
+    }
+}


### PR DESCRIPTION
Adds RBAC for the AIM catalog, modeled on the INTEGRATION scope.

Related issue: https://gravitee.atlassian.net/browse/GMA-754

The catalog source is the ownable unit (items inherit access), and a source can be shared with users or groups. Two levels:
- `ENVIRONMENT_AI_CATALOG` gates create/list at the environment level
- `RoleScope.CATALOG` (`CATALOG_DEFINITION` / `CATALOG_MEMBER`) gates per-source access via membership

Includes the new scope and permissions, the default roles (OWNER/USER + PRIMARY_OWNER), the org seeding, an upgrader to create the roles on existing orgs, and the role-scopes endpoint.

The owner backfill on existing sources and the `@Permissions` annotations come in the AIM module PR, once this milestone is published.