### PR TITLE
feat: show linked API name for portal API navigation items

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -85,16 +85,27 @@
     <header class="panel-header editor-panel__header">
       @if (selectedNavigationItem()) {
         <div class="panel-header__title">
-          <div>
-            {{ selectedNavigationItem().label }}
+          <div class="panel-header__title__main">
+            <div>
+              {{ selectedNavigationItem().label }}
+            </div>
+
+            <div class="panel-header__title__badges">
+              <span [class]="selectedNavigationItemIsPublished() ? 'gio-badge-success' : 'gio-badge-warning'">
+                {{ selectedNavigationItemIsPublished() ? 'Published' : 'Unpublished' }}
+              </span>
+              <span class="gio-badge-primary">{{ selectedNavigationItem().data.visibility | titlecase }}</span>
+            </div>
           </div>
 
-          <div class="panel-header__title__badges">
-            <span [class]="selectedNavigationItemIsPublished() ? 'gio-badge-success' : 'gio-badge-warning'">
-              {{ selectedNavigationItemIsPublished() ? 'Published' : 'Unpublished' }}
-            </span>
-            <span class="gio-badge-primary">{{ selectedNavigationItem().data.visibility | titlecase }}</span>
-          </div>
+          @if (selectedApiId()) {
+            <div class="panel-header__title__linked-api" data-testid="linked-api-header">
+              <span>Linked API:</span>
+              <span class="panel-header__title__linked-api__value">
+                {{ selectedLinkedApiName.isLoading() ? 'Loading...' : (selectedLinkedApiName.value() ?? selectedApiId()) }}
+              </span>
+            </div>
+          }
         </div>
       }
       <div class="panel-header__actions" *gioPermission="{ anyOf: ['environment-documentation-u'] }">

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
@@ -63,11 +63,33 @@ $outline-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter80)
   &__title {
     @include mat.m2-typography-level($typography, 'subtitle-1');
     display: flex;
+    flex-direction: column;
     gap: 4px;
-    align-items: center;
+    align-items: flex-start;
+
+    &__main {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+    }
 
     &__badges {
       display: flex;
+    }
+
+    &__linked-api {
+      @include mat.m2-typography-level($typography, 'body-2');
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, darker80);
+
+      &__value {
+        border-radius: 16px;
+        background-color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, lighter60);
+        color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter40);
+        padding: 2px 12px;
+      }
     }
   }
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -106,6 +106,7 @@ describe('PortalNavigationItemsComponent', () => {
   });
 
   afterEach(() => {
+    flushPendingLinkedApiSearchRequests();
     httpTestingController.verify();
     jest.clearAllMocks();
   });
@@ -1020,6 +1021,8 @@ describe('PortalNavigationItemsComponent', () => {
 
     beforeEach(async () => {
       await expectGetNavigationItems(fakeResponse);
+      flushPendingLinkedApiSearchRequests();
+      await fixture.whenStable();
     });
 
     describe('creating a page under an api from tree node "More actions" menu', () => {
@@ -1861,11 +1864,11 @@ describe('PortalNavigationItemsComponent', () => {
     });
 
     it('should update visibility using edit dialog', async () => {
-      // As items are collapsed by default, expand so the nested API node's menu is reachable.
-      await harness.clickToggleExpansionButton();
+      const apiNode = { id: apiNavItem.id, label: apiNavItem.title, type: apiNavItem.type, data: apiNavItem } as SectionNode;
+      component.onNodeMenuAction({ action: 'edit', itemType: 'API', node: apiNode });
       fixture.detectChanges();
-
-      await harness.editNodeById('nav-api-1');
+      flushPendingLinkedApiSearchRequests();
+      await fixture.whenStable();
 
       const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
       expect(await dialog.getDialogTitle()).toContain('Edit');
@@ -2649,6 +2652,7 @@ describe('PortalNavigationItemsComponent', () => {
       );
 
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, ...createdApis] }));
+      flushPendingLinkedApiSearchRequests();
 
       await fixture.whenStable();
       fixture.detectChanges();
@@ -2768,6 +2772,55 @@ describe('PortalNavigationItemsComponent', () => {
     });
 
     fixture.detectChanges();
+  }
+
+  function expectLinkedApiSearchResponse(apiId: string, apiName = apiId) {
+    const req = httpTestingController.expectOne(request => {
+      return (
+        request.method === 'POST' &&
+        request.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search` &&
+        request.params.get('page') === '1' &&
+        request.params.get('perPage') === '1' &&
+        request.params.get('manageOnly') === 'false' &&
+        request.body?.ids?.[0] === apiId
+      );
+    });
+
+    expect(req.request.body).toEqual({ ids: [apiId] });
+
+    req.flush({
+      data: [{ id: apiId, name: apiName }],
+      pagination: { totalCount: 1 },
+    });
+
+    fixture.detectChanges();
+  }
+
+  function flushPendingLinkedApiSearchRequests() {
+    const requests = httpTestingController.match(request => {
+      return (
+        request.method === 'POST' &&
+        request.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search` &&
+        request.params.get('page') === '1' &&
+        request.params.get('perPage') === '1' &&
+        request.params.get('manageOnly') === 'false' &&
+        Array.isArray(request.body?.ids)
+      );
+    });
+
+    const activeRequests = requests.filter(req => !req.cancelled);
+
+    activeRequests.forEach(req => {
+      const apiId = req.request.body.ids[0];
+      req.flush({
+        data: [{ id: apiId, name: apiId }],
+        pagination: { totalCount: 1 },
+      });
+    });
+
+    if (activeRequests.length > 0) {
+      fixture.detectChanges();
+    }
   }
 
   it('should have unsaved changes when content is modified', async () => {
@@ -3006,6 +3059,7 @@ describe('PortalNavigationItemsComponent', () => {
       const apiItem2 = fakePortalNavigationApi({ id: 'api-nav-2', title: 'API 2', apiId: 'api-id-2' });
 
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [apiItem1, apiItem2] }));
+      expectLinkedApiSearchResponse(apiItem1.apiId, 'Linked API 1');
 
       component.onNodeMoved({
         node: { id: apiItem2.id, label: apiItem2.title, type: 'API', data: apiItem2 },
@@ -3021,6 +3075,16 @@ describe('PortalNavigationItemsComponent', () => {
   });
 
   describe('editing an API item from the toolbar', () => {
+    it('should display the linked API name in the selected item header', async () => {
+      const apiItem = fakePortalNavigationApi({ id: 'api-nav-1', title: 'My API', apiId: 'api-id-1' });
+
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [apiItem] }));
+      expectLinkedApiSearchResponse(apiItem.apiId, 'Echo');
+      fixture.detectChanges();
+
+      expect(await harness.getLinkedApiHeaderText()).toContain('Linked API: Echo');
+    });
+
     it('should open SectionEditorDialog when Edit is clicked on a selected API item', async () => {
       const apiItem = fakePortalNavigationApi({ id: 'api-nav-1', title: 'My API', apiId: 'api-id-1' });
 
@@ -3029,6 +3093,7 @@ describe('PortalNavigationItemsComponent', () => {
       const apiNode: SectionNode = { id: apiItem.id, label: apiItem.title, type: 'API', data: apiItem };
       component.onNodeMenuAction({ action: 'edit', itemType: 'API', node: apiNode });
       fixture.detectChanges();
+      flushPendingLinkedApiSearchRequests();
       await fixture.whenStable();
 
       const dialog = await rootLoader.getHarnessOrNull(SectionEditorDialogHarness);
@@ -3055,6 +3120,7 @@ describe('PortalNavigationItemsComponent', () => {
       const apiNode: SectionNode = { id: apiItem.id, label: apiItem.title, type: 'API', data: apiItem };
       component.onNodeMenuAction({ action: 'edit', itemType: 'API', node: apiNode });
       fixture.detectChanges();
+      flushPendingLinkedApiSearchRequests();
       await fixture.whenStable();
 
       const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
@@ -3106,6 +3172,8 @@ describe('PortalNavigationItemsComponent', () => {
 
       beforeEach(async () => {
         await expectGetNavigationItems(fakeResponse);
+        flushPendingLinkedApiSearchRequests();
+        await fixture.whenStable();
         fixture.detectChanges();
       });
       it('should change state from "More Actions" menu', async () => {
@@ -3179,6 +3247,8 @@ describe('PortalNavigationItemsComponent', () => {
 
       beforeEach(async () => {
         await expectGetNavigationItems(fakeResponse);
+        flushPendingLinkedApiSearchRequests();
+        await fixture.whenStable();
         fixture.detectChanges();
       });
       it('should change state from "More Actions" menu', async () => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -26,7 +26,7 @@ import { Component, computed, DestroyRef, HostListener, inject, NgZone, Signal, 
 import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { AbstractControl, FormControl, ReactiveFormsModule, ValidationErrors, ValidatorFn } from '@angular/forms';
-import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { rxResource, takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { catchError, exhaustMap, filter, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { MatMenuItem, MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
@@ -76,6 +76,7 @@ import { SnackBarService } from '../../services-ngx/snack-bar.service';
 import { GioPermissionModule } from '../../shared/components/gio-permission/gio-permission.module';
 import { PortalNavigationItemService } from '../../services-ngx/portal-navigation-item.service';
 import { PortalPageContentService } from '../../services-ngx/portal-page-content.service';
+import { ApiV2Service } from '../../services-ngx/api-v2.service';
 import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
 import { HasUnsavedChanges } from '../../shared/guards/has-unsaved-changes.guard';
 import { confirmDiscardChanges, normalizeContent } from '../../shared/utils/content.util';
@@ -167,6 +168,14 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     const menuLinks = this.menuLinks();
     return this.mapSelectedNavItemToNode(navId, menuLinks);
   });
+  readonly selectedApiId = computed(() => {
+    const selectedItem = this.selectedNavigationItem()?.data;
+    return selectedItem?.type === 'API' ? selectedItem.apiId : null;
+  });
+  readonly selectedLinkedApiName = rxResource({
+    params: () => this.selectedApiId(),
+    stream: ({ params: apiId }) => (apiId ? this.apiService.resolveNameById(apiId) : of(null)),
+  });
   readonly selectedNavigationItemParent: Signal<SectionNode | null> = computed(() => {
     const selectedNavigationItem = this.selectedNavigationItem();
     const parentId = selectedNavigationItem?.data?.parentId;
@@ -240,6 +249,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     private readonly matDialog: MatDialog,
     private readonly portalNavigationItemsService: PortalNavigationItemService,
     private readonly portalPageContentService: PortalPageContentService,
+    private readonly apiService: ApiV2Service,
   ) {
     this.contentControl.addValidators(this.asyncApiSpecValidator);
     this.setupPageContentSubscription();

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -48,6 +48,7 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
     }),
   );
   private getTitle = this.locatorFor(DivHarness.with({ selector: '.panel-header__title' }));
+  private readonly getLinkedApiHeader = this.locatorForOptional('[data-testid="linked-api-header"]');
   private getPageNotFoundEmptyState = this.locatorForOptional(
     EmptyStateComponentHarness.with({
       title: 'Page Not Found',
@@ -239,6 +240,11 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
     const titleDiv = await this.getTitle();
     const titleText = await titleDiv.getText();
     return titleText.includes('Private');
+  }
+
+  async getLinkedApiHeaderText(): Promise<string | null> {
+    const linkedApiHeader = await this.getLinkedApiHeader();
+    return linkedApiHeader?.text() ?? null;
   }
 
   async editNodeById(id: string): Promise<void> {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
@@ -42,6 +42,15 @@
       }
     </mat-form-field>
 
+    @if (linkedApiName(); as linkedApiName) {
+      <label class="sr-only" for="linked-api-name">Linked API (read-only)</label>
+      <mat-form-field class="section-editor-dialog__linked-api">
+        <mat-label>Linked API (read-only)</mat-label>
+        <input id="linked-api-name" matInput disabled [value]="linkedApiName" data-testid="linked-api-name" />
+        <mat-hint>This is the original API name and cannot be changed.</mat-hint>
+      </mat-form-field>
+    }
+
     @if (type === 'LINK') {
       <div class="form-field-title">Link settings</div>
       <mat-form-field>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
@@ -19,6 +19,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
 
 import { SectionEditorDialogHarness } from './section-editor-dialog.harness';
 import {
@@ -37,6 +38,7 @@ import {
   PortalNavigationItem,
   PortalNavigationItemType,
 } from '../../../entities/management-api-v2';
+import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 
 @Component({
   selector: 'test-host-component',
@@ -90,10 +92,14 @@ describe('SectionEditorDialogComponent', () => {
   let component: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
   let rootLoader: HarnessLoader;
+  let apiResolveNameById: jest.Mock;
 
   beforeEach(async () => {
+    apiResolveNameById = jest.fn().mockReturnValue(of('api-1'));
+
     await TestBed.configureTestingModule({
       imports: [TestHostComponent, GioTestingModule, NoopAnimationsModule],
+      providers: [{ provide: ApiV2Service, useValue: { resolveNameById: apiResolveNameById } }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);
@@ -330,6 +336,11 @@ describe('SectionEditorDialogComponent', () => {
         const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
         expect(await dialog.isPageTypeSelectionVisible()).toBe(false);
       });
+      it('should not show linked API name', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        expect(apiResolveNameById).not.toHaveBeenCalled();
+        expect(await dialog.getLinkedApiNameInputValue()).toBeNull();
+      });
       it('should save the updated title without contentType', async () => {
         const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
         const titleInput = await dialog.getTitleInput();
@@ -387,6 +398,7 @@ describe('SectionEditorDialogComponent', () => {
     });
     describe('when editing an API', () => {
       beforeEach(() => {
+        apiResolveNameById.mockReturnValue(of('Echo API'));
         const existingApi = fakePortalNavigationApi({ id: 'api-nav-1', title: 'Technical API Name', apiId: 'api-1' });
         fixture.componentRef.setInput('type', 'API');
         fixture.componentRef.setInput('existingItem', existingApi);
@@ -403,6 +415,14 @@ describe('SectionEditorDialogComponent', () => {
       it('should prefill the display name', async () => {
         const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
         expect(await dialog.getTitleInputValue()).toBe('Technical API Name');
+      });
+
+      it('should show linked API name as read-only context', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+
+        expect(apiResolveNameById).toHaveBeenCalledWith('api-1');
+        expect(await dialog.getLinkedApiNameInputValue()).toBe('Echo API');
+        expect(await dialog.isLinkedApiNameInputDisabled()).toBe(true);
       });
 
       it('should not allow save when title is not updated', async () => {
@@ -430,6 +450,23 @@ describe('SectionEditorDialogComponent', () => {
           title: 'Consumer API Name',
           visibility: 'PUBLIC',
         });
+      });
+    });
+    describe('when editing an API and linked API lookup resolves to the fallback id', () => {
+      beforeEach(() => {
+        apiResolveNameById.mockReturnValue(of('api-1'));
+        const existingApi = fakePortalNavigationApi({ id: 'api-nav-1', title: 'Technical API Name', apiId: 'api-1' });
+        fixture.componentRef.setInput('type', 'API');
+        fixture.componentRef.setInput('existingItem', existingApi);
+        fixture.detectChanges();
+        component.clicked();
+        fixture.detectChanges();
+      });
+
+      it('should fall back to the linked API id', async () => {
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+
+        expect(await dialog.getLinkedApiNameInputValue()).toBe('api-1');
       });
     });
     describe('when editing a link', () => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Component, computed, HostListener, inject, OnInit, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
@@ -26,14 +27,17 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { GioBannerModule, GioFormSelectionInlineModule } from '@gravitee/ui-particles-angular';
 import { isEqual } from 'lodash';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { Observable, of } from 'rxjs';
 
 import {
+  PortalNavigationApi,
   PortalNavigationItem,
   PortalNavigationItemType,
   PortalNavigationLink,
   PortalPageContentType,
   PortalVisibility,
 } from '../../../entities/management-api-v2';
+import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { urlValidator } from '../../../shared/validators/url.validator';
 import { getPublicVisibilityDisabledTooltip, isPublicVisibilityDisabled } from '../visibility-toggle.util';
 
@@ -137,12 +141,14 @@ export class SectionEditorDialogComponent implements OnInit {
   private readonly data: SectionEditorDialogData = inject(MAT_DIALOG_DATA);
   private readonly iconRegistry = inject(MatIconRegistry);
   private readonly sanitizer = inject(DomSanitizer);
+  private readonly apiService = inject(ApiV2Service);
   readonly publicDisabled: Signal<boolean> = computed(() => {
     return isPublicVisibilityDisabled(this.data.parentItem);
   });
   readonly publicDisabledTooltip: Signal<string> = computed(() => {
     return getPublicVisibilityDisabledTooltip(this.data.parentItem);
   });
+  readonly linkedApiName: Signal<string | null> = toSignal(this.loadLinkedApiName(), { initialValue: null });
   public buttonTitle: string;
 
   constructor() {
@@ -232,5 +238,14 @@ export class SectionEditorDialogComponent implements OnInit {
 
   formIsUnchanged(): boolean {
     return isEqual(this.form.getRawValue(), this.initialFormValues);
+  }
+
+  private loadLinkedApiName(): Observable<string | null> {
+    if (this.data.mode !== 'edit' || this.data.type !== 'API') {
+      return of(null);
+    }
+
+    const apiId = (this.data.existingItem as PortalNavigationApi).apiId;
+    return this.apiService.resolveNameById(apiId);
   }
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.harness.ts
@@ -28,6 +28,9 @@ export class SectionEditorDialogHarness extends ComponentHarness {
   private locateSubmitButton = this.locatorFor(MatButtonHarness.with({ text: /Add|Save/ }));
   private locateFormTitle = this.locatorFor(DivHarness.with({ selector: '[mat-dialog-title]' }));
   private locateAuthenticationToggle = this.locatorFor(MatSlideToggleHarness);
+  private readonly locateLinkedApiNameInput = this.locatorForOptional(
+    MatInputHarness.with({ selector: '[data-testid="linked-api-name"]' }),
+  );
   private locatePageTypeCards = this.locatorForAll(
     GioFormSelectionInlineCardHarness.with({ ancestor: '.section-editor-dialog__page-types' }),
   );
@@ -50,6 +53,16 @@ export class SectionEditorDialogHarness extends ComponentHarness {
   async getUrlInputValue(): Promise<string> {
     const urlInput = await this.locateUrlInput();
     return urlInput.getValue();
+  }
+
+  async getLinkedApiNameInputValue(): Promise<string | null> {
+    const linkedApiInput = await this.locateLinkedApiNameInput();
+    return linkedApiInput?.getValue() ?? null;
+  }
+
+  async isLinkedApiNameInputDisabled(): Promise<boolean | null> {
+    const linkedApiInput = await this.locateLinkedApiNameInput();
+    return linkedApiInput?.isDisabled() ?? null;
   }
 
   async setUrlInputValue(value: string): Promise<void> {

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -361,6 +361,61 @@ describe('ApiV2Service', () => {
     });
   });
 
+  describe('resolveNameById', () => {
+    it('should resolve API name from API id', done => {
+      const apiId = 'api-id';
+
+      apiV2Service.resolveNameById(apiId).subscribe(apiName => {
+        expect(apiName).toEqual('Echo API');
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=1&manageOnly=false`,
+        method: 'POST',
+      });
+
+      expect(req.request.body).toEqual({ ids: [apiId] });
+      req.flush({
+        data: [fakeApiV4({ id: apiId, name: 'Echo API' })],
+      });
+    });
+
+    it('should fall back to API id when API name cannot be resolved', done => {
+      const apiId = 'api-id';
+
+      apiV2Service.resolveNameById(apiId).subscribe(apiName => {
+        expect(apiName).toEqual(apiId);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=1&manageOnly=false`,
+        method: 'POST',
+      });
+
+      expect(req.request.body).toEqual({ ids: [apiId] });
+      req.flush({ data: [] });
+    });
+
+    it('should fall back to API id when API lookup fails', done => {
+      const apiId = 'api-id';
+
+      apiV2Service.resolveNameById(apiId).subscribe(apiName => {
+        expect(apiName).toEqual(apiId);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=1&manageOnly=false`,
+        method: 'POST',
+      });
+
+      expect(req.request.body).toEqual({ ids: [apiId] });
+      req.flush({ message: 'API lookup failed' }, { status: 500, statusText: 'Internal Server Error' });
+    });
+  });
+
   describe('getAll', () => {
     it('should fetch all APIs from the default environment', fakeAsync(() => {
       const apiOne = fakeApiV4({ id: 'api-1' });

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -16,7 +16,7 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { BehaviorSubject, EMPTY, from, mergeMap, Observable, of, timer } from 'rxjs';
-import { distinctUntilChanged, expand, filter, map, scan, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { catchError, distinctUntilChanged, expand, filter, map, scan, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { isEqual } from 'lodash';
 
 import { Constants } from '../entities/Constants';
@@ -245,6 +245,13 @@ export class ApiV2Service {
         ...(manageOnly ? {} : { manageOnly: false }),
       },
     });
+  }
+
+  resolveNameById(apiId: string): Observable<string> {
+    return this.search({ ids: [apiId] }, undefined, 1, 1, false).pipe(
+      map(response => response.data?.[0]?.name ?? apiId),
+      catchError(() => of(apiId)),
+    );
   }
 
   /**


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14503

## Summary

- Show the linked API name in the selected API navigation item header
- Add a read-only `Linked API (read-only)` field in the API navigation item edit dialog
- Resolve the original API name via `ApiV2Service.search({ ids: [apiId] }, undefined, 1, 1, false)`
- Keep API navigation item update payload unchanged

https://github.com/user-attachments/assets/27177b5d-c4c4-4f39-bb24-009c0a9d664f


