### PR TITLE
feat: reveal selected nested portal navigation item

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -1123,6 +1123,46 @@ describe('FlatTreeComponent', () => {
       expect(component.hasExpandableNode()).toBe(true);
     });
 
+    it('should expand ancestors of the selected nested item', async () => {
+      fixture.componentRef.setInput('links', nestedLinks);
+      fixture.componentRef.setInput('selectedId', 'p1');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(await harness.getAllItemTitles()).toEqual(['Folder 1', 'Folder 2', 'Page 1']);
+      expect(component.hasExpandedNode()).toBe(true);
+    });
+
+    it('should keep unrelated branches collapsed when revealing the selected nested item', async () => {
+      const links = [
+        makeItem('f1', 'FOLDER', 'Folder 1', 0),
+        makeItem('p1', 'PAGE', 'Page 1', 0, 'f1'),
+        makeItem('f2', 'FOLDER', 'Folder 2', 1),
+        makeItem('p2', 'PAGE', 'Page 2', 0, 'f2'),
+      ];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.componentRef.setInput('selectedId', 'p2');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(await harness.getAllItemTitles()).toEqual(['Folder 1', 'Folder 2', 'Page 2']);
+      expect(component.hasExpandedNode()).toBe(true);
+    });
+
+    it('should keep the tree collapsed when the selected item is a root item', async () => {
+      fixture.componentRef.setInput('links', nestedLinks);
+      fixture.componentRef.setInput('selectedId', 'f1');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(await harness.getAllItemTitles()).toEqual(['Folder 1']);
+      expect(component.hasExpandedNode()).toBe(false);
+    });
+
     it('should expand all items when expandAllNodes is called', async () => {
       fixture.componentRef.setInput('links', nestedLinks);
       fixture.detectChanges();

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -239,6 +239,24 @@ export class FlatTreeComponent {
       this.tree();
       queueMicrotask(() => this.syncExpansionState());
     });
+
+    effect(() => {
+      const selectedId = this.selectedId();
+      const nodes = this.tree();
+      const tree = this.treeBase();
+
+      if (!selectedId || nodes.length === 0 || !tree) {
+        return;
+      }
+
+      queueMicrotask(() => {
+        if (this.selectedId() !== selectedId || this.tree() !== nodes || this.treeBase() !== tree) {
+          return;
+        }
+
+        this.expandAncestorsOfSelectedNode(selectedId, nodes, tree);
+      });
+    });
   }
 
   onNodeClick(node: FlatTreeNode) {
@@ -435,6 +453,53 @@ export class FlatTreeComponent {
 
   private isWithinSubtree(nodeId: string, root: SectionNode): boolean {
     return (root.children ?? []).some(child => child.id === nodeId || this.isWithinSubtree(nodeId, child));
+  }
+
+  private expandAncestorsOfSelectedNode(selectedId: string, nodes: SectionNode[], tree: MatTree<SectionNode, string>): void {
+    const selectedPath = this.findPathToNode(selectedId, nodes);
+
+    if (!selectedPath || selectedPath.length <= 1) {
+      return;
+    }
+
+    selectedPath.slice(0, -1).forEach(node => tree.expand(node));
+    this.syncExpansionState();
+  }
+
+  private findPathToNode(selectedId: string, nodes: SectionNode[]): SectionNode[] | null {
+    const visitedNodes = new Set<SectionNode>();
+    const stack: Array<{ node: SectionNode; path: SectionNode[] }> = [];
+
+    for (let index = nodes.length - 1; index >= 0; index -= 1) {
+      const node = nodes[index];
+      if (node) {
+        stack.push({ node, path: [node] });
+      }
+    }
+
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (!current || visitedNodes.has(current.node)) {
+        continue;
+      }
+
+      const { node, path } = current;
+      visitedNodes.add(node);
+
+      if (node.id === selectedId) {
+        return path;
+      }
+
+      const children = node.children ?? [];
+      for (let index = children.length - 1; index >= 0; index -= 1) {
+        const child = children[index];
+        if (child) {
+          stack.push({ node: child, path: [...path, child] });
+        }
+      }
+    }
+
+    return null;
   }
 
   private findNodeById(id: string, nodes: SectionNode[] = this.tree()): SectionNode | undefined {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -561,6 +561,55 @@ describe('PortalNavigationItemsComponent', () => {
       expect(routerSpy).toHaveBeenCalledWith(['.'], expect.objectContaining({ queryParams: { navId: createdItem.id } }));
     });
 
+    it('shows the created page in the tree when it is the first child of the folder', async () => {
+      const rootPage = fakePortalNavigationPage({
+        id: 'nav-item-1',
+        title: 'Nav Item 1',
+        portalPageContentId: 'nav-item-1-content',
+      });
+      const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'Folder 1' });
+      const fakeResponse = fakePortalNavigationItemsResponse({ items: [rootPage, folder] });
+
+      await expectGetNavigationItems(fakeResponse);
+      await expectGetPageContent('nav-item-1-content', 'This is the content of Nav Item 1');
+
+      const folderNode = { id: folder.id, label: folder.title, type: folder.type, data: folder } as SectionNode;
+
+      component.onNodeMenuAction({ action: 'create', itemType: 'PAGE', node: folderNode });
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      const title = 'New Child Page';
+      await dialog.setTitleInputValue(title);
+      await dialog.clickSubmitButton();
+
+      const createdItem = fakePortalNavigationPage({
+        id: 'child-page-1',
+        title,
+        area: 'TOP_NAVBAR',
+        type: 'PAGE',
+        parentId: folder.id,
+        portalPageContentId: 'content-id',
+      });
+
+      expectCreateNavigationItem(
+        fakeNewPagePortalNavigationItem({
+          title,
+          area: 'TOP_NAVBAR',
+          type: 'PAGE',
+          parentId: folder.id,
+          contentType: 'GRAVITEE_MARKDOWN',
+        }),
+        createdItem,
+      );
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootPage, folder, createdItem] }));
+      expectGetPageContent('content-id', 'This is the content of New Child Page');
+
+      expect(await harness.getNavigationItemTitles()).toEqual(['Nav Item 1', 'Folder 1', 'New Child Page']);
+      expect(await harness.getSelectedNavigationItemTitle()).toBe('New Child Page');
+      expect(routerSpy).toHaveBeenCalledWith(['.'], expect.objectContaining({ queryParams: { navId: createdItem.id } }));
+    });
+
     it('calls backend create with PRIVATE visibility when parent folder is private', async () => {
       const fakeResponse = fakePortalNavigationItemsResponse({
         items: [
@@ -2105,11 +2154,6 @@ describe('PortalNavigationItemsComponent', () => {
       // Load tree, then expect the component to auto-select the first page within the first folder
       await expectGetNavigationItems(fakeResponse);
       expectGetPageContent('child-content-1', 'This is the content of Child Page 1');
-
-      // As items are collapsed by default, expand so the auto-selected nested page is
-      // rendered and its selected state can be asserted.
-      await harness.clickToggleExpansionButton();
-      fixture.detectChanges();
 
       // Verify selection and navigation
       expect(await harness.getSelectedNavigationItemTitle()).toBe('Child Page 1');


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14466

## Description

- Fixes the Console Portal Editor tree refresh behavior after adding the first page under an empty folder.
- Expands only the ancestor path of the currently selected navigation item, so the newly created nested page becomes visible without expanding unrelated folders or APIs.


https://github.com/user-attachments/assets/9e8604c4-8f87-4c97-a35b-c42c641f74c5


