### PR TITLE
feat: add entity resolver interface and default implementation

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/DefaultEntityResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/DefaultEntityResolver.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.context;
+
+import io.gravitee.gateway.reactive.api.context.EntityResolver;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Default implementation of {@link EntityResolver} backed by a concurrent map.
+ * Populated at reactor startup from the catalog.
+ */
+public class DefaultEntityResolver implements EntityResolver {
+
+    private record Key(String kind, String name) {}
+
+    private final ConcurrentMap<Key, String> registry = new ConcurrentHashMap<>();
+
+    @Override
+    public void register(String kind, String name, String entityId) {
+        registry.put(new Key(kind, name), entityId);
+    }
+
+    @Override
+    public String resolve(String kind, String name) {
+        return registry.getOrDefault(new Key(kind, name), name);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/context/DefaultEntityResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/context/DefaultEntityResolverTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DefaultEntityResolverTest {
+
+    private DefaultEntityResolver cut;
+
+    @BeforeEach
+    void init() {
+        cut = new DefaultEntityResolver();
+    }
+
+    @Test
+    void should_resolve_registered_entity_id() {
+        cut.register("tool", "create_issue", "mcp.jira.tool.create_issue");
+
+        assertThat(cut.resolve("tool", "create_issue")).isEqualTo("mcp.jira.tool.create_issue");
+    }
+
+    @Test
+    void should_return_name_unchanged_when_kind_not_registered() {
+        assertThat(cut.resolve("tool", "create_issue")).isEqualTo("create_issue");
+    }
+
+    @Test
+    void should_return_name_unchanged_when_name_not_registered_for_kind() {
+        cut.register("tool", "create_issue", "mcp.jira.tool.create_issue");
+
+        assertThat(cut.resolve("tool", "delete_issue")).isEqualTo("delete_issue");
+    }
+
+    @Test
+    void should_resolve_multiple_kinds_independently() {
+        cut.register("tool", "create_issue", "mcp.jira.tool.create_issue");
+        cut.register("resource", "issues", "mcp.jira.resource.issues");
+        cut.register("model", "gpt-4o", "llm.openai-gpt-4o");
+
+        assertThat(cut.resolve("tool", "create_issue")).isEqualTo("mcp.jira.tool.create_issue");
+        assertThat(cut.resolve("resource", "issues")).isEqualTo("mcp.jira.resource.issues");
+        assertThat(cut.resolve("model", "gpt-4o")).isEqualTo("llm.openai-gpt-4o");
+    }
+
+    @Test
+    void should_allow_same_name_across_different_kinds() {
+        cut.register("tool", "summary", "mcp.jira.tool.summary");
+        cut.register("prompt", "summary", "mcp.jira.prompt.summary");
+
+        assertThat(cut.resolve("tool", "summary")).isEqualTo("mcp.jira.tool.summary");
+        assertThat(cut.resolve("prompt", "summary")).isEqualTo("mcp.jira.prompt.summary");
+    }
+
+    @Test
+    void should_overwrite_on_duplicate_registration() {
+        cut.register("tool", "create_issue", "mcp.jira.tool.create_issue");
+        cut.register("tool", "create_issue", "mcp.jira-v2.tool.create_issue");
+
+        assertThat(cut.resolve("tool", "create_issue")).isEqualTo("mcp.jira-v2.tool.create_issue");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <gravitee-exchange.version>3.0.0-alpha.2</gravitee-exchange.version>
         <gravitee-expression-language.version>4.3.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>6.1.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>6.2.0</gravitee-gateway-api.version>
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
@@ -337,7 +337,7 @@
         <gravitee-resource-ai-model-token-classification.version>2.0.0</gravitee-resource-ai-model-token-classification.version>
 
         <!-- Gamma plugins -->
-        <gravitee-gamma-module-aim.version>1.0.0-alpha.174</gravitee-gamma-module-aim.version>
+        <gravitee-gamma-module-aim.version>1.0.0-alpha.180</gravitee-gamma-module-aim.version>
         <gravitee-gamma-module-authz.version>1.0.0-alpha.20</gravitee-gamma-module-authz.version>
         <gravitee-gamma-module-edge.version>1.0.0-alpha.2</gravitee-gamma-module-edge.version>
         <gravitee-gamma-module-esm.version>1.0.0-alpha.5</gravitee-gamma-module-esm.version>


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GMA-786
from https://gravitee.atlassian.net/browse/GMA-735
depends on https://github.com/gravitee-io/gravitee-gateway-api/pull/355

Sets the foundation for internal resolution of protocol facing identifier to gamma entity ids.
