### PR TITLE
fix(gamma-apim): set visibility on proxy api create request

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
@@ -84,6 +84,7 @@ export interface CreateApiProxyRequest {
     description: string;
     type: 'PROXY';
     definitionVersion: 'V4';
+    visibility: ApiVisibility;
     allowedInApiProducts: boolean;
     listeners: HttpListener[];
     endpointGroups: HttpEndpointGroup[];

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.spec.ts
@@ -96,6 +96,10 @@ describe('mapFormToCreateRequest', () => {
         expect(req.description).toBe('A test API');
         expect(req.endpointGroups[0].endpoints[0].configuration.target).toBe('https://backend.example.com');
     });
+
+    it('defaults visibility to PRIVATE so the classic console can read the created API', () => {
+        expect(mapFormToCreateRequest(form()).visibility).toBe('PRIVATE');
+    });
 });
 
 describe('mapFormToPlanRequest', () => {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.ts
@@ -88,6 +88,7 @@ export function mapFormToCreateRequest(form: ApiProxyDraft): CreateApiProxyReque
         description: form.apiDescription,
         type: 'PROXY',
         definitionVersion: 'V4',
+        visibility: 'PRIVATE',
         listeners: [buildListener(form)],
         allowedInApiProducts: false,
         endpointGroups: [


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-809
## Description

The "Rest API with API Key" quick-start template built the create proxy API request without a visibility, so APIs created from Gamma had a null visibility. The classic console then failed to read them with "visibility is marked non-null but is null".
Default visibility to PRIVATE in mapFormToCreateRequest and add it to CreateApiProxyRequest, with a unit test covering the default.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

