### PR TITLE
test(portal): fix portal use-case tests for automation-scope constructors

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
@@ -27,6 +27,7 @@ import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.domain_service.PortalAutomationScopeDomainService;
 import io.gravitee.apim.core.portal.domain_service.PortalNavigationSyncDomainService;
 import io.gravitee.apim.core.portal.domain_service.ValidatePortalDomainService;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlanExecutor;
@@ -72,12 +73,14 @@ class DeletePortalUseCaseTest {
             new AutomationManagedNavigationItemsQueryService(portalListingCrudService, pageContentQueryService),
             new NavigationSyncPlanExecutor(navCrudService, navQueryService, pageContentCrudService)
         );
+        var scopeEnforcer = new PortalAutomationScopeDomainService(portalCrudService);
         setupUseCase = new CreateOrUpdatePortalUseCase(
-            new ValidatePortalDomainService(),
+            new ValidatePortalDomainService(scopeEnforcer),
             portalCrudService,
             navSync,
             pageContentQueryService,
-            new PortalDocumentationSyncDomainService(navCrudService, navQueryService)
+            new PortalDocumentationSyncDomainService(navCrudService, navQueryService),
+            scopeEnforcer
         );
         useCase = new DeletePortalUseCase(portalCrudService, navSync);
     }
@@ -145,15 +148,20 @@ class DeletePortalUseCaseTest {
 
     @Test
     void should_not_touch_folders_managed_by_other_portals() {
+        var otherEnvAudit = AuditInfo.builder()
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId("other-env")
+            .actor(AUDIT_INFO.actor())
+            .build();
         var portalA = PortalFixtures.aPortal();
         var portalB = Portal.of(
             PortalId.of("00000000-0000-0000-0000-0000000000a2"),
-            AUDIT_INFO.environmentId(),
-            AUDIT_INFO.organizationId(),
+            otherEnvAudit.environmentId(),
+            otherEnvAudit.organizationId(),
             "Other Portal"
         );
         setupUseCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portalA, List.of(new NavigationPath("/alpha", null))));
-        setupUseCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portalB, List.of(new NavigationPath("/beta", null))));
+        setupUseCase.execute(new CreateOrUpdatePortalUseCase.Input(otherEnvAudit, portalB, List.of(new NavigationPath("/beta", null))));
         assertThat(navCrudService.storage()).hasSize(2);
 
         useCase.execute(new DeletePortalUseCase.Input(AUDIT_INFO, portalA.getId()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/CreateOrUpdatePortalListingUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/CreateOrUpdatePortalListingUseCaseTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_listing.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
 
 import inmemory.PortalCrudServiceInMemory;
 import inmemory.PortalListingCrudServiceInMemory;
@@ -26,6 +27,7 @@ import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.portal.domain_service.PortalAutomationScopeDomainService;
 import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_listing.domain_service.PortalListingSyncDomainService;
 import io.gravitee.apim.core.portal_listing.domain_service.ValidatePortalListingDomainService;
 import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
 import io.gravitee.apim.core.portal_listing.model.PortalListingId;
@@ -61,11 +63,7 @@ class CreateOrUpdatePortalListingUseCaseTest {
 
     @BeforeEach
     void setUp() {
-        useCase = new CreateOrUpdatePortalListingUseCase(
-            validator,
-            portalListingCrudService,
-            org.mockito.Mockito.mock(io.gravitee.apim.core.portal_listing.domain_service.PortalListingSyncDomainService.class)
-        );
+        useCase = new CreateOrUpdatePortalListingUseCase(validator, portalListingCrudService, mock(PortalListingSyncDomainService.class));
     }
 
     @AfterEach
@@ -186,7 +184,8 @@ class CreateOrUpdatePortalListingUseCaseTest {
         establishedCrud.initWith(List.of(Portal.of(PORTAL_ID, AUDIT_INFO.environmentId(), AUDIT_INFO.organizationId(), "Established")));
         var restrictedUseCase = new CreateOrUpdatePortalListingUseCase(
             new ValidatePortalListingDomainService(new PortalAutomationScopeDomainService(establishedCrud)),
-            portalListingCrudService
+            portalListingCrudService,
+            mock(PortalListingSyncDomainService.class)
         );
         var nonDefaultPortalId = PortalId.of(HRIDToUUID.portal().context(AUDIT_INFO).hrid("foo-portal").id());
         var apis = List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1));


### PR DESCRIPTION
master was broken — `mvn clean install` failed compiling test sources in `gravitee-apim-rest-api-service`. Commit 17ea945fd2 (`feat(portal-next): owned-folder lifecycle…`) changed three production constructors but left their tests behind.

Fixes:
- `DeletePortalUseCaseTest` — `ValidatePortalDomainService` and `CreateOrUpdatePortalUseCase` both gained a `PortalAutomationScopeDomainService` arg; wired in a shared scope enforcer (matching the sibling `CreateOrUpdatePortalUseCaseTest`).
- `DeletePortalUseCaseTest.should_not_touch_folders_managed_by_other_portals` — used two portals in one environment, which the new one-portal-per-env rule (ca3775e4d1) now rejects at runtime. Moved the second portal to `other-env`, preserving the test's intent.
- `CreateOrUpdatePortalListingUseCaseTest` — `CreateOrUpdatePortalListingUseCase` gained a `PortalListingSyncDomainService` arg; passed a mock, matching the `@BeforeEach` setup.

Verified locally (JDK 21): `DeletePortalUseCaseTest` 6/6 and `CreateOrUpdatePortalListingUseCaseTest` 9/9 green; full clean reactor builds and installs the module without issue.