### PR TITLE
chore(4.12.x): bump gravitee-gamma-module-esm from 1.0.0-alpha.5 to 1.0.0-alpha.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
         <gravitee-gamma-module-aim.version>1.0.0-alpha.184</gravitee-gamma-module-aim.version>
         <gravitee-gamma-module-authz.version>1.0.0-alpha.20</gravitee-gamma-module-authz.version>
         <gravitee-gamma-module-edge.version>1.0.0-alpha.2</gravitee-gamma-module-edge.version>
-        <gravitee-gamma-module-esm.version>1.0.0-alpha.5</gravitee-gamma-module-esm.version>
+        <gravitee-gamma-module-esm.version>1.0.0-alpha.7</gravitee-gamma-module-esm.version>
 
         <!-- Authz plugins -->
         <gravitee-service-authz-pdp.version>1.0.0-alpha.6</gravitee-service-authz-pdp.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-gamma-module-esm](https://github.com/gravitee-io/gravitee-gamma-module-esm)** from `1.0.0-alpha.5` to `1.0.0-alpha.7` on branch `4.12.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-gamma-module-esm/releases) page for details.