### PR TITLE
refactor(permissions): rename CATALOG scope to AI_CATALOG

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/RoleScope.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/RoleScope.java
@@ -29,5 +29,5 @@ public enum RoleScope {
     INTEGRATION,
     CLUSTER,
     API_PRODUCT,
-    CATALOG,
+    AI_CATALOG,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1905,7 +1905,7 @@ components:
         - INTEGRATION
         - CLUSTER
         - API_PRODUCT
-        - CATALOG
+        - AI_CATALOG
     Member:
       type: object
       properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResource.java
@@ -22,10 +22,10 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.repository.management.model.RoleScope;
 import io.gravitee.rest.api.management.rest.model.wrapper.RoleScopesLinkedHashMap;
 import io.gravitee.rest.api.management.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.permissions.AiCatalogPermission;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
-import io.gravitee.rest.api.model.permissions.CatalogPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
 import io.gravitee.rest.api.model.permissions.IntegrationPermission;
@@ -84,7 +84,10 @@ public class RoleScopesResource extends AbstractResource {
             RoleScope.API_PRODUCT.name(),
             stream(ApiProductPermission.values()).map(ApiProductPermission::getName).sorted().collect(toList())
         );
-        roles.put(RoleScope.CATALOG.name(), stream(CatalogPermission.values()).map(CatalogPermission::getName).sorted().collect(toList()));
+        roles.put(
+            RoleScope.AI_CATALOG.name(),
+            stream(AiCatalogPermission.values()).map(AiCatalogPermission::getName).sorted().collect(toList())
+        );
         return roles;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
@@ -120,7 +120,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
         List.of("DEFINITION", "MEMBER"),
         "CLUSTER",
         List.of("ANALYTICS", "CONFIGURATION", "DEFINITION", "MEMBER"),
-        "CATALOG",
+        "AI_CATALOG",
         List.of("DEFINITION", "MEMBER")
     );
 
@@ -147,7 +147,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
                     "INTEGRATION",
                     "CLUSTER",
                     "API_PRODUCT",
-                    "CATALOG"
+                    "AI_CATALOG"
                 ),
             () -> assertThat(resultRoleScopes.get("ORGANIZATION")).isEqualTo(EXPECTED_ROLE_SCOPES.get("ORGANIZATION")),
             () -> assertThat(resultRoleScopes.get("ENVIRONMENT")).isEqualTo(EXPECTED_ROLE_SCOPES.get("ENVIRONMENT")),
@@ -155,7 +155,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
             () -> assertThat(resultRoleScopes.get("APPLICATION")).isEqualTo(EXPECTED_ROLE_SCOPES.get("APPLICATION")),
             () -> assertThat(resultRoleScopes.get("INTEGRATION")).isEqualTo(EXPECTED_ROLE_SCOPES.get("INTEGRATION")),
             () -> assertThat(resultRoleScopes.get("CLUSTER")).isEqualTo(EXPECTED_ROLE_SCOPES.get("CLUSTER")),
-            () -> assertThat(resultRoleScopes.get("CATALOG")).isEqualTo(EXPECTED_ROLE_SCOPES.get("CATALOG"))
+            () -> assertThat(resultRoleScopes.get("AI_CATALOG")).isEqualTo(EXPECTED_ROLE_SCOPES.get("AI_CATALOG"))
         );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MembershipReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MembershipReferenceType.java
@@ -38,7 +38,7 @@ public enum MembershipReferenceType {
             RoleScope.APPLICATION,
             RoleScope.INTEGRATION,
             RoleScope.CLUSTER,
-            RoleScope.CATALOG
+            RoleScope.AI_CATALOG
         )
     ),
     ENVIRONMENT(EnumSet.allOf(RoleScope.class)),
@@ -46,7 +46,7 @@ public enum MembershipReferenceType {
     PLATFORM(EnumSet.allOf(RoleScope.class)),
     INTEGRATION(EnumSet.allOf(RoleScope.class)),
     CLUSTER(EnumSet.allOf(RoleScope.class)),
-    CATALOG(EnumSet.of(RoleScope.CATALOG));
+    AI_CATALOG(EnumSet.of(RoleScope.AI_CATALOG));
 
     private final EnumSet<RoleScope> roleScopes;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/AiCatalogPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/AiCatalogPermission.java
@@ -18,14 +18,14 @@ package io.gravitee.rest.api.model.permissions;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(enumAsRef = true)
-public enum CatalogPermission implements Permission {
+public enum AiCatalogPermission implements Permission {
     DEFINITION("DEFINITION", 1000),
     MEMBER("MEMBER", 1100);
 
     final String name;
     final int mask;
 
-    CatalogPermission(String name, int mask) {
+    AiCatalogPermission(String name, int mask) {
         this.name = name;
         this.mask = mask;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/Permission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/Permission.java
@@ -46,8 +46,8 @@ public interface Permission {
                 return ClusterPermission.values();
             case API_PRODUCT:
                 return ApiProductPermission.values();
-            case CATALOG:
-                return CatalogPermission.values();
+            case AI_CATALOG:
+                return AiCatalogPermission.values();
             default:
                 throw new IllegalArgumentException("[" + scope + "] are not a RolePermission");
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -133,8 +133,8 @@ public enum RolePermission {
     API_PRODUCT_NOTIFICATION(RoleScope.API_PRODUCT, ApiProductPermission.NOTIFICATION),
     API_PRODUCT_MEMBER(RoleScope.API_PRODUCT, ApiProductPermission.MEMBER),
 
-    CATALOG_DEFINITION(RoleScope.CATALOG, CatalogPermission.DEFINITION),
-    CATALOG_MEMBER(RoleScope.CATALOG, CatalogPermission.MEMBER);
+    AI_CATALOG_DEFINITION(RoleScope.AI_CATALOG, AiCatalogPermission.DEFINITION),
+    AI_CATALOG_MEMBER(RoleScope.AI_CATALOG, AiCatalogPermission.MEMBER);
 
     final RoleScope scope;
     final Permission permission;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RoleScope.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RoleScope.java
@@ -32,5 +32,5 @@ public enum RoleScope {
     INTEGRATION,
     CLUSTER,
     API_PRODUCT,
-    CATALOG,
+    AI_CATALOG,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-rest/src/main/java/io/gravitee/rest/api/rest/filter/PermissionsFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-rest/src/main/java/io/gravitee/rest/api/rest/filter/PermissionsFilter.java
@@ -90,7 +90,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
             case INTEGRATION -> hasPermission(executionContext, permission, getId(INTEGRATION_ID_PARAM, requestContext));
             case CLUSTER -> hasPermission(executionContext, permission, getId(CLUSTER_ID_PARAM, requestContext));
             case API_PRODUCT -> hasPermission(executionContext, permission, getId(API_PRODUCT_ID_PARAM, requestContext));
-            case CATALOG -> hasPermission(executionContext, permission, getId(CATALOG_ID_PARAM, requestContext));
+            case AI_CATALOG -> hasPermission(executionContext, permission, getId(CATALOG_ID_PARAM, requestContext));
             case PLATFORM -> false;
         };
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/MembershipReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/MembershipReferenceType.java
@@ -33,7 +33,7 @@ public enum MembershipReferenceType {
     PLATFORM(EnumSet.allOf(RoleScope.class)),
     INTEGRATION(EnumSet.allOf(RoleScope.class)),
     CLUSTER(EnumSet.allOf(RoleScope.class)),
-    CATALOG(EnumSet.of(RoleScope.CATALOG));
+    AI_CATALOG(EnumSet.of(RoleScope.AI_CATALOG));
 
     private final EnumSet<RoleScope> roleScopes;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/RoleScope.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/RoleScope.java
@@ -29,5 +29,5 @@ public enum RoleScope {
     INTEGRATION,
     CLUSTER,
     API_PRODUCT,
-    CATALOG,
+    AI_CATALOG,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Role.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Role.java
@@ -50,6 +50,6 @@ public class Role {
         INTEGRATION,
         CLUSTER,
         API_PRODUCT,
-        CATALOG,
+        AI_CATALOG,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
@@ -21,10 +21,10 @@ import static java.util.stream.Collectors.toMap;
 
 import io.gravitee.common.util.Maps;
 import io.gravitee.rest.api.model.NewRoleEntity;
+import io.gravitee.rest.api.model.permissions.AiCatalogPermission;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
-import io.gravitee.rest.api.model.permissions.CatalogPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
 import io.gravitee.rest.api.model.permissions.IntegrationPermission;
@@ -262,25 +262,25 @@ public interface DefaultRoleEntityDefinition {
             .build()
     );
 
-    NewRoleEntity ROLE_CATALOG_OWNER = new NewRoleEntity(
+    NewRoleEntity ROLE_AI_CATALOG_OWNER = new NewRoleEntity(
         "OWNER",
         "Catalog Role. Created by Gravitee.io.",
-        CATALOG,
+        AI_CATALOG,
         false,
         Maps.<String, char[]>builder()
-            .put(CatalogPermission.DEFINITION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
-            .put(CatalogPermission.MEMBER.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .put(AiCatalogPermission.DEFINITION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .put(AiCatalogPermission.MEMBER.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
             .build()
     );
 
-    NewRoleEntity ROLE_CATALOG_USER = new NewRoleEntity(
+    NewRoleEntity ROLE_AI_CATALOG_USER = new NewRoleEntity(
         "USER",
         "Default Catalog Role. Created by Gravitee.io.",
-        CATALOG,
+        AI_CATALOG,
         true,
         Maps.<String, char[]>builder()
-            .put(CatalogPermission.DEFINITION.getName(), new char[] { READ.getId() })
-            .put(CatalogPermission.MEMBER.getName(), new char[] { READ.getId() })
+            .put(AiCatalogPermission.DEFINITION.getName(), new char[] { READ.getId() })
+            .put(AiCatalogPermission.MEMBER.getName(), new char[] { READ.getId() })
             .build()
     );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
@@ -52,7 +52,7 @@ public class PermissionServiceImpl extends AbstractService implements Permission
         Pair.of(RoleScope.GROUP, MembershipReferenceType.GROUP),
         Pair.of(RoleScope.INTEGRATION, MembershipReferenceType.INTEGRATION),
         Pair.of(RoleScope.CLUSTER, MembershipReferenceType.CLUSTER),
-        Pair.of(RoleScope.CATALOG, MembershipReferenceType.CATALOG)
+        Pair.of(RoleScope.AI_CATALOG, MembershipReferenceType.AI_CATALOG)
     );
 
     @Autowired

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -30,13 +30,13 @@ import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DE
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DEFAULT_ROLE_APPLICATION_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DEFAULT_ROLE_ENVIRONMENT_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DEFAULT_ROLE_ORGANIZATION_USER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_AI_CATALOG_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_AI_CATALOG_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_OWNER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_PRODUCT_OWNER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_PRODUCT_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_REVIEWER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_APPLICATION_OWNER;
-import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_CATALOG_OWNER;
-import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_CATALOG_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_API_PUBLISHER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_EDGE_MANAGER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_FEDERATION_AGENT;
@@ -56,10 +56,10 @@ import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.NewRoleEntity;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.UpdateRoleEntity;
+import io.gravitee.rest.api.model.permissions.AiCatalogPermission;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
-import io.gravitee.rest.api.model.permissions.CatalogPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
 import io.gravitee.rest.api.model.permissions.GroupPermission;
@@ -129,8 +129,8 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
         Map.entry("<API_PRODUCT> USER", ROLE_API_PRODUCT_USER),
         Map.entry("<CLUSTER> USER", CLUSTER_ROLE_USER),
         Map.entry("<CLUSTER> OWNER", CLUSTER_ROLE_OWNER),
-        Map.entry("<CATALOG> OWNER", ROLE_CATALOG_OWNER),
-        Map.entry("<CATALOG> USER", ROLE_CATALOG_USER)
+        Map.entry("<AI_CATALOG> OWNER", ROLE_AI_CATALOG_OWNER),
+        Map.entry("<AI_CATALOG> USER", ROLE_AI_CATALOG_USER)
     );
 
     @Lazy
@@ -616,12 +616,12 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 ClusterPermission.values(),
                 organizationId
             );
-            // CATALOG - PRIMARY_OWNER
+            // AI_CATALOG - PRIMARY_OWNER
             createOrUpdateSystemRole(
                 executionContext,
                 SystemRole.PRIMARY_OWNER,
-                RoleScope.CATALOG,
-                CatalogPermission.values(),
+                RoleScope.AI_CATALOG,
+                AiCatalogPermission.values(),
                 organizationId
             );
         } catch (TechnicalManagementException ex) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/DefaultOrganizationAdminRoleInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/DefaultOrganizationAdminRoleInitializer.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade.initializer;
 
-import io.gravitee.rest.api.model.permissions.CatalogPermission;
+import io.gravitee.rest.api.model.permissions.AiCatalogPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
 import io.gravitee.rest.api.model.permissions.IntegrationPermission;
@@ -73,8 +73,8 @@ public class DefaultOrganizationAdminRoleInitializer extends OrganizationInitial
         roleService.createOrUpdateSystemRole(
             executionContext,
             SystemRole.PRIMARY_OWNER,
-            RoleScope.CATALOG,
-            CatalogPermission.values(),
+            RoleScope.AI_CATALOG,
+            AiCatalogPermission.values(),
             executionContext.getOrganizationId()
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AiCatalogRolesUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AiCatalogRolesUpgrader.java
@@ -15,9 +15,9 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
-import static io.gravitee.rest.api.model.permissions.RoleScope.CATALOG;
-import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_CATALOG_OWNER;
-import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_CATALOG_USER;
+import static io.gravitee.rest.api.model.permissions.RoleScope.AI_CATALOG;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_AI_CATALOG_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_AI_CATALOG_USER;
 
 import io.gravitee.node.api.upgrader.Upgrader;
 import io.gravitee.node.api.upgrader.UpgraderException;
@@ -31,14 +31,14 @@ import org.springframework.stereotype.Component;
 
 @Component
 @CustomLog
-public class CatalogRolesUpgrader implements Upgrader {
+public class AiCatalogRolesUpgrader implements Upgrader {
 
     private final RoleService roleService;
 
     private final OrganizationRepository organizationRepository;
 
     @Autowired
-    public CatalogRolesUpgrader(RoleService roleService, @Lazy OrganizationRepository organizationRepository) {
+    public AiCatalogRolesUpgrader(RoleService roleService, @Lazy OrganizationRepository organizationRepository) {
         this.roleService = roleService;
         this.organizationRepository = organizationRepository;
     }
@@ -58,22 +58,22 @@ public class CatalogRolesUpgrader implements Upgrader {
     }
 
     private void initializeCatalogRoles(ExecutionContext executionContext) {
-        if (shouldCreateRole(executionContext, ROLE_CATALOG_OWNER.getName())) {
-            log.info("     - <CATALOG> OWNER");
-            roleService.create(executionContext, ROLE_CATALOG_OWNER);
+        if (shouldCreateRole(executionContext, ROLE_AI_CATALOG_OWNER.getName())) {
+            log.info("     - <AI_CATALOG> OWNER");
+            roleService.create(executionContext, ROLE_AI_CATALOG_OWNER);
         }
-        if (shouldCreateRole(executionContext, ROLE_CATALOG_USER.getName())) {
-            log.info("     - <CATALOG> USER");
-            roleService.create(executionContext, ROLE_CATALOG_USER);
+        if (shouldCreateRole(executionContext, ROLE_AI_CATALOG_USER.getName())) {
+            log.info("     - <AI_CATALOG> USER");
+            roleService.create(executionContext, ROLE_AI_CATALOG_USER);
         }
     }
 
     private boolean shouldCreateRole(final ExecutionContext executionContext, String roleName) {
-        return roleService.findByScopeAndName(CATALOG, roleName, executionContext.getOrganizationId()).isEmpty();
+        return roleService.findByScopeAndName(AI_CATALOG, roleName, executionContext.getOrganizationId()).isEmpty();
     }
 
     @Override
     public int getOrder() {
-        return UpgraderOrder.CATALOG_ROLES_UPGRADER;
+        return UpgraderOrder.AI_CATALOG_ROLES_UPGRADER;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -80,5 +80,5 @@ public class UpgraderOrder {
     public static final int EDGE_ROLES_UPGRADER = 955;
     public static final int GAMMA_IDENTITY_ROLES_UPGRADER = 956;
     public static final int GAMMA_AUTHZ_ROLES_UPGRADER = 957;
-    public static final int CATALOG_ROLES_UPGRADER = 958;
+    public static final int AI_CATALOG_ROLES_UPGRADER = 958;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AiCatalogRolesUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AiCatalogRolesUpgraderTest.java
@@ -15,9 +15,9 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
-import static io.gravitee.rest.api.model.permissions.RoleScope.CATALOG;
-import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_CATALOG_OWNER;
-import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_CATALOG_USER;
+import static io.gravitee.rest.api.model.permissions.RoleScope.AI_CATALOG;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_AI_CATALOG_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_AI_CATALOG_USER;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -44,10 +44,10 @@ import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.WARN)
-public class CatalogRolesUpgraderTest {
+public class AiCatalogRolesUpgraderTest {
 
     @InjectMocks
-    CatalogRolesUpgrader upgrader;
+    AiCatalogRolesUpgrader upgrader;
 
     @Mock
     RoleService roleService;
@@ -71,15 +71,17 @@ public class CatalogRolesUpgraderTest {
         when(organizationRepository.findAll()).thenReturn(Set.of(organization));
 
         ExecutionContext expectedExecutionContext = new ExecutionContext(organization);
-        when(roleService.findByScopeAndName(eq(CATALOG), eq(ROLE_CATALOG_OWNER.getName()), eq(organizationId))).thenReturn(
+        when(roleService.findByScopeAndName(eq(AI_CATALOG), eq(ROLE_AI_CATALOG_OWNER.getName()), eq(organizationId))).thenReturn(
             Optional.empty()
         );
-        when(roleService.findByScopeAndName(eq(CATALOG), eq(ROLE_CATALOG_USER.getName()), eq(organizationId))).thenReturn(Optional.empty());
+        when(roleService.findByScopeAndName(eq(AI_CATALOG), eq(ROLE_AI_CATALOG_USER.getName()), eq(organizationId))).thenReturn(
+            Optional.empty()
+        );
 
         upgrader.upgrade();
 
-        verify(roleService).create(expectedExecutionContext, ROLE_CATALOG_OWNER);
-        verify(roleService).create(expectedExecutionContext, ROLE_CATALOG_USER);
+        verify(roleService).create(expectedExecutionContext, ROLE_AI_CATALOG_OWNER);
+        verify(roleService).create(expectedExecutionContext, ROLE_AI_CATALOG_USER);
         verify(roleService).createOrUpdateSystemRoles(expectedExecutionContext, organizationId);
     }
 
@@ -90,22 +92,22 @@ public class CatalogRolesUpgraderTest {
         when(organization.getId()).thenReturn(organizationId);
         when(organizationRepository.findAll()).thenReturn(Set.of(organization));
 
-        when(roleService.findByScopeAndName(eq(CATALOG), eq(ROLE_CATALOG_OWNER.getName()), eq(organizationId))).thenReturn(
+        when(roleService.findByScopeAndName(eq(AI_CATALOG), eq(ROLE_AI_CATALOG_OWNER.getName()), eq(organizationId))).thenReturn(
             Optional.of(new RoleEntity())
         );
-        when(roleService.findByScopeAndName(eq(CATALOG), eq(ROLE_CATALOG_USER.getName()), eq(organizationId))).thenReturn(
+        when(roleService.findByScopeAndName(eq(AI_CATALOG), eq(ROLE_AI_CATALOG_USER.getName()), eq(organizationId))).thenReturn(
             Optional.of(new RoleEntity())
         );
 
         upgrader.upgrade();
 
-        verify(roleService, never()).create(any(), eq(ROLE_CATALOG_OWNER));
-        verify(roleService, never()).create(any(), eq(ROLE_CATALOG_USER));
+        verify(roleService, never()).create(any(), eq(ROLE_AI_CATALOG_OWNER));
+        verify(roleService, never()).create(any(), eq(ROLE_AI_CATALOG_USER));
         verify(roleService).createOrUpdateSystemRoles(any(), eq(organizationId));
     }
 
     @Test
     public void test_order() {
-        Assertions.assertEquals(UpgraderOrder.CATALOG_ROLES_UPGRADER, upgrader.getOrder());
+        Assertions.assertEquals(UpgraderOrder.AI_CATALOG_ROLES_UPGRADER, upgrader.getOrder());
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/gravitee-io/gravitee-api-management/pull/18007.

That PR introduced the env permission `AI_CATALOG` but named the scope `CATALOG` (and `CatalogPermission`, `CATALOG_DEFINITION/MEMBER`), so the same feature had two names. This aligns the scope on `AI_CATALOG`:
- `RoleScope.CATALOG` -> `RoleScope.AI_CATALOG`
- `CatalogPermission` -> `AiCatalogPermission`, `CATALOG_DEFINITION/MEMBER` -> `AI_CATALOG_DEFINITION/MEMBER`
- `MembershipReferenceType.CATALOG` -> `AI_CATALOG`, `CatalogRolesUpgrader` -> `AiCatalogRolesUpgrader`, etc.

Now consistent with the env permission, with the convention used by every other scoped permission (env perm name = scope name, like INTEGRATION/CLUSTER/API_PRODUCT), and `AI_` keeps it distinct from the unrelated `PlanType.CATALOG` and a possible future API catalog.

The env permission `ENVIRONMENT_AI_CATALOG` is unchanged, so the AIM module PRs aren't affected. `PlanType.CATALOG` is untouched.

https://gravitee.atlassian.net/browse/GMA-754