### PR TITLE
fix(gamma): refactor API URL resolution logic and add support for Gam…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/installation/query_service/InstallationAccessQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/installation/query_service/InstallationAccessQueryService.java
@@ -16,7 +16,7 @@
 package io.gravitee.apim.core.installation.query_service;
 
 import io.gravitee.apim.core.installation.model.RestrictedDomain;
-import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -57,5 +57,9 @@ public interface InstallationAccessQueryService {
 
     String getGammaUrl(final String organizationId);
 
+    @Nullable
     String getGammaAPIUrl(final String organizationId);
+
+    @Nullable
+    String getGammaManagementAPIUrl(final String organizationId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImpl.java
@@ -38,9 +38,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import lombok.CustomLog;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -293,18 +293,7 @@ public class InstallationAccessQueryServiceImpl implements InstallationAccessQue
 
     @Override
     public String getConsoleAPIUrl(final String organizationId) {
-        String consoleAPIBaseUrl;
-        if (installationTypeDomainService.isMultiTenant()) {
-            AccessPoint consoleAccessPoint = accessPointQueryService.getConsoleApiAccessPoint(organizationId);
-            consoleAPIBaseUrl = buildHttpUrl(consoleAccessPoint);
-        } else {
-            consoleAPIBaseUrl = consoleApiUrl;
-        }
-        if (consoleAPIBaseUrl != null) {
-            URI fullUrl = URI.create(consoleAPIBaseUrl).resolve(managementProxyPath);
-            return fullUrl.toString();
-        }
-        return null;
+        return resolveApiUrl(organizationId, accessPointQueryService::getConsoleApiAccessPoint, consoleApiUrl, managementProxyPath);
     }
 
     @Override
@@ -360,18 +349,7 @@ public class InstallationAccessQueryServiceImpl implements InstallationAccessQue
 
     @Override
     public String getPortalAPIUrl(final String environmentId) {
-        String portalAPIBaseUrl;
-        if (installationTypeDomainService.isMultiTenant()) {
-            AccessPoint consoleAccessPoint = accessPointQueryService.getPortalApiAccessPoint(environmentId);
-            portalAPIBaseUrl = buildHttpUrl(consoleAccessPoint);
-        } else {
-            portalAPIBaseUrl = portalApiUrl;
-        }
-        if (portalAPIBaseUrl != null) {
-            URI fullUrl = URI.create(portalAPIBaseUrl).resolve(portalProxyPath);
-            return fullUrl.toString();
-        }
-        return null;
+        return resolveApiUrl(environmentId, accessPointQueryService::getPortalApiAccessPoint, portalApiUrl, portalProxyPath);
     }
 
     @Override
@@ -440,18 +418,29 @@ public class InstallationAccessQueryServiceImpl implements InstallationAccessQue
 
     @Override
     public String getGammaAPIUrl(final String organizationId) {
-        String gammaAPIBaseUrl;
-        if (installationTypeDomainService.isMultiTenant()) {
-            AccessPoint gammaAccessPoint = accessPointQueryService.getGammaApiAccessPoint(organizationId);
-            gammaAPIBaseUrl = buildHttpUrl(gammaAccessPoint);
-        } else {
-            gammaAPIBaseUrl = gammaApiUrl;
+        return resolveApiUrl(organizationId, accessPointQueryService::getGammaApiAccessPoint, gammaApiUrl, gammaProxyPath);
+    }
+
+    @Override
+    public String getGammaManagementAPIUrl(final String organizationId) {
+        return resolveApiUrl(organizationId, accessPointQueryService::getGammaApiAccessPoint, gammaApiUrl, managementProxyPath);
+    }
+
+    /**
+     * Resolves an API URL from its base (multi-tenant access point or standalone fallback) and a proxy path suffix.
+     * Returns {@code null} when no base URL can be determined.
+     */
+    private String resolveApiUrl(
+        final String scopeId,
+        final Function<String, AccessPoint> accessPointLookup,
+        final String standaloneUrl,
+        final String proxyPath
+    ) {
+        String baseUrl = installationTypeDomainService.isMultiTenant() ? buildHttpUrl(accessPointLookup.apply(scopeId)) : standaloneUrl;
+        if (baseUrl == null) {
+            return null;
         }
-        if (gammaAPIBaseUrl != null) {
-            URI fullUrl = URI.create(gammaAPIBaseUrl).resolve(gammaProxyPath);
-            return fullUrl.toString();
-        }
-        return null;
+        return URI.create(baseUrl).resolve(proxyPath).toString();
     }
 
     private String buildHttpUrl(final AccessPoint accessPoint) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InstallationAccessQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InstallationAccessQueryServiceInMemory.java
@@ -104,4 +104,9 @@ public class InstallationAccessQueryServiceInMemory implements InstallationAcces
     public String getGammaAPIUrl(final String organizationId) {
         return null;
     }
+
+    @Override
+    public String getGammaManagementAPIUrl(final String organizationId) {
+        return null;
+    }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/GammaUIResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/GammaUIResource.java
@@ -75,7 +75,7 @@ public class GammaUIResource {
                 .toUriString();
         }
 
-        String managementApiUrl = installationAccessQueryService.getConsoleAPIUrl(organizationId);
+        String managementApiUrl = installationAccessQueryService.getGammaManagementAPIUrl(organizationId);
         if (managementApiUrl == null) {
             managementApiUrl = ForwardedHeaderUtils.adaptFromForwardedHeaders(request.getURI(), request.getHeaders())
                 .replacePath(installationAccessQueryService.getConsoleApiPath())

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/GammaUIResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/GammaUIResourceTest.java
@@ -103,11 +103,13 @@ class GammaUIResourceTest extends AbstractResourceTest {
         @Test
         void should_use_management_api_url_from_service() {
             installationAccessQueryService.setConsoleAPIUrl("http://management.example.com/management");
+            installationAccessQueryService.setGammaManagementAPIUrl("http://api.gamma.management.example.com/management");
+            installationAccessQueryService.setGammaAPIUrl("http://api.gamma.management.example.com/gamma");
 
             final Response response = rootTarget().request().get();
 
             var body = response.readEntity(GammaUIResource.GammaBootstrap.class);
-            assertThat(body.managementBaseURL()).isEqualTo("http://management.example.com/management");
+            assertThat(body.managementBaseURL()).isEqualTo("http://api.gamma.management.example.com/management");
         }
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/spring/ConfigurableInstallationAccessQueryService.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/spring/ConfigurableInstallationAccessQueryService.java
@@ -20,11 +20,17 @@ import inmemory.InstallationAccessQueryServiceInMemory;
 public class ConfigurableInstallationAccessQueryService extends InstallationAccessQueryServiceInMemory {
 
     private String gammaAPIUrl;
+    private String gammaManagementAPIUrl;
     private String consoleAPIUrl;
 
     @Override
     public String getGammaAPIUrl(String organizationId) {
         return gammaAPIUrl;
+    }
+
+    @Override
+    public String getGammaManagementAPIUrl(final String organizationId) {
+        return gammaManagementAPIUrl;
     }
 
     @Override
@@ -34,6 +40,10 @@ public class ConfigurableInstallationAccessQueryService extends InstallationAcce
 
     public void setGammaAPIUrl(String gammaAPIUrl) {
         this.gammaAPIUrl = gammaAPIUrl;
+    }
+
+    public void setGammaManagementAPIUrl(String gammaManagementAPIUrl) {
+        this.gammaManagementAPIUrl = gammaManagementAPIUrl;
     }
 
     public void setConsoleAPIUrl(String consoleAPIUrl) {


### PR DESCRIPTION
## Summary

  Adds `InstallationAccessQueryService#getGammaManagementAPIUrl(orgId)` so the Gamma Console bootstrap can expose a `managementBaseURL` that lives under the same host as the Gamma API access point
  (instead of the Console API one). This keeps the auth/XSRF cookie scope consistent across `/gamma/*` and `/management/*` calls made by Gamma modules, fixing 401s on cross-host calls in multi-tenant
  deployments.

  Also dedupes the four sibling `getXxxAPIUrl` methods in `InstallationAccessQueryServiceImpl` (Console, Portal, Gamma, Gamma Management) — they all followed the same shape (resolve a base from access
  point or standalone fallback, then append a proxy path) — into one-line delegates to a single `resolveApiUrl(scopeId, accessPointLookup, standaloneUrl, proxyPath)` helper. Adds the corresponding stub in
   `InstallationAccessQueryServiceInMemory`.

  ## Why

  The previous bootstrap response used `getConsoleAPIUrl(orgId)` for `managementBaseURL`, which resolves to the **console** access point (e.g. `…console.example.com/management`). Cookies set there are
  host-only, so Gamma module calls hitting `…gamma-api.example.com/management/...` could never reuse them and got 401s. Pointing `managementBaseURL` to the Gamma API access point fixes the cookie scope
  without requiring operators to set `jwt.cookie-domain` to a common parent.

linked to https://github.com/gravitee-io/gravitee-cockpit/pull/6811

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

