### PR TITLE
feat(console): remove tech preview banners

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -459,9 +459,6 @@
         <h2>New Developer Portal</h2>
         <mat-card class="portal__form__card">
           <mat-card-content formGroupName="portalNext">
-            <gio-banner-info>
-              {{ integrationsService.bannerMessages.techPreview }}
-            </gio-banner-info>
             <div class="portal-next-settings">
               <gio-form-slide-toggle formGroupName="access" class="portal__form__card__form-field">
                 <gio-form-label>Enable the New Developer Portal</gio-form-label>

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -48,6 +48,11 @@ describe('PortalSettingsComponent', () => {
   let httpTestingController: HttpTestingController;
   let portalSettingsMock;
   let componentHarness: PortalSettingsHarness;
+  const removedBannerMessage = [
+    'This tech preview feature',
+    "is new! We're gathering feedback on it to make it even better,",
+    'so it may change as we make improvements.',
+  ].join(' ');
 
   const init = async (
     permissions: GioTestingPermission = ['environment-settings-u'],
@@ -546,6 +551,23 @@ describe('PortalSettingsComponent', () => {
 
       const toggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next' }));
       expect(await toggle.isChecked()).toBe(true);
+    });
+
+    it('should not show tech preview banner in Portal Next settings', async () => {
+      portalSettingsMock = fakePortalSettings({
+        portalNext: {
+          access: { enabled: true },
+          banner: {
+            enabled: true,
+            title: 'testTitle',
+            subtitle: 'testSubtitle',
+          },
+        },
+      });
+      expectPortalSettingsGetRequest(portalSettingsMock);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).not.toContain(removedBannerMessage);
     });
 
     it('should not show portal next settings if settings does not include: "access.enabled"', async () => {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -27,7 +27,6 @@ import { PortalSettings } from '../../../entities/portal/portalSettings';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import { CorsUtil } from '../../../shared/utils';
 import { Constants } from '../../../entities/Constants';
-import { IntegrationsService } from '../../../services-ngx/integrations.service';
 
 interface PortalForm {
   company: FormGroup<{
@@ -221,7 +220,6 @@ export class PortalSettingsComponent implements OnInit {
     private readonly snackBarService: SnackBarService,
     private readonly permissionService: GioPermissionService,
     private readonly licenseService: GioLicenseService,
-    public readonly integrationsService: IntegrationsService,
     @Inject(Constants) public readonly constants: Constants,
   ) {}
 

--- a/gravitee-apim-console-webui/src/portal/components/header/portal-header.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/header/portal-header.component.html
@@ -32,10 +32,4 @@
       <ng-content select="[additionalActions]" />
     }
   </div>
-
-  @if (showTechPreviewMessage()) {
-    <gio-banner-info>
-      {{ techPreviewMessage }}
-    </gio-banner-info>
-  }
 </div>

--- a/gravitee-apim-console-webui/src/portal/components/header/portal-header.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/header/portal-header.component.ts
@@ -13,21 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, inject, InputSignal, input } from '@angular/core';
-import { GioBannerModule } from '@gravitee/ui-particles-angular';
-
-import { IntegrationsService } from '../../../services-ngx/integrations.service';
+import { Component, InputSignal, input } from '@angular/core';
 
 @Component({
   selector: 'portal-header',
-  imports: [GioBannerModule],
   templateUrl: './portal-header.component.html',
   styleUrl: './portal-header.component.scss',
 })
 export class PortalHeaderComponent {
   title: InputSignal<string> = input.required();
   subtitle: InputSignal<string> = input();
-  showTechPreviewMessage: InputSignal<boolean> = input(true);
   showActions: InputSignal<boolean> = input(false);
-  techPreviewMessage = inject(IntegrationsService).bannerMessages.techPreview;
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<portal-header title="Manage your navigation" [showTechPreviewMessage]="false" />
+<portal-header title="Manage your navigation" />
 
 <main class="page-layout">
   <section class="panel sections-panel" [style.width.px]="panelWidth()">

--- a/gravitee-apim-console-webui/src/services-ngx/integrations.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/integrations.service.ts
@@ -42,7 +42,6 @@ export class IntegrationsService {
   private currentIntegration$: BehaviorSubject<Integration> = new BehaviorSubject<Integration>(null);
 
   public readonly bannerMessages = {
-    techPreview: `This tech preview feature is new! We're gathering feedback on it to make it even better, so it may change as we make improvements.`,
     agentDisconnected: 'Check your agent status and ensure connectivity with the provider to start importing your APIs in Gravitee.',
   };
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14249

## Description

- Removed generic tech preview banners from Console NG Portal pages.
- Removed the same tech preview message from Portal Settings > New Developer Portal and API Quality.
- Cleaned up unused `techPreview` banner message and related component inputs/imports.
- Added regression coverage for the removed banners.

