### PR TITLE
feat: add path setter to HttpRequestInternal to allow entrypoints to …

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
@@ -236,6 +236,12 @@ public abstract class AbstractRequest implements MutableRequest, HttpRequestInte
     }
 
     @Override
+    public HttpRequestInternal path(String path) {
+        this.path = path;
+        return this;
+    }
+
+    @Override
     public MutableRequest pathInfo(String pathInfo) {
         this.pathInfo = pathInfo;
         return this;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/HttpRequestInternal.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/HttpRequestInternal.java
@@ -37,6 +37,14 @@ public interface HttpRequestInternal extends HttpRequest, OnMessagesInterceptor<
     }
 
     /**
+     * Allow setting path.
+     *
+     * @param path the path to set.
+     * @return {@link HttpRequestInternal}.
+     */
+    HttpRequestInternal path(final String path);
+
+    /**
      * Allow setting path info.
      *
      * @param pathInfo the path info to set.


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14363

## Description

Adds a `path(String)` setter to `HttpRequestInternal` so entrypoints can override the request path
exposed to policies and Expression Language (`{#request.path}`).

Previously, only `pathInfo` could be overridden, which meant entrypoints that transform an incoming
request into a different operation (e.g., MCP tool call → `GET /foo `) were invisible to path-based
policies — they would see the original entrypoint path instead of the transformed operation path.

## Additional context
This is part 1 of 2 — the setter in core. Part 2 (usage in the MCP Tool Server entrypoint) will
follow in `gravitee-entrypoint-mcp-tool-server`.

