### PR TITLE
fix(portal-next): gate single-portal-per-env restriction on allowMultiplePortalPerEnv flag

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalAutomationProperties.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalAutomationProperties.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service;
+
+public interface PortalAutomationProperties {
+    boolean allowMultiplePortalPerEnv();
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalAutomationScopeDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalAutomationScopeDomainService.java
@@ -28,19 +28,26 @@ import lombok.RequiredArgsConstructor;
 public class PortalAutomationScopeDomainService {
 
     private final PortalCrudService portalCrudService;
+    private final PortalAutomationProperties properties;
 
     public boolean isDefaultPortal(AuditInfo auditInfo, PortalId portalId) {
         return portalCrudService.findByIdAndEnvironmentId(portalId, auditInfo.environmentId()).isPresent();
     }
 
     public List<Validator.Error> validate(AuditInfo auditInfo, PortalId portalId, String fieldName) {
-        boolean conflict = portalCrudService
-            .findByEnvironmentId(auditInfo.environmentId())
-            .stream()
-            .anyMatch(p -> !p.getId().equals(portalId));
-        if (conflict) {
+        if (hasEstablishedPortalConflict(auditInfo, portalId)) {
             return List.of(Validator.Error.severe("%s does not match the established portal for this environment", fieldName));
         }
         return List.of();
+    }
+
+    private boolean hasEstablishedPortalConflict(AuditInfo auditInfo, PortalId portalId) {
+        if (properties.allowMultiplePortalPerEnv()) {
+            return false;
+        }
+        return portalCrudService
+            .findByEnvironmentId(auditInfo.environmentId())
+            .stream()
+            .anyMatch(p -> !p.getId().equals(portalId));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal/PortalAutomationPropertiesImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal/PortalAutomationPropertiesImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.portal;
+
+import io.gravitee.apim.core.portal.domain_service.PortalAutomationProperties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PortalAutomationPropertiesImpl implements PortalAutomationProperties {
+
+    private final boolean allowMultiplePortalPerEnv;
+
+    public PortalAutomationPropertiesImpl(
+        @Value("${automation.portal.allowMultiplePortalPerEnv:false}") boolean allowMultiplePortalPerEnv
+    ) {
+        this.allowMultiplePortalPerEnv = allowMultiplePortalPerEnv;
+    }
+
+    @Override
+    public boolean allowMultiplePortalPerEnv() {
+        return allowMultiplePortalPerEnv;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.api.query_service.ApiPortalSearchQueryService;
 import io.gravitee.apim.core.event.query_service.EventLatestQueryService;
 import io.gravitee.apim.core.integration.service_provider.A2aAgentFetcher;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
+import io.gravitee.apim.core.portal.domain_service.PortalAutomationProperties;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
@@ -556,6 +557,11 @@ public class InMemoryConfiguration {
     @Bean
     public PortalCrudServiceInMemory portalCrudService() {
         return new PortalCrudServiceInMemory();
+    }
+
+    @Bean
+    public PortalAutomationProperties portalAutomationProperties() {
+        return () -> false;
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalAutomationScopeDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalAutomationScopeDomainServiceTest.java
@@ -39,6 +39,8 @@ class PortalAutomationScopeDomainServiceTest {
 
     private static final PortalId ESTABLISHED_PORTAL_ID = PortalFixtures.PORTAL_ID;
     private static final PortalId OTHER_PORTAL_ID = PortalId.of("00000000-0000-0000-0000-0000000000b2");
+    private static final PortalAutomationProperties SINGLE_PORTAL = () -> false;
+    private static final PortalAutomationProperties MULTI_PORTAL = () -> true;
 
     private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
     private PortalAutomationScopeDomainService domainService;
@@ -46,7 +48,7 @@ class PortalAutomationScopeDomainServiceTest {
     @BeforeEach
     void setUp() {
         portalCrudService.reset();
-        domainService = new PortalAutomationScopeDomainService(portalCrudService);
+        domainService = new PortalAutomationScopeDomainService(portalCrudService, SINGLE_PORTAL);
     }
 
     @Test
@@ -83,6 +85,16 @@ class PortalAutomationScopeDomainServiceTest {
 
         assertThat(errors).hasSize(1);
         assertThat(errors.get(0).getMessage()).contains("portalHrid");
+    }
+
+    @Test
+    void should_allow_a_different_portal_when_allowMultiplePortalPerEnv_is_true() {
+        portalCrudService.initWith(List.of(PortalFixtures.aPortal()));
+        var multiPortalService = new PortalAutomationScopeDomainService(portalCrudService, MULTI_PORTAL);
+
+        var errors = multiPortalService.validate(AUDIT_INFO, OTHER_PORTAL_ID, "hrid");
+
+        assertThat(errors).isEmpty();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
@@ -55,7 +55,7 @@ class CreateOrUpdatePortalUseCaseTest {
         .build();
 
     private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
-    private final PortalAutomationScopeDomainService scopeEnforcer = new PortalAutomationScopeDomainService(portalCrudService);
+    private final PortalAutomationScopeDomainService scopeEnforcer = new PortalAutomationScopeDomainService(portalCrudService, () -> false);
     private final ValidatePortalDomainService validator = new ValidatePortalDomainService(scopeEnforcer);
     private final PortalNavigationItemsCrudServiceInMemory navCrudService = new PortalNavigationItemsCrudServiceInMemory();
     private final PortalNavigationItemsQueryServiceInMemory navQueryService = new PortalNavigationItemsQueryServiceInMemory(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
@@ -73,7 +73,7 @@ class DeletePortalUseCaseTest {
             new AutomationManagedNavigationItemsQueryService(portalListingCrudService, pageContentQueryService),
             new NavigationSyncPlanExecutor(navCrudService, navQueryService, pageContentCrudService)
         );
-        var scopeEnforcer = new PortalAutomationScopeDomainService(portalCrudService);
+        var scopeEnforcer = new PortalAutomationScopeDomainService(portalCrudService, () -> false);
         setupUseCase = new CreateOrUpdatePortalUseCase(
             new ValidatePortalDomainService(scopeEnforcer),
             portalCrudService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/ValidatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/ValidatePortalUseCaseTest.java
@@ -49,7 +49,7 @@ class ValidatePortalUseCaseTest {
     );
 
     private final ValidatePortalDomainService validator = new ValidatePortalDomainService(
-        new PortalAutomationScopeDomainService(new PortalCrudServiceInMemory())
+        new PortalAutomationScopeDomainService(new PortalCrudServiceInMemory(), () -> false)
     );
     private ValidatePortalUseCase useCase;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/CreateOrUpdatePortalListingUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/CreateOrUpdatePortalListingUseCaseTest.java
@@ -57,7 +57,7 @@ class CreateOrUpdatePortalListingUseCaseTest {
     private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
     private final PortalListingCrudServiceInMemory portalListingCrudService = new PortalListingCrudServiceInMemory();
     private final ValidatePortalListingDomainService validator = new ValidatePortalListingDomainService(
-        new PortalAutomationScopeDomainService(portalCrudService)
+        new PortalAutomationScopeDomainService(portalCrudService, () -> false)
     );
     private CreateOrUpdatePortalListingUseCase useCase;
 
@@ -183,7 +183,7 @@ class CreateOrUpdatePortalListingUseCaseTest {
         var establishedCrud = new PortalCrudServiceInMemory();
         establishedCrud.initWith(List.of(Portal.of(PORTAL_ID, AUDIT_INFO.environmentId(), AUDIT_INFO.organizationId(), "Established")));
         var restrictedUseCase = new CreateOrUpdatePortalListingUseCase(
-            new ValidatePortalListingDomainService(new PortalAutomationScopeDomainService(establishedCrud)),
+            new ValidatePortalListingDomainService(new PortalAutomationScopeDomainService(establishedCrud, () -> false)),
             portalListingCrudService,
             mock(PortalListingSyncDomainService.class)
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/ValidatePortalListingUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/ValidatePortalListingUseCaseTest.java
@@ -48,7 +48,7 @@ class ValidatePortalListingUseCaseTest {
     );
 
     private final ValidatePortalListingDomainService validator = new ValidatePortalListingDomainService(
-        new PortalAutomationScopeDomainService(new PortalCrudServiceInMemory())
+        new PortalAutomationScopeDomainService(new PortalCrudServiceInMemory(), () -> false)
     );
     private ValidatePortalListingUseCase useCase;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCaseTest.java
@@ -64,7 +64,7 @@ class CreateOrUpdatePortalDocumentationUseCaseTest {
         navCrudService.storage()
     );
     private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
-    private final PortalAutomationScopeDomainService scopeEnforcer = new PortalAutomationScopeDomainService(portalCrudService);
+    private final PortalAutomationScopeDomainService scopeEnforcer = new PortalAutomationScopeDomainService(portalCrudService, () -> false);
     private final ValidatePortalDocumentationDomainService validator = new ValidatePortalDocumentationDomainService(scopeEnforcer);
     private CreateOrUpdatePortalDocumentationUseCase useCase;
 
@@ -204,7 +204,7 @@ class CreateOrUpdatePortalDocumentationUseCaseTest {
     void should_reject_portal_when_environment_already_has_a_different_portal() {
         var establishedCrud = new PortalCrudServiceInMemory();
         establishedCrud.initWith(List.of(Portal.of(PORTAL_ID, AUDIT_INFO.environmentId(), AUDIT_INFO.organizationId(), "Established")));
-        var restrictedEnforcer = new PortalAutomationScopeDomainService(establishedCrud);
+        var restrictedEnforcer = new PortalAutomationScopeDomainService(establishedCrud, () -> false);
         var restrictedUseCase = new CreateOrUpdatePortalDocumentationUseCase(
             new ValidatePortalDocumentationDomainService(restrictedEnforcer),
             crudService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ValidatePortalDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ValidatePortalDocumentationUseCaseTest.java
@@ -52,7 +52,9 @@ class ValidatePortalDocumentationUseCaseTest {
     @BeforeEach
     void setUp() {
         useCase = new ValidatePortalDocumentationUseCase(
-            new ValidatePortalDocumentationDomainService(new PortalAutomationScopeDomainService(new PortalCrudServiceInMemory()))
+            new ValidatePortalDocumentationDomainService(
+                new PortalAutomationScopeDomainService(new PortalCrudServiceInMemory(), () -> false)
+            )
         );
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-134

## Description

Make `PortalAutomationScopeDomainService` honor the `automation.portal.allowMultiplePortalPerEnv` flag plumbed by the Helm chart in #17932; when `true`, the established-portal conflict check is skipped.