### PR TITLE
chore: bump authz module to 1.0.0-alpha.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
 
         <!-- Gamma plugins -->
         <gravitee-gamma-module-aim.version>1.0.0-alpha.200</gravitee-gamma-module-aim.version>
-        <gravitee-gamma-module-authz.version>1.0.0-alpha.24</gravitee-gamma-module-authz.version>
+        <gravitee-gamma-module-authz.version>1.0.0-alpha.28</gravitee-gamma-module-authz.version>
         <gravitee-gamma-module-edge.version>1.0.0-alpha.4</gravitee-gamma-module-edge.version>
         <gravitee-gamma-module-esm.version>1.0.0-alpha.11</gravitee-gamma-module-esm.version>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Bumps `gravitee-gamma-module-authz.version` from `1.0.0-alpha.24` to `1.0.0-alpha.28` so the distribution bundles the latest released authz Gamma module.

Branched off the latest `4.12.x` (`4.12.0-milestone.6-SNAPSHOT`).

## Additional context

Single-line version bump in the root `pom.xml`.