### PR TITLE
ci: detect gamma module bump from the commit (cwd-independent)

### DIFF
--- a/.circleci/ci/src/index.ts
+++ b/.circleci/ci/src/index.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { changedFiles, isBlank, isRootPomOnlyGammaModuleBump, isSupportBranchOrMaster } from './utils';
+import { changedFiles, isBlank, isCommitOnlyGammaModuleBump, isSupportBranchOrMaster } from './utils';
 import { argv } from 'node:process';
 import { buildCIPipeline, CircleCIEnvironment } from './pipelines';
 import * as fs from 'fs';
@@ -45,9 +45,7 @@ const diffBase = GIT_COMMON_COMMIT_HASH ?? GIT_BASE_BRANCH;
 const changed = isSupportBranchOrMaster(CIRCLE_BRANCH) ? Promise.resolve([]) : changedFiles(diffBase);
 
 changed
-  .then((changes) =>
-    changes.includes('pom.xml') && isRootPomOnlyGammaModuleBump(diffBase) ? changes.filter((file) => file !== 'pom.xml') : changes,
-  )
+  .then((changes) => (isCommitOnlyGammaModuleBump(CIRCLE_SHA1) ? [] : changes))
   .then(
     (changes) =>
       ({

--- a/.circleci/ci/src/utils/git.ts
+++ b/.circleci/ci/src/utils/git.ts
@@ -55,14 +55,28 @@ const keepFirstPathItem = (path: string) => path.split('/')[0];
 const removeDuplicate = (path: string, index: number, arr: string[]) => arr.indexOf(path) === index;
 
 /**
- * Returns true when the only change in the root pom.xml is a version bump of one or more
- * `gravitee-gamma-module-*.version` properties. Those modules are external dependencies that are
- * not built nor tested by this repository, so such a bump must not trigger the full CI.
+ * Returns true when the given commit only bumps one or more `gravitee-gamma-module-*.version`
+ * properties in the root pom.xml and changes nothing else. Those modules are external dependencies
+ * that are not built nor tested by this repository, so such a commit must not trigger the full CI.
+ *
+ * The check runs against the commit and its parent (`${commit}~1..${commit}`), not the PR base.
+ * The base detection can resolve too far back when the branch sits on commits not yet on the target
+ * branch ref, which would pull unrelated changes into the diff and defeat the skip. The commit is
+ * passed explicitly (CIRCLE_SHA1) because CircleCI checks out a PR merge commit, so HEAD would be the
+ * merge and HEAD~1 the base branch, not the actual bump commit.
  */
-export const isRootPomOnlyGammaModuleBump = (from: string, to = 'HEAD'): boolean => {
+export const isCommitOnlyGammaModuleBump = (commit: string): boolean => {
+  const parent = `${commit}~1`;
   try {
-    const { stdout, status } = spawnSync('git', ['--no-pager', 'diff', '-U0', from, to, '--', 'pom.xml'], { encoding: 'utf-8' });
-    return status === 0 && isOnlyGammaModuleVersionBump(stdout);
+    const files = runGit(['--no-pager', 'diff', '--name-only', parent, commit])
+      .split('\n')
+      .filter((file) => file.length > 0);
+    if (files.length !== 1 || files[0] !== 'pom.xml') {
+      return false;
+    }
+    // No pathspec: it would resolve relative to the current working directory (the generator runs from
+    // .circleci/ci). Only pom.xml changed, so the full commit diff is the pom.xml diff.
+    return isOnlyGammaModuleVersionBump(runGit(['--no-pager', 'diff', '-U0', parent, commit]));
   } catch {
     return false;
   }
@@ -71,4 +85,12 @@ export const isRootPomOnlyGammaModuleBump = (from: string, to = 'HEAD'): boolean
 export const isOnlyGammaModuleVersionBump = (diff: string): boolean => {
   const changedLines = diff.split('\n').filter((line) => /^[+-][^+-]/.test(line));
   return changedLines.length > 0 && changedLines.every((line) => /<gravitee-gamma-module-[a-z0-9-]+\.version>/.test(line));
+};
+
+const runGit = (args: string[]): string => {
+  const { stdout, status, stderr } = spawnSync('git', args, { encoding: 'utf-8' });
+  if (status !== 0) {
+    throw new Error(stderr || `git ${args.join(' ')} exited with ${status}`);
+  }
+  return stdout;
 };


### PR DESCRIPTION
## What

Skip the test pipeline when a PR only bumps a gamma module version, by looking at the commit itself (`CIRCLE_SHA1`) instead of the PR base.

Only the `pull_requests` action is affected. Docker image build and delivery (`release`, `full_release`, `build_docker_images`, ...) are separate actions that don't read `changedFiles`, so the bump is still built and delivered normally.

## Why

The first version diffed `pom.xml` against the PR base with a `-- pom.xml` pathspec. That pathspec is resolved from the current directory, and the generator runs from `.circleci/ci`, so the diff matched nothing and the check always returned false. The skip never fired (see #18002, #18008, #18010).

## How

A bump PR is a single commit, so `${CIRCLE_SHA1}~1..${CIRCLE_SHA1}` is exactly its change. We skip when that commit touches only `pom.xml` and every changed line is a `gravitee-gamma-module-*.version` property. No pathspec, so it works regardless of the working directory.

This also avoids a smaller issue: without an open PR (push before the PR exists, mergify backport), the base is guessed by walking up to 100 commits and can land too far back. Looking at the commit sidesteps that.

## Validation

Pushed a temp bump commit on top of this branch (also touching `.circleci`, worst case): CI ran only `fs_scan`, `generate-config` and `Run Danger JS`, no build/test/front/helm. Temp commit removed before review.
