### PR TITLE
fix(api-product): add sharding tag column on api product list

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -9242,6 +9242,14 @@ components:
             primaryOwner:
               $ref: "#/components/schemas/PrimaryOwner"
               description: The primary owner of the API Product
+            tags:
+              type: array
+              description: The list of sharding tags associated with this API Product.
+              items:
+                type: string
+              example:
+                - "internal"
+                - "external"
 
         ApiProductInfo:
           type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductMapperTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ApiProductMapperTest {
+
+    private final ApiProductMapper apiProductMapper = ApiProductMapper.INSTANCE;
+
+    @Test
+    void map_should_include_sharding_tags_in_rest_response() {
+        var coreProduct = ApiProduct.builder().id("product-1").name("aa").tags(Set.of("external", "internal")).build();
+
+        var restProduct = apiProductMapper.map(coreProduct);
+
+        assertThat(restProduct.getTags()).containsExactlyInAnyOrder("external", "internal");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14341

## Description

Maps sharding tag value on api product list page.
**After:**
<img width="1510" height="259" alt="image" src="https://github.com/user-attachments/assets/ad9db062-c8f9-40e1-a43f-e4326a9de783" />

**Before:** 
<img width="1510" height="330" alt="image" src="https://github.com/user-attachments/assets/32e74f59-aa76-4599-af98-602f4d68a421" />


