### PR TITLE
feat: bundle authz reactor and entrypoint in distribution

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1510,6 +1510,19 @@
                 </dependency>
                 <dependency>
                     <groupId>com.graviteesource.entrypoint</groupId>
+                    <artifactId>gravitee-entrypoint-authz</artifactId>
+                    <version>${gravitee-reactor-authz.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.entrypoint</groupId>
                     <artifactId>gravitee-entrypoint-mcp-tool-server</artifactId>
                     <version>${gravitee-entrypoint-mcp-tool-server.version}</version>
                     <type>zip</type>
@@ -2280,6 +2293,19 @@
                     <groupId>com.graviteesource.reactor</groupId>
                     <artifactId>gravitee-reactor-a2a-proxy</artifactId>
                     <version>${gravitee-reactor-a2a-proxy.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.reactor</groupId>
+                    <artifactId>gravitee-reactor-authz</artifactId>
+                    <version>${gravitee-reactor-authz.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
                     <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,7 @@
         <gravitee-reactor-mcp-proxy.version>3.0.0-alpha.10</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>3.0.0-alpha.7</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.3</gravitee-reactor-a2a-proxy.version>
+        <gravitee-reactor-authz.version>1.0.0-alpha.1</gravitee-reactor-authz.version>
         <gravitee-reactor-edge.version>1.0.0-alpha.10</gravitee-reactor-edge.version>
         <gravitee-resource-ai-vector-store-redis.version>2.0.0-alpha.1</gravitee-resource-ai-vector-store-redis.version>
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>


### PR DESCRIPTION
## What

Bundle `gravitee-reactor-authz` and `gravitee-entrypoint-authz` (`1.0.0-alpha.1`) into the gateway distribution, mirroring how the `mcp` / `llm` / `a2a` proxy reactors are wired.

## Why

The AuthZEN entrypoint and authz reactor were previously overlaid into the distribution by hand (local rebuild script). The PDP service (`gravitee-service-authz-pdp`) is already bundled, but its runtime counterpart — the reactor + entrypoint — was missing, so a stock build could not serve AUTHZ-type APIs without manual plugin copying.

## Changes

- **`pom.xml`**: add `gravitee-reactor-authz.version` property (`1.0.0-alpha.1`), grouped with the other reactor versions.
- **`gravitee-apim-distribution/pom.xml`**: add two `zip` runtime dependencies, mirroring the a2a/mcp/llm entries exactly:
  - `com.graviteesource.entrypoint:gravitee-entrypoint-authz`
  - `com.graviteesource.reactor:gravitee-reactor-authz`

Both artifacts share a single version property, the same way `gravitee-reactor-mcp-proxy.version` drives both the mcp reactor and its entrypoint. Artifacts verified present in the release registry.