### PR TITLE
fix(subscription): preserve form metadata on portal configuration update

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResourceTest.java
@@ -17,6 +17,8 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static jakarta.ws.rs.client.Entity.json;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.*;
@@ -35,8 +37,10 @@ import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * @author GraviteeSource Team
@@ -135,6 +139,42 @@ public class ApplicationSubscriptionResourceTest extends AbstractResourceTest {
         verify(subscriptionService).findById(SUBSCRIPTION_ID);
         verify(subscriptionService).update(eq(GraviteeContext.getExecutionContext()), any(UpdateSubscriptionConfigurationEntity.class));
         verifyNoMoreInteractions(subscriptionService);
+    }
+
+    @Test
+    public void should_set_updateMetadata_when_metadata_provided() {
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(fakeSubscriptionEntity);
+
+        UpdateSubscriptionConfigurationEntity entity = new UpdateSubscriptionConfigurationEntity();
+        entity.setMetadata(Map.of("key", "value"));
+
+        when(
+            subscriptionService.update(eq(GraviteeContext.getExecutionContext()), any(UpdateSubscriptionConfigurationEntity.class))
+        ).thenReturn(new SubscriptionEntity());
+
+        Response response = envTarget(SUBSCRIPTION_ID).request().put(json(entity));
+
+        assertEquals(200, response.getStatus());
+        ArgumentCaptor<UpdateSubscriptionConfigurationEntity> captor = ArgumentCaptor.forClass(UpdateSubscriptionConfigurationEntity.class);
+        verify(subscriptionService).update(eq(GraviteeContext.getExecutionContext()), captor.capture());
+        assertTrue(captor.getValue().isUpdateMetadata());
+    }
+
+    @Test
+    public void should_keep_updateMetadata_true_even_when_no_metadata_in_body() {
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(fakeSubscriptionEntity);
+        UpdateSubscriptionConfigurationEntity entity = new UpdateSubscriptionConfigurationEntity();
+
+        when(
+            subscriptionService.update(eq(GraviteeContext.getExecutionContext()), any(UpdateSubscriptionConfigurationEntity.class))
+        ).thenReturn(new SubscriptionEntity());
+
+        Response response = envTarget(SUBSCRIPTION_ID).request().put(json(entity));
+
+        assertEquals(200, response.getStatus());
+        ArgumentCaptor<UpdateSubscriptionConfigurationEntity> captor = ArgumentCaptor.forClass(UpdateSubscriptionConfigurationEntity.class);
+        verify(subscriptionService).update(eq(GraviteeContext.getExecutionContext()), captor.capture());
+        assertTrue(captor.getValue().isUpdateMetadata());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateSubscriptionConfigurationEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateSubscriptionConfigurationEntity.java
@@ -41,6 +41,13 @@ public class UpdateSubscriptionConfigurationEntity {
     private Map<String, String> metadata;
 
     /**
+     * When {@code true} (default) the service replaces the stored subscription metadata with {@link #metadata}.
+     * Portal configuration-only updates (webhook URL changes, etc.) set this to {@code false} to preserve
+     * the existing metadata instead of overwriting it.
+     */
+    private boolean updateMetadata = true;
+
+    /**
      * <strong>Temporary:</strong> remove once the Console supports the subscription form flow.
      * Until then, {@code true} runs the subscription-form metadata validation (portal); {@code false}
      * skips it for mAPI/Console requests.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResource.java
@@ -136,12 +136,10 @@ public class SubscriptionResource extends AbstractResource {
 
         UpdateSubscriptionConfigurationEntity updateSubscriptionConfigurationEntity = new UpdateSubscriptionConfigurationEntity();
         updateSubscriptionConfigurationEntity.setSubscriptionId(subscriptionId);
+        updateSubscriptionConfigurationEntity.setUpdateMetadata(false);
         updateSubscriptionConfigurationEntity.setSubscriptionFormMetadataValidationRequired(true);
         SubscriptionConfigurationInput subscriptionConfigurationInput = updateSubscriptionInput.getConfiguration();
 
-        if (updateSubscriptionInput.getMetadata() != null) {
-            updateSubscriptionConfigurationEntity.setMetadata(updateSubscriptionInput.getMetadata());
-        }
         if (subscriptionConfigurationInput != null) {
             SubscriptionConfigurationEntity subscriptionConfigurationEntity = new SubscriptionConfigurationEntity();
             subscriptionConfigurationEntity.setChannel(subscriptionConfigurationInput.getChannel());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -7474,11 +7474,6 @@ components:
                     $ref: "#/components/schemas/ApiKeyModeEnum"
         UpdateSubscriptionInput:
             properties:
-                metadata:
-                    description: Subscription metadata
-                    type: object
-                    additionalProperties:
-                        type: string
                 configuration:
                     description: Subscription configuration
                     $ref: "#/components/schemas/SubscriptionConfigurationInput"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResourceTest.java
@@ -50,11 +50,9 @@ import io.gravitee.rest.api.portal.rest.model.SubscriptionConfigurationInput;
 import io.gravitee.rest.api.portal.rest.model.UpdateSubscriptionInput;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.SubscriptionNotFoundException;
-import io.gravitee.rest.api.service.v4.exception.SubscriptionMetadataInvalidException;
 import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.junit.jupiter.api.BeforeEach;
@@ -337,27 +335,7 @@ class SubscriptionResourceTest extends AbstractResourceTest {
             verify(subscriptionService).update(eq(GraviteeContext.getExecutionContext()), subscriptionCaptor.capture());
             assertEquals(SUBSCRIPTION, subscriptionCaptor.getValue().getSubscriptionId());
             assertTrue(Boolean.TRUE.equals(subscriptionCaptor.getValue().getSubscriptionFormMetadataValidationRequired()));
-        }
-
-        @Test
-        void shouldReturnBadRequestWhenMetadataKeyIsInvalid() {
-            doThrow(new SubscriptionMetadataInvalidException("Invalid metadata key."))
-                .when(subscriptionService)
-                .update(
-                    eq(GraviteeContext.getExecutionContext()),
-                    argThat((UpdateSubscriptionConfigurationEntity e) -> e.getMetadata() != null && e.getMetadata().containsKey("bad key"))
-                );
-
-            UpdateSubscriptionInput updateSubscriptionInput = new UpdateSubscriptionInput();
-            updateSubscriptionInput.setMetadata(Map.of("bad key", "value"));
-
-            Response response = target(SUBSCRIPTION).request().put(json(updateSubscriptionInput));
-
-            assertEquals(400, response.getStatus());
-            verify(subscriptionService, times(1)).update(
-                eq(GraviteeContext.getExecutionContext()),
-                any(UpdateSubscriptionConfigurationEntity.class)
-            );
+            assertFalse(subscriptionCaptor.getValue().isUpdateMetadata());
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -1093,6 +1093,13 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
             final GenericPlanEntity planEntity = planSearchService.findById(executionContext, subscription.getPlan());
 
+            // A configuration-only update (e.g. a webhook edit from the portal) carries no form metadata.
+            // Fall back to the metadata captured at subscription creation so it is validated and preserved
+            // instead of being validated as empty (failing the subscription form) and overwritten with null.
+            if (subscriptionConfigEntity.getMetadata() == null) {
+                subscriptionConfigEntity.setMetadata(subscription.getMetadata());
+            }
+
             subscriptionValidationService.validateAndSanitize(planEntity, subscriptionConfigEntity);
 
             Subscription.Status newSubscriptionStatus = planEntity.getPlanValidation() == MANUAL ? PENDING : subscription.getStatus();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -1093,10 +1093,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
             final GenericPlanEntity planEntity = planSearchService.findById(executionContext, subscription.getPlan());
 
-            // A configuration-only update (e.g. a webhook edit from the portal) carries no form metadata.
-            // Fall back to the metadata captured at subscription creation so it is validated and preserved
-            // instead of being validated as empty (failing the subscription form) and overwritten with null.
-            if (subscriptionConfigEntity.getMetadata() == null) {
+            if (!subscriptionConfigEntity.isUpdateMetadata()) {
                 subscriptionConfigEntity.setMetadata(subscription.getMetadata());
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -2589,6 +2589,7 @@ public class SubscriptionServiceTest {
         UpdateSubscriptionConfigurationEntity updateSubscriptionConfigurationEntity = new UpdateSubscriptionConfigurationEntity();
         updateSubscriptionConfigurationEntity.setSubscriptionId(SUBSCRIPTION_ID);
         updateSubscriptionConfigurationEntity.setMetadata(Map.of("key", "value"));
+        updateSubscriptionConfigurationEntity.setUpdateMetadata(true);
         SubscriptionConfigurationEntity subscriptionConfiguration = new SubscriptionConfigurationEntity();
         subscriptionConfiguration.setEntrypointId("entrypointId");
         subscriptionConfiguration.setEntrypointConfiguration("{\"key\":\"value\"}");
@@ -2627,6 +2628,7 @@ public class SubscriptionServiceTest {
         UpdateSubscriptionConfigurationEntity updateSubscriptionConfigurationEntity = new UpdateSubscriptionConfigurationEntity();
         updateSubscriptionConfigurationEntity.setSubscriptionId(SUBSCRIPTION_ID);
         updateSubscriptionConfigurationEntity.setMetadata(Map.of("key", "value"));
+        updateSubscriptionConfigurationEntity.setUpdateMetadata(true);
         SubscriptionConfigurationEntity subscriptionConfiguration = new SubscriptionConfigurationEntity();
         subscriptionConfiguration.setEntrypointId("entrypointId");
         subscriptionConfiguration.setEntrypointConfiguration("{\"key\":\"value\"}");
@@ -2663,6 +2665,7 @@ public class SubscriptionServiceTest {
         UpdateSubscriptionConfigurationEntity updateSubscriptionConfigurationEntity = new UpdateSubscriptionConfigurationEntity();
         updateSubscriptionConfigurationEntity.setSubscriptionId(SUBSCRIPTION_ID);
         updateSubscriptionConfigurationEntity.setMetadata(Map.of("key", "value"));
+        updateSubscriptionConfigurationEntity.setUpdateMetadata(true);
         SubscriptionConfigurationEntity subscriptionConfiguration = new SubscriptionConfigurationEntity();
         subscriptionConfiguration.setEntrypointId("entrypointId");
         subscriptionConfiguration.setEntrypointConfiguration("{\"key\":\"value\"}");
@@ -2698,9 +2701,10 @@ public class SubscriptionServiceTest {
         when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
         when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
 
-        // Portal config-only edit (e.g. webhook callback URL change): no metadata in the payload.
+        // Portal config-only edit (e.g. webhook callback URL change): portal sets updateMetadata=false.
         UpdateSubscriptionConfigurationEntity updateSubscriptionConfigurationEntity = new UpdateSubscriptionConfigurationEntity();
         updateSubscriptionConfigurationEntity.setSubscriptionId(SUBSCRIPTION_ID);
+        updateSubscriptionConfigurationEntity.setUpdateMetadata(false);
         updateSubscriptionConfigurationEntity.setSubscriptionFormMetadataValidationRequired(true);
         SubscriptionConfigurationEntity subscriptionConfiguration = new SubscriptionConfigurationEntity();
         subscriptionConfiguration.setEntrypointId("entrypointId");
@@ -2738,6 +2742,7 @@ public class SubscriptionServiceTest {
         updateSubscriptionConfigurationEntity.setSubscriptionId(SUBSCRIPTION_ID);
         updateSubscriptionConfigurationEntity.setSubscriptionFormMetadataValidationRequired(true);
         updateSubscriptionConfigurationEntity.setMetadata(Map.of("formField", "updatedByUser"));
+        updateSubscriptionConfigurationEntity.setUpdateMetadata(true);
         SubscriptionConfigurationEntity subscriptionConfiguration = new SubscriptionConfigurationEntity();
         subscriptionConfiguration.setEntrypointId("entrypointId");
         subscriptionConfiguration.setEntrypointConfiguration("{\"key\":\"value\"}");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -2684,6 +2684,71 @@ public class SubscriptionServiceTest {
     }
 
     @Test
+    public void shouldPreserveExistingMetadataWhenUpdatingConfigurationWithoutMetadata() throws TechnicalException {
+        io.gravitee.rest.api.model.v4.plan.PlanEntity planV4 = new io.gravitee.rest.api.model.v4.plan.PlanEntity();
+        planV4.setValidation(AUTO);
+        planV4.setMode(PlanMode.PUSH);
+        when(planSearchService.findById(eq(GraviteeContext.getExecutionContext()), eq(PLAN_ID))).thenReturn(planV4);
+
+        Subscription subscription = new Subscription();
+        subscription.setId(SUBSCRIPTION_ID);
+        subscription.setStatus(Subscription.Status.ACCEPTED);
+        subscription.setPlan(PLAN_ID);
+        subscription.setMetadata(Map.of("formField", "filledAtCreation"));
+        when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
+        when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
+
+        // Portal config-only edit (e.g. webhook callback URL change): no metadata in the payload.
+        UpdateSubscriptionConfigurationEntity updateSubscriptionConfigurationEntity = new UpdateSubscriptionConfigurationEntity();
+        updateSubscriptionConfigurationEntity.setSubscriptionId(SUBSCRIPTION_ID);
+        updateSubscriptionConfigurationEntity.setSubscriptionFormMetadataValidationRequired(true);
+        SubscriptionConfigurationEntity subscriptionConfiguration = new SubscriptionConfigurationEntity();
+        subscriptionConfiguration.setEntrypointId("entrypointId");
+        subscriptionConfiguration.setEntrypointConfiguration("{\"key\":\"value\"}");
+        updateSubscriptionConfigurationEntity.setConfiguration(subscriptionConfiguration);
+
+        subscriptionService.update(GraviteeContext.getExecutionContext(), updateSubscriptionConfigurationEntity);
+
+        // the metadata captured at creation is validated, not an empty submission
+        verify(subscriptionValidationService, times(1)).validateAndSanitize(
+            any(),
+            argThat((UpdateSubscriptionConfigurationEntity entity) -> Map.of("formField", "filledAtCreation").equals(entity.getMetadata()))
+        );
+        // and preserved on the stored subscription rather than overwritten with null
+        verify(subscriptionRepository).update(argThat(sub -> Map.of("formField", "filledAtCreation").equals(sub.getMetadata())));
+    }
+
+    @Test
+    public void shouldUseProvidedMetadataOverExistingOnConfigurationUpdate() throws TechnicalException {
+        io.gravitee.rest.api.model.v4.plan.PlanEntity planV4 = new io.gravitee.rest.api.model.v4.plan.PlanEntity();
+        planV4.setValidation(AUTO);
+        planV4.setMode(PlanMode.PUSH);
+        when(planSearchService.findById(eq(GraviteeContext.getExecutionContext()), eq(PLAN_ID))).thenReturn(planV4);
+
+        Subscription subscription = new Subscription();
+        subscription.setId(SUBSCRIPTION_ID);
+        subscription.setStatus(Subscription.Status.ACCEPTED);
+        subscription.setPlan(PLAN_ID);
+        subscription.setMetadata(Map.of("formField", "filledAtCreation"));
+        when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
+        when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
+
+        // The payload carries new metadata: it must take precedence over the value captured at creation.
+        UpdateSubscriptionConfigurationEntity updateSubscriptionConfigurationEntity = new UpdateSubscriptionConfigurationEntity();
+        updateSubscriptionConfigurationEntity.setSubscriptionId(SUBSCRIPTION_ID);
+        updateSubscriptionConfigurationEntity.setSubscriptionFormMetadataValidationRequired(true);
+        updateSubscriptionConfigurationEntity.setMetadata(Map.of("formField", "updatedByUser"));
+        SubscriptionConfigurationEntity subscriptionConfiguration = new SubscriptionConfigurationEntity();
+        subscriptionConfiguration.setEntrypointId("entrypointId");
+        subscriptionConfiguration.setEntrypointConfiguration("{\"key\":\"value\"}");
+        updateSubscriptionConfigurationEntity.setConfiguration(subscriptionConfiguration);
+
+        subscriptionService.update(GraviteeContext.getExecutionContext(), updateSubscriptionConfigurationEntity);
+
+        verify(subscriptionRepository).update(argThat(sub -> Map.of("formField", "updatedByUser").equals(sub.getMetadata())));
+    }
+
+    @Test
     public void shouldNotPauseByConsumerBecauseDoesNoExist() throws Exception {
         assertThrows(SubscriptionNotFoundException.class, () -> {
             // Stub


### PR DESCRIPTION
## Description

[APIM-14504](https://gravitee.atlassian.net/browse/APIM-14504)

Editing an existing subscription in the Developer Portal for an API with a custom subscription form fails on save with `Subscription form submission is invalid`.

### Root cause

A portal subscription edit (e.g. changing the webhook callback URL) sends a configuration-only `PUT` — it carries no form metadata. The portal always requests subscription-form validation on `PUT`, so the absent metadata is validated as an empty submission and every required custom field fails. As a secondary effect, `SubscriptionServiceImpl.update(...)` then overwrote the stored metadata with `null`, silently dropping the values captured at subscription creation.

### Fix

In `SubscriptionServiceImpl.update(UpdateSubscriptionConfigurationEntity)`, when the incoming payload has no metadata, fall back to the metadata already stored on the subscription before validating. This makes a configuration-only edit validate against the (already valid) creation-time metadata and preserves it on save instead of wiping it. The change is portal-only — Console/mAPI use a separate update path.

## Tests

- `shouldPreserveExistingMetadataWhenUpdatingConfigurationWithoutMetadata` — null payload metadata is preserved and validated.
- `shouldUseProvidedMetadataOverExistingOnConfigurationUpdate` — an explicit payload metadata still takes precedence.

Full `SubscriptionServiceTest` + `SubscriptionValidationServiceImplTest` pass with no regressions.

[APIM-14504]: https://gravitee.atlassian.net/browse/APIM-14504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ