### PR TITLE
feat(observability): add PAYLOAD search filter with v2 backport

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/data-access/observability-filters-api.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/data-access/observability-filters-api.service.spec.ts
@@ -115,6 +115,48 @@ describe('ObservabilityFiltersApiService', () => {
       });
   });
 
+  it('should map signals from API response to FilterDefinition', done => {
+    const base = CONSTANTS_TESTING.env!.v2BaseURL!;
+    service.getDefinitions().subscribe(defs => {
+      expect(defs[0]).toEqual(
+        expect.objectContaining({
+          name: 'PAYLOAD',
+          label: 'Payload content',
+          type: 'STRING',
+          operators: ['CONTAINS'],
+          signals: ['LOGS'],
+          apiTypes: ['HTTP_PROXY', 'LLM', 'MCP'],
+        }),
+      );
+      done();
+    });
+    const req = httpMock.expectOne(`${base}/observability/filters/definition`);
+    req.flush({
+      data: [
+        {
+          name: 'PAYLOAD',
+          label: 'Payload content',
+          type: 'STRING',
+          operators: ['CONTAINS'],
+          apiTypes: ['HTTP_PROXY', 'LLM', 'MCP'],
+          signals: ['LOGS'],
+        },
+      ],
+    });
+  });
+
+  it('should map definition without signals to undefined', done => {
+    const base = CONSTANTS_TESTING.env!.v2BaseURL!;
+    service.getDefinitions().subscribe(defs => {
+      expect(defs[0].signals).toBeUndefined();
+      done();
+    });
+    const req = httpMock.expectOne(`${base}/observability/filters/definition`);
+    req.flush({
+      data: [{ name: 'URI', label: 'HTTP Path', type: 'STRING', operators: ['EQ'] }],
+    });
+  });
+
   it('should set hasNextPage from page size when pagination is absent', done => {
     const base = CONSTANTS_TESTING.env!.v2BaseURL!;
     service.getValues({ filterName: 'GATEWAY', page: 1, perPage: 10 }).subscribe(result => {

--- a/gravitee-apim-console-webui/src/management/observability/data-access/observability-filters-api.service.ts
+++ b/gravitee-apim-console-webui/src/management/observability/data-access/observability-filters-api.service.ts
@@ -41,6 +41,7 @@ interface FilterSpecApi {
   values?: string[];
   range?: { min: number; max: number };
   apiTypes?: string[];
+  signals?: string[];
 }
 
 interface FilterValuesPaginationApi {
@@ -96,6 +97,7 @@ export class ObservabilityFiltersApiService implements FilterDefinitionProvider,
       range: item.range,
       values: item.enumValues ?? item.values,
       apiTypes: item.apiTypes,
+      signals: item.signals,
     };
   }
 

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
@@ -242,9 +242,7 @@ export class EnvLogsComponent {
       entrypoints: filterMap.get('ENTRYPOINT'),
       errorKeys: filterMap.get('ERROR_KEY'),
       apiProductIds: filterMap.get('API_PRODUCT'),
-      // Scalar / numeric filters (REQUEST_ID, TRANSACTION_ID, URI, RESPONSE_TIME) are
-      // excluded from the filter definitions served by ObservabilityFiltersApiService
-      // until full support is implemented.
+      bodyText: filterMap.get('PAYLOAD')?.[0],
     };
   }
 

--- a/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.spec.ts
@@ -154,6 +154,51 @@ describe('EnvironmentLogsService', () => {
       req.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
     });
 
+    it('should include PAYLOAD filter with CONTAINS operator when bodyText is set', done => {
+      service.searchLogs({ bodyText: 'error 500' }).subscribe(() => done());
+
+      const req = httpTestingController.expectOne({ method: 'POST' });
+      expect(req.request.body.filters).toEqual([{ name: 'PAYLOAD', operator: 'CONTAINS', value: 'error 500' }]);
+      req.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
+    });
+
+    it('should not include PAYLOAD filter when bodyText is undefined', done => {
+      service.searchLogs({ bodyText: undefined }).subscribe(() => done());
+
+      const req = httpTestingController.expectOne({ method: 'POST' });
+      expect(req.request.body.filters).toBeUndefined();
+      req.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
+    });
+
+    it('should not include PAYLOAD filter when bodyText is empty string', done => {
+      service.searchLogs({ bodyText: '' }).subscribe(() => done());
+
+      const req = httpTestingController.expectOne({ method: 'POST' });
+      expect(req.request.body.filters).toBeUndefined();
+      req.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
+    });
+
+    it('should include PAYLOAD alongside other filters', done => {
+      service
+        .searchLogs({
+          bodyText: 'quantum',
+          apiIds: ['api-1'],
+          statuses: [200],
+        })
+        .subscribe(() => done());
+
+      const req = httpTestingController.expectOne({ method: 'POST' });
+      expect(req.request.body.filters).toEqual(
+        expect.arrayContaining([
+          { name: 'API', operator: 'IN', value: ['api-1'] },
+          { name: 'HTTP_STATUS', operator: 'IN', value: ['200'] },
+          { name: 'PAYLOAD', operator: 'CONTAINS', value: 'quantum' },
+        ]),
+      );
+      expect(req.request.body.filters.length).toBe(3);
+      req.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
+    });
+
     it('should not include RESPONSE_TIME filter when responseTime is 0', done => {
       service.searchLogs({ responseTime: 0 }).subscribe(() => done());
 

--- a/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.ts
@@ -82,6 +82,7 @@ export type SearchLogsParam = {
   responseTime?: number;
   errorKeys?: string[];
   apiProductIds?: string[];
+  bodyText?: string;
 };
 
 /** Parses a period string like '-1h', '-30m', '-3d' into milliseconds. Returns null for '0' (none) or unrecognized formats. */
@@ -119,15 +120,16 @@ function buildFilters(param?: SearchLogsParam): LogFilter[] {
     { name: 'API_PRODUCT', values: param.apiProductIds },
   ];
 
-  const scalarFilters: { name: string; value: string | undefined }[] = [
+  const scalarFilters: { name: string; value: string | undefined; operator?: string }[] = [
     { name: 'REQUEST_ID', value: param.requestId },
     { name: 'TRANSACTION_ID', value: param.transactionId },
     { name: 'URI', value: param.uri },
+    { name: 'PAYLOAD', value: param.bodyText, operator: 'CONTAINS' },
   ];
 
   const filters: LogFilter[] = [
     ...arrayFilters.filter(f => f.values?.length).map(f => ({ name: f.name, operator: 'IN' as const, value: f.values! })),
-    ...scalarFilters.filter(f => f.value).map(f => ({ name: f.name, operator: 'EQ' as const, value: f.value! })),
+    ...scalarFilters.filter(f => f.value).map(f => ({ name: f.name, operator: (f.operator ?? 'EQ') as 'EQ', value: f.value! })),
   ];
 
   if (param.responseTime != null && param.responseTime > 0) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
@@ -122,6 +122,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Lucene query parser utilities for query_string escaping in log search adapters -->
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
@@ -149,11 +155,6 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-queryparser</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogDetailQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogDetailQueryAdapter.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import org.apache.lucene.queryparser.flexible.standard.QueryParserUtil;
 import org.springframework.util.CollectionUtils;
 
 public class SearchConnectionLogDetailQueryAdapter {
@@ -80,7 +81,10 @@ public class SearchConnectionLogDetailQueryAdapter {
 
     private static void addBodyTextFilter(ConnectionLogDetailQuery.Filter filter, ArrayList<JsonObject> mustFilterList) {
         if (filter.getBodyText() != null && !filter.getBodyText().isBlank()) {
-            var searchTerm = "\\*.body:" + filter.getBodyText() + (filter.getBodyText().endsWith("*") ? "" : "*");
+            var bodyText = filter.getBodyText();
+            var textToEscape = bodyText.endsWith("*") ? bodyText.substring(0, bodyText.length() - 1) : bodyText;
+            var escapedBodyText = QueryParserUtil.escape(textToEscape);
+            var searchTerm = "\\*.body:" + escapedBodyText + "*";
             mustFilterList.add(JsonObject.of("query_string", JsonObject.of("query", searchTerm)));
         }
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogDetailQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogDetailQueryAdapterTest.java
@@ -295,6 +295,46 @@ class SearchConnectionLogDetailQueryAdapterTest {
                     },"sort":{"@timestamp":{"order":"desc"}}
                  }
                 """
+            ),
+            Arguments.of(
+                ConnectionLogDetailQuery.Filter.builder().bodyText("error:500").build(),
+                """
+                {
+                 "from": 0,
+                 "size": 20,
+                  "query": {
+                        "bool": {
+                            "must": [
+                                 {
+                                     "query_string": {
+                                         "query": "\\\\*.body:error\\\\:500*"
+                                     }
+                                 }
+                            ]
+                        }
+                    },"sort":{"@timestamp":{"order":"desc"}}
+                 }
+                """
+            ),
+            Arguments.of(
+                ConnectionLogDetailQuery.Filter.builder().bodyText("curl*").build(),
+                """
+                {
+                 "from": 0,
+                 "size": 20,
+                  "query": {
+                        "bool": {
+                            "must": [
+                                 {
+                                     "query_string": {
+                                         "query": "\\\\*.body:curl*"
+                                     }
+                                 }
+                            ]
+                        }
+                    },"sort":{"@timestamp":{"order":"desc"}}
+                 }
+                """
             )
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsDefinitionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsDefinitionMapper.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiSpecsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetSpecsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterName;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpecRange;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpecsResponse;
@@ -31,9 +32,12 @@ import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterValu
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterValuesResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricSpecsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ObservabilityFilterName;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ValueMapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -49,6 +53,10 @@ public interface AnalyticsDefinitionMapper {
     }
 
     MetricSpec mapMetricSpec(io.gravitee.apim.core.analytics_engine.model.MetricSpec metricSpec);
+
+    // PAYLOAD is observability-only and must not appear on analytics metric filter lists.
+    @ValueMapping(source = "PAYLOAD", target = MappingConstants.THROW_EXCEPTION)
+    FilterName mapAnalyticsFilterName(io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name name);
 
     List<MetricSpec> mapMetricSpecs(List<io.gravitee.apim.core.analytics_engine.model.MetricSpec> metricSpecs);
 
@@ -70,6 +78,8 @@ public interface AnalyticsDefinitionMapper {
 
     @Mapping(source = "apis", target = "apiTypes")
     FilterSpec mapFilterSpec(io.gravitee.apim.core.analytics_engine.model.FilterSpec filterSpec);
+
+    ObservabilityFilterName mapObservabilityFilterName(io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name name);
 
     ApiName mapApiSpecName(io.gravitee.apim.core.analytics_engine.model.ApiSpec.Name name);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/DashboardMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/DashboardMapper.java
@@ -160,7 +160,7 @@ public interface DashboardMapper {
 
     private Object getFilterInstance(Operator operator, FilterName filterName, Object value) {
         return switch (operator) {
-            case EQ -> new StringFilter().name(filterName).operator(operator).value((String) value);
+            case EQ, CONTAINS -> new StringFilter().name(filterName).operator(operator).value((String) value);
             case LTE, GTE -> new NumberFilter().name(filterName).operator(operator).value(((Number) value).intValue());
             case IN -> new ArrayFilter().name(filterName).operator(operator).value((List<String>) value);
         };

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -1449,6 +1449,63 @@ components:
                 - ENTRYPOINT
             description: Available filter names for filtering analytics data
 
+        ObservabilityFilterName:
+            type: string
+            enum:
+                - API
+                - APPLICATION
+                - PLAN
+                - API_PRODUCT
+                - GATEWAY
+                - TENANT
+                - ZONE
+                - HTTP_METHOD
+                - HTTP_STATUS_CODE_GROUP
+                - HTTP_STATUS
+                - HTTP_PATH
+                - HTTP_PATH_MAPPING
+                - HOST
+                - GEO_IP_COUNTRY
+                - GEO_IP_REGION
+                - GEO_IP_CITY
+                - GEO_IP_CONTINENT
+                - CONSUMER_IP
+                - HTTP_USER_AGENT_OS_NAME
+                - HTTP_USER_AGENT_DEVICE
+                - MESSAGE_CONNECTOR_TYPE
+                - MESSAGE_CONNECTOR_ID
+                - MESSAGE_OPERATION_TYPE
+                - MESSAGE_SIZE
+                - MESSAGE_COUNT
+                - MESSAGE_ERROR_COUNT
+                - HTTP_ENDPOINT_RESPONSE_TIME
+                - HTTP_GATEWAY_LATENCY
+                - HTTP_GATEWAY_RESPONSE_TIME
+                - HTTP_REQUEST_CONTENT_LENGTH
+                - HTTP_RESPONSE_CONTENT_LENGTH
+                - LLM_PROXY_MODEL
+                - LLM_PROXY_PROVIDER
+                - MCP_PROXY_METHOD
+                - MCP_PROXY_TOOL
+                - MCP_PROXY_RESOURCE
+                - MCP_PROXY_PROMPT
+                - API_TYPE
+                - ERROR_KEY
+                - REQUEST_ID
+                - TRANSACTION_ID
+                - PAYLOAD
+                - EDGE_PROVIDER
+                - EDGE_PROCESS
+                - EDGE_CLIENT
+                - EDGE_TYPE
+                - EDGE_VERSION
+                - EDGE_MODEL
+                - EDGE_TOOL
+                - NATIVE_CONNECTION_STATUS
+                - URI
+                - ENTRYPOINT
+            description: Filter names for observability filter definitions, including logs-only filters such as PAYLOAD
+
         Operator:
             type: string
             enum:
@@ -1456,6 +1513,7 @@ components:
                 - IN
                 - LTE
                 - GTE
+                - CONTAINS
             description: Filter operator
 
         MeasureName:
@@ -1554,7 +1612,7 @@ components:
             description: Filter specification for filtering analytics. Available filters are defined for a specific metric.
             properties:
                 name:
-                    $ref: "#/components/schemas/FilterName"
+                    $ref: "#/components/schemas/ObservabilityFilterName"
                 label:
                     type: string
                     description: Human-readable label for the filter
@@ -2273,6 +2331,7 @@ components:
                 propertyName: operator
                 mapping:
                     EQ: "#/components/schemas/StringFilter"
+                    CONTAINS: "#/components/schemas/StringFilter"
                     LTE: "#/components/schemas/NumberFilter"
                     GTE: "#/components/schemas/NumberFilter"
                     IN: "#/components/schemas/ArrayFilter"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
@@ -80,6 +80,16 @@ paths:
                     - name: "RESPONSE_TIME"
                       operator: "LTE"
                       value: 500
+              filter-by-payload:
+                summary: Logs filtered by request/response body content
+                value:
+                  timeRange:
+                    from: "2025-01-01T00:00:00Z"
+                    to: "2025-01-31T23:59:59Z"
+                  filters:
+                    - name: "PAYLOAD"
+                      operator: "CONTAINS"
+                      value: "error 500"
               filter-by-entrypoint:
                 summary: Logs filtered by entrypoint
                 value:
@@ -375,6 +385,7 @@ components:
         propertyName: operator
         mapping:
           EQ: "#/components/schemas/StringFilter"
+          CONTAINS: "#/components/schemas/StringFilter"
           IN: "#/components/schemas/ArrayFilter"
           GTE: "#/components/schemas/NumericFilter"
           LTE: "#/components/schemas/NumericFilter"
@@ -443,7 +454,8 @@ components:
         - RESPONSE_TIME
         - ERROR_KEY
         - API_PRODUCT
-      description: Available filter names for filtering analytics data
+        - PAYLOAD
+      description: Available filter names for filtering connection logs
 
     Operator:
       type: string
@@ -452,5 +464,6 @@ components:
         - GTE
         - LTE
         - IN
+        - CONTAINS
       description: Filter operator
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java
@@ -804,6 +804,44 @@ class LogsSearchResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_accept_payload_contains_filter() {
+            connectionLogsCrudService.initWith(
+                List.of(connectionLogFixtures.aConnectionLog("req1"), connectionLogFixtures.aConnectionLog("req2"))
+            );
+
+            var request = new SearchLogsRequest()
+                .timeRange(
+                    new TimeRange()
+                        .from(OffsetDateTime.parse("2020-01-01T00:00:00.00Z"))
+                        .to(OffsetDateTime.parse("2020-12-31T23:59:59.00Z"))
+                )
+                .addFiltersItem(new Filter(new StringFilter().name(FilterName.PAYLOAD).operator(Operator.CONTAINS).value("error 500")));
+
+            var response = searchTarget.request().post(Entity.json(request));
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(SearchLogsResponse.class)
+                .satisfies(r -> assertThat(r.getData()).isNotNull());
+        }
+
+        @Test
+        void should_accept_payload_contains_filter_via_raw_json() {
+            connectionLogsCrudService.initWith(List.of(connectionLogFixtures.aConnectionLog("req1")));
+
+            var json =
+                "{\"timeRange\":{\"from\":\"2020-01-01T00:00:00Z\",\"to\":\"2020-12-31T23:59:59Z\"}," +
+                "\"filters\":[{\"name\":\"PAYLOAD\",\"operator\":\"CONTAINS\",\"value\":\"search term\"}]}";
+
+            var response = searchTarget.request().post(Entity.json(json));
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(SearchLogsResponse.class)
+                .satisfies(r -> assertThat(r.getData()).isNotNull());
+        }
+
+        @Test
         void should_filter_logs_by_response_time_gte() {
             connectionLogsCrudService.initWith(
                 List.of(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
@@ -69,7 +69,7 @@ class ObservabilityFiltersDefinitionResourceTest extends AbstractResourceTest {
             .hasStatus(200)
             .asEntity(FilterSpecsResponse.class)
             .extracting(FilterSpecsResponse::getData)
-            .satisfies(filters -> assertThat(filters).hasSize(45));
+            .satisfies(filters -> assertThat(filters).hasSize(46));
     }
 
     @Test
@@ -118,6 +118,16 @@ class ObservabilityFiltersDefinitionResourceTest extends AbstractResourceTest {
                     "NATIVE",
                     "EDGE"
                 );
+
+                var payloadFilter = filters
+                    .stream()
+                    .filter(f -> f.getName().getValue().equals("PAYLOAD"))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(payloadFilter.getLabel()).isEqualTo("Payload content");
+                assertThat(payloadFilter.getType()).isEqualTo(FilterSpec.TypeEnum.STRING);
+                assertThat(payloadFilter.getOperators()).containsExactly(Operator.CONTAINS);
+                assertThat(payloadFilter.getApiTypes()).containsExactlyInAnyOrder(ApiName.HTTP_PROXY, ApiName.LLM, ApiName.MCP);
             });
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidator.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.analytics_engine.model.FacetMetricMeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
 import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.TimeRange;
@@ -30,7 +31,9 @@ import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.observability.model.NumberRange;
 import io.gravitee.apim.core.utils.CollectionUtils;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
@@ -41,6 +44,17 @@ public class AnalyticsQueryValidator {
 
     private static final int MAX_FACETS_QUERY_FACETS_SIZE = 3;
     private static final int MAX_TIME_SERIES_QUERY_FACETS_SIZE = 2;
+
+    /**
+     * Filters advertised for observability (logs, value listing) but not supported by the analytics engine.
+     */
+    private static final Set<FilterSpec.Name> ANALYTICS_UNSUPPORTED_FILTERS = EnumSet.of(
+        FilterSpec.Name.PAYLOAD,
+        FilterSpec.Name.API_TYPE,
+        FilterSpec.Name.ERROR_KEY,
+        FilterSpec.Name.REQUEST_ID,
+        FilterSpec.Name.TRANSACTION_ID
+    );
 
     private final AnalyticsDefinitionQueryService definition;
 
@@ -136,6 +150,9 @@ public class AnalyticsQueryValidator {
         for (var filter : filters) {
             if (filter.name() == null) {
                 throw new InvalidQueryException("Filter name cannot be null");
+            }
+            if (ANALYTICS_UNSUPPORTED_FILTERS.contains(filter.name())) {
+                throw InvalidQueryException.forUnsupportedAnalyticsFilter(filter.name().name());
             }
             if (filter.value() == null) {
                 throw InvalidQueryException.forNullFilterValue(filter.name().name());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/exception/InvalidQueryException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/exception/InvalidQueryException.java
@@ -67,6 +67,13 @@ public class InvalidQueryException extends ValidationDomainException {
         return new InvalidQueryException("Filter '" + filterName + "' requires a non-null value");
     }
 
+    public static InvalidQueryException forUnsupportedAnalyticsFilter(String filterName) {
+        return new InvalidQueryException(
+            "Filter '" + filterName + "' is not supported for analytics queries",
+            "analytics.filter.unsupported"
+        );
+    }
+
     public static InvalidQueryException forUnknownAPIType(String apiType) {
         return new InvalidQueryException("Unknown API type '" + apiType + "'", "analytics.filter.invalidValue");
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
@@ -81,5 +81,6 @@ public record FilterSpec(
         ERROR_KEY,
         REQUEST_ID,
         TRANSACTION_ID,
+        PAYLOAD,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/domain_service/FilterContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/domain_service/FilterContext.java
@@ -38,6 +38,7 @@ public final class FilterContext {
     private Long responseTimeTo;
     private Set<String> errorKeys;
     private Set<String> apiProductIds;
+    private String bodyText;
 
     private <T> Set<T> limitBy(Set<T> current, Set<T> incoming) {
         if (incoming == null) {
@@ -99,6 +100,13 @@ public final class FilterContext {
             return;
         }
         this.uri = uri;
+    }
+
+    public void limitByBodyText(String bodyText) {
+        if (bodyText == null) {
+            return;
+        }
+        this.bodyText = bodyText;
     }
 
     public void limitByResponseTimeFrom(Long responseTimeFrom) {
@@ -169,5 +177,9 @@ public final class FilterContext {
 
     public Optional<Set<String>> apiProductIds() {
         return Optional.ofNullable(apiProductIds);
+    }
+
+    public Optional<String> bodyText() {
+        return Optional.ofNullable(bodyText);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/FilterName.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/FilterName.java
@@ -29,4 +29,5 @@ public enum FilterName {
     RESPONSE_TIME,
     ERROR_KEY,
     API_PRODUCT,
+    PAYLOAD,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/Operator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/Operator.java
@@ -20,4 +20,5 @@ public enum Operator {
     IN,
     GTE,
     LTE,
+    CONTAINS,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
@@ -234,6 +234,7 @@ public class SearchEnvironmentLogsUseCase {
         builder.responseTimeRanges(buildResponseTimeRanges(filterContext));
         builder.errorKeys(filterContext.errorKeys().orElseGet(Collections::emptySet));
         builder.apiProductIds(filterContext.apiProductIds().orElseGet(Collections::emptySet));
+        builder.bodyText(filterContext.bodyText().orElse(null));
 
         if (request.timeRange() != null) {
             if (isTimeRangeInvalid(request.timeRange())) {
@@ -251,6 +252,17 @@ public class SearchEnvironmentLogsUseCase {
     }
 
     private void applyStringFilter(StringFilter filter, FilterContext filterContext) {
+        if (filter.name() == FilterName.PAYLOAD) {
+            if (filter.operator() != Operator.CONTAINS) {
+                throw new ValidationDomainException("Filter PAYLOAD only supports operator CONTAINS.");
+            }
+            if (filter.value() == null || filter.value().isBlank()) {
+                throw new ValidationDomainException("Filter PAYLOAD requires a non-blank value.");
+            }
+            filterContext.limitByBodyText(filter.value());
+            return;
+        }
+
         if (filter.operator() == Operator.EQ) {
             updateFilterIds(filter.name(), filterContext, Set.of(filter.value()));
             return;
@@ -320,13 +332,12 @@ public class SearchEnvironmentLogsUseCase {
             case ERROR_KEY -> filterContext.limitByErrorKeys(ids);
             case API_PRODUCT -> filterContext.limitByApiProductIds(ids);
             case URI -> {
-                // For URI, only EQ filters are supported, so we take the first (and presumably
-                // only) value
                 if (!ids.isEmpty()) {
                     filterContext.limitByUri(ids.iterator().next());
                 }
             }
-            default -> throw new IllegalStateException("Unexpected value: " + name);
+            case PAYLOAD -> {}
+            case RESPONSE_TIME -> {}
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/observability/model/FilterOperator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/observability/model/FilterOperator.java
@@ -23,4 +23,5 @@ public enum FilterOperator {
     LTE,
     GTE,
     IN,
+    CONTAINS,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/AnalyticsMeasuresAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/AnalyticsMeasuresAdapter.java
@@ -111,5 +111,9 @@ public interface AnalyticsMeasuresAdapter {
     @ValueMapping(source = "ERROR_KEY", target = MappingConstants.THROW_EXCEPTION)
     @ValueMapping(source = "REQUEST_ID", target = MappingConstants.THROW_EXCEPTION)
     @ValueMapping(source = "TRANSACTION_ID", target = MappingConstants.THROW_EXCEPTION)
+    @ValueMapping(source = "PAYLOAD", target = MappingConstants.THROW_EXCEPTION)
     Filter.Name toFilterName(io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name name);
+
+    @ValueMapping(source = "CONTAINS", target = MappingConstants.THROW_EXCEPTION)
+    Filter.Operator toFilterOperator(io.gravitee.apim.core.observability.model.FilterOperator operator);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
@@ -85,14 +85,18 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
         Pageable pageable,
         List<DefinitionVersion> definitionVersions
     ) {
+        var connectionLogsFilterBuilder = mapToConnectionLogQueryFilterBuilder(logsFilters).apiIds(apiIds);
+        var detailFilterBuilder = mapToConnectionLogDetailQueryFilterBuilder(logsFilters).apiIds(apiIds);
+
         try {
-            var response = getConnectionLogsResponse(
+            return searchConnectionLogsWithOptionalBodyText(
                 executionContext,
-                mapToConnectionLogQueryFilterBuilder(logsFilters).apiIds(apiIds).build(),
+                logsFilters,
                 pageable,
-                definitionVersions
+                definitionVersions,
+                connectionLogsFilterBuilder,
+                detailFilterBuilder
             );
-            return mapToConnectionResponse(response);
         } catch (AnalyticsException e) {
             String joinedApiIds = String.join(",", apiIds);
             log.error("An error occurs while trying to search connection logs of api [apiIds={}]", joinedApiIds, e);
@@ -107,51 +111,18 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
         SearchLogsFilters logsFilters,
         Pageable pageable
     ) {
-        var executeConnectionLogDetailsSearch = logsFilters.bodyText() != null && !logsFilters.bodyText().isBlank();
-        var connectionLogDetailsResponseTotal = 0L;
-
         var connectionLogsFilterBuilder = mapToConnectionLogQueryFilterBuilder(logsFilters).applicationIds(Set.of(applicationId));
+        var detailFilterBuilder = mapToConnectionLogDetailQueryFilterBuilder(logsFilters);
 
         try {
-            if (executeConnectionLogDetailsSearch) {
-                var connectionLogDetailsResponse = searchConnectionLogDetails(
-                    executionContext,
-                    ConnectionLogDetailQuery.builder()
-                        .projectionFields(List.of("_id", "request-id"))
-                        .filter(mapToConnectionLogDetailQueryFilterBuilder(logsFilters).build())
-                        .page(pageable.getPageNumber())
-                        .size(pageable.getPageSize())
-                        .build()
-                );
-
-                if (connectionLogDetailsResponse.total() == 0L) {
-                    return new SearchLogsResponse<>(0, new ArrayList<>());
-                }
-
-                connectionLogDetailsResponseTotal = connectionLogDetailsResponse.total();
-
-                var requestIds = connectionLogDetailsResponse
-                    .data()
-                    .stream()
-                    .map(io.gravitee.repository.log.v4.model.connection.ConnectionLogDetail::getRequestId)
-                    .collect(Collectors.toSet());
-                connectionLogsFilterBuilder.requestIds(requestIds);
-            }
-
-            var connectionLogsResponsePageable = executeConnectionLogDetailsSearch ? new PageableImpl(1, pageable.getPageSize()) : pageable;
-            var connectionLogsResponse = getConnectionLogsResponse(
+            return searchConnectionLogsWithOptionalBodyText(
                 executionContext,
-                connectionLogsFilterBuilder.build(),
-                connectionLogsResponsePageable,
-                List.of(DefinitionVersion.V2, DefinitionVersion.V4)
+                logsFilters,
+                pageable,
+                List.of(DefinitionVersion.V2, DefinitionVersion.V4),
+                connectionLogsFilterBuilder,
+                detailFilterBuilder
             );
-
-            // If a previous search has been done and a full page is being returned in the second search, use the first search total
-            if (executeConnectionLogDetailsSearch && connectionLogsResponse.total() == pageable.getPageSize()) {
-                return mapToConnectionResponse(new LogResponse<>(connectionLogDetailsResponseTotal, connectionLogsResponse.data()));
-            }
-
-            return mapToConnectionResponse(connectionLogsResponse);
         } catch (AnalyticsException e) {
             log.error("An error occurs while trying to search application connection logs [applicationId={}]", applicationId, e);
             throw new TechnicalManagementException("Error while searching application connection logs " + applicationId, e);
@@ -172,6 +143,52 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
             log.error("An error occurs while trying to search connection log of api [apiId={}, requestId={}]", apiId, requestId, e);
             throw new TechnicalManagementException("Error while searching connection log of api " + apiId + " requestId " + requestId, e);
         }
+    }
+
+    private SearchLogsResponse<BaseConnectionLog> searchConnectionLogsWithOptionalBodyText(
+        ExecutionContext executionContext,
+        SearchLogsFilters logsFilters,
+        Pageable pageable,
+        List<DefinitionVersion> definitionVersions,
+        MetricsQuery.Filter.FilterBuilder metricsFilterBuilder,
+        ConnectionLogDetailQuery.Filter.FilterBuilder detailFilterBuilder
+    ) throws AnalyticsException {
+        var hasBodyTextFilter = logsFilters.bodyText() != null && !logsFilters.bodyText().isBlank();
+        long bodySearchTotal = 0L;
+
+        if (hasBodyTextFilter) {
+            var bodySearchResponse = searchConnectionLogDetails(
+                executionContext,
+                ConnectionLogDetailQuery.builder()
+                    .projectionFields(List.of("_id", "request-id"))
+                    .filter(detailFilterBuilder.build())
+                    .page(pageable.getPageNumber())
+                    .size(pageable.getPageSize())
+                    .build()
+            );
+
+            if (bodySearchResponse.total() == 0L) {
+                return new SearchLogsResponse<>(0, new ArrayList<>());
+            }
+
+            bodySearchTotal = bodySearchResponse.total();
+
+            var matchedRequestIds = bodySearchResponse
+                .data()
+                .stream()
+                .map(io.gravitee.repository.log.v4.model.connection.ConnectionLogDetail::getRequestId)
+                .collect(Collectors.toSet());
+            metricsFilterBuilder.requestIds(matchedRequestIds);
+        }
+
+        var metricsPageable = hasBodyTextFilter ? new PageableImpl(1, pageable.getPageSize()) : pageable;
+        var response = getConnectionLogsResponse(executionContext, metricsFilterBuilder.build(), metricsPageable, definitionVersions);
+
+        if (hasBodyTextFilter && response.total() == pageable.getPageSize()) {
+            return mapToConnectionResponse(new LogResponse<>(bodySearchTotal, response.data()));
+        }
+
+        return mapToConnectionResponse(response);
     }
 
     private SearchLogsResponse<BaseConnectionLog> mapToConnectionResponse(LogResponse<Metrics> logs) {
@@ -213,6 +230,12 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
             .mcpProxyPrompts(searchLogsFilters.mcpProxyPrompts());
     }
 
+    /**
+     * Builds a filter for the v4-log index (body text search phase). Only includes fields that
+     * actually exist in v4-log documents: time range, apiIds, requestIds, and bodyText.
+     * Metric-specific fields (statuses, methods, uri, etc.) must NOT be included here — they
+     * only exist in v4-metrics and are applied in the second phase of a two-phase search.
+     */
     private static ConnectionLogDetailQuery.Filter.FilterBuilder mapToConnectionLogDetailQueryFilterBuilder(
         SearchLogsFilters searchLogsFilters
     ) {
@@ -220,10 +243,7 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
             .from(searchLogsFilters.from())
             .to(searchLogsFilters.to())
             .apiIds(searchLogsFilters.apiIds())
-            .methods(searchLogsFilters.methods())
-            .statuses(searchLogsFilters.statuses())
             .requestIds(searchLogsFilters.requestIds())
-            .uri(searchLogsFilters.uri())
             .bodyText(searchLogsFilters.bodyText());
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
@@ -1480,6 +1480,16 @@ spec:
               - EQ
               - IN
 
+        - name: PAYLOAD
+          label: Payload content
+          type: STRING
+          operators:
+              - CONTAINS
+          apis:
+              - HTTP_PROXY
+              - LLM
+              - MCP
+
         - name: API_PRODUCT
           label: API Product
           type: KEYWORD

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidatorTest.java
@@ -68,7 +68,7 @@ class AnalyticsQueryValidatorTest {
 
         @Test
         void should_reject_null_filter_value_in_measures_request() {
-            var nullValueFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.EQ, null);
+            var nullValueFilter = new Filter(FilterSpec.Name.HTTP_METHOD, FilterOperator.EQ, null);
             var request = new MeasuresRequest(
                 VALID_TIME_RANGE,
                 List.of(nullValueFilter),
@@ -166,6 +166,24 @@ class AnalyticsQueryValidatorTest {
             );
 
             validator.validateMeasuresRequest(request);
+        }
+    }
+
+    @Nested
+    class UnsupportedAnalyticsFilters {
+
+        @Test
+        void should_reject_payload_filter_in_measures_request() {
+            var payloadFilter = new Filter(FilterSpec.Name.PAYLOAD, FilterOperator.CONTAINS, "error");
+            var request = new MeasuresRequest(
+                VALID_TIME_RANGE,
+                List.of(payloadFilter),
+                List.of(new MetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT)))
+            );
+
+            assertThatThrownBy(() -> validator.validateMeasuresRequest(request))
+                .isInstanceOf(InvalidQueryException.class)
+                .hasMessageContaining("not supported for analytics queries");
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
@@ -686,6 +686,155 @@ class SearchEnvironmentLogsUseCaseTest {
             );
         }
 
+        @Test
+        void should_map_payload_contains_filter_to_body_text() {
+            var request = new SearchLogsRequest(
+                null,
+                List.of(new Filter(new StringFilter(FilterName.PAYLOAD, Operator.CONTAINS, "error 500"))),
+                1,
+                10
+            );
+
+            when_searching(request);
+
+            var filtersCaptor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+            verify(connectionLogsCrudService).searchApiConnectionLogs(any(), filtersCaptor.capture(), any(), any());
+
+            assertThat(filtersCaptor.getValue().bodyText()).isEqualTo("error 500");
+        }
+
+        @Test
+        void should_set_body_text_to_null_when_no_payload_filter() {
+            var request = new SearchLogsRequest(
+                null,
+                List.of(new Filter(new StringFilter(FilterName.API, Operator.EQ, API1.getId()))),
+                1,
+                10
+            );
+
+            when_searching(request);
+
+            var filtersCaptor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+            verify(connectionLogsCrudService).searchApiConnectionLogs(any(), filtersCaptor.capture(), any(), any());
+
+            assertThat(filtersCaptor.getValue().bodyText()).isNull();
+        }
+
+        @Test
+        void should_use_last_payload_value_when_multiple_payload_filters() {
+            var request = new SearchLogsRequest(
+                null,
+                List.of(
+                    new Filter(new StringFilter(FilterName.PAYLOAD, Operator.CONTAINS, "first")),
+                    new Filter(new StringFilter(FilterName.PAYLOAD, Operator.CONTAINS, "second"))
+                ),
+                1,
+                10
+            );
+
+            when_searching(request);
+
+            var filtersCaptor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+            verify(connectionLogsCrudService).searchApiConnectionLogs(any(), filtersCaptor.capture(), any(), any());
+
+            assertThat(filtersCaptor.getValue().bodyText()).isEqualTo("second");
+        }
+
+        @Test
+        void should_combine_payload_with_other_filters() {
+            var request = new SearchLogsRequest(
+                null,
+                List.of(
+                    new Filter(new StringFilter(FilterName.PAYLOAD, Operator.CONTAINS, "error")),
+                    new Filter(new ArrayFilter(FilterName.HTTP_STATUS, Operator.IN, List.of("500", "502"))),
+                    new Filter(new StringFilter(FilterName.URI, Operator.EQ, "/api/test"))
+                ),
+                1,
+                10
+            );
+
+            when_searching(request);
+
+            var filtersCaptor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+            verify(connectionLogsCrudService).searchApiConnectionLogs(any(), filtersCaptor.capture(), any(), any());
+
+            var filters = filtersCaptor.getValue();
+            assertThat(filters.bodyText()).isEqualTo("error");
+            assertThat(filters.statuses()).containsExactlyInAnyOrder(500, 502);
+            assertThat(filters.uri()).isEqualTo("/api/test");
+        }
+
+        @Test
+        void should_combine_payload_with_other_filters_on_later_pages() {
+            var request = new SearchLogsRequest(
+                null,
+                List.of(
+                    new Filter(new StringFilter(FilterName.PAYLOAD, Operator.CONTAINS, "error")),
+                    new Filter(new ArrayFilter(FilterName.HTTP_STATUS, Operator.IN, List.of("500", "502")))
+                ),
+                3,
+                5
+            );
+
+            when(connectionLogsCrudService.searchApiConnectionLogs(any(), any(), any(), any())).thenReturn(
+                new io.gravitee.rest.api.model.v4.log.SearchLogsResponse<>(25, List.of(LOG1))
+            );
+            when(userContextLoader.loadApis(any())).thenReturn(
+                new UserContext(
+                    AUDIT_INFO,
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.of(List.of(API1))
+                )
+            );
+            when(planCrudService.findByIds(any())).thenReturn(List.of());
+            when(applicationCrudService.findByIds(any(), any())).thenReturn(List.of());
+            when(logNamesPostProcessor.mapLogNames(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
+            when(apiProductQueryService.findByEnvironmentIdAndIdIn(any(), any())).thenReturn(Set.of());
+
+            var output = useCase.execute(new Input(AUDIT_INFO, request));
+
+            var filtersCaptor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+            var pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+            verify(connectionLogsCrudService).searchApiConnectionLogs(any(), filtersCaptor.capture(), pageableCaptor.capture(), any());
+
+            assertThat(filtersCaptor.getValue().bodyText()).isEqualTo("error");
+            assertThat(filtersCaptor.getValue().statuses()).containsExactlyInAnyOrder(500, 502);
+            assertThat(pageableCaptor.getValue().getPageNumber()).isEqualTo(3);
+            assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(5);
+            assertThat(output.response().pagination().totalCount()).isEqualTo(25);
+        }
+
+        @Test
+        void should_reject_blank_payload_value() {
+            var request = new SearchLogsRequest(
+                null,
+                List.of(new Filter(new StringFilter(FilterName.PAYLOAD, Operator.CONTAINS, "   "))),
+                1,
+                10
+            );
+
+            assertThatThrownBy(() -> useCase.execute(new Input(AUDIT_INFO, request)))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("non-blank");
+        }
+
+        @Test
+        void should_reject_invalid_payload_operator() {
+            var request = new SearchLogsRequest(
+                null,
+                List.of(new Filter(new StringFilter(FilterName.PAYLOAD, Operator.EQ, "error"))),
+                1,
+                10
+            );
+
+            assertThatThrownBy(() -> useCase.execute(new Input(AUDIT_INFO, request)))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("CONTAINS");
+        }
+
         @ParameterizedTest
         @MethodSource("responseTimeFiltersProvider")
         void should_map_response_time_filters(List<Filter> filters, List<Range> expectedRanges) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImplTest.java
@@ -240,6 +240,202 @@ class ConnectionLogsCrudServiceImplTest {
     }
 
     @Nested
+    class SearchApiConnectionLogsWithBodyText {
+
+        @Test
+        void should_return_empty_when_no_body_text_matches() throws AnalyticsException {
+            when(logRepository.searchConnectionLogDetails(any(QueryContext.class), any())).thenReturn(new LogResponse<>(0, List.of()));
+
+            var result = logCrudService.searchApiConnectionLogs(
+                GraviteeContext.getExecutionContext(),
+                Set.of("api-1"),
+                SearchLogsFilters.builder().from(0L).to(1L).bodyText("needle").build(),
+                new PageableImpl(1, 10),
+                List.of(DefinitionVersion.V4)
+            );
+
+            assertThat(result.total()).isZero();
+            verify(logRepository).searchConnectionLogDetails(any(QueryContext.class), any());
+            verify(metricsRepository, never()).searchMetrics(any(), any(), any());
+        }
+
+        @Test
+        void should_perform_two_phase_search_when_body_text_matches() throws AnalyticsException {
+            when(logRepository.searchConnectionLogDetails(any(QueryContext.class), any())).thenReturn(
+                new LogResponse<>(
+                    2,
+                    List.of(ConnectionLogDetail.builder().requestId("r-1").build(), ConnectionLogDetail.builder().requestId("r-2").build())
+                )
+            );
+
+            when(metricsRepository.searchMetrics(any(QueryContext.class), any(), eq(List.of(DefinitionVersion.V4)))).thenReturn(
+                new LogResponse<>(2, List.of(Metrics.builder().requestId("r-1").build(), Metrics.builder().requestId("r-2").build()))
+            );
+
+            var result = logCrudService.searchApiConnectionLogs(
+                GraviteeContext.getExecutionContext(),
+                Set.of("api-1"),
+                SearchLogsFilters.builder().from(0L).to(1L).bodyText("needle").build(),
+                new PageableImpl(1, 10),
+                List.of(DefinitionVersion.V4)
+            );
+
+            assertThat(result.total()).isEqualTo(2);
+            assertThat(result.logs()).hasSize(2);
+
+            var detailCaptor = ArgumentCaptor.forClass(ConnectionLogDetailQuery.class);
+            verify(logRepository).searchConnectionLogDetails(any(QueryContext.class), detailCaptor.capture());
+            assertThat(detailCaptor.getValue().getFilter().getBodyText()).isEqualTo("needle");
+            assertThat(detailCaptor.getValue().getFilter().getApiIds()).containsExactly("api-1");
+
+            var metricsCaptor = ArgumentCaptor.forClass(MetricsQuery.class);
+            verify(metricsRepository).searchMetrics(any(QueryContext.class), metricsCaptor.capture(), eq(List.of(DefinitionVersion.V4)));
+            assertThat(metricsCaptor.getValue().getFilter().getRequestIds()).containsExactlyInAnyOrder("r-1", "r-2");
+        }
+
+        @Test
+        void should_skip_two_phase_when_body_text_is_blank() throws AnalyticsException {
+            when(metricsRepository.searchMetrics(any(QueryContext.class), any(), eq(List.of(DefinitionVersion.V4)))).thenReturn(
+                new LogResponse<>(0, List.of())
+            );
+
+            logCrudService.searchApiConnectionLogs(
+                GraviteeContext.getExecutionContext(),
+                Set.of("api-1"),
+                SearchLogsFilters.builder().from(0L).to(1L).bodyText("").build(),
+                new PageableImpl(1, 10),
+                List.of(DefinitionVersion.V4)
+            );
+
+            verify(logRepository, never()).searchConnectionLogDetails(any(), any());
+            verify(metricsRepository).searchMetrics(any(QueryContext.class), any(), eq(List.of(DefinitionVersion.V4)));
+        }
+
+        @Test
+        void should_skip_two_phase_when_body_text_is_null() throws AnalyticsException {
+            when(metricsRepository.searchMetrics(any(QueryContext.class), any(), eq(List.of(DefinitionVersion.V4)))).thenReturn(
+                new LogResponse<>(0, List.of())
+            );
+
+            logCrudService.searchApiConnectionLogs(
+                GraviteeContext.getExecutionContext(),
+                Set.of("api-1"),
+                SearchLogsFilters.builder().from(0L).to(1L).bodyText(null).build(),
+                new PageableImpl(1, 10),
+                List.of(DefinitionVersion.V4)
+            );
+
+            verify(logRepository, never()).searchConnectionLogDetails(any(), any());
+            verify(metricsRepository).searchMetrics(any(QueryContext.class), any(), eq(List.of(DefinitionVersion.V4)));
+        }
+
+        @Test
+        void should_not_pass_metric_fields_to_v4_log_filter_when_combined_with_statuses() throws AnalyticsException {
+            when(logRepository.searchConnectionLogDetails(any(QueryContext.class), any())).thenReturn(
+                new LogResponse<>(1, List.of(ConnectionLogDetail.builder().requestId("r-1").build()))
+            );
+
+            when(metricsRepository.searchMetrics(any(QueryContext.class), any(), eq(List.of(DefinitionVersion.V4)))).thenReturn(
+                new LogResponse<>(1, List.of(Metrics.builder().requestId("r-1").build()))
+            );
+
+            logCrudService.searchApiConnectionLogs(
+                GraviteeContext.getExecutionContext(),
+                Set.of("api-1"),
+                SearchLogsFilters.builder()
+                    .from(0L)
+                    .to(1L)
+                    .bodyText("needle")
+                    .statuses(Set.of(200))
+                    .methods(Set.of(HttpMethod.GET))
+                    .uri("/test")
+                    .build(),
+                new PageableImpl(1, 10),
+                List.of(DefinitionVersion.V4)
+            );
+
+            var detailCaptor = ArgumentCaptor.forClass(ConnectionLogDetailQuery.class);
+            verify(logRepository).searchConnectionLogDetails(any(QueryContext.class), detailCaptor.capture());
+
+            var logFilter = detailCaptor.getValue().getFilter();
+            assertThat(logFilter.getBodyText()).isEqualTo("needle");
+            assertThat(logFilter.getApiIds()).containsExactly("api-1");
+            assertThat(logFilter.getStatuses()).isNull();
+            assertThat(logFilter.getMethods()).isNull();
+            assertThat(logFilter.getUri()).isNull();
+
+            var metricsCaptor = ArgumentCaptor.forClass(MetricsQuery.class);
+            verify(metricsRepository).searchMetrics(any(QueryContext.class), metricsCaptor.capture(), eq(List.of(DefinitionVersion.V4)));
+
+            var metricsFilter = metricsCaptor.getValue().getFilter();
+            assertThat(metricsFilter.getStatuses()).containsExactly(200);
+            assertThat(metricsFilter.getMethods()).containsExactly(HttpMethod.GET);
+            assertThat(metricsFilter.getUri()).isEqualTo("/test");
+            assertThat(metricsFilter.getRequestIds()).containsExactly("r-1");
+        }
+
+        @Test
+        void should_reset_pagination_to_page_1_for_metrics_phase() throws AnalyticsException {
+            when(logRepository.searchConnectionLogDetails(any(QueryContext.class), any())).thenReturn(
+                new LogResponse<>(1, List.of(ConnectionLogDetail.builder().requestId("r-1").build()))
+            );
+
+            when(metricsRepository.searchMetrics(any(QueryContext.class), any(), eq(List.of(DefinitionVersion.V4)))).thenReturn(
+                new LogResponse<>(1, List.of(Metrics.builder().requestId("r-1").build()))
+            );
+
+            logCrudService.searchApiConnectionLogs(
+                GraviteeContext.getExecutionContext(),
+                Set.of("api-1"),
+                SearchLogsFilters.builder().from(0L).to(1L).bodyText("needle").build(),
+                new PageableImpl(3, 10),
+                List.of(DefinitionVersion.V4)
+            );
+
+            var metricsCaptor = ArgumentCaptor.forClass(MetricsQuery.class);
+            verify(metricsRepository).searchMetrics(any(QueryContext.class), metricsCaptor.capture(), eq(List.of(DefinitionVersion.V4)));
+            assertThat(metricsCaptor.getValue().getPage()).isEqualTo(1);
+            assertThat(metricsCaptor.getValue().getSize()).isEqualTo(10);
+        }
+
+        @Test
+        void should_use_body_search_total_when_metrics_returns_full_page() throws AnalyticsException {
+            when(logRepository.searchConnectionLogDetails(any(QueryContext.class), any())).thenReturn(
+                new LogResponse<>(
+                    25,
+                    List.of(
+                        ConnectionLogDetail.builder().requestId("r-1").build(),
+                        ConnectionLogDetail.builder().requestId("r-2").build(),
+                        ConnectionLogDetail.builder().requestId("r-3").build()
+                    )
+                )
+            );
+
+            when(metricsRepository.searchMetrics(any(QueryContext.class), any(), eq(List.of(DefinitionVersion.V4)))).thenReturn(
+                new LogResponse<>(
+                    3,
+                    List.of(
+                        Metrics.builder().requestId("r-1").build(),
+                        Metrics.builder().requestId("r-2").build(),
+                        Metrics.builder().requestId("r-3").build()
+                    )
+                )
+            );
+
+            var result = logCrudService.searchApiConnectionLogs(
+                GraviteeContext.getExecutionContext(),
+                Set.of("api-1"),
+                SearchLogsFilters.builder().from(0L).to(1L).bodyText("needle").build(),
+                new PageableImpl(1, 3),
+                List.of(DefinitionVersion.V4)
+            );
+
+            assertThat(result.total()).isEqualTo(25);
+            assertThat(result.logs()).hasSize(3);
+        }
+    }
+
+    @Nested
     class SearchApplicationConnectionLogs {
 
         @Test
@@ -364,16 +560,7 @@ class ConnectionLogsCrudServiceImplTest {
                 ConnectionLogDetailQuery.builder()
                     .size(3)
                     .projectionFields(List.of("_id", "request-id"))
-                    .filter(
-                        ConnectionLogDetailQuery.Filter.builder()
-                            .to(1L)
-                            .from(0L)
-                            .apiIds(Set.of("api-1"))
-                            .methods(Set.of(HttpMethod.GET))
-                            .statuses(Set.of(3))
-                            .bodyText("curl")
-                            .build()
-                    )
+                    .filter(ConnectionLogDetailQuery.Filter.builder().to(1L).from(0L).apiIds(Set.of("api-1")).bodyText("curl").build())
                     .build()
             );
         }
@@ -443,16 +630,7 @@ class ConnectionLogsCrudServiceImplTest {
             assertThat(captorConnectionLogDetailQuery.getValue()).isEqualTo(
                 ConnectionLogDetailQuery.builder()
                     .projectionFields(List.of("_id", "request-id"))
-                    .filter(
-                        ConnectionLogDetailQuery.Filter.builder()
-                            .to(1L)
-                            .from(0L)
-                            .apiIds(Set.of("api-1"))
-                            .methods(Set.of(HttpMethod.GET))
-                            .statuses(Set.of(3))
-                            .bodyText("curl")
-                            .build()
-                    )
+                    .filter(ConnectionLogDetailQuery.Filter.builder().to(1L).from(0L).apiIds(Set.of("api-1")).bodyText("curl").build())
                     .build()
             );
 
@@ -545,16 +723,7 @@ class ConnectionLogsCrudServiceImplTest {
                 ConnectionLogDetailQuery.builder()
                     .size(3)
                     .projectionFields(List.of("_id", "request-id"))
-                    .filter(
-                        ConnectionLogDetailQuery.Filter.builder()
-                            .to(1L)
-                            .from(0L)
-                            .apiIds(Set.of("api-1"))
-                            .methods(Set.of(HttpMethod.GET))
-                            .statuses(Set.of(3))
-                            .bodyText("curl")
-                            .build()
-                    )
+                    .filter(ConnectionLogDetailQuery.Filter.builder().to(1L).from(0L).apiIds(Set.of("api-1")).bodyText("curl").build())
                     .build()
             );
 

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.html
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.html
@@ -45,13 +45,16 @@
           <mat-option [value]="def" class="gd-add-filter__field-item gd-add-filter__field-option">
             <div class="gd-add-filter__row">
               <span class="gd-add-filter__row-label">{{ def.label }}</span>
-              @if (def.apiTypes?.length) {
-                <span class="gd-add-filter__row-meta">
+              <span class="gd-add-filter__row-meta">
+                @if (isSignalExclusive(def); as exclusiveSignal) {
+                  <span class="gd-add-filter__signal-badge">{{ exclusiveSignal }} only</span>
+                }
+                @if (def.apiTypes?.length) {
                   @for (apiType of def.apiTypes; track apiType) {
                     <span class="gd-add-filter__api-badge">{{ formatApiTypeForDisplay(apiType) }}</span>
                   }
-                </span>
-              }
+                }
+              </span>
             </div>
           </mat-option>
         }

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.scss
@@ -172,9 +172,23 @@
   text-align: right;
 }
 
-// API type pills in the "Filter by" list — same visual family as gd-filter-chip (light fill, darker label).
-// Optional host overrides: --gd-add-filter-type-badge-background, --gd-add-filter-type-badge-foreground,
-// --gd-add-filter-type-badge-font-weight (default to --gd-filter-chip-* when unset).
+.gd-add-filter__signal-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 14px;
+  min-height: 18px;
+  padding: 2px 6px;
+  border-radius: var(--gd-filter-chip-radius, 6px);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  background-color: var(--gd-add-filter-signal-badge-background, #e8f0fe);
+  color: var(--gd-add-filter-signal-badge-foreground, #1a73e8);
+}
+
 .gd-add-filter__api-badge {
   display: inline-flex;
   align-items: center;

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.spec.ts
@@ -56,6 +56,15 @@ const STRING_DEF: FilterDefinition = {
   operators: ['EQ'],
 };
 
+const CONTAINS_STRING_DEF: FilterDefinition = {
+  name: 'PAYLOAD',
+  label: 'Payload content',
+  type: 'STRING',
+  operators: ['CONTAINS'],
+  apiTypes: ['HTTP_PROXY', 'LLM', 'MCP'],
+  signals: ['LOGS'],
+};
+
 const UNKNOWN_TYPE_DEF: FilterDefinition = {
   name: 'FUTURE_FILTER',
   label: 'Future Filter',
@@ -63,7 +72,7 @@ const UNKNOWN_TYPE_DEF: FilterDefinition = {
   operators: ['EQ', 'BETWEEN'],
 };
 
-const ALL_DEFINITIONS = [ENUM_DEF, NUMBER_DEF, KEYWORD_DEF, STRING_DEF, UNKNOWN_TYPE_DEF];
+const ALL_DEFINITIONS = [ENUM_DEF, NUMBER_DEF, KEYWORD_DEF, STRING_DEF, CONTAINS_STRING_DEF, UNKNOWN_TYPE_DEF];
 
 class MockDefinitionProvider implements FilterDefinitionProvider {
   getDefinitions() {
@@ -137,10 +146,11 @@ describe('AddFilterDialogComponent', () => {
     it('should filter definitions by apiType search term', async () => {
       component['fieldControl'].setValue('LLM');
       const filtered = await firstValueFrom(component['filteredDefinitions$']);
-      expect(filtered.length).toBe(2);
+      expect(filtered.length).toBe(3);
       const names = filtered.map(d => d.name);
       expect(names).toContain('HTTP_METHOD');
       expect(names).toContain('API');
+      expect(names).toContain('PAYLOAD');
     });
 
     it('should filter definitions by name (case insensitive)', async () => {
@@ -331,6 +341,62 @@ describe('AddFilterDialogComponent', () => {
         existingCondition: { field: 'HTTP_METHOD', label: 'HTTP Method', operator: 'EQ', values: ['GET'] },
       });
       expect(component['isEditMode']()).toBe(true);
+    });
+  });
+
+  describe('CONTAINS operator (PAYLOAD filter)', () => {
+    beforeEach(async () => {
+      await setup();
+      component['selectDefinition'](CONTAINS_STRING_DEF);
+      fixture.detectChanges();
+    });
+
+    it('should auto-select CONTAINS when it is the only operator', () => {
+      expect(component['selectedOperator']()).toBe('CONTAINS');
+      expect(component['operatorControl'].value).toBe('CONTAINS');
+    });
+
+    it('should expose CONTAINS as only available operator', () => {
+      expect(component['availableOperators']()).toEqual(['CONTAINS']);
+    });
+
+    it('should resolve to STRING type for CONTAINS filter', () => {
+      expect(component['resolvedFilterType']()).toBe('STRING');
+    });
+
+    it('should display operator label as "Contains"', () => {
+      expect(component['operatorLabel']('CONTAINS')).toBe('Contains');
+    });
+
+    it('should confirm with CONTAINS operator and single value', () => {
+      component['selectedValues'].set(['quantum']);
+      fixture.detectChanges();
+
+      component['confirm']();
+
+      expect(dialogRefSpy.close).toHaveBeenCalledWith({
+        field: 'PAYLOAD',
+        label: 'Payload content',
+        operator: 'CONTAINS',
+        values: ['quantum'],
+        valueLabels: ['quantum'],
+      });
+    });
+  });
+
+  describe('signal-exclusive badge', () => {
+    beforeEach(() => setup());
+
+    it('should return "Logs" for a filter with only LOGS signal', () => {
+      expect(component['isSignalExclusive'](CONTAINS_STRING_DEF)).toBe('Logs');
+    });
+
+    it('should return null for a filter spanning multiple signals', () => {
+      expect(component['isSignalExclusive'](ENUM_DEF)).toBeNull();
+    });
+
+    it('should return null for a filter without signals', () => {
+      expect(component['isSignalExclusive'](STRING_DEF)).toBeNull();
     });
   });
 

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.ts
@@ -68,7 +68,7 @@ export interface AddFilterDialogData {
   timeTo?: number;
 }
 
-const KNOWN_OPERATORS: ReadonlySet<string> = new Set<FilterOperator>(['EQ', 'NEQ', 'IN', 'NOT_IN', 'LTE', 'GTE']);
+const KNOWN_OPERATORS: ReadonlySet<string> = new Set<FilterOperator>(['EQ', 'NEQ', 'CONTAINS', 'IN', 'NOT_IN', 'LTE', 'GTE']);
 
 /** Human-readable labels for `FilterDefinition.apiTypes` in the "Filter by" list; tokens not listed stay as-is (e.g. LLM, MCP). */
 const ADD_FILTER_API_TYPE_DISPLAY_LABELS: Readonly<Record<string, string>> = {
@@ -244,6 +244,12 @@ export class AddFilterDialogComponent implements OnInit, AfterViewInit {
     return String(value);
   };
 
+  protected isSignalExclusive(def: FilterDefinition): string | null {
+    if (!def.signals || def.signals.length !== 1) return null;
+    const raw = def.signals[0];
+    return raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase();
+  }
+
   /** Badge text for an API/engine type token from filter definitions. */
   protected formatApiTypeForDisplay(apiType: string): string {
     const key = normalizeApiTypeTokenForLookup(apiType);
@@ -258,6 +264,8 @@ export class AddFilterDialogComponent implements OnInit, AfterViewInit {
         return '=';
       case 'NEQ':
         return '≠';
+      case 'CONTAINS':
+        return 'Contains';
       case 'IN':
         return 'In';
       case 'NOT_IN':

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter.model.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter.model.spec.ts
@@ -13,7 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FilterDefinition, normalizeMembershipOperatorForValues } from './filter.model';
+import {
+  FilterCondition,
+  FilterDefinition,
+  OPERATOR_SYMBOLS,
+  buildChipLabel,
+  buildChipLabelParts,
+  buildChipTooltip,
+  normalizeMembershipOperatorForValues,
+  toRequestFilter,
+} from './filter.model';
 
 describe('normalizeMembershipOperatorForValues', () => {
   const eqIn: Pick<FilterDefinition, 'operators'> = { operators: ['EQ', 'IN'] };
@@ -43,5 +52,76 @@ describe('normalizeMembershipOperatorForValues', () => {
 
   it('should_downgrade_NOT_IN_to_NEQ_for_a_single_value', () => {
     expect(normalizeMembershipOperatorForValues(neqNotIn, 'NOT_IN', 1)).toBe('NEQ');
+  });
+
+  it('should_leave_CONTAINS_unchanged_regardless_of_value_count', () => {
+    const containsOnly: Pick<FilterDefinition, 'operators'> = { operators: ['CONTAINS'] };
+    expect(normalizeMembershipOperatorForValues(containsOnly, 'CONTAINS', 1)).toBe('CONTAINS');
+    expect(normalizeMembershipOperatorForValues(containsOnly, 'CONTAINS', 3)).toBe('CONTAINS');
+  });
+});
+
+describe('OPERATOR_SYMBOLS', () => {
+  it('should have a symbol for CONTAINS', () => {
+    expect(OPERATOR_SYMBOLS['CONTAINS']).toBe('contains');
+  });
+
+  it('should return undefined for unknown operators', () => {
+    expect(OPERATOR_SYMBOLS['UNKNOWN_OP']).toBeUndefined();
+  });
+});
+
+describe('buildChipLabel with CONTAINS operator', () => {
+  it('should display "contains" symbol for CONTAINS operator', () => {
+    const condition: FilterCondition = {
+      field: 'PAYLOAD',
+      label: 'Payload content',
+      operator: 'CONTAINS',
+      values: ['quantum'],
+    };
+    expect(buildChipLabel(condition)).toBe('Payload content contains quantum');
+  });
+});
+
+describe('buildChipLabelParts with CONTAINS operator', () => {
+  it('should produce correct parts for CONTAINS single value', () => {
+    const condition: FilterCondition = {
+      field: 'PAYLOAD',
+      label: 'Payload content',
+      operator: 'CONTAINS',
+      values: ['error message'],
+    };
+    const parts = buildChipLabelParts(condition);
+    expect(parts.name).toBe('Payload content');
+    expect(parts.operator).toBe('contains');
+    expect(parts.value).toBe('error message');
+    expect(parts.isCount).toBe(false);
+  });
+});
+
+describe('buildChipTooltip with CONTAINS operator', () => {
+  it('should format tooltip for CONTAINS filter', () => {
+    const condition: FilterCondition = {
+      field: 'PAYLOAD',
+      label: 'Payload content',
+      operator: 'CONTAINS',
+      values: ['search term'],
+    };
+    expect(buildChipTooltip(condition)).toBe('Payload content contains search term');
+  });
+});
+
+describe('toRequestFilter with CONTAINS operator', () => {
+  it('should produce a scalar value for single CONTAINS filter', () => {
+    const condition: FilterCondition = {
+      field: 'PAYLOAD',
+      label: 'Payload content',
+      operator: 'CONTAINS',
+      values: ['body text'],
+    };
+    const rf = toRequestFilter(condition);
+    expect(rf.name).toBe('PAYLOAD');
+    expect(rf.operator).toBe('CONTAINS');
+    expect(rf.value).toBe('body text');
   });
 });

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter.model.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter.model.ts
@@ -17,7 +17,7 @@ import { FilterName } from '../widget/model/request/enum/filter-name';
 import { RequestFilter } from '../widget/model/request/request';
 
 export type FilterType = 'KEYWORD' | 'STRING' | 'NUMBER' | 'ENUM';
-export type FilterOperator = 'EQ' | 'NEQ' | 'IN' | 'NOT_IN' | 'LTE' | 'GTE';
+export type FilterOperator = 'EQ' | 'NEQ' | 'CONTAINS' | 'IN' | 'NOT_IN' | 'LTE' | 'GTE';
 
 // FilterDefinition — mirrors the backend /filter-definitions endpoint response item.
 // All discriminant fields are widened to handle unknown values from future backend evolutions.
@@ -29,6 +29,7 @@ export interface FilterDefinition {
   range?: { min: number; max: number };
   values?: string[];
   apiTypes?: string[];
+  signals?: string[];
 }
 
 export const ID_BASED_FILTER_NAMES: ReadonlyArray<string> = ['API', 'APPLICATION', 'PLAN', 'API_PRODUCT'];
@@ -54,6 +55,7 @@ export interface FilterCondition {
 export const OPERATOR_SYMBOLS: Partial<Record<string, string>> = {
   EQ: '=',
   NEQ: '≠',
+  CONTAINS: 'contains',
   IN: 'in',
   NOT_IN: 'not in',
   GTE: '≥',

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/domain_service/ObservabilityFilterValidator.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/domain_service/ObservabilityFilterValidator.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.DomainService;
 import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterType;
 import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
 import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
 import java.util.List;
@@ -68,6 +69,20 @@ public class ObservabilityFilterValidator {
             if (!spec.operators().contains(condition.operator())) {
                 throw UnsupportedObservabilityFilterException.unsupportedOperator(condition.name(), condition.operator().name());
             }
+            if (spec.type() == FilterType.STRING && hasOnlyBlankValues(condition)) {
+                throw UnsupportedObservabilityFilterException.blankValue(condition.name());
+            }
         }
+    }
+
+    private static boolean hasOnlyBlankValues(FilterCondition condition) {
+        return (
+            condition.values() == null ||
+            condition.values().isEmpty() ||
+            condition
+                .values()
+                .stream()
+                .allMatch(value -> value == null || value.isBlank())
+        );
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/exception/UnsupportedObservabilityFilterException.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/exception/UnsupportedObservabilityFilterException.java
@@ -48,6 +48,13 @@ public class UnsupportedObservabilityFilterException extends ValidationDomainExc
         );
     }
 
+    public static UnsupportedObservabilityFilterException blankValue(String filterName) {
+        return new UnsupportedObservabilityFilterException(
+            "Filter '" + filterName + "' requires a non-blank value",
+            "observability.filter.blank_value"
+        );
+    }
+
     public static UnsupportedObservabilityFilterException valueListingNotSupported(String filterName, String type) {
         return new UnsupportedObservabilityFilterException(
             "Filter '" + filterName + "' of type " + type + " does not support value listing",

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gamma.rest.core.observability.filter.model;
 
+import static io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator.CONTAINS;
 import static io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator.EQ;
 import static io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator.GTE;
 import static io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator.IN;
@@ -38,8 +39,9 @@ import java.util.Set;
  * {@code HTTP_PATH_MAPPING} is an analytics facet, not a filter, so neither appears here.
  *
  * <p>Operators advertised here are restricted to what the v4 analytics/logs engines actually
- * translate today: {@code EQ, IN} for KEYWORD/ENUM/STRING and {@code EQ, GTE, LTE} for NUMBER.
- * {@code NOT_IN} is intentionally absent until a translator supports it.
+ * translate today: {@code EQ, IN} for KEYWORD/ENUM, {@code EQ} for STRING (except
+ * {@link #PAYLOAD}, logs-only, which supports {@code CONTAINS}), and {@code EQ, GTE, LTE} for
+ * NUMBER. {@code NOT_IN} is intentionally absent until a translator supports it.
  *
  * <p>{@code signals} reflect what is served today (logs + analytics); traces join in a later lot.
  * The trace explorer keeps its own separate registry, so the signal sets here are unaffected by it.
@@ -108,6 +110,7 @@ public enum StaticFilters {
     ERROR_KEY("Error Key", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS_ANALYTICS, Defs.HTTP_LLM_MCP),
     REQUEST_ID("Request ID", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS, Defs.HTTP_LLM_MCP),
     TRANSACTION_ID("Transaction ID", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS, Defs.HTTP_LLM_MCP),
+    PAYLOAD("Payload content", FilterType.STRING, Defs.CONTAINS_ONLY, null, null, Defs.LOGS, Defs.HTTP_LLM_MCP),
 
     // --- LLM ------------------------------------------------------------------------------------
     LLM_PROXY_MODEL("LLM Model", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS_ANALYTICS, Set.of(ApiType.LLM)),
@@ -195,6 +198,7 @@ public enum StaticFilters {
 
         private static final List<FilterOperator> EQ_IN = List.of(EQ, IN);
         private static final List<FilterOperator> EQ_ONLY = List.of(EQ);
+        private static final List<FilterOperator> CONTAINS_ONLY = List.of(CONTAINS);
         private static final List<FilterOperator> NUMBER_OPS = List.of(EQ, GTE, LTE);
 
         private static final Set<Signal> LOGS = Set.of(Signal.LOGS);

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
@@ -278,6 +278,7 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
         Set<String> requestIds = new HashSet<>();
         Set<String> transactionIds = new HashSet<>();
         Set<String> errorKeys = new HashSet<>();
+        String bodyText = null;
         Set<String> apiProductIds = new HashSet<>();
         Set<String> llmProxyModels = new HashSet<>();
         Set<String> llmProxyProviders = new HashSet<>();
@@ -323,6 +324,16 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
                 case "TRANSACTION_ID" -> transactionIds.addAll(values);
                 case "ERROR_KEY" -> errorKeys.addAll(values);
                 case "API_PRODUCT" -> apiProductIds.addAll(values);
+                case "PAYLOAD" -> {
+                    if (values.isEmpty() || values.stream().allMatch(value -> value == null || value.isBlank())) {
+                        throw UnsupportedObservabilityFilterException.blankValue("PAYLOAD");
+                    }
+                    bodyText = values
+                        .stream()
+                        .filter(v -> v != null && !v.isBlank())
+                        .findFirst()
+                        .orElse(null);
+                }
                 default -> throw UnsupportedObservabilityFilterException.searchTranslationNotSupported(condition.name());
             }
         }
@@ -355,6 +366,7 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
         builder.mcpProxyResources(mcpProxyResources);
         builder.mcpProxyPrompts(mcpProxyPrompts);
         builder.uri(uri);
+        builder.bodyText(bodyText);
         builder.responseTimeRanges(responseTimeRanges);
 
         return builder.build();

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/domain_service/ObservabilityFilterValidatorTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/domain_service/ObservabilityFilterValidatorTest.java
@@ -71,6 +71,16 @@ class ObservabilityFilterValidatorTest {
                     null,
                     Set.of(Signal.ANALYTICS),
                     ApiType.ALL
+                ),
+                new FilterSpec(
+                    "PAYLOAD",
+                    "Payload content",
+                    FilterType.STRING,
+                    List.of(FilterOperator.CONTAINS),
+                    null,
+                    null,
+                    Set.of(Signal.LOGS),
+                    Set.of(ApiType.HTTP_PROXY)
                 )
             )
         );
@@ -108,5 +118,14 @@ class ObservabilityFilterValidatorTest {
         assertThatThrownBy(() -> validator.validate(conditions, Signal.LOGS))
             .isInstanceOf(UnsupportedObservabilityFilterException.class)
             .hasMessageContaining("CONTAINS");
+    }
+
+    @Test
+    void should_reject_blank_string_filter_values() {
+        var conditions = List.of(new FilterCondition("PAYLOAD", FilterOperator.CONTAINS, List.of("   ")));
+
+        assertThatThrownBy(() -> validator.validate(conditions, Signal.LOGS))
+            .isInstanceOf(UnsupportedObservabilityFilterException.class)
+            .hasMessageContaining("non-blank");
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
@@ -409,6 +409,66 @@ class ObservabilityLogsDataPortAdapterTest {
         }
     }
 
+    @Nested
+    class PayloadFilter {
+
+        @Test
+        void should_translate_payload_contains_to_body_text() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("PAYLOAD", FilterOperator.CONTAINS, List.of("error 500")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().bodyText()).isEqualTo("error 500");
+        }
+
+        @Test
+        void should_reject_empty_payload_values() {
+            var query = queryWith(new FilterCondition("PAYLOAD", FilterOperator.CONTAINS, List.of()));
+
+            assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
+                .isInstanceOf(UnsupportedObservabilityFilterException.class)
+                .hasMessageContaining("non-blank");
+        }
+
+        @Test
+        void should_use_first_value_when_multiple_payload_values_provided() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("PAYLOAD", FilterOperator.CONTAINS, List.of("first", "second")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().bodyText()).isEqualTo("first");
+        }
+
+        @Test
+        void should_combine_payload_with_other_filters() {
+            stubEmptySearchResult();
+            var query = queryWith(
+                new FilterCondition("PAYLOAD", FilterOperator.CONTAINS, List.of("quantum")),
+                new FilterCondition("HTTP_STATUS", FilterOperator.EQ, List.of("200")),
+                new FilterCondition("HTTP_METHOD", FilterOperator.EQ, List.of("POST"))
+            );
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            var filters = captureSearchFilters();
+            assertThat(filters.bodyText()).isEqualTo("quantum");
+            assertThat(filters.statuses()).containsExactly(200);
+            assertThat(filters.methods()).containsExactly(HttpMethod.POST);
+        }
+
+        @Test
+        void should_translate_payload_with_special_characters() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("PAYLOAD", FilterOperator.CONTAINS, List.of("{\"key\":\"value\"}")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().bodyText()).isEqualTo("{\"key\":\"value\"}");
+        }
+    }
+
     private LogsSearchQuery queryWith(FilterCondition... conditions) {
         return LogsSearchQuery.builder()
             .apiIds(Set.of("api-1"))


### PR DESCRIPTION
## Summary

Add a new `PAYLOAD` search filter (operator: `CONTAINS`) for full-text search on request/response bodies stored in the v4-log Elasticsearch index. The feature is implemented for the Gamma observability endpoint and backported to the Management API v2 `/logs/search` endpoint so it works regardless of whether Gamma is enabled. Closes [GMA-597](https://gravitee.atlassian.net/browse/GMA-597).

## Changes

<img width="917" height="915" alt="Screenshot 2026-06-22 at 12 30 44" src="https://github.com/user-attachments/assets/8b412fce-3030-4536-9b38-9b7f30c2db93" />
<img width="919" height="896" alt="Screenshot 2026-06-22 at 12 31 07" src="https://github.com/user-attachments/assets/e37c7f65-aed7-4322-b3ce-477fa4056ea6" />
<img width="916" height="370" alt="Screenshot 2026-06-22 at 12 30 56" src="https://github.com/user-attachments/assets/09207f3d-3ead-42e2-90f9-b4602fde8ce5" />


https://github.com/user-attachments/assets/0bb0330a-8960-4792-a5a1-882234abf177



### Commit 1 — Gamma Observability Endpoint

#### Backend (Java)

- **`StaticFilters.java`** — Register `PAYLOAD` filter: `FilterType.STRING`, `CONTAINS` operator, `LOGS` signal only, applicable to `HTTP_PROXY / LLM / MCP` API types
- **`ObservabilityLogsDataPortAdapter.java`** — Map `PAYLOAD` condition to `SearchLogsFilters.bodyText`
- **`ConnectionLogsCrudServiceImpl.java`** — Implement two-phase search for `bodyText` on the API logs path:
  1. Phase 1: query v4-log index for body matches → collect `requestIds`
  2. Phase 2: query v4-metrics index with those `requestIds` + all metric-level filters
- **Bug fix** — `mapToConnectionLogDetailQueryFilterBuilder` was passing metric-specific fields (`statuses`, `methods`, `uri`) to the v4-log filter. These fields don't exist in v4-log, causing combined searches (e.g. PAYLOAD + HTTP_STATUS) to return 0 results. Fixed by restricting the v4-log filter to fields that actually exist in that index.

#### Frontend (Angular)

- **`filter.model.ts`** — Add `CONTAINS` to `FilterOperator`, add `signals?: string[]` to `FilterDefinition`
- **`observability-filters-api.service.ts`** — Map `signals` from API response
- **`add-filter-dialog.component.ts`** — Add `CONTAINS` to `KNOWN_OPERATORS`, implement `operatorLabel` for "Contains", add `isSignalExclusive()` for signal badges
- **`add-filter-dialog.component.html/scss`** — Display signal-exclusive badge (e.g. "Logs") on filters restricted to a single signal
- **`env-logs.component.ts`** — Extract `PAYLOAD` filter value and map to `bodyText` param
- **`environment-logs.service.ts`** — Add `bodyText` to `SearchLogsParam`, emit `PAYLOAD` filter with `CONTAINS` operator

### Commit 2 — v2 Backport

The console UI calls `POST /v2/.../logs/search` regardless of Gamma being enabled. Without this backport, sending a PAYLOAD filter caused `IllegalArgumentException` in `FilterName.valueOf("PAYLOAD")`.

- **`openapi-logs.yaml`** — Add `PAYLOAD` to `FilterName` enum, `CONTAINS` to `Operator` enum, discriminator mapping `CONTAINS → StringFilter`, and usage example
- **`FilterName.java`** / **`Operator.java`** (core enums) — Add `PAYLOAD` and `CONTAINS`
- **`FilterContext.java`** — Add `bodyText` field with `limitByBodyText()` and `bodyText()` accessor
- **`SearchEnvironmentLogsUseCase.java`** — Handle `PAYLOAD`/`CONTAINS` in `applyStringFilter`, pass `bodyText` to `SearchLogsFilters` builder, make switch exhaustive
- **Filter definition catalog** — Add `PAYLOAD` to `analytics-definition.yaml` and observability filter definitions endpoint (logs UI)

### Commit 3 — Audit hardening (`da680de4`)

Follow-up fixes from code audit:

- **Analytics catalog** — Remove `PAYLOAD` from analytics `FilterName` enum; introduce `ObservabilityFilterName` (includes logs-only filters) for filter definition responses; reject `PAYLOAD` in `AnalyticsQueryValidator` for analytics queries
- **Validation** — Return HTTP 400 when `PAYLOAD` value is blank/whitespace-only or operator is not `CONTAINS` (v2 `SearchEnvironmentLogsUseCase`, Gamma `ObservabilityFilterValidator` + adapter)
- **Elasticsearch** — Escape `query_string` special characters in `SearchConnectionLogDetailQueryAdapter` body text search
- **OpenAPI** — Fix `openapi-logs.yaml` FilterName description (connection logs, not analytics)

## Test plan

- [ ] Deploy locally and verify `PAYLOAD` appears in `/observability/filters/definition` with `operators: ["CONTAINS"]`
- [ ] Search logs via Gamma endpoint with `PAYLOAD contains "quantum"` → returns matching entries
- [ ] Search logs via v2 endpoint (`POST /v2/.../logs/search`) with `{"name":"PAYLOAD","operator":"CONTAINS","value":"search term"}` → returns 200 OK
- [ ] Combine `PAYLOAD contains "quantum"` + `HTTP_STATUS = 200` → returns correct intersection
- [ ] Search with empty/whitespace payload → returns **400 Bad Request** (not silently ignored)
- [ ] Search with `PAYLOAD` + invalid operator (e.g. `EQ`) → returns **400 Bad Request**
- [ ] Verify `PAYLOAD` does **NOT** appear in analytics `FilterName` enum / analytics query schemas
- [ ] Verify `PAYLOAD` does **NOT** appear in per-metric analytics filter specs (`/analytics/.../metrics/{metric}/filters`)
- [ ] Open "Add filter" dialog → PAYLOAD shows "Logs" badge, auto-selects CONTAINS operator
- [ ] Search with special characters in payload (e.g. `error:500`) → returns expected results (ES escape)

## Reviewer notes

Two areas to focus on:

1. **`ConnectionLogsCrudServiceImpl.mapToConnectionLogDetailQueryFilterBuilder`** (commit 1) — fixes a pre-existing bug where metric-specific fields were sent to the v4-log index. Also impacts `searchApplicationConnectionLogs`.

2. **`SearchEnvironmentLogsUseCase.applyStringFilter`** (commit 2) — the PAYLOAD/CONTAINS check must come before the EQ check to avoid falling through to `updateFilterIds` which doesn't handle PAYLOAD as a set-based filter.

| Endpoint | Method | Change |
|----------|--------|--------|
| `/gamma/.../observability/filters/definition` | `GET` | `PAYLOAD` filter in catalog |
| `/gamma/.../observability/logs` | `POST` | `PAYLOAD` + `CONTAINS` triggers two-phase body text search |
| `/v2/.../logs/search` | `POST` | `PAYLOAD` + `CONTAINS` now accepted and mapped to bodyText |
| `/v2/.../analytics/...` | `POST` | `PAYLOAD` rejected with 400 (logs-only filter) |

Closes GMA-597

[GMA-597]: https://gravitee.atlassian.net/browse/GMA-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ