### PR TITLE
feat(observability): add apiType constraint to Gamma filter values endpoint

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCase.java
@@ -31,11 +31,13 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -57,6 +59,21 @@ public class GetFilterValuesUseCase {
         FilterSpec.Name.API_PRODUCT
     );
 
+    private static final Map<ApiType, String> PLATFORM_TO_WIRE_API_TYPE = Map.of(
+        ApiType.PROXY,
+        "HTTP_PROXY",
+        ApiType.LLM_PROXY,
+        "LLM",
+        ApiType.MCP_PROXY,
+        "MCP",
+        ApiType.MESSAGE,
+        "MESSAGE",
+        ApiType.NATIVE,
+        "NATIVE",
+        ApiType.EDGE,
+        "EDGE"
+    );
+
     private final AnalyticsDefinitionQueryService definitionQueryService;
     private final FilterValuesQueryService filterValuesQueryService;
     private final FilterValueNameResolver filterValueNameResolver;
@@ -65,7 +82,20 @@ public class GetFilterValuesUseCase {
     private final PlanQueryService planQueryService;
     private final ApiProductQueryService apiProductQueryService;
 
-    public record Input(AuditInfo auditInfo, String filterName, Instant from, Instant to, int page, int perPage, String query) {}
+    public record Input(
+        AuditInfo auditInfo,
+        String filterName,
+        Instant from,
+        Instant to,
+        int page,
+        int perPage,
+        String query,
+        Set<ApiType> apiTypes
+    ) {
+        public Input(AuditInfo auditInfo, String filterName, Instant from, Instant to, int page, int perPage, String query) {
+            this(auditInfo, filterName, from, to, page, perPage, query, Set.of());
+        }
+    }
 
     public record Output(FilterValuesPage valuesPage) {}
 
@@ -81,6 +111,9 @@ public class GetFilterValuesUseCase {
         var filterSpec = findFilterSpec(filterSpecName);
 
         var analyticsContext = contextLoader.load(input.auditInfo());
+        if (input.apiTypes() != null && !input.apiTypes().isEmpty()) {
+            analyticsContext = narrowByApiTypes(analyticsContext, input.apiTypes());
+        }
 
         return switch (filterSpec.type()) {
             case ENUM -> handleEnum(filterSpec, input);
@@ -99,6 +132,16 @@ public class GetFilterValuesUseCase {
         }
 
         var stream = enumValues.stream();
+
+        if (filterSpec.name() == FilterSpec.Name.API_TYPE && input.apiTypes() != null && !input.apiTypes().isEmpty()) {
+            Set<String> allowedWireValues = input
+                .apiTypes()
+                .stream()
+                .map(PLATFORM_TO_WIRE_API_TYPE::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+            stream = stream.filter(allowedWireValues::contains);
+        }
 
         if (input.query() != null && !input.query().isBlank()) {
             var lowerQuery = input.query().toLowerCase();
@@ -325,6 +368,31 @@ public class GetFilterValuesUseCase {
                 Map.of("invalidName", filterName, "validNames", Arrays.toString(FilterSpec.Name.values()))
             );
         }
+    }
+
+    private static AnalyticsQueryContext narrowByApiTypes(AnalyticsQueryContext context, Set<ApiType> apiTypes) {
+        Set<String> allowedIds = new HashSet<>();
+        for (var type : apiTypes) {
+            var idsForType = context.apiIdsByType().get(type);
+            if (idsForType != null) {
+                allowedIds.addAll(idsForType);
+            }
+        }
+        var narrowedAuthorizedIds = context.authorizedApiIds().stream().filter(allowedIds::contains).collect(Collectors.toSet());
+        var narrowedNames = context
+            .apiNamesById()
+            .entrySet()
+            .stream()
+            .filter(e -> narrowedAuthorizedIds.contains(e.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return new AnalyticsQueryContext(
+            context.auditInfo(),
+            context.executionContext(),
+            narrowedAuthorizedIds,
+            narrowedNames,
+            context.applicationNamesById(),
+            context.apiIdsByType()
+        );
     }
 
     private FilterSpec findFilterSpec(FilterSpec.Name name) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCaseTest.java
@@ -42,6 +42,7 @@ import io.gravitee.apim.core.observability.model.FilterType;
 import io.gravitee.apim.core.observability.model.NumberRange;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.time.Instant;
@@ -1341,6 +1342,136 @@ class GetFilterValuesUseCaseTest {
                 .first()
                 .satisfies(v -> assertThat(v.value()).isEqualTo("My API Product"));
             assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(1L);
+        }
+    }
+
+    @Nested
+    class ApiTypeConstraints {
+
+        @BeforeEach
+        void setUp() {
+            when(definitionQueryService.getAllFilters()).thenReturn(
+                List.of(
+                    new FilterSpec(
+                        FilterSpec.Name.API_TYPE,
+                        "API Type",
+                        FilterType.ENUM,
+                        List.of("HTTP_PROXY", "LLM", "MESSAGE", "MCP", "NATIVE", "EDGE"),
+                        null,
+                        List.of(FilterOperator.EQ, FilterOperator.IN),
+                        null
+                    ),
+                    new FilterSpec(
+                        FilterSpec.Name.API,
+                        "API",
+                        FilterType.KEYWORD,
+                        null,
+                        null,
+                        List.of(FilterOperator.EQ, FilterOperator.IN),
+                        null
+                    )
+                )
+            );
+        }
+
+        @Test
+        void should_restrict_api_type_enum_values_when_apiTypes_provided() {
+            var output = useCase.execute(
+                new GetFilterValuesUseCase.Input(
+                    AUDIT_INFO,
+                    "API_TYPE",
+                    null,
+                    null,
+                    1,
+                    10,
+                    null,
+                    Set.of(ApiType.MCP_PROXY, ApiType.LLM_PROXY)
+                )
+            );
+
+            assertThat(output.valuesPage().data()).extracting(FilterValue::value).containsExactlyInAnyOrder("MCP", "LLM");
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(2L);
+        }
+
+        @Test
+        void should_return_all_api_type_enum_values_when_apiTypes_empty() {
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API_TYPE", null, null, 1, 10, null, Set.of()));
+
+            assertThat(output.valuesPage().data())
+                .extracting(FilterValue::value)
+                .containsExactly("HTTP_PROXY", "LLM", "MESSAGE", "MCP", "NATIVE", "EDGE");
+        }
+
+        @Test
+        void should_combine_apiTypes_and_query_on_api_type_enum() {
+            var output = useCase.execute(
+                new GetFilterValuesUseCase.Input(
+                    AUDIT_INFO,
+                    "API_TYPE",
+                    null,
+                    null,
+                    1,
+                    10,
+                    "m",
+                    Set.of(ApiType.MCP_PROXY, ApiType.LLM_PROXY, ApiType.MESSAGE)
+                )
+            );
+
+            assertThat(output.valuesPage().data()).extracting(FilterValue::value).containsExactlyInAnyOrder("LLM", "MESSAGE", "MCP");
+        }
+
+        @Test
+        void should_narrow_keyword_filter_authorized_ids_by_apiTypes() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of("api-proxy-1", "api-mcp-1", "api-native-1"),
+                    Map.of("api-proxy-1", "Proxy API", "api-mcp-1", "MCP API", "api-native-1", "Native API"),
+                    Map.of(),
+                    Map.of(
+                        ApiType.PROXY,
+                        Set.of("api-proxy-1"),
+                        ApiType.MCP_PROXY,
+                        Set.of("api-mcp-1"),
+                        ApiType.NATIVE,
+                        Set.of("api-native-1")
+                    )
+                )
+            );
+
+            var output = useCase.execute(
+                new GetFilterValuesUseCase.Input(AUDIT_INFO, "API", null, null, 1, 10, "API", Set.of(ApiType.MCP_PROXY))
+            );
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("MCP API");
+                    assertThat(v.id()).isEqualTo("api-mcp-1");
+                });
+        }
+
+        @Test
+        void should_return_empty_when_apiTypes_matches_no_authorized_ids() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of("api-proxy-1"),
+                    Map.of("api-proxy-1", "Proxy API"),
+                    Map.of(),
+                    Map.of(ApiType.PROXY, Set.of("api-proxy-1"))
+                )
+            );
+
+            var output = useCase.execute(
+                new GetFilterValuesUseCase.Input(AUDIT_INFO, "API", null, null, 1, 10, "API", Set.of(ApiType.MCP_PROXY))
+            );
+
+            assertThat(output.valuesPage().data()).isEmpty();
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(0L);
         }
     }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/port/service_provider/ObservabilityFilterDataPort.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/port/service_provider/ObservabilityFilterDataPort.java
@@ -15,9 +15,11 @@
  */
 package io.gravitee.gamma.rest.core.observability.filter.port.service_provider;
 
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterValuesPage;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Core-side port onto the store-backed observability filter data: distinct values for KEYWORD
@@ -38,8 +40,10 @@ public interface ObservabilityFilterDataPort {
      * {@link io.gravitee.gamma.rest.core.observability.filter.model.FilterValue#value()} is the
      * entity id and {@code label} its display name; for direct-value filters the value is the raw
      * indexed value and {@code label} is {@code null}.
+     *
+     * @param apiTypes optional API-type constraint to narrow results (empty = unconstrained)
      */
-    FilterValuesPage listKeywordValues(String filterName, String query, Long from, Long to, int page, int perPage);
+    FilterValuesPage listKeywordValues(String filterName, String query, Long from, Long to, int page, int perPage, Set<ApiType> apiTypes);
 
     /** Bulk id → label resolution, grouped per requested filter. */
     List<ResolvedLabels> resolveLabels(List<ResolveRequest> requests);

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCase.java
@@ -18,12 +18,14 @@ package io.gravitee.gamma.rest.core.observability.filter.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.gamma.rest.core.observability.filter.exception.ObservabilityFilterNotFoundException;
 import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterValue;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterValuesPage;
 import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
 import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.ObservabilityFilterDataPort;
 import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 
 /**
@@ -61,17 +63,22 @@ public class GetObservabilityFilterValuesUseCase {
     private final FilterRegistry filterRegistry;
     private final ObservabilityFilterDataPort filterDataPort;
 
-    public record Input(String filterName, String query, Long from, Long to, Integer page, Integer perPage) {}
+    public record Input(String filterName, String query, Long from, Long to, Integer page, Integer perPage, Set<ApiType> apiTypes) {
+        public Input(String filterName, String query, Long from, Long to, Integer page, Integer perPage) {
+            this(filterName, query, from, to, page, perPage, Set.of());
+        }
+    }
 
     public record Output(FilterValuesPage values, int page, int perPage) {}
 
     public Output execute(Input input) {
-        FilterSpec spec = lookupFilter(input.filterName());
+        Set<ApiType> apiTypes = input.apiTypes() != null ? input.apiTypes() : Set.of();
+        FilterSpec spec = lookupFilter(input.filterName(), apiTypes);
         int page = resolvePage(input);
         int perPage = resolvePerPage(input);
         FilterValuesPage values = switch (spec.type()) {
-            case ENUM -> handleEnum(spec, input, page, perPage);
-            case KEYWORD -> filterDataPort.listKeywordValues(spec.name(), input.query(), input.from(), input.to(), page, perPage);
+            case ENUM -> handleEnum(spec, input, apiTypes, page, perPage);
+            case KEYWORD -> filterDataPort.listKeywordValues(spec.name(), input.query(), input.from(), input.to(), page, perPage, apiTypes);
             case NUMBER, STRING, BOOLEAN -> throw UnsupportedObservabilityFilterException.valueListingNotSupported(
                 spec.name(),
                 spec.type().name()
@@ -88,17 +95,24 @@ public class GetObservabilityFilterValuesUseCase {
         return (input.perPage() != null && input.perPage() > 0) ? Math.min(input.perPage(), MAX_PER_PAGE) : DEFAULT_PER_PAGE;
     }
 
-    private FilterSpec lookupFilter(String filterName) {
+    private FilterSpec lookupFilter(String filterName, Set<ApiType> apiTypes) {
         return filterRegistry
-            .getFilters(null, null)
+            .getFilters(null, apiTypes.isEmpty() ? null : apiTypes)
             .stream()
             .filter(s -> s.name().equals(filterName))
             .findFirst()
             .orElseThrow(() -> new ObservabilityFilterNotFoundException(filterName));
     }
 
-    private static FilterValuesPage handleEnum(FilterSpec spec, Input input, int page, int perPage) {
+    private static FilterValuesPage handleEnum(FilterSpec spec, Input input, Set<ApiType> apiTypes, int page, int perPage) {
         List<FilterSpec.EnumValue> enumValues = spec.enumValues() == null ? List.of() : spec.enumValues();
+        if (!apiTypes.isEmpty() && "API_TYPE".equals(spec.name())) {
+            Set<String> allowedValues = apiTypes.stream().map(Enum::name).collect(java.util.stream.Collectors.toSet());
+            enumValues = enumValues
+                .stream()
+                .filter(v -> allowedValues.contains(v.value()))
+                .toList();
+        }
         if (enumValues.isEmpty()) {
             return new FilterValuesPage(List.of(), 0L);
         }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityFilterDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityFilterDataPortAdapter.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterValue;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterValuesPage;
 import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.ObservabilityFilterDataPort;
@@ -28,7 +29,11 @@ import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.time.Instant;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -51,13 +56,46 @@ public class ObservabilityFilterDataPortAdapter implements ObservabilityFilterDa
     private final GetFilterValuesUseCase getFilterValuesUseCase;
     private final ResolveFilterLabelsUseCase resolveFilterLabelsUseCase;
 
+    private static final Map<ApiType, io.gravitee.definition.model.v4.ApiType> GAMMA_TO_PLATFORM_API_TYPE;
+
+    static {
+        var map = new EnumMap<ApiType, io.gravitee.definition.model.v4.ApiType>(ApiType.class);
+        map.put(ApiType.HTTP_PROXY, io.gravitee.definition.model.v4.ApiType.PROXY);
+        map.put(ApiType.LLM, io.gravitee.definition.model.v4.ApiType.LLM_PROXY);
+        map.put(ApiType.MCP, io.gravitee.definition.model.v4.ApiType.MCP_PROXY);
+        map.put(ApiType.MESSAGE, io.gravitee.definition.model.v4.ApiType.MESSAGE);
+        map.put(ApiType.NATIVE, io.gravitee.definition.model.v4.ApiType.NATIVE);
+        map.put(ApiType.EDGE, io.gravitee.definition.model.v4.ApiType.EDGE);
+        GAMMA_TO_PLATFORM_API_TYPE = Map.copyOf(map);
+    }
+
     @Override
-    public FilterValuesPage listKeywordValues(String filterName, String query, Long from, Long to, int page, int perPage) {
+    public FilterValuesPage listKeywordValues(
+        String filterName,
+        String query,
+        Long from,
+        Long to,
+        int page,
+        int perPage,
+        Set<ApiType> apiTypes
+    ) {
         try {
             Instant fromInstant = from != null ? Instant.ofEpochMilli(from) : null;
             Instant toInstant = to != null ? Instant.ofEpochMilli(to) : null;
+            Set<io.gravitee.definition.model.v4.ApiType> platformApiTypes = apiTypes == null || apiTypes.isEmpty()
+                ? Set.of()
+                : apiTypes.stream().map(GAMMA_TO_PLATFORM_API_TYPE::get).filter(java.util.Objects::nonNull).collect(Collectors.toSet());
             var output = getFilterValuesUseCase.execute(
-                new GetFilterValuesUseCase.Input(currentAuditInfo(), filterName, fromInstant, toInstant, page, perPage, query)
+                new GetFilterValuesUseCase.Input(
+                    currentAuditInfo(),
+                    filterName,
+                    fromInstant,
+                    toInstant,
+                    page,
+                    perPage,
+                    query,
+                    platformApiTypes
+                )
             );
             var valuesPage = output.valuesPage();
             List<FilterValue> data = valuesPage.data().stream().map(ObservabilityFilterDataPortAdapter::toCoreValue).toList();

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/filters/ObservabilityFiltersResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/filters/ObservabilityFiltersResource.java
@@ -112,11 +112,20 @@ public class ObservabilityFiltersResource {
         @QueryParam("from") Long from,
         @QueryParam("to") Long to,
         @QueryParam("page") Integer page,
-        @QueryParam("perPage") Integer perPage
+        @QueryParam("perPage") Integer perPage,
+        @QueryParam("apiType") List<String> apiTypes
     ) {
         checkReadObservabilityPermission();
         var output = getFilterValuesUseCase.execute(
-            new GetObservabilityFilterValuesUseCase.Input(filterName, query, from, to, page, perPage)
+            new GetObservabilityFilterValuesUseCase.Input(
+                filterName,
+                query,
+                from,
+                to,
+                page,
+                perPage,
+                parse(apiTypes, ApiType.class, ApiType::valueOf, "apiType")
+            )
         );
         List<FilterValueDto> data = output.values().data().stream().map(FilterValueDto::from).toList();
         return PaginatedResponseDto.of(data, output.values().totalElements(), output.page(), output.perPage());

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -224,6 +224,19 @@ paths:
                       default: 10
                       minimum: 1
                       maximum: 100
+                - name: apiType
+                  in: query
+                  required: false
+                  description: |
+                      API kind(s) to restrict returned values to. Repeat for multiple values.
+                      When present, ENUM filters only return values matching the requested kinds,
+                      and KEYWORD filters only return entities associated with APIs of the requested kinds.
+                      When absent, no API-type constraint is applied (backward compatible).
+                  example: MCP
+                  schema:
+                      type: array
+                      items:
+                          $ref: "#/components/schemas/ApiType"
             responses:
                 "200":
                     description: A page of selectable values.

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCaseTest.java
@@ -20,12 +20,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.gravitee.gamma.rest.core.observability.filter.exception.ObservabilityFilterNotFoundException;
 import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterValue;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterValuesPage;
 import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.ObservabilityFilterDataPort;
 import io.gravitee.gamma.rest.infra.adapter.SpiFilterRegistry;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -117,6 +119,25 @@ class GetObservabilityFilterValuesUseCaseTest {
         assertThat(dataPort.lastFilterName).isNull();
     }
 
+    @Test
+    void should_restrict_api_type_enum_values_when_apiTypes_constraint_is_provided() {
+        var output = useCase.execute(
+            new GetObservabilityFilterValuesUseCase.Input("API_TYPE", null, null, null, null, null, Set.of(ApiType.MCP, ApiType.LLM))
+        );
+
+        assertThat(output.values().totalElements()).isEqualTo(2L);
+        assertThat(output.values().data()).extracting(FilterValue::value).containsExactlyInAnyOrder("MCP", "LLM");
+    }
+
+    @Test
+    void should_propagate_apiTypes_to_the_data_port_for_keyword_filters() {
+        dataPort.nextPage = new FilterValuesPage(List.of(new FilterValue("api-1", "Petstore")), 1L);
+
+        useCase.execute(new GetObservabilityFilterValuesUseCase.Input("API", null, null, null, null, null, Set.of(ApiType.HTTP_PROXY)));
+
+        assertThat(dataPort.lastApiTypes).containsExactly(ApiType.HTTP_PROXY);
+    }
+
     private static final class RecordingDataPort implements ObservabilityFilterDataPort {
 
         private FilterValuesPage nextPage = new FilterValuesPage(List.of(), 0L);
@@ -126,15 +147,25 @@ class GetObservabilityFilterValuesUseCaseTest {
         private Long lastTo;
         private Integer lastPage;
         private Integer lastPerPage;
+        private Set<ApiType> lastApiTypes;
 
         @Override
-        public FilterValuesPage listKeywordValues(String filterName, String query, Long from, Long to, int page, int perPage) {
+        public FilterValuesPage listKeywordValues(
+            String filterName,
+            String query,
+            Long from,
+            Long to,
+            int page,
+            int perPage,
+            Set<ApiType> apiTypes
+        ) {
             this.lastFilterName = filterName;
             this.lastQuery = query;
             this.lastFrom = from;
             this.lastTo = to;
             this.lastPage = page;
             this.lastPerPage = perPage;
+            this.lastApiTypes = apiTypes;
             return nextPage;
         }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/use_case/ResolveObservabilityFilterLabelsUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/use_case/ResolveObservabilityFilterLabelsUseCaseTest.java
@@ -63,7 +63,15 @@ class ResolveObservabilityFilterLabelsUseCaseTest {
         private Map<String, Map<String, String>> labelsByFilter = Map.of();
 
         @Override
-        public FilterValuesPage listKeywordValues(String filterName, String query, Long from, Long to, int page, int perPage) {
+        public FilterValuesPage listKeywordValues(
+            String filterName,
+            String query,
+            Long from,
+            Long to,
+            int page,
+            int perPage,
+            java.util.Set<io.gravitee.gamma.rest.core.observability.filter.model.ApiType> apiTypes
+        ) {
             return new FilterValuesPage(List.of(), 0L);
         }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/observability/filters/ObservabilityFiltersResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/observability/filters/ObservabilityFiltersResourceTest.java
@@ -256,6 +256,29 @@ class ObservabilityFiltersResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_forward_apiType_query_params_to_the_use_case() {
+            when(getFilterValuesUseCase.execute(any())).thenReturn(
+                new GetObservabilityFilterValuesUseCase.Output(new FilterValuesPage(List.of(), 0L), 1, 10)
+            );
+
+            rootTarget("API_TYPE/values").queryParam("apiType", "MCP").queryParam("apiType", "LLM").request().get();
+
+            ArgumentCaptor<GetObservabilityFilterValuesUseCase.Input> captor = ArgumentCaptor.forClass(
+                GetObservabilityFilterValuesUseCase.Input.class
+            );
+            Mockito.verify(getFilterValuesUseCase).execute(captor.capture());
+            assertThat(captor.getValue().apiTypes()).containsExactlyInAnyOrder(ApiType.MCP, ApiType.LLM);
+        }
+
+        @Test
+        void should_return_400_for_unknown_apiType_value() {
+            Response response = rootTarget("API_TYPE/values").queryParam("apiType", "NOPE").request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+            Mockito.verifyNoInteractions(getFilterValuesUseCase);
+        }
+
+        @Test
         void should_return_403_when_caller_cannot_read_observability() {
             when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
 


### PR DESCRIPTION
## Summary

Add an optional `apiType` query parameter to the Gamma `GET /observability/filters/{filterName}/values` endpoint, allowing callers to restrict returned values to specific API kinds (e.g. MCP, LLM). This prevents filters from surfacing irrelevant values when the UI scope is limited to a particular API type.

Closes [GMA-770](https://gravitee.atlassian.net/browse/GMA-770)

<img width="932" height="962" alt="Screenshot 2026-06-19 at 08 20 36" src="https://github.com/user-attachments/assets/a028895f-ae8c-4cf7-a75c-5755ecea7241" />
<img width="935" height="667" alt="Screenshot 2026-06-19 at 08 20 58" src="https://github.com/user-attachments/assets/a90ee0db-630e-46fc-ba78-94a510ba3f17" />
<img width="918" height="974" alt="Screenshot 2026-06-19 at 08 20 49" src="https://github.com/user-attachments/assets/cc5aa61c-9aab-49f9-8957-8f1d16dd53b5" />


## Changes

- **Gamma REST resource** (`ObservabilityFiltersResource`): accept a repeated `apiType` query param, parse and validate it (400 on unknown values)
- **Gamma use case** (`GetObservabilityFilterValuesUseCase`): filter ENUM values (e.g. `API_TYPE`) to only matching kinds; propagate the constraint to the data port for KEYWORD filters
- **Gamma data port** (`ObservabilityFilterDataPort`): add `Set<ApiType> apiTypes` to `listKeywordValues` signature
- **Gamma infra adapter** (`ObservabilityFilterDataPortAdapter`): map Gamma `ApiType` → platform `ApiType` and pass to the platform use case
- **Platform use case** (`GetFilterValuesUseCase`): new `apiTypes` field on `Input`; narrow `AnalyticsQueryContext.authorizedApiIds` via `apiIdsByType()` when set
- **OpenAPI spec**: document the new `apiType` query parameter with reference to the existing `ApiType` schema
- **Unit tests**: cover ENUM restriction, KEYWORD propagation, and REST layer validation

## Test plan

- [ ] Call `GET /gamma/.../observability/filters/API_TYPE/values?apiType=MCP&apiType=LLM` and verify only MCP and LLM are returned
- [ ] Call `GET /gamma/.../observability/filters/API/values?apiType=HTTP_PROXY` and verify only HTTP Proxy APIs are returned
- [ ] Call without `apiType` and confirm full unfiltered results (backward compatible)
- [ ] Call with an unknown `apiType` value (e.g. `NOPE`) and verify HTTP 400
- [ ] Confirm Management V2 `/environments/{envId}/analytics/filters/{filterName}/values` is unchanged

[GMA-770]: https://gravitee.atlassian.net/browse/GMA-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ