### PR TITLE
fix(api-product): e2e api incremental growth

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductTagDomainService;
+import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
@@ -32,6 +33,7 @@ import io.gravitee.apim.core.audit.model.ApiProductAuditLogEntity;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.event.ApiProductAuditEvent;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
@@ -69,6 +71,7 @@ public class UpdateApiProductUseCase {
     private final PlanQueryService planQueryService;
     private final PlanCrudService planCrudService;
     private final ApiProductTagDomainService apiProductTagDomainService;
+    private final DeployApiProductDomainService deployApiProductDomainService;
 
     public Output execute(Input input) {
         if (!licenseDomainService.isApiProductDeploymentAllowed(input.auditInfo().organizationId())) {
@@ -129,8 +132,12 @@ public class UpdateApiProductUseCase {
         }
         apiProductIndexerDomainService.index(oneShotIndexation(input.auditInfo()), updated, primaryOwner);
 
+        if (hasApiMembershipChanged(beforeUpdate.getApiIds(), updated.getApiIds())) {
+            deployMembershipChangeToGateway(input.auditInfo(), updated);
+        }
+
         createAuditLog(beforeUpdate, updated, input.auditInfo());
-        // Notification reflects the persisted record change; gateway deploy is explicit via DeployApiProductUseCase.
+
         triggerNotificationDomainService.triggerApiProductNotification(
             input.auditInfo().organizationId(),
             input.auditInfo().environmentId(),
@@ -195,6 +202,23 @@ public class UpdateApiProductUseCase {
         );
         planDef.setTags(cleanedTags.isEmpty() ? null : cleanedTags);
         planCrudService.update(plan);
+    }
+
+    private void deployMembershipChangeToGateway(AuditInfo auditInfo, ApiProduct updated) {
+        try {
+            validateApiProductService.validateForDeploy(updated);
+            deployApiProductDomainService.deploy(auditInfo, updated);
+        } catch (ValidationDomainException e) {
+            log.warn("API Product [{}] membership was updated but not deployed to the gateway. {}", updated.getId(), e.getMessage());
+        } catch (Exception e) {
+            log.error("Unexpected error deploying API Product [{}] membership change to the gateway", updated.getId(), e);
+        }
+    }
+
+    private static boolean hasApiMembershipChanged(Set<String> previousApiIds, Set<String> currentApiIds) {
+        Set<String> previous = previousApiIds != null ? previousApiIds : Set.of();
+        Set<String> current = currentApiIds != null ? currentApiIds : Set.of();
+        return !previous.equals(current);
     }
 
     private void createAuditLog(ApiProduct before, ApiProduct after, AuditInfo auditInfo) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
@@ -42,6 +42,7 @@ import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductTagDomainService;
+import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
@@ -79,6 +80,7 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
     private final TriggerNotificationDomainServiceInMemory triggerNotificationDomainService =
         new TriggerNotificationDomainServiceInMemory();
     private final ApiProductTagDomainService apiProductTagDomainService = mock(ApiProductTagDomainService.class);
+    private final DeployApiProductDomainService deployApiProductDomainService = mock(DeployApiProductDomainService.class);
 
     private UpdateApiProductUseCase updateApiProductUseCase;
 
@@ -107,7 +109,8 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
             triggerNotificationDomainService,
             planQueryService,
             planCrudService,
-            apiProductTagDomainService
+            apiProductTagDomainService,
+            deployApiProductDomainService
         );
     }
 
@@ -142,6 +145,7 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
         );
 
         verify(apiProductIndexerDomainService).index(any(), eq(output.apiProduct()), any());
+        verify(deployApiProductDomainService).deploy(AUDIT_INFO, output.apiProduct());
     }
 
     @Test
@@ -524,6 +528,50 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
         var output = updateApiProductUseCase.execute(input);
 
         assertThat(output.apiProduct().getApiIds()).containsExactlyInAnyOrder("api-1", "api-2");
+        verify(deployApiProductDomainService, never()).deploy(any(), any());
+    }
+
+    @Test
+    void should_deploy_to_gateway_when_api_membership_changes() {
+        givenPublishedApiProductPlan();
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .apiIds(Set.of("api-1"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        Api api1 = createV4ProxyApi("api-1", true);
+        Api api2 = createV4ProxyApi("api-2", true);
+        apiCrudService.initWith(List.of(api1, api2));
+
+        var toUpdate = UpdateApiProduct.builder().apiIds(Set.of("api-1", "api-2")).build();
+        var output = updateApiProductUseCase.execute(new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO));
+
+        verify(deployApiProductDomainService).deploy(AUDIT_INFO, output.apiProduct());
+    }
+
+    @Test
+    void should_not_deploy_to_gateway_when_only_tags_change() {
+        givenPublishedApiProductPlan();
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .tags(Set.of("internal"))
+            .apiIds(Set.of("api-1"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        var toUpdate = UpdateApiProduct.builder().tags(Set.of("internal", "external")).build();
+        updateApiProductUseCase.execute(new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO));
+
+        verify(deployApiProductDomainService, never()).deploy(any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14342

## Description

Restores selective gateway sync when an API Product’s API membership (apiIds) changes, fixing the failing E2E test api-product-incremental-growth.

When API Product sharding tags were introduced, UpdateApiProductUseCase stopped auto-deploying on every update so tag changes could follow an explicit Deploy flow (save → out of sync → deploy). That also removed deploy-on-membership-change, which broke incremental growth: after adding api2/api3 via PUT, the gateway registry still only indexed api1, so product-only APIs were never deployed and returned 404.

This PR reintroduces auto-deploy only when apiIds change. Tag-only and metadata-only updates still do not trigger a deploy, preserving the sharding-tag UX on the Deployment tab.

