### PR TITLE
fix: log com.graviteesource.gamma modules at INFO

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/logback.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/logback.xml
@@ -74,6 +74,7 @@
         <appender-ref ref="FILE-UPGRADERS" />
     </logger>
     <logger name="io.gravitee" level="INFO" />
+    <logger name="com.graviteesource.gamma" level="INFO" />
     <logger name="org.eclipse.jetty" level="INFO" />
 
     <!-- Strictly speaking, the level attribute is not necessary since -->


### PR DESCRIPTION
## Why

Gamma module logs never surface. The distribution `logback.xml` routes `io.gravitee` at INFO and leaves everything else on `root` at `WARN`. Gamma modules log under `com.graviteesource.gamma.*`, which matches no `<logger>` entry, so their INFO is dropped.

Concretely: a module upgrader runs and its node-level `Apply <Upgrader>` line shows up (it's `io.gravitee.node...`, so INFO), but the upgrader's own INFO output (e.g. a data migration reporting how many rows it rewrote) is filtered out, with no trace in either `gravitee.log` or `gravitee-upgraders.log`.

## Change

One logger entry, mirroring the existing `io.gravitee` one, so gamma modules log at INFO like the rest of the platform:

```xml
<logger name="io.gravitee" level="INFO" />
<logger name="com.graviteesource.gamma" level="INFO" />
<logger name="org.eclipse.jetty" level="INFO" />
```

Their INFO now lands in `gravitee.log`, next to the node's `Apply <Upgrader>` line. Not routed to `FILE-UPGRADERS` on purpose: that file is scoped to the rest-api upgrade package, and a broad `com.graviteesource.gamma` route would send all module logs there, not just upgraders.
