### PR TITLE
fix(gamma): console ui issues — tasks & approvals navigation and consumer search

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/components/TaskRow.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/components/TaskRow.spec.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+import { TaskRow } from './TaskRow';
+import { useModulesStore } from '../../../features/modules';
+import { resetAllStores } from '../../../testing/helpers';
+import type { TaskView } from '../tasks.types';
+
+function makeTask(overrides: Partial<TaskView> = {}): TaskView {
+    return {
+        id: 'task-1',
+        type: 'SUBSCRIPTION_APPROVAL',
+        category: 'SUBSCRIPTION',
+        categoryLabel: 'Subscription Approval',
+        actionLabel: 'Validate subscription',
+        iconKey: 'subscription',
+        area: { key: 'apim', label: 'API Management' },
+        title: 'Passenger App → Flight Status API',
+        subtitle: 'Plan: Gold',
+        createdAt: 0,
+        to: '/environments/env-1/apim/apis/api-http/consumers/sub-1',
+        toModuleId: 'apim',
+        entity: { type: 'SUBSCRIPTION_APPROVAL', created_at: 0, data: {} },
+        ...overrides,
+    };
+}
+
+function seedModule(id: string) {
+    useModulesStore.setState({
+        modules: [{ id, name: 'API Management', version: '1.0', remoteName: 'remote', exposedModule: 'App' }],
+    });
+}
+
+function LocationProbe() {
+    return <span data-testid="location">{useLocation().pathname}</span>;
+}
+
+function renderRow(task: TaskView) {
+    return render(
+        <MemoryRouter initialEntries={['/start']}>
+            <TaskRow task={task} />
+            <Routes>
+                <Route path="*" element={<LocationProbe />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('TaskRow', () => {
+    beforeEach(() => {
+        resetAllStores();
+    });
+
+    it('navigates to the task target when its module is available', () => {
+        seedModule('apim');
+        renderRow(makeTask());
+
+        fireEvent.click(screen.getByRole('button', { name: /Validate subscription/ }));
+
+        expect(screen.getByTestId('location').textContent).toBe('/environments/env-1/apim/apis/api-http/consumers/sub-1');
+    });
+
+    it('renders no action and never navigates when the task has no destination', () => {
+        renderRow(makeTask({ actionLabel: 'Validate user', to: null, toModuleId: null }));
+
+        expect(screen.getByText('Passenger App → Flight Status API')).toBeTruthy();
+        expect(screen.queryByRole('button')).toBeNull();
+        expect(screen.getByTestId('location').textContent).toBe('/start');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/components/TaskRow.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/components/TaskRow.tsx
@@ -34,6 +34,7 @@ const AREA_CLASS: Record<TaskAreaKey, string> = {
     apim: 'border-primary/30 text-primary',
     mcp: 'border-highlight/30 text-highlight',
     ai: 'border-highlight/30 text-highlight',
+    llm: 'border-highlight/30 text-highlight',
     kafka: 'border-warning/30 text-warning',
     users: 'border-success/30 text-success',
 };
@@ -43,12 +44,12 @@ export function TaskRow({ task, onNavigate }: { task: TaskView; onNavigate?: () 
     const modules = useModulesStore(s => s.modules);
     const Icon = ICONS[task.iconKey];
 
+    const hasTarget = Boolean(task.to && task.toModuleId);
     const targetModule = task.toModuleId ? modules.find(m => m.id === task.toModuleId) : undefined;
     const targetLabel = task.toModuleId ? getModuleLabel(task.toModuleId, targetModule?.name) : undefined;
 
     const handleAction = () => {
         if (!task.to || !task.toModuleId) {
-            toast.error('This task cannot be opened yet.');
             return;
         }
         if (!targetModule) {
@@ -84,13 +85,15 @@ export function TaskRow({ task, onNavigate }: { task: TaskView; onNavigate?: () 
                             {task.comment}
                         </p>
                     )}
-                    <div className="flex items-center gap-3 pt-1">
-                        <Button size="sm" onClick={handleAction}>
-                            {task.actionLabel}
-                            <ArrowRightIcon className="size-3" aria-hidden />
-                        </Button>
-                        {targetLabel && <span className="text-xs text-muted-foreground">Opens {targetLabel}</span>}
-                    </div>
+                    {hasTarget && (
+                        <div className="flex items-center gap-3 pt-1">
+                            <Button size="sm" onClick={handleAction}>
+                                {task.actionLabel}
+                                <ArrowRightIcon className="size-3" aria-hidden />
+                            </Button>
+                            {targetLabel && <span className="text-xs text-muted-foreground">Opens {targetLabel}</span>}
+                        </div>
+                    )}
                 </div>
             </CardContent>
         </Card>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.spec.ts
@@ -42,9 +42,9 @@ describe('resolveArea', () => {
         expect(resolveArea('mcp-proxy')).toEqual({ key: 'mcp', label: 'MCP' });
     });
 
-    it('labels llm-proxy and a2a-proxy as AI Agent', () => {
-        expect(resolveArea('llm-proxy').key).toBe('ai');
-        expect(resolveArea('a2a-proxy').key).toBe('ai');
+    it('labels llm-proxy as LLM and a2a-proxy as AI Agent', () => {
+        expect(resolveArea('llm-proxy')).toEqual({ key: 'llm', label: 'LLM' });
+        expect(resolveArea('a2a-proxy')).toEqual({ key: 'ai', label: 'AI Agent' });
     });
 
     it('labels native as Kafka', () => {
@@ -119,7 +119,7 @@ describe('toTaskView', () => {
         expect(view.to).toBe('/environments/staging/apim/apis/api-staging/consumers/sub-3');
     });
 
-    it('labels an MCP subscription as MCP and routes it to the Agent Management module', () => {
+    it('deep-links an MCP subscription to the proxy Consumers list (no per-subscription page yet)', () => {
         const entity: TaskEntity = {
             type: 'SUBSCRIPTION_APPROVAL',
             created_at: 1,
@@ -130,19 +130,19 @@ describe('toTaskView', () => {
 
         expect(view.area).toEqual({ key: 'mcp', label: 'MCP' });
         expect(view.toModuleId).toBe('aim');
-        expect(view.to).toBe('/environments/prod/aim');
+        expect(view.to).toBe('/environments/prod/aim/mcp-proxy/api-mcp/consumers');
     });
 
-    it('labels LLM and A2A subscriptions as AI Agent and routes them to the Agent Management module', () => {
+    it('deep-links LLM subscriptions to the llm-router consumer page and A2A to the agent-runtime API page', () => {
         const llm = toTaskView(subscription('api-llm'), metadata, resolveEnvHrid);
-        expect(llm.area).toEqual({ key: 'ai', label: 'AI Agent' });
+        expect(llm.area).toEqual({ key: 'llm', label: 'LLM' });
         expect(llm.toModuleId).toBe('aim');
-        expect(llm.to).toBe('/environments/prod/aim');
+        expect(llm.to).toBe('/environments/prod/aim/llm-router/api-llm/consumers/sub-api-llm');
 
         const a2a = toTaskView(subscription('api-a2a'), metadata, resolveEnvHrid);
         expect(a2a.area).toEqual({ key: 'ai', label: 'AI Agent' });
         expect(a2a.toModuleId).toBe('aim');
-        expect(a2a.to).toBe('/environments/prod/aim');
+        expect(a2a.to).toBe('/environments/prod/aim/agent-runtime/api-a2a');
     });
 
     it('labels a native subscription as Kafka and routes it to the Event Stream Management module', () => {
@@ -161,6 +161,14 @@ describe('toTaskView', () => {
         expect(view.to).toBe('/environments/prod/apim/api-products/product-1/consumers/sub-9');
     });
 
+    it('falls back to the apim consumer deep link when apiType metadata is missing (legacy tasks)', () => {
+        const view = toTaskView(subscription('api-legacy'), metadata, resolveEnvHrid);
+
+        expect(view.area.key).toBe('apim');
+        expect(view.toModuleId).toBe('apim');
+        expect(view.to).toBe('/environments/prod/apim/apis/api-legacy/consumers/sub-api-legacy');
+    });
+
     it('builds a review task linking to the API page', () => {
         const entity: TaskEntity = { type: 'IN_REVIEW', created_at: 1, data: { referenceId: 'api-http' } };
 
@@ -171,6 +179,25 @@ describe('toTaskView', () => {
         expect(view.subtitle).toBe('Ready to be reviewed');
         expect(view.to).toBe('/environments/prod/apim/apis/api-http');
         expect(view.toModuleId).toBe('apim');
+    });
+
+    it('deep-links an LLM review task to the llm-router API page instead of the module root', () => {
+        const entity: TaskEntity = { type: 'IN_REVIEW', created_at: 1, data: { referenceId: 'api-llm' } };
+
+        const view = toTaskView(entity, metadata, resolveEnvHrid);
+
+        expect(view.area.key).toBe('llm');
+        expect(view.toModuleId).toBe('aim');
+        expect(view.to).toBe('/environments/prod/aim/llm-router/api-llm');
+    });
+
+    it('deep-links an MCP review task to the mcp-proxy API page', () => {
+        const entity: TaskEntity = { type: 'IN_REVIEW', created_at: 1, data: { referenceId: 'api-mcp' } };
+
+        const view = toTaskView(entity, metadata, resolveEnvHrid);
+
+        expect(view.toModuleId).toBe('aim');
+        expect(view.to).toBe('/environments/prod/aim/mcp-proxy/api-mcp');
     });
 
     it('builds a changes-requested task carrying the reviewer comment', () => {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.ts
@@ -47,25 +47,40 @@ const ACTION_LABEL: Record<TaskType, string> = {
     PROMOTION_APPROVAL: 'Review promotion',
 };
 
-const AREA_BY_API_TYPE: Record<string, TaskArea> = {
-    'mcp-proxy': { key: 'mcp', label: 'MCP' },
-    'llm-proxy': { key: 'ai', label: 'AI Agent' },
-    'a2a-proxy': { key: 'ai', label: 'AI Agent' },
-    native: { key: 'kafka', label: 'Kafka' },
-    proxy: { key: 'apim', label: 'API Management' },
-    message: { key: 'apim', label: 'API Management' },
-};
+type ConsumerLevel = 'detail' | 'list' | 'none';
+
+interface ApiTypeConfig {
+    readonly area: TaskArea;
+    readonly moduleId: string;
+    readonly route?: { readonly section: string; readonly consumers: ConsumerLevel };
+}
 
 const API_MANAGEMENT_AREA: TaskArea = { key: 'apim', label: 'API Management' };
 const USERS_AREA: TaskArea = { key: 'users', label: 'Users' };
 
-const AREA_MODULE: Record<TaskArea['key'], string> = {
-    apim: 'apim',
-    mcp: 'aim',
-    ai: 'aim',
-    kafka: 'esm',
-    users: 'authz',
+const API_TYPE_CONFIG: Record<string, ApiTypeConfig> = {
+    proxy: { area: API_MANAGEMENT_AREA, moduleId: 'apim', route: { section: 'apis', consumers: 'detail' } },
+    message: { area: API_MANAGEMENT_AREA, moduleId: 'apim', route: { section: 'apis', consumers: 'detail' } },
+    'mcp-proxy': { area: { key: 'mcp', label: 'MCP' }, moduleId: 'aim', route: { section: 'mcp-proxy', consumers: 'list' } },
+    'llm-proxy': { area: { key: 'llm', label: 'LLM' }, moduleId: 'aim', route: { section: 'llm-router', consumers: 'detail' } },
+    'a2a-proxy': { area: { key: 'ai', label: 'AI Agent' }, moduleId: 'aim', route: { section: 'agent-runtime', consumers: 'none' } },
+    native: { area: { key: 'kafka', label: 'Kafka' }, moduleId: 'esm' },
 };
+
+const DEFAULT_CONFIG: ApiTypeConfig = { area: API_MANAGEMENT_AREA, moduleId: 'apim', route: { section: 'apis', consumers: 'detail' } };
+
+const API_PRODUCT_CONFIG: ApiTypeConfig = {
+    area: API_MANAGEMENT_AREA,
+    moduleId: 'apim',
+    route: { section: 'api-products', consumers: 'detail' },
+};
+
+function configFor(apiType: string | undefined, referenceType: string | undefined): ApiTypeConfig {
+    if (referenceType === 'API_PRODUCT') {
+        return API_PRODUCT_CONFIG;
+    }
+    return (apiType ? API_TYPE_CONFIG[apiType] : undefined) ?? DEFAULT_CONFIG;
+}
 
 export type TaskSortOrder = 'newest' | 'oldest';
 
@@ -97,7 +112,7 @@ export function resolveArea(apiType?: string | null): TaskArea {
     if (!apiType) {
         return API_MANAGEMENT_AREA;
     }
-    return AREA_BY_API_TYPE[apiType] ?? API_MANAGEMENT_AREA;
+    return API_TYPE_CONFIG[apiType]?.area ?? API_MANAGEMENT_AREA;
 }
 
 export function formatRelativeTime(createdAt: number, now: number = Date.now()): string {
@@ -128,12 +143,37 @@ function metaField(metadata: TaskMetadata, id: string | undefined, field: string
     return str(metadata[id]?.[field]);
 }
 
+function envPath(envHrid: string, ...segments: string[]): string {
+    return ['/environments', envHrid, ...segments].join('/');
+}
+
 function apimPath(envHrid: string, ...segments: string[]): string {
-    return ['/environments', envHrid, 'apim', ...segments].join('/');
+    return envPath(envHrid, 'apim', ...segments);
 }
 
 function moduleRoot(envHrid: string, moduleId: string): string {
     return `/environments/${envHrid}/${moduleId}`;
+}
+
+function resolveApiTarget(config: ApiTypeConfig, envHrid: string, refId: string | undefined): string {
+    if (!config.route || !refId) {
+        return moduleRoot(envHrid, config.moduleId);
+    }
+    return envPath(envHrid, config.moduleId, config.route.section, refId);
+}
+
+function resolveConsumerTarget(config: ApiTypeConfig, envHrid: string, refId: string | undefined, subscriptionId: string): string {
+    if (!config.route || !refId) {
+        return moduleRoot(envHrid, config.moduleId);
+    }
+    const { section, consumers } = config.route;
+    if (consumers === 'detail' && subscriptionId) {
+        return envPath(envHrid, config.moduleId, section, refId, 'consumers', subscriptionId);
+    }
+    if (consumers === 'list') {
+        return envPath(envHrid, config.moduleId, section, refId, 'consumers');
+    }
+    return envPath(envHrid, config.moduleId, section, refId);
 }
 
 export type ResolveEnvHrid = (environmentId?: string) => string;
@@ -161,44 +201,38 @@ export function toTaskView(entity: TaskEntity, metadata: TaskMetadata, resolveEn
             const appName = metaField(metadata, application, 'name') ?? application ?? 'Application';
             const refName = metaField(metadata, refId, 'name') ?? refId ?? 'API';
             const planName = metaField(metadata, plan, 'name') ?? plan ?? '';
-            const area = referenceType === 'API_PRODUCT' ? API_MANAGEMENT_AREA : resolveArea(metaField(metadata, refId, 'apiType'));
-            const moduleId = AREA_MODULE[area.key];
-            const apimResource = referenceType === 'API_PRODUCT' ? 'api-products' : 'apis';
+            const apiType = metaField(metadata, refId, 'apiType');
+            const config = configFor(apiType, referenceType);
             const envHrid = resolveEnvHrid(metaField(metadata, refId, 'environmentId'));
-            const to =
-                moduleId === 'apim'
-                    ? refId
-                        ? apimPath(envHrid, apimResource, refId, 'consumers', subscriptionId)
-                        : null
-                    : moduleRoot(envHrid, moduleId);
+            const to = resolveConsumerTarget(config, envHrid, refId, subscriptionId);
             return {
                 ...base,
                 id: `SUBSCRIPTION_APPROVAL:${subscriptionId || refId || application}`,
-                area,
+                area: config.area,
                 title: `${appName} → ${refName}`,
                 subtitle: planName ? `Plan: ${planName}` : '',
                 to,
-                toModuleId: to ? moduleId : null,
+                toModuleId: config.moduleId,
             };
         }
         case 'IN_REVIEW':
         case 'REQUEST_FOR_CHANGES': {
             const referenceId = str(data.referenceId) ?? '';
             const apiName = metaField(metadata, referenceId, 'name') ?? referenceId ?? 'API';
-            const area = resolveArea(metaField(metadata, referenceId, 'apiType'));
-            const moduleId = AREA_MODULE[area.key];
+            const apiType = metaField(metadata, referenceId, 'apiType');
+            const config = configFor(apiType, undefined);
             const comment = str(data.comment);
             const envHrid = resolveEnvHrid(metaField(metadata, referenceId, 'environmentId'));
-            const to = moduleId === 'apim' ? (referenceId ? apimPath(envHrid, 'apis', referenceId) : null) : moduleRoot(envHrid, moduleId);
+            const to = resolveApiTarget(config, envHrid, referenceId);
             return {
                 ...base,
                 id: `${type}:${referenceId}`,
-                area,
+                area: config.area,
                 title: apiName,
                 subtitle: type === 'IN_REVIEW' ? 'Ready to be reviewed' : 'Changes requested by reviewer',
                 comment,
                 to,
-                toModuleId: to ? moduleId : null,
+                toModuleId: config.moduleId,
             };
         }
         case 'USER_REGISTRATION_APPROVAL': {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.types.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.types.ts
@@ -31,7 +31,7 @@ export interface TasksResponse {
 
 export type TaskCategory = 'SUBSCRIPTION' | 'API_REVIEW' | 'CHANGES_REQUESTED' | 'USER_REGISTRATION' | 'API_PROMOTION';
 
-export type TaskAreaKey = 'apim' | 'mcp' | 'ai' | 'kafka' | 'users';
+export type TaskAreaKey = 'apim' | 'mcp' | 'ai' | 'llm' | 'kafka' | 'users';
 
 export interface TaskArea {
     readonly key: TaskAreaKey;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/pages/detail/consumers/ApiProductConsumersPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/pages/detail/consumers/ApiProductConsumersPage.spec.tsx
@@ -146,6 +146,17 @@ jest.mock('@gravitee/graphene-core', () => {
             placeholder?: string;
             type?: string;
         }) => <input id={id} value={value} onChange={onChange} placeholder={placeholder} type={type ?? 'text'} />,
+        InputGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        InputGroupAddon: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        InputGroupInput: ({
+            value,
+            onChange,
+            placeholder,
+        }: {
+            value?: string;
+            onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+            placeholder?: string;
+        }) => <input value={value} onChange={onChange} placeholder={placeholder} />,
         Label: ({ children, htmlFor }: { children: ReactNode; htmlFor?: string }) => <label htmlFor={htmlFor}>{children}</label>,
         Select: ({ value, onValueChange, children }: { value?: string; onValueChange?: (v: string) => void; children: ReactNode }) => (
             <select value={value} onChange={e => onValueChange?.(e.target.value)}>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/consumers/ApplicationSearchList.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/consumers/ApplicationSearchList.spec.tsx
@@ -23,7 +23,9 @@ jest.mock('@gravitee/graphene-core', () => ({
             {children}
         </button>
     ),
-    Input: ({
+    InputGroup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    InputGroupAddon: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    InputGroupInput: ({
         value,
         onChange,
         placeholder,

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/consumers/ApplicationSearchList.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/consumers/ApplicationSearchList.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Badge, Button, Input, Skeleton } from '@gravitee/graphene-core';
+import { Badge, Button, InputGroup, InputGroupAddon, InputGroupInput, Skeleton } from '@gravitee/graphene-core';
 import { MonitorIcon, SearchIcon, XIcon } from '@gravitee/graphene-core/icons';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -64,13 +64,12 @@ export function ApplicationSearchList({ selected, onSelect }: Readonly<Applicati
 
     return (
         <div className="space-y-2">
-            <div className="relative">
-                <SearchIcon
-                    className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
-                    aria-hidden
-                />
-                <Input className="pl-8" placeholder="Type to search applications…" value={query} onChange={handleQuery} />
-            </div>
+            <InputGroup>
+                <InputGroupAddon align="inline-start">
+                    <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                </InputGroupAddon>
+                <InputGroupInput placeholder="Type to search applications…" value={query} onChange={handleQuery} />
+            </InputGroup>
 
             <div className="rounded-md border overflow-y-auto" style={{ maxHeight: '14rem' }}>
                 {!hasQuery && (


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-801

## Description

Two gamma console UI fixes:

1. **Tasks & Approvals navigation** (`gamma-console`) — subscription and review tasks only deep-linked into APIM; LLM, MCP, AI Agent and Kafka tasks fell back to the module root, so approvers landed on the wrong page. Replaced the APIM-only path logic with a single `apiType` registry that resolves the deepest valid target (consumer page → API page → module root). LLM opens the llm-router consumer page, MCP opens its consumers list, AI Agent opens the agent-runtime API page; APIM unchanged. Also unified the area/module/route maps, relabeled `llm-proxy` as its own "LLM" area, restored the APIM deep link for legacy tasks missing `apiType`, and stopped showing a "cannot be opened yet" error on tasks with no destination (e.g. user registration).

2. **Consumer search icon overlap** (`gamma-apim`) — the application search on the API and API Product consumer pages hand-rolled the leading icon, so it overlapped the input text. Switched to Graphene's `InputGroup` / `InputGroupAddon` / `InputGroupInput` primitives, which reserve space for the icon.

## Additional context

- Two commits: one for tasks & approvals, one for the consumer search fix.
- Test suites updated and passing for both areas (gamma-console + gamma-apim).
- Follow-ups (not in this PR): flip MCP consumer level to `detail` once the deployed proxy exposes a per-subscription page; add a consumer page for AI Agent (`agent-runtime`); define the Kafka (`esm`) URL convention; and a durable SDK deep-link contract so the host stops hardcoding module URL shapes.

Made with [Cursor](https://cursor.com)