### PR TITLE
fix: distinguish "not yet started" from "expired" subscription error message

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/SecurityChainDiagnostic.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/SecurityChainDiagnostic.java
@@ -28,6 +28,7 @@ public class SecurityChainDiagnostic {
     private static final String MESSAGE_INVALID_TOKEN = "The provided authentication token is invalid";
     private static final String MESSAGE_NOT_AUTHORIZED = "The provided credentials are not authorized";
     private static final String MESSAGE_EXPIRED = "Access has expired for the provided credentials";
+    private static final String MESSAGE_NOT_YET_STARTED = "The subscription has not yet started for the provided credentials";
     private static final String MESSAGE_NO_PLAN_MATCHED = "No plan matched the request";
     private static final String MESSAGE_NO_TOKEN = "The request did not include an authentication token";
     private static final String MESSAGE_UNAUTHORIZED = "Unauthorized";
@@ -39,6 +40,7 @@ public class SecurityChainDiagnostic {
     List<String> noMatchingRulePlans;
     List<NoSubscriptionInfo> noSubscriptionPlans;
     List<String> expiredSubscriptionPlans;
+    List<String> notYetStartedSubscriptionPlans;
 
     private record NoSubscriptionInfo(String planName, String tokenType, String maskedToken) {}
 
@@ -93,6 +95,13 @@ public class SecurityChainDiagnostic {
         expiredSubscriptionPlans.add(planName + " (application: " + applicationName + ")");
     }
 
+    public void markPlanHasNotYetStartedSubscription(String planName, String applicationName) {
+        if (notYetStartedSubscriptionPlans == null) {
+            notYetStartedSubscriptionPlans = new ArrayList<>();
+        }
+        notYetStartedSubscriptionPlans.add(planName + " (application: " + applicationName + ")");
+    }
+
     public void markPlanHasInvalidToken(String planName) {
         if (invalidTokenPlans == null) {
             invalidTokenPlans = new ArrayList<>();
@@ -117,6 +126,10 @@ public class SecurityChainDiagnostic {
             return MESSAGE_EXPIRED;
         }
 
+        if (notYetStartedSubscriptionPlans != null) {
+            return MESSAGE_NOT_YET_STARTED;
+        }
+
         if (noMatchingRulePlans != null) {
             return MESSAGE_NO_PLAN_MATCHED;
         }
@@ -139,6 +152,10 @@ public class SecurityChainDiagnostic {
 
         if (expiredSubscriptionPlans != null) {
             return new Exception("The subscription has expired for the following " + formatPlans(expiredSubscriptionPlans));
+        }
+
+        if (notYetStartedSubscriptionPlans != null) {
+            return new Exception("The subscription has not yet started for the following " + formatPlans(notYetStartedSubscriptionPlans));
         }
 
         if (noMatchingRulePlans != null) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/AbstractSecurityPlan.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/AbstractSecurityPlan.java
@@ -37,6 +37,7 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import jakarta.annotation.Nonnull;
+import java.util.Date;
 import java.util.Optional;
 import lombok.CustomLog;
 
@@ -170,7 +171,12 @@ public abstract class AbstractSecurityPlan<T extends BaseSecurityPolicy, C exten
                     ctx.setInternalAttribute(ATTR_INTERNAL_SUBSCRIPTION, subscription);
                     return true;
                 }
-                securityChainDiagnostic.markPlanHasExpiredSubscription(planContext.planName(), subscription.getApplicationName());
+                Date startingAt = subscription.getStartingAt();
+                if (startingAt != null && startingAt.after(new Date(ctx.timestamp()))) {
+                    securityChainDiagnostic.markPlanHasNotYetStartedSubscription(planContext.planName(), subscription.getApplicationName());
+                } else {
+                    securityChainDiagnostic.markPlanHasExpiredSubscription(planContext.planName(), subscription.getApplicationName());
+                }
             } else {
                 securityChainDiagnostic.markPlanHasNoSubscription(
                     planContext.planName(),

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/security/SecurityChainDiagnosticTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/security/SecurityChainDiagnosticTest.java
@@ -80,6 +80,15 @@ class SecurityChainDiagnosticTest {
         }
 
         @Test
+        @DisplayName("Should return not yet started message when verbose401 is true")
+        void shouldReturnNotYetStartedMessage() {
+            var verbose = new SecurityChainDiagnostic(true);
+            verbose.markPlanHasNotYetStartedSubscription("plan1", "app1");
+
+            assertThat(verbose.message()).isEqualTo("The subscription has not yet started for the provided credentials");
+        }
+
+        @Test
         @DisplayName("Should return no plan matched message when verbose401 is true")
         void shouldReturnNoMatchingRuleMessage() {
             var verbose = new SecurityChainDiagnostic(true);
@@ -253,6 +262,21 @@ class SecurityChainDiagnosticTest {
         }
 
         @Test
+        @DisplayName("Should return exception for not yet started subscription plans")
+        void shouldReturnExceptionForNotYetStartedSubscriptionPlans() {
+            // Given
+            diagnostic.markPlanHasNotYetStartedSubscription("plan1", "app1");
+
+            // When
+            Exception cause = diagnostic.cause();
+
+            // Then
+            assertThat(cause.getMessage()).isEqualTo(
+                "The subscription has not yet started for the following plan: plan1 (application: app1)"
+            );
+        }
+
+        @Test
         @DisplayName("Should return exception for no matching rule plans")
         void shouldReturnExceptionForNoMatchingRulePlans() {
             // Given
@@ -318,6 +342,36 @@ class SecurityChainDiagnosticTest {
 
             // Then
             assertThat(cause.getMessage()).isEqualTo("No subscription was found for API Key: sh***rt (plan: plan2)");
+        }
+
+        @Test
+        @DisplayName("Should prioritize expired subscription over not yet started subscription")
+        void shouldPrioritizeExpiredSubscriptionOverNotYetStarted() {
+            // Given
+            diagnostic.markPlanHasNotYetStartedSubscription("plan1", "app1");
+            diagnostic.markPlanHasExpiredSubscription("plan2", "app2");
+
+            // When
+            Exception cause = diagnostic.cause();
+
+            // Then
+            assertThat(cause.getMessage()).isEqualTo("The subscription has expired for the following plan: plan2 (application: app2)");
+        }
+
+        @Test
+        @DisplayName("Should prioritize not yet started subscription over no matching rule")
+        void shouldPrioritizeNotYetStartedSubscriptionOverNoMatchingRule() {
+            // Given
+            diagnostic.markPlanHasNoMachingRule("plan1");
+            diagnostic.markPlanHasNotYetStartedSubscription("plan2", "app1");
+
+            // When
+            Exception cause = diagnostic.cause();
+
+            // Then
+            assertThat(cause.getMessage()).isEqualTo(
+                "The subscription has not yet started for the following plan: plan2 (application: app1)"
+            );
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/security/plan/HttpSecurityPlanTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/security/plan/HttpSecurityPlanTest.java
@@ -44,6 +44,7 @@ import io.gravitee.gateway.reactive.handlers.api.security.plan.SecurityPlanConte
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.observers.TestObserver;
+import java.util.Date;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -224,6 +225,33 @@ class HttpSecurityPlanTest {
         verify(subscriptionService).getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID);
         obs.assertResult(false);
         verify(ctx, times(1)).setInternalAttribute(eq(ATTR_INTERNAL_SECURITY_TOKEN), any());
+    }
+
+    @Test
+    void canExecute_shouldReturnFalse_whenPolicyHasSecurityToken_butFoundSubscriptionHasNotYetStarted() {
+        long now = System.currentTimeMillis();
+        when(ctx.getComponent(SubscriptionService.class)).thenReturn(subscriptionService);
+        when(ctx.getInternalAttribute(ATTR_INTERNAL_SECURITY_DIAGNOSTIC)).thenReturn(securityChainDiagnostic);
+        when(policy.requireSubscription(ctx)).thenReturn(true);
+        when(policy.extractSecurityToken(ctx)).thenReturn(Maybe.just(securityToken));
+        when(plan.getId()).thenReturn(PLAN_ID);
+        when(ctx.getAttribute(ContextAttributes.ATTR_API)).thenReturn(API_ID);
+        when(ctx.timestamp()).thenReturn(now);
+
+        // subscription found but with a future start date
+        final Subscription subscription = mock(Subscription.class);
+        when(subscription.getPlan()).thenReturn(PLAN_ID);
+        when(subscription.isTimeValid(anyLong())).thenReturn(false);
+        when(subscription.getStartingAt()).thenReturn(new Date(now + 86_400_000)); // tomorrow
+        when(subscriptionService.getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID)).thenReturn(Optional.of(subscription));
+
+        final HttpSecurityPlan cut = new HttpSecurityPlan(SecurityPlanContext.builder().fromV2(plan).build(), policy);
+        final TestObserver<Boolean> obs = cut.canExecute(ctx).test();
+
+        verify(subscriptionService).getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID);
+        verify(securityChainDiagnostic).markPlanHasNotYetStartedSubscription(any(), any());
+        verify(securityChainDiagnostic, never()).markPlanHasExpiredSubscription(any(), any());
+        obs.assertResult(false);
     }
 
     @Test


### PR DESCRIPTION
## Purpose

Fix the misleading error message when a subscription has a future "Start At" date - the gateway incorrectly reports the subscription has "expired" instead of "not yet started".

## Summary of changes

- **SecurityChainDiagnostic**: Added a new notYetStartedSubscriptionPlans tracking list with dedicated markPlanHasNotYetStartedSubscription() method, and corresponding entries in message() and cause() with appropriate priority (after expired, before no matching rule).
- **AbstractSecurityPlan**: When isTimeValid() returns false, now checks whether startingAt is in the future to distinguish "not yet started" from "expired" and calls the appropriate diagnostic method.
- **Tests**: Added unit tests for the new message/cause in SecurityChainDiagnosticTest (message, cause, priority) and a new test in HttpSecurityPlanTest verifying the correct diagnostic is called for not-yet-started subscriptions.

## Out of scope

- The v1 security chain (CheckSubscriptionPolicy in gravitee-apim-gateway-security-jwt and gravitee-apim-gateway-security-oauth2) — these don't use SecurityChainDiagnostic and have no verbose error messaging.
- Exposing cause in response templates via EvaluableExecutionFailure — currently only message is available.

## Testing

- Unit tests: 45 tests passing in SecurityChainDiagnosticTest and HttpSecurityPlanTest.
- Local reproduction: With verbose401=true, confirmed the wrong message ("Access has expired") before the fix and the correct message ("The subscription has not yet started") after patching the gateway jar.
- Remote reproduction (4.10): Reproduced the bug on apim-4-10-x — confirmed the gateway logs show "The subscription has expired" for a subscription with a future start date.

## Related PRs / tickets

https://gravitee.atlassian.net/browse/APIM-14490

## Demo

**Before fix:**

https://github.com/user-attachments/assets/98d4b25c-9271-43db-8a69-7fbc0dbd2f53

**After fix:**


https://github.com/user-attachments/assets/d3884360-7ee3-4dab-9f61-c58f2a994227

