### PR TITLE
feat: allow customizing API navigation item display name

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -2963,13 +2963,57 @@ describe('PortalNavigationItemsComponent', () => {
 
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [apiItem] }));
 
-      const apiNode = { id: apiItem.id, label: apiItem.title, type: 'API', data: apiItem } as any;
+      const apiNode: SectionNode = { id: apiItem.id, label: apiItem.title, type: 'API', data: apiItem };
       component.onNodeMenuAction({ action: 'edit', itemType: 'API', node: apiNode });
       fixture.detectChanges();
       await fixture.whenStable();
 
       const dialog = await rootLoader.getHarnessOrNull(SectionEditorDialogHarness);
       expect(dialog).toBeTruthy();
+    });
+
+    it('should update API display name while preserving linked API id', async () => {
+      const apiItem = fakePortalNavigationApi({
+        id: 'api-nav-1',
+        title: 'Technical API Name',
+        apiId: 'api-id-1',
+        parentId: 'folder-1',
+        order: 2,
+        published: true,
+        visibility: 'PUBLIC',
+      });
+      const updatedApiItem = fakePortalNavigationApi({
+        ...apiItem,
+        title: 'Consumer API Name',
+      });
+
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [apiItem] }));
+
+      const apiNode: SectionNode = { id: apiItem.id, label: apiItem.title, type: 'API', data: apiItem };
+      component.onNodeMenuAction({ action: 'edit', itemType: 'API', node: apiNode });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      expect(await dialog.getTitleInputValue()).toBe('Technical API Name');
+
+      await dialog.setTitleInputValue('Consumer API Name');
+      await dialog.clickSubmitButton();
+      fixture.detectChanges();
+
+      expectPutPortalNavigationItem(
+        apiItem.id,
+        fakeUpdateApiPortalNavigationItem({
+          title: 'Consumer API Name',
+          parentId: apiItem.parentId,
+          order: apiItem.order,
+          published: apiItem.published,
+          visibility: apiItem.visibility,
+          apiId: apiItem.apiId,
+        }),
+        updatedApiItem,
+      );
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [updatedApiItem] }));
     });
   });
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
@@ -33,16 +33,14 @@
         }
       </gio-form-selection-inline>
     }
-    @if (type !== 'API') {
-      <div class="form-field-title">Title</div>
-      <mat-form-field>
-        <mat-label>{{ type | titlecase }} Title</mat-label>
-        <input matInput formControlName="title" required />
-        @if (form.controls.title.hasError('required')) {
-          <mat-error>Title is required</mat-error>
-        }
-      </mat-form-field>
-    }
+    <div class="form-field-title">Title</div>
+    <mat-form-field>
+      <mat-label>{{ titleFieldLabel }}</mat-label>
+      <input matInput formControlName="title" required />
+      @if (form.controls.title.hasError('required')) {
+        <mat-error>Title is required</mat-error>
+      }
+    </mat-form-field>
 
     @if (type === 'LINK') {
       <div class="form-field-title">Link settings</div>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
@@ -24,13 +24,19 @@ import { SectionEditorDialogHarness } from './section-editor-dialog.harness';
 import {
   SectionEditorDialogComponent,
   SectionEditorDialogData,
-  SectionEditorDialogItemType,
   SectionEditorDialogMode,
   SectionEditorDialogResult,
 } from './section-editor-dialog.component';
 
 import { GioTestingModule } from '../../../shared/testing';
-import { fakePortalNavigationFolder, fakePortalNavigationLink, fakePortalNavigationPage } from '../../../entities/management-api-v2';
+import {
+  fakePortalNavigationApi,
+  fakePortalNavigationFolder,
+  fakePortalNavigationLink,
+  fakePortalNavigationPage,
+  PortalNavigationItem,
+  PortalNavigationItemType,
+} from '../../../entities/management-api-v2';
 
 @Component({
   selector: 'test-host-component',
@@ -38,18 +44,15 @@ import { fakePortalNavigationFolder, fakePortalNavigationLink, fakePortalNavigat
 })
 class TestHostComponent {
   mode = input<SectionEditorDialogMode>('create');
-  type = input<SectionEditorDialogItemType>('PAGE');
-  existingItem = input<any>();
-  parentItem = input<any>(fakePortalNavigationFolder({ visibility: 'PUBLIC' }));
+  type = input<PortalNavigationItemType>('PAGE');
+  existingItem = input<PortalNavigationItem>();
+  parentItem = input<PortalNavigationItem | undefined>(fakePortalNavigationFolder({ visibility: 'PUBLIC' }));
 
   dialogValue: SectionEditorDialogResult;
   private matDialog = inject(MatDialog);
 
   public clicked(): void {
-    const data: SectionEditorDialogData =
-      this.mode() === 'create'
-        ? { mode: 'create', type: this.type(), parentItem: this.parentItem() }
-        : { mode: 'edit', type: this.type(), existingItem: this.existingItem(), parentItem: this.parentItem() };
+    const data = this.buildDialogData();
     this.matDialog
       .open<SectionEditorDialogComponent, SectionEditorDialogData>(SectionEditorDialogComponent, {
         width: '500px',
@@ -61,6 +64,25 @@ class TestHostComponent {
           this.dialogValue = result;
         },
       });
+  }
+
+  private buildDialogData(): SectionEditorDialogData {
+    const type = this.type();
+
+    if (this.mode() === 'create') {
+      if (type === 'API') {
+        throw new Error('API items use ApiSectionEditorDialog in create mode');
+      }
+
+      return { mode: 'create', type, parentItem: this.parentItem() };
+    }
+
+    const existingItem = this.existingItem();
+    if (!existingItem) {
+      throw new Error('existingItem is required in edit mode');
+    }
+
+    return { mode: 'edit', type, existingItem, parentItem: this.parentItem() };
   }
 }
 
@@ -361,6 +383,53 @@ describe('SectionEditorDialogComponent', () => {
         const toggle = await dialog.getAuthenticationToggle();
 
         expect(await toggle.isChecked()).toEqual(true);
+      });
+    });
+    describe('when editing an API', () => {
+      beforeEach(() => {
+        const existingApi = fakePortalNavigationApi({ id: 'api-nav-1', title: 'Technical API Name', apiId: 'api-1' });
+        fixture.componentRef.setInput('type', 'API');
+        fixture.componentRef.setInput('existingItem', existingApi);
+        fixture.detectChanges();
+        component.clicked();
+        fixture.detectChanges();
+      });
+
+      it('should display the correct title', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        expect(await dialog.getDialogTitle()).toBe('Edit "Technical API Name" api');
+      });
+
+      it('should prefill the display name', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        expect(await dialog.getTitleInputValue()).toBe('Technical API Name');
+      });
+
+      it('should not allow save when title is not updated', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+
+        expect(await dialog.isSubmitButtonDisabled()).toEqual(true);
+      });
+
+      it('should not allow empty display name', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+
+        await dialog.setTitleInputValue('');
+
+        expect(await dialog.isSubmitButtonDisabled()).toEqual(true);
+      });
+
+      it('should save the updated display name', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+
+        await dialog.setTitleInputValue('Consumer API Name');
+        await dialog.clickSubmitButton();
+        fixture.detectChanges();
+
+        expect(component.dialogValue).toEqual({
+          title: 'Consumer API Name',
+          visibility: 'PUBLIC',
+        });
       });
     });
     describe('when editing a link', () => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
@@ -21,7 +21,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconRegistry } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { LowerCasePipe, TitleCasePipe } from '@angular/common';
+import { LowerCasePipe } from '@angular/common';
 import { DomSanitizer } from '@angular/platform-browser';
 import { GioBannerModule, GioFormSelectionInlineModule } from '@gravitee/ui-particles-angular';
 import { isEqual } from 'lodash';
@@ -76,6 +76,13 @@ export const PORTAL_PAGE_CONTENT_TYPE_OPTIONS: PortalPageTypeOption[] = [
   { value: 'ASYNCAPI', label: 'AsyncAPI', icon: 'gio:async-api', available: true },
 ];
 
+const TITLE_FIELD_LABEL_BY_TYPE: Record<PortalNavigationItemType, string> = {
+  API: 'API Display Name',
+  FOLDER: 'Folder Title',
+  LINK: 'Link Title',
+  PAGE: 'Page Title',
+};
+
 interface SectionFormControls {
   title: FormControl<string>;
   isPrivate: FormControl<boolean>;
@@ -101,7 +108,6 @@ type SectionForm = FormGroup<SectionFormControls>;
     MatFormFieldModule,
     MatSlideToggleModule,
     MatInputModule,
-    TitleCasePipe,
     GioBannerModule,
     GioFormSelectionInlineModule,
     LowerCasePipe,
@@ -120,6 +126,7 @@ export class SectionEditorDialogComponent implements OnInit {
   public type: PortalNavigationItemType;
   public mode: SectionEditorDialogMode;
   public title: string;
+  public titleFieldLabel: string;
   readonly pageContentTypeOptions = PORTAL_PAGE_CONTENT_TYPE_OPTIONS;
 
   showPageTypeSelection(): boolean {
@@ -142,6 +149,7 @@ export class SectionEditorDialogComponent implements OnInit {
     this.iconRegistry.addSvgIconInNamespace('gio', 'async-api', this.sanitizer.bypassSecurityTrustResourceUrl('assets/logo_asyncapi.svg'));
     this.type = this.data.type;
     this.mode = this.data.mode;
+    this.titleFieldLabel = TITLE_FIELD_LABEL_BY_TYPE[this.type];
     if (this.data.mode === 'create') {
       this.title = `Add ${this.type.toLowerCase()}`;
       this.buttonTitle = 'Add';


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14503

## Description

Implements APIM-14503 by allowing API navigation items to have a custom display name in the Developer Portal navigation editor.

## Changes

- Shows an editable `API Display Name` field when editing API navigation items.
- Keeps the linked `apiId` unchanged when saving a custom display name.
- Preserves existing API creation behavior: new API nav items still default to the linked API name.
- Adds regression coverage for API display name editing and update payload.



https://github.com/user-attachments/assets/9573acd4-889a-4883-887e-61b225c1069a

