### PR TITLE
fix(repository): rename edge config mongo collection via upgrader

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/edge/EdgeConfigCollectionRenameUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/edge/EdgeConfigCollectionRenameUpgrader.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.edge;
+
+import com.mongodb.MongoNamespace;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.plan.PlanReferenceTypeUpgrader;
+import lombok.CustomLog;
+import org.springframework.stereotype.Component;
+
+/**
+ * Renames the edge configuration collection from its former hard-coded name {@code aim_module_edge_config}
+ * to the prefix-aware name {@code <management.mongodb.prefix>edge_config} used by
+ * {@code com.graviteesource.gamma.module.edge.infra.repository.EdgeConfigurationDocument}.
+ *
+ * <p>The migration is idempotent: it renames only when the legacy collection exists and the target one does not.
+ *
+ * @author GraviteeSource Team
+ */
+@Component
+@CustomLog
+public class EdgeConfigCollectionRenameUpgrader extends MongoUpgrader {
+
+    public static final int EDGE_CONFIG_COLLECTION_RENAME_UPGRADER_ORDER = PlanReferenceTypeUpgrader.PLAN_REFERENCE_TYPE_UPGRADER_ORDER + 1;
+
+    /** Former collection name, persisted without the management prefix. */
+    static final String LEGACY_COLLECTION_NAME = "aim_module_edge_config";
+
+    /** New collection name, to be combined with the management prefix. */
+    static final String EDGE_CONFIG_COLLECTION_NAME = "edge_config";
+
+    @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
+            final String targetCollectionName = buildCollectionName(EDGE_CONFIG_COLLECTION_NAME);
+
+            if (!template.collectionExists(LEGACY_COLLECTION_NAME)) {
+                log.debug("Legacy collection '{}' not found, nothing to migrate", LEGACY_COLLECTION_NAME);
+                return true;
+            }
+
+            if (template.collectionExists(targetCollectionName)) {
+                log.warn(
+                    "Both legacy collection '{}' and target collection '{}' exist, skipping rename to avoid data loss",
+                    LEGACY_COLLECTION_NAME,
+                    targetCollectionName
+                );
+                return true;
+            }
+
+            log.info("Renaming edge configuration collection '{}' to '{}'", LEGACY_COLLECTION_NAME, targetCollectionName);
+            var legacyCollection = template.getCollection(LEGACY_COLLECTION_NAME);
+            var targetNamespace = new MongoNamespace(template.getDb().getName(), targetCollectionName);
+            legacyCollection.renameCollection(targetNamespace);
+            return true;
+        });
+    }
+
+    @Override
+    public int getOrder() {
+        return EDGE_CONFIG_COLLECTION_RENAME_UPGRADER_ORDER;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/edge/EdgeConfigCollectionRenameUpgraderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/edge/EdgeConfigCollectionRenameUpgraderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.edge;
+
+import static io.gravitee.repository.mongodb.management.upgrade.upgrader.edge.EdgeConfigCollectionRenameUpgrader.EDGE_CONFIG_COLLECTION_NAME;
+import static io.gravitee.repository.mongodb.management.upgrade.upgrader.edge.EdgeConfigCollectionRenameUpgrader.LEGACY_COLLECTION_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.management.AbstractManagementRepositoryTest;
+import jakarta.inject.Inject;
+import org.bson.Document;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+public class EdgeConfigCollectionRenameUpgraderTest extends AbstractManagementRepositoryTest {
+
+    @Inject
+    private MongoTemplate mongoTemplate;
+
+    @Inject
+    private Environment environment;
+
+    private EdgeConfigCollectionRenameUpgrader upgrader;
+    private String targetCollectionName;
+
+    @Override
+    protected String getTestCasesPath() {
+        // No fixtures: the upgrader manipulates collections directly.
+        return null;
+    }
+
+    @Before
+    public void initUpgrader() {
+        upgrader = new EdgeConfigCollectionRenameUpgrader();
+        upgrader.setMongoTemplate(mongoTemplate);
+        upgrader.setEnvironment(environment);
+        targetCollectionName = environment.getProperty("management.mongodb.prefix", "") + EDGE_CONFIG_COLLECTION_NAME;
+        dropCollections();
+    }
+
+    @After
+    public void cleanUp() {
+        dropCollections();
+    }
+
+    private void dropCollections() {
+        mongoTemplate.getCollection(LEGACY_COLLECTION_NAME).drop();
+        mongoTemplate.getCollection(targetCollectionName).drop();
+    }
+
+    @Test
+    public void upgrade_should_rename_legacy_collection_to_prefixed_name() throws Exception {
+        // Given
+        mongoTemplate.getCollection(LEGACY_COLLECTION_NAME).insertOne(new Document("_id", "env-1").append("gatewayUrl", "http://gw"));
+
+        // When
+        boolean result = upgrader.upgrade();
+
+        // Then
+        assertThat(result).isTrue();
+        assertThat(mongoTemplate.collectionExists(LEGACY_COLLECTION_NAME)).isFalse();
+        assertThat(mongoTemplate.collectionExists(targetCollectionName)).isTrue();
+        Document migrated = mongoTemplate.getCollection(targetCollectionName).find(new Document("_id", "env-1")).first();
+        assertThat(migrated).isNotNull();
+        assertThat(migrated.getString("gatewayUrl")).isEqualTo("http://gw");
+    }
+
+    @Test
+    public void upgrade_should_be_noop_when_legacy_collection_is_absent() throws Exception {
+        // When
+        boolean result = upgrader.upgrade();
+
+        // Then
+        assertThat(result).isTrue();
+        assertThat(mongoTemplate.collectionExists(targetCollectionName)).isFalse();
+    }
+
+    @Test
+    public void upgrade_should_skip_when_target_collection_already_exists() throws Exception {
+        // Given
+        mongoTemplate.getCollection(LEGACY_COLLECTION_NAME).insertOne(new Document("_id", "legacy"));
+        mongoTemplate.getCollection(targetCollectionName).insertOne(new Document("_id", "current"));
+
+        // When
+        boolean result = upgrader.upgrade();
+
+        // Then both collections are left untouched to avoid data loss
+        assertThat(result).isTrue();
+        assertThat(mongoTemplate.getCollection(LEGACY_COLLECTION_NAME).countDocuments()).isEqualTo(1);
+        assertThat(mongoTemplate.getCollection(targetCollectionName).find(new Document("_id", "current")).first()).isNotNull();
+    }
+
+    @Test
+    public void upgrade_should_be_idempotent() throws Exception {
+        // Given
+        mongoTemplate.getCollection(LEGACY_COLLECTION_NAME).insertOne(new Document("_id", "env-1"));
+
+        // When
+        boolean first = upgrader.upgrade();
+        boolean second = upgrader.upgrade();
+
+        // Then
+        assertThat(first).isTrue();
+        assertThat(second).isTrue();
+        assertThat(mongoTemplate.collectionExists(LEGACY_COLLECTION_NAME)).isFalse();
+        assertThat(mongoTemplate.getCollection(targetCollectionName).countDocuments()).isEqualTo(1);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
         <!-- Gamma plugins -->
         <gravitee-gamma-module-aim.version>1.0.0-alpha.174</gravitee-gamma-module-aim.version>
         <gravitee-gamma-module-authz.version>1.0.0-alpha.20</gravitee-gamma-module-authz.version>
-        <gravitee-gamma-module-edge.version>1.0.0-alpha.1</gravitee-gamma-module-edge.version>
+        <gravitee-gamma-module-edge.version>1.0.0-alpha.2</gravitee-gamma-module-edge.version>
         <gravitee-gamma-module-esm.version>1.0.0-alpha.5</gravitee-gamma-module-esm.version>
 
         <!-- Authz plugins -->


### PR DESCRIPTION
## Description

The edge configuration MongoDB collection used by `gravitee-gamma-module-edge` was initially created with a hard-coded name `aim_module_edge_config`, without honoring the `management.mongodb.prefix` setting. `EdgeConfigurationDocument` now declares the prefix-aware name `#{@environment.getProperty('management.mongodb.prefix')}edge_config`, in line with the rest of the APIM/AIM Mongo documents.

This PR adds an idempotent upgrader that renames the legacy collection to the new prefix-aware name so existing customers don't lose their data:

- `aim_module_edge_config` → `<management.mongodb.prefix>edge_config`
- Rename happens only when the legacy collection exists and the target one does not.
- If both collections coexist, the rename is skipped (warning logged) to avoid any data loss.

It also bumps the `gravitee-gamma-module-edge` dependency to `1.0.0-gma-728-edge-configuration-permission-SNAPSHOT`.

The upgrader extends the existing `MongoUpgrader` framework (same pattern as `PlanReferenceTypeUpgrader`), so it lives in `gravitee-apim-repository-mongodb`: Mongo on the compile classpath, registered in the main application context (picked up by `UpgraderServiceImpl`), and only present on MongoDB deployments.

## Test plan

- 4 tests on a real MongoDB instance (`EdgeConfigCollectionRenameUpgraderTest`):
  - renames the legacy collection to the prefixed name (preserving documents)
  - no-op when the legacy collection is absent
  - skips when the target collection already exists
  - idempotent across repeated runs
