### PR TITLE
feat: create docker images for apim based on the redhat/ubi9 docker image

### DIFF
--- a/gravitee-apim-gateway/docker/Dockerfile.ubi9
+++ b/gravitee-apim-gateway/docker/Dockerfile.ubi9
@@ -1,0 +1,43 @@
+#
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# First stage to share environment variable
+FROM graviteeio/java:21-ubi9 AS base-ubi9
+ENV GRAVITEEIO_HOME=/opt/graviteeio-gateway
+
+USER root
+RUN set -eux; \
+    dnf install --assumeyes \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm; \
+    dnf install --assumeyes --allowerasing jemalloc; \
+    dnf clean all; \
+    rm -rf /var/cache/dnf/*
+
+
+# Second stage to add the folder and change the permissions and ownership
+FROM base-ubi9 AS builder
+COPY --chown=graviteeio:graviteeio ./distribution ${GRAVITEEIO_HOME}/
+RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
+    chmod -R g=u ${GRAVITEEIO_HOME}
+
+# Third stage to build the final docker image. COPY preserves ownership & permissions
+FROM base-ubi9
+LABEL maintainer="contact@graviteesource.com"
+COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
+WORKDIR ${GRAVITEEIO_HOME}
+EXPOSE 8082
+USER graviteeio
+ENTRYPOINT ["./bin/gravitee"]

--- a/gravitee-apim-rest-api/docker/Dockerfile.ubi9
+++ b/gravitee-apim-rest-api/docker/Dockerfile.ubi9
@@ -1,0 +1,43 @@
+#
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# First stage to share environment variable
+FROM graviteeio/java:21-ubi9 AS base-ubi9
+ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
+
+USER root
+RUN set -eux; \
+    dnf install --assumeyes \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm; \
+    dnf install --assumeyes --allowerasing jemalloc; \
+    dnf clean all; \
+    rm -rf /var/cache/dnf/*
+
+
+# Second stage to add the folder and change the permissions and ownership
+FROM base-ubi9 AS builder
+COPY --chown=graviteeio:graviteeio ./distribution ${GRAVITEEIO_HOME}/
+RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
+    chmod -R g=u ${GRAVITEEIO_HOME}
+
+# Third stage to build the final docker image. COPY preserves ownership & permissions
+FROM base-ubi9
+LABEL maintainer="contact@graviteesource.com"
+COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
+WORKDIR ${GRAVITEEIO_HOME}
+EXPOSE 8083
+USER graviteeio
+ENTRYPOINT ["./bin/gravitee"]


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14506

To test locally the docker images:

1. create the ubi9 java base image
- retrieve this PR => https://github.com/gravitee-io/gravitee-docker/pull/238
- go inside
```
cd images/java
docker build . -t graviteeio/java:21-ubi9 -f Dockerfile.ubi9
```

2. Build the APIM project from this PR:
`mvn clean install -U -DskipTests=true -Dskip.validation -Dskip.ui.build=true -T 2C -P bundle-default,bundle-dev`

3. Create the GW docker image
```
cd gravitee-apim-gateway/docker
cp -r ../gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution ./distribution
docker build . -t graviteeio/apim-gateway:ubi9 -f Dockerfile.ubi9
```

4. Create the management API docker image
```
cd gravitee-apim-rest-api/docker
cp -r ../gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution/ ./distribution
docker build . -t graviteeio/apim-management-api:ubi9 -f Dockerfile.ubi9
```

5. use these new local docker images in your docker-compose file