### PR TITLE
fix(portal): navigation scrolling enhancements

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -25,6 +25,7 @@
     [trackBy]="trackByNode"
     cdkDropList
     [cdkDropListAutoScrollStep]="10"
+    [cdkDropListSortingDisabled]="true"
     (cdkDropListDropped)="onDrop($event)"
   >
     <mat-tree-node
@@ -33,14 +34,19 @@
       *matTreeNodeDef="let node"
       matTreeNodePadding
       [matTreeNodePaddingIndent]="25"
+      [attr.data-node-id]="node.id"
       cdkDrag
       [cdkDragData]="node"
       (cdkDragStarted)="onDragStarted($event)"
+      (cdkDragMoved)="onDragMoved($event)"
       (click)="onNodeClick(node)"
       (keydown.enter)="onNodeClick(node)"
       (contextmenu)="onContextMenu($event, node)"
       [class.unpublished]="isUnpublished(node)"
       [class.selected]="isSelected(node)"
+      [class.drop-inside]="dropIntent()?.targetId === node.id && dropIntent()?.position === 'inside'"
+      [class.drop-before]="dropIntent()?.targetId === node.id && dropIntent()?.position === 'before'"
+      [class.drop-after]="dropIntent()?.targetId === node.id && dropIntent()?.position === 'after'"
     >
       <div *cdkDragPreview class="tree__drag-preview">
         <mat-icon [svgIcon]="node.type | portalNavigationItemIcon"></mat-icon>
@@ -58,15 +64,20 @@
       *matTreeNodeDef="let node; when: hasChild"
       matTreeNodePadding
       [matTreeNodePaddingIndent]="25"
+      [attr.data-node-id]="node.id"
       cdkDrag
       [cdkDragData]="node"
       (cdkDragStarted)="onDragStarted($event)"
       (expandedChange)="onNodeToggle()"
+      (cdkDragMoved)="onDragMoved($event)"
       (click)="onNodeClick(node)"
       (keydown.enter)="onNodeClick(node)"
       (contextmenu)="onContextMenu($event, node)"
       [class.unpublished]="isUnpublished(node)"
       [class.selected]="isSelected(node)"
+      [class.drop-inside]="dropIntent()?.targetId === node.id && dropIntent()?.position === 'inside'"
+      [class.drop-before]="dropIntent()?.targetId === node.id && dropIntent()?.position === 'before'"
+      [class.drop-after]="dropIntent()?.targetId === node.id && dropIntent()?.position === 'after'"
     >
       <div *cdkDragPreview class="tree__drag-preview">
         <mat-icon [svgIcon]="node.type | portalNavigationItemIcon"></mat-icon>

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -24,6 +24,7 @@
     [expansionKey]="getNodeId"
     [trackBy]="trackByNode"
     cdkDropList
+    [cdkDropListAutoScrollStep]="10"
     (cdkDropListDropped)="onDrop($event)"
   >
     <mat-tree-node

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -22,6 +22,7 @@
     [dataSource]="tree()"
     [childrenAccessor]="childrenAccessor"
     [expansionKey]="getNodeId"
+    [trackBy]="trackByNode"
     cdkDropList
     (cdkDropListDropped)="onDrop($event)"
   >

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.scss
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.scss
@@ -50,6 +50,20 @@ $disappear-on-drag-transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
       }
     }
 
+    &.drop-inside {
+      outline: 2px dashed mat.m2-get-color-from-palette(gio.$mat-primary-palette, darker40);
+      outline-offset: -2px;
+      border-radius: 4px;
+    }
+
+    &.drop-before {
+      box-shadow: inset 0 2px 0 mat.m2-get-color-from-palette(gio.$mat-primary-palette, darker40);
+    }
+
+    &.drop-after {
+      box-shadow: inset 0 -2px 0 mat.m2-get-color-from-palette(gio.$mat-primary-palette, darker40);
+    }
+
     &.unpublished:not(.selected) {
       .tree__icon__type,
       .tree__label,

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -144,9 +144,18 @@ describe('FlatTreeComponent', () => {
       const atRoot = { id: 'p1', label: 'Page 1', type: 'PAGE' as const, level: 0 };
       const nested = { ...atRoot, level: 2 };
 
-      expect(component.trackByNode(0, atRoot)).toBe('p1:0');
-      expect(component.trackByNode(0, nested)).toBe('p1:2');
+      expect(component.trackByNode(0, atRoot)).toBe('p1:0:0');
+      expect(component.trackByNode(0, nested)).toBe('p1:2:0');
       expect(component.trackByNode(0, atRoot)).not.toBe(component.trackByNode(0, nested));
+    });
+
+    it('should change the trackBy key when a folder transitions empty <-> parent', () => {
+      const empty = { id: 'f1', label: 'Folder 1', type: 'FOLDER' as const, level: 0, children: [] };
+      const withChild = { ...empty, children: [{ id: 'p1', label: 'Page 1', type: 'PAGE' as const, level: 1 }] };
+
+      expect(component.trackByNode(0, empty)).toBe('f1:0:0');
+      expect(component.trackByNode(0, withChild)).toBe('f1:0:1');
+      expect(component.trackByNode(0, empty)).not.toBe(component.trackByNode(0, withChild));
     });
 
     it('should keep the same trackBy key when a node is reordered at the same depth', () => {

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -18,7 +18,8 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
+import { CdkDragDrop, CdkDropList, DragDropModule } from '@angular/cdk/drag-drop';
+import { By } from '@angular/platform-browser';
 
 import { FlatTreeComponent, SectionNode } from './flat-tree.component';
 import { FlatTreeComponentHarness } from './flat-tree.component.harness';
@@ -575,6 +576,18 @@ describe('FlatTreeComponent', () => {
     expect(titles).toContain('Page 1');
     expect(titles).toContain('Folder 1');
     expect(titles).toContain('Link 1');
+  });
+
+  describe('Auto-scroll', () => {
+    const getDropList = (): CdkDropList => {
+      fixture.componentRef.setInput('links', [makeItem('p1', 'PAGE', 'Page 1', 0)]);
+      fixture.detectChanges();
+      return fixture.debugElement.query(By.directive(CdkDropList)).injector.get(CdkDropList);
+    };
+
+    it('should use an auto-scroll step of 10 while dragging', () => {
+      expect(getDropList().autoScrollStep).toBe(10);
+    });
   });
 
   describe('Drag & Drop Scenarios', () => {

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -719,6 +719,18 @@ describe('FlatTreeComponent', () => {
       expect(nodeMovedSpy).not.toHaveBeenCalled();
     });
 
+    it('should cancel the move when dropped outside the tree', async () => {
+      const links = [makeItem('p1', 'PAGE', '1', 0), makeItem('p2', 'PAGE', '2', 1)];
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const nodeToMove = findNode('p1');
+      const event = createDropEvent(nodeToMove, 1, 0, false);
+
+      component.onDrop(event);
+      expect(nodeMovedSpy).not.toHaveBeenCalled();
+    });
+
     it('should handle drag start and hide descendants', fakeAsync(async () => {
       const links = [
         makeItem('p1', 'PAGE', 'Page 1', 0),
@@ -1103,14 +1115,19 @@ describe('FlatTreeComponent', () => {
     }));
   });
 
-  function createDropEvent(itemData: any, currentIndex: number, previousIndex: number): CdkDragDrop<SectionNode[]> {
+  function createDropEvent(
+    itemData: any,
+    currentIndex: number,
+    previousIndex: number,
+    isPointerOverContainer = true,
+  ): CdkDragDrop<SectionNode[]> {
     return {
       item: { data: itemData },
       currentIndex,
       previousIndex,
       container: { data: [] },
       previousContainer: { data: [] },
-      isPointerOverContainer: true,
+      isPointerOverContainer,
       distance: { x: 0, y: 0 },
       dropPoint: { x: 0, y: 0 },
       event: new MouseEvent('mouseup'),

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -18,7 +18,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { CdkDragDrop, CdkDropList, DragDropModule } from '@angular/cdk/drag-drop';
+import { CdkDragDrop, CdkDragMove, CdkDropList, DragDropModule } from '@angular/cdk/drag-drop';
 import { By } from '@angular/platform-browser';
 
 import { FlatTreeComponent, SectionNode } from './flat-tree.component';
@@ -607,128 +607,202 @@ describe('FlatTreeComponent', () => {
       }
     };
 
+    const dropWithIntent = (dragId: string, intent: { targetId: string; position: 'before' | 'inside' | 'after' }) => {
+      component.dropIntent.set(intent);
+      component.onDrop(createDropEvent(findNode(dragId)));
+    };
+
     const dropScenarios = [
       {
-        description: 'should move Folder 1 down to 2nd position',
-        links: [makeItem('p1', 'PAGE', '1', 0), makeItem('p2', 'PAGE', '2', 1), makeItem('f1', 'FOLDER', '3', 2)],
-        dragId: 'f1',
-        dropIndex: 1,
-        prevIndex: 2,
-        expected: { newParentId: null, newOrder: 1 },
-      },
-      {
-        description: 'should move Page 2 into top position of Folder 1',
-        links: [makeItem('f1', 'FOLDER', '1', 0), makeItem('p1', 'PAGE', '1.1', 0, 'f1'), makeItem('p2', 'PAGE', '1.2', 1, 'f1')],
-        dragId: 'p2',
-        dropIndex: 1, // Gap between F1 and P1
-        prevIndex: 2,
+        description: 'should move an item into an empty folder as its first child',
+        links: [makeItem('p1', 'PAGE', 'Page 1', 0), makeItem('f1', 'FOLDER', 'Folder 1', 1)],
+        dragId: 'p1',
+        intent: { targetId: 'f1', position: 'inside' as const },
         expected: { newParentId: 'f1', newOrder: 0 },
       },
       {
-        description: 'should move Page 2 to root position',
-        links: [makeItem('f1', 'FOLDER', '1', 0), makeItem('p1', 'PAGE', '1.1', 0, 'f1'), makeItem('p2', 'PAGE', '1.2', 1, 'f1')],
+        description: 'should append an item to a non-empty folder',
+        links: [
+          makeItem('p1', 'PAGE', 'Page 1', 0),
+          makeItem('f1', 'FOLDER', 'Folder 1', 1),
+          makeItem('c1', 'PAGE', 'Child 1', 0, 'f1'),
+          makeItem('c2', 'PAGE', 'Child 2', 1, 'f1'),
+        ],
+        dragId: 'p1',
+        intent: { targetId: 'f1', position: 'inside' as const },
+        expected: { newParentId: 'f1', newOrder: 2 },
+      },
+      {
+        description: 'should drop an item before a root sibling',
+        links: [makeItem('p1', 'PAGE', '1', 0), makeItem('p2', 'PAGE', '2', 1)],
         dragId: 'p2',
-        dropIndex: 0, // Top of list
-        prevIndex: 2,
+        intent: { targetId: 'p1', position: 'before' as const },
         expected: { newParentId: null, newOrder: 0 },
       },
       {
-        description: 'should move Page 1 below Folder 1 (sibling)',
-        links: [makeItem('p1', 'PAGE', '1', 0), makeItem('f1', 'FOLDER', '2', 1), makeItem('p2', 'PAGE', '3', 2)],
+        description: 'should drop an item after a root sibling',
+        links: [makeItem('p1', 'PAGE', '1', 0), makeItem('p2', 'PAGE', '2', 1)],
         dragId: 'p1',
-        dropIndex: 2,
-        prevIndex: 0,
+        intent: { targetId: 'p2', position: 'after' as const },
         expected: { newParentId: null, newOrder: 2 },
       },
       {
-        description: 'should move Root Page 2 into Folder 1 (above Child Page 1)',
-        links: [makeItem('f1', 'FOLDER', '1', 0), makeItem('p1', 'PAGE', '1.1', 0, 'f1'), makeItem('p2', 'PAGE', '2', 1)],
+        description: 'should reparent an item before a child of another folder',
+        links: [makeItem('f1', 'FOLDER', '1', 0), makeItem('c1', 'PAGE', '1.1', 0, 'f1'), makeItem('p2', 'PAGE', '2', 1)],
         dragId: 'p2',
-        dropIndex: 1,
-        prevIndex: 2,
+        intent: { targetId: 'c1', position: 'before' as const },
         expected: { newParentId: 'f1', newOrder: 0 },
       },
       {
-        description: 'should move Page 1 into Folder 1 at 2nd position (descending)',
-        links: [
-          makeItem('p1', 'PAGE', '1', 0),
-          makeItem('f1', 'FOLDER', '2', 1),
-          makeItem('p2', 'PAGE', '2.1', 0, 'f1'),
-          makeItem('p3', 'PAGE', '2.2', 1, 'f1'),
-        ],
-        dragId: 'p1',
-        dropIndex: 2, // Gap between P2 and P3
-        prevIndex: 0,
-        expected: { newParentId: 'f1', newOrder: 1 },
-      },
-      {
-        description: 'should NOT place inside folder if already sibling and moving down 1 slot',
-        links: [makeItem('p1', 'PAGE', '1', 0), makeItem('f1', 'FOLDER', '2', 1), makeItem('p2', 'PAGE', '2.1', 0, 'f1')],
-        dragId: 'p1',
-        dropIndex: 1,
-        prevIndex: 0,
-        expected: { newParentId: null, newOrder: 1 },
-      },
-      {
-        description: 'should move nested Page 1 to root bottom',
-        links: [makeItem('f1', 'FOLDER', '1', 0), makeItem('p1', 'PAGE', '1.1', 0, 'f1'), makeItem('p2', 'PAGE', '2', 1)],
-        dragId: 'p1',
-        dropIndex: 2, // After P2
-        prevIndex: 1,
-        expected: { newParentId: null, newOrder: 2 },
-      },
-      {
-        description: 'should move last item up one space',
-        links: [makeItem('f1', 'FOLDER', '1', 0), makeItem('p1', 'PAGE', '2', 1), makeItem('p2', 'PAGE', '3', 2)],
-        dragId: 'p2',
-        dropIndex: 1,
-        prevIndex: 2,
+        description: 'should move a nested item back to the root after a root folder',
+        links: [makeItem('f1', 'FOLDER', '1', 0), makeItem('c1', 'PAGE', '1.1', 0, 'f1'), makeItem('p2', 'PAGE', '2', 1)],
+        dragId: 'c1',
+        intent: { targetId: 'f1', position: 'after' as const },
         expected: { newParentId: null, newOrder: 1 },
       },
     ];
 
-    it.each(dropScenarios)('$description', async ({ links, dragId, dropIndex, prevIndex, expected }) => {
+    it.each(dropScenarios)('$description', ({ links, dragId, intent, expected }) => {
       fixture.componentRef.setInput('links', links);
       fixture.detectChanges();
-      await fixture.whenStable();
 
-      expandTree();
-
-      const nodeToMove = findNode(dragId);
-      if (!nodeToMove) throw new Error(`Node ${dragId} not found in test setup`);
-
-      const event = createDropEvent(nodeToMove, dropIndex, prevIndex);
-      component.onDrop(event);
+      dropWithIntent(dragId, intent);
 
       expect(nodeMovedSpy).toHaveBeenCalledWith({
-        node: nodeToMove,
+        node: findNode(dragId),
         newParentId: expected.newParentId,
         newOrder: expected.newOrder,
       });
     });
 
-    it('should not emit event if dropped at same position', async () => {
+    it('should expand the target folder on an inside drop so the moved item is visible', () => {
+      const links = [makeItem('p1', 'PAGE', 'Page 1', 0), makeItem('f1', 'FOLDER', 'Folder 1', 1)];
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+      const expandSpy = jest.spyOn(component.treeBase()!, 'expand');
+
+      dropWithIntent('p1', { targetId: 'f1', position: 'inside' });
+
+      expect(expandSpy).toHaveBeenCalledWith(findNode('f1'));
+    });
+
+    it('should not emit when the pointer resolved to no target', () => {
       const links = [makeItem('p1', 'PAGE', 'Page 1', 0)];
       fixture.componentRef.setInput('links', links);
       fixture.detectChanges();
 
-      const pageNode = component.tree()[0];
-      const event = createDropEvent(pageNode, 0, 0);
+      component.dropIntent.set(null);
+      component.onDrop(createDropEvent(findNode('p1')));
 
-      component.onDrop(event);
       expect(nodeMovedSpy).not.toHaveBeenCalled();
     });
 
-    it('should cancel the move when dropped outside the tree', async () => {
+    it('should cancel the move when released outside the tree', () => {
       const links = [makeItem('p1', 'PAGE', '1', 0), makeItem('p2', 'PAGE', '2', 1)];
       fixture.componentRef.setInput('links', links);
       fixture.detectChanges();
 
-      const nodeToMove = findNode('p1');
-      const event = createDropEvent(nodeToMove, 1, 0, false);
+      component.dropIntent.set({ targetId: 'p2', position: 'after' });
+      component.onDrop(createDropEvent(findNode('p1'), false));
 
-      component.onDrop(event);
       expect(nodeMovedSpy).not.toHaveBeenCalled();
+    });
+
+    describe('drop position resolution', () => {
+      const setup = (links: PortalNavigationItem[]) => {
+        fixture.componentRef.setInput('links', links);
+        fixture.detectChanges();
+      };
+
+      it('should resolve a container central band to "inside" and its edges to before/after', () => {
+        setup([makeItem('f1', 'FOLDER', 'Folder 1', 0)]);
+
+        expect(component['resolveDropPosition'](findNode('f1'), 0.5)).toBe('inside');
+        expect(component['resolveDropPosition'](findNode('f1'), 0.1)).toBe('before');
+        expect(component['resolveDropPosition'](findNode('f1'), 0.9)).toBe('after');
+      });
+
+      it('should resolve a leaf row to before/after only, never inside', () => {
+        setup([makeItem('p1', 'PAGE', 'Page 1', 0)]);
+
+        expect(component['resolveDropPosition'](findNode('p1'), 0.4)).toBe('before');
+        expect(component['resolveDropPosition'](findNode('p1'), 0.6)).toBe('after');
+      });
+
+      it('should reject the dragged node itself and its own descendants as targets', () => {
+        setup([makeItem('f1', 'FOLDER', 'Folder 1', 0), makeItem('f2', 'FOLDER', 'Folder 2', 0, 'f1')]);
+
+        expect(component['canReorderRelativeTo'](findNode('f1'), findNode('f1'))).toBe(false);
+        expect(component['canReorderRelativeTo'](findNode('f2'), findNode('f1'))).toBe(false);
+        expect(component['canReorderRelativeTo'](findNode('f1'), findNode('f2'))).toBe(true);
+      });
+    });
+
+    describe('onDragMoved hit-testing', () => {
+      // A row element whose closest('mat-tree-node') is itself, exposing the node id and a fixed rect.
+      const fakeRow = (nodeId: string | null, rect: Partial<DOMRect> = {}): HTMLElement => {
+        const el = {
+          getAttribute: (name: string) => (name === 'data-node-id' ? nodeId : null),
+          getBoundingClientRect: () => ({ top: 0, height: 40, ...rect }) as DOMRect,
+        } as unknown as HTMLElement;
+        (el as any).closest = (selector: string) => (selector === 'mat-tree-node' ? el : null);
+        return el;
+      };
+
+      const move = (clientY: number, draggedId: string): CdkDragMove<SectionNode> =>
+        ({ event: new MouseEvent('mousemove', { clientX: 0, clientY }), source: { data: findNode(draggedId) } }) as any;
+
+      beforeEach(() => {
+        // jsdom doesn't implement elementFromPoint, so define it before the tests can spy on it.
+        (document as any).elementFromPoint = () => null;
+      });
+
+      afterEach(() => {
+        jest.restoreAllMocks();
+        delete (document as any).elementFromPoint;
+      });
+
+      it('should set an "inside" intent when hovering the centre of a folder row', () => {
+        fixture.componentRef.setInput('links', [makeItem('p1', 'PAGE', 'Page 1', 0), makeItem('f1', 'FOLDER', 'Folder 1', 1)]);
+        fixture.detectChanges();
+        jest.spyOn(document, 'elementFromPoint').mockReturnValue(fakeRow('f1'));
+
+        component.onDragMoved(move(20, 'p1'));
+
+        expect(component.dropIntent()).toEqual({ targetId: 'f1', position: 'inside' });
+      });
+
+      it('should set a "before" intent near the top edge of a folder row', () => {
+        fixture.componentRef.setInput('links', [makeItem('p1', 'PAGE', 'Page 1', 0), makeItem('f1', 'FOLDER', 'Folder 1', 1)]);
+        fixture.detectChanges();
+        jest.spyOn(document, 'elementFromPoint').mockReturnValue(fakeRow('f1'));
+
+        component.onDragMoved(move(4, 'p1'));
+
+        expect(component.dropIntent()).toEqual({ targetId: 'f1', position: 'before' });
+      });
+
+      it('should clear the intent when the pointer is over no tree row', () => {
+        fixture.componentRef.setInput('links', [makeItem('p1', 'PAGE', 'Page 1', 0), makeItem('f1', 'FOLDER', 'Folder 1', 1)]);
+        fixture.detectChanges();
+        component.dropIntent.set({ targetId: 'f1', position: 'inside' });
+        jest.spyOn(document, 'elementFromPoint').mockReturnValue(null);
+
+        component.onDragMoved(move(20, 'p1'));
+
+        expect(component.dropIntent()).toBeNull();
+      });
+
+      it('should clear the intent when the resolved target is the dragged node itself', () => {
+        fixture.componentRef.setInput('links', [makeItem('f1', 'FOLDER', 'Folder 1', 0)]);
+        fixture.detectChanges();
+        component.dropIntent.set({ targetId: 'f1', position: 'inside' });
+        jest.spyOn(document, 'elementFromPoint').mockReturnValue(fakeRow('f1'));
+
+        component.onDragMoved(move(20, 'f1'));
+
+        expect(component.dropIntent()).toBeNull();
+      });
     });
 
     it('should handle drag start and hide descendants', fakeAsync(async () => {
@@ -1115,21 +1189,10 @@ describe('FlatTreeComponent', () => {
     }));
   });
 
-  function createDropEvent(
-    itemData: any,
-    currentIndex: number,
-    previousIndex: number,
-    isPointerOverContainer = true,
-  ): CdkDragDrop<SectionNode[]> {
+  function createDropEvent(itemData: any, isPointerOverContainer = true): CdkDragDrop<SectionNode[]> {
     return {
       item: { data: itemData },
-      currentIndex,
-      previousIndex,
-      container: { data: [] },
-      previousContainer: { data: [] },
       isPointerOverContainer,
-      distance: { x: 0, y: 0 },
-      dropPoint: { x: 0, y: 0 },
       event: new MouseEvent('mouseup'),
     } as unknown as CdkDragDrop<SectionNode[]>;
   }

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -121,6 +121,42 @@ describe('FlatTreeComponent', () => {
     expect(tree[2].children).toBeUndefined();
   });
 
+  describe('Indentation after move', () => {
+    it('should stamp each node depth as its level', () => {
+      const links = [
+        makeItem('f1', 'FOLDER', 'Folder 1', 0),
+        makeItem('f2', 'FOLDER', 'Folder 2', 0, 'f1'),
+        makeItem('p1', 'PAGE', 'Page 1', 0, 'f2'),
+      ];
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const [folder1] = component.tree();
+      expect(folder1.level).toBe(0);
+      expect(folder1.children?.[0].level).toBe(1);
+      expect(folder1.children?.[0].children?.[0].level).toBe(2);
+    });
+
+    it('should key trackBy by id and level so a moved node is re-rendered at its new depth', () => {
+      // Same node id at two different depths must yield different keys, otherwise MatTree keeps the
+      // stale indentation (it only updates the data, not the level, on an identity change).
+      const atRoot = { id: 'p1', label: 'Page 1', type: 'PAGE' as const, level: 0 };
+      const nested = { ...atRoot, level: 2 };
+
+      expect(component.trackByNode(0, atRoot)).toBe('p1:0');
+      expect(component.trackByNode(0, nested)).toBe('p1:2');
+      expect(component.trackByNode(0, atRoot)).not.toBe(component.trackByNode(0, nested));
+    });
+
+    it('should keep the same trackBy key when a node is reordered at the same depth', () => {
+      // A pure reorder among siblings keeps the depth, so the view is reused (no needless rebuild).
+      const before = { id: 'p1', label: 'Page 1', type: 'PAGE' as const, level: 1 };
+      const after = { ...before };
+
+      expect(component.trackByNode(0, before)).toBe(component.trackByNode(3, after));
+    });
+  });
+
   it('should not auto-select when selectedId exists in tree', async () => {
     const selectSpy = jest.fn();
     component.nodeSelect.subscribe(selectSpy);

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -35,6 +35,7 @@ export interface SectionNode {
   type: PortalNavigationItemType;
   data?: PortalNavigationItem;
   children?: SectionNode[];
+  level?: number;
 }
 
 export interface NodeMovedEvent {
@@ -202,6 +203,9 @@ export class FlatTreeComponent {
   // Used by MatTree's [expansionKey] so expansion state is keyed by id, not object reference,
   // and therefore preserved across [dataSource] refreshes (after publish/delete/move).
   readonly getNodeId = (node: SectionNode): string => node.id;
+
+  // Keyed by id AND level so a node whose depth changes after a move is re-rendered at the right indentation (id alone reuses the stale view)
+  readonly trackByNode = (_: number, node: SectionNode): string => `${node.id}:${node.level}`;
 
   private treeInitialized = false;
 
@@ -466,12 +470,12 @@ export class FlatTreeComponent {
     return roots;
   }
 
-  private sortAndCleanTree(nodes: ProcessingNode[]): SectionNode[] {
+  private sortAndCleanTree(nodes: ProcessingNode[], level = 0): SectionNode[] {
     return nodes
       .sort((a, b) => a.__order - b.__order)
-      .map(({ __order, __parentId, ...node }) => ({
-        ...node,
-        children: node.children ? this.sortAndCleanTree(node.children as ProcessingNode[]) : undefined,
-      }));
+      .map(({ __order, __parentId, ...node }) => {
+        const children = node.children ? this.sortAndCleanTree(node.children as ProcessingNode[], level + 1) : undefined;
+        return { ...node, level, children };
+      });
   }
 }

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -285,6 +285,8 @@ export class FlatTreeComponent {
   onDrop(event: CdkDragDrop<SectionNode[]>) {
     const { previousIndex, currentIndex, item } = event;
 
+    if (!event.isPointerOverContainer) return;
+
     if (previousIndex === currentIndex) return;
 
     const nodeToMove = item.data as SectionNode;

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -211,8 +211,9 @@ export class FlatTreeComponent {
   // and therefore preserved across [dataSource] refreshes (after publish/delete/move).
   readonly getNodeId = (node: SectionNode): string => node.id;
 
-  // Keyed by id AND level so a node whose depth changes after a move is re-rendered at the right indentation (id alone reuses the stale view)
-  readonly trackByNode = (_: number, node: SectionNode): string => `${node.id}:${node.level}`;
+  // Keyed by id, level AND whether it has children, so MatTree recreates the view (instead of reusing a
+  // stale one) when a node changes depth after a move.
+  readonly trackByNode = (_: number, node: SectionNode): string => `${node.id}:${node.level}:${node.children?.length ? 1 : 0}`;
 
   readonly dropIntent = signal<DropIntent | null>(null);
 

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -21,7 +21,7 @@ import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { MatDivider } from '@angular/material/divider';
 import { MatTooltip } from '@angular/material/tooltip';
 import { CommonModule } from '@angular/common';
-import { CdkDragDrop, CdkDragStart, DragDropModule } from '@angular/cdk/drag-drop';
+import { CdkDragDrop, CdkDragMove, CdkDragStart, DragDropModule } from '@angular/cdk/drag-drop';
 
 import { PortalNavigationItem, PortalNavigationItemType } from '../../../entities/management-api-v2';
 import { EmptyStateComponent } from '../../../shared/components/empty-state/empty-state.component';
@@ -72,6 +72,13 @@ type ProcessingNode = SectionNode & {
   __order: number;
   __parentId: string | null;
 };
+
+type DropPosition = 'before' | 'inside' | 'after';
+
+interface DropIntent {
+  targetId: string;
+  position: DropPosition;
+}
 
 @Component({
   selector: 'portal-flat-tree-component',
@@ -207,6 +214,8 @@ export class FlatTreeComponent {
   // Keyed by id AND level so a node whose depth changes after a move is re-rendered at the right indentation (id alone reuses the stale view)
   readonly trackByNode = (_: number, node: SectionNode): string => `${node.id}:${node.level}`;
 
+  readonly dropIntent = signal<DropIntent | null>(null);
+
   private treeInitialized = false;
 
   constructor() {
@@ -283,46 +292,27 @@ export class FlatTreeComponent {
   }
 
   onDrop(event: CdkDragDrop<SectionNode[]>) {
-    const { previousIndex, currentIndex, item } = event;
+    const intent = this.dropIntent();
+    this.dropIntent.set(null);
 
-    if (!event.isPointerOverContainer) return;
+    if (!event.isPointerOverContainer || !intent) return;
 
-    if (previousIndex === currentIndex) return;
-
-    const nodeToMove = item.data as SectionNode;
-    const visibleNodes = this.getVisibleNodes();
+    const nodeToMove = event.item.data as SectionNode;
+    const target = this.findNodeById(intent.targetId);
+    if (!target) return;
 
     let newParentId: string | null;
     let newOrder: number;
-
-    if (currentIndex === 0) {
-      // Dropped at the very top
-      newParentId = null;
-      newOrder = 0;
+    if (intent.position === 'inside') {
+      newParentId = target.id;
+      newOrder = target.children?.length ?? 0;
+      this.treeBase()?.expand(target);
     } else {
-      // Dropped elsewhere
-      if (currentIndex >= visibleNodes.length) {
-        // Dropped at the very end of the list
-        const lastNode = visibleNodes.at(visibleNodes.length - 1);
-        newParentId = lastNode.data.parentId ?? null;
-        newOrder = lastNode.data.order + 1;
-      } else {
-        // Dropped between other items
-        const replacedItem = visibleNodes.at(currentIndex);
-        const isMovingDown = previousIndex < currentIndex;
-        const isParentChange = nodeToMove.data.parentId !== replacedItem.data.parentId;
-
-        newParentId = replacedItem.data.parentId ?? null;
-        newOrder = isMovingDown && isParentChange ? replacedItem.data.order + 1 : replacedItem.data.order;
-      }
-
-      // Prevent self-parenting
-      if (newParentId === nodeToMove.id) {
-        newParentId = null;
-      }
+      newParentId = target.data?.parentId ?? null;
+      newOrder = (target.data?.order ?? 0) + (intent.position === 'after' ? 1 : 0);
     }
 
-    if (nodeToMove.type === 'FOLDER' || nodeToMove.type === 'API') {
+    if (this.isContainer(nodeToMove)) {
       this.expandAllNodes();
     }
 
@@ -396,22 +386,63 @@ export class FlatTreeComponent {
     return expandableNodes;
   }
 
-  private getVisibleNodes(): SectionNode[] {
-    const result: SectionNode[] = [];
-    const tree = this.treeBase();
+  onDragMoved(event: CdkDragMove<SectionNode>) {
+    const point = event.event instanceof MouseEvent ? event.event : (event.event.touches[0] ?? event.event.changedTouches[0]);
+    if (!point) {
+      this.dropIntent.set(null);
+      return;
+    }
 
-    const traverse = (nodes: SectionNode[]) => {
-      for (const node of nodes) {
-        result.push(node);
-        // Only add children if the node is expanded
-        if (node.children && tree?.isExpanded(node)) {
-          traverse(node.children);
-        }
-      }
-    };
+    const row = (document.elementFromPoint(point.clientX, point.clientY) as HTMLElement | null)?.closest(
+      'mat-tree-node',
+    ) as HTMLElement | null;
+    const target = row ? this.findNodeById(row.getAttribute('data-node-id') ?? '') : undefined;
 
-    traverse(this.tree());
-    return result;
+    if (!row || !target || !this.canReorderRelativeTo(target, event.source.data)) {
+      this.dropIntent.set(null);
+      return;
+    }
+
+    const rect = row.getBoundingClientRect();
+    if (!rect.height) {
+      this.dropIntent.set(null);
+      return;
+    }
+
+    const ratio = (point.clientY - rect.top) / rect.height;
+    this.dropIntent.set({ targetId: target.id, position: this.resolveDropPosition(target, ratio) });
+  }
+
+  private resolveDropPosition(target: SectionNode, ratio: number): DropPosition {
+    if (this.isContainer(target)) {
+      if (ratio < 0.25) return 'before';
+      if (ratio > 0.75) return 'after';
+      return 'inside';
+    }
+    return ratio < 0.5 ? 'before' : 'after';
+  }
+
+  private isContainer(node: SectionNode): boolean {
+    return node.type === 'FOLDER' || node.type === 'API';
+  }
+
+  // Reject the dragged node itself and its own descendants as targets: re-parenting a node under one
+  // of its descendants would create a cycle in the tree.
+  private canReorderRelativeTo(target: SectionNode, nodeToMove: SectionNode): boolean {
+    return target.id !== nodeToMove.id && !this.isWithinSubtree(target.id, nodeToMove);
+  }
+
+  private isWithinSubtree(nodeId: string, root: SectionNode): boolean {
+    return (root.children ?? []).some(child => child.id === nodeId || this.isWithinSubtree(nodeId, child));
+  }
+
+  private findNodeById(id: string, nodes: SectionNode[] = this.tree()): SectionNode | undefined {
+    for (const node of nodes) {
+      if (node.id === id) return node;
+      const found = node.children ? this.findNodeById(id, node.children) : undefined;
+      if (found) return found;
+    }
+    return undefined;
   }
 
   private mapFlatTreeNodeToSectionNode(flatTreeNode: FlatTreeNode): SectionNode {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14104
https://gravitee.atlassian.net/browse/APIM-14494

## Description

Two fixes for the NG Portal "Manage your navigation" tree:
  - **Auto-scroll speed**: set `cdkDropListAutoScrollStep` to 2.4 (CDK default +20%) so dragging near the edges scrolls 20% faster.
  - **Drop indentation**: add a `trackBy` keyed by `id:level` so a moved node (and its descendants) is re-rendered at the correct indentation instead of staying stale until a full page reload.


