### PR TITLE
chore(ui): rename dashboard nav to quick start in APIM module

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -71,7 +71,7 @@ import { UserPermissionsPage } from '../features/apis/pages/detail/user-permissi
 import { PolicyStudioPage } from '../features/apis/pages/policy-studio/PolicyStudioPage';
 import { ScratchWizardPage } from '../features/apis/pages/ScratchWizardPage';
 import { TemplateWizardPage } from '../features/apis/pages/TemplateWizardPage';
-import { DashboardPage } from '../features/dashboard/pages/DashboardPage';
+import { QuickStartPage } from '../features/dashboard/pages/QuickStartPage';
 import { SettingsPage } from '../features/settings/pages/SettingsPage';
 import { createTracingApiPaginatedLoader } from '../lib/api/tracing-api-loader';
 import { useEnvironmentId } from '../lib/hooks/useEnvironmentId';
@@ -181,8 +181,8 @@ export function AppRoutes() {
                 <OnboardingTourHostConnected />
                 <Routes>
                     <Route element={<ModuleLayout />}>
-                        <Route index element={<DashboardPage />} />
-                        <Route path="dashboard" element={<DashboardPage />} />
+                        <Route index element={<QuickStartPage />} />
+                        <Route path="quick-start" element={<QuickStartPage />} />
                         <Route path="apis">
                             <Route index element={<ApisPage />} />
                             <Route path="new">

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/onboarding/tours.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/onboarding/tours.ts
@@ -42,7 +42,7 @@ export const APIM_OVERVIEW_TOUR: CoachmarkTourDefinition = {
             title: 'Welcome to API Management',
             description:
                 'This is your command center for HTTP APIs. Use the sidebar to move between building proxies and products, and observing traffic. This quick tour walks you through each section.',
-            navKey: 'dashboard',
+            navKey: 'quick-start',
         },
         {
             id: 'api-proxies',
@@ -73,8 +73,8 @@ export const APIM_OVERVIEW_TOUR: CoachmarkTourDefinition = {
             icon: RocketIcon,
             title: "You're ready to go",
             description:
-                'Create your first API Proxy from the dashboard whenever you are ready. You can replay this tour any time from the "Take the tour" button on the dashboard.',
-            navKey: 'dashboard',
+                'Create your first API Proxy from the Quick Start page whenever you are ready. You can replay this tour any time from the "Take the tour" button on the Quick Start page.',
+            navKey: 'quick-start',
         },
     ],
 };

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/__tests__/routes.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/__tests__/routes.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+jest.mock('../observability', () => ({
+    observability: {
+        resolveRouteKey: () => null,
+    },
+}));
+
+import { getActiveNavKey, isRouteKey, ROUTES } from '../routes';
+
+describe('getActiveNavKey', () => {
+    it('returns quick-start for root path', () => {
+        expect(getActiveNavKey('/')).toBe('quick-start');
+    });
+
+    it('returns quick-start for /quick-start', () => {
+        expect(getActiveNavKey('/quick-start')).toBe('quick-start');
+    });
+
+    it('returns apis for /apis', () => {
+        expect(getActiveNavKey('/apis')).toBe('apis');
+    });
+
+    it('handles host-prefixed standard routes', () => {
+        expect(getActiveNavKey('/environments/DEFAULT/apim/apis', 'environments/DEFAULT/apim')).toBe('apis');
+        expect(getActiveNavKey('/environments/DEFAULT/apim/quick-start', 'environments/DEFAULT/apim')).toBe('quick-start');
+    });
+});
+
+describe('isRouteKey', () => {
+    it('recognises quick-start', () => {
+        expect(isRouteKey('quick-start')).toBe(true);
+    });
+
+    it('rejects dashboard', () => {
+        expect(isRouteKey('dashboard')).toBe(false);
+    });
+});
+
+describe('ROUTES', () => {
+    it('has a path and label for the quick start route', () => {
+        expect(ROUTES['quick-start']).toEqual({ path: 'quick-start', label: 'Quick Start' });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/navigation.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 import type { NavGroup } from '@gravitee/graphene-core';
-import { ArchiveIcon, HomeIcon, RadioIcon } from '@gravitee/graphene-core/icons';
+import { ArchiveIcon, RadioIcon, RocketIcon } from '@gravitee/graphene-core/icons';
 
 import { observability } from './observability';
 import { ROUTES } from './routes';
 
 export const NAV_GROUPS: NavGroup[] = [
     {
-        label: 'Dashboard',
-        items: [{ key: 'dashboard', title: ROUTES.dashboard.label, icon: HomeIcon }],
+        label: 'General',
+        items: [{ key: 'quick-start', title: ROUTES['quick-start'].label, icon: RocketIcon }],
     },
     {
         label: 'Manage',

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/routes.ts
@@ -18,7 +18,7 @@ import type { ModuleRouteConfig } from '@gravitee/gamma-modules-sdk/routing';
 import { observability } from './observability';
 
 export const ROUTE_KEYS = [
-    'dashboard',
+    'quick-start',
     'apis',
     'api-products',
     'analytics',
@@ -30,10 +30,10 @@ export const ROUTE_KEYS = [
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
 const ROUTE_KEY_SET = new Set<string>(ROUTE_KEYS);
-const DEFAULT_ROUTE_KEY: RouteKey = 'dashboard';
+const DEFAULT_ROUTE_KEY: RouteKey = 'quick-start';
 
 export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: string }> = {
-    dashboard: { path: '', label: 'Dashboard' },
+    'quick-start': { path: 'quick-start', label: 'Quick Start' },
     apis: { path: 'apis', label: 'API Proxies' },
     'api-products': { path: 'api-products', label: 'API Products' },
     analytics: { path: 'analytics', label: 'Analytics' },

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/pages/QuickStartPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/pages/QuickStartPage.tsx
@@ -22,7 +22,7 @@ import { APIM_ROUTE_CONFIG } from '../../../config/routes';
 import { DashboardEmptyLanding, DashboardView } from '../components';
 import { useDashboardStats } from '../hooks/useDashboardStats';
 
-function DashboardPageSkeleton() {
+function QuickStartPageSkeleton() {
     return (
         <div className="space-y-6">
             <div className="flex items-start justify-between gap-4">
@@ -47,7 +47,7 @@ function DashboardPageSkeleton() {
     );
 }
 
-export function DashboardPage() {
+export function QuickStartPage() {
     const navigate = useNavigate();
     const location = useLocation();
     const { navigateToKey, modulePrefix } = useModuleRouting(APIM_ROUTE_CONFIG);
@@ -68,7 +68,7 @@ export function DashboardPage() {
     // Show skeleton while env is resolving (queries idle → isLoading=false in TanStack v5)
     // or while the first fetch is in-flight. Only drop it once we have a definitive answer.
     if (stats.hasContent === null && !stats.isError) {
-        return <DashboardPageSkeleton />;
+        return <QuickStartPageSkeleton />;
     }
 
     if (stats.isError) {


### PR DESCRIPTION
## Summary
Renames the top APIM module side navigation entry from Dashboard to Quick Start under a General section, with a rocket icon and an aligned `/quick-start` route. The page component is also renamed from `DashboardPage` to `QuickStartPage` for consistency.

Inspired by https://github.com/gravitee-io/gravitee-gamma-module-aim/pull/413.

Before
<img width="251" height="410" alt="Screenshot 2026-06-22 at 10 06 46" src="https://github.com/user-attachments/assets/c8dc157b-bbe7-40b0-a98b-5fa37b1c6f20" />


After
<img width="253" height="405" alt="Screenshot 2026-06-22 at 10 22 51" src="https://github.com/user-attachments/assets/26558a51-0755-4327-88fa-d2897d77d79e" />


## Changes
- Update the first nav group label from "Dashboard" to "General"
- Rename route key/path from `dashboard` to `quick-start` with label "Quick Start"
- Replace `HomeIcon` with `RocketIcon` from `@gravitee/graphene-core/icons`
- Rename `DashboardPage` component/file to `QuickStartPage`
- Route: `<Route path="quick-start" element={<QuickStartPage />} />`
- Update onboarding tour nav keys to `quick-start`
- Add route resolution unit tests

## Test plan
- [ ] Open the APIM module in gamma-console and verify the top side nav shows "General" with a "Quick Start" entry and rocket icon
- [ ] Click the entry and confirm it navigates to `/quick-start`
- [ ] Verify other nav groups (Manage, Observability) are unchanged
- [ ] Replay the onboarding tour and confirm welcome/final steps navigate to Quick Start

> ⚠️ This PR includes UI changes — please add screenshots or a recording before requesting review.