### PR TITLE
fix: [regression] dynamic routing redirect rules broken in apim 4.10.18 – el expression / group capture failure on v2 proxy api

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/flow/condition/evaluation/PathPatterns.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/flow/condition/evaluation/PathPatterns.java
@@ -48,7 +48,7 @@ public class PathPatterns {
                 if (branch.startsWith(PATH_PARAM_PREFIX)) {
                     buffer.append(PATH_PARAM_REGEX);
                 } else {
-                    buffer.append(Pattern.quote(branch));
+                    buffer.append(branch);
                 }
 
                 buffer.append(PATH_SEPARATOR);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/PathBasedConditionEvaluatorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/PathBasedConditionEvaluatorTest.java
@@ -170,4 +170,31 @@ public class PathBasedConditionEvaluatorTest {
 
         assertTrue(evaluator.evaluate(context, flow));
     }
+
+    @Test
+    public void shouldEvaluate_startsWith_regexCaptureGroup() {
+        when(request.pathInfo()).thenReturn("/300/products");
+        when(flow.getOperator()).thenReturn(Operator.STARTS_WITH);
+        when(flow.getPath()).thenReturn("/(.*)/products");
+
+        assertTrue(evaluator.evaluate(context, flow));
+    }
+
+    @Test
+    public void shouldEvaluate_startsWith_regexCaptureGroup_withSubpath() {
+        when(request.pathInfo()).thenReturn("/300/products/123");
+        when(flow.getOperator()).thenReturn(Operator.STARTS_WITH);
+        when(flow.getPath()).thenReturn("/(.*)/products");
+
+        assertTrue(evaluator.evaluate(context, flow));
+    }
+
+    @Test
+    public void shouldNotEvaluate_startsWith_regexCaptureGroup_differentResource() {
+        when(request.pathInfo()).thenReturn("/300/purchase-orders");
+        when(flow.getOperator()).thenReturn(Operator.STARTS_WITH);
+        when(flow.getPath()).thenReturn("/(.*)/products");
+
+        assertFalse(evaluator.evaluate(context, flow));
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/reactive/v4/flow/selection/HttpSelectorConditionFilterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/reactive/v4/flow/selection/HttpSelectorConditionFilterTest.java
@@ -139,4 +139,28 @@ class HttpSelectorConditionFilterTest {
         final TestObserver<Flow> obs = cut.filter(ctx, flow).test();
         obs.assertResult();
     }
+
+    @Test
+    void shouldNotFilterWhenPathStartsWithRegexCaptureGroup() {
+        when(request.pathInfo()).thenReturn("/300/products");
+        HttpSelector httpSelector = new HttpSelector();
+        httpSelector.setPath("/(.*)/products");
+        httpSelector.setPathOperator(Operator.STARTS_WITH);
+        when(flow.selectorByType(SelectorType.HTTP)).thenReturn(Optional.of(httpSelector));
+
+        final TestObserver<Flow> obs = cut.filter(ctx, flow).test();
+        obs.assertResult(flow);
+    }
+
+    @Test
+    void shouldFilterWhenPathDoesNotMatchRegexCaptureGroup() {
+        when(request.pathInfo()).thenReturn("/300/purchase-orders");
+        HttpSelector httpSelector = new HttpSelector();
+        httpSelector.setPath("/(.*)/products");
+        httpSelector.setPathOperator(Operator.STARTS_WITH);
+        when(flow.selectorByType(SelectorType.HTTP)).thenReturn(Optional.of(httpSelector));
+
+        final TestObserver<Flow> obs = cut.filter(ctx, flow).test();
+        obs.assertResult();
+    }
 }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14526