### PR TITLE
fix(gateway): isolate distributed sync Redis keys by cluster id

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/fetcher/DistributedEventFetcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/fetcher/DistributedEventFetcher.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.services.sync.process.distributed.fetcher;
 
 import static io.gravitee.gateway.services.sync.process.repository.DefaultSyncManager.TIMEFRAME_DELAY;
 
+import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.repository.distributedsync.api.DistributedEventRepository;
 import io.gravitee.repository.distributedsync.api.search.DistributedEventCriteria;
 import io.gravitee.repository.distributedsync.model.DistributedEvent;
@@ -38,6 +39,7 @@ import lombok.experimental.Accessors;
 public class DistributedEventFetcher {
 
     private final DistributedEventRepository distributedEventRepository;
+    private final ClusterManager clusterManager;
 
     @Getter
     @Accessors(fluent = true)
@@ -52,6 +54,7 @@ public class DistributedEventFetcher {
         AtomicBoolean lastPage = new AtomicBoolean();
         AtomicLong page = new AtomicLong(0L);
         DistributedEventCriteria distributedEventCriteria = DistributedEventCriteria.builder()
+            .clusterId(clusterManager.clusterId())
             .from(from == null ? -1 : from - TIMEFRAME_DELAY)
             .to(to == null ? -1 : to + TIMEFRAME_DELAY)
             .type(type)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncService.java
@@ -46,6 +46,7 @@ import io.gravitee.node.api.Node;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.repository.distributedsync.api.DistributedEventRepository;
 import io.gravitee.repository.distributedsync.api.DistributedSyncStateRepository;
+import io.gravitee.repository.distributedsync.model.DistributedEvent;
 import io.gravitee.repository.distributedsync.model.DistributedEventType;
 import io.gravitee.repository.distributedsync.model.DistributedSyncAction;
 import io.gravitee.repository.distributedsync.model.DistributedSyncState;
@@ -85,6 +86,12 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         if (distributedSyncRepoType == null || distributedSyncRepoType.isEmpty()) {
             throw new SyncException(
                 "Distributed sync configuration invalid. No repository configured, check 'distributed-sync.type' value."
+            );
+        }
+        String clusterId = clusterManager.clusterId();
+        if (clusterId == null || clusterId.isBlank()) {
+            throw new SyncException(
+                "Distributed sync requires a non-blank cluster id from the cluster manager (configure Hazelcast cluster-name)."
             );
         }
     }
@@ -141,11 +148,12 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
                 log.debug("Node is primary, distributing API reactor event for {}", deployable.id());
                 return apiMapper
                     .to(deployable)
-                    .flatMapCompletable(distributedEventRepository::createOrUpdate)
+                    .flatMapCompletable(this::createOrUpdateEvent)
                     .andThen(
                         Completable.defer(() -> {
                             if (deployable.syncAction() == SyncAction.UNDEPLOY) {
                                 return distributedEventRepository.updateAll(
+                                    clusterManager.clusterId(),
                                     DistributedEventType.API,
                                     deployable.apiId(),
                                     DistributedSyncAction.UNDEPLOY,
@@ -161,12 +169,17 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         });
     }
 
+    private Completable createOrUpdateEvent(final DistributedEvent event) {
+        event.setClusterId(clusterManager.clusterId());
+        return distributedEventRepository.createOrUpdate(event);
+    }
+
     @Override
     public Completable distributeIfNeeded(final SingleSubscriptionDeployable deployable) {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing subscription event for {}", deployable.id());
-                return subscriptionMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return subscriptionMapper.to(deployable).flatMapCompletable(this::createOrUpdateEvent);
             }
             log.debug("Not a primary node, skipping subscription event distribution");
             return Completable.complete();
@@ -178,7 +191,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing API key event for {}", deployable.id());
-                return apiKeyMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return apiKeyMapper.to(deployable).flatMapCompletable(this::createOrUpdateEvent);
             }
             log.debug("Not a primary node, skipping API key event distribution");
             return Completable.complete();
@@ -190,7 +203,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing organization event for {}", deployable.id());
-                return organizationMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return organizationMapper.to(deployable).flatMapCompletable(this::createOrUpdateEvent);
             }
             log.debug("Not a primary node, skipping organization event distribution");
             return Completable.complete();
@@ -202,7 +215,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing dictionary event for {}", deployable.id());
-                return dictionaryMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return dictionaryMapper.to(deployable).flatMapCompletable(this::createOrUpdateEvent);
             }
             log.debug("Not a primary node, skipping dictionary event distribution");
             return Completable.complete();
@@ -214,7 +227,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing license event for organization {}", deployable.id());
-                return licenseMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return licenseMapper.to(deployable).flatMapCompletable(this::createOrUpdateEvent);
             }
             log.debug("Not a primary node, skipping license event distribution");
             return Completable.complete();
@@ -226,7 +239,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing access point event for {}", deployable.id());
-                return accessPointMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return accessPointMapper.to(deployable).flatMapCompletable(this::createOrUpdateEvent);
             }
             log.debug("Not a primary node, skipping access point event distribution");
             return Completable.complete();
@@ -238,7 +251,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing shared policy group event for {}", deployable.id());
-                return sharedPolicyGroupMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return sharedPolicyGroupMapper.to(deployable).flatMapCompletable(this::createOrUpdateEvent);
             }
             log.debug("Not a primary node, skipping shared policy group event distribution");
             return Completable.complete();
@@ -264,7 +277,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing node metadata event for {}", deployable.id());
-                return nodeMetadataMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return nodeMetadataMapper.to(deployable).flatMapCompletable(this::createOrUpdateEvent);
             }
             log.debug("Not a primary node, skipping node metadata event distribution");
             return Completable.complete();
@@ -276,7 +289,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing authz entity event for {}", deployable.entityId());
-                return authzEntityMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return authzEntityMapper.to(deployable).flatMapCompletable(this::createOrUpdateEvent);
             }
             log.debug("Not a primary node, skipping authz entity event distribution");
             return Completable.complete();
@@ -288,7 +301,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing authz policy event for {}", deployable.docId());
-                return authzPolicyMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return authzPolicyMapper.to(deployable).flatMapCompletable(this::createOrUpdateEvent);
             }
             log.debug("Not a primary node, skipping authz policy event distribution");
             return Completable.complete();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/spring/DistributedSyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/spring/DistributedSyncConfiguration.java
@@ -121,9 +121,10 @@ public class DistributedSyncConfiguration {
     @Bean
     public DistributedEventFetcher distributedEventFetcher(
         @Lazy DistributedEventRepository distributedEventRepository,
+        ClusterManager clusterManager,
         @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems
     ) {
-        return new DistributedEventFetcher(distributedEventRepository, bulkItems);
+        return new DistributedEventFetcher(distributedEventRepository, clusterManager, bulkItems);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/fetcher/DistributedEventFetcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/fetcher/DistributedEventFetcherTest.java
@@ -15,11 +15,15 @@
  */
 package io.gravitee.gateway.services.sync.process.distributed.fetcher;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.repository.distributedsync.api.DistributedEventRepository;
+import io.gravitee.repository.distributedsync.api.search.DistributedEventCriteria;
 import io.gravitee.repository.distributedsync.model.DistributedEvent;
 import io.gravitee.repository.distributedsync.model.DistributedEventType;
 import io.reactivex.rxjava3.core.Flowable;
@@ -29,6 +33,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -40,14 +45,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class DistributedEventFetcherTest {
 
+    private static final String CLUSTER_ID = "test-cluster";
+
     @Mock
     private DistributedEventRepository distributedEventRepository;
+
+    @Mock
+    private ClusterManager clusterManager;
 
     private DistributedEventFetcher cut;
 
     @BeforeEach
     public void beforeEach() {
-        cut = new DistributedEventFetcher(distributedEventRepository, 1);
+        when(clusterManager.clusterId()).thenReturn(CLUSTER_ID);
+        cut = new DistributedEventFetcher(distributedEventRepository, clusterManager, 1);
     }
 
     @Test
@@ -61,7 +72,7 @@ class DistributedEventFetcherTest {
 
     @Test
     void should_fetch_latest_event_and_complete_when_no_more_page() {
-        cut = new DistributedEventFetcher(distributedEventRepository, 1);
+        cut = new DistributedEventFetcher(distributedEventRepository, clusterManager, 1);
         DistributedEvent distributedEvent1 = DistributedEvent.builder().id("1").build();
         DistributedEvent distributedEvent2 = DistributedEvent.builder().id("2").build();
         when(distributedEventRepository.search(any(), eq(0L), eq(1L))).thenReturn(Flowable.just(distributedEvent1));
@@ -73,5 +84,15 @@ class DistributedEventFetcherTest {
             .assertValueAt(0, distributedEvent1)
             .assertValueAt(1, distributedEvent2)
             .assertComplete();
+    }
+
+    @Test
+    void should_search_with_cluster_id() {
+        when(distributedEventRepository.search(any(), any(), any())).thenReturn(Flowable.empty());
+        cut.fetchLatest(null, null, DistributedEventType.API, Set.of()).test().assertComplete();
+
+        ArgumentCaptor<DistributedEventCriteria> criteriaCaptor = ArgumentCaptor.forClass(DistributedEventCriteria.class);
+        verify(distributedEventRepository).search(criteriaCaptor.capture(), eq(0L), eq(1L));
+        assertThat(criteriaCaptor.getValue().getClusterId()).isEqualTo(CLUSTER_ID);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncServiceTest.java
@@ -52,6 +52,7 @@ import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.node.api.cluster.Member;
 import io.gravitee.repository.distributedsync.api.DistributedEventRepository;
 import io.gravitee.repository.distributedsync.api.DistributedSyncStateRepository;
+import io.gravitee.repository.distributedsync.model.DistributedEvent;
 import io.gravitee.repository.distributedsync.model.DistributedSyncState;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -61,6 +62,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -159,6 +161,18 @@ class DefaultDistributedSyncServiceTest {
         }
 
         @Test
+        void should_not_validate_when_cluster_id_is_null() {
+            when(clusterManager.clusterId()).thenReturn(null);
+            assertThrows(SyncException.class, () -> cut.validate());
+        }
+
+        @Test
+        void should_not_validate_when_cluster_id_is_blank() {
+            when(clusterManager.clusterId()).thenReturn("   ");
+            assertThrows(SyncException.class, () -> cut.validate());
+        }
+
+        @Test
         void should_be_enabled() {
             assertThat(cut.isEnabled()).isTrue();
         }
@@ -190,6 +204,14 @@ class DefaultDistributedSyncServiceTest {
         void should_distribute_api() {
             cut.distributeIfNeeded(ApiReactorDeployable.builder().build()).test().assertComplete();
             verify(distributedEventRepository).createOrUpdate(any());
+        }
+
+        @Test
+        void should_distribute_api_with_cluster_id() {
+            ArgumentCaptor<DistributedEvent> captor = ArgumentCaptor.forClass(DistributedEvent.class);
+            cut.distributeIfNeeded(ApiReactorDeployable.builder().build()).test().assertComplete();
+            verify(distributedEventRepository).createOrUpdate(captor.capture());
+            assertThat(captor.getValue().getClusterId()).isEqualTo("clusterId");
         }
 
         @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/distributedsync/api/DistributedEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/distributedsync/api/DistributedEventRepository.java
@@ -50,6 +50,7 @@ public interface DistributedEventRepository {
     /**
      * This method allows to update all distributed event associated to reference id and type.
      *
+     * @param clusterId cluster identifier used to scope distributed events
      * @param refType {@link DistributedEventType} used to filter distributed events
      * @param refId {@link String} used to filter distributed events
      * @param syncAction {@link DistributedSyncAction} to update
@@ -57,6 +58,7 @@ public interface DistributedEventRepository {
      * @return {@link Completable}
      */
     Completable updateAll(
+        final String clusterId,
         final DistributedEventType refType,
         final String refId,
         final DistributedSyncAction syncAction,

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/distributedsync/api/search/DistributedEventCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/distributedsync/api/search/DistributedEventCriteria.java
@@ -33,6 +33,8 @@ import lombok.Getter;
 @EqualsAndHashCode
 public class DistributedEventCriteria {
 
+    private final String clusterId;
+
     private final DistributedEventType type;
 
     private final Set<DistributedSyncAction> syncActions;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/distributedsync/model/DistributedEvent.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/distributedsync/model/DistributedEvent.java
@@ -37,6 +37,8 @@ import lombok.experimental.FieldNameConstants;
 @ToString
 public class DistributedEvent {
 
+    private String clusterId;
+
     private String refId;
 
     private DistributedEventType refType;

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/distributedsync/RediSearchTagValues.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/distributedsync/RediSearchTagValues.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.distributedsync;
+
+/**
+ * RediSearch TAG field value escaping for query strings.
+ */
+final class RediSearchTagValues {
+
+    private static final String TAG_QUERY_SPECIAL_CHARACTERS = ",.<>{}[]\"':;!@#$%^&*()-+=~\\/?| ";
+
+    private RediSearchTagValues() {}
+
+    static String escapeTagValue(final String value) {
+        if (value == null) {
+            return null;
+        }
+        var escaped = new StringBuilder(value.length() * 2);
+        for (char character : value.toCharArray()) {
+            if (TAG_QUERY_SPECIAL_CHARACTERS.indexOf(character) >= 0) {
+                escaped.append('\\');
+            }
+            escaped.append(character);
+        }
+        return escaped.toString();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/distributedsync/RedisDistributedEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/distributedsync/RedisDistributedEventRepository.java
@@ -44,10 +44,12 @@ import lombok.CustomLog;
 @CustomLog
 public class RedisDistributedEventRepository implements DistributedEventRepository {
 
-    private static final String REDIS_INDEX_NAME = "distributed-event-search-idx";
+    private static final String REDIS_INDEX_NAME = "distributed-event-search-idx-v2";
     private static final String REDIS_KEY_PREFIX = "distributed_event" + REDIS_KEY_SEPARATOR;
     private static final String REDIS_SEARCH_RESULTS_FIELD = "results";
     private static final String REDIS_RESPONSE_ATTRIBUTES_FIELD = "extra_attributes";
+    private static final String CLUSTER_ID_REQUIRED_MESSAGE = "Distributed event clusterId is required";
+    private static final String CLUSTER_ID_PARAMETER_REQUIRED_MESSAGE = "clusterId is required";
 
     private final RedisClient redisClient;
 
@@ -84,17 +86,24 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
 
     @Override
     public Completable createOrUpdate(final DistributedEvent distributedEvent) {
+        if (distributedEvent.getClusterId() == null || distributedEvent.getClusterId().isBlank()) {
+            return Completable.error(new IllegalArgumentException(CLUSTER_ID_REQUIRED_MESSAGE));
+        }
         return createOrUpdateKey(buildEventKey(distributedEvent), distributedEvent);
     }
 
     @Override
     public Completable updateAll(
+        final String clusterId,
         final DistributedEventType refType,
         final String refId,
         final DistributedSyncAction syncAction,
         final Date updatedAt
     ) {
-        String matchingKey = REDIS_KEY_PREFIX + refType.name() + REDIS_KEY_SEPARATOR + refId + "*";
+        if (clusterId == null || clusterId.isBlank()) {
+            return Completable.error(new IllegalArgumentException(CLUSTER_ID_PARAMETER_REQUIRED_MESSAGE));
+        }
+        String matchingKey = REDIS_KEY_PREFIX + clusterId + REDIS_KEY_SEPARATOR + refType.name() + REDIS_KEY_SEPARATOR + refId + "*";
         AtomicInteger cursor = new AtomicInteger(0);
         return Single.defer(() ->
             Single.fromCompletionStage(
@@ -138,6 +147,8 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
             "1",
             REDIS_KEY_PREFIX,
             "SCHEMA",
+            DistributedEvent.Fields.clusterId,
+            "TAG",
             DistributedEvent.Fields.type,
             "TAG",
             DistributedEvent.Fields.syncAction,
@@ -171,6 +182,15 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
         }
 
         var query = new StringBuilder();
+        if (criteria.getClusterId() != null) {
+            query
+                .append("@")
+                .append(DistributedEvent.Fields.clusterId)
+                .append(":{")
+                .append(RediSearchTagValues.escapeTagValue(criteria.getClusterId()))
+                .append("}");
+        }
+
         if (criteria.getType() != null) {
             query.append("@" + DistributedEvent.Fields.type + ":{").append(criteria.getType()).append("}");
         }
@@ -195,6 +215,10 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
     private List<String> buildUpdateArgs(String key, DistributedEvent distributedEvent) {
         var args = new ArrayList<String>();
         args.add(key);
+        if (distributedEvent.getClusterId() != null) {
+            args.add(DistributedEvent.Fields.clusterId);
+            args.add(distributedEvent.getClusterId());
+        }
         if (distributedEvent.getId() != null) {
             args.add(DistributedEvent.Fields.id);
             args.add(distributedEvent.getId());
@@ -222,6 +246,12 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
         var distributedEventBuilder = DistributedEvent.builder();
 
         var attributes = getResultAttributes(item);
+
+        // Get clusterId
+        var clusterId = attributes.get(DistributedEvent.Fields.clusterId);
+        if (clusterId != null) {
+            distributedEventBuilder.clusterId(clusterId.toString());
+        }
 
         // Get id
         var id = attributes.get(DistributedEvent.Fields.id);
@@ -253,10 +283,14 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
     }
 
     private String buildEventKey(DistributedEvent distributedEvent) {
-        var builder = new StringBuilder().append(REDIS_KEY_PREFIX);
+        var builder = new StringBuilder().append(REDIS_KEY_PREFIX).append(distributedEvent.getClusterId());
 
         if (distributedEvent.getRefId() != null && distributedEvent.getRefType() != null) {
-            builder.append(distributedEvent.getRefType().name()).append(REDIS_KEY_SEPARATOR).append(distributedEvent.getRefId());
+            builder
+                .append(REDIS_KEY_SEPARATOR)
+                .append(distributedEvent.getRefType().name())
+                .append(REDIS_KEY_SEPARATOR)
+                .append(distributedEvent.getRefId());
         }
 
         return builder

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/distributedsync/RediSearchTagValuesTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/distributedsync/RediSearchTagValuesTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.distributedsync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RediSearchTagValuesTest {
+
+    @Test
+    void should_escape_redisearch_tag_query_special_characters() {
+        assertThat(RediSearchTagValues.escapeTagValue("cluster/a b|c?d")).isEqualTo("cluster\\/a\\ b\\|c\\?d");
+    }
+
+    @Test
+    void should_leave_alphanumeric_cluster_id_unchanged() {
+        assertThat(RediSearchTagValues.escapeTagValue("my-release-apim-gateway-external-hz57")).isEqualTo(
+            "my\\-release\\-apim\\-gateway\\-external\\-hz57"
+        );
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/distributedsync/DistributedEventRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/distributedsync/DistributedEventRepositoryTest.java
@@ -354,7 +354,7 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
     @Test
     public void should_update_all_related_to_api() throws InterruptedException {
         Date updateAt = new Date();
-        distributedEventRepository
+        var testObserver = distributedEventRepository
             .updateAll(TEST_CLUSTER_ID, DistributedEventType.API, "1", DistributedSyncAction.UNDEPLOY, updateAt)
             .andThen(
                 distributedEventRepository.search(
@@ -363,21 +363,14 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
                     -1L
                 )
             )
-            .test()
-            .await()
-            .assertValueCount(2)
-            .assertValueAt(0, distributedEvent -> {
-                assertThat(distributedEvent).isNotNull();
-                assertThat(distributedEvent.getSyncAction()).isEqualTo(DistributedSyncAction.UNDEPLOY);
-                assertThat(distributedEvent.getUpdatedAt()).isEqualTo(updateAt);
-                return true;
-            })
-            .assertValueAt(1, distributedEvent -> {
-                assertThat(distributedEvent).isNotNull();
-                assertThat(distributedEvent.getSyncAction()).isEqualTo(DistributedSyncAction.UNDEPLOY);
-                assertThat(distributedEvent.getUpdatedAt()).isEqualTo(updateAt);
-                return true;
-            });
+            .test();
+        testObserver.await().assertComplete();
+        assertThat(testObserver.values()).hasSize(3);
+        assertThat(testObserver.values()).extracting(DistributedEvent::getId).containsExactlyInAnyOrder("1", "4", "5");
+        assertThat(testObserver.values()).allSatisfy(distributedEvent -> {
+            assertThat(distributedEvent.getSyncAction()).isEqualTo(DistributedSyncAction.UNDEPLOY);
+            assertThat(distributedEvent.getUpdatedAt()).isEqualTo(updateAt);
+        });
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/distributedsync/DistributedEventRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/distributedsync/DistributedEventRepositoryTest.java
@@ -36,6 +36,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 @CustomLog
 public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
 
+    private static final String TEST_CLUSTER_ID = "test-cluster";
+
     @Autowired
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     DistributedEventRepository distributedEventRepository;
@@ -60,7 +62,7 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
     @Test
     public void should_return_all_distributed_event_without_criteria_and_page() throws InterruptedException {
         distributedEventRepository
-            .search(null, -1L, -1L)
+            .search(DistributedEventCriteria.builder().clusterId(TEST_CLUSTER_ID).build(), -1L, -1L)
             .test()
             .await()
             .assertValueAt(0, distributedEvent -> {
@@ -122,7 +124,7 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
     @Test
     public void should_return_paginated_distributed_event_without_criteria() throws InterruptedException {
         distributedEventRepository
-            .search(null, 0L, 1L)
+            .search(DistributedEventCriteria.builder().clusterId(TEST_CLUSTER_ID).build(), 0L, 1L)
             .test()
             .await()
             .assertValue(distributedEvent -> {
@@ -136,7 +138,7 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
             });
 
         distributedEventRepository
-            .search(null, 1L, 1L)
+            .search(DistributedEventCriteria.builder().clusterId(TEST_CLUSTER_ID).build(), 1L, 1L)
             .test()
             .await()
             .assertValue(distributedEvent -> {
@@ -150,7 +152,7 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
             });
 
         distributedEventRepository
-            .search(null, 2L, 1L)
+            .search(DistributedEventCriteria.builder().clusterId(TEST_CLUSTER_ID).build(), 2L, 1L)
             .test()
             .await()
             .assertValue(distributedEvent -> {
@@ -167,7 +169,7 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
     @Test
     public void should_return_only_api_distributed_event() throws InterruptedException {
         distributedEventRepository
-            .search(DistributedEventCriteria.builder().type(DistributedEventType.API).build(), -1L, -1L)
+            .search(DistributedEventCriteria.builder().clusterId(TEST_CLUSTER_ID).type(DistributedEventType.API).build(), -1L, -1L)
             .test()
             .await()
             .assertValueAt(0, distributedEvent -> {
@@ -194,7 +196,11 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
     public void should_return_only_deployed_api_distributed_event() throws InterruptedException {
         distributedEventRepository
             .search(
-                DistributedEventCriteria.builder().type(DistributedEventType.API).syncActions(Set.of(DistributedSyncAction.DEPLOY)).build(),
+                DistributedEventCriteria.builder()
+                    .clusterId(TEST_CLUSTER_ID)
+                    .type(DistributedEventType.API)
+                    .syncActions(Set.of(DistributedSyncAction.DEPLOY))
+                    .build(),
                 -1L,
                 -1L
             )
@@ -216,6 +222,7 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
         distributedEventRepository
             .search(
                 DistributedEventCriteria.builder()
+                    .clusterId(TEST_CLUSTER_ID)
                     .type(DistributedEventType.API)
                     .syncActions(Set.of(DistributedSyncAction.DEPLOY, DistributedSyncAction.UNDEPLOY))
                     .build(),
@@ -247,7 +254,14 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
     @Test
     public void should_return_updated_after_from_distributed_event() throws InterruptedException {
         distributedEventRepository
-            .search(DistributedEventCriteria.builder().from(Instant.parse("2023-04-25T15:24:40.051Z").toEpochMilli()).build(), -1L, -1L)
+            .search(
+                DistributedEventCriteria.builder()
+                    .clusterId(TEST_CLUSTER_ID)
+                    .from(Instant.parse("2023-04-25T15:24:40.051Z").toEpochMilli())
+                    .build(),
+                -1L,
+                -1L
+            )
             .test()
             .await()
             .assertValueAt(0, distributedEvent -> {
@@ -291,7 +305,14 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
     @Test
     public void should_return_updated_before_to_distributed_event() throws InterruptedException {
         distributedEventRepository
-            .search(DistributedEventCriteria.builder().to(Instant.parse("2023-04-25T15:24:40.051Z").toEpochMilli()).build(), -1L, -1L)
+            .search(
+                DistributedEventCriteria.builder()
+                    .clusterId(TEST_CLUSTER_ID)
+                    .to(Instant.parse("2023-04-25T15:24:40.051Z").toEpochMilli())
+                    .build(),
+                -1L,
+                -1L
+            )
             .test()
             .await()
             .assertValue(distributedEvent -> {
@@ -310,6 +331,7 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
         distributedEventRepository
             .search(
                 DistributedEventCriteria.builder()
+                    .clusterId(TEST_CLUSTER_ID)
                     .from(Instant.parse("2023-04-24T15:24:40.051Z").toEpochMilli())
                     .to(Instant.parse("2023-04-26T15:25:00.051Z").toEpochMilli())
                     .build(),
@@ -333,8 +355,14 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
     public void should_update_all_related_to_api() throws InterruptedException {
         Date updateAt = new Date();
         distributedEventRepository
-            .updateAll(DistributedEventType.API, "1", DistributedSyncAction.UNDEPLOY, updateAt)
-            .andThen(distributedEventRepository.search(DistributedEventCriteria.builder().from(updateAt.getTime()).build(), -1L, -1L))
+            .updateAll(TEST_CLUSTER_ID, DistributedEventType.API, "1", DistributedSyncAction.UNDEPLOY, updateAt)
+            .andThen(
+                distributedEventRepository.search(
+                    DistributedEventCriteria.builder().clusterId(TEST_CLUSTER_ID).from(updateAt.getTime()).build(),
+                    -1L,
+                    -1L
+                )
+            )
             .test()
             .await()
             .assertValueCount(2)
@@ -348,6 +376,36 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
                 assertThat(distributedEvent).isNotNull();
                 assertThat(distributedEvent.getSyncAction()).isEqualTo(DistributedSyncAction.UNDEPLOY);
                 assertThat(distributedEvent.getUpdatedAt()).isEqualTo(updateAt);
+                return true;
+            });
+    }
+
+    @Test
+    public void should_not_return_events_from_other_cluster() throws InterruptedException {
+        distributedEventRepository
+            .createOrUpdate(
+                DistributedEvent.builder()
+                    .clusterId("other-cluster")
+                    .id("other-api")
+                    .payload("payload")
+                    .type(DistributedEventType.API)
+                    .syncAction(DistributedSyncAction.DEPLOY)
+                    .updatedAt(Date.from(Instant.parse("2023-04-24T15:24:34.051Z")))
+                    .build()
+            )
+            .blockingAwait();
+
+        distributedEventRepository
+            .search(DistributedEventCriteria.builder().clusterId(TEST_CLUSTER_ID).type(DistributedEventType.API).build(), -1L, -1L)
+            .test()
+            .await()
+            .assertValueCount(2)
+            .assertValueAt(0, distributedEvent -> {
+                assertThat(distributedEvent.getId()).isEqualTo("1");
+                return true;
+            })
+            .assertValueAt(1, distributedEvent -> {
+                assertThat(distributedEvent.getId()).isEqualTo("2");
                 return true;
             });
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/distributedsyncevent-tests/distributedEvents.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/distributedsyncevent-tests/distributedEvents.json
@@ -1,5 +1,6 @@
 [
   {
+    "clusterId": "test-cluster",
     "id": "1",
     "payload": "payload",
     "type": "API",
@@ -7,6 +8,7 @@
     "updatedAt": "2023-04-24T15:24:34.051Z"
   },
   {
+    "clusterId": "test-cluster",
     "id": "2",
     "payload": "payload",
     "type": "API",
@@ -14,6 +16,7 @@
     "updatedAt": "2023-04-25T15:24:54.051Z"
   },
   {
+    "clusterId": "test-cluster",
     "id": "3",
     "payload": "payload",
     "type": "DICTIONARY",
@@ -21,6 +24,7 @@
     "updatedAt": "2023-04-26T15:25:14.051Z"
   },
   {
+    "clusterId": "test-cluster",
     "id": "4",
     "payload": "payload",
     "type": "API_KEY",
@@ -30,6 +34,7 @@
     "refType" : "API"
   },
   {
+    "clusterId": "test-cluster",
     "id": "5",
     "payload": "payload",
     "type": "SUBSCRIPTION",
@@ -39,6 +44,7 @@
     "refType" : "API"
   },
   {
+    "clusterId": "test-cluster",
     "id": "DEFAULT",
     "payload": "payload",
     "type": "LICENSE",

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -4,6 +4,7 @@
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
 ### 4.12.0
+- Render `config/hazelcast.xml` for gateway Hazelcast clustering (`gateway.cluster.type=hazelcast`) with Kubernetes discovery via the `-hz` Service. Cluster name defaults to `<release>-<sharding_tags>` so Redis distributed-event namespace (clusterId) changes when sharding tags change; override with `gateway.cluster.hazelcast.clusterName`. Require `gateway.cluster` when `gateway.distributedSync` is enabled; auto-enable `services.sync.repository` and `services.sync.distributed`.
 - Support multiple custom domains for native Kafka APIs with `gateway.kafka.routingHostMode.domains` (list). `defaultDomain` is deprecated and ignored when `domains` is set.
 - Document `gateway.services.metrics.kafka.durations.principalName` to add the `principal_name` tag to Kafka duration metrics (disabled by default).
 - Add support for Kubernetes Gateway API HTTPRoute for all components (API, Gateway, User Interface, Portal).

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -67,3 +67,5 @@ annotations:
       description: "`gateway.kafka.routingHostMode.defaultDomain` is deprecated in favor of `domains` and ignored when `domains` is set"
     - kind: added
       description: "Document `gateway.services.metrics.kafka.durations.principalName` to add the principal_name tag to Kafka duration metrics (disabled by default)"
+    - kind: added
+      description: 'Render config/hazelcast.xml for gateway Hazelcast clustering (gateway.cluster.type=hazelcast) with Kubernetes discovery. Cluster name defaults to release-sharding_tags for Redis distributed-event isolation; require gateway.cluster when gateway.distributedSync is enabled'

--- a/helm/README.md
+++ b/helm/README.md
@@ -388,7 +388,11 @@ See [Elasticsearch](https://artifacthub.io/packages/helm/bitnami/elasticsearch) 
 | `gateway.websocket`                            | Whether websocket protocol is enabled or not                                                                                                                                                               | `false`                                                                                                                                                                                                                     |
 | `gateway.apiKey.header`                        | Header used for the API Key. Set an empty value to prohibit its use.                                                                                                                                       | `X-Gravitee-Api-Key`                                                                                                                                                                                                        |
 | `gateway.apiKey.param`                         | Query parameter used for the API Key. Set an empty value to prohibit its use.                                                                                                                              | `api-key`                                                                                                                                                                                                                   |
-| `gateway.sharding_tags`                        | Sharding tags (comma separated list)                                                                                                                                                                       | ``                                                                                                                                                                                                                          |
+| `gateway.sharding_tags`                        | Sharding tags (comma separated list). With distributed sync, deploy one Helm release per tag cluster; cluster-name defaults to `<release>-<tags>`.                                                        | ``                                                                                                                                                                                                                          |
+| `gateway.cluster.type`                         | Gateway Hazelcast clustering for distributed sync primary election. Set to `hazelcast` when `gateway.distributedSync` is enabled. Renders `config/hazelcast.xml`.                                            | ``                                                                                                                                                                                                                          |
+| `gateway.cluster.hazelcast.clusterName`        | Hazelcast cluster name (Redis distributed-event namespace / clusterId). Defaults to `<release>-<sharding_tags>`; must change when sharding tags change (manual Redis cleanup required).                     | ``                                                                                                                                                                                                                          |
+| `gateway.cluster.hazelcast.port`               | Hazelcast cluster member port for gateway node clustering (distinct from rate-limit Hazelcast port).                                                                                                       | `5701`                                                                                                                                                                                                                      |
+| `gateway.distributedSync`                      | Redis distributed sync store configuration. Requires `gateway.cluster.type=hazelcast` and `replicaCount > 1`. Enables `services.sync.repository` and `services.sync.distributed` in `gravitee.yml`. See [Gateway distributed sync](#gateway-distributed-sync) for deployment constraints. | ``                                                                                                                                                                                                                          |
 | `gateway.ingress.enabled`                      | Whether Ingress is enabled or not                                                                                                                                                                          | `true`                                                                                                                                                                                                                      |
 | `gateway.ingress.path`                         | The ingress path which should match for incoming requests to the gateway.                                                                                                                                  | `/gateway`                                                                                                                                                                                                                  |
 | `gateway.ingress.hosts`                        | If `gateway.ingress.enabled` is enabled, set possible ingress hosts                                                                                                                                        | `[apim.example.com]`                                                                                                                                                                                                        |
@@ -401,6 +405,44 @@ See [Elasticsearch](https://artifacthub.io/packages/helm/bitnami/elasticsearch) 
 | `gateway.resources.requests.memory`            | K8s pod deployment requests definition for memory                                                                                                                                                          | `256Mi`                                                                                                                                                                                                                     |
 | `gateway.lifecycle.postStart`                  | K8s pod deployment [postStart](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#define-poststart-and-prestop-handlers) command definition                          | `null`                                                                                                                                                                                                                      |
 | `gateway.lifecycle.preStop`                    | K8s pod deployment [preStop](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#define-poststart-and-prestop-handlers) command definition                            | `null`                                                                                                                                                                                                                      |
+
+#### Gateway distributed sync
+
+Distributed sync lets multiple gateway replicas share sync state through Redis while electing a primary node via Hazelcast. Deploy **one gateway Helm release per sharding tag set** (e.g. external, internal). Releases may share the same Redis instance; each must have a distinct Hazelcast `cluster-name` (runtime `clusterId`) so distributed-event keys are isolated.
+
+**Cluster name** defaults to `<release-name>-<sharding_tags>` (slugged). It stays stable across rolling upgrades when the release name and tags are unchanged (same HZ cluster, reuse Redis, incremental sync). If `gateway.sharding_tags` change, the cluster name changes, a new HZ cluster is formed, and stale `distributed_event:<oldClusterId>:*` keys in Redis must be deleted manually.
+
+**Deployment constraints** (required when `gateway.distributedSync` is enabled):
+
+| Scenario | Requirement |
+|----------|-------------|
+| **Fresh install** | Start with `gateway.replicaCount: 1`. Wait until the primary has synchronized (gateway ready; Redis holds `distributed_sync_state` and events). Scale up **one replica at a time**. A Deployment cannot guarantee one-by-one pod creation on first install. |
+| **Upgrade** | Set `gateway.deployment.strategy.rollingUpdate` to `maxUnavailable: 0` and `maxSurge: 1` so pods join the Hazelcast cluster one at a time. Chart default is `maxUnavailable: 1`; override when distributed sync is on. |
+
+**Why:** Secondary gateways read distributed state from Redis. Initial sync on a secondary is one-shot; the primary must populate Redis before secondaries rely on it.
+
+Example values when distributed sync is enabled:
+
+```yaml
+gateway:
+  replicaCount: 1   # increase one step at a time after primary is ready
+  sharding_tags: external
+  cluster:
+    type: hazelcast
+  distributedSync:
+    type: redis
+    redis:
+      host: redis
+      port: 6379
+  deployment:
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
+```
+
+See also the comment block above `gateway.cluster` in [values.yaml](values.yaml).
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -11,3 +11,10 @@ cluster (rate-limit budgets multiplied by replica count). Either set
 apim.managedServiceAccount=true, or grant the gateway ServiceAccount get/list permissions
 on endpoints/pods/nodes/services in namespace {{ .Release.Namespace }} out-of-band.
 {{- end }}
+{{- if include "gateway.distributedSync.enabled" . }}
+
+NOTE: Gateway distributed sync is enabled. Use one Helm release per sharding tag cluster with a
+unique Hazelcast cluster-name (default: "<release>-<sharding_tags>"). All releases may share Redis;
+distributed_event keys are scoped by clusterId. If sharding_tags or cluster-name change, delete
+stale distributed_event:* and distributed_sync_state:* keys for the old clusterId in Redis manually.
+{{- end }}

--- a/helm/templates/gateway/_gateway-distributed-sync-config.tpl
+++ b/helm/templates/gateway/_gateway-distributed-sync-config.tpl
@@ -1,0 +1,81 @@
+{{/*
+Renders the distributed-sync block in gravitee.yml when gateway.distributedSync is a map with type.
+When gateway.distributedSync is boolean true (legacy values), sync flags are enabled elsewhere and
+Redis settings are expected from external gravitee.yml configuration.
+*/}}
+{{- define "gateway.distributedSync.graviteeYaml" -}}
+{{- $ds := .Values.gateway.distributedSync -}}
+{{- if and (kindIs "map" $ds) $ds.type -}}
+    distributed-sync:
+      type: {{ $ds.type }}
+      {{- if eq $ds.type "redis" }}
+      redis:
+        host: {{ $ds.redis.host }}
+        port: {{ $ds.redis.port }}
+        {{- if $ds.redis.username }}
+        username: {{ $ds.redis.username }}
+        {{- end }}
+        {{- if $ds.redis.password }}
+        password: {{ $ds.redis.password }}
+        {{- end }}
+        {{- if $ds.redis.ssl }}
+        ssl: {{ $ds.redis.ssl }}
+        hostnameVerificationAlgorithm: {{ $ds.redis.hostnameVerificationAlgorithm | default "NONE" }}
+        trustAll: {{ if hasKey $ds.redis "trustAll" }}{{ $ds.redis.trustAll }}{{else}}true{{end}}
+        tlsProtocols: {{ $ds.redis.tlsProtocols | default "TLSv1.2" }}
+        {{- if $ds.redis.tlsCiphers }}
+        tlsCiphers: {{ $ds.redis.tlsCiphers | quote }}
+        {{- end }}
+        alpn: {{ $ds.redis.alpn | default false }}
+        openssl: {{ $ds.redis.openssl | default false }}
+        {{- end }}
+        {{- if $ds.redis.keystore }}
+        keystore:
+          type: {{ $ds.redis.keystore.type | default "pem" }}
+          path: {{ $ds.redis.keystore.path | default "${gravitee.home}/security/redis-keystore.jks" }}
+          password: {{ required "The password required to access the keystore must be provided (i.e.kubernetes://{{NAMESPACE}}/secrets/{{SECRET_NAME}}/{{KEY_NAME}})" $ds.redis.keystore.password }}
+          {{- if $ds.redis.keystore.keyPassword }}
+          keyPassword: {{ $ds.redis.keystore.keyPassword | quote }}
+          {{- end }}
+          {{- if $ds.redis.keystore.alias }}
+          alias: {{ $ds.redis.keystore.alias }}
+          {{- end }}
+          {{- if and ( eq $ds.redis.keystore.type "pem" ) ( empty $ds.redis.keystore.certificates ) }}
+            {{ fail "When configuring Gravitee to use a keystore for mTLS, your certificates must be provided!" }}
+          {{- end }}
+          certificates:
+            {{- range $ds.redis.keystore.certificates }}
+            - cert: {{ .cert }}
+              key: {{ .key }}
+            {{- end }}
+        {{- end}}
+        {{- if $ds.redis.truststore }}
+        truststore:
+          type: {{ $ds.redis.truststore.type | default "pem" }}
+          path: {{ $ds.redis.truststore.path | default "${gravitee.home}/security/redis-truststore.jks" }}
+          password: {{ required "The password required to access the truststore must be provided! (i.e.kubernetes://{{NAMESPACE}}/secrets/{{SECRET_NAME}}/{{KEY_NAME}})" $ds.redis.truststore.password }}
+          {{- if $ds.redis.truststore.alias }}
+          alias: {{ $ds.redis.truststore.alias }}
+          {{- end }}
+        {{- end }}
+        {{- if (not (empty (($ds.redis.sentinel).nodes))) }}
+        sentinel:
+          master: {{ $ds.redis.sentinel.master }}
+          nodes:
+            {{- range $ds.redis.sentinel.nodes }}
+            - host: {{ .host }}
+              port: {{ .port }}
+            {{- end }}
+        {{- end }}
+        {{- if (not (empty ($ds.redis.operation))) }}
+        operation:
+          timeout: {{ $ds.redis.operation.timeout | default "10" }}
+        {{- end }}
+        {{- if (not (empty ($ds.redis.tcp))) }}
+        tcp:
+          connectTimeout: {{ $ds.redis.tcp.connectTimeout | default "5000" }}
+          idleTimeout: {{ $ds.redis.tcp.idleTimeout | default "0" }}
+        {{- end }}
+      {{- end }}
+{{- end -}}
+{{- end -}}

--- a/helm/templates/gateway/_gateway-helpers.tpl
+++ b/helm/templates/gateway/_gateway-helpers.tpl
@@ -181,6 +181,55 @@ Logic:
 - Phase 3: check top-level gateway.httpRoute (if enabled with hostnames).
 Returns the URL as https://host/path or empty string if no route is found.
 */}}
+{{/*
+Hazelcast cluster name for gateway node clustering (distributed sync primary election).
+Defaults to "<release-fullname>-<sharding-tags-slug>" so clusterId changes when sharding_tags change.
+Override with gateway.cluster.hazelcast.clusterName when needed.
+Redis distributed-event keys are scoped by runtime clusterId derived from this name.
+*/}}
+{{- define "gateway.distributedSync.enabled" -}}
+{{- $ds := .Values.gateway.distributedSync -}}
+{{- if kindIs "bool" $ds -}}
+{{- if $ds -}}true{{- end -}}
+{{- else if kindIs "map" $ds -}}
+{{- if not (hasKey $ds "enabled") -}}true
+{{- else if $ds.enabled -}}true
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Fail when distributed sync is enabled without gateway Hazelcast clustering.
+Included from always-rendered templates (e.g. deployment) so external-config installs are covered.
+*/}}
+{{- define "gateway.distributedSync.validate" -}}
+{{- if include "gateway.distributedSync.enabled" . -}}
+{{- if ne (dig "cluster" "type" "" .Values.gateway) "hazelcast" -}}
+{{- fail "gateway.cluster.type must be set to hazelcast when gateway.distributedSync is enabled (cluster-scoped Redis requires a dedicated Hazelcast cluster per gateway Helm release)" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "gateway.cluster.hazelcast.clusterName" -}}
+{{- if dig "cluster" "hazelcast" "clusterName" "" .Values.gateway -}}
+{{- .Values.gateway.cluster.hazelcast.clusterName | trim | trunc 63 | trimSuffix "-" -}}
+{{- else if .Values.gateway.sharding_tags -}}
+{{- $tagsSlug := .Values.gateway.sharding_tags | lower | replace " " "" | replace "," "-" | replace "!" "not-" -}}
+{{- $maxBaseLen := sub 63 (add (len $tagsSlug) 1) | int -}}
+{{- if not (gt $maxBaseLen 0) -}}
+{{- fail (printf "gateway.cluster.hazelcast.clusterName must be set explicitly: sharding_tags %q is too long for a derived Hazelcast cluster name (63 character limit)" .Values.gateway.sharding_tags) -}}
+{{- end -}}
+{{- $base := include "gravitee.gateway.fullname" . | trunc $maxBaseLen | trimSuffix "-" -}}
+{{- $derived := printf "%s-%s" $base $tagsSlug -}}
+{{- if gt (len $derived) 63 -}}
+{{- fail (printf "gateway.cluster.hazelcast.clusterName must be set explicitly: cannot derive a unique cluster name for sharding_tags %q (release/fullname too long). Set gateway.cluster.hazelcast.clusterName" .Values.gateway.sharding_tags) -}}
+{{- end -}}
+{{- $derived -}}
+{{- else -}}
+{{- include "gravitee.gateway.fullname" . | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "gateway.route.portalEntrypointUrl" -}}
 {{- $result := dict "url" "" -}}
 {{- $servers := default (list) .Values.gateway.servers -}}

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.gateway.enabled) (or (not (include "gateway.externalConfig" .)) (.Values.gateway.logging.debug) (.Values.gateway.logback.override)) -}}
+{{- include "gateway.distributedSync.validate" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -33,82 +34,12 @@ data:
       type: {{ .Values.gateway.cluster.type }}
       {{- if eq .Values.gateway.cluster.type "hazelcast" }}
       hazelcast:
-        config-path: {{ .Values.gateway.cluster.hazelcast.configPath }}
+        config-path: {{ dig "cluster" "hazelcast" "configPath" "${gravitee.home}/config/hazelcast.xml" .Values.gateway }}
       {{- end }}
     {{- end }}
 
-    {{- if .Values.gateway.distributedSync }}
-    distributed-sync:
-      type: {{ .Values.gateway.distributedSync.type }}
-      {{- if eq .Values.gateway.distributedSync.type "redis" }}
-      redis:
-        host: {{ .Values.gateway.distributedSync.redis.host }}
-        port: {{ .Values.gateway.distributedSync.redis.port }}
-        {{- if .Values.gateway.distributedSync.redis.username }}
-        username: {{ .Values.gateway.distributedSync.redis.username }}
-        {{- end }}
-        {{- if .Values.gateway.distributedSync.redis.password }}
-        password: {{ .Values.gateway.distributedSync.redis.password }}
-        {{- end }}
-        {{- if .Values.gateway.distributedSync.redis.ssl }}
-        ssl: {{ .Values.gateway.distributedSync.redis.ssl }}
-        hostnameVerificationAlgorithm: {{ .Values.gateway.distributedSync.redis.hostnameVerificationAlgorithm | default "NONE" }}
-        trustAll: {{ if hasKey .Values.gateway.distributedSync.redis "trustAll" }}{{ .Values.gateway.distributedSync.redis.trustAll }}{{else}}true{{end}}
-        tlsProtocols: {{ .Values.gateway.distributedSync.redis.tlsProtocols | default "TLSv1.2" }}
-        {{- if .Values.gateway.distributedSync.redis.tlsCiphers }}
-        tlsCiphers: {{ .Values.gateway.distributedSync.redis.tlsCiphers | quote }}
-        {{- end }}
-        alpn: {{ .Values.gateway.distributedSync.redis.alpn | default false }}
-        openssl: {{ .Values.gateway.distributedSync.redis.openssl | default false }}
-        {{- end }}
-        {{- if .Values.gateway.distributedSync.redis.keystore }}
-        keystore:
-          type: {{ .Values.gateway.distributedSync.redis.keystore.type | default "pem" }}
-          path: {{ .Values.gateway.distributedSync.redis.keystore.path | default "${gravitee.home}/security/redis-keystore.jks" }}
-          password: {{ required "The password required to access the keystore must be provided (i.e.kubernetes://{{NAMESPACE}}/secrets/{{SECRET_NAME}}/{{KEY_NAME}})" .Values.gateway.distributedSync.redis.keystore.password }}
-          {{- if .Values.gateway.distributedSync.redis.keystore.keyPassword }}
-          keyPassword: {{ .Values.gateway.distributedSync.redis.keystore.keyPassword | quote }}
-          {{- end }}
-          {{- if .Values.gateway.distributedSync.redis.keystore.alias }}
-          alias: {{ .Values.gateway.distributedSync.redis.keystore.alias }}
-          {{- end }}
-          {{- if and ( eq .Values.gateway.distributedSync.redis.keystore.type "pem" ) ( empty .Values.gateway.distributedSync.redis.keystore.certificates ) }}
-            {{ fail "When configuring Gravitee to use a keystore for mTLS, your certificates must be provided!" }}
-          {{- end }}
-          certificates:
-            {{- range .Values.gateway.distributedSync.redis.keystore.certificates }}
-            - cert: {{ .cert }}
-              key: {{ .key }}
-            {{- end }}
-        {{- end}}
-        {{- if .Values.gateway.distributedSync.redis.truststore }}
-        truststore:
-          type: {{ .Values.gateway.distributedSync.redis.truststore.type | default "pem" }}
-          path: {{ .Values.gateway.distributedSync.redis.truststore.path | default "${gravitee.home}/security/redis-truststore.jks" }}
-          password: {{ required "The password required to access the truststore must be provided! (i.e.kubernetes://{{NAMESPACE}}/secrets/{{SECRET_NAME}}/{{KEY_NAME}})" .Values.gateway.distributedSync.redis.truststore.password }}
-          {{- if .Values.gateway.distributedSync.redis.truststore.alias }}
-          alias: {{ .Values.gateway.distributedSync.redis.truststore.alias }}
-          {{- end }}
-        {{- end }}
-        {{- if (not (empty ((.Values.gateway.distributedSync.redis.sentinel).nodes))) }}
-        sentinel:
-          master: {{ .Values.gateway.distributedSync.redis.sentinel.master }}
-          nodes:
-            {{- range .Values.gateway.distributedSync.redis.sentinel.nodes }}
-            - host: {{ .host }}
-              port: {{ .port }}
-            {{- end }}
-        {{- end }}
-        {{- if (not (empty (.Values.gateway.distributedSync.redis.operation))) }}
-        operation:
-          timeout: {{ .Values.gateway.distributedSync.redis.operation.timeout | default "10" }}
-        {{- end }}
-        {{- if (not (empty (.Values.gateway.distributedSync.redis.tcp))) }}
-        tcp:
-          connectTimeout: {{ .Values.gateway.distributedSync.redis.tcp.connectTimeout | default "5000" }}
-          idleTimeout: {{ .Values.gateway.distributedSync.redis.tcp.idleTimeout | default "0" }}
-        {{- end }}
-      {{- end }}
+    {{- if include "gateway.distributedSync.enabled" . }}
+    {{- include "gateway.distributedSync.graviteeYaml" . }}
     {{- end }}
     # Gateway HTTP server
     {{- if .Values.gateway.servers }}
@@ -788,7 +719,24 @@ data:
               password: {{ .Values.gateway.services.core.http.ssl.keystore.password }}
           {{- end }}
 
+{{- if include "gateway.distributedSync.enabled" . }}
+      sync:
+        enabled: true
+        repository:
+          enabled: true
+        distributed:
+          enabled: true
+{{- with .Values.gateway.services.sync }}
+{{- if .delay }}
+        delay: {{ .delay }}
+{{- end }}
+{{- if .unit }}
+        unit: {{ .unit }}
+{{- end }}
+{{- end }}
+{{- else }}
       sync: {{ toYaml .Values.gateway.services.sync | nindent 8 }}
+{{- end }}
 
       {{- if .Values.gateway.services.ratelimit }}
       {{- if .Values.gateway.services.ratelimit.async }}
@@ -950,6 +898,36 @@ data:
     {{- end}}
 
   {{- end }}
+{{- if eq (dig "cluster" "type" "" .Values.gateway) "hazelcast" }}
+{{- $hzClusterPort := dig "cluster" "hazelcast" "port" 5701 .Values.gateway }}
+  hazelcast.xml: |-
+    <?xml version="1.0" encoding="UTF-8"?>
+    <hazelcast xmlns="http://www.hazelcast.com/schema/config"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.hazelcast.com/schema/config
+               http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
+        <cluster-name>{{ include "gateway.cluster.hazelcast.clusterName" . }}</cluster-name>
+        <properties>
+            <property name="hazelcast.discovery.enabled">true</property>
+            <property name="hazelcast.max.wait.seconds.before.join">3</property>
+            <property name="hazelcast.member.list.publish.interval.seconds">5</property>
+            <property name="hazelcast.socket.client.bind.any">false</property>
+            <property name="hazelcast.logging.type">slf4j</property>
+        </properties>
+        <network>
+            <port auto-increment="true" port-count="100">{{ $hzClusterPort }}</port>
+            <join>
+                <multicast enabled="false"/>
+                <tcp-ip enabled="false"/>
+                <kubernetes enabled="true">
+                    <namespace>{{ .Release.Namespace }}</namespace>
+                    <service-name>{{ template "gravitee.gateway.fullname" . }}-hz</service-name>
+                    <service-port>{{ $hzClusterPort }}</service-port>
+                </kubernetes>
+            </join>
+        </network>
+    </hazelcast>
+{{- end }}
 {{- if eq .Values.ratelimit.type "hazelcast" }}
 {{- $hzCfg := dict }}
 {{- if and .Values.gateway.ratelimit (kindIs "map" .Values.gateway.ratelimit) }}{{ $hzCfg = (.Values.gateway.ratelimit.hazelcast | default dict) }}{{ end }}

--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.gateway.enabled -}}
+{{- include "gateway.distributedSync.validate" . -}}
 {{- $initContainers := .Values.initContainers -}}
 {{- $serviceAccount := include "apim.serviceAccount" . -}}
 {{- $logbackVolumeName := include "gateway.logbackVolumeName" . -}}
@@ -263,6 +264,11 @@ spec:
             - name: config
               mountPath: /opt/graviteeio-gateway/config/gravitee.yml
               subPath: gravitee.yml
+          {{- if and (eq (dig "cluster" "type" "" .Values.gateway) "hazelcast") (not (include "gateway.externalConfig" .)) }}
+            - name: config
+              mountPath: /opt/graviteeio-gateway/config/hazelcast.xml
+              subPath: hazelcast.xml
+          {{- end }}
           {{- if and (eq .Values.ratelimit.type "hazelcast") (not (include "gateway.externalConfig" .)) }}
             - name: config
               mountPath: /opt/graviteeio-gateway/config/hazelcast-ratelimit.xml

--- a/helm/templates/gateway/gateway-hz-service.yaml
+++ b/helm/templates/gateway/gateway-hz-service.yaml
@@ -2,6 +2,7 @@
 {{- $hzCfg := dict }}
 {{- if and .Values.gateway.ratelimit (kindIs "map" .Values.gateway.ratelimit) }}{{ $hzCfg = (.Values.gateway.ratelimit.hazelcast | default dict) }}{{ end }}
 {{- $hzRateLimitPort := $hzCfg.port | default 5901 }}
+{{- $hzClusterPort := dig "cluster" "hazelcast" "port" 5701 .Values.gateway }}
 {{- if $hzActive }}
 apiVersion: v1
 kind: Service
@@ -35,8 +36,8 @@ spec:
       name: {{ printf "%s-%s" (.Values.gateway.name | trunc 56 | trimSuffix "-") "hz-rl" }}
     {{- end }}
     {{- if eq (dig "cluster" "type" "" .Values.gateway) "hazelcast" }}
-    - port: 5701
-      targetPort: 5701
+    - port: {{ $hzClusterPort }}
+      targetPort: {{ $hzClusterPort }}
       protocol: TCP
       name: {{ printf "%s-%s" (.Values.gateway.name | trunc 56 | trimSuffix "-") "hz-cl" }}
     {{- end }}

--- a/helm/tests/gateway/configmap_distributed_sync_test.yaml
+++ b/helm/tests/gateway/configmap_distributed_sync_test.yaml
@@ -6,6 +6,8 @@ tests:
     template: gateway/gateway-configmap.yaml
     set:
       gateway:
+        cluster:
+          type: hazelcast
         distributedSync:
           enabled: true
           type: redis
@@ -26,6 +28,8 @@ tests:
     template: gateway/gateway-configmap.yaml
     set:
       gateway:
+        cluster:
+          type: hazelcast
         distributedSync:
           enabled: true
           type: redis
@@ -50,6 +54,8 @@ tests:
     template: gateway/gateway-configmap.yaml
     set:
       gateway:
+        cluster:
+          type: hazelcast
         distributedSync:
           enabled: true
           type: redis
@@ -79,6 +85,8 @@ tests:
     template: gateway/gateway-configmap.yaml
     set:
       gateway:
+        cluster:
+          type: hazelcast
         distributedSync:
           enabled: true
           type: redis
@@ -109,6 +117,8 @@ tests:
     template: gateway/gateway-configmap.yaml
     set:
       gateway:
+        cluster:
+          type: hazelcast
         distributedSync:
           enabled: true
           type: redis
@@ -143,6 +153,8 @@ tests:
     template: gateway/gateway-configmap.yaml
     set:
       gateway:
+        cluster:
+          type: hazelcast
         distributedSync:
           enabled: true
           type: redis

--- a/helm/tests/gateway/configmap_hazelcast_cluster_test.yaml
+++ b/helm/tests/gateway/configmap_hazelcast_cluster_test.yaml
@@ -1,0 +1,259 @@
+suite: Test Gateway configmap - Hazelcast cluster (distributed sync)
+templates:
+  - "gateway/gateway-configmap.yaml"
+  - "gateway/gateway-deployment.yaml"
+tests:
+  - it: configmap omits hazelcast.xml when gateway cluster is not hazelcast
+    template: gateway/gateway-configmap.yaml
+    asserts:
+      - notExists:
+          path: data["hazelcast.xml"]
+
+  - it: configmap renders hazelcast.xml with release name when cluster is hazelcast
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        cluster:
+          type: hazelcast
+    asserts:
+      - exists:
+          path: data["hazelcast.xml"]
+      - matchRegex:
+          path: data["hazelcast.xml"]
+          pattern: "<cluster-name>RELEASE-NAME-apim-gateway</cluster-name>"
+      - matchRegex:
+          path: data["hazelcast.xml"]
+          pattern: "<service-name>RELEASE-NAME-apim-gateway-hz</service-name>"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "config-path: \\$\\{gravitee.home\\}/config/hazelcast.xml"
+
+  - it: configmap derives cluster-name from sharding tags
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        sharding_tags: external
+        cluster:
+          type: hazelcast
+    asserts:
+      - matchRegex:
+          path: data["hazelcast.xml"]
+          pattern: "<cluster-name>RELEASE-NAME-apim-gateway-external</cluster-name>"
+
+  - it: configmap uses explicit clusterName override
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        sharding_tags: external
+        cluster:
+          type: hazelcast
+          hazelcast:
+            clusterName: apim-gw-interop-eus2-01-pri-ext
+    asserts:
+      - matchRegex:
+          path: data["hazelcast.xml"]
+          pattern: "<cluster-name>apim-gw-interop-eus2-01-pri-ext</cluster-name>"
+
+  - it: configmap uses configured cluster hazelcast port
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        cluster:
+          type: hazelcast
+          hazelcast:
+            port: 5702
+    asserts:
+      - matchRegex:
+          path: data["hazelcast.xml"]
+          pattern: "<port auto-increment=\"true\" port-count=\"100\">5702</port>"
+      - matchRegex:
+          path: data["hazelcast.xml"]
+          pattern: "<service-port>5702</service-port>"
+
+  - it: configmap fails when distributedSync is enabled without gateway cluster
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        distributedSync:
+          enabled: true
+          type: redis
+          redis:
+            host: redis
+            port: 6379
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.cluster.type must be set to hazelcast when gateway.distributedSync is enabled (cluster-scoped Redis requires a dedicated Hazelcast cluster per gateway Helm release)"
+
+  - it: configmap enables sync repository and distributed when distributedSync is set
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        cluster:
+          type: hazelcast
+        distributedSync:
+          type: redis
+          redis:
+            host: redis-shared
+            port: 6379
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            distributed-sync:
+            \s*type: redis
+            \s*redis:
+            \s*host: redis-shared
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            sync:
+            \s*enabled: true
+            \s*repository:
+            \s*enabled: true
+            \s*distributed:
+            \s*enabled: true
+
+  - it: configmap omits distributed sync when enabled is false
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        distributedSync:
+          enabled: false
+          type: redis
+          redis:
+            host: redis
+            port: 6379
+    asserts:
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            distributed-sync:
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            sync:
+            \s*enabled: true
+            \s*repository:
+            \s*enabled: true
+            \s*distributed:
+            \s*enabled: true
+
+  - it: configmap does not fail when distributed sync is disabled without gateway cluster
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        distributedSync:
+          enabled: false
+          type: redis
+          redis:
+            host: redis
+            port: 6379
+    asserts:
+      - exists:
+          path: data["gravitee.yml"]
+
+  - it: deployment mounts hazelcast.xml when gateway cluster is hazelcast
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        cluster:
+          type: hazelcast
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /opt/graviteeio-gateway/config/hazelcast.xml
+            subPath: hazelcast.xml
+
+  - it: deployment omits hazelcast.xml mount when gateway cluster is not hazelcast
+    template: gateway/gateway-deployment.yaml
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /opt/graviteeio-gateway/config/hazelcast.xml
+            subPath: hazelcast.xml
+
+  - it: derives distinct cluster-names for sharding tags with long fullname
+    template: gateway/gateway-configmap.yaml
+    set:
+      fullnameOverride: gravitee-long-release-name-for-cluster-truncation-test
+      gateway:
+        sharding_tags: external
+        cluster:
+          type: hazelcast
+    asserts:
+      - matchRegex:
+          path: data["hazelcast.xml"]
+          pattern: "<cluster-name>gravitee-long-release-name-for-cluster-truncation-test-external</cluster-name>"
+
+  - it: derives different cluster-names for external and internal sharding tags
+    template: gateway/gateway-configmap.yaml
+    set:
+      fullnameOverride: gravitee-long-release-name-for-cluster-truncation-test
+      gateway:
+        sharding_tags: internal
+        cluster:
+          type: hazelcast
+    asserts:
+      - matchRegex:
+          path: data["hazelcast.xml"]
+          pattern: "<cluster-name>gravitee-long-release-name-for-cluster-truncation-test-internal</cluster-name>"
+
+  - it: fails when derived cluster name cannot include sharding tags
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        sharding_tags: this-is-an-extremely-long-sharding-tag-value-that-exceeds-the-hazelcast-cluster-name-limit
+        cluster:
+          type: hazelcast
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.cluster.hazelcast.clusterName must be set explicitly: sharding_tags \"this-is-an-extremely-long-sharding-tag-value-that-exceeds-the-hazelcast-cluster-name-limit\" is too long for a derived Hazelcast cluster name (63 character limit)"
+
+  - it: enables sync flags when distributedSync is boolean true without inline redis config
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        cluster:
+          type: hazelcast
+        distributedSync: true
+    asserts:
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            distributed-sync:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            sync:
+            \s*enabled: true
+            \s*repository:
+            \s*enabled: true
+            \s*distributed:
+            \s*enabled: true
+
+  - it: deployment fails when distributedSync enabled without hazelcast with external config
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        extraVolumes: |
+          - name: config
+            configMap:
+              name: external-gateway-config
+        distributedSync:
+          type: redis
+          redis:
+            host: redis
+            port: 6379
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.cluster.type must be set to hazelcast when gateway.distributedSync is enabled (cluster-scoped Redis requires a dedicated Hazelcast cluster per gateway Helm release)"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1265,16 +1265,50 @@ gateway:
   type: Deployment
   name: gateway
 
-  # Distributed sync configuration (requires replicaCount > 1)
-  # Uncomment below for Hazelcast cluster cache synchronization
+  # Distributed sync configuration (requires replicaCount > 1 and a dedicated Hazelcast cluster per Helm release).
+  # Deploy one gateway Helm release per sharding tag set (e.g. external, internal, aog). All releases may share
+  # the same Redis, but each must have a distinct Hazelcast cluster-name (clusterId) so distributed-event keys
+  # are isolated. By default cluster-name is "<release-name>-<sharding-tags>"; override with
+  # gateway.cluster.hazelcast.clusterName. If sharding_tags change, cluster-name must change too and stale
+  # distributed_event:* keys in Redis for the old clusterId must be deleted manually.
+  #
+  # Cluster name stability:
+  #   - Rolling upgrade with unchanged release name and sharding_tags → same HZ cluster and Redis namespace;
+  #     gateways reuse Redis state (incremental sync, no systematic full DB fetch).
+  #   - sharding_tags change → new cluster-name / clusterId → new HZ cluster; primary repopulates Redis.
+  #
+  # Deployment constraints (required when distributed sync is enabled):
+  #   Secondary gateways read distributed state from Redis; initial sync is one-shot. The primary pod must
+  #   populate Redis before secondaries join the Hazelcast cluster.
+  #
+  #   Fresh install — a Deployment cannot guarantee one-by-one pod creation:
+  #     1. Set replicaCount: 1 and install/upgrade.
+  #     2. Wait until the primary has synchronized (gateway ready, Redis holds distributed_sync_state and events).
+  #     3. Scale up one replica at a time (e.g. replicaCount: 2, then 3, …).
+  #
+  #   Upgrade — pods must join the HZ cluster one at a time:
+  #     Set gateway.deployment.strategy.rollingUpdate to maxUnavailable: 0 and maxSurge: 1 (see deployment
+  #     section below). Default chart values use maxUnavailable: 1; override when distributed sync is on.
+  #
+  #   Example rolling strategy when distributed sync is enabled:
+  #     deployment:
+  #       strategy:
+  #         type: RollingUpdate
+  #         rollingUpdate:
+  #           maxUnavailable: 0
+  #           maxSurge: 1
+  #
+  # Uncomment below for Hazelcast gateway clustering (required for distributed sync)
 #  cluster:
 #    type: hazelcast
 #    hazelcast:
-#      configPath: /opt/graviteeio-gateway/config/hazelcast.xml
+#      # Rendered automatically as config/hazelcast.xml when type is hazelcast
+#      # configPath: ${gravitee.home}/config/hazelcast.xml
+#      # clusterName: my-release-external   # optional; defaults to "<release>-<sharding_tags>"
+#      port: 5701
 
-  # Uncomment below to enable Redis-based distributed sync
+  # Uncomment below to enable Redis-based distributed sync (also enables services.sync.repository/distributed)
 #  distributedSync:
-#    enabled: true
 #    type: redis
 #    redis:
 #      host: redis
@@ -1646,6 +1680,8 @@ gateway:
     strategy:
       type: RollingUpdate
       rollingUpdate:
+        # When gateway.distributedSync is enabled, set maxUnavailable: 0 and maxSurge: 1 (see distributed
+        # sync comments at the top of the gateway section).
         maxUnavailable: 1
     topologySpreadConstraints: []
     # revisionHistoryLimit: 10
@@ -1714,7 +1750,9 @@ gateway:
   #    password: secret
   #  sni: true
   replicaCount: 1
-  # sharding_tags:
+  # One comma-separated sharding tag set per gateway Helm release (e.g. external, internal, aog).
+  # Must stay aligned with gateway.cluster.hazelcast.clusterName / default "<release>-<tags>" naming.
+  # sharding_tags: external
   # tenant:
   websocket: false
 #  haproxy: # Support for https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt


### PR DESCRIPTION
## Issue

Fixes cross-cluster API corruption when multiple gateway clusters (external / internal / AOG) share one Redis for distributed sync. Each primary was writing tag-filtered API payloads to global Redis keys; last writer wins caused secondaries to deploy partial APIs and log "There is no published plan associated to this API, skipping deployment...".

## Description

Scope distributed-event reads/writes by Hazelcast clusterId (derived from cluster-name). Helm renders hazelcast.xml, derives cluster-name from <release>-<sharding_tags>, and validates that distributed sync is paired with a dedicated Hazelcast cluster per Helm release.

Documented deployment constraints for distributed sync (primary must populate Redis before secondaries join):

Fresh install: replicaCount: 1, wait for primary sync, then scale up one replica at a time
Upgrade: maxUnavailable: 0, maxSurge: 1

See helm/README.md (Gateway distributed sync) and the comment block in helm/values.yaml.

### Changes

- Add clusterId to DistributedEvent model, criteria, and Redis keys/index
- Stamp clusterId on write; filter fetches by clusterManager.clusterId()
- New RediSearch index distributed-event-search-idx-v2 with TAG field on clusterId
- Runtime validation: fail if distributed sync is enabled but clusterId is null/blank
- Helm: auto-render hazelcast.xml; cluster-name defaults to <release>-<sharding_tags> with truncation that preserves tag suffix
- Helm: fail-fast if distributedSync without gateway.cluster.type=hazelcast (validated on deployment, including externalConfig installs)
- Helm: backward-compatible gateway.distributedSync — boolean true, map without enabled, and enabled: true are all supported
- Docs: distributed sync runbook in helm/README.md and helm/values.yaml

### Upgrade / breaking notes

- Redis migration required: old keys (distributed_event:API:...) are not read
- After upgrade: delete stale distributed_event:* and distributed_sync_state:* for old clusterIds; drop old search index if present; rolling restart gateways; allow resync
- DistributedEventRepository.updateAll() signature adds clusterId parameter
- Operational model: one Helm release per sharding-tag cluster; distinct Hazelcast cluster-name per release; shared Redis is OK. Changing sharding_tags changes clusterId — manual Redis cleanup required
- Rolling upgrade: when distributed sync is enabled, use maxUnavailable: 0 / maxSurge: 1 (documented; chart default remains maxUnavailable: 1)

### Out of scope (follow-up)

- Resilience: secondary handover when Redis state is empty (architect round 2)
- Clone / full API payload to Redis with consumer-side PlanAppender

## Additional context

<img width="1816" height="1082" alt="image" src="https://github.com/user-attachments/assets/29498ac5-9046-4879-a327-da232bd13e70" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

