### PR TITLE
fix(debug): prefer gateway with matching sharding tag over most recently started

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/debug/use_case/DebugApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/debug/use_case/DebugApiUseCase.java
@@ -52,6 +52,7 @@ import io.gravitee.rest.api.model.PlanStatus;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -204,15 +205,34 @@ public class DebugApiUseCase {
     }
 
     private Instance selectTargetGateway(String organizationId, String environmentId, DebugApiProxy debugApi) {
+        final Set<String> apiTags = debugApi.getTags();
         return instanceQueryService
             .findAllStarted(organizationId, environmentId)
             .stream()
             .filter(Instance::isClusterPrimaryNode)
             .filter(instance -> instance.isRunningForEnvironment(environmentId))
             .filter(Instance::hasDebugPluginInstalled)
-            .filter(instance -> EnvironmentUtils.hasMatchingTags(ofNullable(instance.getTags()), debugApi.getTags()))
-            .max(Comparator.comparing(Instance::getStartedAt))
+            .filter(instance -> EnvironmentUtils.hasMatchingTags(ofNullable(instance.getTags()), apiTags))
+            // A tagless gateway (e.g. the SaaS gateway) matches every API, so it passes the tag filter alongside a
+            // gateway that explicitly carries the API's sharding tag. Prefer the explicit tag match so that a debug
+            // request for a sharded API is routed to its dedicated (e.g. hybrid) gateway rather than the tagless one;
+            // only fall back to the most recently started gateway when no explicit match exists.
+            .max(Comparator.comparing((Instance instance) -> hasExplicitTagMatch(instance, apiTags)).thenComparing(Instance::getStartedAt))
             .orElseThrow(() -> new DebugApiNoCompatibleInstanceException(debugApi.getId()));
+    }
+
+    /**
+     * Returns {@code true} when the gateway has at least one (non-exclusion) tag that positively matches the API's
+     * sharding tags. A tagless gateway, or one matching only because the API is excluded by another gateway's
+     * {@code !tag}, is not considered an explicit match.
+     */
+    private static boolean hasExplicitTagMatch(Instance instance, Set<String> apiTags) {
+        var includedTags = ofNullable(instance.getTags())
+            .orElseGet(List::of)
+            .stream()
+            .filter(tag -> !tag.startsWith("!"))
+            .toList();
+        return !includedTags.isEmpty() && EnvironmentUtils.hasMatchingTags(Optional.of(includedTags), apiTags);
     }
 
     private static void disableLoggingForDebug(DebugApiProxy debugApi) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/debug/use_case/DebugApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/debug/use_case/DebugApiUseCaseTest.java
@@ -513,6 +513,141 @@ class DebugApiUseCaseTest {
         }
     }
 
+    @Nested
+    class GatewaySelectionByTag {
+
+        @Test
+        @SneakyThrows
+        void should_select_gateway_with_matching_tag_over_more_recently_started_tagless_gateway() {
+            // hybrid gateway carries the sharding tag but was started earlier
+            var hybridGateway = Instance.builder()
+                .id("hybrid-gateway")
+                .startedAt(new Date(1_000))
+                .clusterPrimaryNode(true)
+                .environments(Set.of(ENVIRONMENT_ID))
+                .plugins(Set.of(PluginEntity.builder().id(DEBUG_PLUGIN_ID).build()))
+                .tags(List.of("valid-tag"))
+                .build();
+            // SaaS gateway is tagless (matches every API) and was started most recently
+            var saasGateway = Instance.builder()
+                .id("saas-gateway")
+                .startedAt(new Date())
+                .clusterPrimaryNode(true)
+                .environments(Set.of(ENVIRONMENT_ID))
+                .plugins(Set.of(PluginEntity.builder().id(DEBUG_PLUGIN_ID).build()))
+                .build();
+            instanceQueryService.initWith(List.of(saasGateway, hybridGateway));
+
+            var plan = fixtures.core.model.PlanFixtures.aPlanV2();
+            plan.setReferenceType(GenericPlanEntity.ReferenceType.API);
+            plan.setReferenceId(API_ID);
+            givenExistingPlan(plan);
+            givenExistingApi(ApiFixtures.aProxyApiV2().setTags(Set.of("valid-tag")));
+
+            final DebugApiUseCase.Output output = cut.execute(new DebugApiUseCase.Input(API_ID, new HttpRequest("/", "GET"), AUDIT_INFO));
+
+            assertThat(output.debugApiEvent().getProperties()).containsEntry(Event.EventProperties.GATEWAY_ID, "hybrid-gateway");
+        }
+
+        @Test
+        @SneakyThrows
+        void should_select_most_recently_started_gateway_when_api_has_no_tag() {
+            var olderGateway = Instance.builder()
+                .id("older-gateway")
+                .startedAt(new Date(1_000))
+                .clusterPrimaryNode(true)
+                .environments(Set.of(ENVIRONMENT_ID))
+                .plugins(Set.of(PluginEntity.builder().id(DEBUG_PLUGIN_ID).build()))
+                .build();
+            var newerGateway = Instance.builder()
+                .id("newer-gateway")
+                .startedAt(new Date())
+                .clusterPrimaryNode(true)
+                .environments(Set.of(ENVIRONMENT_ID))
+                .plugins(Set.of(PluginEntity.builder().id(DEBUG_PLUGIN_ID).build()))
+                .build();
+            instanceQueryService.initWith(List.of(olderGateway, newerGateway));
+
+            var plan = fixtures.core.model.PlanFixtures.aPlanV2();
+            plan.setReferenceType(GenericPlanEntity.ReferenceType.API);
+            plan.setReferenceId(API_ID);
+            givenExistingPlan(plan);
+            givenExistingApi(ApiFixtures.aProxyApiV2());
+
+            final DebugApiUseCase.Output output = cut.execute(new DebugApiUseCase.Input(API_ID, new HttpRequest("/", "GET"), AUDIT_INFO));
+
+            assertThat(output.debugApiEvent().getProperties()).containsEntry(Event.EventProperties.GATEWAY_ID, "newer-gateway");
+        }
+
+        @Test
+        @SneakyThrows
+        void should_select_most_recently_started_gateway_among_several_matching_tagged_gateways() {
+            var olderTaggedGateway = Instance.builder()
+                .id("older-tagged-gateway")
+                .startedAt(new Date(1_000))
+                .clusterPrimaryNode(true)
+                .environments(Set.of(ENVIRONMENT_ID))
+                .plugins(Set.of(PluginEntity.builder().id(DEBUG_PLUGIN_ID).build()))
+                .tags(List.of("valid-tag"))
+                .build();
+            var newerTaggedGateway = Instance.builder()
+                .id("newer-tagged-gateway")
+                .startedAt(new Date())
+                .clusterPrimaryNode(true)
+                .environments(Set.of(ENVIRONMENT_ID))
+                .plugins(Set.of(PluginEntity.builder().id(DEBUG_PLUGIN_ID).build()))
+                .tags(List.of("valid-tag"))
+                .build();
+            instanceQueryService.initWith(List.of(olderTaggedGateway, newerTaggedGateway));
+
+            var plan = fixtures.core.model.PlanFixtures.aPlanV2();
+            plan.setReferenceType(GenericPlanEntity.ReferenceType.API);
+            plan.setReferenceId(API_ID);
+            givenExistingPlan(plan);
+            givenExistingApi(ApiFixtures.aProxyApiV2().setTags(Set.of("valid-tag")));
+
+            final DebugApiUseCase.Output output = cut.execute(new DebugApiUseCase.Input(API_ID, new HttpRequest("/", "GET"), AUDIT_INFO));
+
+            // both gateways explicitly match the tag, so the tie-breaker (most recently started) applies
+            assertThat(output.debugApiEvent().getProperties()).containsEntry(Event.EventProperties.GATEWAY_ID, "newer-tagged-gateway");
+        }
+
+        @Test
+        @SneakyThrows
+        void should_prefer_explicit_tag_match_over_gateway_matching_only_by_exclusion_tag() {
+            // this gateway has no positive tag — it only matches the API because the API is not in its excluded tags
+            var excludingGateway = Instance.builder()
+                .id("excluding-gateway")
+                .startedAt(new Date())
+                .clusterPrimaryNode(true)
+                .environments(Set.of(ENVIRONMENT_ID))
+                .plugins(Set.of(PluginEntity.builder().id(DEBUG_PLUGIN_ID).build()))
+                .tags(List.of("!other-tag"))
+                .build();
+            // this gateway explicitly carries the API's tag but was started earlier
+            var taggedGateway = Instance.builder()
+                .id("tagged-gateway")
+                .startedAt(new Date(1_000))
+                .clusterPrimaryNode(true)
+                .environments(Set.of(ENVIRONMENT_ID))
+                .plugins(Set.of(PluginEntity.builder().id(DEBUG_PLUGIN_ID).build()))
+                .tags(List.of("valid-tag"))
+                .build();
+            instanceQueryService.initWith(List.of(excludingGateway, taggedGateway));
+
+            var plan = fixtures.core.model.PlanFixtures.aPlanV2();
+            plan.setReferenceType(GenericPlanEntity.ReferenceType.API);
+            plan.setReferenceId(API_ID);
+            givenExistingPlan(plan);
+            givenExistingApi(ApiFixtures.aProxyApiV2().setTags(Set.of("valid-tag")));
+
+            final DebugApiUseCase.Output output = cut.execute(new DebugApiUseCase.Input(API_ID, new HttpRequest("/", "GET"), AUDIT_INFO));
+
+            // the exclusion-only gateway is a wildcard match (like a tagless one), so the explicit match wins despite being older
+            assertThat(output.debugApiEvent().getProperties()).containsEntry(Event.EventProperties.GATEWAY_ID, "tagged-gateway");
+        }
+    }
+
     private static Instance validInstance() {
         return Instance.builder()
             .id(GATEWAY_ID)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14389
## Description

Root cause

DebugApiUseCase.selectTargetGateway filtered candidate gateways with EnvironmentUtils.hasMatchingTags, which treats a tagless gateway as matching every API. So both the tagless SaaS gateway and the tag-matching hybrid gateway passed the filter, and the tie-breaker (max by startedAt) picked whichever started most recently — the SaaS gateway.

Fix

Make gateway selection prefer an explicit (positive, non-exclusion) sharding-tag match, falling back to most-recently-started only when no explicit match exists:
- Added hasExplicitTagMatch(instance, apiTags) — true only when the gateway carries a non-! tag that positively matches the API's tags (tagless gateways, and gateways matching only via an exclusion !tag, are not explicit matches).
- Ordered the selection by explicit-match first, then startedAt.

Behavior is unchanged when the API has no tag, or when only one gateway matches (still most-recently-started).

Tests

DebugApiUseCaseTest.GatewaySelectionByTag:
- tagged gateway wins over a more-recently-started tagless gateway (the bug)
- no API tag → most-recently-started gateway still wins (no regression)
- multiple matching tagged gateways → most-recently-started tagged wins (tie-breaker)
- explicit tag match preferred over a gateway matching only via an exclusion !tag

All 54 tests in the class pass. Also verified end-to-end locally: with the API tagged hybrid, debug routes to the tagged gateway; with the tag removed, it routes to the tagless gateway.

## Additional context


https://github.com/user-attachments/assets/19b4b0cc-7285-428b-9266-77c9dfa22f16



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

