### PR TITLE
revert(gamma-apim): widen alert and plan forms (#18186)

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/pages/detail/plans/ApiProductPlanFormPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/pages/detail/plans/ApiProductPlanFormPage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Button, Skeleton } from '@gravitee/graphene-core';
+import { Button, PageFocused, Skeleton } from '@gravitee/graphene-core';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { usePlan } from '../../../../apis/hooks/usePlans';
@@ -50,7 +50,11 @@ export function ApiProductPlanFormPage() {
         if (!canCreate) {
             return <Navigate to=".." replace />;
         }
-        return <PlanFormWizard ctx={ctx} securityType={securityType as PlanSecurityType} referenceTags={product?.tags} />;
+        return (
+            <PageFocused>
+                <PlanFormWizard ctx={ctx} securityType={securityType as PlanSecurityType} referenceTags={product?.tags} />
+            </PageFocused>
+        );
     }
 
     return <PlanEditWrapper ctx={ctx} planId={planId ?? ''} canUpdate={canUpdate} referenceTags={product?.tags} />;
@@ -86,13 +90,15 @@ function PlanEditWrapper({
     }
 
     return (
-        <PlanFormWizard
-            ctx={ctx}
-            securityType={plan.security.type}
-            planId={planId}
-            readOnly={plan.status === 'CLOSED' || !canUpdate}
-            securityLocked={plan.status !== 'STAGING' && plan.status !== 'CLOSED'}
-            referenceTags={referenceTags}
-        />
+        <PageFocused>
+            <PlanFormWizard
+                ctx={ctx}
+                securityType={plan.security.type}
+                planId={planId}
+                readOnly={plan.status === 'CLOSED' || !canUpdate}
+                securityLocked={plan.status !== 'STAGING' && plan.status !== 'CLOSED'}
+                referenceTags={referenceTags}
+            />
+        </PageFocused>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/AlertFormPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/AlertFormPage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Button, cn, Skeleton } from '@gravitee/graphene-core';
+import { Button, cn, PageFocused, Skeleton } from '@gravitee/graphene-core';
 import { ArrowLeftIcon } from '@gravitee/graphene-core/icons';
 
 import { AlertsTab } from './AlertsTab';
@@ -79,124 +79,128 @@ export function AlertFormPage() {
     }
 
     return (
-        <div className="space-y-6">
-            {/* ─── Header ─────────────────────────────────────────────────── */}
-            <div>
-                <Button variant="ghost" size="sm" className="-ml-2 mb-3 text-muted-foreground" onClick={handleCancel}>
-                    <ArrowLeftIcon className="size-4" />
-                    Back to alerts
-                </Button>
-                <h1 className="text-2xl font-semibold">{isUpdate ? 'Update alert' : 'Create new alert'}</h1>
-                <p className="mt-1 text-sm text-muted-foreground">
-                    Configure your own alerts. Get notified when a metric condition is met, when data is missing, or when an endpoint health
-                    check status changes.
-                </p>
-            </div>
-
-            {/* ─── Save error ──────────────────────────────────────────────── */}
-            {saveError && (
-                <div
-                    className="rounded-lg p-3"
-                    style={{ background: 'hsl(var(--destructive) / 0.08)', border: '1px solid hsl(var(--destructive) / 0.3)' }}
-                >
-                    <p className="text-xs text-destructive">{saveError}</p>
-                </div>
-            )}
-
-            <div>
-                {/* ── Tab bar ──────────────────────────────────────────────── */}
-                <div role="tablist" className="flex gap-1 border-b">
-                    {(isUpdate ? (['alerts', 'notifications', 'history'] as const) : (['alerts', 'notifications'] as const)).map(tab => (
-                        <button
-                            key={tab}
-                            role="tab"
-                            type="button"
-                            aria-selected={activeTab === tab}
-                            onClick={() => setActiveTab(tab)}
-                            className={cn(
-                                '-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors',
-                                activeTab === tab
-                                    ? 'border-primary text-foreground'
-                                    : 'border-transparent text-muted-foreground hover:border-muted-foreground hover:text-foreground',
-                            )}
-                        >
-                            {tab.charAt(0).toUpperCase() + tab.slice(1)}
-                        </button>
-                    ))}
+        <PageFocused>
+            <div className="space-y-6">
+                {/* ─── Header ─────────────────────────────────────────────────── */}
+                <div>
+                    <Button variant="ghost" size="sm" className="-ml-2 mb-3 text-muted-foreground" onClick={handleCancel}>
+                        <ArrowLeftIcon className="size-4" />
+                        Back to alerts
+                    </Button>
+                    <h1 className="text-2xl font-semibold">{isUpdate ? 'Update alert' : 'Create new alert'}</h1>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Configure your own alerts. Get notified when a metric condition is met, when data is missing, or when an endpoint
+                        health check status changes.
+                    </p>
                 </div>
 
-                {/* ── Tab panels ───────────────────────────────────────────── */}
-                {activeTab === 'alerts' && (
-                    <AlertsTab
-                        name={name}
-                        setName={setName}
-                        description={description}
-                        setDescription={setDescription}
-                        severity={severity}
-                        setSeverity={setSeverity}
-                        enabled={enabled}
-                        setEnabled={setEnabled}
-                        ruleId={ruleId}
-                        handleRuleChange={handleRuleChange}
-                        isUpdate={isUpdate}
-                        canEdit={canEdit}
-                        errors={errors}
-                        setErrors={setErrors}
-                        markDirty={markDirty}
-                        timeframes={timeframes}
-                        addTimeframe={addTimeframe}
-                        removeTimeframe={removeTimeframe}
-                        toggleTimeframeDay={toggleTimeframeDay}
-                        updateTimeframeHour={updateTimeframeHour}
-                        conditions={conditions}
-                        updateCondition={updateCondition}
-                        metricsForRule={metricsForRule}
-                        filters={filters}
-                        addFilter={addFilter}
-                        updateFilter={updateFilter}
-                        removeFilter={removeFilter}
-                        selectedRule={selectedRule}
-                    />
+                {/* ─── Save error ──────────────────────────────────────────────── */}
+                {saveError && (
+                    <div
+                        className="rounded-lg p-3"
+                        style={{ background: 'hsl(var(--destructive) / 0.08)', border: '1px solid hsl(var(--destructive) / 0.3)' }}
+                    >
+                        <p className="text-xs text-destructive">{saveError}</p>
+                    </div>
                 )}
 
-                {activeTab === 'notifications' && (
-                    <NotificationsTab
-                        dampening={dampening}
-                        setDampening={setDampening}
-                        notifications={notifications}
-                        addNotification={addNotification}
-                        removeNotification={removeNotification}
-                        updateNotificationTarget={updateNotificationTarget}
-                        canEdit={canEdit}
-                        markDirty={markDirty}
-                    />
+                <div>
+                    {/* ── Tab bar ──────────────────────────────────────────────── */}
+                    <div role="tablist" className="flex gap-1 border-b">
+                        {(isUpdate ? (['alerts', 'notifications', 'history'] as const) : (['alerts', 'notifications'] as const)).map(
+                            tab => (
+                                <button
+                                    key={tab}
+                                    role="tab"
+                                    type="button"
+                                    aria-selected={activeTab === tab}
+                                    onClick={() => setActiveTab(tab)}
+                                    className={cn(
+                                        '-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors',
+                                        activeTab === tab
+                                            ? 'border-primary text-foreground'
+                                            : 'border-transparent text-muted-foreground hover:border-muted-foreground hover:text-foreground',
+                                    )}
+                                >
+                                    {tab.charAt(0).toUpperCase() + tab.slice(1)}
+                                </button>
+                            ),
+                        )}
+                    </div>
+
+                    {/* ── Tab panels ───────────────────────────────────────────── */}
+                    {activeTab === 'alerts' && (
+                        <AlertsTab
+                            name={name}
+                            setName={setName}
+                            description={description}
+                            setDescription={setDescription}
+                            severity={severity}
+                            setSeverity={setSeverity}
+                            enabled={enabled}
+                            setEnabled={setEnabled}
+                            ruleId={ruleId}
+                            handleRuleChange={handleRuleChange}
+                            isUpdate={isUpdate}
+                            canEdit={canEdit}
+                            errors={errors}
+                            setErrors={setErrors}
+                            markDirty={markDirty}
+                            timeframes={timeframes}
+                            addTimeframe={addTimeframe}
+                            removeTimeframe={removeTimeframe}
+                            toggleTimeframeDay={toggleTimeframeDay}
+                            updateTimeframeHour={updateTimeframeHour}
+                            conditions={conditions}
+                            updateCondition={updateCondition}
+                            metricsForRule={metricsForRule}
+                            filters={filters}
+                            addFilter={addFilter}
+                            updateFilter={updateFilter}
+                            removeFilter={removeFilter}
+                            selectedRule={selectedRule}
+                        />
+                    )}
+
+                    {activeTab === 'notifications' && (
+                        <NotificationsTab
+                            dampening={dampening}
+                            setDampening={setDampening}
+                            notifications={notifications}
+                            addNotification={addNotification}
+                            removeNotification={removeNotification}
+                            updateNotificationTarget={updateNotificationTarget}
+                            canEdit={canEdit}
+                            markDirty={markDirty}
+                        />
+                    )}
+
+                    {isUpdate && activeTab === 'history' && <HistoryTab historyPage={historyPage} />}
+                </div>
+
+                {/* ─── Save bar ────────────────────────────────────────────────── */}
+                {canEdit && isDirty && (
+                    <div className="sticky bottom-0 z-10 -mx-6 flex items-center justify-end gap-3 border-t bg-background px-6 py-3">
+                        <Button variant="outline" onClick={handleCancel}>
+                            Cancel
+                        </Button>
+                        <Button onClick={handleSave} disabled={isPending}>
+                            {isPending ? 'Saving…' : isUpdate ? 'Save' : 'Create'}
+                        </Button>
+                    </div>
                 )}
 
-                {isUpdate && activeTab === 'history' && <HistoryTab historyPage={historyPage} />}
+                {canEdit && !isDirty && !isUpdate && (
+                    <div className="flex items-center justify-end gap-3 pt-2">
+                        <Button variant="outline" onClick={handleCancel}>
+                            Cancel
+                        </Button>
+                        <Button onClick={handleSave} disabled={isPending}>
+                            {isPending ? 'Creating…' : 'Create'}
+                        </Button>
+                    </div>
+                )}
             </div>
-
-            {/* ─── Save bar ────────────────────────────────────────────────── */}
-            {canEdit && isDirty && (
-                <div className="sticky bottom-0 z-10 -mx-6 flex items-center justify-end gap-3 border-t bg-background px-6 py-3">
-                    <Button variant="outline" onClick={handleCancel}>
-                        Cancel
-                    </Button>
-                    <Button onClick={handleSave} disabled={isPending}>
-                        {isPending ? 'Saving…' : isUpdate ? 'Save' : 'Create'}
-                    </Button>
-                </div>
-            )}
-
-            {canEdit && !isDirty && !isUpdate && (
-                <div className="flex items-center justify-end gap-3 pt-2">
-                    <Button variant="outline" onClick={handleCancel}>
-                        Cancel
-                    </Button>
-                    <Button onClick={handleSave} disabled={isPending}>
-                        {isPending ? 'Creating…' : 'Create'}
-                    </Button>
-                </div>
-            )}
-        </div>
+        </PageFocused>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/plans/plan-form/PlanFormWizard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/plans/plan-form/PlanFormWizard.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Alert, AlertDescription, Button, Skeleton } from '@gravitee/graphene-core';
+import { Alert, AlertDescription, Button, PageFocused, Skeleton } from '@gravitee/graphene-core';
 import { ArrowLeftIcon } from '@gravitee/graphene-core/icons';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -130,95 +130,97 @@ export function PlanFormWizard({
     const isLastStep = stepIndex === totalSteps - 1;
 
     return (
-        <div className="flex flex-col gap-6">
-            {/* Header */}
-            <div className="flex items-center gap-3">
-                <Button type="button" variant="ghost" size="icon" onClick={() => navigate('..')}>
-                    <ArrowLeftIcon className="size-4" aria-hidden />
-                    <span className="sr-only">Back to plans</span>
-                </Button>
-                <div>
-                    <h1 className="text-2xl font-semibold tracking-tight">
-                        {readOnly ? 'View plan' : isEdit ? 'Edit plan' : `Create plan`}
-                    </h1>
-                    <p className="text-sm text-muted-foreground">
-                        {readOnly ? 'View' : isEdit ? 'Edit' : 'New'} {PLAN_SECURITY_LABELS[form.securityType]} plan
-                    </p>
+        <PageFocused>
+            <div className="flex flex-col gap-6">
+                {/* Header */}
+                <div className="flex items-center gap-3">
+                    <Button type="button" variant="ghost" size="icon" onClick={() => navigate('..')}>
+                        <ArrowLeftIcon className="size-4" aria-hidden />
+                        <span className="sr-only">Back to plans</span>
+                    </Button>
+                    <div>
+                        <h1 className="text-2xl font-semibold tracking-tight">
+                            {readOnly ? 'View plan' : isEdit ? 'Edit plan' : `Create plan`}
+                        </h1>
+                        <p className="text-sm text-muted-foreground">
+                            {readOnly ? 'View' : isEdit ? 'Edit' : 'New'} {PLAN_SECURITY_LABELS[form.securityType]} plan
+                        </p>
+                    </div>
+                </div>
+
+                {securityLocked && (
+                    <Alert>
+                        <AlertDescription>
+                            Security and restrictions settings are read-only for published or deprecated plans. Only general settings can be
+                            updated.
+                        </AlertDescription>
+                    </Alert>
+                )}
+
+                {/* Step indicator */}
+                <PlanFormStepIndicator steps={steps} />
+
+                {/* Step content */}
+                {isGeneralStep && (
+                    <PlanGeneralStep
+                        ctx={ctx}
+                        securityType={securityType}
+                        value={form.general}
+                        onChange={(general: GeneralFormData) => setForm({ ...form, general })}
+                        errors={generalErrors}
+                        readOnly={readOnly}
+                        referenceTags={referenceTags}
+                    />
+                )}
+
+                {isSecurityStep && (
+                    <PlanSecurityStep
+                        ctx={ctx}
+                        securityType={securityType}
+                        value={form.security}
+                        onChange={(security: SecurityFormData) => setForm({ ...form, security })}
+                        readOnly={readOnly || securityLocked}
+                    />
+                )}
+
+                {isRestrictionsStep && (
+                    <PlanRestrictionsStep
+                        value={form.restrictions}
+                        onChange={(restrictions: RestrictionsFormData) => setForm({ ...form, restrictions })}
+                        readOnly={readOnly || securityLocked}
+                    />
+                )}
+
+                {/* Mutation error */}
+                {mutationError && (
+                    <Alert variant="destructive">
+                        <AlertDescription>{mutationError}</AlertDescription>
+                    </Alert>
+                )}
+
+                {/* Navigation */}
+                <div className="flex items-center justify-between pt-2">
+                    <Button type="button" variant="outline" onClick={stepIndex === 0 ? () => navigate('..') : handleBack}>
+                        {stepIndex === 0 ? 'Cancel' : 'Previous'}
+                    </Button>
+
+                    {readOnly ? (
+                        isLastStep ? (
+                            <Button type="button" variant="outline" onClick={() => navigate('..')}>
+                                Close
+                            </Button>
+                        ) : (
+                            <Button type="button" onClick={handleNext}>
+                                Next
+                            </Button>
+                        )
+                    ) : (
+                        <Button type="button" onClick={isLastStep ? handleSubmit : handleNext} disabled={isPending}>
+                            {isLastStep ? (isPending ? 'Saving…' : isEdit ? 'Save changes' : 'Create plan') : 'Next'}
+                        </Button>
+                    )}
                 </div>
             </div>
-
-            {securityLocked && (
-                <Alert>
-                    <AlertDescription>
-                        Security and restrictions settings are read-only for published or deprecated plans. Only general settings can be
-                        updated.
-                    </AlertDescription>
-                </Alert>
-            )}
-
-            {/* Step indicator */}
-            <PlanFormStepIndicator steps={steps} />
-
-            {/* Step content */}
-            {isGeneralStep && (
-                <PlanGeneralStep
-                    ctx={ctx}
-                    securityType={securityType}
-                    value={form.general}
-                    onChange={(general: GeneralFormData) => setForm({ ...form, general })}
-                    errors={generalErrors}
-                    readOnly={readOnly}
-                    referenceTags={referenceTags}
-                />
-            )}
-
-            {isSecurityStep && (
-                <PlanSecurityStep
-                    ctx={ctx}
-                    securityType={securityType}
-                    value={form.security}
-                    onChange={(security: SecurityFormData) => setForm({ ...form, security })}
-                    readOnly={readOnly || securityLocked}
-                />
-            )}
-
-            {isRestrictionsStep && (
-                <PlanRestrictionsStep
-                    value={form.restrictions}
-                    onChange={(restrictions: RestrictionsFormData) => setForm({ ...form, restrictions })}
-                    readOnly={readOnly || securityLocked}
-                />
-            )}
-
-            {/* Mutation error */}
-            {mutationError && (
-                <Alert variant="destructive">
-                    <AlertDescription>{mutationError}</AlertDescription>
-                </Alert>
-            )}
-
-            {/* Navigation */}
-            <div className="flex items-center justify-between pt-2">
-                <Button type="button" variant="outline" onClick={stepIndex === 0 ? () => navigate('..') : handleBack}>
-                    {stepIndex === 0 ? 'Cancel' : 'Previous'}
-                </Button>
-
-                {readOnly ? (
-                    isLastStep ? (
-                        <Button type="button" variant="outline" onClick={() => navigate('..')}>
-                            Close
-                        </Button>
-                    ) : (
-                        <Button type="button" onClick={handleNext}>
-                            Next
-                        </Button>
-                    )
-                ) : (
-                    <Button type="button" onClick={isLastStep ? handleSubmit : handleNext} disabled={isPending}>
-                        {isLastStep ? (isPending ? 'Saving…' : isEdit ? 'Save changes' : 'Create plan') : 'Next'}
-                    </Button>
-                )}
-            </div>
-        </div>
+        </PageFocused>
     );
 }


### PR DESCRIPTION
Reverts #18186.

The design team raised concerns about the widened layout, so this restores the previous `PageFocused` (focused-width) container on the Alert and Plan forms.

- Reverts commit 304a982147 (3 files: `AlertFormPage.tsx`, `PlanFormWizard.tsx`, `ApiProductPlanFormPage.tsx`).
- Clean revert — `tsc`, ESLint, and the gamma-apim test suite all pass.