### PR TITLE
chore: reverting traffic-shadowing to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
         <gravitee-policy-retry.version>3.0.1</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>1.4.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.6.0</gravitee-policy-ssl-enforcement.version>
-        <gravitee-policy-traffic-shadowing.version>3.0.1</gravitee-policy-traffic-shadowing.version>
+        <gravitee-policy-traffic-shadowing.version>3.0.0</gravitee-policy-traffic-shadowing.version>
         <gravitee-policy-transform-avro-json.version>4.0.0</gravitee-policy-transform-avro-json.version>
         <gravitee-policy-transform-avro-protobuf.version>1.0.9</gravitee-policy-transform-avro-protobuf.version>
         <gravitee-policy-transform-protobuf-json.version>2.0.1</gravitee-policy-transform-protobuf-json.version>


### PR DESCRIPTION
Revert traffic shadowing policy to 3.0.0

