### PR TITLE
feat(helm): expose async flush interval

### DIFF
--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -790,6 +790,18 @@ data:
 
       sync: {{ toYaml .Values.gateway.services.sync | nindent 8 }}
 
+      {{- if .Values.gateway.services.ratelimit }}
+      {{- if .Values.gateway.services.ratelimit.async }}
+      {{- if .Values.gateway.services.ratelimit.async.flushInterval }}
+      # Asynchronous (non-strict) rate-limit service: how often per-node local counters/buckets are
+      # reconciled to the store. Shared by all rate-limit-family policies in async mode.
+      ratelimit:
+        async:
+          flushInterval: {{ .Values.gateway.services.ratelimit.async.flushInterval }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+
       # Service used to store and cache api-keys from the management repository to avoid direct repository communication
       # while serving requests.
       apikeyscache:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1856,6 +1856,12 @@ gateway:
 
   # system: {}
   services:
+    # Asynchronous (non-strict) rate-limiting reconcile interval, shared by the rate-limit, quota,
+    # spike-arrest and token-bucket policies. Lower = tighter accuracy + more store round-trips;
+    # higher = fewer round-trips + more cross-node over-admission. Omit to keep the default (5000 ms).
+    # ratelimit:
+    #   async:
+    #     flushInterval: 5000 # milliseconds
     core:
       http:
         enabled: true


### PR DESCRIPTION
## What

Surfaces the new global gateway property **`services.ratelimit.async.flushInterval`** (async rate-limit reconcile interval) in the helm chart.

- `gateway-configmap.yaml`: renders `services.ratelimit.async.flushInterval` **only when set** (under `gateway.services.ratelimit.async.flushInterval`), so the gateway's built-in default (5000 ms) stays authoritative when unset.
- `values.yaml`: documented (commented) option under `gateway.services`.

## Why

The async (non-strict) flush interval was hardcoded to 5s. The consuming code change is in the rate-limit plugin (gravitee-policy-ratelimit, APIM-14500); this exposes the knob to helm users. The property is optional and harmless when the deployed gateway doesn't yet read it.

## Verified

`helm template` (offline, stub deps):
- set `--set gateway.services.ratelimit.async.flushInterval=2000` → renders `services.ratelimit.async.flushInterval: 2000`
- unset → not rendered (default 5000 applies)

Implements the helm part of APIM-14500. Pairs with gravitee-policy-ratelimit PR #145.