### PR TITLE
chore(deps): bump promoted libs and plugins to released versions

### DIFF
--- a/gravitee-apim-bom/pom.xml
+++ b/gravitee-apim-bom/pom.xml
@@ -102,6 +102,12 @@
             </dependency>
 
             <dependency>
+                <groupId>io.gravitee.elasticsearch</groupId>
+                <artifactId>gravitee-common-elasticsearch</artifactId>
+                <version>${gravitee-common-elasticsearch.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.graviteesource.common</groupId>
                 <artifactId>gravitee-common-mcp</artifactId>
                 <version>${gravitee-common-mcp.version}</version>

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/pom.xml
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/pom.xml
@@ -29,8 +29,6 @@
     <name>Gravitee.io APIM - Reporter - Elasticsearch</name>
 
     <properties>
-        <gravitee-common-elasticsearch.version>7.0.0-alpha.1</gravitee-common-elasticsearch.version>
-
         <maven-remote-resources-plugin.version>3.3.0</maven-remote-resources-plugin.version>
 
         <publish-folder-path>graviteeio-apim/plugins/reporters</publish-folder-path>
@@ -41,7 +39,6 @@
         <dependency>
             <groupId>io.gravitee.elasticsearch</groupId>
             <artifactId>gravitee-common-elasticsearch</artifactId>
-            <version>${gravitee-common-elasticsearch.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
@@ -32,7 +32,6 @@
 
     <properties>
         <gravitee-reporter-common.version>1.12.1</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>7.0.0-beta.1</gravitee-common-elasticsearch.version>
         <opensearch-testcontainers.version>2.1.4</opensearch-testcontainers.version>
 
         <!-- Property used by the publication job in CI-->
@@ -58,7 +57,6 @@
         <dependency>
             <groupId>io.gravitee.elasticsearch</groupId>
             <artifactId>gravitee-common-elasticsearch</artifactId>
-            <version>${gravitee-common-elasticsearch.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.freemarker</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,22 +50,23 @@
              https://github.com/awhitford/lombok.maven/issues/179 -->
         <maven-lombok.version>1.18.36</maven-lombok.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>9.0.0-alpha.6</gravitee-bom.version>
+        <gravitee-bom.version>9.0.0</gravitee-bom.version>
         <gravitee-alert-api.version>3.0.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.12.0</gravitee-cockpit-api.version>
         <gravitee-cloud-initializer.version>2.3.1</gravitee-cloud-initializer.version>
         <logback-ecs-encoder.version>1.7.0</logback-ecs-encoder.version>
-        <gravitee-common.version>5.0.0-alpha.1</gravitee-common.version>
+        <gravitee-common.version>5.0.0</gravitee-common.version>
+        <gravitee-common-elasticsearch.version>7.0.0</gravitee-common-elasticsearch.version>
         <gravitee-common-mcp.version>1.2.0</gravitee-common-mcp.version>
-        <gravitee-connector-api.version>2.0.0-alpha.1</gravitee-connector-api.version>
-        <gravitee-exchange.version>3.0.0-alpha.2</gravitee-exchange.version>
+        <gravitee-connector-api.version>2.0.0</gravitee-connector-api.version>
+        <gravitee-exchange.version>3.0.0</gravitee-exchange.version>
         <gravitee-expression-language.version>4.3.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>6.2.0</gravitee-gateway-api.version>
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
-        <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
-        <gravitee-node.version>9.0.0-alpha.19</gravitee-node.version>
+        <gravitee-kubernetes.version>4.0.0</gravitee-kubernetes.version>
+        <gravitee-node.version>9.0.0</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>2.0.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.4</gravitee-plugin.version>
@@ -176,9 +177,9 @@
 
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
-        <gravitee-alert-engine-connectors-ws.version>3.0.0-alpha.1</gravitee-alert-engine-connectors-ws.version>
+        <gravitee-alert-engine-connectors-ws.version>3.0.0</gravitee-alert-engine-connectors-ws.version>
         <gravitee-connector-http.version>6.0.0-alpha.2</gravitee-connector-http.version>
-        <gravitee-policy-apikey.version>6.0.0-alpha.2</gravitee-policy-apikey.version>
+        <gravitee-policy-apikey.version>6.0.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>3.2.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>3.1.1</gravitee-policy-assign-content.version>
         <gravitee-policy-assign-metrics.version>3.1.0</gravitee-policy-assign-metrics.version>
@@ -229,7 +230,7 @@
         <gravitee-policy-rest-to-soap.version>1.14.1</gravitee-policy-rest-to-soap.version>
         <gravitee-policy-retry.version>4.1.1</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>2.1.0</gravitee-policy-role-based-access-control.version>
-        <gravitee-policy-ssl-enforcement.version>1.7.0-alpha.2</gravitee-policy-ssl-enforcement.version>
+        <gravitee-policy-ssl-enforcement.version>1.7.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>3.0.0</gravitee-policy-traffic-shadowing.version>
         <gravitee-policy-transform-avro-json.version>5.2.0</gravitee-policy-transform-avro-json.version>
         <gravitee-policy-transform-avro-protobuf.version>1.0.9</gravitee-policy-transform-avro-protobuf.version>
@@ -247,18 +248,18 @@
 
         <gravitee-resource-cache.version>3.0.0</gravitee-resource-cache.version>
         <gravitee-resource-oauth2-provider-am.version>5.0.0-alpha.3</gravitee-resource-oauth2-provider-am.version>
-        <gravitee-resource-oauth2-provider-auth0.version>2.0.0-alpha.1</gravitee-resource-oauth2-provider-auth0.version>
+        <gravitee-resource-oauth2-provider-auth0.version>2.0.0</gravitee-resource-oauth2-provider-auth0.version>
         <gravitee-resource-oauth2-provider-entra-id.version>2.0.0-alpha.2</gravitee-resource-oauth2-provider-entra-id.version>
         <gravitee-resource-oauth2-provider-generic.version>6.0.0-alpha.3</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-resource-content-provider-inline.version>1.1.1</gravitee-resource-content-provider-inline.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
         <!-- Management API Only -->
-        <gravitee-cockpit-connectors-ws.version>6.0.0-alpha.4</gravitee-cockpit-connectors-ws.version>
+        <gravitee-cockpit-connectors-ws.version>6.0.0</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>2.1.1</gravitee-fetcher-bitbucket.version>
         <gravitee-fetcher-git.version>3.0.0</gravitee-fetcher-git.version>
         <gravitee-fetcher-github.version>2.2.1</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>2.1.2</gravitee-fetcher-gitlab.version>
-        <gravitee-fetcher-http.version>3.0.0-alpha.1</gravitee-fetcher-http.version>
+        <gravitee-fetcher-http.version>3.0.0</gravitee-fetcher-http.version>
         <gravitee-notifier-email.version>3.0.0</gravitee-notifier-email.version>
         <gravitee-notifier-slack.version>2.0.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>2.0.0</gravitee-notifier-webhook.version>
@@ -275,14 +276,14 @@
         <gravitee-policy-aws-lambda.version>3.4.0</gravitee-policy-aws-lambda.version>
         <gravitee-policy-circuit-breaker.version>2.0.0</gravitee-policy-circuit-breaker.version>
         <gravitee-policy-geoip-filtering.version>2.2.2</gravitee-policy-geoip-filtering.version>
-        <gravitee-resource-auth-provider-http.version>2.0.0-alpha.1</gravitee-resource-auth-provider-http.version>
+        <gravitee-resource-auth-provider-http.version>2.0.0</gravitee-resource-auth-provider-http.version>
         <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>
         <gravitee-resource-auth-provider-ldap.version>2.0.1</gravitee-resource-auth-provider-ldap.version>
         <gravitee-resource-cache-redis.version>5.0.0-alpha.4</gravitee-resource-cache-redis.version>
         <gravitee-resource-oauth2-provider-keycloak.version>4.0.0-alpha.1</gravitee-resource-oauth2-provider-keycloak.version>
         <gravitee-resource-ai-model-text-classification.version>2.2.1</gravitee-resource-ai-model-text-classification.version>
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>
-        <gravitee-inference-service.version>2.0.0-alpha.2</gravitee-inference-service.version>
+        <gravitee-inference-service.version>2.0.0</gravitee-inference-service.version>
         <gravitee-secretprovider-kubernetes.version>2.0.0</gravitee-secretprovider-kubernetes.version>
         <gravitee-policy-ai-prompt-token-tracking.version>2.0.0</gravitee-policy-ai-prompt-token-tracking.version>
         <gravitee-policy-ai-prompt-guard-rails.version>4.0.1</gravitee-policy-ai-prompt-guard-rails.version>
@@ -305,7 +306,7 @@
         <gravitee-endpoint-agent-to-agent.version>2.0.0</gravitee-endpoint-agent-to-agent.version>
         <gravitee-policy-graphql-rate-limit.version>1.0.2</gravitee-policy-graphql-rate-limit.version>
         <gravitee-resource-schema-registry-confluent.version>5.0.0-alpha.1</gravitee-resource-schema-registry-confluent.version>
-        <gravitee-resource-schema-registry-embedded.version>1.0.0-alpha.1</gravitee-resource-schema-registry-embedded.version>
+        <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>11.0.0-alpha.4</gravitee-reactor-message.version>
         <gravitee-reactor-native-kafka.version>7.0.0-alpha.25</gravitee-reactor-native-kafka.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0</gravitee-kubernetes.version>
-        <gravitee-node.version>9.0.0</gravitee-node.version>
+        <gravitee-node.version>9.1.0</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>2.0.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.4</gravitee-plugin.version>


### PR DESCRIPTION
## Issue

N/A — no associated ticket

## Description

Bump the promoted 4.12.x train libraries and plugins to their released versions: `gravitee-bom`, `gravitee-node`, `gravitee-common`, `gravitee-connector-api`, `gravitee-exchange`, `gravitee-kubernetes`, `gravitee-fetcher-http`, `gravitee-inference-service`, `gravitee-alert-engine-connectors-ws`, `gravitee-cockpit-connectors-ws`, `gravitee-common-elasticsearch`, `gravitee-policy-apikey`, `gravitee-policy-ssl-enforcement`, `gravitee-resource-auth-provider-http` and `gravitee-resource-schema-registry-embedded`.

Also aligns the two `gravitee-common-elasticsearch` pins (reporter-elasticsearch / repository-elasticsearch) to `7.0.0`.

## Additional context

Plugins and libraries not yet released are intentionally left on their alpha/milestone versions (e.g. `gravitee-connector-http` and other apim-bom consumers, to be released after the APIM milestone).
