### PR TITLE
chore(distribution): bundle token-bucket rate-limit policy (5.0.0-alpha.5)

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -717,6 +717,19 @@
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
+            <artifactId>gravitee-policy-token-bucket-ratelimit</artifactId>
+            <version>${gravitee-policy-ratelimit.version}</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-regex-threat-protection</artifactId>
             <version>${gravitee-policy-regex-threat-protection.version}</version>
             <type>zip</type>

--- a/pom.xml
+++ b/pom.xml
@@ -219,10 +219,11 @@
         <gravitee-policy-oas-validation.version>1.2.3</gravitee-policy-oas-validation.version>
         <gravitee-policy-openid-connect-userinfo.version>1.7.0</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>2.2.1</gravitee-policy-override-http-method.version>
-        <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
-        <!--    <gravitee-policy-quota.version>4.3.0</gravitee-policy-quota.version>    -->
-        <!--    <gravitee-policy-spikearrest.version>4.3.0</gravitee-policy-spikearrest.version>    -->
-        <gravitee-policy-ratelimit.version>4.3.0</gravitee-policy-ratelimit.version>
+        <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest, policy-token-bucket-ratelimit and gateway-services-ratelimit    -->
+        <!--    <gravitee-policy-quota.version>5.0.0-alpha.5</gravitee-policy-quota.version>    -->
+        <!--    <gravitee-policy-spikearrest.version>5.0.0-alpha.5</gravitee-policy-spikearrest.version>    -->
+        <!--    <gravitee-policy-token-bucket-ratelimit.version>5.0.0-alpha.5</gravitee-policy-token-bucket-ratelimit.version>    -->
+        <gravitee-policy-ratelimit.version>5.0.0-alpha.5</gravitee-policy-ratelimit.version>
         <gravitee-policy-regex-threat-protection.version>1.6.0</gravitee-policy-regex-threat-protection.version>
         <gravitee-policy-request-content-limit.version>1.8.1</gravitee-policy-request-content-limit.version>
         <gravitee-policy-request-validation.version>1.15.1</gravitee-policy-request-validation.version>


### PR DESCRIPTION
## What

Wires the **token-bucket rate-limit policy** into `gravitee-apim-distribution`, and aligns the whole rate-limit policy bundle to **`5.0.0-alpha.5`**.

- `gravitee-apim-distribution/pom.xml`: add `gravitee-policy-token-bucket-ratelimit` as a runtime `zip` plugin (same shape as the sibling rate-limit policies).
- `pom.xml`: bump `gravitee-policy-ratelimit.version` → `5.0.0-alpha.5`. That single property versions the whole bundle from the `gravitee-policy-ratelimit` repo — `policy-quota`, `policy-spikearrest`, `policy-token-bucket-ratelimit` and `gateway-services-ratelimit` — so they all move together (commented per-policy properties kept in sync as documentation).

Part of **APIM-14485** (epic APIM-14481).

## Why `5.0.0-alpha.5` for the whole bundle

Token-bucket only exists from the `5.0.0` line of the rate-limit bundle, which targets APIM 4.12 (the breaking change). Since this distribution is on `4.12.x`, the bundle must be on `5.x` per the policy's compatibility matrix. All five artifacts are published at `5.0.0-alpha.5` and resolve from the Gravitee repository, so the distribution build is unaffected.

## Scope / notes

- **Distribution wiring only.** The mvn integration test from the original story was **dropped**: the gateway-tests-sdk uses mock/NoOp repository beans (no token-bucket repo, no real-plugin loading), so a rate-limit policy can't be exercised against a real store there. Backend storage is covered by the repository contract matrix (Mongo/Redis/JDBC×dialects/Hazelcast); end-to-end is validated by the smoke test below.
- **Smoke test (pending):** real apim-worktree run (mAPI + gateway on MongoDB) of the customer scenario — `refillRate=3/s`, `burstCapacity=300` → 300 pass, 301 → `429` + `Retry-After`, ~1s later 3 more pass, `X-Rate-Limit-*` asserted.

## Release gating (do not merge to a GA `4.12.x` as-is)

`5.0.0-alpha.x` is a **prerelease** that transitively pins apim `4.12.0-milestone.6-SNAPSHOT`. Two consequences:
- The policy bundle's **Maven Central** publish currently fails (Central forbids SNAPSHOT dependencies) — it only publishes to the Gravitee repo, which is why this distribution build still resolves it.
- Before `4.12.x` ships, apim must publish a **non-SNAPSHOT** 4.12 prerelease containing the token-bucket SPI (e.g. `4.12.0-milestone.6`), the policy bundle must re-release against it, and this property must move to that released policy version (e.g. `5.0.0`).

Refs: APIM-14485, APIM-14481