### PR TITLE
fix(repository): retry jdbc token-bucket on innodb deadlock

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepository.java
@@ -71,6 +71,9 @@ public class JdbcTokenBucketRateLimitRepository implements TokenBucketRateLimitR
     /** SQLState class 23 == integrity constraint violation; a primary-key clash on first insert lands here. */
     private static final String INTEGRITY_VIOLATION_SQLSTATE_CLASS = "23";
 
+    /** SQLState class 40 == transaction rollback; MySQL/MariaDB/SQL Server report 40001 on an InnoDB/range-lock deadlock, PostgreSQL 40P01. */
+    private static final String TRANSIENT_ROLLBACK_SQLSTATE_CLASS = "40";
+
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
@@ -117,9 +120,9 @@ public class JdbcTokenBucketRateLimitRepository implements TokenBucketRateLimitR
             try {
                 return consumeInTransaction(key, tokensRequested, refillRate, refillPeriodMillis, capacity, nowMillis, supplier);
             } catch (SQLException e) {
-                // Another request inserted this key first; retry — the row now exists and the locking
-                // SELECT will serialise on it.
-                if (isIntegrityViolation(e) && attempt < MAX_INSERT_RETRIES) {
+                // Concurrent first-insert race; the row now exists, so the retry's locking SELECT serialises on it.
+                // PostgreSQL surfaces it as an integrity violation, MySQL/MariaDB as an InnoDB deadlock.
+                if ((isIntegrityViolation(e) || isTransientRollback(e)) && attempt < MAX_INSERT_RETRIES) {
                     continue;
                 }
                 throw e;
@@ -215,6 +218,16 @@ public class JdbcTokenBucketRateLimitRepository implements TokenBucketRateLimitR
         for (SQLException current = e; current != null; current = current.getNextException()) {
             String sqlState = current.getSQLState();
             if (sqlState != null && sqlState.startsWith(INTEGRITY_VIOLATION_SQLSTATE_CLASS)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isTransientRollback(SQLException e) {
+        for (SQLException current = e; current != null; current = current.getNextException()) {
+            String sqlState = current.getSQLState();
+            if (sqlState != null && sqlState.startsWith(TRANSIENT_ROLLBACK_SQLSTATE_CLASS)) {
                 return true;
             }
         }


### PR DESCRIPTION
## What

Makes the JDBC token-bucket repository retry on **transient transaction-rollback (deadlock / serialization) failures**, not just primary-key integrity violations.

## Why

`AbstractTokenBucketRateLimitRepositoryContractTest#concurrent_consumes_never_exceed_available_tokens` fails on **MySQL/MariaDB** in the CI dialect matrix:

```
Deadlock found when trying to get lock (1213-40001)
  at JdbcTokenBucketRateLimitRepository.insert(...)
```

For a key that does not exist yet, every concurrent request does `SELECT ... FOR UPDATE` (matching no row) then `INSERT`. On InnoDB that `SELECT ... FOR UPDATE` takes a **gap / insert-intention lock**, so the racing inserts of the same PK **deadlock** (SQLState `40001`). PostgreSQL surfaces the same race as a **unique violation** (SQLState class `23`), already handled by the retry loop. SQL Server serialises it via `UPDLOCK/HOLDLOCK` and does not deadlock here (all SQL Server matrix versions were already green). Local runs were on PostgreSQL only, so the matrix caught the MySQL/MariaDB path.

## Change

`consumeWithRetry` now also retries when the failure is a transient rollback, detected by **SQLState class `40`** — the portable signal across every supported dialect (MySQL/MariaDB/SQL Server `40001`, PostgreSQL `40P01`), mirroring the existing `isIntegrityViolation` (class `23`) check. The failed transaction has already rolled back and, once any insert commits, the row exists, so the retry takes the row lock and serialises on the `UPDATE` path. `MAX_INSERT_RETRIES` (5) is unchanged and ample; no backoff is needed (the blocking JDBC path runs on a worker pool, not the event loop).

## Testing

Ran the full `JdbcTokenBucketRateLimitRepositoryTest` (13 tests) locally via Testcontainers; the concurrency test was also run repeatedly on MariaDB to check for flakiness.

| Dialect | Before | After |
|---|---|---|
| MariaDB 10.4 | ❌ deadlock | ✅ 13/13 (repeated runs green) |
| MySQL 8.0 | ❌ deadlock | ✅ 13/13 |
| PostgreSQL 13 | ✅ | ✅ 13/13 (no regression) |
| SQL Server | ✅ (no deadlock) | ✅ (covered defensively by SQLState 40) |

Refs: APIM-14483