### PR TITLE
fix(api-product): API Product plan sharding tags not being cleared wh…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapper.java
@@ -104,7 +104,7 @@ public interface ApiProductPlanMapper {
 
     @Named("mapPlanUpdateTags")
     default Set<String> mapPlanUpdateTags(List<String> tags) {
-        if (CollectionUtils.isEmpty(tags)) {
+        if (tags == null) {
             return null;
         }
         return new HashSet<>(tags);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapperTest.java
@@ -27,17 +27,27 @@ class ApiProductPlanMapperTest {
     private final ApiProductPlanMapper apiProductPlanMapper = ApiProductPlanMapper.INSTANCE;
 
     @Test
-    void mapToPlanUpdates_should_leave_tags_null_when_source_omits_tags() {
+    void mapToPlanUpdates_should_leave_tags_null_when_source_tags_explicitly_null() {
         var updatePlan = new UpdateGenericApiProductPlan();
         updatePlan.setName("Updated Plan");
-        updatePlan.setDescription("Updated description");
+        updatePlan.setTags(null);
 
         PlanUpdates result = apiProductPlanMapper.mapToPlanUpdates(updatePlan);
 
         assertThat(result).isNotNull();
         assertThat(result.getTags()).isNull();
         assertThat(result.getName()).isEqualTo("Updated Plan");
-        assertThat(result.getDescription()).isEqualTo("Updated description");
+    }
+
+    @Test
+    void mapToPlanUpdates_should_clear_tags_when_source_sends_empty_list() {
+        var updatePlan = new UpdateGenericApiProductPlan();
+        updatePlan.setName("Updated Plan");
+        updatePlan.setTags(List.of());
+
+        PlanUpdates result = apiProductPlanMapper.mapToPlanUpdates(updatePlan);
+
+        assertThat(result.getTags()).isNotNull().isEmpty();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductPlanResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductPlanResourceTest.java
@@ -48,6 +48,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
@@ -200,6 +201,40 @@ class ApiProductPlanResourceTest extends AbstractResourceTest {
                 soft.assertThat(input.planToUpdate().getReferenceId()).isEqualTo(API_PRODUCT_ID);
                 soft.assertThat(input.auditInfo()).isNotNull();
             });
+        }
+
+        @Test
+        void should_map_empty_tags_to_clear_plan_tags() {
+            Plan updatedPlan = Plan.builder()
+                .id(PLAN_ID)
+                .name("Updated Plan")
+                .referenceId(API_PRODUCT_ID)
+                .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+                .definitionVersion(DefinitionVersion.V4)
+                .planDefinitionHttpV4(
+                    io.gravitee.definition.model.v4.plan.Plan.builder()
+                        .id(PLAN_ID)
+                        .name("Updated Plan")
+                        .security(PlanSecurity.builder().type("API_KEY").build())
+                        .mode(PlanMode.STANDARD)
+                        .status(PlanStatus.PUBLISHED)
+                        .build()
+                )
+                .build();
+
+            when(updatePlanUseCase.execute(any())).thenReturn(new UpdateApiProductPlanUseCase.Output(updatedPlan));
+
+            var updatePayload = new UpdateGenericApiProductPlan();
+            updatePayload.setName("Updated Plan");
+            updatePayload.setTags(List.of());
+
+            try (Response response = rootTarget().request().put(json(updatePayload))) {
+                assertThat(response.getStatus()).isEqualTo(OK_200);
+            }
+
+            var captor = ArgumentCaptor.forClass(UpdateApiProductPlanUseCase.Input.class);
+            verify(updatePlanUseCase).execute(captor.capture());
+            assertThat(captor.getValue().planToUpdate().getTags()).isEmpty();
         }
 
         @Test


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-14341

## Description

Fix API Product plan sharding tags not being cleared when removed from the Console.
When a user unchecked all sharding tags on an API Product plan and saved, the UI showed success but tags persisted on reload (plan list "Deploy on" column and plan detail).

**Root cause:** `ApiProductPlanMapper.mapPlanUpdateTags()` treated an empty tag list (`[]`) the same as omitted tags (`null`) by mapping both to `null`. In `PlanUpdates.applyTo()`, `null` means "do not change tags", so cleared tags were never persisted.
**Fix:** Only map `null` → `null` (skip tag update). Map `[]` → empty `Set` (clear tags). Map `["tag"]` → `Set` with values (unchanged).
This aligns API Product plan tag updates with regular API plan updates (`PlanMapper`), which never had the `isEmpty → null` guard.

After fix:
<img width="1501" height="739" alt="image" src="https://github.com/user-attachments/assets/2031057c-7fe9-41d1-a81c-54693f48e867" />
<img width="1501" height="739" alt="image" src="https://github.com/user-attachments/assets/c5c32424-1a6b-4287-bd5d-364dfd258f32" />
<img width="1501" height="739" alt="image" src="https://github.com/user-attachments/assets/71420b65-57c3-4b60-931a-11be6d5a7aff" />