### PR TITLE
fix(gamma): correct home metrics, dark-mode badge, and api product nav

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.spec.tsx
@@ -62,7 +62,6 @@ function seedMetricHandlers(overrides?: {
     policyCount?: number;
     principalCount?: number;
     mcpServerCount?: number;
-    requestsTotal?: number;
     deviceCount?: number;
 }) {
     const {
@@ -72,7 +71,6 @@ function seedMetricHandlers(overrides?: {
         policyCount = 0,
         principalCount = 0,
         mcpServerCount = 0,
-        requestsTotal = 0,
         deviceCount = 0,
     } = overrides ?? {};
 
@@ -82,9 +80,6 @@ function seedMetricHandlers(overrides?: {
     respondWith('get', `${TEST_GAMMA_BASE}/environments/env-1-id/modules/authz/policies`, { total: policyCount });
     respondWith('get', `${TEST_GAMMA_BASE}/environments/env-1-id/modules/authz/entities`, { total: principalCount });
     respondWith('get', `${TEST_GAMMA_BASE}/environments/env-1-id/modules/aim/catalog/items`, { total: mcpServerCount });
-    respondWith('get', `${TEST_MANAGEMENT_V2_ENVIRONMENT_BASE}/env-1-id/analytics/request-response-time`, {
-        requestsTotal,
-    });
     // Edge device count derives from the analytics facets endpoint: one EDGE_CLIENT bucket per device.
     respondWith('post', `${TEST_MANAGEMENT_V2_ENVIRONMENT_BASE}/env-1-id/analytics/facets`, {
         metrics: [{ name: 'EDGE_HEARTBEAT_COUNT', buckets: Array.from({ length: deviceCount }, (_v, i) => ({ key: `device-${i}` })) }],

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.stories.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.stories.tsx
@@ -50,7 +50,6 @@ interface MetricOverrides {
     policyCount?: number | null;
     principalCount?: number | null;
     mcpServerCount?: number | null;
-    requestsTotal?: number | null;
     deviceCount?: number | null;
 }
 
@@ -68,12 +67,6 @@ const ROUTES: readonly RouteMatch[] = [
     { prefix: GAMMA_ORG_PREFIX, path: '/modules/authz/policies', key: 'policyCount', toBody: n => ({ total: n }) },
     { prefix: GAMMA_ORG_PREFIX, path: '/modules/authz/entities', key: 'principalCount', toBody: n => ({ total: n }) },
     { prefix: GAMMA_ORG_PREFIX, path: '/modules/aim/catalog/items', key: 'mcpServerCount', toBody: n => ({ total: n }) },
-    {
-        prefix: MANAGEMENT_V2_ENV_PREFIX,
-        path: '/analytics/request-response-time',
-        key: 'requestsTotal',
-        toBody: n => ({ requestsTotal: n }),
-    },
     {
         prefix: MANAGEMENT_V2_ENV_PREFIX,
         path: '/analytics/facets',
@@ -194,7 +187,6 @@ export const FullAccess: Story = {
             policyCount: 23,
             principalCount: 45,
             mcpServerCount: 6,
-            requestsTotal: 12400,
             deviceCount: 18,
         },
     },
@@ -212,7 +204,6 @@ export const EmptyEnvironment: Story = {
             policyCount: 0,
             principalCount: 0,
             mcpServerCount: 0,
-            requestsTotal: 0,
             deviceCount: 0,
         },
     },
@@ -230,7 +221,7 @@ export const EmptyEnvironment: Story = {
 export const PartialData: Story = {
     args: {
         modules: ALL_MODULES.filter(m => m.id !== 'aim'),
-        metrics: { apiCount: 24, agentCount: null, appCount: 0, policyCount: 5, principalCount: 12, requestsTotal: 3200 },
+        metrics: { apiCount: 24, agentCount: null, appCount: 0, policyCount: 5, principalCount: 12 },
     },
     parameters: {
         docs: {
@@ -246,7 +237,7 @@ export const PartialData: Story = {
 export const WithoutAgentManagement: Story = {
     args: {
         modules: ALL_MODULES.filter(m => m.id !== 'aim'),
-        metrics: { apiCount: 24, agentCount: null, appCount: 3, policyCount: 10, principalCount: 8, requestsTotal: 5600 },
+        metrics: { apiCount: 24, agentCount: null, appCount: 3, policyCount: 10, principalCount: 8 },
     },
     parameters: {
         docs: {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.tsx
@@ -30,7 +30,6 @@ import {
     useDeviceCount,
     useMcpServerCount,
     usePrincipalCount,
-    useTrafficStats,
 } from './useModuleMetrics';
 import { useUser } from '../../features/auth';
 import { useEnvironmentStore } from '../../features/environment/environment.store';
@@ -58,7 +57,6 @@ export function HomePage({ modules, loading, error, onRetry }: HomePageProps) {
     const isAvailable = (moduleId: ModuleId) => availableModuleIds.has(moduleId);
 
     const apiCount = useApiCount({ enabled: !loading && isAvailable('apim') });
-    const trafficStats = useTrafficStats({ enabled: !loading && isAvailable('apim') });
     const agentCount = useAgentCount({ enabled: !loading && isAvailable('aim') });
     const mcpServerCount = useMcpServerCount({ enabled: !loading && isAvailable('aim') });
     const appCount = useActiveAppCount({ enabled: !loading && isAvailable('platform') });
@@ -69,7 +67,6 @@ export function HomePage({ modules, loading, error, onRetry }: HomePageProps) {
     const moduleMetrics: Partial<Record<ModuleId, CardMetrics>> = {
         apim: {
             primary: { value: apiCount, label: pluralize(apiCount, 'API', 'APIs') },
-            secondary: trafficStats ? { value: trafficStats.requestsTotal, label: 'requests/24h' } : undefined,
         },
         aim: {
             primary: { value: agentCount, label: pluralize(agentCount, 'agent', 'agents') },

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/useModuleMetrics.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/useModuleMetrics.ts
@@ -26,11 +26,21 @@ interface CountHookOptions {
 }
 
 /**
+ * The gamma APIM module only manages V4 HTTP proxy APIs, so the card count must match what the
+ * module's own API list shows. Mirrors the module's server-side `apiTypes` filter
+ * (`gravitee-gamma-module-apim` → `features/apis/services/apiList.ts`).
+ */
+const V4_HTTP_PROXY_API_TYPES = ['V4_HTTP_PROXY'];
+
+/**
  * Live count for the API Management card.
  *
  * Hits the APIM v2 search endpoint with `perPage=1` — we only need the
  * `pagination.totalCount`. Routed through `managementV2EnvironmentApi` whose base URL is
  * `${managementBaseURL}/v2/environments`, so we only pass the envId-scoped suffix.
+ *
+ * Scoped to V4 HTTP proxy APIs so the count matches the APIM module's list rather than every
+ * API type in the environment.
  */
 export function useApiCount({ enabled = true }: CountHookOptions = {}): number | null {
     const environmentId = useEnvironmentStore(s => s.environmentId);
@@ -44,7 +54,9 @@ export function useApiCount({ enabled = true }: CountHookOptions = {}): number |
 
         let cancelled = false;
         managementV2EnvironmentApi
-            .post<{ pagination?: { totalCount?: number } }>(`/${encodeURIComponent(environmentId)}/apis/_search?page=1&perPage=1`, {})
+            .post<{ pagination?: { totalCount?: number } }>(`/${encodeURIComponent(environmentId)}/apis/_search?page=1&perPage=1`, {
+                apiTypes: [...V4_HTTP_PROXY_API_TYPES],
+            })
             .then(res => {
                 if (!cancelled) setCount(res?.pagination?.totalCount ?? null);
             })
@@ -242,37 +254,4 @@ export function useDeviceCount({ enabled = true }: CountHookOptions = {}): numbe
     }, [enabled, environmentId]);
 
     return count;
-}
-
-export interface TrafficStats {
-    readonly requestsTotal: number;
-}
-
-/** 24h traffic stats for the API Management card. */
-export function useTrafficStats({ enabled = true }: CountHookOptions = {}): TrafficStats | null {
-    const environmentId = useEnvironmentStore(s => s.environmentId);
-    const [stats, setStats] = useState<TrafficStats | null>(null);
-
-    useEffect(() => {
-        setStats(null);
-        if (!enabled || !environmentId) return;
-
-        const now = Date.now();
-        const from = now - 24 * 60 * 60 * 1000;
-
-        let cancelled = false;
-        managementV2EnvironmentApi
-            .get<{ requestsTotal?: number }>(`/${encodeURIComponent(environmentId)}/analytics/request-response-time?from=${from}&to=${now}`)
-            .then(res => {
-                if (!cancelled && res?.requestsTotal !== null && res?.requestsTotal !== undefined) {
-                    setStats({ requestsTotal: res.requestsTotal });
-                }
-            })
-            .catch(() => {});
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, environmentId]);
-
-    return stats;
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -99,8 +99,8 @@ function buildObserveBreadcrumbItem(segment: { label: string; routeKey?: string 
 function ModuleLayout() {
     const location = useLocation();
     const navigate = useNavigate();
-    const activeNavKey = useMemo(() => getActiveNavKey(location.pathname), [location.pathname]);
     const { modulePrefix } = useMemo(() => resolveModulePath(location.pathname, APIM_ROUTE_CONFIG), [location.pathname]);
+    const activeNavKey = useMemo(() => getActiveNavKey(location.pathname, modulePrefix), [location.pathname, modulePrefix]);
 
     const handleNavSelect = useCallback(
         (key: string) => {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/routes.ts
@@ -54,18 +54,36 @@ export const APIM_ROUTE_CONFIG: ModuleRouteConfig<RouteKey> = {
     defaultRouteKey: DEFAULT_ROUTE_KEY,
 } as const;
 
+/** Index of the first segment that belongs to the module (i.e. after its mount prefix). */
+function moduleRelativeStartIndex(segments: readonly string[], modulePrefix?: string): number {
+    const prefix = (modulePrefix ?? '').split('/').filter(Boolean);
+    if (prefix.length === 0) return 0;
+    for (let i = 0; i + prefix.length <= segments.length; i++) {
+        if (prefix.every((seg, j) => segments[i + j] === seg)) {
+            return i + prefix.length;
+        }
+    }
+    return 0;
+}
+
 /**
  * Resolves the active sidebar key from a URL pathname.
  *
  * Observability composite keys (`observe/*`) are reparsed by the lib itself via
  * `observability.resolveRouteKey`. Other keys are matched by scanning segments.
+ *
+ * Scanning is scoped to the module-relative path (everything after `modulePrefix`, e.g. the host
+ * `environments/{hrid}/{module}` mount) and returns the first/outermost route-key segment, so:
+ *  - the top-level section wins over nested sub-routes sharing a route-key name — an API Product's
+ *    APIs tab (`api-products/:productId/apis`) resolves to `api-products`, not `apis`; and
+ *  - a host segment such as an environment hrid that happens to match a route-key name cannot win.
  */
-export function getActiveNavKey(pathname: string): RouteKey {
+export function getActiveNavKey(pathname: string, modulePrefix?: string): RouteKey {
     const observabilityKey = observability.resolveRouteKey(pathname);
     if (observabilityKey !== null && isRouteKey(observabilityKey)) return observabilityKey;
 
     const segments = pathname.split('/').filter(Boolean);
-    for (let i = segments.length - 1; i >= 0; i--) {
+    for (let i = moduleRelativeStartIndex(segments, modulePrefix); i < segments.length; i++) {
         if (isRouteKey(segments[i])) {
             return segments[i] as RouteKey;
         }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailLayout.tsx
@@ -24,7 +24,7 @@ import {
     Skeleton,
     useLayoutConfig,
 } from '@gravitee/graphene-core';
-import { AppWindowIcon } from '@gravitee/graphene-core/icons';
+import { AppWindowIcon, CircleCheckIcon, CircleStopIcon } from '@gravitee/graphene-core/icons';
 import { useMemo, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
@@ -45,14 +45,16 @@ import { formatApplicationOwnerLabel, formatApplicationSecurityTypeLabel } from 
 function StatusBadge({ status }: { status: ApplicationStatus }) {
     if (status === 'ACTIVE') {
         return (
-            <Badge className="h-6 w-fit rounded-md border-0 bg-primary px-2.5 text-xs font-medium lowercase text-primary-foreground">
-                active
+            <Badge className="gap-1 h-5 w-fit px-1.5 text-xs font-medium bg-success/10 text-success border-transparent">
+                <CircleCheckIcon className="size-3" />
+                Active
             </Badge>
         );
     }
     return (
-        <Badge className="h-6 w-fit rounded-md border-0 bg-muted px-2.5 text-xs font-medium lowercase text-muted-foreground">
-            archived
+        <Badge variant="secondary" className="gap-1 h-5 w-fit px-1.5 text-xs font-medium">
+            <CircleStopIcon className="size-3" />
+            Archived
         </Badge>
     );
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-690

## Description

- platform: use graphene success/secondary status badge so the application "active" state is visible in dark mode instead of the low-contrast bg-primary chip
- console home: scope the api management card count to v4 http proxy apis (matching the apim module) and drop the env-wide requests/24h metric
- apim: resolve the active nav key from the module-relative, outermost segment so an api product's apis tab highlights "api products" (not "api proxies")

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

