### PR TITLE
fix(gateway): unique bean names for distributed dictionary/organization synchronizers

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/spring/DistributedSyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/spring/DistributedSyncConfiguration.java
@@ -164,7 +164,7 @@ public class DistributedSyncConfiguration {
     }
 
     @Bean
-    public DistributedDictionarySynchronizer dictionarySynchronizer(
+    public DistributedDictionarySynchronizer distributedDictionarySynchronizer(
         DistributedEventFetcher distributedEventFetcher,
         DictionaryMapper dictionaryMapper,
         DeployerFactory deployerFactory,
@@ -181,7 +181,7 @@ public class DistributedSyncConfiguration {
     }
 
     @Bean
-    public DistributedOrganizationSynchronizer organizationSynchronizer(
+    public DistributedOrganizationSynchronizer distributedOrganizationSynchronizer(
         DistributedEventFetcher distributedEventFetcher,
         OrganizationMapper organizationMapper,
         DeployerFactory deployerFactory,


### PR DESCRIPTION
## Problem

When **distributed sync (Gateway Cluster sync with Redis)** is enabled, secondary gateway nodes never synchronize dictionaries and organizations from Redis. EL expressions like `#dictionaries['global']['runtime']` resolve to `null` on secondary nodes → requests fail with HTTP 500, while the primary node keeps working (the classic "one gateway returns 200, the other 500" symptom). Restarting the primary can propagate the missing dictionary cluster-wide.

## Root cause

`DistributedSyncConfiguration` declares its dictionary/organization synchronizer beans as `dictionarySynchronizer` and `organizationSynchronizer` — the same bean names used by the repository synchronizer beans in `RepositorySyncConfiguration`. The gateway runs on a plain Spring context where `allowBeanDefinitionOverriding` defaults to `true`, so the repository beans (`RepositorySynchronizer`) silently override the distributed ones. The distributed dictionary/organization synchronizers are therefore never registered as `DistributedSynchronizer` beans, and the secondary-node sync path (`List<DistributedSynchronizer>`) skips them. Other types are unaffected because their bean names are unique (`distributedApiSynchronizer`, etc.).

##  Fix
Rename the two beans to `distributedDictionarySynchronizer` / `distributedOrganizationSynchronizer` so the names are unique, and both synchronizers are registered and executed on secondary nodes.

## Verification
Reproduced on a local kind cluster (APIM 4.11.10, 2 gateways, distributed sync + Redis):

- **Before**: secondary node logs missing dictionary(s) synchronized and organization(s) synchronized; requests alternate 200/500; restarting a pod → all 500.

https://github.com/user-attachments/assets/985e3d0b-84f5-46b1-8a28-ecc55a149b11


- **After**: both nodes log 1 dictionary(s) synchronized and deploy the dictionary; all requests return 200, including after restarting a single pod.

https://github.com/user-attachments/assets/fdb23bfd-6aef-4b42-9dc4-33bc50538ae4


