### PR TITLE
fix(console): preserve secondary endpoint flag on edit

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.spec.ts
@@ -370,6 +370,73 @@ describe('ApiEndpointComponent', () => {
         expect(routerNavigationSpy).toHaveBeenCalledWith(['../../'], { relativeTo: expect.anything() });
       });
 
+      it('should preserve secondary flag when editing a secondary endpoint', async () => {
+        const apiV4 = fakeApiV4({
+          id: API_ID,
+          endpointGroups: [
+            fakeEndpointGroupV4({
+              endpoints: [
+                {
+                  name: 'primary',
+                  type: 'kafka',
+                  weight: 1,
+                  inheritConfiguration: false,
+                  secondary: false,
+                  configuration: {
+                    bootstrapServers: 'localhost:9092',
+                  },
+                },
+                {
+                  name: 'fallback',
+                  type: 'kafka',
+                  weight: 1,
+                  inheritConfiguration: false,
+                  secondary: true,
+                  configuration: {
+                    bootstrapServers: 'localhost:9092',
+                  },
+                },
+              ],
+            }),
+          ],
+        });
+
+        await initComponent(apiV4, { apiId: API_ID, groupIndex: 0, endpointIndex: 1 });
+
+        fixture.detectChanges();
+        expect(await componentHarness.getEndpointName()).toStrictEqual('fallback');
+
+        await componentHarness.fillInputName('fallback updated');
+        fixture.detectChanges();
+
+        await componentHarness.clickSaveButton();
+
+        expectApiGetRequest(apiV4);
+
+        const updatedApi: ApiV4 = {
+          ...apiV4,
+          endpointGroups: [
+            {
+              ...apiV4.endpointGroups[0],
+              endpoints: [
+                apiV4.endpointGroups[0].endpoints[0],
+                {
+                  ...apiV4.endpointGroups[0].endpoints[1],
+                  name: 'fallback updated',
+                  sharedConfigurationOverride: {
+                    test: undefined,
+                  },
+                  secondary: true,
+                  tenants: undefined,
+                },
+              ],
+            },
+          ],
+        };
+        expectApiPutRequest(updatedApi);
+        expect(routerNavigationSpy).toHaveBeenCalledWith(['../../'], { relativeTo: expect.anything() });
+      });
+
       it('should edit and save a native kafka endpoint without weight', async () => {
         const apiV4 = fakeApiV4({
           id: API_ID,

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
@@ -143,6 +143,7 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
       configuration: this.formGroup.get('configuration').value,
       sharedConfigurationOverride: inheritConfiguration ? {} : this.formGroup.get('sharedConfigurationOverride').value,
       inheritConfiguration,
+      ...(this.endpoint?.secondary != null ? { secondary: this.endpoint.secondary } : {}),
     };
 
     if (this.isHttpProxyApi) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14462

## Description

The v4 Console endpoint editor was silently resetting the secondary flag to false when saving any endpoint change. The onSave() method in ApiEndpointComponent rebuilt the endpoint object without carrying over the secondary property from the original endpoint.
                                                                                                                                                                                                                                                                   **Root cause**: updatedEndpoint in onSave() did not include the secondary field.                                                                                                                                                                                      
   
**Fix**: Carry forward this.endpoint.secondary when editing an existing endpoint.  

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

