### PR TITLE
feat(repository): token-bucket rate-limit storage backends

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/api/TokenBucketCalculator.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/api/TokenBucketCalculator.java
@@ -135,6 +135,17 @@ public final class TokenBucketCalculator {
      * contract violation instead of dividing by zero (Mongo/Redis) or letting a negative request inflate
      * the balance above capacity (which would corrupt the bucket and over-admit afterwards).
      *
+     * <p><strong>Safe-magnitude ceiling.</strong> This calculator and the Java backends (JDBC, Hazelcast)
+     * use exact 64-bit integer division; Mongo ({@code $divide} always yields a double) and Redis (Lua 5.1
+     * numbers are IEEE doubles) re-express the same math in floating point. As long as the products
+     * {@code effectiveElapsed * refillRate} and {@code capacity * refillPeriodMillis} stay below 2^53 the
+     * floating-point {@code floor()} matches this integer reference exactly, so all five backends agree.
+     * The {@code maxUsefulElapsed} cap keeps the first product bounded for any input; the second is bounded
+     * by the configured {@code capacity} and {@code refillPeriodMillis}, which for any realistic rate-limit
+     * configuration are many orders of magnitude below 2^53. Beyond that ceiling Mongo/Redis may land one
+     * token off the integer backends — a benign one-token divergence, never an over-admission. The bound is
+     * documented rather than enforced so an existing high-capacity configuration is not rejected on upgrade.
+     *
      * @throws IllegalArgumentException if {@code refillPeriodMillis <= 0}, {@code tokensRequested < 0} or {@code capacity < 0}
      */
     public static void requireValidArgs(long tokensRequested, long refillPeriodMillis, long capacity) {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/api/TokenBucketConsumeResult.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/api/TokenBucketConsumeResult.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.repository.ratelimit.api;
 
+import java.io.Serializable;
+
 /**
  * Outcome of a single {@link TokenBucketRateLimitRepository#refillAndTryConsume} operation.
  *
@@ -24,4 +26,4 @@ package io.gravitee.repository.ratelimit.api;
  *                              supplied {@code now} when tokens already remain
  * @author GraviteeSource Team
  */
-public record TokenBucketConsumeResult(boolean allowed, long remainingTokens, long nextAvailableAtMillis) {}
+public record TokenBucketConsumeResult(boolean allowed, long remainingTokens, long nextAvailableAtMillis) implements Serializable {}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/model/TokenBucket.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/model/TokenBucket.java
@@ -50,6 +50,13 @@ public class TokenBucket implements Serializable {
         this.key = key;
     }
 
+    public TokenBucket(final TokenBucket other) {
+        this.key = other.key;
+        this.tokens = other.tokens;
+        this.lastRefillTime = other.lastRefillTime;
+        this.subscription = other.subscription;
+    }
+
     public String getKey() {
         return key;
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/ratelimit/AbstractTokenBucketRateLimitRepositoryContractTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/ratelimit/AbstractTokenBucketRateLimitRepositoryContractTest.java
@@ -56,7 +56,8 @@ public abstract class AbstractTokenBucketRateLimitRepositoryContractTest {
 
     protected abstract TokenBucketRateLimitRepository<TokenBucket> createRepository();
 
-    private TokenBucketRateLimitRepository<TokenBucket> repository;
+    /** The repository under test, recreated before each test. Exposed so backend subclasses can add storage-specific tests (e.g. TTL eviction). */
+    protected TokenBucketRateLimitRepository<TokenBucket> repository;
 
     @BeforeEach
     void setUp() {

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/pom.xml
@@ -68,6 +68,13 @@
 
         <!-- Test scope -->
         <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/ratelimit/HazelcastTokenBucketRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/ratelimit/HazelcastTokenBucketRateLimitRepository.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.hazelcast.ratelimit;
+
+import com.hazelcast.map.IMap;
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.reactivex.rxjava3.core.Single;
+import java.util.function.Supplier;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Hazelcast-backed {@link TokenBucketRateLimitRepository}. Each operation is one
+ * {@link IMap#submitToKey} call: Hazelcast routes the entry processor to the partition owner of the
+ * key, runs it under the partition lock, and replicates the result to backup members.
+ */
+@CustomLog
+@RequiredArgsConstructor
+public final class HazelcastTokenBucketRateLimitRepository implements TokenBucketRateLimitRepository<TokenBucket> {
+
+    private final IMap<String, TokenBucket> buckets;
+
+    @Override
+    public Single<TokenBucketConsumeResult> refillAndTryConsume(
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        Supplier<TokenBucket> supplier
+    ) {
+        TokenBucket seed = supplier.get();
+        return Single.fromCompletionStage(
+            buckets.submitToKey(
+                key,
+                new RefillAndTryConsumeEntryProcessor(tokensRequested, refillRate, refillPeriodMillis, capacity, nowMillis, seed)
+            )
+        ).doOnError(t -> log.warn("Hazelcast token-bucket consume failed for key={}", key, t));
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/ratelimit/RateLimitRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/ratelimit/RateLimitRepositoryConfiguration.java
@@ -22,7 +22,9 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.properties.ClusterProperty;
 import io.gravitee.repository.ratelimit.api.RateLimitRepository;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
 import io.gravitee.repository.ratelimit.model.RateLimit;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
 import java.io.FileNotFoundException;
 import java.util.Locale;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,6 +41,7 @@ import org.springframework.context.annotation.Configuration;
 public class RateLimitRepositoryConfiguration {
 
     public static final String RATE_LIMIT_MAP = "rate-limits";
+    public static final String TOKEN_BUCKET_MAP = "token-buckets";
 
     @Value("${ratelimit.hazelcast.config-path:${gravitee.home}/config/hazelcast-ratelimit.xml}")
     private String hazelcastConfigFilePath;
@@ -59,6 +62,11 @@ public class RateLimitRepositoryConfiguration {
     @Bean
     public RateLimitRepository<RateLimit> rateLimitRepository(HazelcastInstance ratelimitHazelcastInstance) {
         return new HazelcastRateLimitRepository(ratelimitHazelcastInstance.getMap(RATE_LIMIT_MAP));
+    }
+
+    @Bean
+    public TokenBucketRateLimitRepository<TokenBucket> tokenBucketRateLimitRepository(HazelcastInstance ratelimitHazelcastInstance) {
+        return new HazelcastTokenBucketRateLimitRepository(ratelimitHazelcastInstance.getMap(TOKEN_BUCKET_MAP));
     }
 
     private Config fromFilePath(String filePath) throws FileNotFoundException {

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/ratelimit/RefillAndTryConsumeEntryProcessor.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/ratelimit/RefillAndTryConsumeEntryProcessor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.hazelcast.ratelimit;
+
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.ExtendedMapEntry;
+import io.gravitee.repository.ratelimit.api.TokenBucketCalculator;
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Atomic token-bucket refill-and-consume running on the Hazelcast partition owner.
+ *
+ * <p>All time-dependent inputs ({@code nowMillis}) are captured by the caller (not read inside
+ * {@link #process}) so the processor is deterministic — backup partition members re-run it with the
+ * same inputs and reach the same state as the primary.
+ */
+public final class RefillAndTryConsumeEntryProcessor
+    implements EntryProcessor<String, TokenBucket, TokenBucketConsumeResult>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final long tokensRequested;
+    private final long refillRate;
+    private final long refillPeriodMillis;
+    private final long capacity;
+    private final long nowMillis;
+    private final TokenBucket seed;
+
+    public RefillAndTryConsumeEntryProcessor(
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        TokenBucket seed
+    ) {
+        this.tokensRequested = tokensRequested;
+        this.refillRate = refillRate;
+        this.refillPeriodMillis = refillPeriodMillis;
+        this.capacity = capacity;
+        this.nowMillis = nowMillis;
+        this.seed = Objects.requireNonNull(seed, "seed");
+    }
+
+    @Override
+    public TokenBucketConsumeResult process(Map.Entry<String, TokenBucket> entry) {
+        TokenBucket current = entry.getValue();
+        if (current == null) {
+            // copy ctor; never mutate the seed (the processor may be re-run on backup members)
+            current = TokenBucketCalculator.newFullBucket(new TokenBucket(seed), capacity, nowMillis);
+        }
+
+        TokenBucketConsumeResult result = TokenBucketCalculator.refillAndTryConsume(
+            current,
+            tokensRequested,
+            refillRate,
+            refillPeriodMillis,
+            capacity,
+            nowMillis
+        );
+
+        // Evict once the bucket would have refilled to full anyway: a long-idle entry is then recreated
+        // full on next access, equivalent to keeping it. Shared TTL with the other backends; a zero rate
+        // yields an effectively-forever TTL so a never-refilling bucket persists.
+        long ttlMs = TokenBucketCalculator.ttlMillis(refillRate, refillPeriodMillis, capacity);
+        ((ExtendedMapEntry<String, TokenBucket>) entry).setValue(current, ttlMs, TimeUnit.MILLISECONDS);
+        return result;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/test/java/io/gravitee/repository/hazelcast/ratelimit/HazelcastTokenBucketRateLimitRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/test/java/io/gravitee/repository/hazelcast/ratelimit/HazelcastTokenBucketRateLimitRepositoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.hazelcast.ratelimit;
+
+import static io.gravitee.repository.hazelcast.ratelimit.RateLimitRepositoryConfiguration.TOKEN_BUCKET_MAP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.FileSystemXmlConfig;
+import com.hazelcast.core.EntryView;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.ClusterProperty;
+import io.gravitee.repository.ratelimit.AbstractTokenBucketRateLimitRepositoryContractTest;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Runs the shared {@link AbstractTokenBucketRateLimitRepositoryContractTest} against the
+ * Hazelcast backend. A fresh embedded instance per test gives each test an isolated, empty store.
+ */
+class HazelcastTokenBucketRateLimitRepositoryTest extends AbstractTokenBucketRateLimitRepositoryContractTest {
+
+    private HazelcastInstance hazelcast;
+
+    @Override
+    protected TokenBucketRateLimitRepository<TokenBucket> createRepository() {
+        try {
+            Config config = new FileSystemXmlConfig("src/test/resources/cluster.xml");
+            config.setProperty(ClusterProperty.HEALTH_MONITORING_LEVEL.getName(), "OFF");
+            config.setInstanceName("test-tokenbucket-hz-" + System.nanoTime());
+            hazelcast = Hazelcast.newHazelcastInstance(config);
+            return new HazelcastTokenBucketRateLimitRepository(hazelcast.getMap(TOKEN_BUCKET_MAP));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to start embedded Hazelcast", e);
+        }
+    }
+
+    @AfterEach
+    void shutdownHazelcast() {
+        if (hazelcast != null) {
+            hazelcast.shutdown();
+        }
+    }
+
+    @Test
+    void sets_entry_ttl_to_the_full_refill_window() {
+        // capacity 100 at 2 tokens per 1000ms => the bucket would refill fully in 50s, so the entry is
+        // given a 50s TTL: long enough that it is never evicted before it would be full, after which
+        // evicting and recreating it full is equivalent to keeping it.
+        repository.refillAndTryConsume("ttl", 1, 2, 1_000L, 100, System.currentTimeMillis(), () -> new TokenBucket("ttl")).blockingGet();
+
+        EntryView<String, TokenBucket> view = hazelcast.<String, TokenBucket>getMap(TOKEN_BUCKET_MAP).getEntryView("ttl");
+        assertThat(view.getTtl()).isEqualTo(50_000L);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -129,6 +129,13 @@
         </dependency>
         <dependency>
             <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
             <artifactId>gravitee-apim-repository-test</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/common/AbstractJdbcRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/common/AbstractJdbcRepositoryConfiguration.java
@@ -199,6 +199,11 @@ public abstract class AbstractJdbcRepositoryConfiguration implements Application
                 escapeReservedWordsSufixChar = ']';
                 pagingQuery = MSSQL_PAGING_QUERY;
                 break;
+            default:
+                escapeReservedWordsPrefixChar = '`';
+                escapeReservedWordsSufixChar = '`';
+                pagingQuery = DEFAULT_PAGING_QUERY;
+                break;
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepository.java
@@ -51,6 +51,13 @@ import org.springframework.stereotype.Repository;
  *
  * <p>The first request for a key has no row to lock, so a concurrent insert can lose the race with a
  * duplicate-key error; that is retried, and the retry locks the now-existing row.
+ *
+ * <p><strong>No automatic eviction.</strong> Unlike the other backends — Mongo (TTL index), Redis
+ * ({@code PEXPIREAT}) and Hazelcast (entry TTL) all honour {@link TokenBucketCalculator#ttlMillis} — a
+ * relational table has no native row TTL, so token-bucket rows persist until purged externally. For
+ * high-cardinality keyspaces (per-subscription/per-resource) this table grows with the number of distinct
+ * keys ever seen. This is an operational trade-off, not a correctness one: a stale row simply refills to
+ * full on its next touch, exactly like a fresh bucket, so retention never affects rate-limit decisions.
  */
 @CustomLog
 @Repository("tokenBucketRateLimitRepository")

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepository.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.ratelimit;
+
+import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
+import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.isSqlServer;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketCalculator;
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.reactivex.rxjava3.core.Single;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Supplier;
+import javax.sql.DataSource;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * JDBC-backed {@link TokenBucketRateLimitRepository}. Per request it opens a connection, turns
+ * <strong>auto-commit off</strong>, takes a row lock with {@code SELECT ... FOR UPDATE} (a
+ * {@code WITH (UPDLOCK, HOLDLOCK)} hint on SQL Server, which lacks ANSI {@code FOR UPDATE}),
+ * refills/consumes via {@link TokenBucketCalculator}, writes the row back and commits — all on that
+ * same connection. The row lock serialises concurrent requests on a key so the bucket cannot be
+ * over-consumed.
+ *
+ * <p>The connection and transaction are managed explicitly rather than relying on an ambient Spring
+ * transaction: a {@code SELECT ... FOR UPDATE} executed in auto-commit mode releases its lock the
+ * instant the statement returns, which provides no serialisation at all and silently over-admits
+ * under concurrency. Owning the connection here guarantees the lock is held across the whole
+ * read-modify-write regardless of how the surrounding context wires its transaction manager.
+ *
+ * <p>The first request for a key has no row to lock, so a concurrent insert can lose the race with a
+ * duplicate-key error; that is retried, and the retry locks the now-existing row.
+ */
+@CustomLog
+@Repository("tokenBucketRateLimitRepository")
+public class JdbcTokenBucketRateLimitRepository implements TokenBucketRateLimitRepository<TokenBucket> {
+
+    private static final int MAX_INSERT_RETRIES = 5;
+
+    /** Upper bound on each statement, preserved from the previous transaction-template timeout so a request cannot block indefinitely on the row lock. */
+    private static final int STATEMENT_TIMEOUT_SECONDS = 5;
+
+    /** SQLState class 23 == integrity constraint violation; a primary-key clash on first insert lands here. */
+    private static final String INTEGRITY_VIOLATION_SQLSTATE_CLASS = "23";
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private final String selectForUpdateSql;
+    private final String selectSqlServerSql;
+    private final String insertSql;
+    private final String updateSql;
+
+    public JdbcTokenBucketRateLimitRepository(@Value("${ratelimit.jdbc.prefix:}") String tablePrefix) {
+        String table = tablePrefix + "tokenbucket";
+        String key = escapeReservedWord("key");
+        String columns = key + ", tokens, last_refill, subscription";
+        this.selectForUpdateSql = "select " + columns + " from " + table + " where " + key + " = ? for update";
+        this.selectSqlServerSql = "select " + columns + " from " + table + " with (updlock, holdlock) where " + key + " = ?";
+        this.insertSql = "insert into " + table + " (" + key + ", tokens, last_refill, subscription) values (?, ?, ?, ?)";
+        this.updateSql = "update " + table + " set tokens = ?, last_refill = ?, subscription = ? where " + key + " = ?";
+    }
+
+    @Override
+    public Single<TokenBucketConsumeResult> refillAndTryConsume(
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        Supplier<TokenBucket> supplier
+    ) {
+        return Single.fromCallable(() ->
+            consumeWithRetry(key, tokensRequested, refillRate, refillPeriodMillis, capacity, nowMillis, supplier)
+        );
+    }
+
+    private TokenBucketConsumeResult consumeWithRetry(
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        Supplier<TokenBucket> supplier
+    ) throws SQLException {
+        for (int attempt = 0; ; attempt++) {
+            try {
+                return consumeInTransaction(key, tokensRequested, refillRate, refillPeriodMillis, capacity, nowMillis, supplier);
+            } catch (SQLException e) {
+                // Another request inserted this key first; retry — the row now exists and the locking
+                // SELECT will serialise on it.
+                if (isIntegrityViolation(e) && attempt < MAX_INSERT_RETRIES) {
+                    continue;
+                }
+                throw e;
+            }
+        }
+    }
+
+    private TokenBucketConsumeResult consumeInTransaction(
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        Supplier<TokenBucket> supplier
+    ) throws SQLException {
+        final DataSource dataSource = jdbcTemplate.getDataSource();
+        try (Connection connection = dataSource.getConnection()) {
+            final boolean previousAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try {
+                TokenBucket bucket = selectForUpdate(connection, key);
+                boolean isNew = bucket == null;
+                if (isNew) {
+                    bucket = TokenBucketCalculator.newFullBucket(supplier.get(), capacity, nowMillis);
+                }
+
+                TokenBucketConsumeResult result = TokenBucketCalculator.refillAndTryConsume(
+                    bucket,
+                    tokensRequested,
+                    refillRate,
+                    refillPeriodMillis,
+                    capacity,
+                    nowMillis
+                );
+
+                if (isNew) {
+                    insert(connection, key, bucket);
+                } else {
+                    update(connection, key, bucket);
+                }
+                connection.commit();
+                return result;
+            } catch (SQLException | RuntimeException e) {
+                connection.rollback();
+                throw e;
+            } finally {
+                connection.setAutoCommit(previousAutoCommit);
+            }
+        }
+    }
+
+    private TokenBucket selectForUpdate(Connection connection, String key) throws SQLException {
+        try (PreparedStatement ps = connection.prepareStatement(isSqlServer() ? selectSqlServerSql : selectForUpdateSql)) {
+            ps.setQueryTimeout(STATEMENT_TIMEOUT_SECONDS);
+            ps.setString(1, key);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    return null;
+                }
+                TokenBucket bucket = new TokenBucket(rs.getString(1));
+                bucket.setTokens(rs.getLong(2));
+                bucket.setLastRefillTime(rs.getLong(3));
+                bucket.setSubscription(rs.getString(4));
+                return bucket;
+            }
+        }
+    }
+
+    private void insert(Connection connection, String key, TokenBucket bucket) throws SQLException {
+        try (PreparedStatement ps = connection.prepareStatement(insertSql)) {
+            ps.setQueryTimeout(STATEMENT_TIMEOUT_SECONDS);
+            ps.setString(1, key);
+            ps.setLong(2, bucket.getTokens());
+            ps.setLong(3, bucket.getLastRefillTime());
+            ps.setString(4, bucket.getSubscription());
+            ps.executeUpdate();
+        }
+    }
+
+    private void update(Connection connection, String key, TokenBucket bucket) throws SQLException {
+        try (PreparedStatement ps = connection.prepareStatement(updateSql)) {
+            ps.setQueryTimeout(STATEMENT_TIMEOUT_SECONDS);
+            ps.setLong(1, bucket.getTokens());
+            ps.setLong(2, bucket.getLastRefillTime());
+            ps.setString(3, bucket.getSubscription());
+            ps.setString(4, key);
+            ps.executeUpdate();
+        }
+    }
+
+    private static boolean isIntegrityViolation(SQLException e) {
+        for (SQLException current = e; current != null; current = current.getNextException()) {
+            String sqlState = current.getSQLState();
+            if (sqlState != null && sqlState.startsWith(INTEGRITY_VIOLATION_SQLSTATE_CLASS)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/20_add_tokenbucket_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/20_add_tokenbucket_table.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_add_tokenbucket_table
+      author: GraviteeSource Team
+      changes:
+        - createTable:
+            tableName: ${gravitee_rate_limit_prefix}tokenbucket
+            columns:
+              - column: {name: key, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_rate_limit_prefix}tokenbucket" } }
+              - column: {name: tokens, type: bigint, constraints: { nullable: false } }
+              - column: {name: last_refill, type: bigint, constraints: { nullable: false } }
+              - column: {name: subscription, type: nvarchar(256), constraints: { nullable: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/20_add_tokenbucket_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/20_add_tokenbucket_table.yml
@@ -6,7 +6,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_rate_limit_prefix}tokenbucket
             columns:
-              - column: {name: key, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_rate_limit_prefix}tokenbucket" } }
+              - column: {name: key, type: nvarchar(128), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_rate_limit_prefix}tokenbucket" } }
               - column: {name: tokens, type: bigint, constraints: { nullable: false } }
               - column: {name: last_refill, type: bigint, constraints: { nullable: false } }
               - column: {name: subscription, type: nvarchar(256), constraints: { nullable: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -383,3 +383,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/18_add_portal_navigation_to_portals.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/19_add_api_product_tags_table.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/20_add_tokenbucket_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcPortalNotificationConfigRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcPortalNotificationConfigRepositoryTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.jdbc.management;
 
+import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.setEscapeReservedWordFromDatabaseType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -47,6 +48,9 @@ public class JdbcPortalNotificationConfigRepositoryTest {
     @BeforeEach
     @SneakyThrows
     void setUp() {
+        // generateQuery asserts backtick escaping; pin the process-global SQL dialect so it can't be
+        // left as '"' by a prior Postgres-context test running earlier in the JVM.
+        setEscapeReservedWordFromDatabaseType("mariadb");
         jdbcTemplate = mock(JdbcTemplate.class);
         Field field = JdbcAbstractRepository.class.getDeclaredField("jdbcTemplate");
         field.setAccessible(true);

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepositoryTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.ratelimit;
+
+import io.gravitee.repository.jdbc.JdbcTestRepositoryConfiguration;
+import io.gravitee.repository.ratelimit.AbstractTokenBucketRateLimitRepositoryContractTest;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import java.sql.Connection;
+import java.util.Properties;
+import javax.sql.DataSource;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Runs the shared {@link AbstractTokenBucketRateLimitRepositoryContractTest} against a JDBC database.
+ * Boots the standard JDBC test context (a database container + the component-scanned repository) and
+ * applies the Liquibase schema once, with the same prefixes the repository reads so the table names
+ * line up. The database is selected by the {@code jdbcType} property (PostgreSQL by default). No
+ * per-test cleanup is needed: the container is fresh and the contract suite uses a distinct key per test.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = JdbcTestRepositoryConfiguration.class)
+class JdbcTokenBucketRateLimitRepositoryTest extends AbstractTokenBucketRateLimitRepositoryContractTest {
+
+    private static volatile boolean schemaReady = false;
+
+    @Autowired
+    private TokenBucketRateLimitRepository<TokenBucket> tokenBucketRepository;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private Properties graviteeProperties;
+
+    @Override
+    protected TokenBucketRateLimitRepository<TokenBucket> createRepository() {
+        ensureSchema();
+        return tokenBucketRepository;
+    }
+
+    private synchronized void ensureSchema() {
+        if (schemaReady) {
+            return;
+        }
+        String managementPrefix = graviteeProperties.getProperty("management.jdbc.prefix", "");
+        String rateLimitPrefix = graviteeProperties.getProperty("ratelimit.jdbc.prefix", "");
+        System.setProperty("liquibase.databaseChangeLogTableName", managementPrefix + "databasechangelog");
+        System.setProperty("liquibase.databaseChangeLogLockTableName", managementPrefix + "databasechangeloglock");
+        System.setProperty("gravitee_prefix", managementPrefix);
+        System.setProperty("gravitee_rate_limit_prefix", rateLimitPrefix);
+
+        try (Connection connection = dataSource.getConnection()) {
+            new Liquibase(
+                "liquibase/master.yml",
+                new ClassLoaderResourceAccessor(getClass().getClassLoader()),
+                new JdbcConnection(connection)
+            ).update((Contexts) null);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to set up the JDBC schema via Liquibase", e);
+        }
+        schemaReady = true;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
@@ -172,6 +172,13 @@
         <!-- Test scope -->
         <dependency>
             <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
             <artifactId>gravitee-apim-repository-test</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/ratelimit/MongoTokenBucketRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/ratelimit/MongoTokenBucketRateLimitRepository.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.ratelimit;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketCalculator;
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.reactivex.rxjava3.core.Single;
+import java.util.Date;
+import java.util.function.Supplier;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
+import org.springframework.data.mongodb.core.ReactiveMongoOperations;
+import org.springframework.data.mongodb.core.aggregation.AggregationExpression;
+import org.springframework.data.mongodb.core.aggregation.AggregationUpdate;
+import org.springframework.data.mongodb.core.aggregation.ArithmeticOperators;
+import org.springframework.data.mongodb.core.aggregation.ComparisonOperators;
+import org.springframework.data.mongodb.core.aggregation.ConditionalOperators;
+import org.springframework.data.mongodb.core.aggregation.ConvertOperators;
+import org.springframework.data.mongodb.core.aggregation.SetOperation;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import reactor.adapter.rxjava.RxJava3Adapter;
+
+/**
+ * MongoDB-backed {@link TokenBucketRateLimitRepository}. Refill-and-consume is a single atomic
+ * {@code findAndModify} using an aggregation update pipeline, so concurrent requests on a key are
+ * serialised by MongoDB's document-level atomicity without a read-modify-write race.
+ *
+ * <p>Balances are whole tokens (see {@link TokenBucketCalculator}) and the pipeline mirrors that
+ * calculator's integer math server-side. The refill clock is the caller-supplied {@code nowMillis};
+ * the TTL {@code expire_at} uses real wall-clock time, since eviction is a storage concern. The TTL
+ * index itself is created on the rate-limit datastore by {@link RateLimitRepositoryConfiguration}.
+ */
+public class MongoTokenBucketRateLimitRepository implements TokenBucketRateLimitRepository<TokenBucket> {
+
+    static final String COLLECTION = "tokenbucket";
+    static final String FIELD_EXPIRE_AT = "expire_at";
+
+    private static final String FIELD_ID = "_id";
+    private static final String FIELD_TOKENS = "tokens";
+    private static final String FIELD_LAST_REFILL = "last_refill";
+    private static final String FIELD_SUBSCRIPTION = "subscription";
+    // Transient scratch (pre-consume balance): the pipeline sets it so `tokensAfter` can reference it and
+    // toResult can read back whether the request was satisfiable. It must survive into the returned doc
+    // (findAndModify returnNew), so it is not $unset; it is overwritten on every request.
+    private static final String FIELD_REFILLED = "_refilled";
+
+    private final ReactiveMongoOperations mongoOperations;
+    private final String collection;
+
+    public MongoTokenBucketRateLimitRepository(ReactiveMongoOperations mongoOperations, String prefix) {
+        this.mongoOperations = mongoOperations;
+        this.collection = prefix + COLLECTION;
+    }
+
+    @Override
+    public Single<TokenBucketConsumeResult> refillAndTryConsume(
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        Supplier<TokenBucket> supplier
+    ) {
+        TokenBucketCalculator.requireValidArgs(tokensRequested, refillPeriodMillis, capacity);
+
+        String subscription = supplier.get().getSubscription();
+        Date expireAt = new Date(System.currentTimeMillis() + TokenBucketCalculator.ttlMillis(refillRate, refillPeriodMillis, capacity));
+        // Cap the elapsed span (a long-idle bucket never accrues past capacity) so elapsed * refillRate
+        // cannot overflow a 64-bit long for huge idle gaps. A zero rate never refills.
+        long maxUsefulElapsed = refillRate > 0 ? (capacity * refillPeriodMillis) / refillRate + refillPeriodMillis : 0L;
+
+        // The refill anchor, defaulting to now for a missing bucket (so a fresh bucket starts full).
+        AggregationExpression anchor = ConditionalOperators.ifNull(FIELD_LAST_REFILL).then(nowMillis);
+        // elapsed = max(0, now - anchor), expressed via (anchor - now) so the document field is the
+        // operand base: when anchor >= now (out-of-order / no time passed) elapsed is 0, else now - anchor.
+        AggregationExpression anchorMinusNow = ArithmeticOperators.valueOf(anchor).subtract(nowMillis);
+        AggregationExpression elapsed = ConditionalOperators.when(ComparisonOperators.valueOf(anchorMinusNow).greaterThanEqualToValue(0L))
+            .then(0L)
+            .otherwise(ArithmeticOperators.valueOf(anchorMinusNow).multiplyBy(-1));
+        // effectiveElapsed = min(elapsed, maxUsefulElapsed) to bound the multiplication below.
+        AggregationExpression effectiveElapsed = ConditionalOperators.when(
+            ComparisonOperators.valueOf(elapsed).greaterThanValue(maxUsefulElapsed)
+        )
+            .then(maxUsefulElapsed)
+            .otherwise(elapsed);
+        // refillAmount = floor(effectiveElapsed * refillRate / refillPeriodMillis) as a long — whole tokens.
+        // A zero rate yields 0 (no refill).
+        AggregationExpression refillAmount = refillRate <= 0
+            ? (AggregationExpression) context -> new org.bson.Document("$literal", 0L)
+            : ConvertOperators.valueOf(
+                ArithmeticOperators.valueOf(
+                    ArithmeticOperators.valueOf(ArithmeticOperators.valueOf(effectiveElapsed).multiplyBy(refillRate)).divideBy(
+                        refillPeriodMillis
+                    )
+                ).floor()
+            ).convertToLong();
+        // refilled = min(capacity, currentTokens + refillAmount); a missing bucket defaults to full.
+        AggregationExpression currentTokens = ConditionalOperators.ifNull(FIELD_TOKENS).then(capacity);
+        AggregationExpression refilledRaw = ArithmeticOperators.valueOf(currentTokens).add(refillAmount);
+        AggregationExpression refilled = ConditionalOperators.when(ComparisonOperators.valueOf(refilledRaw).greaterThanValue(capacity))
+            .then(capacity)
+            .otherwise(refilledRaw);
+
+        // tokens after consume: subtract when the refilled balance covers the request, otherwise leave it.
+        AggregationExpression tokensAfter = ConditionalOperators.when(
+            ComparisonOperators.valueOf(FIELD_REFILLED).greaterThanEqualToValue(tokensRequested)
+        )
+            .then(ArithmeticOperators.valueOf(FIELD_REFILLED).subtract(tokensRequested))
+            .otherwiseValueOf(FIELD_REFILLED);
+        // Anchor forward to now only once a whole token is credited (refillAmount > 0); otherwise leave it
+        // put so an out-of-order or sub-token elapsed keeps accumulating instead of being discarded or
+        // re-credited (which would over-admit).
+        AggregationExpression nextAnchor = ConditionalOperators.when(ComparisonOperators.valueOf(refillAmount).greaterThanValue(0L))
+            .then(nowMillis)
+            .otherwise(anchor);
+
+        AggregationUpdate update = AggregationUpdate.update()
+            .set(SetOperation.set(FIELD_REFILLED).toValue(refilled))
+            .set(SetOperation.set(FIELD_SUBSCRIPTION).toValue(ConditionalOperators.ifNull(FIELD_SUBSCRIPTION).then(subscription)))
+            .set(SetOperation.set(FIELD_TOKENS).toValue(tokensAfter))
+            .set(SetOperation.set(FIELD_LAST_REFILL).toValue(nextAnchor))
+            .set(SetOperation.set(FIELD_EXPIRE_AT).toValue(expireAt));
+
+        Query query = new Query(Criteria.where(FIELD_ID).is(key));
+        // A single atomic findAndModify(upsert): unlike JDBC (SELECT-then-INSERT, which retries the
+        // first-insert race) there is no select/insert window here, so no E11000 retry is needed — same
+        // pattern as MongoRateLimitRepository.
+        FindAndModifyOptions options = new FindAndModifyOptions().returnNew(true).upsert(true);
+
+        return RxJava3Adapter.monoToSingle(
+            mongoOperations
+                .findAndModify(query, update, options, Document.class, collection)
+                .map(document -> toResult(document, tokensRequested, refillRate, refillPeriodMillis, nowMillis))
+        );
+    }
+
+    private static TokenBucketConsumeResult toResult(
+        Document document,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long nowMillis
+    ) {
+        long refilled = asLong(document, FIELD_REFILLED);
+        long tokensAfter = asLong(document, FIELD_TOKENS);
+        boolean allowed = refilled >= tokensRequested;
+        return new TokenBucketConsumeResult(
+            allowed,
+            tokensAfter,
+            TokenBucketCalculator.nextAvailableAtMillis(tokensAfter, refillRate, refillPeriodMillis, nowMillis)
+        );
+    }
+
+    private static long asLong(Document document, String field) {
+        Object value = document.get(field);
+        if (!(value instanceof Number number)) {
+            throw new IllegalStateException("token-bucket field '" + field + "' is missing or not numeric: " + value);
+        }
+        return number.longValue();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/ratelimit/RateLimitRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/ratelimit/RateLimitRepositoryConfiguration.java
@@ -18,14 +18,18 @@ package io.gravitee.repository.mongodb.ratelimit;
 import io.gravitee.platform.repository.api.Scope;
 import io.gravitee.repository.mongodb.common.MongoFactory;
 import io.gravitee.repository.ratelimit.api.RateLimitRepository;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
 import java.net.URI;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories;
 
 /**
@@ -69,5 +73,21 @@ public class RateLimitRepositoryConfiguration {
     @Bean
     public RateLimitRepository rateLimitRepository() {
         return new MongoRateLimitRepository();
+    }
+
+    @Bean
+    public TokenBucketRateLimitRepository<TokenBucket> tokenBucketRateLimitRepository(
+        @Qualifier("rateLimitMongoTemplate") ReactiveMongoOperations rateLimitMongoTemplate
+    ) {
+        String prefix = environment.getProperty("ratelimit.mongodb.prefix", "");
+        // Evict idle buckets via a TTL index on expire_at. Created here on the rate-limit datastore —
+        // the only place this collection lives — mirroring MongoRateLimitRepository's gateway-side TTL
+        // index. The management upgrader framework runs against the management datastore, so it cannot
+        // create indexes here.
+        rateLimitMongoTemplate
+            .indexOps(prefix + MongoTokenBucketRateLimitRepository.COLLECTION)
+            .ensureIndex(new Index(MongoTokenBucketRateLimitRepository.FIELD_EXPIRE_AT, Sort.Direction.ASC).expire(0L))
+            .subscribe();
+        return new MongoTokenBucketRateLimitRepository(rateLimitMongoTemplate, prefix);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/ratelimit/MongoTokenBucketRateLimitRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/ratelimit/MongoTokenBucketRateLimitRepositoryTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import io.gravitee.repository.ratelimit.AbstractTokenBucketRateLimitRepositoryContractTest;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import java.util.Date;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Runs the shared {@link AbstractTokenBucketRateLimitRepositoryContractTest} against MongoDB. A
+ * single container is started for the class; the collection is dropped before each test so every
+ * test sees an empty store.
+ */
+class MongoTokenBucketRateLimitRepositoryTest extends AbstractTokenBucketRateLimitRepositoryContractTest {
+
+    private static final String DATABASE = "gravitee-test";
+
+    private static MongoDBContainer mongoContainer;
+    private static MongoClient mongoClient;
+
+    @BeforeAll
+    static void startMongo() {
+        mongoContainer = new MongoDBContainer(DockerImageName.parse("mongo:6.0"));
+        mongoContainer.start();
+        mongoClient = MongoClients.create(mongoContainer.getReplicaSetUrl());
+    }
+
+    @AfterAll
+    static void stopMongo() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+        if (mongoContainer != null) {
+            mongoContainer.stop();
+        }
+    }
+
+    private ReactiveMongoTemplate template;
+
+    @Override
+    protected TokenBucketRateLimitRepository<TokenBucket> createRepository() {
+        template = new ReactiveMongoTemplate(mongoClient, DATABASE);
+        template.dropCollection("tokenbucket").block();
+        return new MongoTokenBucketRateLimitRepository(template, "");
+    }
+
+    @Test
+    void sets_expire_at_to_the_full_refill_window() {
+        long before = System.currentTimeMillis();
+        // capacity 100 at 2 tokens per 1000ms => the bucket would refill fully in 50s, so the entry is
+        // given an expire_at ~50s out: long enough that it is never evicted before it would be full.
+        repository.refillAndTryConsume("ttl", 1, 2, 1_000L, 100, before, () -> new TokenBucket("ttl")).blockingGet();
+
+        Document stored = template.findById("ttl", Document.class, "tokenbucket").block();
+        assertThat(stored).isNotNull();
+        assertThat(stored.getDate("expire_at")).isBetween(new Date(before + 49_000L), new Date(before + 60_000L));
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpRateLimitRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpRateLimitRepositoryConfiguration.java
@@ -16,8 +16,11 @@
 package io.gravitee.repository.noop;
 
 import io.gravitee.repository.noop.ratelimit.NoOpRateLimitRepository;
+import io.gravitee.repository.noop.ratelimit.NoOpTokenBucketRateLimitRepository;
 import io.gravitee.repository.ratelimit.api.RateLimitRepository;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
 import io.gravitee.repository.ratelimit.model.RateLimit;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -31,5 +34,10 @@ public class NoOpRateLimitRepositoryConfiguration {
     @Bean
     public RateLimitRepository<RateLimit> rateLimitRepository() {
         return new NoOpRateLimitRepository();
+    }
+
+    @Bean
+    public TokenBucketRateLimitRepository<TokenBucket> tokenBucketRateLimitRepository() {
+        return new NoOpTokenBucketRateLimitRepository();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/ratelimit/NoOpTokenBucketRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/ratelimit/NoOpTokenBucketRateLimitRepository.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop.ratelimit;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.reactivex.rxjava3.core.Single;
+import java.util.function.Supplier;
+
+/**
+ * No-op {@link TokenBucketRateLimitRepository}: rate limiting is disabled. Mirrors
+ * {@link NoOpRateLimitRepository} by returning {@code null}, which the policy treats as
+ * "no enforcement" (pass-through).
+ *
+ * @author GraviteeSource Team
+ */
+public class NoOpTokenBucketRateLimitRepository implements TokenBucketRateLimitRepository<TokenBucket> {
+
+    @Override
+    public Single<TokenBucketConsumeResult> refillAndTryConsume(
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        Supplier<TokenBucket> supplier
+    ) {
+        return null;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/ratelimit/NoOpTokenBucketRateLimitRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/ratelimit/NoOpTokenBucketRateLimitRepositoryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop.ratelimit;
+
+import static org.junit.Assert.*;
+
+import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.reactivex.rxjava3.core.Single;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class NoOpTokenBucketRateLimitRepositoryTest extends AbstractNoOpRepositoryTest {
+
+    @Autowired
+    private TokenBucketRateLimitRepository<TokenBucket> cut;
+
+    @Test
+    public void refillAndTryConsume() {
+        Single<TokenBucketConsumeResult> result = cut.refillAndTryConsume("test_key", 1L, 10L, 1_000L, 100L, 1_000L, () ->
+            new TokenBucket("test_key")
+        );
+
+        assertNull(result);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/pom.xml
@@ -111,6 +111,14 @@
 
 		<!-- Test scope -->
 		<dependency>
+			<groupId>io.gravitee.apim.repository</groupId>
+			<artifactId>gravitee-apim-repository-api</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 			<scope>test</scope>

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RateLimitRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RateLimitRepositoryConfiguration.java
@@ -16,6 +16,8 @@
 package io.gravitee.repository.redis.ratelimit;
 
 import io.gravitee.platform.repository.api.Scope;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
 import io.gravitee.repository.redis.common.RedisConnectionFactory;
 import io.gravitee.repository.redis.vertx.RedisClient;
 import io.vertx.core.Vertx;
@@ -33,6 +35,8 @@ public class RateLimitRepositoryConfiguration {
 
     public static final String SCRIPT_RATELIMIT_KEY = "ratelimit";
     public static final String SCRIPTS_RATELIMIT_LUA = "scripts/ratelimit/ratelimit.lua";
+    public static final String SCRIPT_TOKEN_BUCKET_KEY = "token-bucket";
+    public static final String SCRIPTS_TOKEN_BUCKET_LUA = "scripts/token-bucket/token-bucket.lua";
 
     @Bean("redisRateLimitClient")
     public RedisClient redisRedisClient(Environment environment, Vertx vertx) {
@@ -40,7 +44,7 @@ public class RateLimitRepositoryConfiguration {
             environment,
             vertx,
             Scope.RATE_LIMIT.getName(),
-            Map.of(SCRIPT_RATELIMIT_KEY, SCRIPTS_RATELIMIT_LUA)
+            Map.of(SCRIPT_RATELIMIT_KEY, SCRIPTS_RATELIMIT_LUA, SCRIPT_TOKEN_BUCKET_KEY, SCRIPTS_TOKEN_BUCKET_LUA)
         ).createRedisClient();
     }
 
@@ -50,5 +54,13 @@ public class RateLimitRepositoryConfiguration {
         @Value("${ratelimit.redis.operation.timeout:10}") int operationTimeout
     ) {
         return new RedisRateLimitRepository(redisClient, operationTimeout);
+    }
+
+    @Bean
+    public TokenBucketRateLimitRepository<TokenBucket> tokenBucketRateLimitRepository(
+        @Qualifier("redisRateLimitClient") RedisClient redisClient,
+        @Value("${ratelimit.redis.operation.timeout:10}") int operationTimeout
+    ) {
+        return new RedisTokenBucketRateLimitRepository(redisClient, operationTimeout);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisTokenBucketRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisTokenBucketRateLimitRepository.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.ratelimit;
+
+import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPT_TOKEN_BUCKET_KEY;
+
+import io.gravitee.repository.exception.RedisNotConnectedException;
+import io.gravitee.repository.exception.RedisOperationTimeoutException;
+import io.gravitee.repository.ratelimit.api.TokenBucketCalculator;
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.gravitee.repository.redis.vertx.RedisClient;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.redis.client.Response;
+import io.vertx.rxjava3.SingleHelper;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import lombok.CustomLog;
+
+/**
+ * Redis-backed {@link TokenBucketRateLimitRepository}. Refill-and-consume is a single atomic Lua
+ * script ({@code token-bucket.lua}) executed via {@code EVALSHA}, with the same {@code NOSCRIPT} ->
+ * {@code EVAL} fallback as the rate-limit repository so it is correct on Redis Cluster.
+ */
+@CustomLog
+public class RedisTokenBucketRateLimitRepository implements TokenBucketRateLimitRepository<TokenBucket> {
+
+    private static final String REDIS_KEY_PREFIX = "tokenbucket:";
+
+    private static final String NOSCRIPT_PREFIX = "NOSCRIPT";
+
+    private final RedisClient redisClient;
+    private final int operationTimeout;
+    private final AtomicLong operationFailureCounter;
+
+    public RedisTokenBucketRateLimitRepository(final RedisClient redisClient, int operationTimeout) {
+        this.redisClient = redisClient;
+        this.operationTimeout = operationTimeout;
+        this.operationFailureCounter = new AtomicLong(0);
+    }
+
+    @Override
+    public Single<TokenBucketConsumeResult> refillAndTryConsume(
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        Supplier<TokenBucket> supplier
+    ) {
+        TokenBucketCalculator.requireValidArgs(tokensRequested, refillPeriodMillis, capacity);
+        if (!redisClient.isConnected()) {
+            return Single.error(new RedisNotConnectedException());
+        }
+
+        String subscription = supplier.get().getSubscription();
+        long expireAt = System.currentTimeMillis() + TokenBucketCalculator.ttlMillis(refillRate, refillPeriodMillis, capacity);
+        String redisKey = REDIS_KEY_PREFIX + key;
+
+        return SingleHelper.toSingle(
+            (Consumer<Handler<AsyncResult<Response>>>) asyncResultHandler ->
+                redisClient
+                    .redisApi()
+                    .flatMap(redisAPI ->
+                        redisAPI
+                            .evalsha(
+                                args(
+                                    redisClient.scriptSha1(SCRIPT_TOKEN_BUCKET_KEY),
+                                    redisKey,
+                                    tokensRequested,
+                                    refillRate,
+                                    refillPeriodMillis,
+                                    capacity,
+                                    nowMillis,
+                                    subscription,
+                                    expireAt
+                                )
+                            )
+                            .recover(t -> {
+                                if (!isNoScript(t)) {
+                                    return Future.failedFuture(t);
+                                }
+                                final String source = redisClient.scriptSource(SCRIPT_TOKEN_BUCKET_KEY);
+                                if (source == null) {
+                                    return Future.failedFuture(
+                                        new IllegalStateException(
+                                            "Cannot recover from NOSCRIPT: token-bucket script source unavailable (script was never loaded)"
+                                        )
+                                    );
+                                }
+                                // On Redis Cluster, SCRIPT LOAD only reaches the contacted node; an EVALSHA routed by
+                                // hash slot to another master returns NOSCRIPT. NOSCRIPT means the script did not run,
+                                // so replaying via EVAL (which caches it on that node) cannot double-consume.
+                                log.debug(
+                                    "EVALSHA returned NOSCRIPT; falling back to EVAL to load the token-bucket script on the target node"
+                                );
+                                return redisAPI
+                                    .eval(
+                                        args(
+                                            source,
+                                            redisKey,
+                                            tokensRequested,
+                                            refillRate,
+                                            refillPeriodMillis,
+                                            capacity,
+                                            nowMillis,
+                                            subscription,
+                                            expireAt
+                                        )
+                                    )
+                                    .recover(evalError -> {
+                                        evalError.addSuppressed(t);
+                                        return Future.failedFuture(evalError);
+                                    });
+                            })
+                    )
+                    .onFailure(this::logOperationFailure)
+                    .onComplete(asyncResultHandler)
+        )
+            .map(response -> {
+                boolean allowed = response.get(0).toLong() == 1L;
+                long newTokens = response.get(1).toLong();
+                return new TokenBucketConsumeResult(
+                    allowed,
+                    newTokens,
+                    TokenBucketCalculator.nextAvailableAtMillis(newTokens, refillRate, refillPeriodMillis, nowMillis)
+                );
+            })
+            .timeout(operationTimeout, TimeUnit.MILLISECONDS, Single.error(new RedisOperationTimeoutException(operationTimeout)));
+    }
+
+    // numkeys is "1": only the bucket key is a KEY, so all keys touched share one hash slot.
+    // scriptRef is a SHA on the EVALSHA path and the script source on the EVAL fallback path.
+    static List<String> args(
+        String scriptRef,
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long now,
+        String subscription,
+        long expireAt
+    ) {
+        return Arrays.asList(
+            scriptRef,
+            "1", // numkeys
+            key,
+            Long.toString(tokensRequested),
+            Long.toString(refillRate),
+            Long.toString(refillPeriodMillis),
+            Long.toString(capacity),
+            Long.toString(now),
+            subscription == null ? "" : subscription,
+            Long.toString(expireAt)
+        );
+    }
+
+    // package-private for direct unit testing of the cause-chain matcher
+    static boolean isNoScript(Throwable t) {
+        int depth = 0;
+        for (Throwable cause = t; cause != null && depth < 20; cause = cause.getCause(), depth++) {
+            String message = cause.getMessage();
+            if (message != null && message.stripLeading().regionMatches(true, 0, NOSCRIPT_PREFIX, 0, NOSCRIPT_PREFIX.length())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void logOperationFailure(Throwable t) {
+        long failureCount = operationFailureCounter.getAndIncrement();
+        if (failureCount < 10) {
+            log.warn("Failed to run token-bucket script on Redis {}", t.getMessage());
+        } else if (failureCount % 10000 == 0) {
+            log.warn("Failed to run token-bucket script on Redis {} ({} times)", t.getMessage(), failureCount);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/resources/scripts/token-bucket/token-bucket.lua
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/resources/scripts/token-bucket/token-bucket.lua
@@ -14,7 +14,8 @@ local expireAt = tonumber(ARGV[7]) -- PEXPIREAT target, epoch millis (real clock
 local tokens = tonumber(redis.call('HGET', key, 'tokens'))
 local lastRefill = tonumber(redis.call('HGET', key, 'last_refill'))
 
--- A fresh bucket starts full.
+-- A new bucket is initialised at capacity so a first-time consumer can burst immediately,
+-- without waiting for tokens to accrue.
 if tokens == nil then
     tokens = capacity
     lastRefill = now

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/resources/scripts/token-bucket/token-bucket.lua
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/resources/scripts/token-bucket/token-bucket.lua
@@ -1,0 +1,57 @@
+-- Atomic token-bucket refill-and-consume.
+-- KEYS[1] is the only key so all touched keys share one Redis Cluster hash slot (avoids CROSSSLOT);
+-- everything else is passed as ARGV. Balances are whole tokens; the rate is refillRate tokens per
+-- refillPeriod ms, so all refill arithmetic is integer, matching the Java TokenBucketCalculator.
+local key = KEYS[1]
+local requested = tonumber(ARGV[1]) -- whole tokens to consume
+local refillRate = tonumber(ARGV[2]) -- whole tokens added per refill period (0 disables refill)
+local refillPeriod = tonumber(ARGV[3]) -- refill period, in milliseconds
+local capacity = tonumber(ARGV[4]) -- burst capacity, whole tokens
+local now = tonumber(ARGV[5]) -- caller clock, epoch millis
+local subscription = ARGV[6]
+local expireAt = tonumber(ARGV[7]) -- PEXPIREAT target, epoch millis (real clock)
+
+local tokens = tonumber(redis.call('HGET', key, 'tokens'))
+local lastRefill = tonumber(redis.call('HGET', key, 'last_refill'))
+
+-- A fresh bucket starts full.
+if tokens == nil then
+    tokens = capacity
+    lastRefill = now
+end
+
+-- Whole tokens accrued = floor(elapsed * refillRate / refillPeriod). Elapsed is clamped to 0 (out-of-order
+-- timestamps never accrue negatively) and capped (a long-idle bucket never accrues past capacity) so the
+-- multiplication stays exact in Lua's number type.
+local elapsed = now - lastRefill
+if elapsed < 0 then
+    elapsed = 0
+end
+local newLast = lastRefill
+if refillRate > 0 and refillPeriod > 0 then
+    local maxUsefulElapsed = math.floor(capacity * refillPeriod / refillRate) + refillPeriod
+    if elapsed > maxUsefulElapsed then
+        elapsed = maxUsefulElapsed
+    end
+    local refill = math.floor(elapsed * refillRate / refillPeriod)
+    if refill > 0 then
+        tokens = tokens + refill
+        if tokens > capacity then
+            tokens = capacity
+        end
+        -- Anchor forward to now only once a whole token is credited; until then the elapsed time keeps
+        -- accumulating against the unchanged anchor (no accrual lost, no re-credit). Mirrors the calculator.
+        newLast = now
+    end
+end
+
+local allowed = 0
+if tokens >= requested then
+    tokens = tokens - requested
+    allowed = 1
+end
+
+redis.call('HSET', key, 'tokens', tokens, 'last_refill', newLast, 'subscription', subscription)
+redis.call('PEXPIREAT', key, expireAt)
+
+return { allowed, tokens }

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisTokenBucketRateLimitRepositoryFallbackTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisTokenBucketRateLimitRepositoryFallbackTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.gravitee.repository.redis.vertx.RedisClient;
+import io.vertx.core.Future;
+import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.Response;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Mock-based coverage of the token-bucket Redis repository's {@code NOSCRIPT -> EVAL} Redis-Cluster
+ * fallback and the {@code isNoScript} cause-chain matcher — neither is exercised by the container test
+ * (which only hits the EVALSHA happy path).
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisTokenBucketRateLimitRepositoryFallbackTest {
+
+    @Test
+    void falls_back_to_eval_when_cluster_node_returns_noscript() {
+        RedisClient redisClient = mock(RedisClient.class);
+        RedisAPI redisAPI = mock(RedisAPI.class);
+
+        when(redisClient.isConnected()).thenReturn(true);
+        when(redisClient.scriptSha1("token-bucket")).thenReturn("the-sha");
+        when(redisClient.scriptSource("token-bucket")).thenReturn("the-script-source");
+        when(redisClient.redisApi()).thenReturn(Future.succeededFuture(redisAPI));
+        // EVALSHA fails: the slot's master never received the SCRIPT LOAD (NOSCRIPT = script did not run).
+        when(redisAPI.evalsha(anyList())).thenReturn(Future.failedFuture(new RuntimeException("NOSCRIPT No matching script")));
+        // EVAL with the source succeeds; the Lua returns { allowed = 1, tokens = 5 }.
+        // Build the response mock first — calling a stubbing method inside when(...) breaks Mockito.
+        Response evalResponse = consumeResponse(1L, 5L);
+        when(redisAPI.eval(anyList())).thenReturn(Future.succeededFuture(evalResponse));
+
+        var repository = new RedisTokenBucketRateLimitRepository(redisClient, 2000);
+        TokenBucketConsumeResult result = repository
+            .refillAndTryConsume("my-key", 1, 10, 1_000L, 20, 1_000L, () -> new TokenBucket("my-key"))
+            .blockingGet();
+
+        // Result is mapped from the fallback EVAL response, not the supplier default.
+        assertThat(result.allowed()).isTrue();
+        assertThat(result.remainingTokens()).isEqualTo(5L);
+        // The fallback EVAL must carry the script SOURCE (first ARGV), not the SHA.
+        verify(redisAPI).eval(argThatStartsWith("the-script-source"));
+    }
+
+    @Test
+    void propagates_non_noscript_errors_without_falling_back_to_eval() {
+        RedisClient redisClient = mock(RedisClient.class);
+        RedisAPI redisAPI = mock(RedisAPI.class);
+
+        when(redisClient.isConnected()).thenReturn(true);
+        when(redisClient.scriptSha1("token-bucket")).thenReturn("the-sha");
+        when(redisClient.redisApi()).thenReturn(Future.succeededFuture(redisAPI));
+        // A non-NOSCRIPT error (e.g. LOADING) must NOT trigger an EVAL replay — the script may have run.
+        when(redisAPI.evalsha(anyList())).thenReturn(Future.failedFuture(new RuntimeException("LOADING Redis is loading the dataset")));
+
+        var repository = new RedisTokenBucketRateLimitRepository(redisClient, 2000);
+
+        assertThatThrownBy(() ->
+            repository.refillAndTryConsume("my-key", 1, 10, 1_000L, 20, 1_000L, () -> new TokenBucket("my-key")).blockingGet()
+        ).hasMessageContaining("LOADING");
+        verify(redisAPI, never()).eval(anyList());
+    }
+
+    @Test
+    void isNoScript_matches_through_the_cause_chain_only() {
+        assertThat(RedisTokenBucketRateLimitRepository.isNoScript(new RuntimeException("NOSCRIPT No matching script"))).isTrue();
+        assertThat(
+            RedisTokenBucketRateLimitRepository.isNoScript(new RuntimeException("wrapper", new IllegalStateException("NOSCRIPT x")))
+        ).isTrue();
+        assertThat(RedisTokenBucketRateLimitRepository.isNoScript(new RuntimeException("LOADING dataset"))).isFalse();
+        assertThat(RedisTokenBucketRateLimitRepository.isNoScript(new RuntimeException((String) null))).isFalse();
+    }
+
+    private static Response consumeResponse(long allowed, long tokens) {
+        Response allowedField = longResponse(allowed);
+        Response tokensField = longResponse(tokens);
+        Response r = mock(Response.class);
+        when(r.get(0)).thenReturn(allowedField);
+        when(r.get(1)).thenReturn(tokensField);
+        return r;
+    }
+
+    private static Response longResponse(long value) {
+        Response r = mock(Response.class);
+        when(r.toLong()).thenReturn(value);
+        return r;
+    }
+
+    private static List<String> argThatStartsWith(String first) {
+        return org.mockito.ArgumentMatchers.argThat(list -> list != null && !list.isEmpty() && first.equals(list.get(0)));
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisTokenBucketRateLimitRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisTokenBucketRateLimitRepositoryTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.ratelimit;
+
+import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPTS_TOKEN_BUCKET_LUA;
+import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPT_TOKEN_BUCKET_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import io.gravitee.platform.repository.api.Scope;
+import io.gravitee.repository.ratelimit.AbstractTokenBucketRateLimitRepositoryContractTest;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.gravitee.repository.redis.common.RedisConnectionFactory;
+import io.gravitee.repository.redis.vertx.RedisClient;
+import io.vertx.core.Vertx;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.mock.env.MockEnvironment;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Runs the shared {@link AbstractTokenBucketRateLimitRepositoryContractTest} against a standalone
+ * Redis. Each test flushes the database first so it sees an empty store. Requires a Docker daemon;
+ * skipped (not failed) when none is available.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedisTokenBucketRateLimitRepositoryTest extends AbstractTokenBucketRateLimitRepositoryContractTest {
+
+    private final Vertx vertx = Vertx.vertx();
+    private GenericContainer<?> redis;
+    private RedisClient redisClient;
+    private RedisTokenBucketRateLimitRepository repo;
+
+    @BeforeAll
+    void startRedis() throws Exception {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker not available — skipping Redis token-bucket test");
+        redis = new GenericContainer<>(DockerImageName.parse("redis:7.4")).withExposedPorts(6379).waitingFor(Wait.forListeningPort());
+        redis.start();
+
+        String prefix = Scope.RATE_LIMIT.getName() + ".redis.";
+        MockEnvironment env = new MockEnvironment();
+        env.setProperty(prefix + "host", redis.getHost());
+        env.setProperty(prefix + "port", String.valueOf(redis.getMappedPort(6379)));
+
+        redisClient = new RedisConnectionFactory(
+            env,
+            vertx,
+            Scope.RATE_LIMIT.getName(),
+            Map.of(SCRIPT_TOKEN_BUCKET_KEY, SCRIPTS_TOKEN_BUCKET_LUA)
+        ).createRedisClient();
+        awaitConnected(redisClient);
+
+        repo = new RedisTokenBucketRateLimitRepository(redisClient, 5000);
+    }
+
+    @AfterAll
+    void stopRedis() {
+        if (redis != null) {
+            redis.stop();
+        }
+        vertx.close();
+    }
+
+    @Override
+    protected TokenBucketRateLimitRepository<TokenBucket> createRepository() {
+        flushAll();
+        return repo;
+    }
+
+    @Test
+    void sets_key_ttl_to_the_full_refill_window() throws Exception {
+        // capacity 100 at 2 tokens per 1000ms => the bucket would refill fully in 50s, so the key gets a ~50s TTL.
+        repo.refillAndTryConsume("ttl", 1, 2, 1_000L, 100, System.currentTimeMillis(), () -> new TokenBucket("ttl")).blockingGet();
+
+        long pttl = Long.parseLong(redis.execInContainer("redis-cli", "pttl", "tokenbucket:ttl").getStdout().trim());
+        assertThat(pttl).isBetween(45_000L, 51_000L);
+    }
+
+    private void flushAll() {
+        try {
+            redis.execInContainer("redis-cli", "flushall");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to flush Redis between tests", e);
+        }
+    }
+
+    private static void awaitConnected(RedisClient client) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (!client.isConnected() && System.currentTimeMillis() < deadline) {
+            TimeUnit.MILLISECONDS.sleep(200);
+        }
+        assertThat(client.isConnected()).as("Redis client connected").isTrue();
+    }
+}


### PR DESCRIPTION
## What

Implements `TokenBucketRateLimitRepository` across **all five** rate-limit storage backends. Stacked on the contract PR #18056 (APIM-14482); this PR's diff is the backends only.

Implements **APIM-14483** (epic **APIM-14481**).

## Backends

| Backend | Atomic refill + consume | Contract suite |
|---|---|---|
| Hazelcast | `EntryProcessor` on the partition owner (reuses `TokenBucketCalculator`) | ✅ + TTL |
| MongoDB | single `findAndModify` with an aggregation-update pipeline | ✅ + TTL |
| Redis | atomic Lua (`token-bucket.lua`), `EVALSHA`→`EVAL` NOSCRIPT fallback | ✅ + TTL |
| JDBC | `SELECT … FOR UPDATE` (SQL Server `UPDLOCK/HOLDLOCK`) + insert-retry, reuses calculator | ✅ |
| NoOp | returns null (disabled) | own test |

All backends use the same **whole-token integer** math (`refillRate` tokens per `refillPeriodMillis`): the Java backends reuse `TokenBucketCalculator`; Mongo re-expresses it in the aggregation pipeline and Redis in Lua. Each registers its `TokenBucketRateLimitRepository` bean (resolvable by the policy via `ctx.getComponent`). TTL = time to refill the whole bucket (`capacity * refillPeriodMillis / refillRate`, floored at 10s); a zero rate persists.

## Testing

Each backend extends the shared contract suite (via the `repository-api` test-jar): starts full, refills per period, caps at capacity, rejects when empty, **multi-token consume + partial-rejection (no over-draw)**, next-token timing, out-of-order safety, and **no over-consume under concurrency**. Mongo/Redis/JDBC run via Testcontainers (JDBC on PostgreSQL); Hazelcast/NoOp need no Docker. Also verified end-to-end through the gateway against all five stores, and across **two clustered gateways on Hazelcast** — one shared bucket, no over-admission.

## Caveats

- JDBC contract suite run locally on PostgreSQL; MySQL/MariaDB/SQL Server via the CI dialect matrix.
- Additive only: new Mongo collection / Redis keyspace / Hazelcast map / JDBC table (new Liquibase changeset); existing `RateLimit` storage untouched.

Refs: APIM-14481, APIM-14483
