### PR TITLE
feat(repository): token-bucket rate-limit storage contract

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/pom.xml
@@ -57,4 +57,21 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Publish the rate-limit/token-bucket contract test suite so backend modules can extend it. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/api/TokenBucketCalculator.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/api/TokenBucketCalculator.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.ratelimit.api;
+
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import java.time.Duration;
+
+/**
+ * The token-bucket algorithm, expressed as pure functions over {@link TokenBucket} state and a
+ * caller-supplied clock. This is the canonical reference the persistent backends must match: the
+ * Java backends (in-memory, JDBC, Hazelcast) reuse it directly, while Mongo/Redis re-express the
+ * same integer math in their own server-side language.
+ *
+ * <p>The rate is expressed as {@code refillRate} whole tokens per {@code refillPeriodMillis}
+ * milliseconds (e.g. 100 tokens / 60000 ms). Balances are whole tokens and every operation is integer
+ * arithmetic, so there is no floating-point drift. Tokens accrue in whole units: the refill anchor is
+ * advanced to {@code now} only once at least one whole token has been credited; until then the elapsed
+ * time keeps accumulating against the unchanged anchor, so no accrual is silently discarded. This can
+ * never over-admit; under traffic that is sparse and not aligned to the refill period it may be at
+ * most one in-flight token stricter than a continuous-accrual model.
+ *
+ * @author GraviteeSource Team
+ */
+public final class TokenBucketCalculator {
+
+    /** Lower bound on a bucket's TTL so a high-rate/low-capacity bucket is not evicted within seconds of use. */
+    private static final long MIN_TTL_MS = 10_000L;
+
+    /** A zero-rate (never-refilling) bucket must persist to keep enforcing; this is "effectively forever". */
+    private static final long ZERO_RATE_TTL_MS = Duration.ofDays(3650).toMillis();
+
+    private TokenBucketCalculator() {}
+
+    /**
+     * Create a bucket that starts <em>full</em> (at {@code capacity}) as of {@code nowMillis}.
+     *
+     * @param seed     the seed bucket carrying identity (key, subscription)
+     * @param capacity burst capacity, in whole tokens
+     * @param nowMillis current time, in epoch millis
+     * @return the same instance, with tokens set to capacity and refill anchored at {@code nowMillis}
+     */
+    public static TokenBucket newFullBucket(TokenBucket seed, long capacity, long nowMillis) {
+        seed.setTokens(capacity);
+        seed.setLastRefillTime(nowMillis);
+        return seed;
+    }
+
+    /**
+     * Refill {@code bucket} based on time elapsed since its last refill (capped at {@code capacity}),
+     * then try to consume {@code tokensRequested} tokens. Mutates {@code bucket} in place.
+     *
+     * @param refillRate         whole tokens added per {@code refillPeriodMillis} ({@code <= 0} disables refill)
+     * @param refillPeriodMillis the refill period, in milliseconds (must be {@code > 0})
+     * @return the outcome: whether the request was allowed, remaining whole tokens, and when the next token is due
+     * @throws IllegalArgumentException if {@code refillPeriodMillis <= 0}, {@code tokensRequested < 0} or {@code capacity < 0}
+     */
+    public static TokenBucketConsumeResult refillAndTryConsume(
+        TokenBucket bucket,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis
+    ) {
+        requireValidArgs(tokensRequested, refillPeriodMillis, capacity);
+
+        long elapsed = nowMillis - bucket.getLastRefillTime();
+        if (elapsed > 0 && refillRate > 0) {
+            // Whole tokens accrued = floor(elapsed * refillRate / refillPeriodMillis). Cap the elapsed
+            // span to the time that would refill the whole bucket, so elapsed * refillRate cannot overflow
+            // on extreme idle gaps. This assumes capacity * refillPeriodMillis itself fits in a long (true
+            // for any sane capacity/period); beyond that the cap wraps and refill degrades toward 0 — which
+            // is fail-closed.
+            long maxUsefulElapsed = (capacity * refillPeriodMillis) / refillRate + refillPeriodMillis;
+            long effectiveElapsed = Math.min(elapsed, maxUsefulElapsed);
+            long refill = (effectiveElapsed * refillRate) / refillPeriodMillis;
+            if (refill > 0) {
+                bucket.setTokens(Math.min(capacity, bucket.getTokens() + refill));
+                // Anchor forward to now only once a whole token is credited; until then the elapsed time
+                // keeps accumulating against the unchanged anchor, so no accrual is lost. Forward-only:
+                // out-of-order (elapsed <= 0) leaves the anchor put, and a later request cannot re-accrue
+                // this window (which would over-admit).
+                bucket.setLastRefillTime(nowMillis);
+            }
+        }
+
+        boolean allowed = false;
+        if (bucket.getTokens() >= tokensRequested) {
+            bucket.setTokens(bucket.getTokens() - tokensRequested);
+            allowed = true;
+        }
+
+        long tokensAfter = bucket.getTokens();
+        return new TokenBucketConsumeResult(
+            allowed,
+            tokensAfter,
+            nextAvailableAtMillis(tokensAfter, refillRate, refillPeriodMillis, nowMillis)
+        );
+    }
+
+    /**
+     * When at least one whole token is available, the next token is available "now"; otherwise it is
+     * one refill interval — {@code ceil(refillPeriodMillis / refillRate)} — from now.
+     *
+     * <p>Public so backends that compute the new balance server-side (e.g. MongoDB's update pipeline)
+     * can derive this result field consistently with the Java path.
+     */
+    public static long nextAvailableAtMillis(long tokensAfter, long refillRate, long refillPeriodMillis, long nowMillis) {
+        if (tokensAfter >= 1) {
+            return nowMillis;
+        }
+        if (refillRate <= 0) {
+            return Long.MAX_VALUE;
+        }
+        // ceil(refillPeriodMillis / refillRate): the time to accrue one whole token.
+        long waitMillis = (refillPeriodMillis + refillRate - 1) / refillRate;
+        return nowMillis + waitMillis;
+    }
+
+    /**
+     * Validate the per-request arguments shared by every backend, so all of them fail the same way on a
+     * contract violation instead of dividing by zero (Mongo/Redis) or letting a negative request inflate
+     * the balance above capacity (which would corrupt the bucket and over-admit afterwards).
+     *
+     * @throws IllegalArgumentException if {@code refillPeriodMillis <= 0}, {@code tokensRequested < 0} or {@code capacity < 0}
+     */
+    public static void requireValidArgs(long tokensRequested, long refillPeriodMillis, long capacity) {
+        if (refillPeriodMillis <= 0) {
+            throw new IllegalArgumentException("refillPeriodMillis must be > 0, was " + refillPeriodMillis);
+        }
+        if (tokensRequested < 0 || capacity < 0) {
+            throw new IllegalArgumentException("tokensRequested and capacity must be >= 0, were " + tokensRequested + "/" + capacity);
+        }
+    }
+
+    /**
+     * TTL for a stored bucket: the time to refill the whole capacity, floored at {@value #MIN_TTL_MS} ms.
+     * An idle bucket that would have refilled to full is equivalent to a fresh (full) one, so evicting it
+     * is safe and bounds storage to roughly the active keys. A zero rate never refills, so it must persist.
+     * Shared by every backend so eviction is uniform.
+     */
+    public static long ttlMillis(long refillRate, long refillPeriodMillis, long capacity) {
+        if (refillRate <= 0) {
+            return ZERO_RATE_TTL_MS;
+        }
+        return Math.max(MIN_TTL_MS, (capacity * refillPeriodMillis) / refillRate);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/api/TokenBucketConsumeResult.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/api/TokenBucketConsumeResult.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.ratelimit.api;
+
+/**
+ * Outcome of a single {@link TokenBucketRateLimitRepository#refillAndTryConsume} operation.
+ *
+ * @param allowed              whether the request was permitted (a token was available and consumed)
+ * @param remainingTokens      whole tokens left in the bucket after the operation, floored to an integer
+ * @param nextAvailableAtMillis epoch millis at which at least one token will be available; equal to the
+ *                              supplied {@code now} when tokens already remain
+ * @author GraviteeSource Team
+ */
+public record TokenBucketConsumeResult(boolean allowed, long remainingTokens, long nextAvailableAtMillis) {}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/api/TokenBucketRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/api/TokenBucketRateLimitRepository.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.ratelimit.api;
+
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.reactivex.rxjava3.core.Single;
+import java.util.function.Supplier;
+
+/**
+ * Storage contract for token-bucket (burst) rate limiting.
+ *
+ * <p>Separate from {@link RateLimitRepository}, whose fixed-window {@code incrementAndGet} cannot
+ * express token-bucket semantics (it always increments, even for rejected requests, and has no
+ * notion of time-based refill capped at a burst capacity).
+ *
+ * @author GraviteeSource Team
+ */
+public interface TokenBucketRateLimitRepository<T extends TokenBucket> {
+    /**
+     * Atomically refill the bucket based on elapsed time, then try to consume {@code tokensRequested}
+     * tokens. The bucket is created <em>full</em> (at {@code capacity}) on first use.
+     *
+     * @param key                the bucket key
+     * @param tokensRequested    whole tokens to consume (typically 1)
+     * @param refillRate         whole tokens added per refill period ({@code <= 0} disables refill)
+     * @param refillPeriodMillis the refill period, in milliseconds (must be {@code > 0})
+     * @param capacity           burst capacity — the maximum number of accumulated tokens
+     * @param nowMillis          caller-supplied current time, in epoch millis (the authoritative clock)
+     * @param supplier           supplies the seed bucket (key, subscription) when none exists yet
+     * @return the outcome: whether the request was allowed, remaining tokens, and when the next token is due;
+     *         or a {@code null} reference (not an empty or error {@code Single}) when rate limiting is
+     *         <em>disabled</em> (the no-op backend), which callers must treat as pass-through — mirrors
+     *         {@link RateLimitRepository#incrementAndGet}
+     * @throws IllegalArgumentException if {@code refillPeriodMillis <= 0}, {@code tokensRequested < 0} or {@code capacity < 0}
+     */
+    Single<TokenBucketConsumeResult> refillAndTryConsume(
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        Supplier<T> supplier
+    );
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/model/TokenBucket.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/model/TokenBucket.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.ratelimit.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Persisted state of a single token-bucket rate-limit key.
+ *
+ * <p>Unlike {@link RateLimit} (a fixed-window counter), this models burst behaviour: tokens refill
+ * over time up to a burst capacity, and each request consumes tokens.
+ *
+ * <p>The available balance is stored in <em>whole tokens</em>. The refill rate is configured as a
+ * whole-token count per period (e.g. 100 tokens / 60s), so all refill arithmetic is integer with no
+ * floating-point drift across the heterogeneous backends.
+ *
+ * @author GraviteeSource Team
+ */
+public class TokenBucket implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String key;
+
+    /** Available balance, in whole tokens. */
+    private long tokens;
+
+    /** Epoch millis of the last refill applied to {@link #tokens}. */
+    private long lastRefillTime;
+
+    private String subscription;
+
+    private TokenBucket() {}
+
+    public TokenBucket(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public long getTokens() {
+        return tokens;
+    }
+
+    public void setTokens(long tokens) {
+        this.tokens = tokens;
+    }
+
+    public long getLastRefillTime() {
+        return lastRefillTime;
+    }
+
+    public void setLastRefillTime(long lastRefillTime) {
+        this.lastRefillTime = lastRefillTime;
+    }
+
+    public String getSubscription() {
+        return subscription;
+    }
+
+    public void setSubscription(String subscription) {
+        this.subscription = subscription;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TokenBucket that = (TokenBucket) o;
+        return Objects.equals(key, that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key);
+    }
+
+    @Override
+    public String toString() {
+        return "TokenBucket{key='" + key + "', tokens=" + tokens + ", lastRefillTime=" + lastRefillTime + '}';
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/ratelimit/AbstractTokenBucketRateLimitRepositoryContractTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/ratelimit/AbstractTokenBucketRateLimitRepositoryContractTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioural contract every {@link TokenBucketRateLimitRepository} implementation must satisfy.
+ *
+ * <p>The rate is expressed as {@code refillRate} whole tokens per {@code refillPeriodMillis} (e.g.
+ * {@code (2, 1000)} = 2 tokens/s, {@code (1, 2000)} = 1 token every 2s). All timing is driven by an
+ * explicit {@code nowMillis} argument rather than a wall clock, so the contract is fully deterministic
+ * across the in-memory reference and the persistent backends. Backends provide their implementation by
+ * overriding {@link #createRepository()}.
+ *
+ * <p><strong>Entry TTL is intentionally out of scope for this suite.</strong> {@link
+ * io.gravitee.repository.ratelimit.api.TokenBucketCalculator#ttlMillis} defines the shared eviction rule,
+ * but expiry is storage-native (Mongo TTL index, Redis {@code PEXPIRE}, a JDBC reaper, Hazelcast entry TTL)
+ * and cannot be meaningfully asserted against an in-memory map. TTL conformance is therefore verified
+ * per-backend in APIM-14483, not here.
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public abstract class AbstractTokenBucketRateLimitRepositoryContractTest {
+
+    protected abstract TokenBucketRateLimitRepository<TokenBucket> createRepository();
+
+    private TokenBucketRateLimitRepository<TokenBucket> repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = createRepository();
+    }
+
+    private static Supplier<TokenBucket> seed(String key) {
+        return () -> {
+            TokenBucket bucket = new TokenBucket(key);
+            bucket.setSubscription("sub-1");
+            return bucket;
+        };
+    }
+
+    @Test
+    void fresh_bucket_is_full_so_first_request_is_allowed() {
+        TokenBucketConsumeResult result = repository.refillAndTryConsume("k1", 1, 3, 1_000L, 300, 1_000L, seed("k1")).blockingGet();
+
+        assertThat(result.allowed()).isTrue();
+        assertThat(result.remainingTokens()).isEqualTo(299);
+    }
+
+    @Test
+    void empty_bucket_rejects_further_requests() {
+        Supplier<TokenBucket> seed = seed("k2");
+        // capacity 2 at a fixed instant (no refill): drain both tokens, then the third must be rejected
+        repository.refillAndTryConsume("k2", 1, 1, 1_000L, 2, 1_000L, seed).blockingGet();
+        repository.refillAndTryConsume("k2", 1, 1, 1_000L, 2, 1_000L, seed).blockingGet();
+
+        TokenBucketConsumeResult result = repository.refillAndTryConsume("k2", 1, 1, 1_000L, 2, 1_000L, seed).blockingGet();
+
+        assertThat(result.allowed()).isFalse();
+        assertThat(result.remainingTokens()).isZero();
+    }
+
+    @Test
+    void tokens_refill_over_elapsed_time() {
+        Supplier<TokenBucket> seed = seed("k3");
+        // capacity 10, 2 tokens per 1000ms; drain to empty at t=1000ms
+        for (int i = 0; i < 10; i++) {
+            repository.refillAndTryConsume("k3", 1, 2, 1_000L, 10, 1_000L, seed).blockingGet();
+        }
+
+        // 1000ms later, 2 tokens have refilled: this request is allowed and leaves 1
+        TokenBucketConsumeResult result = repository.refillAndTryConsume("k3", 1, 2, 1_000L, 10, 2_000L, seed).blockingGet();
+
+        assertThat(result.allowed()).isTrue();
+        assertThat(result.remainingTokens()).isEqualTo(1);
+    }
+
+    @Test
+    void refill_never_exceeds_capacity() {
+        Supplier<TokenBucket> seed = seed("k4");
+        // capacity 5, very high rate (1000 tokens per 1000ms); consume 1 at t=0 (5 -> 4)
+        repository.refillAndTryConsume("k4", 1, 1000, 1_000L, 5, 0L, seed).blockingGet();
+
+        // after a huge idle period an uncapped bucket would massively overflow; it must cap at 5,
+        // so consuming 1 leaves 4 (not thousands)
+        TokenBucketConsumeResult result = repository.refillAndTryConsume("k4", 1, 1000, 1_000L, 5, 3_600_000L, seed).blockingGet();
+
+        assertThat(result.allowed()).isTrue();
+        assertThat(result.remainingTokens()).isEqualTo(4);
+    }
+
+    @Test
+    void each_token_takes_a_full_refill_period() {
+        Supplier<TokenBucket> seed = seed("k8");
+        // capacity 1, 1 token per 2000ms: after draining, a token is due exactly one period later.
+        repository.refillAndTryConsume("k8", 1, 1, 2_000L, 1, 0L, seed).blockingGet(); // drain the single token
+
+        // 1999ms is one millisecond short of a whole token — still rejected; the elapsed time is kept,
+        // not discarded, so the very next millisecond tips it over.
+        boolean allowedAt1999 = repository.refillAndTryConsume("k8", 1, 1, 2_000L, 1, 1_999L, seed).blockingGet().allowed();
+        boolean allowedAt2000 = repository.refillAndTryConsume("k8", 1, 1, 2_000L, 1, 2_000L, seed).blockingGet().allowed();
+
+        assertThat(allowedAt1999).isFalse();
+        assertThat(allowedAt2000).isTrue();
+    }
+
+    @Test
+    void rate_above_one_refills_multiple_tokens_per_period() {
+        Supplier<TokenBucket> seed = seed("k9");
+        // capacity 10, 5 tokens per 1000ms; drain to empty at t=0
+        for (int i = 0; i < 10; i++) {
+            repository.refillAndTryConsume("k9", 1, 5, 1_000L, 10, 0L, seed).blockingGet();
+        }
+
+        // one full period later exactly 5 tokens have refilled: consume 1 and 4 remain (never more)
+        TokenBucketConsumeResult result = repository.refillAndTryConsume("k9", 1, 5, 1_000L, 10, 1_000L, seed).blockingGet();
+
+        assertThat(result.allowed()).isTrue();
+        assertThat(result.remainingTokens()).isEqualTo(4);
+    }
+
+    @Test
+    void reports_when_next_token_becomes_available_once_empty() {
+        Supplier<TokenBucket> seed = seed("k5");
+        // capacity 1, 2 tokens per 1000ms (one token every 500ms); consume the only token at t=1000
+        repository.refillAndTryConsume("k5", 1, 2, 1_000L, 1, 1_000L, seed).blockingGet();
+
+        // a second request at the same instant is rejected; the next token is due 500ms later
+        TokenBucketConsumeResult result = repository.refillAndTryConsume("k5", 1, 2, 1_000L, 1, 1_000L, seed).blockingGet();
+
+        assertThat(result.allowed()).isFalse();
+        assertThat(result.nextAvailableAtMillis()).isEqualTo(1_500L);
+    }
+
+    @Test
+    void out_of_order_timestamps_do_not_inflate_refill() {
+        Supplier<TokenBucket> seed = seed("k7");
+        long base = 1_000_000L; // capacity 10, 1 token per 1000ms
+        // consume at base, then 500ms later (half a token, floored to 0), then replay an *earlier*
+        // timestamp, then the 500ms timestamp again. A correct bucket must not let the out-of-order
+        // replay drag the refill anchor backward and re-accrue a refill.
+        repository.refillAndTryConsume("k7", 1, 1, 1_000L, 10, base, seed).blockingGet();
+        repository.refillAndTryConsume("k7", 1, 1, 1_000L, 10, base + 500, seed).blockingGet();
+        repository.refillAndTryConsume("k7", 1, 1, 1_000L, 10, base, seed).blockingGet(); // out-of-order (earlier)
+        TokenBucketConsumeResult result = repository.refillAndTryConsume("k7", 1, 1, 1_000L, 10, base + 500, seed).blockingGet();
+
+        // 4 tokens consumed; no whole token ever legitimately refilled within 500ms, so 6 remain.
+        // A backend that moves the anchor backward inflates this to 7.
+        assertThat(result.remainingTokens()).isEqualTo(6);
+    }
+
+    @Test
+    void multi_token_request_consumes_rejects_and_never_overdraws() {
+        Supplier<TokenBucket> seed = seed("kmt");
+        // capacity 10, refill disabled (0 tokens per period): consume 3 in one request -> 7 remain
+        TokenBucketConsumeResult three = repository.refillAndTryConsume("kmt", 3, 0, 1_000L, 10, 1_000L, seed).blockingGet();
+        assertThat(three.allowed()).isTrue();
+        assertThat(three.remainingTokens()).isEqualTo(7);
+
+        // a request larger than the remaining balance (8 > 7) is rejected and must NOT draw the balance down
+        TokenBucketConsumeResult tooMany = repository.refillAndTryConsume("kmt", 8, 0, 1_000L, 10, 1_000L, seed).blockingGet();
+        assertThat(tooMany.allowed()).isFalse();
+        assertThat(tooMany.remainingTokens()).isEqualTo(7);
+
+        // a request for exactly the remaining balance (7) is allowed and empties the bucket
+        TokenBucketConsumeResult exact = repository.refillAndTryConsume("kmt", 7, 0, 1_000L, 10, 1_000L, seed).blockingGet();
+        assertThat(exact.allowed()).isTrue();
+        assertThat(exact.remainingTokens()).isZero();
+    }
+
+    @Test
+    void next_available_is_now_when_tokens_remain() {
+        Supplier<TokenBucket> seed = seed("kna");
+        // capacity 5, 1 token per 1000ms; one consume leaves 4, so the next token is available immediately
+        TokenBucketConsumeResult result = repository.refillAndTryConsume("kna", 1, 1, 1_000L, 5, 1_000L, seed).blockingGet();
+
+        assertThat(result.allowed()).isTrue();
+        assertThat(result.remainingTokens()).isEqualTo(4);
+        assertThat(result.nextAvailableAtMillis()).isEqualTo(1_000L);
+    }
+
+    @Test
+    void next_available_is_max_value_when_refill_is_disabled() {
+        Supplier<TokenBucket> seed = seed("knr");
+        // capacity 1, refill disabled (0 tokens per period); once empty, the next token never comes
+        repository.refillAndTryConsume("knr", 1, 0, 1_000L, 1, 1_000L, seed).blockingGet();
+        TokenBucketConsumeResult result = repository.refillAndTryConsume("knr", 1, 0, 1_000L, 1, 1_000L, seed).blockingGet();
+
+        assertThat(result.allowed()).isFalse();
+        assertThat(result.nextAvailableAtMillis()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    void rejects_invalid_arguments() {
+        Supplier<TokenBucket> seed = seed("kerr");
+        // every backend must reject the same contract violations identically (no divide-by-zero or over-draw)
+        assertThatThrownBy(() -> repository.refillAndTryConsume("kerr", 1, 1, 0, 10, 1_000L, seed).blockingGet()).isInstanceOf(
+            IllegalArgumentException.class
+        ); // refillPeriodMillis <= 0
+        assertThatThrownBy(() -> repository.refillAndTryConsume("kerr", -1, 1, 1_000L, 10, 1_000L, seed).blockingGet()).isInstanceOf(
+            IllegalArgumentException.class
+        ); // tokensRequested < 0
+        assertThatThrownBy(() -> repository.refillAndTryConsume("kerr", 1, 1, 1_000L, -1, 1_000L, seed).blockingGet()).isInstanceOf(
+            IllegalArgumentException.class
+        ); // capacity < 0
+    }
+
+    @Test
+    void concurrent_consumes_never_exceed_available_tokens() throws Exception {
+        Supplier<TokenBucket> seed = seed("k6");
+        int capacity = 100;
+        int attempts = 200; // twice the capacity, all at the same instant so no refill can occur
+
+        ExecutorService pool = Executors.newFixedThreadPool(16);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger allowed = new AtomicInteger();
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < attempts; i++) {
+            futures.add(
+                pool.submit(() -> {
+                    start.await();
+                    // refillRate 0: refill disabled, so exactly `capacity` requests can ever succeed
+                    if (repository.refillAndTryConsume("k6", 1, 0, 1_000L, capacity, 1_000L, seed).blockingGet().allowed()) {
+                        allowed.incrementAndGet();
+                    }
+                    return null;
+                })
+            );
+        }
+        start.countDown();
+        for (Future<?> f : futures) {
+            f.get();
+        }
+        pool.shutdown();
+
+        assertThat(allowed).hasValue(capacity);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/ratelimit/InMemoryTokenBucketRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/ratelimit/InMemoryTokenBucketRateLimitRepository.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.ratelimit;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketCalculator;
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.reactivex.rxjava3.core.Single;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+
+/**
+ * In-memory reference implementation of {@link TokenBucketRateLimitRepository}, used as the
+ * executable specification that the persistent backends must match. Atomicity per key is provided
+ * by {@link ConcurrentMap#compute}, which runs its remapping function atomically.
+ */
+public class InMemoryTokenBucketRateLimitRepository implements TokenBucketRateLimitRepository<TokenBucket> {
+
+    private final ConcurrentMap<String, TokenBucket> buckets = new ConcurrentHashMap<>();
+
+    @Override
+    public Single<TokenBucketConsumeResult> refillAndTryConsume(
+        String key,
+        long tokensRequested,
+        long refillRate,
+        long refillPeriodMillis,
+        long capacity,
+        long nowMillis,
+        Supplier<TokenBucket> supplier
+    ) {
+        return Single.fromCallable(() -> {
+            TokenBucketConsumeResult[] result = new TokenBucketConsumeResult[1];
+            buckets.compute(key, (k, existing) -> {
+                TokenBucket bucket = existing != null ? existing : TokenBucketCalculator.newFullBucket(supplier.get(), capacity, nowMillis);
+                result[0] = TokenBucketCalculator.refillAndTryConsume(
+                    bucket,
+                    tokensRequested,
+                    refillRate,
+                    refillPeriodMillis,
+                    capacity,
+                    nowMillis
+                );
+                return bucket;
+            });
+            return result[0];
+        });
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/ratelimit/InMemoryTokenBucketRateLimitRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/ratelimit/InMemoryTokenBucketRateLimitRepositoryTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.ratelimit;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+
+/**
+ * Runs the {@link AbstractTokenBucketRateLimitRepositoryContractTest} against the in-memory reference
+ * implementation.
+ */
+class InMemoryTokenBucketRateLimitRepositoryTest extends AbstractTokenBucketRateLimitRepositoryContractTest {
+
+    @Override
+    protected TokenBucketRateLimitRepository<TokenBucket> createRepository() {
+        return new InMemoryTokenBucketRateLimitRepository();
+    }
+}


### PR DESCRIPTION
## What

Foundation for token-bucket (burst) rate limiting: the storage **contract**, shared by all backends.

Implements **APIM-14482** (epic **APIM-14481**). The five backend implementations build on this and are in the stacked PR (APIM-14483).

## Contents (all in `gravitee-apim-repository-api`, additive — existing `RateLimit` untouched)

- `TokenBucketRateLimitRepository<T extends TokenBucket>` — one atomic op `refillAndTryConsume(key, tokensRequested, refillRate, refillPeriodMillis, capacity, nowMillis, supplier)`.
- `TokenBucket` model — `tokens` (whole tokens), `lastRefillTime`, `subscription`.
- `TokenBucketConsumeResult` — `allowed`, `remainingTokens`, `nextAvailableAtMillis`.
- `TokenBucketCalculator` — the pure reference algorithm (refill → cap → try-consume), reused by the Java backends and re-expressed server-side by Mongo/Redis.
- `AbstractTokenBucketRateLimitRepositoryContractTest` + `InMemoryTokenBucketRateLimitRepository` — the executable spec, **published as a `test-jar`** (this module's `maven-jar-plugin` `test-jar` execution) so each backend in APIM-14483 extends it.

## Design

- The rate is **`refillRate` whole tokens per `refillPeriodMillis`** (e.g. 100 tokens / 60000 ms). Balances are **whole tokens** and all refill arithmetic is **integer** — no scaled/milli storage and no floating point, so every backend is deterministic.
- Tokens accrue in whole units: `floor(elapsed * refillRate / refillPeriodMillis)`. The refill anchor advances to `now` only once a whole token is credited, so the sub-token remainder is preserved as not-yet-elapsed time. This never over-admits; under sparse, period-misaligned traffic it can be at most one in-flight token stricter than a continuous-accrual model.
- `nowMillis` is caller-supplied (gateway clock), matching the existing rate-limit convention — keeps the contract suite deterministic across backends.
- Preconditions are validated at the boundary (`refillPeriodMillis > 0`, `tokensRequested >= 0`, `capacity >= 0` → `IllegalArgumentException`). The bucket starts full; rate/period/capacity are passed per call so config changes apply immediately.

Refs: APIM-14481, APIM-14482
