### PR TITLE
fix: remove mat cards. cancel edit instead of resetting form. use signals.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
@@ -16,154 +16,137 @@
 
 -->
 @if (application$ | async; as application) {
-  <mat-card appearance="outlined" class="settings-edit">
-    <mat-card-content>
-      <form [formGroup]="applicationSettingsForm" class="settings-edit__form">
-        <div class="settings-edit__form__general">
-          <span class="next-gen-h3" i18n="@@applicationDetailsTitleApplicationSettings">Application details</span>
-          <div class="settings-edit__form__field">
-            <p class="next-gen-body" i18n="@@applicationNameApplicationSettings">Application name *</p>
-            <mat-form-field appearance="outline">
-              <input matInput formControlName="name" aria-label="Application name" data-testId="name" />
-              <mat-error i18n="@@nameRequiredApplicationSettings">Application name is required</mat-error>
-            </mat-form-field>
-          </div>
-          <div class="settings-edit__form__field">
-            <p class="next-gen-body" i18n="@@applicationDescriptionApplicationSettings">Description (optional)</p>
-            <mat-form-field appearance="outline">
-              <textarea
-                matInput
-                formControlName="description"
-                aria-label="Application description"
-                data-testId="description"
-                rows="1"
-              ></textarea>
-            </mat-form-field>
-          </div>
-          <div class="settings-edit__form__field">
-            <p class="next-gen-body" i18n="@@applicationDomainApplicationSettings">Domain (optional)</p>
-            <p class="next-gen-body" i18n="@@hintDomainApplicationSettings">Enter the domain to be used by the application</p>
-            <mat-form-field appearance="outline">
-              <input matInput formControlName="domain" aria-label="Domain" data-testId="domain" />
-            </mat-form-field>
-          </div>
+  <h1 class="next-gen-h3" i18n="@@applicationDetailsTitleApplicationSettings">Application details</h1>
+  <form [formGroup]="applicationSettingsForm" class="settings-edit__form">
+    <div class="settings-edit__form__general">
+      <span class="next-gen-h5" i18n="@@applicationDetailsGeneralTitleApplicationSettings">General</span>
+      <div class="settings-edit__form__field">
+        <p class="next-gen-body" i18n="@@applicationNameApplicationSettings">Application name *</p>
+        <mat-form-field appearance="outline">
+          <input matInput formControlName="name" aria-label="Application name" data-testId="name" />
+          <mat-error i18n="@@nameRequiredApplicationSettings">Application name is required</mat-error>
+        </mat-form-field>
+      </div>
+      <div class="settings-edit__form__field">
+        <p class="next-gen-body" i18n="@@applicationDescriptionApplicationSettings">Description (optional)</p>
+        <mat-form-field appearance="outline">
+          <textarea
+            matInput
+            formControlName="description"
+            aria-label="Application description"
+            data-testId="description"
+            rows="1"
+          ></textarea>
+        </mat-form-field>
+      </div>
+      <div class="settings-edit__form__field">
+        <p class="next-gen-body" i18n="@@applicationDomainApplicationSettings">Domain (optional)</p>
+        <p class="next-gen-body" i18n="@@hintDomainApplicationSettings">Enter the domain to be used by the application</p>
+        <mat-form-field appearance="outline">
+          <input matInput formControlName="domain" aria-label="Domain" data-testId="domain" />
+        </mat-form-field>
+      </div>
+    </div>
+
+    <div class="settings-edit__form__security">
+      <span class="next-gen-h5" i18n="@@applicationSecurityTitleApplicationSettings">Application security</span>
+      @if (application.settings.app) {
+        <div class="settings-edit__form__field">
+          <p class="next-gen-body" i18n="@@applicationTypeApplicationSettings">Application type</p>
+          <mat-form-field appearance="outline">
+            <input matInput formControlName="appType" aria-label="Application type" data-testId="simple-type" />
+            <mat-hint i18n="@@hintApplicationTypeApplicationSettings">Type of the application (mobile, web, ...) </mat-hint>
+          </mat-form-field>
         </div>
-
-        <mat-divider />
-
-        <div class="settings-edit__form__security">
-          <span class="next-gen-h5" i18n="@@applicationSecurityTitleApplicationSettings">Application security</span>
-          @if (application.settings.app) {
-            <div class="settings-edit__form__field">
-              <p class="next-gen-body" i18n="@@applicationTypeApplicationSettings">Application type</p>
-              <mat-form-field appearance="outline">
-                <input matInput formControlName="appType" aria-label="Application type" data-testId="simple-type" />
-                <mat-hint i18n="@@hintApplicationTypeApplicationSettings">Type of the application (mobile, web, ...) </mat-hint>
-              </mat-form-field>
-            </div>
-            <div class="settings-edit__form__field">
-              <p class="next-gen-body" i18n="@@applicationClientIdApplicationSettings">ClientID</p>
-              <mat-form-field appearance="outline">
-                <input matInput formControlName="appClientId" aria-label="Client ID" data-testId="simple-clientId" />
-                <mat-hint i18n="@@hintClientIdApplicationSettings"
-                  >This field is required to subscribe to certain types of API Plan (OAuth2, JWT)
-                </mat-hint>
-              </mat-form-field>
-            </div>
-          } @else if (application.settings.oauth) {
-            <div class="settings-edit__form__security__subtitle">
-              <mat-chip data-testId="type">{{ applicationTypeConfiguration().name }}</mat-chip>
-            </div>
-            <div class="settings-edit__form__security__copy-code">
-              <app-copy-code id="client-id" title="Client ID" [text]="application.settings.oauth.client_id ?? ''" data-testId="clientId" />
-              <app-copy-code
-                id="client-secret"
-                title="Client Secret"
-                [text]="application.settings.oauth.client_secret ?? ''"
-                [mode]="'PASSWORD'"
-                data-testId="clientSecret"
-              />
-            </div>
-            @if (applicationTypeConfiguration().requires_redirect_uris) {
-              <div class="settings-edit__form__field">
-                <p class="next-gen-body" i18n="@@applicationRedirectUrisApplicationSettings">Redirect URIs *</p>
-                <mat-form-field appearance="outline">
-                  <mat-chip-grid
-                    #redirectURIChipGrid
-                    aria-label="Redirect URIs"
-                    formControlName="oauthRedirectUris"
-                    data-testId="redirectUris"
-                  >
-                    @for (uri of applicationSettingsForm.controls.oauthRedirectUris.value; track uri) {
-                      <mat-chip-row (removed)="removeRedirectUri(uri)">
-                        {{ uri }}
-                        <button matChipRemove aria-label="'remove redirect URI' + uri">
-                          <mat-icon>cancel</mat-icon>
-                        </button>
-                      </mat-chip-row>
-                    }
-                    <input
-                      placeholder="Add redirect URI..."
-                      [matChipInputFor]="redirectURIChipGrid"
-                      [matChipInputAddOnBlur]="true"
-                      (matChipInputTokenEnd)="addRedirectUri($event)"
-                    />
-                  </mat-chip-grid>
-                  <mat-hint i18n="@@hintRedirectUrisApplicationSettings"
-                    >URIs where the authorization server will send OAuth responses
-                  </mat-hint>
-                  <mat-error i18n="@@redirectUrisRequiredApplicationSettings">At least one redirect URI is required </mat-error>
-                </mat-form-field>
-              </div>
-            }
-            <div class="settings-edit__form__field">
-              <p class="next-gen-body" i18n="@@applicationGrantTypesApplicationSettings">Grant types *</p>
-              <mat-form-field appearance="outline">
-                <mat-select formControlName="oauthGrantTypes" multiple aria-label="Grant types" data-testId="grantTypes">
-                  @for (grantType of grantTypesList; track grantType) {
-                    <mat-option [value]="grantType.type" [disabled]="grantType.isDisabled">{{ grantType.name }} </mat-option>
-                  }
-                </mat-select>
-                <mat-hint i18n="@@hintGrantTypesApplicationSettings"
-                  >Grant types allowed for the client. Please set only grant types you need for security reasons
-                </mat-hint>
-                <mat-error i18n="@@grantTypesRequiredApplicationSettings">At least one grant type is required </mat-error>
-              </mat-form-field>
-            </div>
-          }
+        <div class="settings-edit__form__field">
+          <p class="next-gen-body" i18n="@@applicationClientIdApplicationSettings">ClientID</p>
+          <mat-form-field appearance="outline">
+            <input matInput formControlName="appClientId" aria-label="Client ID" data-testId="simple-clientId" />
+            <mat-hint i18n="@@hintClientIdApplicationSettings"
+              >This field is required to subscribe to certain types of API Plan (OAuth2, JWT)
+            </mat-hint>
+          </mat-form-field>
         </div>
-
-        @if (mtlsEnabled) {
-          <app-application-tab-settings-certificates
-            [applicationId]="applicationId()"
-            [userApplicationPermissions]="userApplicationPermissions()"
+      } @else if (application.settings.oauth) {
+        <div class="settings-edit__form__security__subtitle">
+          <mat-chip data-testId="type">{{ applicationTypeConfiguration().name }}</mat-chip>
+        </div>
+        <div class="settings-edit__form__security__copy-code">
+          <app-copy-code id="client-id" title="Client ID" [text]="application.settings.oauth.client_id ?? ''" data-testId="clientId" />
+          <app-copy-code
+            id="client-secret"
+            title="Client Secret"
+            [text]="application.settings.oauth.client_secret ?? ''"
+            [mode]="'PASSWORD'"
+            data-testId="clientSecret"
           />
-        }
-
-        <div class="settings-edit__form__actions">
-          <button
-            mat-flat-button
-            class="secondary-button"
-            (click)="submit()"
-            [disabled]="applicationSettingsForm.invalid || (formUnchanged$ | async)"
-            i18n="@@saveApplicationSettings"
-            aria-label="Save application"
-            data-testId="save"
-          >
-            Save
-          </button>
-          <button
-            mat-stroked-button
-            (click)="reset()"
-            [disabled]="formUnchanged$ | async"
-            i18n="@@discardChangesApplicationSettings"
-            aria-label="Discard changes"
-            data-testId="discard"
-          >
-            Discard changes
-          </button>
         </div>
-      </form>
-    </mat-card-content>
-  </mat-card>
+        @if (applicationTypeConfiguration().requires_redirect_uris) {
+          <div class="settings-edit__form__field">
+            <p class="next-gen-body" i18n="@@applicationRedirectUrisApplicationSettings">Redirect URIs *</p>
+            <mat-form-field appearance="outline">
+              <mat-chip-grid #redirectURIChipGrid aria-label="Redirect URIs" formControlName="oauthRedirectUris" data-testId="redirectUris">
+                @for (uri of applicationSettingsForm.controls.oauthRedirectUris.value; track uri) {
+                  <mat-chip-row (removed)="removeRedirectUri(uri)">
+                    {{ uri }}
+                    <button matChipRemove aria-label="'remove redirect URI' + uri">
+                      <mat-icon>cancel</mat-icon>
+                    </button>
+                  </mat-chip-row>
+                }
+                <input
+                  placeholder="Add redirect URI..."
+                  [matChipInputFor]="redirectURIChipGrid"
+                  [matChipInputAddOnBlur]="true"
+                  (matChipInputTokenEnd)="addRedirectUri($event)"
+                />
+              </mat-chip-grid>
+              <mat-hint i18n="@@hintRedirectUrisApplicationSettings"
+                >URIs where the authorization server will send OAuth responses
+              </mat-hint>
+              <mat-error i18n="@@redirectUrisRequiredApplicationSettings">At least one redirect URI is required </mat-error>
+            </mat-form-field>
+          </div>
+        }
+        <div class="settings-edit__form__field">
+          <p class="next-gen-body" i18n="@@applicationGrantTypesApplicationSettings">Grant types *</p>
+          <mat-form-field appearance="outline">
+            <mat-select formControlName="oauthGrantTypes" multiple aria-label="Grant types" data-testId="grantTypes">
+              @for (grantType of grantTypesList; track grantType) {
+                <mat-option [value]="grantType.type" [disabled]="grantType.isDisabled">{{ grantType.name }} </mat-option>
+              }
+            </mat-select>
+            <mat-hint i18n="@@hintGrantTypesApplicationSettings"
+              >Grant types allowed for the client. Please set only grant types you need for security reasons
+            </mat-hint>
+            <mat-error i18n="@@grantTypesRequiredApplicationSettings">At least one grant type is required </mat-error>
+          </mat-form-field>
+        </div>
+      }
+    </div>
+
+    @if (mtlsEnabled) {
+      <app-application-tab-settings-certificates
+        [applicationId]="applicationId()"
+        [userApplicationPermissions]="userApplicationPermissions()"
+      />
+    }
+
+    <div class="settings-edit__form__actions">
+      <button
+        mat-flat-button
+        class="secondary-button"
+        (click)="submit()"
+        [disabled]="applicationSettingsForm.invalid || (formUnchanged$ | async)"
+        i18n="@@saveApplicationSettings"
+        aria-label="Save application"
+        data-testId="save"
+      >
+        Save
+      </button>
+      <button mat-stroked-button (click)="cancel()" i18n="@@cancelApplicationSettings" aria-label="Cancel" data-testId="cancel">
+        Cancel
+      </button>
+    </div>
+  </form>
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.scss
@@ -16,17 +16,21 @@
 @use '../../../../../scss/theme';
 @use '@angular/material' as mat;
 
-.settings-edit {
-  mat-card-content {
-    display: flex;
-    flex-direction: column;
-    padding-top: 8px;
-  }
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
 
+h1 {
+  margin: 5px 0;
+}
+
+.settings-edit {
   &__form {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 28px;
 
     &__general,
     &__security {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.spec.ts
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
 
 import { ApplicationTabSettingsEditComponent } from './application-tab-settings-edit.component';
+import { ApplicationTabSettingsEditHarness } from './application-tab-settings-edit.harness';
 import { fakeApplication, fakeSimpleApplicationType } from '../../../../../entities/application/application.fixture';
 import { fakeUserApplicationPermissions } from '../../../../../entities/permission/permission.fixtures';
 import { ApplicationCertificateService } from '../../../../../services/application-certificate.service';
@@ -27,17 +29,40 @@ import { ConfigService } from '../../../../../services/config.service';
 
 describe('ApplicationTabSettingsEditComponent', () => {
   const APPLICATION_ID = 'test-app-id';
+  const simpleApplication = fakeApplication({
+    id: APPLICATION_ID,
+    name: 'Simple application',
+    applicationType: 'SIMPLE',
+    settings: {
+      app: {
+        type: 'mobile',
+        client_id: 'test-client-id',
+      },
+    },
+  });
+
   let fixture: ComponentFixture<ApplicationTabSettingsEditComponent>;
   let component: ApplicationTabSettingsEditComponent;
 
-  async function init(configuration: object) {
+  async function init(
+    configuration: object = {},
+    options: {
+      application?: ReturnType<typeof fakeApplication>;
+      save?: jest.Mock;
+    } = {},
+  ) {
+    TestBed.resetTestingModule();
+
+    const application = options.application ?? simpleApplication;
+    const save = options.save ?? jest.fn().mockReturnValue(of(application));
+
     await TestBed.configureTestingModule({
       imports: [ApplicationTabSettingsEditComponent, NoopAnimationsModule],
       providers: [
         { provide: ConfigService, useValue: { configuration } },
         { provide: ApplicationCertificateService, useValue: { list: jest.fn().mockReturnValue(of({ data: [] })) } },
-        { provide: ApplicationService, useValue: { get: () => of(fakeApplication()), save: jest.fn() } },
-        { provide: Router, useValue: { url: '/', navigate: jest.fn() } },
+        { provide: ApplicationService, useValue: { get: () => of(application), save } },
+        { provide: Router, useValue: { url: '/', navigate: jest.fn().mockResolvedValue(true) } },
       ],
     }).compileComponents();
 
@@ -48,6 +73,11 @@ describe('ApplicationTabSettingsEditComponent', () => {
     fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions());
     fixture.detectChanges();
     await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  async function getEditHarness(): Promise<ApplicationTabSettingsEditHarness> {
+    return TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationTabSettingsEditHarness);
   }
 
   describe('mtlsEnabled', () => {
@@ -67,6 +97,40 @@ describe('ApplicationTabSettingsEditComponent', () => {
       await init({});
 
       expect((component as unknown as { mtlsEnabled: boolean }).mtlsEnabled).toBe(false);
+    });
+  });
+
+  describe('submit action', () => {
+    it('should close the edit view after a successful save', async () => {
+      const savedApplication = fakeApplication({
+        ...simpleApplication,
+        name: 'Saved application',
+      });
+      const save = jest.fn().mockReturnValue(of(savedApplication));
+      await init({}, { application: simpleApplication, save });
+      const editClosedSpy = jest.fn();
+      component.editClosed.subscribe(editClosedSpy);
+      const editHarness = await getEditHarness();
+
+      await editHarness.changeName('Saved application');
+      await editHarness.saveApplication();
+      await fixture.whenStable();
+
+      expect(save).toHaveBeenCalled();
+      expect(editClosedSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('cancel action', () => {
+    it('should close the edit view when the cancel button is clicked', async () => {
+      await init();
+      const editClosedSpy = jest.fn();
+      component.editClosed.subscribe(editClosedSpy);
+      const editHarness = await getEditHarness();
+
+      await editHarness.cancelChanges();
+
+      expect(editClosedSpy).toHaveBeenCalled();
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { AsyncPipe } from '@angular/common';
-import { Component, inject, input, OnInit } from '@angular/core';
+import { Component, inject, input, OnInit, output } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -89,6 +89,8 @@ export class ApplicationTabSettingsEditComponent implements OnInit {
   applicationTypeConfiguration = input.required<ApplicationType>();
   userApplicationPermissions = input.required<UserApplicationPermissions>();
 
+  editClosed = output<void>();
+
   protected get mtlsEnabled(): boolean {
     return this.configService.configuration?.portalNext?.mtls?.enabled === true;
   }
@@ -137,7 +139,7 @@ export class ApplicationTabSettingsEditComponent implements OnInit {
       this.addValidatorsOnForm();
 
       this.initialValues = this.convertToVM(application);
-      this.reset();
+      this.resetForm();
       this.formUnchanged$ = this.applicationSettingsForm.valueChanges.pipe(
         startWith(this.initialValues),
         map(value => isEqual(this.initialValues, value)),
@@ -171,7 +173,11 @@ export class ApplicationTabSettingsEditComponent implements OnInit {
     }
   }
 
-  reset() {
+  cancel(): void {
+    this.editClosed.emit();
+  }
+
+  resetForm(): void {
     this.applicationSettingsForm.patchValue(this.initialValues);
   }
 
@@ -183,7 +189,7 @@ export class ApplicationTabSettingsEditComponent implements OnInit {
       .pipe(
         tap(app => {
           this.initialValues = this.convertToVM(app);
-          this.reset();
+          this.editClosed.emit();
           const url = this.router.url;
           return this.router.navigate([url], { onSameUrlNavigation: 'reload' });
         }),

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.harness.ts
@@ -36,7 +36,7 @@ export class ApplicationTabSettingsEditHarness extends ContentContainerComponent
   protected locateRedirectUris = this.getHarnessOrNull(MatChipGridHarness.with({ selector: '[data-testId="redirectUris"]' }));
   protected locateGrantTypes = this.getHarnessOrNull(MatSelectHarness.with({ selector: '[data-testId="grantTypes"]' }));
   protected locateSaveButton = this.getHarness(MatButtonHarness.with({ selector: '[data-testId="save"]' }));
-  protected locateDiscardButton = this.getHarness(MatButtonHarness.with({ selector: '[data-testId="discard"]' }));
+  protected locateCancelButton = this.getHarness(MatButtonHarness.with({ selector: '[data-testId="cancel"]' }));
   public async getCertificatesSection(): Promise<ApplicationTabSettingsCertificatesHarness | null> {
     return this.locateCertificatesSection();
   }
@@ -147,10 +147,10 @@ export class ApplicationTabSettingsEditHarness extends ContentContainerComponent
   }
 
   public async isDiscardButtonDisabled(): Promise<boolean> {
-    return this.locateDiscardButton.then(button => button.isDisabled());
+    return this.locateCancelButton.then(button => button.isDisabled());
   }
-  public async discardChanges(): Promise<void> {
-    return this.locateDiscardButton.then(button => button.click());
+  public async cancelChanges(): Promise<void> {
+    return this.locateCancelButton.then(button => button.click());
   }
 
   private async getCopyCodeHarnessOrNull(title: string): Promise<CopyCodeHarness | null> {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-read/application-tab-settings-read.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-read/application-tab-settings-read.component.html
@@ -15,132 +15,128 @@
     limitations under the License.
 
 -->
-<mat-card appearance="outlined" class="settings-view">
-  <mat-card-content>
-    <div class="settings-view__header">
-      <span class="next-gen-h3" data-testId="name">{{ readOnlyValues().name }}</span>
-      <div class="settings-view__header__actions">
-        <ng-content select="[additionalActions]" />
-        @if (canUpdate()) {
-          <button
-            mat-stroked-button
-            (click)="editClicked.emit()"
-            i18n="@@editApplicationSettings"
-            aria-label="Edit application"
-            data-testId="edit"
-          >
-            Edit
-          </button>
-        }
+<div class="settings-view__header">
+  <h1 class="next-gen-h3" data-testId="name">{{ readOnlyValues().name }}</h1>
+  <div class="settings-view__header__actions">
+    @if (canUpdate()) {
+      <button
+        mat-stroked-button
+        (click)="editClicked.emit()"
+        i18n="@@editApplicationSettings"
+        aria-label="Edit application"
+        data-testId="edit"
+      >
+        Edit
+      </button>
+    }
+    <ng-content select="[additionalActions]" />
+  </div>
+</div>
+
+<div class="settings-view__details" [appIsNarrow]="'settings-view__details--stacked'">
+  <div class="settings-view__details__row">
+    <span class="material-icons icon-small settings-view__details__row__icon">person</span>
+    <span class="settings-view__details__row__label next-gen-body" i18n="@@ownerLabelApplicationSettings">Owner</span>
+    <span class="next-gen-body" data-testId="owner">{{ readOnlyValues().ownerDisplayName }}</span>
+  </div>
+
+  <div class="settings-view__details__row">
+    <span class="material-icons icon-small settings-view__details__row__icon">dns</span>
+    <span class="settings-view__details__row__label next-gen-body" i18n="@@typeLabelApplicationSettings">Type</span>
+    <span class="next-gen-body" data-testId="type">{{ readOnlyValues().type }}</span>
+  </div>
+
+  <div class="settings-view__details__row">
+    <span class="material-icons icon-small settings-view__details__row__icon">calendar_today</span>
+    <span class="settings-view__details__row__label next-gen-body" i18n="@@creationDateLabelApplicationSettings">Creation date</span>
+    <span class="next-gen-body" data-testId="createdAt">{{ readOnlyValues().createdAt | date: 'yyyy-MM-dd' }}</span>
+  </div>
+
+  <div class="settings-view__details__row">
+    <span class="material-icons icon-small settings-view__details__row__icon">schedule</span>
+    <span class="settings-view__details__row__label next-gen-body" i18n="@@updatedLabelApplicationSettings">Updated</span>
+    <span class="next-gen-body" data-testId="updatedAt">{{ getRelativeTime(readOnlyValues().updatedAt) }}</span>
+  </div>
+
+  <div class="settings-view__details__row">
+    <span class="material-icons icon-small settings-view__details__row__icon">link</span>
+    <span class="settings-view__details__row__label next-gen-body" i18n="@@domainLabelApplicationSettings">Domain</span>
+    @if (readOnlyValues().domain) {
+      <span class="next-gen-body" data-testId="domain">{{ readOnlyValues().domain }}</span>
+    } @else {
+      <span class="next-gen-body settings-view__details__row__value--not-set" data-testId="domain" i18n="@@notSetApplicationSettings"
+        >Not set</span
+      >
+    }
+  </div>
+
+  <div class="settings-view__details__row">
+    <span class="material-icons icon-small settings-view__details__row__icon">security</span>
+    <span class="settings-view__details__row__label next-gen-body" i18n="@@securityLabelApplicationSettings">Security</span>
+    <mat-chip data-testId="securityType">{{ readOnlyValues().securityType }}</mat-chip>
+  </div>
+
+  @if (readOnlyValues().grantTypes) {
+    <div class="settings-view__details__row">
+      <span class="material-icons icon-small settings-view__details__row__icon">lock</span>
+      <span class="settings-view__details__row__label next-gen-body" i18n="@@rightsAuthorizedLabelApplicationSettings"
+        >Rights authorized</span
+      >
+      <span class="next-gen-body" data-testId="grantTypes">{{ readOnlyValues().grantTypes }}</span>
+    </div>
+  }
+
+  @if (readOnlyValues().clientId) {
+    <div class="settings-view__details__row">
+      <span class="material-icons icon-small settings-view__details__row__icon">tag</span>
+      <span class="settings-view__details__row__label next-gen-body" i18n="@@clientIdLabelApplicationSettings">Client ID</span>
+      <div class="settings-view__details__row__value-group">
+        <span class="next-gen-body" data-testId="clientId">{{ readOnlyValues().clientId }}</span>
+        <app-copy-code-icon [contentToCopy]="readOnlyValues().clientId!" i18n-label label="Copy Client ID" />
       </div>
     </div>
+  }
 
-    <div class="settings-view__details" [appIsNarrow]="'settings-view__details--stacked'">
-      <div class="settings-view__details__row">
-        <span class="material-icons icon-small settings-view__details__row__icon">person</span>
-        <span class="settings-view__details__row__label next-gen-body" i18n="@@ownerLabelApplicationSettings">Owner</span>
-        <span class="next-gen-body" data-testId="owner">{{ readOnlyValues().ownerDisplayName }}</span>
-      </div>
-
-      <div class="settings-view__details__row">
-        <span class="material-icons icon-small settings-view__details__row__icon">dns</span>
-        <span class="settings-view__details__row__label next-gen-body" i18n="@@typeLabelApplicationSettings">Type</span>
-        <span class="next-gen-body" data-testId="type">{{ readOnlyValues().type }}</span>
-      </div>
-
-      <div class="settings-view__details__row">
-        <span class="material-icons icon-small settings-view__details__row__icon">calendar_today</span>
-        <span class="settings-view__details__row__label next-gen-body" i18n="@@creationDateLabelApplicationSettings">Creation date</span>
-        <span class="next-gen-body" data-testId="createdAt">{{ readOnlyValues().createdAt | date: 'yyyy-MM-dd' }}</span>
-      </div>
-
-      <div class="settings-view__details__row">
-        <span class="material-icons icon-small settings-view__details__row__icon">schedule</span>
-        <span class="settings-view__details__row__label next-gen-body" i18n="@@updatedLabelApplicationSettings">Updated</span>
-        <span class="next-gen-body" data-testId="updatedAt">{{ getRelativeTime(readOnlyValues().updatedAt) }}</span>
-      </div>
-
-      <div class="settings-view__details__row">
-        <span class="material-icons icon-small settings-view__details__row__icon">link</span>
-        <span class="settings-view__details__row__label next-gen-body" i18n="@@domainLabelApplicationSettings">Domain</span>
-        @if (readOnlyValues().domain) {
-          <span class="next-gen-body" data-testId="domain">{{ readOnlyValues().domain }}</span>
-        } @else {
-          <span class="next-gen-body settings-view__details__row__value--not-set" data-testId="domain" i18n="@@notSetApplicationSettings"
-            >Not set</span
-          >
-        }
-      </div>
-
-      <div class="settings-view__details__row">
-        <span class="material-icons icon-small settings-view__details__row__icon">security</span>
-        <span class="settings-view__details__row__label next-gen-body" i18n="@@securityLabelApplicationSettings">Security</span>
-        <mat-chip data-testId="securityType">{{ readOnlyValues().securityType }}</mat-chip>
-      </div>
-
-      @if (readOnlyValues().grantTypes) {
-        <div class="settings-view__details__row">
-          <span class="material-icons icon-small settings-view__details__row__icon">lock</span>
-          <span class="settings-view__details__row__label next-gen-body" i18n="@@rightsAuthorizedLabelApplicationSettings"
-            >Rights authorized</span
-          >
-          <span class="next-gen-body" data-testId="grantTypes">{{ readOnlyValues().grantTypes }}</span>
-        </div>
-      }
-
-      @if (readOnlyValues().clientId) {
-        <div class="settings-view__details__row">
-          <span class="material-icons icon-small settings-view__details__row__icon">tag</span>
-          <span class="settings-view__details__row__label next-gen-body" i18n="@@clientIdLabelApplicationSettings">Client ID</span>
-          <div class="settings-view__details__row__value-group">
-            <span class="next-gen-body" data-testId="clientId">{{ readOnlyValues().clientId }}</span>
-            <app-copy-code-icon [contentToCopy]="readOnlyValues().clientId!" i18n-label label="Copy Client ID" />
-          </div>
-        </div>
-      }
-
-      @if (readOnlyValues().clientSecret) {
-        <div class="settings-view__details__row">
-          <span class="material-icons icon-small settings-view__details__row__icon">key</span>
-          <span class="settings-view__details__row__label next-gen-body" i18n="@@clientSecretLabelApplicationSettings">Client Secret</span>
-          <div class="settings-view__details__row__value-group">
-            <span class="next-gen-body" data-testId="clientSecret">
-              {{ clientSecretVisible() ? readOnlyValues().clientSecret : '••••••••••••••••' }}
-            </span>
-            <button
-              mat-icon-button
-              class="settings-view__details__row__secret-toggle"
-              (click)="clientSecretVisible.set(!clientSecretVisible())"
-              [attr.aria-label]="clientSecretVisible() ? 'Hide Client Secret' : 'Show Client Secret'"
-            >
-              <span class="material-icons icon-small">{{ clientSecretVisible() ? 'visibility_off' : 'visibility' }}</span>
-            </button>
-            <app-copy-code-icon [contentToCopy]="readOnlyValues().clientSecret!" i18n-label label="Copy Client Secret" />
-          </div>
-        </div>
-      }
-
-      @if (readOnlyValues().redirectUris) {
-        <div class="settings-view__details__row">
-          <span class="material-icons icon-small settings-view__details__row__icon">open_in_new</span>
-          <span class="settings-view__details__row__label next-gen-body" i18n="@@redirectUrisLabelApplicationSettings">Redirect URIs</span>
-          <div class="settings-view__details__row__value-group">
-            <span class="next-gen-body" data-testId="redirectUris">{{ readOnlyValues().redirectUris }}</span>
-            <app-copy-code-icon [contentToCopy]="readOnlyValues().redirectUris!" i18n-label label="Copy Redirect URIs" />
-          </div>
-        </div>
-      }
-    </div>
-
-    <div class="settings-view__description">
-      <span class="next-gen-body" i18n="@@descriptionLabelApplicationSettings">Application description</span>
-      @if (readOnlyValues().description) {
-        <span class="next-gen-body" data-testId="description">{{ readOnlyValues().description }}</span>
-      } @else {
-        <span class="next-gen-body settings-view__description__empty" data-testId="description" i18n="@@noDescriptionApplicationSettings"
-          >No description added.</span
+  @if (readOnlyValues().clientSecret) {
+    <div class="settings-view__details__row">
+      <span class="material-icons icon-small settings-view__details__row__icon">key</span>
+      <span class="settings-view__details__row__label next-gen-body" i18n="@@clientSecretLabelApplicationSettings">Client Secret</span>
+      <div class="settings-view__details__row__value-group">
+        <span class="next-gen-body" data-testId="clientSecret">
+          {{ clientSecretVisible() ? readOnlyValues().clientSecret : '••••••••••••••••' }}
+        </span>
+        <button
+          mat-icon-button
+          class="settings-view__details__row__secret-toggle"
+          (click)="clientSecretVisible.set(!clientSecretVisible())"
+          [attr.aria-label]="clientSecretVisible() ? 'Hide Client Secret' : 'Show Client Secret'"
         >
-      }
+          <span class="material-icons icon-small">{{ clientSecretVisible() ? 'visibility_off' : 'visibility' }}</span>
+        </button>
+        <app-copy-code-icon [contentToCopy]="readOnlyValues().clientSecret!" i18n-label label="Copy Client Secret" />
+      </div>
     </div>
-  </mat-card-content>
-</mat-card>
+  }
+
+  @if (readOnlyValues().redirectUris) {
+    <div class="settings-view__details__row">
+      <span class="material-icons icon-small settings-view__details__row__icon">open_in_new</span>
+      <span class="settings-view__details__row__label next-gen-body" i18n="@@redirectUrisLabelApplicationSettings">Redirect URIs</span>
+      <div class="settings-view__details__row__value-group">
+        <span class="next-gen-body" data-testId="redirectUris">{{ readOnlyValues().redirectUris }}</span>
+        <app-copy-code-icon [contentToCopy]="readOnlyValues().redirectUris!" i18n-label label="Copy Redirect URIs" />
+      </div>
+    </div>
+  }
+</div>
+
+<div class="settings-view__description">
+  <span class="next-gen-body" i18n="@@descriptionLabelApplicationSettings">Application description</span>
+  @if (readOnlyValues().description) {
+    <span class="next-gen-body" data-testId="description">{{ readOnlyValues().description }}</span>
+  } @else {
+    <span class="next-gen-body settings-view__description__empty" data-testId="description" i18n="@@noDescriptionApplicationSettings"
+      >No description added.</span
+    >
+  }
+</div>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-read/application-tab-settings-read.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-read/application-tab-settings-read.component.scss
@@ -16,15 +16,21 @@
 
 @use '../../../../../scss/theme' as theme;
 
-.settings-view {
+:host {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 32px;
+}
 
+.settings-view {
   &__header {
     display: flex;
     align-items: center;
     justify-content: space-between;
+
+    h1 {
+      margin: 5px 0;
+    }
 
     &__actions {
       display: flex;
@@ -34,7 +40,6 @@
   }
 
   &__details {
-    margin-top: 16px;
     display: flex;
     flex-direction: column;
     gap: 12px;

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.html
@@ -21,6 +21,7 @@
       [applicationId]="application.id"
       [applicationTypeConfiguration]="applicationTypeConfiguration()"
       [userApplicationPermissions]="userApplicationPermissions()"
+      (editClosed)="isEditing.set(false)"
     />
   } @else {
     <app-application-tab-settings-read

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.update.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.update.spec.ts
@@ -21,6 +21,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
 
 import { ApplicationTabSettingsEditHarness } from './application-tab-settings-edit/application-tab-settings-edit.harness';
+import { ApplicationTabSettingsReadHarness } from './application-tab-settings-read/application-tab-settings-read.harness';
 import { ApplicationTabSettingsComponent } from './application-tab-settings.component';
 import { ConfirmDialogComponent } from '../../../../components/confirm-dialog/confirm-dialog.component';
 import { Application, ApplicationType } from '../../../../entities/application/application';
@@ -470,14 +471,77 @@ describe('ApplicationTabSettingsComponent', () => {
     });
 
     it('Should be able to discard changes', async () => {
-      expect(await updateHarness.isDiscardButtonDisabled()).toBeTruthy();
-
       await updateHarness.changeName('New Value');
-      expect(await updateHarness.isDiscardButtonDisabled()).toBeFalsy();
 
-      await updateHarness.discardChanges();
-      expect(await updateHarness.getName()).toEqual('Native application');
-      expect(await updateHarness.isDiscardButtonDisabled()).toBeTruthy();
+      await updateHarness.cancelChanges();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      flushGetRequests(
+        fakeApplication({
+          id: applicationId,
+          name: 'Native application',
+          description: 'Native description',
+          picture: 'data:image/png;base64,xxxxxxxx',
+          applicationType: 'NATIVE',
+          settings: {
+            oauth: {
+              client_id: 'my client id',
+              client_secret: 'my client secret',
+              redirect_uris: ['http://localhost/native'],
+              response_types: ['code'],
+              grant_types: ['authorization_code'],
+              renew_client_secret_supported: false,
+            },
+            app: undefined,
+          },
+        }),
+      );
+      await fixture.whenStable();
+
+      expect(fixture.componentRef.instance.isEditing()).toBe(false);
+      const readHarness = await loader.getHarness(ApplicationTabSettingsReadHarness);
+      expect(await readHarness.getName()).toEqual('Native application');
+    });
+
+    it('should close edit mode after saving changes', async () => {
+      await updateHarness.changeName('Updated native application');
+      await updateHarness.saveApplication();
+
+      const updatedApplication = fakeApplication({
+        id: applicationId,
+        name: 'Updated native application',
+        description: 'Native description',
+        picture: 'data:image/png;base64,xxxxxxxx',
+        applicationType: 'NATIVE',
+        settings: {
+          oauth: {
+            client_id: 'my client id',
+            client_secret: 'my client secret',
+            redirect_uris: ['http://localhost/native'],
+            response_types: ['code'],
+            grant_types: ['authorization_code'],
+            renew_client_secret_supported: false,
+          },
+          app: undefined,
+        },
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}`,
+        method: 'PUT',
+      });
+      req.flush(updatedApplication);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      flushGetRequests(updatedApplication);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.componentRef.instance.isEditing()).toBe(false);
+      const readHarness = await loader.getHarness(ApplicationTabSettingsReadHarness);
+      expect(await readHarness.getName()).toEqual('Updated native application');
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.scss
@@ -59,6 +59,6 @@
   }
 
   &__content {
-    padding-top: 32px;
+    padding: 32px 0;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/applications/create-application/create-application.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/applications/create-application/create-application.component.html
@@ -180,7 +180,7 @@
       <app-loader />
     }
 
-    @if (hasApplicationError) {
+    @if (hasApplicationError()) {
       <div class="m3-title-medium error-message" i18n="@@createApplicationGeneralErrorMessage">
         There was an error creating your application and it could not be processed. Try again, and if the issue persists, contact your
         portal administrator.

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/applications/create-application/create-application.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/applications/create-application/create-application.component.spec.ts
@@ -624,7 +624,7 @@ describe('CreateApplicationComponent', () => {
 
       fixture.detectChanges();
 
-      expect(component.hasApplicationError).toBe(true);
+      expect(component.hasApplicationError()).toBe(true);
       expect(consoleErrorSpy).toHaveBeenCalled();
 
       const errorMessage = fixture.nativeElement.querySelector('.error-message');

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/applications/create-application/create-application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/applications/create-application/create-application.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, computed, DestroyRef, effect, inject } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { AbstractControl, FormControl, FormGroup, FormRecord, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -130,7 +130,7 @@ export class CreateApplicationComponent {
     }));
   });
 
-  hasApplicationError: boolean = false;
+  hasApplicationError = signal(false);
 
   constructor() {
     this.breadcrumbService.set([
@@ -174,7 +174,7 @@ export class CreateApplicationComponent {
           this.router.navigate(['/dashboard/applications', application.id]);
         },
         error: err => {
-          this.hasApplicationError = true;
+          this.hasApplicationError.set(true);
           console.error('Error creating application:', err);
         },
       });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13520

### Description

Multiple fixes for Application screen to make it consistent with the rest of the dev portal:
- **Style consistency**: removed mat cards and make application screens consistent with the rest of the portal. Replaced card titles with semantic headings, adjusted spacing on the host and form sections, and tweaked application details content padding.

- **Edit cancelling**: Cancel now returns to the read view instead of resetting form values while staying in edit mode.
- **Signals**: Converted hasApplicationError from a plain boolean to a signal in CreateApplicationComponent, with matching template and spec updates.

### Screenshots / video

https://github.com/user-attachments/assets/1337912f-9d43-47d1-b9fa-7afeee1f72c4


