### PR TITLE
fix(analytics): allow API_TYPE filter in analytics queries

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidator.java
@@ -50,7 +50,6 @@ public class AnalyticsQueryValidator {
      */
     private static final Set<FilterSpec.Name> ANALYTICS_UNSUPPORTED_FILTERS = EnumSet.of(
         FilterSpec.Name.PAYLOAD,
-        FilterSpec.Name.API_TYPE,
         FilterSpec.Name.ERROR_KEY,
         FilterSpec.Name.REQUEST_ID,
         FilterSpec.Name.TRANSACTION_ID


### PR DESCRIPTION
## Summary
`API_TYPE` was incorrectly blocked by the analytics query validator, causing a "Filter 'API_TYPE' is not supported for analytics queries" error. This is a regression introduced by PR #18078 (PAYLOAD feature).

## Changes
- Remove `FilterSpec.Name.API_TYPE` from the `ANALYTICS_UNSUPPORTED_FILTERS` set in `AnalyticsQueryValidator`
- `API_TYPE` is a valid cross-cutting filter present in both `FilterName` and `ObservabilityFilterName` OpenAPI enums, used by the frontend for analytics dashboards

Refs GMA-597

## Test plan
- [ ] Open an analytics dashboard that uses the API Type filter
- [ ] Verify the filter works without returning a 400 error
- [ ] Confirm other unsupported filters (PAYLOAD, ERROR_KEY, REQUEST_ID, TRANSACTION_ID) are still rejected