### PR TITLE
feat(console): improve new developer portal settings hierarchy

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -462,86 +462,107 @@
             <gio-banner-info>
               {{ integrationsService.bannerMessages.techPreview }}
             </gio-banner-info>
-            <gio-form-slide-toggle formGroupName="access" class="portal__form__card__form-field">
-              <gio-form-label>Enable the New Developer Portal</gio-form-label>
-              <mat-slide-toggle
-                id="enable-portal-next"
-                formControlName="enabled"
-                gioFormSlideToggle
-                aria-label="New Portal Enabled"
-              ></mat-slide-toggle>
-            </gio-form-slide-toggle>
-            <gio-form-slide-toggle formGroupName="mtls" class="portal__form__card__form-field">
-              <gio-form-label>Enable mTLS Certificate Management</gio-form-label>
-              <mat-slide-toggle
-                id="enable-portal-next-mtls"
-                formControlName="enabled"
-                gioFormSlideToggle
-                aria-label="mTLS Certificate Management Enabled"
-              ></mat-slide-toggle>
-            </gio-form-slide-toggle>
-            <gio-form-slide-toggle formGroupName="analytics" class="portal__form__card__form-field">
-              <gio-form-label>Enable Analytics</gio-form-label>
-              <mat-slide-toggle
-                id="enable-portal-next-analytics"
-                formControlName="enabled"
-                gioFormSlideToggle
-                aria-label="Analytics Enabled"
-              ></mat-slide-toggle>
-            </gio-form-slide-toggle>
-            <div formGroupName="applications">
-              <div formGroupName="membership">
-                <gio-form-slide-toggle class="portal__form__card__form-field">
-                  <gio-form-label>Enable Application Membership Settings</gio-form-label>
-                  <mat-slide-toggle
-                    id="enable-portal-next-member-mapping"
-                    formControlName="enabled"
-                    gioFormSlideToggle
-                    aria-label="Application Membership Settings Enabled"
-                  ></mat-slide-toggle>
-                </gio-form-slide-toggle>
-                <gio-form-slide-toggle formGroupName="transferOwnership" class="portal__form__card__form-field">
-                  <gio-form-label>Enable Transfer of Application Ownership</gio-form-label>
-                  <mat-slide-toggle
-                    id="enable-portal-next-transfer-ownership"
-                    formControlName="enabled"
-                    gioFormSlideToggle
-                    aria-label="Transfer of Application Ownership Enabled"
-                  ></mat-slide-toggle>
-                </gio-form-slide-toggle>
-                <gio-form-slide-toggle formGroupName="invitations" class="portal__form__card__form-field">
-                  <gio-form-label>Enable Application Membership Invitation</gio-form-label>
-                  <mat-slide-toggle
-                    id="enable-portal-next-invitations"
-                    formControlName="enabled"
-                    gioFormSlideToggle
-                    aria-label="Application Membership Invitation Enabled"
-                  ></mat-slide-toggle>
-                </gio-form-slide-toggle>
-              </div>
+            <div class="portal-next-settings">
+              <gio-form-slide-toggle formGroupName="access" class="portal__form__card__form-field">
+                <gio-form-label>Enable the New Developer Portal</gio-form-label>
+                <mat-slide-toggle
+                  id="enable-portal-next"
+                  formControlName="enabled"
+                  gioFormSlideToggle
+                  aria-label="New Portal Enabled"
+                ></mat-slide-toggle>
+              </gio-form-slide-toggle>
+              <mat-card class="portal-next-settings__group" aria-label="New Developer Portal options">
+                <mat-card-content class="portal-next-settings__group-content">
+                  <gio-form-slide-toggle formGroupName="mtls" class="portal__form__card__form-field">
+                    <gio-form-label>Enable mTLS Certificate Management</gio-form-label>
+                    <mat-slide-toggle
+                      id="enable-portal-next-mtls"
+                      formControlName="enabled"
+                      gioFormSlideToggle
+                      aria-label="mTLS Certificate Management Enabled"
+                    ></mat-slide-toggle>
+                  </gio-form-slide-toggle>
+                  <gio-form-slide-toggle formGroupName="analytics" class="portal__form__card__form-field">
+                    <gio-form-label>Enable Analytics</gio-form-label>
+                    <mat-slide-toggle
+                      id="enable-portal-next-analytics"
+                      formControlName="enabled"
+                      gioFormSlideToggle
+                      aria-label="Analytics Enabled"
+                    ></mat-slide-toggle>
+                  </gio-form-slide-toggle>
+                  <div formGroupName="applications">
+                    <div formGroupName="membership">
+                      <gio-form-slide-toggle class="portal__form__card__form-field">
+                        <gio-form-label>Enable Application Membership Settings</gio-form-label>
+                        <mat-slide-toggle
+                          id="enable-portal-next-member-mapping"
+                          formControlName="enabled"
+                          gioFormSlideToggle
+                          aria-label="Application Membership Settings Enabled"
+                        ></mat-slide-toggle>
+                      </gio-form-slide-toggle>
+                      <mat-card
+                        class="portal-next-settings__group portal-next-settings__group--nested"
+                        aria-label="Application membership options"
+                      >
+                        <mat-card-content class="portal-next-settings__group-content">
+                          <gio-form-slide-toggle formGroupName="transferOwnership" class="portal__form__card__form-field">
+                            <gio-form-label>Enable Transfer of Application Ownership</gio-form-label>
+                            <mat-slide-toggle
+                              id="enable-portal-next-transfer-ownership"
+                              formControlName="enabled"
+                              gioFormSlideToggle
+                              aria-label="Transfer of Application Ownership Enabled"
+                            ></mat-slide-toggle>
+                          </gio-form-slide-toggle>
+                          <gio-form-slide-toggle formGroupName="invitations" class="portal__form__card__form-field">
+                            <gio-form-label>Enable Application Membership Invitation</gio-form-label>
+                            <mat-slide-toggle
+                              id="enable-portal-next-invitations"
+                              formControlName="enabled"
+                              gioFormSlideToggle
+                              aria-label="Application Membership Invitation Enabled"
+                            ></mat-slide-toggle>
+                          </gio-form-slide-toggle>
+                        </mat-card-content>
+                      </mat-card>
+                    </div>
+                  </div>
+                </mat-card-content>
+              </mat-card>
             </div>
-            @if (!!settings.portalNext?.access?.enabled) {
-              <div class="new-developer-portal-actions">
-                @if (portalUrl) {
-                  <a mat-raised-button [href]="portalUrl" target="_blank" color="primary" class="new-developer-portal-actions__content">
-                    <div>Open Website</div>
-                    <mat-icon [inline]="true" svgIcon="gio:external-link"></mat-icon>
-                  </a>
-                }
+            <div class="new-developer-portal-actions">
+              @if (portalUrl) {
                 <a
-                  mat-stroked-button
-                  [routerLink]="[environmentRootRouterLink, '_portal']"
+                  mat-raised-button
+                  [href]="portalUrl"
                   target="_blank"
+                  color="primary"
+                  [disabled]="!isPortalNextAccessEnabled"
                   class="new-developer-portal-actions__content"
-                  *gioPermission="{
-                    anyOf: ['environment-settings-u', 'environment-settings-r', 'environment-theme-u', 'environment-theme-r'],
-                  }"
+                  data-testid="open-website"
                 >
-                  <div>Open Settings</div>
+                  <div>Open Website</div>
                   <mat-icon [inline]="true" svgIcon="gio:external-link"></mat-icon>
                 </a>
-              </div>
-            }
+              }
+              <a
+                mat-stroked-button
+                [routerLink]="[environmentRootRouterLink, '_portal']"
+                target="_blank"
+                [disabled]="!isPortalNextAccessEnabled"
+                class="new-developer-portal-actions__content"
+                data-testid="open-settings"
+                *gioPermission="{
+                  anyOf: ['environment-settings-u', 'environment-settings-r', 'environment-theme-u', 'environment-theme-r'],
+                }"
+              >
+                <div>Open Settings</div>
+                <mat-icon [inline]="true" svgIcon="gio:external-link"></mat-icon>
+              </a>
+            </div>
           </mat-card-content>
         </mat-card>
       }

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.scss
@@ -69,6 +69,27 @@ $typography: map.get(gio.$mat-theme, typography);
   }
 }
 
+.portal-next-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &__group {
+    display: block;
+
+    &--nested {
+      margin-top: 8px;
+      margin-left: 16px;
+    }
+  }
+
+  &__group-content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+}
+
 .form-field-container {
   display: flex;
   justify-content: space-between;

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -22,6 +22,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
+import { MatButtonHarness } from '@angular/material/button/testing';
 import {
   GioFormTagsInputHarness,
   GioLicenseService,
@@ -94,8 +95,8 @@ describe('PortalSettingsComponent', () => {
   });
 
   describe('Portal settings form', () => {
-    beforeEach(() => {
-      init();
+    beforeEach(async () => {
+      await init();
     });
 
     it('display settings form and edit Company field', async () => {
@@ -256,6 +257,7 @@ describe('PortalSettingsComponent', () => {
 
     it('display settings form and edit Portal Next transfer of ownership toggle', async () => {
       portalSettingsMock = fakePortalSettings();
+      portalSettingsMock.portalNext.applications.membership.enabled = true;
       expectPortalSettingsGetRequest(portalSettingsMock);
       const saveBar = await loader.getHarness(GioSaveBarHarness);
       expect(await saveBar.isVisible()).toBe(false);
@@ -273,6 +275,7 @@ describe('PortalSettingsComponent', () => {
 
     it('display settings form and edit Portal Next invitations toggle', async () => {
       portalSettingsMock = fakePortalSettings();
+      portalSettingsMock.portalNext.applications.membership.enabled = true;
       expectPortalSettingsGetRequest(portalSettingsMock);
       const saveBar = await loader.getHarness(GioSaveBarHarness);
       expect(await saveBar.isVisible()).toBe(false);
@@ -286,6 +289,169 @@ describe('PortalSettingsComponent', () => {
       const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
       expect(req.request.method).toEqual('POST');
       expect(req.request.body.portalNext.applications.membership.invitations.enabled).toEqual(true);
+    });
+
+    it('should disable Portal Next child toggles when Portal Next is disabled and enable them again when Portal Next is enabled', async () => {
+      portalSettingsMock = fakePortalSettings();
+      portalSettingsMock.portalNext.access.enabled = false;
+      portalSettingsMock.portalNext.mtls.enabled = true;
+      portalSettingsMock.portalNext.analytics.enabled = true;
+      portalSettingsMock.portalNext.applications.membership.enabled = true;
+      portalSettingsMock.portalNext.applications.membership.transferOwnership.enabled = true;
+      portalSettingsMock.portalNext.applications.membership.invitations.enabled = true;
+      expectPortalSettingsGetRequest(portalSettingsMock);
+
+      const portalNextToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next' }));
+      const mtlsToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-mtls' }));
+      const analyticsToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-analytics' }));
+      const membershipToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-member-mapping' }));
+      const transferOwnershipToggle = await loader.getHarness(
+        MatSlideToggleHarness.with({ selector: '#enable-portal-next-transfer-ownership' }),
+      );
+      const invitationsToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-invitations' }));
+
+      expect(await mtlsToggle.isDisabled()).toEqual(true);
+      expect(await analyticsToggle.isDisabled()).toEqual(true);
+      expect(await membershipToggle.isDisabled()).toEqual(true);
+      expect(await transferOwnershipToggle.isDisabled()).toEqual(true);
+      expect(await invitationsToggle.isDisabled()).toEqual(true);
+      expect(await mtlsToggle.isChecked()).toEqual(true);
+      expect(await transferOwnershipToggle.isChecked()).toEqual(true);
+
+      await portalNextToggle.toggle();
+
+      expect(await mtlsToggle.isDisabled()).toEqual(false);
+      expect(await analyticsToggle.isDisabled()).toEqual(false);
+      expect(await membershipToggle.isDisabled()).toEqual(false);
+      expect(await transferOwnershipToggle.isDisabled()).toEqual(false);
+      expect(await invitationsToggle.isDisabled()).toEqual(false);
+    });
+
+    it('should disable membership child toggles when application membership is disabled and enable them again when membership is enabled', async () => {
+      portalSettingsMock = fakePortalSettings();
+      portalSettingsMock.portalNext.applications.membership.enabled = false;
+      portalSettingsMock.portalNext.applications.membership.transferOwnership.enabled = true;
+      portalSettingsMock.portalNext.applications.membership.invitations.enabled = true;
+      expectPortalSettingsGetRequest(portalSettingsMock);
+
+      const membershipToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-member-mapping' }));
+      const transferOwnershipToggle = await loader.getHarness(
+        MatSlideToggleHarness.with({ selector: '#enable-portal-next-transfer-ownership' }),
+      );
+      const invitationsToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-invitations' }));
+
+      expect(await transferOwnershipToggle.isDisabled()).toEqual(true);
+      expect(await invitationsToggle.isDisabled()).toEqual(true);
+      expect(await transferOwnershipToggle.isChecked()).toEqual(true);
+      expect(await invitationsToggle.isChecked()).toEqual(true);
+
+      await membershipToggle.toggle();
+
+      expect(await transferOwnershipToggle.isDisabled()).toEqual(false);
+      expect(await invitationsToggle.isDisabled()).toEqual(false);
+    });
+
+    it('should keep readonly Portal Next child toggles disabled when their parents are enabled', async () => {
+      portalSettingsMock = fakePortalSettings();
+      portalSettingsMock.portalNext.applications.membership.enabled = true;
+      portalSettingsMock.metadata.readonly = ['portal.next.mtls.enabled', 'portal.next.applications.membership.invitations.enabled'];
+      expectPortalSettingsGetRequest(portalSettingsMock);
+
+      const mtlsToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-mtls' }));
+      const analyticsToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-analytics' }));
+      const transferOwnershipToggle = await loader.getHarness(
+        MatSlideToggleHarness.with({ selector: '#enable-portal-next-transfer-ownership' }),
+      );
+      const invitationsToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-invitations' }));
+
+      expect(await mtlsToggle.isDisabled()).toEqual(true);
+      expect(await analyticsToggle.isDisabled()).toEqual(false);
+      expect(await transferOwnershipToggle.isDisabled()).toEqual(false);
+      expect(await invitationsToggle.isDisabled()).toEqual(true);
+    });
+
+    it('should preserve Portal Next child toggle values when disabled controls are saved', async () => {
+      portalSettingsMock = fakePortalSettings();
+      portalSettingsMock.portalNext.mtls.enabled = true;
+      portalSettingsMock.portalNext.analytics.enabled = true;
+      portalSettingsMock.portalNext.applications.membership.enabled = true;
+      portalSettingsMock.portalNext.applications.membership.transferOwnership.enabled = true;
+      portalSettingsMock.portalNext.applications.membership.invitations.enabled = true;
+      expectPortalSettingsGetRequest(portalSettingsMock);
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+
+      const portalNextToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next' }));
+      const mtlsToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-mtls' }));
+      const transferOwnershipToggle = await loader.getHarness(
+        MatSlideToggleHarness.with({ selector: '#enable-portal-next-transfer-ownership' }),
+      );
+
+      await portalNextToggle.toggle();
+
+      expect(await mtlsToggle.isDisabled()).toEqual(true);
+      expect(await mtlsToggle.isChecked()).toEqual(true);
+      expect(await transferOwnershipToggle.isDisabled()).toEqual(true);
+      expect(await transferOwnershipToggle.isChecked()).toEqual(true);
+
+      await saveBar.clickSubmit();
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body.portalNext.access.enabled).toEqual(false);
+      expect(req.request.body.portalNext.mtls.enabled).toEqual(true);
+      expect(req.request.body.portalNext.analytics.enabled).toEqual(true);
+      expect(req.request.body.portalNext.applications.membership.enabled).toEqual(true);
+      expect(req.request.body.portalNext.applications.membership.transferOwnership.enabled).toEqual(true);
+      expect(req.request.body.portalNext.applications.membership.invitations.enabled).toEqual(true);
+    });
+
+    it('should preserve membership child toggle values when membership disabled controls are saved', async () => {
+      portalSettingsMock = fakePortalSettings();
+      portalSettingsMock.portalNext.applications.membership.enabled = true;
+      portalSettingsMock.portalNext.applications.membership.transferOwnership.enabled = true;
+      portalSettingsMock.portalNext.applications.membership.invitations.enabled = true;
+      expectPortalSettingsGetRequest(portalSettingsMock);
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+
+      const membershipToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-member-mapping' }));
+      const transferOwnershipToggle = await loader.getHarness(
+        MatSlideToggleHarness.with({ selector: '#enable-portal-next-transfer-ownership' }),
+      );
+      const invitationsToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-invitations' }));
+
+      await membershipToggle.toggle();
+
+      expect(await transferOwnershipToggle.isDisabled()).toEqual(true);
+      expect(await transferOwnershipToggle.isChecked()).toEqual(true);
+      expect(await invitationsToggle.isDisabled()).toEqual(true);
+      expect(await invitationsToggle.isChecked()).toEqual(true);
+
+      await saveBar.clickSubmit();
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body.portalNext.applications.membership.enabled).toEqual(false);
+      expect(req.request.body.portalNext.applications.membership.transferOwnership.enabled).toEqual(true);
+      expect(req.request.body.portalNext.applications.membership.invitations.enabled).toEqual(true);
+    });
+
+    it('should disable Portal Next action buttons when New Developer Portal is disabled and enable them again when it is enabled', async () => {
+      portalSettingsMock = fakePortalSettings();
+      portalSettingsMock.portal.url = 'https://portal.example.com';
+      portalSettingsMock.portalNext.access.enabled = false;
+      expectPortalSettingsGetRequest(portalSettingsMock);
+
+      const portalNextToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next' }));
+      const openWebsiteButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="open-website"]' }));
+      const openSettingsButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="open-settings"]' }));
+
+      expect(await openWebsiteButton.isDisabled()).toEqual(true);
+      expect(await openSettingsButton.isDisabled()).toEqual(true);
+
+      await portalNextToggle.toggle();
+
+      expect(await openWebsiteButton.isDisabled()).toEqual(false);
+      expect(await openSettingsButton.isDisabled()).toEqual(false);
     });
 
     it('display settings form and edit CORS fields', async () => {
@@ -357,8 +523,8 @@ describe('PortalSettingsComponent', () => {
     });
   });
   describe('Portal next setting form', () => {
-    beforeEach(() => {
-      init();
+    beforeEach(async () => {
+      await init();
     });
     it('should show portal next settings if settings have "access.enabled = true"', async () => {
       portalSettingsMock = fakePortalSettings({
@@ -401,8 +567,8 @@ describe('PortalSettingsComponent', () => {
   });
 
   describe('Portal next setting form', () => {
-    beforeEach(() => {
-      init(['environment-integration-u'], {
+    beforeEach(async () => {
+      await init(['environment-integration-u'], {
         tier: 'oss',
         packs: [],
         features: [],

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -176,6 +176,7 @@ export class PortalSettingsComponent implements OnInit {
   settings: PortalSettings;
   portalForm: FormGroup<PortalForm>;
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+  private hasEnvironmentSettingsUpdatePermission = false;
   public formInitialValues: unknown;
   public defaultHttpHeaders = CorsUtil.defaultHttpHeaders.map(e => e);
   public httpMethods = CorsUtil.httpMethods;
@@ -255,6 +256,10 @@ export class PortalSettingsComponent implements OnInit {
   }
 
   initialPortalForm() {
+    this.hasEnvironmentSettingsUpdatePermission = this.permissionService.hasAnyMatching(['environment-settings-u']);
+    const isPortalNextEnabled = !!this.settings.portalNext?.access?.enabled;
+    const isPortalNextApplicationMembershipEnabled = !!this.settings.portalNext?.applications?.membership?.enabled;
+
     this.portalForm = new FormGroup<PortalForm>({
       company: new FormGroup({
         name: new FormControl({
@@ -431,31 +436,37 @@ export class PortalSettingsComponent implements OnInit {
         mtls: new FormGroup({
           enabled: new FormControl({
             value: !!this.settings.portalNext?.mtls?.enabled,
-            disabled: this.isReadonly('portal.next.mtls.enabled'),
+            disabled: this.isReadonly('portal.next.mtls.enabled') || !isPortalNextEnabled,
           }),
         }),
         analytics: new FormGroup({
           enabled: new FormControl({
             value: !!this.settings.portalNext?.analytics?.enabled,
-            disabled: this.isReadonly('portal.next.analytics.enabled'),
+            disabled: this.isReadonly('portal.next.analytics.enabled') || !isPortalNextEnabled,
           }),
         }),
         applications: new FormGroup({
           membership: new FormGroup({
             enabled: new FormControl({
               value: !!this.settings.portalNext?.applications?.membership?.enabled,
-              disabled: this.isReadonly('portal.next.applications.membership.enabled'),
+              disabled: this.isReadonly('portal.next.applications.membership.enabled') || !isPortalNextEnabled,
             }),
             transferOwnership: new FormGroup({
               enabled: new FormControl({
                 value: !!this.settings.portalNext?.applications?.membership?.transferOwnership?.enabled,
-                disabled: this.isReadonly('portal.next.applications.membership.transferOwnership.enabled'),
+                disabled:
+                  this.isReadonly('portal.next.applications.membership.transferOwnership.enabled') ||
+                  !isPortalNextEnabled ||
+                  !isPortalNextApplicationMembershipEnabled,
               }),
             }),
             invitations: new FormGroup({
               enabled: new FormControl({
                 value: !!this.settings.portalNext?.applications?.membership?.invitations?.enabled,
-                disabled: this.isReadonly('portal.next.applications.membership.invitations.enabled'),
+                disabled:
+                  this.isReadonly('portal.next.applications.membership.invitations.enabled') ||
+                  !isPortalNextEnabled ||
+                  !isPortalNextApplicationMembershipEnabled,
               }),
             }),
           }),
@@ -575,7 +586,7 @@ export class PortalSettingsComponent implements OnInit {
       }),
     });
 
-    if (!this.permissionService.hasAnyMatching(['environment-settings-u'])) {
+    if (!this.hasEnvironmentSettingsUpdatePermission) {
       this.portalForm.disable();
     }
 
@@ -617,6 +628,20 @@ export class PortalSettingsComponent implements OnInit {
       });
 
     this.portalForm
+      .get('portalNext.access.enabled')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.updatePortalNextDependentControls();
+      });
+
+    this.portalForm
+      .get('portalNext.applications.membership.enabled')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.updatePortalNextDependentControls();
+      });
+
+    this.portalForm
       .get('openAPIDocViewer.openAPIDocType.redoc.enabled')
       .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(selectedValue => {
@@ -645,6 +670,7 @@ export class PortalSettingsComponent implements OnInit {
 
   onSubmit() {
     delete this.portalForm.value.portal.homepageTitleToggle;
+    const portalNextFormValue = this.portalForm.controls.portalNext.getRawValue();
 
     const updatedSettingsPayload = {
       ...this.settings,
@@ -712,19 +738,22 @@ export class PortalSettingsComponent implements OnInit {
       },
       portalNext: {
         ...this.settings.portalNext,
-        ...this.portalForm.get('portalNext').value,
+        ...portalNextFormValue,
         access: {
-          ...this.settings.portalNext.access,
-          ...this.portalForm.get('portalNext.access').value,
+          ...this.settings.portalNext?.access,
+          ...portalNextFormValue.access,
         },
-        mtls: this.portalForm.controls.portalNext.controls.mtls.value,
-        analytics: this.portalForm.controls.portalNext.controls.analytics.value,
+        mtls: portalNextFormValue.mtls,
+        analytics: portalNextFormValue.analytics,
         applications: {
+          ...this.settings.portalNext?.applications,
+          ...portalNextFormValue.applications,
           membership: {
-            enabled: this.portalForm.controls.portalNext.controls.applications.controls.membership.controls.enabled.value,
-            transferOwnership:
-              this.portalForm.controls.portalNext.controls.applications.controls.membership.controls.transferOwnership.value,
-            invitations: this.portalForm.controls.portalNext.controls.applications.controls.membership.controls.invitations.value,
+            ...this.settings.portalNext?.applications?.membership,
+            ...portalNextFormValue.applications.membership,
+            enabled: portalNextFormValue.applications.membership.enabled,
+            transferOwnership: portalNextFormValue.applications.membership.transferOwnership,
+            invitations: portalNextFormValue.applications.membership.invitations,
           },
         },
       },
@@ -741,5 +770,47 @@ export class PortalSettingsComponent implements OnInit {
 
   isReadonly(property: string): boolean {
     return PortalSettingsService.isReadonly(this.settings, property);
+  }
+
+  get isPortalNextAccessEnabled(): boolean {
+    return !!this.portalForm?.controls.portalNext.controls.access.controls.enabled.value;
+  }
+
+  private updatePortalNextDependentControls(): void {
+    const portalNextControls = this.portalForm.controls.portalNext.controls;
+    const applicationMembershipControls = portalNextControls.applications.controls.membership.controls;
+    const isPortalNextEnabled = portalNextControls.access.controls.enabled.value;
+    const isApplicationMembershipEnabled = applicationMembershipControls.enabled.value;
+
+    this.updatePortalNextControlDisabledState(portalNextControls.mtls.controls.enabled, 'portal.next.mtls.enabled', !isPortalNextEnabled);
+    this.updatePortalNextControlDisabledState(
+      portalNextControls.analytics.controls.enabled,
+      'portal.next.analytics.enabled',
+      !isPortalNextEnabled,
+    );
+    this.updatePortalNextControlDisabledState(
+      applicationMembershipControls.enabled,
+      'portal.next.applications.membership.enabled',
+      !isPortalNextEnabled,
+    );
+    this.updatePortalNextControlDisabledState(
+      applicationMembershipControls.transferOwnership.controls.enabled,
+      'portal.next.applications.membership.transferOwnership.enabled',
+      !isPortalNextEnabled || !isApplicationMembershipEnabled,
+    );
+    this.updatePortalNextControlDisabledState(
+      applicationMembershipControls.invitations.controls.enabled,
+      'portal.next.applications.membership.invitations.enabled',
+      !isPortalNextEnabled || !isApplicationMembershipEnabled,
+    );
+  }
+
+  private updatePortalNextControlDisabledState(control: FormControl<boolean>, readonlyProperty: string, shouldDisable: boolean): void {
+    if (!this.hasEnvironmentSettingsUpdatePermission || this.isReadonly(readonlyProperty) || shouldDisable) {
+      control.disable({ emitEvent: false });
+      return;
+    }
+
+    control.enable({ emitEvent: false });
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14452

## Description

- Group New Developer Portal dependent settings into nested Material cards.
- Disable child Portal Next toggles when their parent toggle is off while preserving their values.
- Preserve disabled Portal Next child values in the settings save payload.
- Disable Open Website and Open Settings actions when New Developer Portal is disabled.



https://github.com/user-attachments/assets/3b949251-3866-43ba-930a-8c603d0d098a

