### PR TITLE
feat(apim): allow reusing a custom api key once its previous usage is inactive

### DIFF
--- a/gravitee-apim-console-webui/src/entities/Constants.ts
+++ b/gravitee-apim-console-webui/src/entities/Constants.ts
@@ -144,6 +144,9 @@ export interface EnvSettings {
       customApiKey: {
         enabled: boolean;
       };
+      customApiKeyReuse: {
+        enabled: boolean;
+      };
       sharedApiKey: {
         enabled: boolean;
       };

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -189,6 +189,9 @@ export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration
         customApiKey: {
           enabled: true,
         },
+        customApiKeyReuse: {
+          enabled: false,
+        },
         sharedApiKey: {
           enabled: false,
         },

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -170,6 +170,9 @@ export interface PortalSettingsPlan {
     customApiKey: {
       enabled: boolean;
     };
+    customApiKeyReuse: {
+      enabled: boolean;
+    };
     sharedApiKey: {
       enabled: boolean;
     };

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.http-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.http-proxy.component.spec.ts
@@ -72,6 +72,7 @@ describe('ApiCreationV4Component - HTTP Proxy', () => {
               customApiKey: {
                 enabled: true,
               },
+              customApiKeyReuse: { enabled: false },
               sharedApiKey: {
                 enabled: true,
               },

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.agent-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.agent-proxy.component.spec.ts
@@ -72,6 +72,7 @@ describe('ApiCreationV4Component - Message - Agent Proxy', () => {
               customApiKey: {
                 enabled: true,
               },
+              customApiKeyReuse: { enabled: false },
               sharedApiKey: {
                 enabled: true,
               },

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.component.spec.ts
@@ -70,6 +70,7 @@ describe('ApiCreationV4Component - Message', () => {
               customApiKey: {
                 enabled: true,
               },
+              customApiKeyReuse: { enabled: false },
               sharedApiKey: {
                 enabled: true,
               },

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.llm-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.llm-proxy.component.spec.ts
@@ -68,6 +68,7 @@ describe('ApiCreationV4Component - PROXY - LLM Proxy', () => {
               customApiKey: {
                 enabled: true,
               },
+              customApiKeyReuse: { enabled: false },
               sharedApiKey: {
                 enabled: true,
               },

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.mcp-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.mcp-proxy.component.spec.ts
@@ -68,6 +68,7 @@ describe('ApiCreationV4Component - PROXY - MCP Proxy', () => {
               customApiKey: {
                 enabled: true,
               },
+              customApiKeyReuse: { enabled: false },
               sharedApiKey: {
                 enabled: true,
               },

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
@@ -76,6 +76,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
               customApiKey: {
                 enabled: true,
               },
+              customApiKeyReuse: { enabled: false },
               sharedApiKey: {
                 enabled: true,
               },

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.navigation.component.spec.ts
@@ -127,6 +127,7 @@ describe('ApiCreationV4Component - Navigation', () => {
               customApiKey: {
                 enabled: true,
               },
+              customApiKeyReuse: { enabled: false },
               sharedApiKey: {
                 enabled: true,
               },

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.oem.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.oem.component.spec.ts
@@ -78,6 +78,7 @@ describe('ApiCreationV4Component - OEM', () => {
               customApiKey: {
                 enabled: true,
               },
+              customApiKeyReuse: { enabled: false },
               sharedApiKey: {
                 enabled: true,
               },

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.tcp-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.tcp-proxy.component.spec.ts
@@ -73,6 +73,7 @@ describe('ApiCreationV4Component - TCP Proxy', () => {
               customApiKey: {
                 enabled: true,
               },
+              customApiKeyReuse: { enabled: false },
               sharedApiKey: {
                 enabled: true,
               },

--- a/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.spec.ts
@@ -94,6 +94,7 @@ describe('ApiPlanListComponent', () => {
               customApiKey: {
                 enabled: true,
               },
+              customApiKeyReuse: { enabled: false },
               sharedApiKey: {
                 enabled: true,
               },

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.spec.ts
@@ -120,6 +120,7 @@ describe('Subscription creation dialog', () => {
               const constants = CONSTANTS_TESTING;
               set(constants, 'env.settings.plan.security', {
                 customApiKey: { enabled: true },
+                customApiKeyReuse: { enabled: false },
                 sharedApiKey: { enabled: false },
               });
               return constants;
@@ -226,6 +227,7 @@ describe('Subscription creation dialog', () => {
                 const constants = CONSTANTS_TESTING;
                 set(constants, 'env.settings.plan.security', {
                   customApiKey: { enabled: true },
+                  customApiKeyReuse: { enabled: false },
                   sharedApiKey: { enabled: false },
                 });
                 return constants;
@@ -356,6 +358,7 @@ describe('Subscription creation dialog', () => {
                 const constants = CONSTANTS_TESTING;
                 set(constants, 'env.settings.plan.security', {
                   customApiKey: { enabled: true },
+                  customApiKeyReuse: { enabled: false },
                   sharedApiKey: { enabled: true },
                 });
                 return constants;
@@ -574,6 +577,7 @@ describe('Subscription creation dialog', () => {
                 const constants = CONSTANTS_TESTING;
                 set(constants, 'env.settings.plan.security', {
                   customApiKey: { enabled: true },
+                  customApiKeyReuse: { enabled: false },
                   sharedApiKey: { enabled: true },
                 });
                 return constants;
@@ -648,6 +652,7 @@ describe('Subscription creation dialog', () => {
                 const constants = CONSTANTS_TESTING;
                 set(constants, 'env.settings.plan.security', {
                   customApiKey: { enabled: false },
+                  customApiKeyReuse: { enabled: false },
                 });
                 return constants;
               },

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.spec.ts
@@ -1323,6 +1323,7 @@ describe('ApiSubscriptionEditComponent', () => {
           const constants = { ...CONSTANTS_TESTING };
           set(constants, 'env.settings.plan.security', {
             customApiKey: { enabled: canUseCustomApiKey },
+            customApiKeyReuse: { enabled: false },
           });
           return constants;
         },

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.spec.ts
@@ -96,6 +96,7 @@ describe('ApiSubscriptionListComponent', () => {
               'env.settings.plan.security',
               planSecurity ?? {
                 customApiKey: { enabled: true },
+                customApiKeyReuse: { enabled: false },
               },
             );
             return constants;
@@ -401,6 +402,7 @@ describe('ApiSubscriptionListComponent', () => {
     it('should create subscription to an API Key plan in exclusive API Key mode without customApiKey', fakeAsync(async () => {
       await init({
         customApiKey: { enabled: true },
+        customApiKeyReuse: { enabled: false },
         sharedApiKey: { enabled: true },
       });
       const planV4 = fakePlanV4({ generalConditions: undefined });
@@ -454,6 +456,7 @@ describe('ApiSubscriptionListComponent', () => {
     it('should create subscription to a api key plan in shared API Key mode without customApiKey', fakeAsync(async () => {
       await init({
         customApiKey: { enabled: true },
+        customApiKeyReuse: { enabled: false },
         sharedApiKey: { enabled: true },
       });
       const planV4 = fakePlanV4({ generalConditions: undefined });
@@ -508,6 +511,7 @@ describe('ApiSubscriptionListComponent', () => {
     it('should not display custom api key for applications with share api key mode', fakeAsync(async () => {
       await init({
         customApiKey: { enabled: true },
+        customApiKeyReuse: { enabled: false },
         sharedApiKey: { enabled: true },
       });
       const planV4 = fakePlanV4({ generalConditions: undefined });
@@ -673,6 +677,7 @@ describe('ApiSubscriptionListComponent', () => {
     it('should not display custom api key nor API Key mode for federated API', fakeAsync(async () => {
       await init({
         customApiKey: { enabled: true },
+        customApiKeyReuse: { enabled: false },
         sharedApiKey: { enabled: true },
       });
       const planV4 = fakePlanV4({ generalConditions: undefined });

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.spec.ts
@@ -67,6 +67,7 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
         oauth2: { enabled: true },
         keyless: { enabled: true },
         customApiKey: { enabled: false },
+        customApiKeyReuse: { enabled: false },
         sharedApiKey: { enabled: false },
         mtls: { enabled: false },
       },

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -74,6 +74,15 @@
           <mat-slide-toggle formControlName="enabled" gioFormSlideToggle aria-label="Allow custom API Key"></mat-slide-toggle>
         </gio-form-slide-toggle>
         <gio-form-slide-toggle
+          [matTooltip]="'Configuration provided by the system'"
+          [matTooltipDisabled]="!isReadonly('plan.security.apikey.allowCustomReuse.enabled')"
+          formGroupName="customApiKeyReuse"
+          class="portal__form__card__form-field"
+        >
+          <gio-form-label>Allow custom API Key reuse</gio-form-label>
+          <mat-slide-toggle formControlName="enabled" gioFormSlideToggle aria-label="Allow custom API Key reuse"></mat-slide-toggle>
+        </gio-form-slide-toggle>
+        <gio-form-slide-toggle
           formGroupName="sharedApiKey"
           [matTooltip]="'Configuration provided by the system'"
           [matTooltipDisabled]="!isReadonly('plan.security.apikey.sharedApiKey.enabled')"

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -43,6 +43,9 @@ interface PortalForm {
     customApiKey: FormGroup<{
       enabled: FormControl<boolean>;
     }>;
+    customApiKeyReuse: FormGroup<{
+      enabled: FormControl<boolean>;
+    }>;
     sharedApiKey: FormGroup<{
       enabled: FormControl<boolean>;
     }>;
@@ -280,6 +283,15 @@ export class PortalSettingsComponent implements OnInit {
           enabled: new FormControl({
             value: this.settings.plan.security.customApiKey.enabled,
             disabled: this.isReadonly('plan.security.apikey.allowCustom.enabled') || !this.settings.plan.security.apikey.enabled,
+          }),
+        }),
+        customApiKeyReuse: new FormGroup({
+          enabled: new FormControl({
+            value: this.settings.plan.security.customApiKeyReuse.enabled,
+            disabled:
+              this.isReadonly('plan.security.apikey.allowCustomReuse.enabled') ||
+              !this.settings.plan.security.apikey.enabled ||
+              !this.settings.plan.security.customApiKey.enabled,
           }),
         }),
         sharedApiKey: new FormGroup({
@@ -597,10 +609,24 @@ export class PortalSettingsComponent implements OnInit {
         if (!selectedValue) {
           this.portalForm.get('security.customApiKey.enabled').setValue(false);
           this.portalForm.get('security.sharedApiKey.enabled').setValue(false);
+          this.portalForm.get('security.customApiKeyReuse.enabled').setValue(false);
         }
         if (selectedValue) {
           this.portalForm.get('security.customApiKey.enabled').enable();
           this.portalForm.get('security.sharedApiKey.enabled').enable();
+        }
+      });
+
+    // Reusing a custom API Key only makes sense when custom API Keys are allowed
+    this.portalForm
+      .get('security.customApiKey.enabled')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(selectedValue => {
+        if (!selectedValue) {
+          this.portalForm.get('security.customApiKeyReuse.enabled').setValue(false);
+          this.portalForm.get('security.customApiKeyReuse.enabled').disable();
+        } else if (!this.isReadonly('plan.security.apikey.allowCustomReuse.enabled')) {
+          this.portalForm.get('security.customApiKeyReuse.enabled').enable();
         }
       });
 

--- a/gravitee-apim-console-webui/src/services-ngx/constants.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/constants.service.spec.ts
@@ -58,6 +58,7 @@ describe('ConstantsService', () => {
         customApiKey: {
           enabled: true,
         },
+        customApiKeyReuse: { enabled: false },
         sharedApiKey: {
           enabled: true,
         },
@@ -89,6 +90,7 @@ describe('ConstantsService', () => {
         customApiKey: {
           enabled: false,
         },
+        customApiKeyReuse: { enabled: false },
         sharedApiKey: {
           enabled: false,
         },
@@ -124,6 +126,7 @@ describe('ConstantsService', () => {
         customApiKey: {
           enabled: true,
         },
+        customApiKeyReuse: { enabled: false },
         sharedApiKey: {
           enabled: true,
         },
@@ -273,6 +276,7 @@ describe('ConstantsService', () => {
           customApiKey: {
             enabled: false,
           },
+          customApiKeyReuse: { enabled: false },
           sharedApiKey: {
             enabled: false,
           },
@@ -304,6 +308,7 @@ describe('ConstantsService', () => {
         customApiKey: {
           enabled: true,
         },
+        customApiKeyReuse: { enabled: false },
         sharedApiKey: {
           enabled: true,
         },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -200,6 +200,11 @@ public enum Key {
         Boolean.FALSE.toString(),
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
+    PLAN_SECURITY_APIKEY_CUSTOM_REUSE_ALLOWED(
+        "plan.security.apikey.allowCustomReuse.enabled",
+        Boolean.FALSE.toString(),
+        new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
+    ),
     PLAN_SECURITY_APIKEY_SHARED_ALLOWED("plan.security.apikey.allowShared.enabled", Boolean.FALSE.toString(), Set.of(ENVIRONMENT, SYSTEM)),
     PLAN_SECURITY_KEYLESS_ENABLED("plan.security.keyless.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PLAN_SECURITY_SUBSCRIPTION_ENABLED(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PlanSettings.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PlanSettings.java
@@ -48,6 +48,9 @@ public class PlanSettings {
         @ParameterKey(Key.PLAN_SECURITY_APIKEY_CUSTOM_ALLOWED)
         private Enabled customApiKey;
 
+        @ParameterKey(Key.PLAN_SECURITY_APIKEY_CUSTOM_REUSE_ALLOWED)
+        private Enabled customApiKeyReuse;
+
         @ParameterKey(Key.PLAN_SECURITY_APIKEY_SHARED_ALLOWED)
         private Enabled sharedApiKey;
 
@@ -80,6 +83,14 @@ public class PlanSettings {
 
         public void setCustomApiKey(Enabled customApiKey) {
             this.customApiKey = customApiKey;
+        }
+
+        public Enabled getCustomApiKeyReuse() {
+            return customApiKeyReuse;
+        }
+
+        public void setCustomApiKeyReuse(Enabled customApiKeyReuse) {
+            this.customApiKeyReuse = customApiKeyReuse;
         }
 
         public Enabled getOauth2() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/domain_service/GenerateApiKeyDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/domain_service/GenerateApiKeyDomainService.java
@@ -32,14 +32,19 @@ import io.gravitee.apim.core.audit.model.ApiProductAuditLogEntity;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.event.ApiKeyAuditEvent;
+import io.gravitee.apim.core.parameters.model.ParameterContext;
+import io.gravitee.apim.core.parameters.query_service.ParametersQueryService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.exceptions.ApiKeyAlreadyExistingException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -52,6 +57,7 @@ public class GenerateApiKeyDomainService {
     private final ApiKeyQueryService apiKeyQueryService;
     private final ApplicationCrudService applicationCrudService;
     private final AuditDomainService auditService;
+    private final ParametersQueryService parametersQueryService;
 
     public ApiKeyEntity generate(SubscriptionEntity subscription, AuditInfo auditInfo, String customApiKey) {
         var app = applicationCrudService.findById(subscription.getApplicationId(), auditInfo.environmentId());
@@ -79,11 +85,21 @@ public class GenerateApiKeyDomainService {
     private ApiKeyEntity generate(AuditInfo auditInfo, SubscriptionEntity subscription, String apiKeyValue, boolean federated) {
         log.debug("Generate an API Key for subscription {}", subscription);
 
+        if (!federated && Objects.nonNull(apiKeyValue) && !apiKeyValue.isEmpty()) {
+            Optional<ApiKeyEntity> existingKey = findExistingKey(apiKeyValue, subscription);
+            if (existingKey.isPresent()) {
+                if (canReuse(existingKey.get(), auditInfo)) {
+                    return reuseExistingKey(existingKey.get(), subscription, auditInfo);
+                }
+                throw new ApiKeyAlreadyExistingException();
+            }
+        }
+
         ApiKeyEntity apiKey = generateForSubscription(subscription, apiKeyValue, federated);
         apiKeyCrudService.create(apiKey);
 
         // Audit
-        createAuditLog(apiKey, subscription, auditInfo);
+        createAuditLog(apiKey, subscription, auditInfo, ApiKeyAuditEvent.APIKEY_CREATED);
 
         return apiKey;
     }
@@ -102,29 +118,65 @@ public class GenerateApiKeyDomainService {
         }
 
         if (Objects.nonNull(customApiKey) && !customApiKey.isEmpty()) {
-            if (!isKeyExistFor(customApiKey, subscription)) {
-                throw new ApiKeyAlreadyExistingException();
-            }
             return ApiKeyEntity.generateForSubscription(subscription, customApiKey);
         }
 
         return ApiKeyEntity.generateForSubscription(subscription);
     }
 
-    private boolean isKeyExistFor(String apiKeyValue, SubscriptionEntity subscription) {
+    private Optional<ApiKeyEntity> findExistingKey(String apiKeyValue, SubscriptionEntity subscription) {
         String referenceId = subscription.getReferenceId();
         String referenceType = subscription.getReferenceType() != null ? subscription.getReferenceType().name() : null;
         log.debug(
-            "Check if an API Key can be created for reference {} (type {}) and application {}",
+            "Look up an existing API Key for reference {} (type {}) and application {}",
             referenceId,
             referenceType,
             subscription.getApplicationId()
         );
 
         if (referenceId != null && referenceType != null) {
-            return apiKeyQueryService.findByKeyAndReferenceIdAndReferenceType(apiKeyValue, referenceId, referenceType).isEmpty();
+            return apiKeyQueryService.findByKeyAndReferenceIdAndReferenceType(apiKeyValue, referenceId, referenceType);
         }
-        return apiKeyQueryService.findByKeyAndApiId(apiKeyValue, subscription.getApiId()).isEmpty();
+        return apiKeyQueryService.findByKeyAndApiId(apiKeyValue, subscription.getApiId());
+    }
+
+    private boolean canReuse(ApiKeyEntity existingKey, AuditInfo auditInfo) {
+        return isInactive(existingKey) && isCustomKeyReuseAllowed(auditInfo);
+    }
+
+    /**
+     * A custom key can be reused only when its previous usage is no longer active, i.e. the key has been
+     * revoked or has expired (which mirrors a closed or ended subscription). A paused key still belongs to
+     * an active subscription and is therefore never reusable.
+     */
+    private boolean isInactive(ApiKeyEntity apiKey) {
+        return apiKey.isRevoked() || apiKey.isExpired();
+    }
+
+    private boolean isCustomKeyReuseAllowed(AuditInfo auditInfo) {
+        return parametersQueryService.findAsBoolean(
+            Key.PLAN_SECURITY_APIKEY_CUSTOM_REUSE_ALLOWED,
+            new ParameterContext(auditInfo.environmentId(), auditInfo.organizationId(), ParameterReferenceType.ENVIRONMENT)
+        );
+    }
+
+    /**
+     * Reuse the existing (inactive) API Key by reactivating it and attaching the new subscription, instead of
+     * creating a duplicate {@code (reference, key)} record. The previous subscription link is kept for history;
+     * the gateway only resolves a key through its active subscriptions, so the closed one stays inert.
+     */
+    private ApiKeyEntity reuseExistingKey(ApiKeyEntity existingKey, SubscriptionEntity subscription, AuditInfo auditInfo) {
+        var reused = existingKey
+            .reactivate()
+            .addSubscription(subscription.getId())
+            .toBuilder()
+            .expireAt(subscription.getEndingAt())
+            .build();
+
+        apiKeyCrudService.update(reused);
+        createAuditLog(reused, subscription, auditInfo, ApiKeyAuditEvent.APIKEY_REACTIVATED);
+
+        return reused;
     }
 
     private ApiKeyEntity findOrGenerate(
@@ -145,7 +197,12 @@ public class GenerateApiKeyDomainService {
         apiKeyCrudService.update(apiKey.addSubscription(subscription.getId()));
     }
 
-    private void createAuditLog(ApiKeyEntity createdApiKeyEntity, SubscriptionEntity subscription, AuditInfo auditInfo) {
+    private void createAuditLog(
+        ApiKeyEntity createdApiKeyEntity,
+        SubscriptionEntity subscription,
+        AuditInfo auditInfo,
+        ApiKeyAuditEvent event
+    ) {
         boolean isApiProduct = SubscriptionReferenceType.API_PRODUCT.equals(subscription.getReferenceType());
         String referenceId = isApiProduct ? subscription.getReferenceId() : subscription.getApiId();
 
@@ -162,7 +219,7 @@ public class GenerateApiKeyDomainService {
                     .organizationId(auditInfo.organizationId())
                     .environmentId(auditInfo.environmentId())
                     .apiProductId(referenceId)
-                    .event(ApiKeyAuditEvent.APIKEY_CREATED)
+                    .event(event)
                     .actor(auditInfo.actor())
                     .oldValue(null)
                     .newValue(createdApiKeyEntity)
@@ -176,7 +233,7 @@ public class GenerateApiKeyDomainService {
                     .organizationId(auditInfo.organizationId())
                     .environmentId(auditInfo.environmentId())
                     .apiId(referenceId)
-                    .event(ApiKeyAuditEvent.APIKEY_CREATED)
+                    .event(event)
                     .actor(auditInfo.actor())
                     .oldValue(null)
                     .newValue(createdApiKeyEntity)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -45,6 +45,8 @@ import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.key.ApiKeyQuery;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.v4.api.GenericApiModel;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
@@ -53,6 +55,7 @@ import io.gravitee.rest.api.service.ApiKeyService;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.NotifierService;
+import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
@@ -124,6 +127,9 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
     @Lazy
     @Autowired
     private ApiProductsRepository apiProductsRepository;
+
+    @Autowired
+    private ParameterService parameterService;
 
     @Override
     public ApiKeyEntity generate(
@@ -558,16 +564,27 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
             referenceType,
             applicationId
         );
+        boolean reuseAllowed = parameterService.findAsBoolean(
+            executionContext,
+            Key.PLAN_SECURITY_APIKEY_CUSTOM_REUSE_ALLOWED,
+            ParameterReferenceType.ENVIRONMENT
+        );
         return findByKeyAndEnvironmentId(executionContext, apiKey)
             .stream()
-            .noneMatch(existingKey -> isConflictingKeyForReference(existingKey, referenceId, referenceType, applicationId));
+            .noneMatch(existingKey -> isConflictingKeyForReference(existingKey, referenceId, referenceType, applicationId, reuseAllowed));
     }
 
-    private boolean isConflictingKeyForReference(ApiKeyEntity existingKey, String referenceId, String referenceType, String applicationId) {
+    private boolean isConflictingKeyForReference(
+        ApiKeyEntity existingKey,
+        String referenceId,
+        String referenceType,
+        String applicationId,
+        boolean reuseAllowed
+    ) {
         if (!existingKey.getApplication().getId().equals(applicationId)) {
             return true;
         }
-        return existingKey
+        boolean matchesReference = existingKey
             .getSubscriptions()
             .stream()
             .anyMatch(
@@ -578,6 +595,16 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                         referenceType.equals(sub.getReferenceType())) ||
                     (SubscriptionReferenceType.API.name().equals(referenceType) && referenceId.equals(sub.getApi()))
             );
+        if (!matchesReference) {
+            return false;
+        }
+        // Same application and same reference: it conflicts unless reuse is allowed and the existing key is
+        // no longer active (revoked or expired), i.e. its previous subscription is closed or ended.
+        return !(reuseAllowed && isInactive(existingKey));
+    }
+
+    private boolean isInactive(ApiKeyEntity apiKey) {
+        return apiKey.isRevoked() || apiKey.isExpired();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -170,8 +170,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
         try {
             log.debug("Renew API Key for subscription {}", subscription.getId());
 
-            ApiKey newApiKey = generateForSubscription(executionContext, subscription, customApiKey);
-            newApiKey = apiKeyRepository.create(newApiKey);
+            ApiKey newApiKey = createOrReuseForSubscription(executionContext, subscription, customApiKey);
 
             // Expire previously generated keys
             expireApiKeys(executionContext, apiKeyRepository.findBySubscription(subscription.getId()), newApiKey);
@@ -288,8 +287,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
         try {
             log.debug("Generate an API Key for subscription {}", subscription);
 
-            ApiKey apiKey = generateForSubscription(executionContext, subscription, customApiKey);
-            apiKey = apiKeyRepository.create(apiKey);
+            ApiKey apiKey = createOrReuseForSubscription(executionContext, subscription, customApiKey);
 
             //TODO: Send a notification to the application owner
 
@@ -564,11 +562,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
             referenceType,
             applicationId
         );
-        boolean reuseAllowed = parameterService.findAsBoolean(
-            executionContext,
-            Key.PLAN_SECURITY_APIKEY_CUSTOM_REUSE_ALLOWED,
-            ParameterReferenceType.ENVIRONMENT
-        );
+        boolean reuseAllowed = isCustomKeyReuseAllowed(executionContext);
         return findByKeyAndEnvironmentId(executionContext, apiKey)
             .stream()
             .noneMatch(existingKey -> isConflictingKeyForReference(existingKey, referenceId, referenceType, applicationId, reuseAllowed));
@@ -605,6 +599,60 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
 
     private boolean isInactive(ApiKeyEntity apiKey) {
         return apiKey.isRevoked() || apiKey.isExpired();
+    }
+
+    private boolean isInactive(ApiKey apiKey) {
+        boolean expired = apiKey.getExpireAt() != null && apiKey.getExpireAt().before(new Date());
+        return apiKey.isRevoked() || expired;
+    }
+
+    private boolean isCustomKeyReuseAllowed(ExecutionContext executionContext) {
+        return parameterService.findAsBoolean(
+            executionContext,
+            Key.PLAN_SECURITY_APIKEY_CUSTOM_REUSE_ALLOWED,
+            ParameterReferenceType.ENVIRONMENT
+        );
+    }
+
+    /**
+     * Create a new API Key for the subscription, or — when reuse is enabled and a same-reference key with the
+     * given custom value already exists but is inactive (revoked or expired) — reactivate that existing record
+     * instead of inserting a duplicate. Keeping a single physical (reference, key) record is what allows the
+     * gateway (whose cache is keyed by api + key) to stay consistent without any gateway-side change.
+     */
+    private ApiKey createOrReuseForSubscription(ExecutionContext executionContext, SubscriptionEntity subscription, String customApiKey)
+        throws TechnicalException {
+        if (isNotEmpty(customApiKey) && isCustomKeyReuseAllowed(executionContext)) {
+            Optional<ApiKey> reusable = findReusableInactiveKey(customApiKey, subscription);
+            if (reusable.isPresent()) {
+                return reactivateForSubscription(reusable.get(), subscription);
+            }
+        }
+        return apiKeyRepository.create(generateForSubscription(executionContext, subscription, customApiKey));
+    }
+
+    private Optional<ApiKey> findReusableInactiveKey(String customApiKey, SubscriptionEntity subscription) throws TechnicalException {
+        String referenceId = subscription.getReferenceId() != null ? subscription.getReferenceId() : subscription.getApi();
+        String referenceType = subscription.getReferenceType() != null
+            ? subscription.getReferenceType()
+            : SubscriptionReferenceType.API.name();
+        return apiKeyRepository
+            .findByKeyAndReferenceIdAndReferenceType(customApiKey, referenceId, referenceType)
+            .filter(key -> subscription.getApplication().equals(key.getApplication()))
+            .filter(this::isInactive);
+    }
+
+    private ApiKey reactivateForSubscription(ApiKey apiKey, SubscriptionEntity subscription) throws TechnicalException {
+        apiKey.setRevoked(false);
+        apiKey.setRevokedAt(null);
+        List<String> subscriptions = new ArrayList<>(apiKey.getSubscriptions());
+        if (!subscriptions.contains(subscription.getId())) {
+            subscriptions.add(subscription.getId());
+        }
+        apiKey.setSubscriptions(subscriptions);
+        apiKey.setExpireAt(subscription.getEndingAt());
+        apiKey.setUpdatedAt(new Date());
+        return apiKeyRepository.update(apiKey);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/GenerateApiKeyDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/GenerateApiKeyDomainServiceTest.java
@@ -26,6 +26,7 @@ import inmemory.ApiKeyQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.ParametersQueryServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
@@ -36,8 +37,10 @@ import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.repository.management.model.Parameter;
 import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.ApiKeyAlreadyExistingException;
 import java.time.Clock;
@@ -84,6 +87,7 @@ class GenerateApiKeyDomainServiceTest {
     ApplicationCrudServiceInMemory applicationCrudService = new ApplicationCrudServiceInMemory();
     AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
     UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+    ParametersQueryServiceInMemory parametersQueryService = new ParametersQueryServiceInMemory();
 
     GenerateApiKeyDomainService service;
 
@@ -99,7 +103,8 @@ class GenerateApiKeyDomainServiceTest {
             apiKeyCrudService,
             new ApiKeyQueryServiceInMemory(apiKeyCrudService),
             applicationCrudService,
-            new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor())
+            new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor()),
+            parametersQueryService
         );
 
         applicationCrudService.initWith(List.of(APPLICATION_1));
@@ -107,7 +112,7 @@ class GenerateApiKeyDomainServiceTest {
 
     @AfterEach
     void tearDown() {
-        Stream.of(apiKeyCrudService, auditCrudService, userCrudService).forEach(InMemoryAlternative::reset);
+        Stream.of(apiKeyCrudService, auditCrudService, userCrudService, parametersQueryService).forEach(InMemoryAlternative::reset);
     }
 
     @AfterAll
@@ -314,6 +319,151 @@ class GenerateApiKeyDomainServiceTest {
         assertThat(apiKeyCrudService.storage()).anyMatch(
             key -> "federated-key".equals(key.getKey()) && key.getSubscriptions().contains(SUBSCRIPTION_ID_1)
         );
+    }
+
+    @Test
+    void should_not_reuse_revoked_custom_key_when_flag_disabled() {
+        // Given a revoked key with the same value, but the reuse flag is disabled (default)
+        givenApiKey(
+            ApiKeyFixtures.anApiKey()
+                .toBuilder()
+                .applicationId(APPLICATION_ID)
+                .subscriptions(List.of(SUBSCRIPTION_ID_1))
+                .key("reusable-key")
+                .revoked(true)
+                .build()
+        );
+
+        // When
+        var throwable = catchThrowable(() ->
+            service.generate(SUBSCRIPTION_1.toBuilder().id(SUBSCRIPTION_ID_2).build(), AUDIT_INFO, "reusable-key")
+        );
+
+        // Then
+        assertThat(throwable).isInstanceOf(ApiKeyAlreadyExistingException.class);
+    }
+
+    @Nested
+    class WhenCustomKeyReuseEnabled {
+
+        private static final SubscriptionEntity NEW_SUBSCRIPTION = SUBSCRIPTION_1.toBuilder().id(SUBSCRIPTION_ID_2).build();
+
+        @BeforeEach
+        void setUp() {
+            parametersQueryService.define(
+                Parameter.builder().key(Key.PLAN_SECURITY_APIKEY_CUSTOM_REUSE_ALLOWED.key()).value("true").build()
+            );
+        }
+
+        @Test
+        void reactivate_and_repoint_existing_revoked_key() {
+            // Given a revoked key (e.g. its subscription was closed)
+            givenApiKey(
+                ApiKeyFixtures.anApiKey()
+                    .toBuilder()
+                    .id("existing-key-id")
+                    .applicationId(APPLICATION_ID)
+                    .subscriptions(List.of(SUBSCRIPTION_ID_1))
+                    .key("reusable-key")
+                    .revoked(true)
+                    .revokedAt(INSTANT_NOW.minusSeconds(3600).atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+
+            // When
+            var result = service.generate(NEW_SUBSCRIPTION, AUDIT_INFO, "reusable-key");
+
+            // Then: a single record is reactivated, repointed and its expiry aligned with the new subscription
+            assertThat(apiKeyCrudService.storage()).hasSize(1);
+            assertThat(result.getId()).isEqualTo("existing-key-id");
+            assertThat(result.isRevoked()).isFalse();
+            assertThat(result.getRevokedAt()).isNull();
+            assertThat(result.getSubscriptions()).containsExactly(SUBSCRIPTION_ID_1, SUBSCRIPTION_ID_2);
+            assertThat(result.getExpireAt()).isEqualTo(NEW_SUBSCRIPTION.getEndingAt());
+        }
+
+        @Test
+        void reactivate_existing_expired_key() {
+            // Given an expired (but not revoked) key
+            givenApiKey(
+                ApiKeyFixtures.anApiKey()
+                    .toBuilder()
+                    .applicationId(APPLICATION_ID)
+                    .subscriptions(List.of(SUBSCRIPTION_ID_1))
+                    .key("reusable-key")
+                    .revoked(false)
+                    .expireAt(INSTANT_NOW.minusSeconds(3600).atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+
+            // When
+            var result = service.generate(NEW_SUBSCRIPTION, AUDIT_INFO, "reusable-key");
+
+            // Then
+            assertThat(apiKeyCrudService.storage()).hasSize(1);
+            assertThat(result.isExpired()).isFalse();
+            assertThat(result.getExpireAt()).isEqualTo(NEW_SUBSCRIPTION.getEndingAt());
+        }
+
+        @Test
+        void emit_reactivated_audit_on_reuse() {
+            // Given
+            givenApiKey(
+                ApiKeyFixtures.anApiKey()
+                    .toBuilder()
+                    .applicationId(APPLICATION_ID)
+                    .subscriptions(List.of(SUBSCRIPTION_ID_1))
+                    .key("reusable-key")
+                    .revoked(true)
+                    .build()
+            );
+
+            // When
+            service.generate(NEW_SUBSCRIPTION, AUDIT_INFO, "reusable-key");
+
+            // Then
+            assertThat(auditCrudService.storage()).anyMatch(audit -> ApiKeyAuditEvent.APIKEY_REACTIVATED.name().equals(audit.getEvent()));
+        }
+
+        @Test
+        void reject_reuse_when_existing_key_is_still_active() {
+            // Given an active key (default fixture is not revoked and expires in 2051)
+            givenApiKey(
+                ApiKeyFixtures.anApiKey()
+                    .toBuilder()
+                    .applicationId(APPLICATION_ID)
+                    .subscriptions(List.of(SUBSCRIPTION_ID_1))
+                    .key("reusable-key")
+                    .build()
+            );
+
+            // When
+            var throwable = catchThrowable(() -> service.generate(NEW_SUBSCRIPTION, AUDIT_INFO, "reusable-key"));
+
+            // Then
+            assertThat(throwable).isInstanceOf(ApiKeyAlreadyExistingException.class);
+        }
+
+        @Test
+        void reject_reuse_when_existing_key_is_only_paused() {
+            // Given a paused key: its subscription is still active, so the key must not be reused
+            givenApiKey(
+                ApiKeyFixtures.anApiKey()
+                    .toBuilder()
+                    .applicationId(APPLICATION_ID)
+                    .subscriptions(List.of(SUBSCRIPTION_ID_1))
+                    .key("reusable-key")
+                    .revoked(false)
+                    .paused(true)
+                    .build()
+            );
+
+            // When
+            var throwable = catchThrowable(() -> service.generate(NEW_SUBSCRIPTION, AUDIT_INFO, "reusable-key"));
+
+            // Then
+            assertThat(throwable).isInstanceOf(ApiKeyAlreadyExistingException.class);
+        }
     }
 
     @SneakyThrows

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/ReconcileApiKeysDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/ReconcileApiKeysDomainServiceTest.java
@@ -22,6 +22,7 @@ import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApiKeyQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
+import inmemory.ParametersQueryServiceInMemory;
 import inmemory.SubscriptionCrudServiceInMemory;
 import inmemory.TriggerNotificationDomainServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
@@ -92,7 +93,8 @@ class ReconcileApiKeysDomainServiceTest {
             apiKeyCrudService,
             new ApiKeyQueryServiceInMemory(apiKeyCrudService),
             applicationCrudService,
-            auditDomainService
+            auditDomainService,
+            new ParametersQueryServiceInMemory()
         );
         var revokeApiKeyDomainService = new RevokeApiKeyDomainService(
             apiKeyCrudService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainServiceTest.java
@@ -130,7 +130,8 @@ class AcceptSubscriptionDomainServiceTest {
             apiKeyCrudService,
             new ApiKeyQueryServiceInMemory(apiKeyCrudService),
             applicationCrudService,
-            auditDomainService
+            auditDomainService,
+            new ParametersQueryServiceInMemory()
         );
 
         ApplicationPrimaryOwnerDomainService applicationPrimaryOwnerDomainService = new ApplicationPrimaryOwnerDomainService(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/AcceptSubscriptionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/AcceptSubscriptionUseCaseTest.java
@@ -120,7 +120,8 @@ class AcceptSubscriptionUseCaseTest {
             apiKeyCrudService,
             new ApiKeyQueryServiceInMemory(apiKeyCrudService),
             applicationCrudService,
-            auditDomainService
+            auditDomainService,
+            new ParametersQueryServiceInMemory()
         );
 
         ApplicationPrimaryOwnerDomainService applicationPrimaryOwnerDomainService = new ApplicationPrimaryOwnerDomainService(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDDomainServiceImplTest.java
@@ -38,6 +38,7 @@ import inmemory.IntegrationAgentInMemory;
 import inmemory.IntegrationCrudServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.MetadataCrudServiceInMemory;
+import inmemory.ParametersQueryServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import inmemory.SubscriptionCrudServiceInMemory;
@@ -759,7 +760,8 @@ class SubscriptionCRDDomainServiceImplTest {
             apiKeyCrudService,
             new ApiKeyQueryServiceInMemory(apiKeyCrudService),
             applicationCrudService,
-            auditDomainService()
+            auditDomainService(),
+            new ParametersQueryServiceInMemory()
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -19,6 +19,7 @@ import static io.gravitee.repository.management.model.ApiKey.AuditEvent.APIKEY_E
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
@@ -181,6 +182,50 @@ public class ApiKeyServiceTest {
         assertTrue(properties.containsKey(Audit.AuditProperties.API));
         assertTrue(properties.containsKey(Audit.AuditProperties.API_KEY));
         assertTrue(properties.containsKey(Audit.AuditProperties.APPLICATION));
+    }
+
+    @Test
+    public void shouldReuseInactiveCustomKeyInsteadOfCreatingDuplicate() throws TechnicalException {
+        String customKey = "reusable-key";
+
+        when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
+        when(subscription.getApplication()).thenReturn(APPLICATION_ID);
+        when(subscription.getApi()).thenReturn(API_ID);
+        when(subscription.getEndingAt()).thenReturn(Date.from(new Date().toInstant().plus(1, ChronoUnit.DAYS)));
+        when(subscriptionService.findByIdIn(any())).thenReturn(Set.of(subscription));
+        when(applicationService.findById(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID))).thenReturn(application);
+
+        // Reuse is enabled for the environment
+        when(
+            parameterService.findAsBoolean(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Key.PLAN_SECURITY_APIKEY_CUSTOM_REUSE_ALLOWED),
+                eq(ParameterReferenceType.ENVIRONMENT)
+            )
+        ).thenReturn(true);
+
+        // An inactive (revoked) key with the same value already exists for this API
+        ApiKey existing = new ApiKey();
+        existing.setId("existing-id");
+        existing.setKey(customKey);
+        existing.setApplication(APPLICATION_ID);
+        existing.setSubscriptions(new ArrayList<>(List.of("old-subscription")));
+        existing.setRevoked(true);
+        when(apiKeyRepository.findByKeyAndReferenceIdAndReferenceType(customKey, API_ID, "API")).thenReturn(Optional.of(existing));
+        when(apiKeyRepository.update(any())).thenAnswer(returnsFirstArg());
+
+        // Run
+        apiKeyService.generate(GraviteeContext.getExecutionContext(), application, subscription, customKey);
+
+        // Verify: the existing record is reactivated (update), never a new (api, key) record (create)
+        verify(apiKeyRepository, never()).create(any());
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        verify(apiKeyRepository).update(captor.capture());
+        ApiKey reused = captor.getValue();
+        assertEquals("existing-id", reused.getId());
+        assertFalse(reused.isRevoked());
+        assertNull(reused.getRevokedAt());
+        assertTrue(reused.getSubscriptions().contains(SUBSCRIPTION_ID));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -49,6 +49,8 @@ import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.PlanSecurityType;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.ApiKeyGenerator;
@@ -58,6 +60,7 @@ import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.EmailService;
 import io.gravitee.rest.api.service.NotifierService;
+import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiKeyAlreadyActivatedException;
@@ -143,6 +146,9 @@ public class ApiKeyServiceTest {
 
     @Mock
     private ApiProductsRepository apiProductsRepository;
+
+    @Mock
+    private ParameterService parameterService;
 
     @Test
     public void shouldGenerate() throws TechnicalException {
@@ -918,6 +924,48 @@ public class ApiKeyServiceTest {
         );
 
         assertFalse(canCreate);
+    }
+
+    @Test
+    public void canCreate_should_return_true_when_reuse_allowed_and_existing_key_is_revoked() throws Exception {
+        String apiKeyToCreate = "apikey-i-want-to-reuse";
+        String apiId = "my-api-id";
+        String applicationId = "my-application-id";
+
+        ApplicationEntity application = new ApplicationEntity();
+        application.setId(applicationId);
+
+        SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity.setId("subscription-1");
+        subscriptionEntity.setApplication(applicationId);
+        subscriptionEntity.setApi(apiId);
+
+        ApiKey existingApiKey = new ApiKey();
+        existingApiKey.setSubscriptions(List.of("subscription-1"));
+        existingApiKey.setApplication(applicationId);
+        existingApiKey.setKey(apiKeyToCreate);
+        existingApiKey.setRevoked(true);
+
+        when(apiKeyRepository.findByKeyAndEnvironmentId(apiKeyToCreate, ENVIRONMENT_ID)).thenReturn(List.of(existingApiKey));
+        when(applicationService.findById(eq(GraviteeContext.getExecutionContext()), eq(applicationId))).thenReturn(application);
+        when(subscriptionService.findByIdIn(List.of("subscription-1"))).thenReturn(Set.of(subscriptionEntity));
+        when(
+            parameterService.findAsBoolean(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Key.PLAN_SECURITY_APIKEY_CUSTOM_REUSE_ALLOWED),
+                eq(ParameterReferenceType.ENVIRONMENT)
+            )
+        ).thenReturn(true);
+
+        boolean canCreate = apiKeyService.canCreate(
+            GraviteeContext.getExecutionContext(),
+            apiKeyToCreate,
+            apiId,
+            io.gravitee.apim.core.subscription.model.SubscriptionReferenceType.API.name(),
+            applicationId
+        );
+
+        assertTrue(canCreate);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
@@ -155,6 +155,7 @@ class ConfigServiceTest {
         params.put(LOGGING_MESSAGE_SAMPLING_PROBABILISTIC_DEFAULT.key(), singletonList("0.01"));
         params.put(Key.LOGGING_MESSAGE_SAMPLING_TEMPORAL_LIMIT.key(), singletonList("PT1S"));
         params.put(PORTAL_NEXT_SEARCH_FUZZY.key(), singletonList("true"));
+        params.put(Key.PLAN_SECURITY_APIKEY_CUSTOM_REUSE_ALLOWED.key(), singletonList("true"));
 
         when(
             mockParameterService.findAll(
@@ -177,6 +178,9 @@ class ConfigServiceTest {
         assertThat(portalSettings.getReCaptcha().getSiteKey()).as("recaptcha siteKey").isEqualTo("my-site-key");
         assertThat(portalSettings.getReCaptcha().getEnabled()).as("recaptcha enabled").isEqualTo(Boolean.TRUE);
         assertThat(portalSettings.getPlan().getSecurity().getKeyless().isEnabled()).as("plan security keyless").isEqualTo(Boolean.TRUE);
+        assertThat(portalSettings.getPlan().getSecurity().getCustomApiKeyReuse().isEnabled())
+            .as("plan security custom api key reuse")
+            .isTrue();
         assertThat(portalSettings.getOpenAPIDocViewer().getOpenAPIDocType().getSwagger().isEnabled())
             .as("open api swagger enabled")
             .isEqualTo(Boolean.TRUE);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11204

## Description

This PR lets a consumer reuse a known custom API key value once its previous usage is no longer active, instead of being rejected with "key already exists".

When subscribing (or renewing) with a custom API key whose value matches a key that has been **revoked or expired** (typically because its previous subscription was closed or ended), the existing record is **reactivated and repointed** to the new subscription rather than rejected or duplicated. A key that is still **active** with the same value is still rejected.

The behaviour is opt-in per environment through a new setting `plan.security.apikey.allowCustomReuse.enabled` (disabled by default), exposed as a toggle in the portal security settings (only enabled when API key plans and custom API keys are both allowed).

Key design points:
- **Reactivate-and-repoint** the existing inactive record — no hard delete (revoked keys and closed subscriptions stay part of the history) and no duplicate `(reference, key)` record, so the gateway (whose cache is keyed by `api + key`) needs **no change**.
- Uniqueness stays scoped **per API / reference** — no new repository index and no migration.
- Handled consistently across all entry points: the subscription accept flow (`GenerateApiKeyDomainService`), the legacy `ApiKeyServiceImpl` generate/renew paths, and the `_verify` pre-check used by the console to validate a custom key.

## Additional context

- New environment setting: `plan.security.apikey.allowCustomReuse.enabled` (default `false`).
- A key is considered reusable only when **revoked or expired**; a paused key still belongs to an active subscription and is never reused.
