### PR TITLE
fix(dynamic-properties): allow disabling dynamic properties on V4 APIs

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
@@ -101,11 +101,24 @@ export class ApiDynamicPropertiesV4Component implements OnInit, OnDestroy {
 
           this.initialFormValue = this.form.getRawValue();
 
+          // gio-form-json-schema calls onChange when rendering (incl. async $ref
+          // resolution), which marks the configuration control dirty even though no
+          // user interaction occurred. Suppress dirty marking on the configuration
+          // control during initialization, then restore normal behavior.
+          const configControl = this.form.controls.configuration;
+          const originalMarkAsDirty = configControl.markAsDirty.bind(configControl);
+          configControl.markAsDirty = () => {};
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ((window as any).__zone_symbol__setTimeout || setTimeout)(() => {
+            configControl.markAsDirty = originalMarkAsDirty;
+            this.initialFormValue = this.form.getRawValue();
+          }, 2000);
+
           this.form.controls.enabled.valueChanges.pipe(distinctUntilChanged(), takeUntil(this.unsubscribe$)).subscribe(enabled => {
             if (enabled) {
-              this.form.controls.configuration.enable();
+              this.form.controls.configuration.enable({ emitEvent: false });
             } else {
-              this.form.controls.configuration.disable();
+              this.form.controls.configuration.disable({ emitEvent: false });
             }
           });
         }),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -317,9 +317,14 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
             throw new DynamicPropertiesInvalidException(dynamicProperties.getType());
         }
 
-        dynamicProperties.setConfiguration(
-            this.apiServicePluginService.validateApiServiceConfiguration(dynamicProperties.getType(), dynamicProperties.getConfiguration())
-        );
+        if (dynamicProperties.isEnabled()) {
+            dynamicProperties.setConfiguration(
+                this.apiServicePluginService.validateApiServiceConfiguration(
+                    dynamicProperties.getType(),
+                    dynamicProperties.getConfiguration()
+                )
+            );
+        }
     }
 
     public List<Resource> validateAndSanitize(List<Resource> resources) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -46,6 +46,7 @@ import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.flow.selector.Selector;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
@@ -55,6 +56,7 @@ import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.DynamicPropertiesInvalidException;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.LifecycleStateChangeNotAllowedException;
 import io.gravitee.rest.api.service.v4.ApiServicePluginService;
@@ -561,5 +563,40 @@ public class ApiValidationServiceImplTest {
         if (failed && !shouldFail) {
             fail("Should be possible to change the lifecycle state of a " + fromLifecycleState + " API to " + lifecycleState);
         }
+    }
+
+    @Test
+    public void should_not_validate_configuration_when_dynamic_properties_disabled() {
+        Service dynamicProperties = Service.builder().enabled(false).type("http-dynamic-properties").configuration("{}").build();
+
+        apiValidationService.validateDynamicProperties(dynamicProperties);
+
+        verify(apiServicePluginService, never()).validateApiServiceConfiguration(any(), any());
+    }
+
+    @Test
+    public void should_validate_configuration_when_dynamic_properties_enabled() {
+        Service dynamicProperties = Service.builder().enabled(true).type("http-dynamic-properties").configuration("{}").build();
+        when(apiServicePluginService.validateApiServiceConfiguration("http-dynamic-properties", "{}")).thenReturn("{}");
+
+        apiValidationService.validateDynamicProperties(dynamicProperties);
+
+        verify(apiServicePluginService, times(1)).validateApiServiceConfiguration("http-dynamic-properties", "{}");
+    }
+
+    @Test
+    public void should_not_validate_when_dynamic_properties_is_null() {
+        apiValidationService.validateDynamicProperties(null);
+
+        verify(apiServicePluginService, never()).validateApiServiceConfiguration(any(), any());
+    }
+
+    @Test
+    public void should_throw_when_dynamic_properties_type_is_blank() {
+        Service dynamicProperties = Service.builder().enabled(true).type("").build();
+
+        assertThatThrownBy(() -> apiValidationService.validateDynamicProperties(dynamicProperties)).isInstanceOf(
+            DynamicPropertiesInvalidException.class
+        );
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14505

## Purpose

Allow users to disable dynamic properties on V4 APIs. Previously, toggling "Enabled" to OFF and saving failed with HTTP 400 #: required key [url] not found.

## Summary of changes

  - **Backend (ApiValidationServiceImpl.java)**: Skip schema validation of dynamic property configuration when enabled=false. The schema requires url, method, schedule unconditionally, but these fields are irrelevant when the service is disabled.
  - **Frontend (api-dynamic-properties-v4.component.ts)**: Suppress markAsDirty on the configuration control during the initialization window. gio-form-json-schema calls onChange asynchronously during rendering (including $ref resolution), which falsely marks the
  form dirty on page load, causing a spurious "unsaved changes" banner.
  - **Tests**: 4 new backend unit tests covering enabled/disabled/null/blank-type scenarios.

##  Out of scope

  - Changes to the dynamic property JSON schema itself (schema-form.json) - validation is skipped rather than making url conditionally required, to keep the fix minimal and backward-compatible.
  - gio-form-json-schema or gio-save-bar component changes (upstream ui-particles-angular library).

##  Testing

  - Created a V4 Proxy API, enabled dynamic properties, saved, navigated away and back — no false "unsaved changes" banner
  - Toggled enabled to OFF, saved — succeeds (was HTTP 400 before)
  - Re-enabled, changed fields, saved — succeeds, banner behaves correctly
  - 4 new backend unit tests pass
  - 4 existing frontend unit tests pass

##  Demo

**Before Fix:**

https://github.com/user-attachments/assets/fe197fcb-7b1d-47fe-b4c6-772df612d262

**After Fix:**

https://github.com/user-attachments/assets/936134d6-cea0-48cb-96be-b45322e54f1e
