### PR TITLE
feat(portal): add collapse/expand all navigation items button 

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -76,6 +76,7 @@
         class="tree__icon expand-collapse-icon"
         [attr.data-test-icon]="'toggle'"
         [svgIcon]="treeBase.isExpanded(node) ? 'gio:nav-arrow-down' : 'gio:nav-arrow-right'"
+        (click)="onNodeToggle()"
         aria-hidden="true"
       />
       <ng-container *ngTemplateOutlet="nodeContent; context: { $implicit: node }"></ng-container>

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -59,6 +59,7 @@
       cdkDrag
       [cdkDragData]="node"
       (cdkDragStarted)="onDragStarted($event)"
+      (expandedChange)="onNodeToggle()"
       (click)="onNodeClick(node)"
       (keydown.enter)="onNodeClick(node)"
       (contextmenu)="onContextMenu($event, node)"
@@ -76,7 +77,6 @@
         class="tree__icon expand-collapse-icon"
         [attr.data-test-icon]="'toggle'"
         [svgIcon]="treeBase.isExpanded(node) ? 'gio:nav-arrow-down' : 'gio:nav-arrow-right'"
-        (click)="onNodeToggle()"
         aria-hidden="true"
       />
       <ng-container *ngTemplateOutlet="nodeContent; context: { $implicit: node }"></ng-container>

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -1034,6 +1034,26 @@ describe('FlatTreeComponent', () => {
 
       expect(component.hasExpandedNode()).toBe(true);
     }));
+
+    it('should resync the expansion state when the tree data changes', fakeAsync(() => {
+      const remainingFolder = [makeItem('f2', 'FOLDER', 'Folder 2', 1), makeItem('c2', 'PAGE', 'Child 2', 0, 'f2')];
+      const links = [makeItem('f1', 'FOLDER', 'Folder 1', 0), makeItem('c1', 'PAGE', 'Child 1', 0, 'f1'), ...remainingFolder];
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+      tick();
+
+      component.treeBase()!.expand(component.tree()[0]);
+      component.onNodeToggle();
+      tick();
+      expect(component.hasExpandedNode()).toBe(true);
+
+      // The expanded folder is removed (e.g. deleted) and the list refreshes via [links].
+      fixture.componentRef.setInput('links', remainingFolder);
+      fixture.detectChanges();
+      tick();
+
+      expect(component.hasExpandedNode()).toBe(false);
+    }));
   });
 
   function createDropEvent(itemData: any, currentIndex: number, previousIndex: number): CdkDragDrop<SectionNode[]> {

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -1021,19 +1021,17 @@ describe('FlatTreeComponent', () => {
       expect(component.hasExpandedNode()).toBe(false);
     });
 
-    it('should sync the expansion state after a single node toggle', fakeAsync(() => {
+    it('should sync the expansion state after a single node toggle via the DOM', async () => {
       fixture.componentRef.setInput('links', nestedLinks);
       fixture.detectChanges();
-      tick();
+      await fixture.whenStable();
       expect(component.hasExpandedNode()).toBe(false);
 
-      const folderNode = component.tree()[0];
-      component.treeBase()!.expand(folderNode);
-      component.onNodeToggle();
-      tick();
+      const folderNode = await harness.getNodeHarnessByTitle('Folder 1');
+      await folderNode.toggle();
 
       expect(component.hasExpandedNode()).toBe(true);
-    }));
+    });
 
     it('should resync the expansion state when the tree data changes', fakeAsync(() => {
       const remainingFolder = [makeItem('f2', 'FOLDER', 'Folder 2', 1), makeItem('c2', 'PAGE', 'Child 2', 0, 'f2')];

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -79,6 +79,12 @@ describe('FlatTreeComponent', () => {
     }
   };
 
+  // As items are collapsed by default, expand so nested nodes are rendered and reachable.
+  const expandTree = () => {
+    component.expandAllNodes();
+    fixture.detectChanges();
+  };
+
   it('should build a sorted tree with proper types and parent/child relationships', () => {
     const links = [
       // root page with smallest order -> should be first
@@ -297,6 +303,8 @@ describe('FlatTreeComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
+    expandTree();
+
     await harness.selectPublishById('p1');
     await fixture.whenStable();
 
@@ -436,6 +444,8 @@ describe('FlatTreeComponent', () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
+      expandTree();
+
       const publishButton = await harness.openPublishMenuAndGetItem('child-page-1');
       expect(publishButton).toBeTruthy();
       expect(await publishButton.isDisabled()).toBe(true);
@@ -453,6 +463,8 @@ describe('FlatTreeComponent', () => {
       fixture.componentRef.setInput('links', links);
       fixture.detectChanges();
       await fixture.whenStable();
+
+      expandTree();
 
       const publishButton = await harness.openPublishMenuAndGetItem('child-page-1');
       expect(publishButton).toBeTruthy();
@@ -475,6 +487,8 @@ describe('FlatTreeComponent', () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
+      expandTree();
+
       const publishButton = await harness.openPublishMenuAndGetItem('child-page-1');
       expect(publishButton).toBeTruthy();
       expect(await publishButton.isDisabled()).toBe(false);
@@ -490,6 +504,8 @@ describe('FlatTreeComponent', () => {
 
     fixture.componentRef.setInput('links', links);
     fixture.detectChanges();
+    await fixture.whenStable();
+    expandTree();
 
     const titles = await harness.getAllItemTitles();
     expect(titles).toContain('Folder 1');
@@ -627,6 +643,8 @@ describe('FlatTreeComponent', () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
+      expandTree();
+
       const nodeToMove = findNode(dragId);
       if (!nodeToMove) throw new Error(`Node ${dragId} not found in test setup`);
 
@@ -661,6 +679,8 @@ describe('FlatTreeComponent', () => {
       fixture.componentRef.setInput('links', links);
       fixture.detectChanges();
       tick();
+
+      expandTree();
 
       const folderNode = findNode('f1');
       component.onDragStarted({ source: { data: folderNode } } as any);
@@ -938,6 +958,82 @@ describe('FlatTreeComponent', () => {
 
       expect(onContextMenuSpy).toHaveBeenCalledTimes(1);
     });
+  });
+
+  describe('collapse / expand all', () => {
+    const nestedLinks = [
+      makeItem('f1', 'FOLDER', 'Folder 1', 0),
+      makeItem('f2', 'FOLDER', 'Folder 2', 0, 'f1'),
+      makeItem('p1', 'PAGE', 'Page 1', 0, 'f2'),
+    ];
+
+    it('should collapse all items by default on initial load', async () => {
+      fixture.componentRef.setInput('links', nestedLinks);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const titles = await harness.getAllItemTitles();
+      expect(titles).toEqual(['Folder 1']);
+      expect(component.hasExpandedNode()).toBe(false);
+      expect(component.hasExpandableNode()).toBe(true);
+    });
+
+    it('should expand all items when expandAllNodes is called', async () => {
+      fixture.componentRef.setInput('links', nestedLinks);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      component.expandAllNodes();
+      fixture.detectChanges();
+
+      const titles = await harness.getAllItemTitles();
+      expect(titles).toContain('Folder 1');
+      expect(titles).toContain('Folder 2');
+      expect(titles).toContain('Page 1');
+      expect(component.hasExpandedNode()).toBe(true);
+    });
+
+    it('should collapse all items when collapseAllNodes is called', async () => {
+      fixture.componentRef.setInput('links', nestedLinks);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      component.expandAllNodes();
+      fixture.detectChanges();
+      expect(component.hasExpandedNode()).toBe(true);
+
+      component.collapseAllNodes();
+      fixture.detectChanges();
+
+      const titles = await harness.getAllItemTitles();
+      expect(titles).toEqual(['Folder 1']);
+      expect(component.hasExpandedNode()).toBe(false);
+    });
+
+    it('should report no expandable node when the tree only contains leaf items', async () => {
+      const leafLinks = [makeItem('p1', 'PAGE', 'Page 1', 0), makeItem('l1', 'LINK', 'Link 1', 1)];
+      fixture.componentRef.setInput('links', leafLinks);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(component.hasExpandableNode()).toBe(false);
+      expect(component.hasExpandedNode()).toBe(false);
+    });
+
+    it('should sync the expansion state after a single node toggle', fakeAsync(() => {
+      fixture.componentRef.setInput('links', nestedLinks);
+      fixture.detectChanges();
+      tick();
+      expect(component.hasExpandedNode()).toBe(false);
+
+      const folderNode = component.tree()[0];
+      component.treeBase()!.expand(folderNode);
+      component.onNodeToggle();
+      tick();
+
+      expect(component.hasExpandedNode()).toBe(true);
+    }));
   });
 
   function createDropEvent(itemData: any, currentIndex: number, previousIndex: number): CdkDragDrop<SectionNode[]> {

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -175,7 +175,8 @@ export class FlatTreeComponent {
   });
 
   readonly hasExpandedNode = signal(false);
-  readonly hasExpandableNode = computed(() => this.collectExpandableNodes(this.tree()).length > 0);
+  private readonly expandableNodes = computed(() => this.collectExpandableNodes(this.tree()));
+  readonly hasExpandableNode = computed(() => this.expandableNodes().length > 0);
 
   isSelected = (node: FlatTreeNode) => this.selectedId() === node.id;
 
@@ -358,8 +359,7 @@ export class FlatTreeComponent {
   }
 
   onNodeToggle(): void {
-    // matTreeNodeToggle mutates the expansion model on the same click, defer so we sync after it applies
-    queueMicrotask(() => this.syncExpansionState());
+    this.syncExpansionState();
   }
 
   private collapseNode(node: SectionNode): void {
@@ -373,8 +373,7 @@ export class FlatTreeComponent {
       this.hasExpandedNode.set(false);
       return;
     }
-    const expandableNodes = this.collectExpandableNodes(this.tree());
-    this.hasExpandedNode.set(expandableNodes.some(node => tree.isExpanded(node)));
+    this.hasExpandedNode.set(this.expandableNodes().some(node => tree.isExpanded(node)));
   }
 
   private collectExpandableNodes(nodes: SectionNode[]): SectionNode[] {

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -174,6 +174,9 @@ export class FlatTreeComponent {
     return publishStateByNodeId;
   });
 
+  readonly hasExpandedNode = signal(false);
+  readonly hasExpandableNode = computed(() => this.collectExpandableNodes(this.tree()).length > 0);
+
   isSelected = (node: FlatTreeNode) => this.selectedId() === node.id;
 
   isUnpublished = (node: FlatTreeNode) => node.data?.published === false;
@@ -212,7 +215,7 @@ export class FlatTreeComponent {
       if (nodes.length === 0 || !tree || this.treeInitialized) return;
 
       queueMicrotask(() => {
-        tree.expandAll();
+        this.collapseAllNodes();
         this.treeInitialized = true;
       });
     });
@@ -308,7 +311,7 @@ export class FlatTreeComponent {
     }
 
     if (nodeToMove.type === 'FOLDER' || nodeToMove.type === 'API') {
-      this.treeBase()?.expandAll();
+      this.expandAllNodes();
     }
 
     this.nodeMoved.emit({ node: nodeToMove, newParentId, newOrder });
@@ -335,9 +338,52 @@ export class FlatTreeComponent {
 
     // If it's a folder, find all its descendants to hide them
     if (draggedNode.type === 'FOLDER' && draggedNode.children) {
-      const tree = this.treeBase();
-      tree.collapse(draggedNode);
+      this.collapseNode(draggedNode);
     }
+  }
+
+  expandAllNodes(): void {
+    this.treeBase()?.expandAll();
+    this.syncExpansionState();
+  }
+
+  collapseAllNodes(): void {
+    this.treeBase()?.collapseAll();
+    this.syncExpansionState();
+  }
+
+  onNodeToggle(): void {
+    // matTreeNodeToggle mutates the expansion model on the same click, defer so we sync after it applies
+    queueMicrotask(() => this.syncExpansionState());
+  }
+
+  private collapseNode(node: SectionNode): void {
+    this.treeBase()?.collapse(node);
+    this.syncExpansionState();
+  }
+
+  private syncExpansionState(): void {
+    const tree = this.treeBase();
+    if (!tree) {
+      this.hasExpandedNode.set(false);
+      return;
+    }
+    const expandableNodes = this.collectExpandableNodes(this.tree());
+    this.hasExpandedNode.set(expandableNodes.some(node => tree.isExpanded(node)));
+  }
+
+  private collectExpandableNodes(nodes: SectionNode[]): SectionNode[] {
+    const expandableNodes: SectionNode[] = [];
+    const walk = (currentNodes: SectionNode[]) => {
+      for (const node of currentNodes) {
+        if (node.children && node.children.length > 0) {
+          expandableNodes.push(node);
+          walk(node.children);
+        }
+      }
+    };
+    walk(nodes);
+    return expandableNodes;
   }
 
   private getVisibleNodes(): SectionNode[] {

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -219,6 +219,11 @@ export class FlatTreeComponent {
         this.treeInitialized = true;
       });
     });
+
+    effect(() => {
+      this.tree();
+      queueMicrotask(() => this.syncExpansionState());
+    });
   }
 
   onNodeClick(node: FlatTreeNode) {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -21,32 +21,45 @@
   <section class="panel sections-panel" [style.width.px]="panelWidth()">
     <header class="panel-header sections-panel__header">
       <h3>Navigation items</h3>
-      <div class="panel-header__actions" *gioPermission="{ anyOf: ['environment-documentation-c'] }">
+      <div class="panel-header__actions">
         <button
           mat-stroked-button
           type="button"
-          aria-label="Add new section"
-          [matMenuTriggerFor]="addSectionMenu"
-          (menuClosed)="addSectionMenuOpen = false"
-          (menuOpened)="addSectionMenuOpen = true"
+          data-testid="toggle-tree-expansion"
+          [disabled]="!canToggleTreeExpansion()"
+          [attr.aria-label]="isAnyTreeNodeExpanded() ? 'Collapse all navigation items' : 'Expand all navigation items'"
+          [matTooltip]="isAnyTreeNodeExpanded() ? 'Collapse all' : 'Expand all'"
+          (click)="onToggleTreeExpansion()"
         >
-          <span class="panel-header__actions__add__label"
-            >Add
-            <mat-icon svgIcon="gio:nav-arrow-down" class="panel-header__actions__add__label__icon" [class.opened]="addSectionMenuOpen">
-            </mat-icon>
-          </span>
+          <mat-icon>{{ isAnyTreeNodeExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
         </button>
-        <mat-menu #addSectionMenu="matMenu">
-          <button mat-menu-item (click)="onAddSection('PAGE')">
-            <mat-icon [svgIcon]="'PAGE' | portalNavigationItemIcon"></mat-icon> Add Page
+        <ng-container *gioPermission="{ anyOf: ['environment-documentation-c'] }">
+          <button
+            mat-stroked-button
+            type="button"
+            aria-label="Add new section"
+            [matMenuTriggerFor]="addSectionMenu"
+            (menuClosed)="addSectionMenuOpen = false"
+            (menuOpened)="addSectionMenuOpen = true"
+          >
+            <span class="panel-header__actions__add__label"
+              >Add
+              <mat-icon svgIcon="gio:nav-arrow-down" class="panel-header__actions__add__label__icon" [class.opened]="addSectionMenuOpen">
+              </mat-icon>
+            </span>
           </button>
-          <button mat-menu-item (click)="onAddSection('LINK')">
-            <mat-icon [svgIcon]="'LINK' | portalNavigationItemIcon"></mat-icon> Add Link
-          </button>
-          <button mat-menu-item (click)="onAddSection('FOLDER')">
-            <mat-icon [svgIcon]="'FOLDER' | portalNavigationItemIcon"></mat-icon> Add Folder
-          </button>
-        </mat-menu>
+          <mat-menu #addSectionMenu="matMenu">
+            <button mat-menu-item (click)="onAddSection('PAGE')">
+              <mat-icon [svgIcon]="'PAGE' | portalNavigationItemIcon"></mat-icon> Add Page
+            </button>
+            <button mat-menu-item (click)="onAddSection('LINK')">
+              <mat-icon [svgIcon]="'LINK' | portalNavigationItemIcon"></mat-icon> Add Link
+            </button>
+            <button mat-menu-item (click)="onAddSection('FOLDER')">
+              <mat-icon [svgIcon]="'FOLDER' | portalNavigationItemIcon"></mat-icon> Add Folder
+            </button>
+          </mat-menu>
+        </ng-container>
       </div>
     </header>
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -152,6 +152,60 @@ describe('PortalNavigationItemsComponent', () => {
     });
   });
 
+  describe('collapse / expand all toggle', () => {
+    const setupWithNestedItems = async () => {
+      const rootPage = fakePortalNavigationPage({ id: 'root-page', title: 'Root Page', order: 0, portalPageContentId: 'root-content' });
+      const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'Folder 1', order: 1 });
+      const childPage = fakePortalNavigationPage({
+        id: 'child-page',
+        title: 'Child Page',
+        order: 0,
+        parentId: 'folder-1',
+        portalPageContentId: 'child-content',
+      });
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootPage, folder, childPage] }));
+      expectGetPageContent('root-content', 'Root content');
+    };
+
+    it('collapses all items by default and shows the expand-all control', async () => {
+      await setupWithNestedItems();
+
+      expect(await harness.getNavigationItemTitles()).toEqual(['Root Page', 'Folder 1']);
+      expect(await harness.getToggleExpansionAriaLabel()).toBe('Expand all navigation items');
+      expect(await harness.isToggleExpansionButtonDisabled()).toBe(false);
+    });
+
+    it('expands all items and switches to the collapse-all control when toggled', async () => {
+      await setupWithNestedItems();
+
+      await harness.clickToggleExpansionButton();
+      fixture.detectChanges();
+
+      expect(await harness.getNavigationItemTitles()).toEqual(['Root Page', 'Folder 1', 'Child Page']);
+      expect(await harness.getToggleExpansionAriaLabel()).toBe('Collapse all navigation items');
+    });
+
+    it('collapses all items again when toggled from the expanded state', async () => {
+      await setupWithNestedItems();
+
+      await harness.clickToggleExpansionButton();
+      fixture.detectChanges();
+      await harness.clickToggleExpansionButton();
+      fixture.detectChanges();
+
+      expect(await harness.getNavigationItemTitles()).toEqual(['Root Page', 'Folder 1']);
+      expect(await harness.getToggleExpansionAriaLabel()).toBe('Expand all navigation items');
+    });
+
+    it('disables the toggle when the tree has no expandable item', async () => {
+      const rootPage = fakePortalNavigationPage({ id: 'root-page', title: 'Root Page', portalPageContentId: 'root-content' });
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootPage] }));
+      expectGetPageContent('root-content', 'Root content');
+
+      expect(await harness.isToggleExpansionButtonDisabled()).toBe(true);
+    });
+  });
+
   describe('adding a section', () => {
     let dialogHarness: SectionEditorDialogHarness;
     const fakeResponse = fakePortalNavigationItemsResponse({
@@ -1807,6 +1861,10 @@ describe('PortalNavigationItemsComponent', () => {
     });
 
     it('should update visibility using edit dialog', async () => {
+      // As items are collapsed by default, expand so the nested API node's menu is reachable.
+      await harness.clickToggleExpansionButton();
+      fixture.detectChanges();
+
       await harness.editNodeById('nav-api-1');
 
       const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
@@ -2044,6 +2102,11 @@ describe('PortalNavigationItemsComponent', () => {
       // Load tree, then expect the component to auto-select the first page within the first folder
       await expectGetNavigationItems(fakeResponse);
       expectGetPageContent('child-content-1', 'This is the content of Child Page 1');
+
+      // As items are collapsed by default, expand so the auto-selected nested page is
+      // rendered and its selected state can be asserted.
+      await harness.clickToggleExpansionButton();
+      fixture.detectChanges();
 
       // Verify selection and navigation
       expect(await harness.getSelectedNavigationItemTitle()).toBe('Child Page 1');

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -134,6 +134,10 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   readonly isLoadingPageContent = signal(false);
 
   editor = viewChild(GraviteeMarkdownEditorComponent);
+  private readonly flatTree = viewChild(FlatTreeComponent);
+
+  readonly canToggleTreeExpansion = computed(() => this.flatTree()?.hasExpandableNode() ?? false);
+  readonly isAnyTreeNodeExpanded = computed(() => this.flatTree()?.hasExpandedNode() ?? false);
 
   // Menu Data State
   private readonly refreshMenuList = new BehaviorSubject(1);
@@ -243,6 +247,18 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
 
   onSelect($event: SectionNode) {
     this.checkUnsavedChangesAndRun(() => this.navigateToItemByNavId($event.id));
+  }
+
+  onToggleTreeExpansion() {
+    const flatTree = this.flatTree();
+    if (!flatTree) {
+      return;
+    }
+    if (this.isAnyTreeNodeExpanded()) {
+      flatTree.collapseAllNodes();
+    } else {
+      flatTree.expandAllNodes();
+    }
   }
 
   onAddSection(sectionType: PortalNavigationItemType) {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -29,6 +29,7 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   static hostSelector = 'portal-navigation-items';
 
   private getAddButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Add new section"]' }));
+  private getToggleExpansionButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="toggle-tree-expansion"]' }));
   private getPreviewToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-testid="preview-toggle"]' }));
   private getEditButton = this.locatorFor(MatButtonHarness.with({ text: /Edit/i }));
   private getSaveButton = this.locatorFor(MatButtonHarness.with({ text: /Save/i }));
@@ -71,6 +72,22 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   async clickAddButton(): Promise<void> {
     const button = await this.getAddButton();
     return button.click();
+  }
+
+  async clickToggleExpansionButton(): Promise<void> {
+    const button = await this.getToggleExpansionButton();
+    return button.click();
+  }
+
+  async isToggleExpansionButtonDisabled(): Promise<boolean> {
+    const button = await this.getToggleExpansionButton();
+    return button.isDisabled();
+  }
+
+  async getToggleExpansionAriaLabel(): Promise<string | null> {
+    const button = await this.getToggleExpansionButton();
+    const host = await button.host();
+    return host.getAttribute('aria-label');
   }
 
   async clickEditButton(): Promise<void> {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14469

## Description

Adds a toolbar toggle to the "Navigation items" panel of portal settings to collapse/expand the whole navigation tree in one click.

### Behaviour
- Two-state icon button, left of **Add**: `unfold_more` (Expand all) when everything is collapsed, `unfold_less` (Collapse all) when at least one folder/API is expanded.
- **Items are now collapsed by default** on load.
- Disabled when no item is expandable; visible regardless of edit permission (read-only action).

### Notes
- Expansion state lives in `MatTree` (keyed by id) and is exposed to the toolbar via `FlatTreeComponent`.
- 2nd commit fixes a stale icon: after a CRUD refresh of the list (e.g. deleting an expanded folder), an `effect` resyncs the toggle state.

## Additional context


https://github.com/user-attachments/assets/07be3a1d-57aa-47fb-8787-b9b19dbe8ddf

