### PR TITLE
feat(am-connection): persist environment id and verify the AM organization

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/AmConnection.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/AmConnection.java
@@ -26,6 +26,7 @@ public class AmConnection {
     private String organizationId;
     private String baseUrl;
     private String serviceAccountAccessTokenEncrypted;
+    private String amOrganizationId;
     private String environmentId;
     private String defaultDomainId;
     private String defaultDomainHrid;
@@ -56,6 +57,14 @@ public class AmConnection {
 
     public void setServiceAccountAccessTokenEncrypted(String serviceAccountAccessTokenEncrypted) {
         this.serviceAccountAccessTokenEncrypted = serviceAccountAccessTokenEncrypted;
+    }
+
+    public String getAmOrganizationId() {
+        return amOrganizationId;
+    }
+
+    public void setAmOrganizationId(String amOrganizationId) {
+        this.amOrganizationId = amOrganizationId;
     }
 
     public String getEnvironmentId() {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAmConnectionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAmConnectionRepository.java
@@ -44,6 +44,7 @@ public class JdbcAmConnectionRepository extends JdbcAbstractRepository<AmConnect
             .addColumn("organization_id", Types.NVARCHAR, String.class)
             .addColumn("base_url", Types.NVARCHAR, String.class)
             .addColumn("service_account_access_token_encrypted", Types.CLOB, String.class)
+            .addColumn("am_organization_id", Types.NVARCHAR, String.class)
             .addColumn("environment_id", Types.NVARCHAR, String.class)
             .addColumn("default_domain_id", Types.NVARCHAR, String.class)
             .addColumn("default_domain_hrid", Types.NVARCHAR, String.class)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/21_add_am_organization_id_to_am_connections.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/21_add_am_organization_id_to_am_connections.yml
@@ -9,3 +9,12 @@ databaseChangeLog:
               - column:
                   name: am_organization_id
                   type: nvarchar(64)
+        # Backfill existing connections to AM's built-in DEFAULT org so save/test (which now require a
+        # non-blank org) keep working without relying on the UI pre-fill — protects non-UI REST consumers.
+        - update:
+            tableName: ${gravitee_prefix}am_connections
+            columns:
+              - column:
+                  name: am_organization_id
+                  value: DEFAULT
+            where: am_organization_id IS NULL

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/21_add_am_organization_id_to_am_connections.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/21_add_am_organization_id_to_am_connections.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_21_add_am_organization_id_to_am_connections
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}am_connections
+            columns:
+              - column:
+                  name: am_organization_id
+                  type: nvarchar(64)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -385,3 +385,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/19_add_api_product_tags_table.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/20_add_tokenbucket_table.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/21_add_am_organization_id_to_am_connections.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAmConnectionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAmConnectionRepository.java
@@ -87,6 +87,7 @@ public class MongoAmConnectionRepository implements AmConnectionRepository {
         mongo.setOrganizationId(amConnection.getOrganizationId());
         mongo.setBaseUrl(amConnection.getBaseUrl());
         mongo.setServiceAccountAccessTokenEncrypted(amConnection.getServiceAccountAccessTokenEncrypted());
+        mongo.setAmOrganizationId(amConnection.getAmOrganizationId());
         mongo.setEnvironmentId(amConnection.getEnvironmentId());
         mongo.setDefaultDomainId(amConnection.getDefaultDomainId());
         mongo.setDefaultDomainHrid(amConnection.getDefaultDomainHrid());
@@ -103,6 +104,7 @@ public class MongoAmConnectionRepository implements AmConnectionRepository {
         amConnection.setOrganizationId(mongo.getOrganizationId());
         amConnection.setBaseUrl(mongo.getBaseUrl());
         amConnection.setServiceAccountAccessTokenEncrypted(mongo.getServiceAccountAccessTokenEncrypted());
+        amConnection.setAmOrganizationId(mongo.getAmOrganizationId());
         amConnection.setEnvironmentId(mongo.getEnvironmentId());
         amConnection.setDefaultDomainId(mongo.getDefaultDomainId());
         amConnection.setDefaultDomainHrid(mongo.getDefaultDomainHrid());

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/AmConnectionMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/AmConnectionMongo.java
@@ -36,6 +36,7 @@ public class AmConnectionMongo {
 
     private String baseUrl;
     private String serviceAccountAccessTokenEncrypted;
+    private String amOrganizationId;
     private String environmentId;
     private String defaultDomainId;
     private String defaultDomainHrid;

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AmConnectionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AmConnectionRepositoryTest.java
@@ -39,6 +39,7 @@ public class AmConnectionRepositoryTest extends AbstractManagementRepositoryTest
         amConnection.setOrganizationId("org-create");
         amConnection.setBaseUrl("https://am-create.example.com");
         amConnection.setServiceAccountAccessTokenEncrypted("cipher-create");
+        amConnection.setAmOrganizationId("am-org-create");
         amConnection.setEnvironmentId("env-create");
         amConnection.setDefaultDomainId("domain-create");
         amConnection.setDefaultDomainHrid("domain-hrid-create");
@@ -54,6 +55,7 @@ public class AmConnectionRepositoryTest extends AbstractManagementRepositoryTest
         assertEquals("org-create", saved.getOrganizationId());
         assertEquals("https://am-create.example.com", saved.getBaseUrl());
         assertEquals("cipher-create", saved.getServiceAccountAccessTokenEncrypted());
+        assertEquals("am-org-create", saved.getAmOrganizationId());
         assertEquals("env-create", saved.getEnvironmentId());
         assertEquals("domain-create", saved.getDefaultDomainId());
         assertEquals("domain-hrid-create", saved.getDefaultDomainHrid());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/AmConnectionEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/AmConnectionEntity.java
@@ -29,6 +29,7 @@ public class AmConnectionEntity {
     private String organizationId;
     private String baseUrl;
     private String serviceAccountAccessToken;
+    private String amOrganizationId;
     private String environmentId;
     private String defaultDomainId;
     private String defaultDomainHrid;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImpl.java
@@ -81,6 +81,7 @@ public class AmConnectionServiceImpl implements AmConnectionService {
             AmConnection model = new AmConnection();
             model.setOrganizationId(organizationId);
             model.setBaseUrl(stripTrailingSlashes(entity.getBaseUrl()));
+            model.setAmOrganizationId(entity.getAmOrganizationId());
             model.setEnvironmentId(entity.getEnvironmentId());
             model.setDefaultDomainId(entity.getDefaultDomainId());
             model.setDefaultDomainHrid(entity.getDefaultDomainHrid());
@@ -123,6 +124,7 @@ public class AmConnectionServiceImpl implements AmConnectionService {
         entity.setOrganizationId(model.getOrganizationId());
         entity.setBaseUrl(model.getBaseUrl());
         entity.setServiceAccountAccessToken(decryptOrNull(model.getServiceAccountAccessTokenEncrypted()));
+        entity.setAmOrganizationId(model.getAmOrganizationId());
         entity.setEnvironmentId(model.getEnvironmentId());
         entity.setDefaultDomainId(model.getDefaultDomainId());
         entity.setDefaultDomainHrid(model.getDefaultDomainHrid());

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/core/am/domain_service/AmConnectionViewDomainService.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/core/am/domain_service/AmConnectionViewDomainService.java
@@ -34,6 +34,7 @@ public class AmConnectionViewDomainService {
     public record View(
         String baseUrl,
         boolean hasAccessToken,
+        String amOrganizationId,
         String environmentId,
         String defaultDomainId,
         String defaultDomainHrid,
@@ -45,11 +46,12 @@ public class AmConnectionViewDomainService {
         boolean hasToken = amConnectionRepository.hasTokenForOrg(orgId);
 
         String baseUrl = connection.map(c -> c.baseUrl() == null ? "" : c.baseUrl()).orElse("");
+        String amOrganizationId = connection.map(AmConnection::amOrganizationId).orElse(null);
         String environmentId = connection.map(AmConnection::environmentId).orElse(null);
         String defaultDomainId = connection.map(AmConnection::defaultDomainId).orElse(null);
         String defaultDomainHrid = connection.map(AmConnection::defaultDomainHrid).orElse(null);
         String gatewayUrl = connection.map(AmConnection::gatewayUrl).orElse(null);
 
-        return new View(baseUrl, hasToken, environmentId, defaultDomainId, defaultDomainHrid, gatewayUrl);
+        return new View(baseUrl, hasToken, amOrganizationId, environmentId, defaultDomainId, defaultDomainHrid, gatewayUrl);
     }
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/core/am/use_case/connection/GetAmConnectionUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/core/am/use_case/connection/GetAmConnectionUseCase.java
@@ -30,6 +30,7 @@ public class GetAmConnectionUseCase {
     public record Output(
         String baseUrl,
         boolean hasAccessToken,
+        String amOrganizationId,
         String environmentId,
         String defaultDomainId,
         String defaultDomainHrid,
@@ -41,6 +42,7 @@ public class GetAmConnectionUseCase {
         return new Output(
             view.baseUrl(),
             view.hasAccessToken(),
+            view.amOrganizationId(),
             view.environmentId(),
             view.defaultDomainId(),
             view.defaultDomainHrid(),

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/core/am/use_case/connection/SaveAmConnectionUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/core/am/use_case/connection/SaveAmConnectionUseCase.java
@@ -16,6 +16,7 @@
 package io.gravitee.gamma.module.platform.core.am.use_case.connection;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.plugin.gamma.api.identity.AmConnection;
 import io.gravitee.apim.plugin.gamma.api.identity.AmConnectionRepository;
 import io.gravitee.gamma.module.platform.core.am.domain_service.AmConnectionViewDomainService;
@@ -32,6 +33,7 @@ public class SaveAmConnectionUseCase {
         String orgId,
         String baseUrl,
         String serviceAccountAccessToken,
+        String amOrganizationId,
         String environmentId,
         String defaultDomainId,
         String defaultDomainHrid,
@@ -41,6 +43,7 @@ public class SaveAmConnectionUseCase {
     public record Output(
         String baseUrl,
         boolean hasAccessToken,
+        String amOrganizationId,
         String environmentId,
         String defaultDomainId,
         String defaultDomainHrid,
@@ -48,11 +51,18 @@ public class SaveAmConnectionUseCase {
     ) {}
 
     public Output execute(Input input) {
+        // The DTO already enforces a non-blank baseUrl; the AM organization is just as required for
+        // a usable connection, so reject it here too rather than persist a half-configured one that
+        // every later AM call would fail on.
+        if (input.amOrganizationId() == null || input.amOrganizationId().isBlank()) {
+            throw new ValidationDomainException("AM organization is required");
+        }
         amConnectionRepository.save(
             input.orgId(),
             new AmConnection(
                 input.baseUrl(),
                 input.serviceAccountAccessToken(),
+                input.amOrganizationId(),
                 input.environmentId(),
                 input.defaultDomainId(),
                 input.defaultDomainHrid(),
@@ -63,6 +73,7 @@ public class SaveAmConnectionUseCase {
         return new Output(
             view.baseUrl(),
             view.hasAccessToken(),
+            view.amOrganizationId(),
             view.environmentId(),
             view.defaultDomainId(),
             view.defaultDomainHrid(),

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/core/am/use_case/connection/SaveAmConnectionUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/core/am/use_case/connection/SaveAmConnectionUseCase.java
@@ -57,12 +57,14 @@ public class SaveAmConnectionUseCase {
         if (input.amOrganizationId() == null || input.amOrganizationId().isBlank()) {
             throw new ValidationDomainException("AM organization is required");
         }
+        // Store the trimmed org so the persisted value matches what TestAmConnectionUseCase verifies.
+        var amOrganizationId = input.amOrganizationId().trim();
         amConnectionRepository.save(
             input.orgId(),
             new AmConnection(
                 input.baseUrl(),
                 input.serviceAccountAccessToken(),
-                input.amOrganizationId(),
+                amOrganizationId,
                 input.environmentId(),
                 input.defaultDomainId(),
                 input.defaultDomainHrid(),

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/core/am/use_case/connection/TestAmConnectionUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/core/am/use_case/connection/TestAmConnectionUseCase.java
@@ -32,7 +32,7 @@ public class TestAmConnectionUseCase {
     private final AmConnectionRepository amConnectionRepository;
     private final AmConnectionTester amConnectionTester;
 
-    public record Input(String orgId, String inboundBaseUrl, String inboundAccessToken) {}
+    public record Input(String orgId, String inboundBaseUrl, String inboundAccessToken, String inboundAmOrganizationId) {}
 
     public record Output(AmConnectionTestResult result) {}
 
@@ -45,6 +45,9 @@ public class TestAmConnectionUseCase {
             ? (input.inboundAccessToken().isEmpty() ? null : input.inboundAccessToken())
             : stored.map(AmConnection::serviceAccountAccessToken).orElse(null);
 
+        String amOrganizationId = (input.inboundAmOrganizationId() != null && !input.inboundAmOrganizationId().isBlank())
+            ? input.inboundAmOrganizationId().trim()
+            : stored.map(AmConnection::amOrganizationId).orElse(null);
         String environmentId = stored.map(AmConnection::environmentId).orElse(null);
         String defaultDomainId = stored.map(AmConnection::defaultDomainId).orElse(null);
         String defaultDomainHrid = stored.map(AmConnection::defaultDomainHrid).orElse(null);
@@ -52,7 +55,7 @@ public class TestAmConnectionUseCase {
         return new Output(
             amConnectionTester.test(
                 input.orgId(),
-                new AmConnection(baseUrl, accessToken, environmentId, defaultDomainId, defaultDomainHrid, gatewayUrl)
+                new AmConnection(baseUrl, accessToken, amOrganizationId, environmentId, defaultDomainId, defaultDomainHrid, gatewayUrl)
             )
         );
     }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkConnectionTester.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkConnectionTester.java
@@ -37,18 +37,23 @@ public class AmSdkConnectionTester implements AmConnectionTester {
         if (connection.serviceAccountAccessToken() == null || connection.serviceAccountAccessToken().isBlank()) {
             return AmConnectionTestResult.failure(400, "service-account access token is required");
         }
+        if (connection.amOrganizationId() == null || connection.amOrganizationId().isBlank()) {
+            return AmConnectionTestResult.failure(400, "AM organization is required");
+        }
 
+        // Probe the configured AM organization (not the APIM orgId) so an invalid org is rejected here.
+        String amOrganizationId = connection.amOrganizationId();
         AmApis apis = clientFactory.forConnection(connection);
         try {
-            AmSdkInvocations.await(apis.defaults().listEnvironments(orgId));
+            AmSdkInvocations.await(apis.defaults().listEnvironments(amOrganizationId));
             return AmConnectionTestResult.success();
         } catch (RuntimeException e) {
             Throwable cause = e.getCause();
             if (cause instanceof ApiException ae) {
-                log.warn("AM test connection failed for org {}: {} ({})", orgId, ae.getCode(), ae.getMessage());
+                log.warn("AM test connection failed for AM organization {}: {} ({})", amOrganizationId, ae.getCode(), ae.getMessage());
                 return AmConnectionTestResult.failure(ae.getCode(), truncate(ae.getResponseBody()));
             }
-            log.warn("AM test connection failed for org {}: {}", orgId, e.getMessage());
+            log.warn("AM test connection failed for AM organization {}: {}", amOrganizationId, e.getMessage());
             return AmConnectionTestResult.failure(503, "AM unreachable: " + e.getMessage());
         }
     }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkConnectionTester.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkConnectionTester.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.gamma.module.platform.infra.service_provider;
 
-import io.gravitee.am.sdk.management.invoker.ApiException;
 import io.gravitee.apim.plugin.gamma.api.identity.AmConnection;
+import io.gravitee.gamma.module.platform.core.am.exception.AmUpstreamException;
 import io.gravitee.gamma.module.platform.core.am.model.AmModels.AmConnectionTestResult;
 import io.gravitee.gamma.module.platform.core.am.port.service_provider.AmConnectionTester;
 import io.gravitee.gamma.module.platform.infra.service_provider.AmSdkClientFactory.AmApis;
@@ -47,21 +47,16 @@ public class AmSdkConnectionTester implements AmConnectionTester {
         try {
             AmSdkInvocations.await(apis.defaults().listEnvironments(amOrganizationId));
             return AmConnectionTestResult.success();
+        } catch (AmUpstreamException e) {
+            // await() already distilled AM's response into a human-readable message (via describeBody)
+            // and preserved the upstream status. The status still rides along on the result for the
+            // network/log trail, but the user-facing message frames it as a rejected connection.
+            int status = e.upstreamStatus() != null ? e.upstreamStatus() : 503;
+            log.warn("AM test connection failed for AM organization {}: {} ({})", amOrganizationId, status, e.getMessage());
+            return AmConnectionTestResult.failure(status, "Access Management rejected the connection: " + e.getMessage());
         } catch (RuntimeException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof ApiException ae) {
-                log.warn("AM test connection failed for AM organization {}: {} ({})", amOrganizationId, ae.getCode(), ae.getMessage());
-                return AmConnectionTestResult.failure(ae.getCode(), truncate(ae.getResponseBody()));
-            }
             log.warn("AM test connection failed for AM organization {}: {}", amOrganizationId, e.getMessage());
-            return AmConnectionTestResult.failure(503, "AM unreachable: " + e.getMessage());
+            return AmConnectionTestResult.failure(503, "Could not reach Access Management. Check the base URL.");
         }
-    }
-
-    private static String truncate(String s) {
-        if (s == null) {
-            return null;
-        }
-        return s.length() > 500 ? s.substring(0, 500) + "..." : s;
     }
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/rest/resource/am/AmConnectionResource.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/rest/resource/am/AmConnectionResource.java
@@ -58,6 +58,7 @@ public class AmConnectionResource {
         return new AmConnectionResponse(
             output.baseUrl(),
             output.hasAccessToken(),
+            output.amOrganizationId(),
             output.environmentId(),
             output.defaultDomainId(),
             output.defaultDomainHrid(),
@@ -80,6 +81,7 @@ public class AmConnectionResource {
                 orgId,
                 req.baseUrl(),
                 req.serviceAccountAccessToken(),
+                req.amOrganizationId(),
                 req.environmentId(),
                 req.defaultDomainId(),
                 req.defaultDomainHrid(),
@@ -89,6 +91,7 @@ public class AmConnectionResource {
         return new AmConnectionResponse(
             output.baseUrl(),
             output.hasAccessToken(),
+            output.amOrganizationId(),
             output.environmentId(),
             output.defaultDomainId(),
             output.defaultDomainHrid(),
@@ -109,8 +112,11 @@ public class AmConnectionResource {
     public AmConnectionTestResultResponse test(@PathParam("orgId") String orgId, AmConnectionRequest req) {
         String inboundBaseUrl = req == null ? null : req.baseUrl();
         String inboundToken = req == null ? null : req.serviceAccountAccessToken();
+        String inboundAmOrganizationId = req == null ? null : req.amOrganizationId();
         return AmDtoMapper.toDto(
-            testAmConnectionUseCase.execute(new TestAmConnectionUseCase.Input(orgId, inboundBaseUrl, inboundToken)).result()
+            testAmConnectionUseCase
+                .execute(new TestAmConnectionUseCase.Input(orgId, inboundBaseUrl, inboundToken, inboundAmOrganizationId))
+                .result()
         );
     }
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/rest/resource/dto/am/AmDtos.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/rest/resource/dto/am/AmDtos.java
@@ -29,6 +29,7 @@ public final class AmDtos {
     public record AmConnectionRequest(
         @NotBlank String baseUrl,
         String serviceAccountAccessToken,
+        String amOrganizationId,
         String environmentId,
         String defaultDomainId,
         String defaultDomainHrid,
@@ -39,6 +40,7 @@ public final class AmDtos {
     public record AmConnectionResponse(
         String baseUrl,
         boolean hasAccessToken,
+        String amOrganizationId,
         String environmentId,
         String defaultDomainId,
         String defaultDomainHrid,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.spec.tsx
@@ -16,6 +16,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { AmConfigPanel } from './AmConfigPanel';
+import { AM_CONFIG_PANEL_TEST_IDS } from './amConfigPanelTestIds';
 import { resolveOrganizationId } from '../../../shared/api/apimClient';
 import { getAmConnection, isAmUnavailable, listEnvironments, saveAmConnection, testAmConnection } from '../services/amManagement';
 import { loadAmConfig, saveAmConfig } from '../utils/amConfig';
@@ -60,11 +61,15 @@ const STORED_CONNECTION = {
 };
 
 function org() {
-    return screen.getByPlaceholderText('DEFAULT') as HTMLInputElement;
+    return screen.getByTestId(AM_CONFIG_PANEL_TEST_IDS.organizationInput) as HTMLInputElement;
 }
 
 function saveButton() {
-    return screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+    return screen.getByTestId(AM_CONFIG_PANEL_TEST_IDS.saveButton) as HTMLButtonElement;
+}
+
+function verifyButton() {
+    return screen.getByTestId(AM_CONFIG_PANEL_TEST_IDS.verifyButton);
 }
 
 function renderPanel() {
@@ -111,7 +116,7 @@ describe('AmConfigPanel', () => {
         await waitFor(() => expect(org().value).toBe('DEFAULT'));
 
         fireEvent.change(org(), { target: { value: '  am-org  ' } });
-        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+        fireEvent.click(saveButton());
 
         await waitFor(() => expect(mockSaveAmConnection).toHaveBeenCalled());
         expect(mockSaveAmConnection.mock.calls[0][1]).toEqual(expect.objectContaining({ amOrganizationId: 'am-org' }));
@@ -123,7 +128,7 @@ describe('AmConfigPanel', () => {
         renderPanel();
         await waitFor(() => expect(org().value).toBe('DEFAULT'));
 
-        fireEvent.click(screen.getByRole('button', { name: 'Verify & Load' }));
+        fireEvent.click(verifyButton());
 
         await screen.findByText('Connection succeeded');
         expect(mockTestAmConnection.mock.calls[0][2]).toBeInstanceOf(AbortSignal);
@@ -140,8 +145,8 @@ describe('AmConfigPanel', () => {
         renderPanel();
         await waitFor(() => expect(org().value).toBe('DEFAULT'));
 
-        fireEvent.click(screen.getByRole('button', { name: 'Verify & Load' }));
-        fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+        fireEvent.click(verifyButton());
+        fireEvent.click(await screen.findByTestId(AM_CONFIG_PANEL_TEST_IDS.cancelVerifyButton));
 
         await screen.findByText('Cancelled');
         expect(mockSaveAmConnection).not.toHaveBeenCalled();
@@ -158,7 +163,7 @@ describe('AmConfigPanel', () => {
         renderPanel();
         await waitFor(() => expect(org().value).toBe('DEFAULT'));
 
-        fireEvent.click(screen.getByRole('button', { name: 'Verify & Load' }));
+        fireEvent.click(verifyButton());
         await waitFor(() => expect(capturedSignal).toBeDefined());
         fireEvent.change(org(), { target: { value: 'am-org' } });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.spec.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { AmConfigPanel } from './AmConfigPanel';
+import { resolveOrganizationId } from '../../../shared/api/apimClient';
+import { getAmConnection, isAmUnavailable, listEnvironments, saveAmConnection, testAmConnection } from '../services/amManagement';
+import { loadAmConfig, saveAmConfig } from '../utils/amConfig';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(() => ({ id: 'gravitee-env-1' })),
+}));
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    resolveOrganizationId: jest.fn(),
+}));
+
+jest.mock('../services/amManagement', () => ({
+    getAmConnection: jest.fn(),
+    isAmUnavailable: jest.fn(() => false),
+    listDomains: jest.fn(),
+    listDomainEntrypoints: jest.fn(),
+    listEnvironments: jest.fn(),
+    saveAmConnection: jest.fn(),
+    testAmConnection: jest.fn(),
+    getDomain: jest.fn(),
+}));
+
+jest.mock('../utils/amConfig', () => ({
+    loadAmConfig: jest.fn(),
+    saveAmConfig: jest.fn(),
+}));
+
+const mockGetAmConnection = jest.mocked(getAmConnection);
+const mockTestAmConnection = jest.mocked(testAmConnection);
+const mockSaveAmConnection = jest.mocked(saveAmConnection);
+const mockListEnvironments = jest.mocked(listEnvironments);
+
+const STORED_CONNECTION = {
+    baseUrl: 'https://am.example',
+    hasAccessToken: true,
+    amOrganizationId: 'DEFAULT',
+    environmentId: null,
+    defaultDomainId: null,
+    defaultDomainHrid: null,
+    gatewayUrl: null,
+};
+
+function org() {
+    return screen.getByPlaceholderText('DEFAULT') as HTMLInputElement;
+}
+
+function saveButton() {
+    return screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+}
+
+function renderPanel() {
+    const onSaved = jest.fn();
+    render(<AmConfigPanel onSaved={onSaved} />);
+    return { onSaved };
+}
+
+describe('AmConfigPanel', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.mocked(loadAmConfig).mockReturnValue({
+            organizationId: 'apim-org',
+            environmentId: '',
+            domainId: '',
+            graviteeEnvironmentId: 'gravitee-env-1',
+        });
+        jest.mocked(resolveOrganizationId).mockResolvedValue('apim-org');
+        jest.mocked(isAmUnavailable).mockReturnValue(false);
+        // A stored connection means the panel loads verified and lists environments; keep that empty.
+        mockGetAmConnection.mockResolvedValue({ ...STORED_CONNECTION });
+        mockListEnvironments.mockResolvedValue([]);
+        jest.mocked(saveAmConfig).mockReturnValue(undefined);
+    });
+
+    it('pre-fills the AM organization with DEFAULT', async () => {
+        renderPanel();
+
+        await waitFor(() => expect(org().value).toBe('DEFAULT'));
+    });
+
+    it('disables Save when the organization is only whitespace', async () => {
+        renderPanel();
+        await waitFor(() => expect(org().value).toBe('DEFAULT'));
+
+        fireEvent.change(org(), { target: { value: '   ' } });
+
+        expect(saveButton().disabled).toBe(true);
+    });
+
+    it('trims the organization before persisting on Save', async () => {
+        mockSaveAmConnection.mockResolvedValue({ ...STORED_CONNECTION });
+        renderPanel();
+        await waitFor(() => expect(org().value).toBe('DEFAULT'));
+
+        fireEvent.change(org(), { target: { value: '  am-org  ' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => expect(mockSaveAmConnection).toHaveBeenCalled());
+        expect(mockSaveAmConnection.mock.calls[0][1]).toEqual(expect.objectContaining({ amOrganizationId: 'am-org' }));
+    });
+
+    it('passes an abort signal to the verify call and reports success', async () => {
+        mockTestAmConnection.mockResolvedValue({ ok: true });
+        mockSaveAmConnection.mockResolvedValue({ ...STORED_CONNECTION });
+        renderPanel();
+        await waitFor(() => expect(org().value).toBe('DEFAULT'));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Verify & Load' }));
+
+        await screen.findByText('Connection succeeded');
+        expect(mockTestAmConnection.mock.calls[0][2]).toBeInstanceOf(AbortSignal);
+    });
+
+    it('aborts the in-flight verify and shows Cancelled when Cancel is clicked', async () => {
+        // Reject only once the request is aborted, so the Cancel button drives the outcome.
+        mockTestAmConnection.mockImplementation(
+            (_cfg, _req, signal?: AbortSignal) =>
+                new Promise((_resolve, reject) => {
+                    signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+                }),
+        );
+        renderPanel();
+        await waitFor(() => expect(org().value).toBe('DEFAULT'));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Verify & Load' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+        await screen.findByText('Cancelled');
+        expect(mockSaveAmConnection).not.toHaveBeenCalled();
+    });
+
+    it('aborts an in-flight verify when a field is edited', async () => {
+        let capturedSignal: AbortSignal | undefined;
+        mockTestAmConnection.mockImplementation((_cfg, _req, signal?: AbortSignal) => {
+            capturedSignal = signal;
+            return new Promise((_resolve, reject) => {
+                signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+            });
+        });
+        renderPanel();
+        await waitFor(() => expect(org().value).toBe('DEFAULT'));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Verify & Load' }));
+        await waitFor(() => expect(capturedSignal).toBeDefined());
+        fireEvent.change(org(), { target: { value: 'am-org' } });
+
+        await waitFor(() => expect(capturedSignal?.aborted).toBe(true));
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.tsx
@@ -44,6 +44,7 @@ import {
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import { resolveOrganizationId } from '../../../shared/api/apimClient';
+import { AM_CONFIG_PANEL_TEST_IDS } from './amConfigPanelTestIds';
 import {
     getAmConnection,
     getDomain,
@@ -399,6 +400,7 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
                         value={form.baseUrl}
                         onChange={v => setField('baseUrl', v)}
                         placeholder="http://localhost:8093"
+                        testId={AM_CONFIG_PANEL_TEST_IDS.baseUrlInput}
                     />
 
                     <TextField
@@ -406,6 +408,7 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
                         value={form.amOrganizationId}
                         onChange={v => setField('amOrganizationId', v)}
                         placeholder="DEFAULT"
+                        testId={AM_CONFIG_PANEL_TEST_IDS.organizationInput}
                     />
 
                     <TextField
@@ -414,14 +417,26 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
                         onChange={v => setField('accessToken', v)}
                         placeholder={form.hadAccessToken ? '●●●●●●●● (saved — leave blank to keep)' : 'Bearer token issued by AM'}
                         type="password"
+                        testId={AM_CONFIG_PANEL_TEST_IDS.accessTokenInput}
                     />
 
                     <div className="flex items-center gap-2">
-                        <Button type="button" variant="outline" onClick={handleTest} disabled={testing || !form.baseUrl}>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={handleTest}
+                            disabled={testing || !form.baseUrl}
+                            data-testid={AM_CONFIG_PANEL_TEST_IDS.verifyButton}
+                        >
                             {testing ? 'Verifying…' : 'Verify & Load'}
                         </Button>
                         {testing && (
-                            <Button type="button" variant="ghost" onClick={handleCancelTest}>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                onClick={handleCancelTest}
+                                data-testid={AM_CONFIG_PANEL_TEST_IDS.cancelVerifyButton}
+                            >
                                 Cancel
                             </Button>
                         )}
@@ -535,7 +550,7 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
             )}
 
             <div className="flex gap-2">
-                <Button type="submit" disabled={!canSaveConnection || saving}>
+                <Button type="submit" disabled={!canSaveConnection || saving} data-testid={AM_CONFIG_PANEL_TEST_IDS.saveButton}>
                     {saving ? 'Saving…' : 'Save'}
                 </Button>
                 {onCancel && (
@@ -555,6 +570,7 @@ function TextField({
     placeholder,
     type = 'text',
     disabled = false,
+    testId,
 }: {
     label: string;
     value: string;
@@ -562,6 +578,7 @@ function TextField({
     placeholder?: string;
     type?: string;
     disabled?: boolean;
+    testId?: string;
 }) {
     const id = useId();
     return (
@@ -574,6 +591,7 @@ function TextField({
                     onChange={e => onChange(e.target.value)}
                     placeholder={placeholder}
                     disabled={disabled}
+                    data-testid={testId}
                 />
             ) : (
                 <Input
@@ -583,6 +601,7 @@ function TextField({
                     placeholder={placeholder}
                     type={type}
                     disabled={disabled}
+                    data-testid={testId}
                 />
             )}
         </Field>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.tsx
@@ -343,7 +343,8 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
 
     const handleCancelTest = () => testAbortRef.current?.abort();
 
-    const canSaveConnection = Boolean(form.baseUrl) && Boolean(form.accessToken || form.hadAccessToken);
+    const canSaveConnection =
+        Boolean(form.baseUrl) && Boolean(form.amOrganizationId.trim()) && Boolean(form.accessToken || form.hadAccessToken);
     const canSaveSelection = Boolean(cfg.organizationId && cfg.environmentId && cfg.domainId);
 
     const submit = async (e: React.FormEvent) => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.tsx
@@ -112,6 +112,8 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
     const set = <K extends keyof AmConfig>(key: K, value: AmConfig[K]) => setCfg(prev => ({ ...prev, [key]: value }));
     const setField = <K extends keyof FormState>(key: K, value: FormState[K]) => {
         setForm(prev => ({ ...prev, [key]: value }));
+        // Abort any in-flight verify so a late result against the old creds can't flip verified back on.
+        testAbortRef.current?.abort();
         setConnectionVerified(false);
         setTestResult(null);
         setConnectionSaved(false);
@@ -296,7 +298,7 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
     const buildRequest = (): AmConnectionRequest => ({
         baseUrl: form.baseUrl,
         serviceAccountAccessToken: form.accessToken || undefined,
-        amOrganizationId: form.amOrganizationId || null,
+        amOrganizationId: form.amOrganizationId.trim() || null,
         environmentId: cfg.environmentId || null,
         defaultDomainId: cfg.domainId || null,
         defaultDomainHrid: domainHrid || null,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.tsx
@@ -43,8 +43,8 @@ import {
 } from '@gravitee/graphene-core';
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 
-import { resolveOrganizationId } from '../../../shared/api/apimClient';
 import { AM_CONFIG_PANEL_TEST_IDS } from './amConfigPanelTestIds';
+import { resolveOrganizationId } from '../../../shared/api/apimClient';
 import {
     getAmConnection,
     getDomain,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.tsx
@@ -66,12 +66,15 @@ interface FormState {
     baseUrl: string;
     accessToken: string;
     hadAccessToken: boolean;
+    amOrganizationId: string;
 }
 
 const EMPTY_FORM: FormState = {
     baseUrl: '',
     accessToken: '',
     hadAccessToken: false,
+    // AM addresses resources per organization; defaults to AM's built-in DEFAULT org.
+    amOrganizationId: 'DEFAULT',
 };
 
 export function AmConfigPanel({ onSaved, onCancel }: Props) {
@@ -103,6 +106,8 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
     const [connectionVerified, setConnectionVerified] = useState(false);
     // Bumped to force the env/domain effects to re-query when connectionVerified hasn't changed.
     const [scopeRefreshKey, setScopeRefreshKey] = useState(0);
+    // Lets the user cancel an in-flight verify (an unreachable URL otherwise blocks for the backend's 30s timeout).
+    const testAbortRef = useRef<AbortController | null>(null);
 
     const set = <K extends keyof AmConfig>(key: K, value: AmConfig[K]) => setCfg(prev => ({ ...prev, [key]: value }));
     const setField = <K extends keyof FormState>(key: K, value: FormState[K]) => {
@@ -160,6 +165,7 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
                     baseUrl: view.baseUrl,
                     accessToken: '',
                     hadAccessToken: view.hasAccessToken,
+                    amOrganizationId: view.amOrganizationId || 'DEFAULT',
                 });
                 setSavedDomain(view.defaultDomainId ? { id: view.defaultDomainId, hrid: view.defaultDomainHrid ?? null } : null);
                 // Restore the server's environment/domain only when localStorage has none; reading prev
@@ -290,6 +296,7 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
     const buildRequest = (): AmConnectionRequest => ({
         baseUrl: form.baseUrl,
         serviceAccountAccessToken: form.accessToken || undefined,
+        amOrganizationId: form.amOrganizationId || null,
         environmentId: cfg.environmentId || null,
         defaultDomainId: cfg.domainId || null,
         defaultDomainHrid: domainHrid || null,
@@ -297,10 +304,15 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
     });
 
     const handleTest = async () => {
+        const controller = new AbortController();
+        testAbortRef.current = controller;
+        // Auto-abort just past the backend's 30s ceiling so a passive user isn't stuck indefinitely;
+        // the Cancel button lets them bail sooner.
+        const timeout = setTimeout(() => controller.abort(), 31_000);
         setTesting(true);
         setTestResult(null);
         try {
-            const result = await testAmConnection(cfg, buildRequest());
+            const result = await testAmConnection(cfg, buildRequest(), controller.signal);
             setTestResult({
                 ok: result.ok,
                 message: result.ok ? 'Connection succeeded' : `${result.status ?? '?'}: ${result.message ?? 'failed'}`,
@@ -318,12 +330,17 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
             }
             setConnectionVerified(result.ok);
         } catch (e) {
-            setTestResult({ ok: false, message: e instanceof Error ? e.message : String(e) });
+            const aborted = controller.signal.aborted || (e instanceof DOMException && e.name === 'AbortError');
+            setTestResult({ ok: false, message: aborted ? 'Cancelled' : e instanceof Error ? e.message : String(e) });
             setConnectionVerified(false);
         } finally {
+            clearTimeout(timeout);
+            testAbortRef.current = null;
             setTesting(false);
         }
     };
+
+    const handleCancelTest = () => testAbortRef.current?.abort();
 
     const canSaveConnection = Boolean(form.baseUrl) && Boolean(form.accessToken || form.hadAccessToken);
     const canSaveSelection = Boolean(cfg.organizationId && cfg.environmentId && cfg.domainId);
@@ -364,7 +381,7 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
     }
 
     return (
-        <form onSubmit={submit} className="grid gap-4 max-w-2xl">
+        <form onSubmit={submit} className="grid gap-4">
             <Card>
                 <CardHeader>
                     <CardTitle>Gravitee Access Management connection</CardTitle>
@@ -374,19 +391,17 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
                 </CardHeader>
                 <CardContent className="grid gap-4">
                     <TextField
-                        label="Organization"
-                        value={cfg.organizationId}
-                        onChange={v => set('organizationId', v)}
-                        placeholder="DEFAULT"
-                        // Bootstrap-resolved and feeds moduleBaseUrl(); editing it points requests at a bogus path.
-                        disabled
-                    />
-
-                    <TextField
                         label="Gravitee Access Management base URL"
                         value={form.baseUrl}
                         onChange={v => setField('baseUrl', v)}
                         placeholder="http://localhost:8093"
+                    />
+
+                    <TextField
+                        label="Access Management organization"
+                        value={form.amOrganizationId}
+                        onChange={v => setField('amOrganizationId', v)}
+                        placeholder="DEFAULT"
                     />
 
                     <TextField
@@ -399,8 +414,13 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
 
                     <div className="flex items-center gap-2">
                         <Button type="button" variant="outline" onClick={handleTest} disabled={testing || !form.baseUrl}>
-                            {testing ? 'Testing…' : 'Test connection'}
+                            {testing ? 'Verifying…' : 'Verify & Load'}
                         </Button>
+                        {testing && (
+                            <Button type="button" variant="ghost" onClick={handleCancelTest}>
+                                Cancel
+                            </Button>
+                        )}
                         {testResult && (
                             <span className={testResult.ok ? 'text-sm text-success' : 'text-sm text-destructive'}>
                                 {testResult.message}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/AmConfigPanel.tsx
@@ -315,7 +315,8 @@ export function AmConfigPanel({ onSaved, onCancel }: Props) {
             const result = await testAmConnection(cfg, buildRequest(), controller.signal);
             setTestResult({
                 ok: result.ok,
-                message: result.ok ? 'Connection succeeded' : `${result.status ?? '?'}: ${result.message ?? 'failed'}`,
+                // Status code is intentionally omitted — the message is enough; the network request has the rest.
+                message: result.ok ? 'Connection succeeded' : (result.message ?? 'Verification failed'),
             });
             if (result.ok) {
                 // Persist immediately so the env/domain queries below run against the tested creds,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/amConfigPanelTestIds.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/components/amConfigPanelTestIds.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const AM_CONFIG_PANEL_TEST_IDS = {
+    baseUrlInput: 'am-base-url-input',
+    organizationInput: 'am-organization-input',
+    accessTokenInput: 'am-access-token-input',
+    verifyButton: 'am-verify-button',
+    cancelVerifyButton: 'am-cancel-verify-button',
+    saveButton: 'am-save-button',
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/services/amManagement.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/services/amManagement.ts
@@ -53,10 +53,11 @@ export function saveAmConnection(cfg: AmConfig, payload: AmConnectionRequest): P
     return gammaFetchJson<AmConnectionView>(`${moduleBaseUrl(cfg)}/am-config`, { method: 'PUT', body: JSON.stringify(payload) });
 }
 
-export function testAmConnection(cfg: AmConfig, payload: AmConnectionRequest): Promise<AmConnectionTestResult> {
+export function testAmConnection(cfg: AmConfig, payload: AmConnectionRequest, signal?: AbortSignal): Promise<AmConnectionTestResult> {
     return gammaFetchJson<AmConnectionTestResult>(`${moduleBaseUrl(cfg)}/am-config/_test`, {
         method: 'POST',
         body: JSON.stringify(payload),
+        signal,
     });
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/types/amManagement.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/access-management/types/amManagement.ts
@@ -28,6 +28,7 @@ export interface AmDomain {
 export interface AmConnectionView {
     baseUrl: string;
     hasAccessToken: boolean;
+    amOrganizationId?: string | null;
     environmentId?: string | null;
     defaultDomainId?: string | null;
     defaultDomainHrid?: string | null;
@@ -37,6 +38,7 @@ export interface AmConnectionView {
 export interface AmConnectionRequest {
     baseUrl: string;
     serviceAccountAccessToken?: string | null;
+    amOrganizationId?: string | null;
     environmentId?: string | null;
     defaultDomainId?: string | null;
     defaultDomainHrid?: string | null;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/core/am/use_case/GetAmConnectionUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/core/am/use_case/GetAmConnectionUseCaseTest.java
@@ -54,7 +54,9 @@ class GetAmConnectionUseCaseTest {
 
     @Test
     void should_report_token_present_even_when_decrypt_failed() {
-        when(repository.findByOrg("ORG")).thenReturn(Optional.of(new AmConnection("https://am.example", null, null, null, null, null)));
+        when(repository.findByOrg("ORG")).thenReturn(
+            Optional.of(new AmConnection("https://am.example", null, null, null, null, null, null))
+        );
         when(repository.hasTokenForOrg("ORG")).thenReturn(true);
 
         var output = useCase.execute(new GetAmConnectionUseCase.Input("ORG"));

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/core/am/use_case/SaveAmConnectionUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/core/am/use_case/SaveAmConnectionUseCaseTest.java
@@ -118,6 +118,20 @@ class SaveAmConnectionUseCaseTest {
     }
 
     @Test
+    void should_trim_am_organization_before_persisting() {
+        when(repository.findByOrg("ORG")).thenReturn(Optional.empty());
+        when(repository.hasTokenForOrg("ORG")).thenReturn(true);
+
+        useCase.execute(
+            new SaveAmConnectionUseCase.Input("ORG", "https://am.example", "secret-token", "  am-org  ", null, null, null, null)
+        );
+
+        var saved = ArgumentCaptor.forClass(AmConnection.class);
+        Mockito.verify(repository).save(Mockito.eq("ORG"), saved.capture());
+        assertThat(saved.getValue().amOrganizationId()).isEqualTo("am-org");
+    }
+
+    @Test
     void should_reject_blank_am_organization() {
         assertThatThrownBy(() ->
             useCase.execute(new SaveAmConnectionUseCase.Input("ORG", "https://am.example", "secret-token", "   ", null, null, null, null))

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/core/am/use_case/SaveAmConnectionUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/core/am/use_case/SaveAmConnectionUseCaseTest.java
@@ -16,8 +16,11 @@
 package io.gravitee.gamma.module.platform.core.am.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.plugin.gamma.api.identity.AmConnection;
 import io.gravitee.apim.plugin.gamma.api.identity.AmConnectionRepository;
 import io.gravitee.gamma.module.platform.core.am.domain_service.AmConnectionViewDomainService;
@@ -52,6 +55,7 @@ class SaveAmConnectionUseCaseTest {
                 "ORG",
                 "https://am.example",
                 "secret-token",
+                "am-org-1",
                 "env-1",
                 "domain-1",
                 "my-domain",
@@ -62,14 +66,16 @@ class SaveAmConnectionUseCaseTest {
         var saved = ArgumentCaptor.forClass(AmConnection.class);
         Mockito.verify(repository).save(Mockito.eq("ORG"), saved.capture());
         assertThat(saved.getValue()).isEqualTo(
-            new AmConnection("https://am.example", "secret-token", "env-1", "domain-1", "my-domain", "https://gw.example")
+            new AmConnection("https://am.example", "secret-token", "am-org-1", "env-1", "domain-1", "my-domain", "https://gw.example")
         );
     }
 
     @Test
     void should_return_readback_view_with_token_flagged_present() {
         when(repository.findByOrg("ORG")).thenReturn(
-            Optional.of(new AmConnection("https://am.example", "secret-token", "env-1", "domain-1", "my-domain", "https://gw.example"))
+            Optional.of(
+                new AmConnection("https://am.example", "secret-token", "am-org-1", "env-1", "domain-1", "my-domain", "https://gw.example")
+            )
         );
         when(repository.hasTokenForOrg("ORG")).thenReturn(true);
 
@@ -78,6 +84,7 @@ class SaveAmConnectionUseCaseTest {
                 "ORG",
                 "https://am.example",
                 "secret-token",
+                "am-org-1",
                 "env-1",
                 "domain-1",
                 "my-domain",
@@ -97,12 +104,36 @@ class SaveAmConnectionUseCaseTest {
     void should_report_no_token_when_blank_token_clears_it() {
         // Blank token clears the saved ciphertext (see AmConnectionRepository#save semantics),
         // so the read-back reports the connection present but no token.
-        when(repository.findByOrg("ORG")).thenReturn(Optional.of(new AmConnection("https://am.example", null, null, null, null, null)));
+        when(repository.findByOrg("ORG")).thenReturn(
+            Optional.of(new AmConnection("https://am.example", null, null, null, null, null, null))
+        );
         when(repository.hasTokenForOrg("ORG")).thenReturn(false);
 
-        var output = useCase.execute(new SaveAmConnectionUseCase.Input("ORG", "https://am.example", "", null, null, null, null));
+        var output = useCase.execute(
+            new SaveAmConnectionUseCase.Input("ORG", "https://am.example", "", "am-org-1", null, null, null, null)
+        );
 
         assertThat(output.baseUrl()).isEqualTo("https://am.example");
         assertThat(output.hasAccessToken()).isFalse();
+    }
+
+    @Test
+    void should_reject_blank_am_organization() {
+        assertThatThrownBy(() ->
+            useCase.execute(new SaveAmConnectionUseCase.Input("ORG", "https://am.example", "secret-token", "   ", null, null, null, null))
+        )
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("AM organization is required");
+
+        Mockito.verify(repository, never()).save(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void should_reject_null_am_organization() {
+        assertThatThrownBy(() ->
+            useCase.execute(new SaveAmConnectionUseCase.Input("ORG", "https://am.example", "secret-token", null, null, null, null, null))
+        ).isInstanceOf(ValidationDomainException.class);
+
+        Mockito.verify(repository, never()).save(Mockito.any(), Mockito.any());
     }
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/core/am/use_case/TestAmConnectionUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/core/am/use_case/TestAmConnectionUseCaseTest.java
@@ -89,7 +89,7 @@ class TestAmConnectionUseCaseTest {
     }
 
     @Test
-    void should_fall_back_to_stored_when_inbound_blank() {
+    void should_fall_back_to_stored_base_url_and_token_when_inbound_blank() {
         when(repository.findByOrg("ORG")).thenReturn(
             Optional.of(new AmConnection("https://stored.example", "stored-token", null, null, null, null, null))
         );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/core/am/use_case/TestAmConnectionUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/core/am/use_case/TestAmConnectionUseCaseTest.java
@@ -51,22 +51,51 @@ class TestAmConnectionUseCaseTest {
         when(repository.findByOrg("ORG")).thenReturn(Optional.empty());
         when(tester.test(Mockito.eq("ORG"), Mockito.any())).thenReturn(AmConnectionTestResult.success());
 
-        useCase.execute(new TestAmConnectionUseCase.Input("ORG", "https://am.example/", "inbound-token"));
+        useCase.execute(new TestAmConnectionUseCase.Input("ORG", "https://am.example/", "inbound-token", "am-org"));
 
         ArgumentCaptor<AmConnection> captor = ArgumentCaptor.forClass(AmConnection.class);
         verify(tester).test(Mockito.eq("ORG"), captor.capture());
         assertThat(captor.getValue().baseUrl()).isEqualTo("https://am.example");
         assertThat(captor.getValue().serviceAccountAccessToken()).isEqualTo("inbound-token");
+        assertThat(captor.getValue().amOrganizationId()).isEqualTo("am-org");
+    }
+
+    @Test
+    void should_use_inbound_am_organization_over_stored() {
+        when(repository.findByOrg("ORG")).thenReturn(
+            Optional.of(new AmConnection("https://stored.example", "stored-token", "stored-am-org", null, null, null, null))
+        );
+        when(tester.test(Mockito.eq("ORG"), Mockito.any())).thenReturn(AmConnectionTestResult.success());
+
+        useCase.execute(new TestAmConnectionUseCase.Input("ORG", "https://am.example", "inbound-token", "  edited-am-org  "));
+
+        ArgumentCaptor<AmConnection> captor = ArgumentCaptor.forClass(AmConnection.class);
+        verify(tester).test(Mockito.eq("ORG"), captor.capture());
+        assertThat(captor.getValue().amOrganizationId()).isEqualTo("edited-am-org");
+    }
+
+    @Test
+    void should_fall_back_to_stored_am_organization_when_inbound_blank() {
+        when(repository.findByOrg("ORG")).thenReturn(
+            Optional.of(new AmConnection("https://stored.example", "stored-token", "stored-am-org", null, null, null, null))
+        );
+        when(tester.test(Mockito.eq("ORG"), Mockito.any())).thenReturn(AmConnectionTestResult.success());
+
+        useCase.execute(new TestAmConnectionUseCase.Input("ORG", "https://am.example", "inbound-token", "   "));
+
+        ArgumentCaptor<AmConnection> captor = ArgumentCaptor.forClass(AmConnection.class);
+        verify(tester).test(Mockito.eq("ORG"), captor.capture());
+        assertThat(captor.getValue().amOrganizationId()).isEqualTo("stored-am-org");
     }
 
     @Test
     void should_fall_back_to_stored_when_inbound_blank() {
         when(repository.findByOrg("ORG")).thenReturn(
-            Optional.of(new AmConnection("https://stored.example", "stored-token", null, null, null, null))
+            Optional.of(new AmConnection("https://stored.example", "stored-token", null, null, null, null, null))
         );
         when(tester.test(Mockito.eq("ORG"), Mockito.any())).thenReturn(AmConnectionTestResult.success());
 
-        useCase.execute(new TestAmConnectionUseCase.Input("ORG", "", null));
+        useCase.execute(new TestAmConnectionUseCase.Input("ORG", "", null, null));
 
         ArgumentCaptor<AmConnection> captor = ArgumentCaptor.forClass(AmConnection.class);
         verify(tester).test(Mockito.eq("ORG"), captor.capture());
@@ -77,11 +106,11 @@ class TestAmConnectionUseCaseTest {
     @Test
     void should_treat_empty_inbound_token_as_clear() {
         when(repository.findByOrg("ORG")).thenReturn(
-            Optional.of(new AmConnection("https://stored.example", "stored-token", null, null, null, null))
+            Optional.of(new AmConnection("https://stored.example", "stored-token", null, null, null, null, null))
         );
         when(tester.test(Mockito.eq("ORG"), Mockito.any())).thenReturn(AmConnectionTestResult.failure(400, "no token"));
 
-        useCase.execute(new TestAmConnectionUseCase.Input("ORG", "https://am.example", ""));
+        useCase.execute(new TestAmConnectionUseCase.Input("ORG", "https://am.example", "", null));
 
         ArgumentCaptor<AmConnection> captor = ArgumentCaptor.forClass(AmConnection.class);
         verify(tester).test(Mockito.eq("ORG"), captor.capture());

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkConnectionTesterTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkConnectionTesterTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.module.platform.infra.service_provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.am.sdk.management.api.DefaultApi;
+import io.gravitee.am.sdk.management.invoker.ApiException;
+import io.gravitee.am.sdk.management.model.Environment;
+import io.gravitee.apim.plugin.gamma.api.identity.AmConnection;
+import io.gravitee.gamma.module.platform.core.am.model.AmModels.AmConnectionTestResult;
+import io.gravitee.gamma.module.platform.infra.service_provider.AmSdkClientFactory.AmApis;
+import io.vertx.core.Future;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AmSdkConnectionTesterTest {
+
+    private static final String APIM_ORG = "DEFAULT";
+
+    private AmSdkClientFactory clientFactory;
+    private DefaultApi defaults;
+    private AmSdkConnectionTester tester;
+
+    @BeforeEach
+    void setUp() {
+        clientFactory = Mockito.mock(AmSdkClientFactory.class);
+        defaults = Mockito.mock(DefaultApi.class);
+        tester = new AmSdkConnectionTester(clientFactory);
+    }
+
+    private AmConnection connection(String amOrganizationId) {
+        return new AmConnection("https://am.example", "token", amOrganizationId, null, null, null, null);
+    }
+
+    @Test
+    void should_probe_the_configured_am_organization_not_the_apim_org() {
+        when(clientFactory.forConnection(any())).thenReturn(new AmApis(null, defaults, null));
+        when(defaults.listEnvironments("am-org")).thenReturn(Future.succeededFuture(List.<Environment>of()));
+
+        var result = tester.test(APIM_ORG, connection("am-org"));
+
+        assertThat(result.ok()).isTrue();
+        // The whole point of the fix: AM is queried with the connection's amOrganizationId,
+        // never the APIM org passed as the first argument.
+        verify(defaults).listEnvironments("am-org");
+        verify(defaults, never()).listEnvironments(APIM_ORG);
+    }
+
+    @Test
+    void should_fail_fast_when_am_organization_is_blank_without_calling_am() {
+        var result = tester.test(APIM_ORG, connection("   "));
+
+        assertThat(result.ok()).isFalse();
+        assertThat(result.status()).isEqualTo(400);
+        assertThat(result.message()).contains("AM organization is required");
+        verifyNoInteractions(clientFactory);
+    }
+
+    @Test
+    void should_surface_am_status_when_organization_is_rejected() {
+        when(clientFactory.forConnection(any())).thenReturn(new AmApis(null, defaults, null));
+        when(defaults.listEnvironments("bogus")).thenReturn(
+            Future.failedFuture(new ApiException(404, "Not Found", null, "{\"message\":\"organization [bogus] not found\"}"))
+        );
+
+        var result = tester.test(APIM_ORG, connection("bogus"));
+
+        assertThat(result.ok()).isFalse();
+        assertThat(result.status()).isEqualTo(404);
+    }
+
+    @Test
+    void should_require_base_url() {
+        var result = tester.test(APIM_ORG, new AmConnection("", "token", "am-org", null, null, null, null));
+
+        assertThat(result).isEqualTo(AmConnectionTestResult.failure(400, "baseUrl is required"));
+        verifyNoInteractions(clientFactory);
+    }
+
+    @Test
+    void should_require_access_token() {
+        var result = tester.test(APIM_ORG, new AmConnection("https://am.example", " ", "am-org", null, null, null, null));
+
+        assertThat(result.ok()).isFalse();
+        assertThat(result.status()).isEqualTo(400);
+        assertThat(result.message()).contains("access token is required");
+        verifyNoInteractions(clientFactory);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkConnectionTesterTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkConnectionTesterTest.java
@@ -81,16 +81,20 @@ class AmSdkConnectionTesterTest {
     }
 
     @Test
-    void should_surface_am_status_when_organization_is_rejected() {
+    void should_surface_am_status_and_a_clean_message_when_organization_is_rejected() {
         when(clientFactory.forConnection(any())).thenReturn(new AmApis(null, defaults, null));
         when(defaults.listEnvironments("bogus")).thenReturn(
-            Future.failedFuture(new ApiException(404, "Not Found", null, "{\"message\":\"organization [bogus] not found\"}"))
+            Future.failedFuture(new ApiException(403, "Forbidden", null, "{\"message\":\"Permission denied\",\"http_status\":403}"))
         );
 
         var result = tester.test(APIM_ORG, connection("bogus"));
 
         assertThat(result.ok()).isFalse();
-        assertThat(result.status()).isEqualTo(404);
+        // Status still rides along on the result (the UI no longer renders it, but logs/tests can).
+        assertThat(result.status()).isEqualTo(403);
+        // Readable, framed message — AM's reason unwrapped from the raw JSON body.
+        assertThat(result.message()).isEqualTo("Access Management rejected the connection: Permission denied");
+        assertThat(result.message()).doesNotContain("{", "http_status");
     }
 
     @Test

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/rest/resource/am/AmConnectionResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/rest/resource/am/AmConnectionResourceTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.module.platform.rest.resource.am;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gamma.module.platform.core.am.model.AmModels.AmConnectionTestResult;
+import io.gravitee.gamma.module.platform.core.am.use_case.connection.GetAmConnectionUseCase;
+import io.gravitee.gamma.module.platform.core.am.use_case.connection.SaveAmConnectionUseCase;
+import io.gravitee.gamma.module.platform.core.am.use_case.connection.TestAmConnectionUseCase;
+import io.gravitee.gamma.module.platform.rest.resource.dto.am.AmDtos.AmConnectionRequest;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+// Resource-level wiring test: confirms the JAX-RS resource forwards request-body fields into the
+// use-case Input. Guards the regression where /_test silently dropped amOrganizationId. Mockito
+// @InjectMocks fills the resource's @Inject fields by type, so no Jersey container is needed.
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AmConnectionResourceTest {
+
+    @Mock
+    private GetAmConnectionUseCase getAmConnectionUseCase;
+
+    @Mock
+    private SaveAmConnectionUseCase saveAmConnectionUseCase;
+
+    @Mock
+    private TestAmConnectionUseCase testAmConnectionUseCase;
+
+    @InjectMocks
+    private AmConnectionResource resource;
+
+    private AmConnectionRequest request(String amOrganizationId) {
+        return new AmConnectionRequest("https://am.example", "token", amOrganizationId, "env", "dom", "dom-hrid", "https://gw");
+    }
+
+    @Test
+    void test_endpoint_forwards_am_organization_id_from_body() {
+        when(testAmConnectionUseCase.execute(any())).thenReturn(new TestAmConnectionUseCase.Output(AmConnectionTestResult.success()));
+
+        resource.test("APIM-ORG", request("am-org"));
+
+        var captor = ArgumentCaptor.forClass(TestAmConnectionUseCase.Input.class);
+        verify(testAmConnectionUseCase).execute(captor.capture());
+        assertThat(captor.getValue().orgId()).isEqualTo("APIM-ORG");
+        assertThat(captor.getValue().inboundBaseUrl()).isEqualTo("https://am.example");
+        assertThat(captor.getValue().inboundAmOrganizationId()).isEqualTo("am-org");
+    }
+
+    @Test
+    void test_endpoint_tolerates_a_null_body() {
+        when(testAmConnectionUseCase.execute(any())).thenReturn(new TestAmConnectionUseCase.Output(AmConnectionTestResult.success()));
+
+        resource.test("APIM-ORG", null);
+
+        var captor = ArgumentCaptor.forClass(TestAmConnectionUseCase.Input.class);
+        verify(testAmConnectionUseCase).execute(captor.capture());
+        assertThat(captor.getValue().orgId()).isEqualTo("APIM-ORG");
+        assertThat(captor.getValue().inboundBaseUrl()).isNull();
+        assertThat(captor.getValue().inboundAmOrganizationId()).isNull();
+    }
+
+    @Test
+    void save_endpoint_forwards_am_organization_id_from_body() {
+        when(saveAmConnectionUseCase.execute(any())).thenReturn(
+            new SaveAmConnectionUseCase.Output("https://am.example", true, "am-org", "env", "dom", "dom-hrid", "https://gw")
+        );
+
+        resource.save("APIM-ORG", request("am-org"));
+
+        var captor = ArgumentCaptor.forClass(SaveAmConnectionUseCase.Input.class);
+        verify(saveAmConnectionUseCase).execute(captor.capture());
+        assertThat(captor.getValue().orgId()).isEqualTo("APIM-ORG");
+        assertThat(captor.getValue().amOrganizationId()).isEqualTo("am-org");
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/rest/resource/dto/am/AmConnectionRequestBindingTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/rest/resource/dto/am/AmConnectionRequestBindingTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.module.platform.rest.resource.dto.am;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gamma.module.platform.rest.resource.dto.am.AmDtos.AmConnectionRequest;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+// Guards the serialization + bean-validation layers the AmConnectionResource @InjectMocks wiring test
+// can't reach: the original /_test drop-bug lived in Jackson binding, and @NotBlank baseUrl is only
+// enforced on the save DTO. /_test deliberately takes the unannotated body (partial-body tolerance),
+// so it has no DTO constraint to assert here.
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AmConnectionRequestBindingTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static ValidatorFactory factory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        // ParameterMessageInterpolator avoids the optional jakarta.el dependency in unit tests.
+        factory = Validation.byDefaultProvider()
+            .configure()
+            .messageInterpolator(new ParameterMessageInterpolator())
+            .buildValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        factory.close();
+    }
+
+    @Test
+    void deserializes_am_organization_id_from_the_request_body() throws Exception {
+        var json = """
+            {
+              "baseUrl": "https://am.example",
+              "serviceAccountAccessToken": "token",
+              "amOrganizationId": "am-org",
+              "environmentId": "env",
+              "defaultDomainId": "dom",
+              "defaultDomainHrid": "dom-hrid",
+              "gatewayUrl": "https://gw"
+            }
+            """;
+
+        var req = MAPPER.readValue(json, AmConnectionRequest.class);
+
+        assertThat(req.amOrganizationId()).isEqualTo("am-org");
+        assertThat(req.baseUrl()).isEqualTo("https://am.example");
+        assertThat(req.serviceAccountAccessToken()).isEqualTo("token");
+    }
+
+    @Test
+    void leaves_unset_fields_null_without_dropping_others() throws Exception {
+        var req = MAPPER.readValue("{\"baseUrl\":\"https://am.example\",\"amOrganizationId\":\"am-org\"}", AmConnectionRequest.class);
+
+        assertThat(req.baseUrl()).isEqualTo("https://am.example");
+        assertThat(req.amOrganizationId()).isEqualTo("am-org");
+        assertThat(req.serviceAccountAccessToken()).isNull();
+        assertThat(req.environmentId()).isNull();
+    }
+
+    @Test
+    void accepts_a_request_with_a_non_blank_base_url() {
+        var req = new AmConnectionRequest("https://am.example", "token", "am-org", null, null, null, null);
+
+        assertThat(validator.validate(req)).isEmpty();
+    }
+
+    @Test
+    void rejects_a_blank_base_url() {
+        var req = new AmConnectionRequest("  ", "token", "am-org", null, null, null, null);
+
+        var violations = validator.validate(req);
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getPropertyPath()).hasToString("baseUrl");
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/AmConnection.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/AmConnection.java
@@ -19,13 +19,16 @@ package io.gravitee.apim.plugin.gamma.api.identity;
  * Shared connection details a gamma module uses to reach an AM instance for an organization.
  * Storage and token encryption are owned by APIM rest-api core; see {@link AmConnectionRepository}.
  *
- * <p>Nullable fields ({@code serviceAccountAccessToken}, {@code environmentId},
- * {@code defaultDomainId}, {@code defaultDomainHrid}, {@code gatewayUrl}) may be {@code null} when
- * not yet configured. {@code environmentId} is the AM environment the {@code defaultDomainId} lives in.
+ * <p>Nullable fields ({@code serviceAccountAccessToken}, {@code amOrganizationId},
+ * {@code environmentId}, {@code defaultDomainId}, {@code defaultDomainHrid}, {@code gatewayUrl}) may
+ * be {@code null} when not yet configured. {@code amOrganizationId} is the AM organization and
+ * {@code environmentId} the AM environment that the {@code defaultDomainId} lives in — these are the
+ * AM-side coordinates, distinct from the APIM organization used as the storage key.
  */
 public record AmConnection(
     String baseUrl,
     String serviceAccountAccessToken,
+    String amOrganizationId,
     String environmentId,
     String defaultDomainId,
     String defaultDomainHrid,
@@ -43,6 +46,8 @@ public record AmConnection(
             baseUrl +
             ", serviceAccountAccessToken=" +
             (serviceAccountAccessToken == null ? "null" : "***") +
+            ", amOrganizationId=" +
+            amOrganizationId +
             ", environmentId=" +
             environmentId +
             ", defaultDomainId=" +

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/ApimAmConnectionRepository.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/ApimAmConnectionRepository.java
@@ -48,6 +48,7 @@ public class ApimAmConnectionRepository implements AmConnectionRepository {
         return new AmConnection(
             e.getBaseUrl(),
             e.getServiceAccountAccessToken(),
+            e.getAmOrganizationId(),
             e.getEnvironmentId(),
             e.getDefaultDomainId(),
             e.getDefaultDomainHrid(),
@@ -60,6 +61,7 @@ public class ApimAmConnectionRepository implements AmConnectionRepository {
         e.setOrganizationId(orgId);
         e.setBaseUrl(c.baseUrl());
         e.setServiceAccountAccessToken(c.serviceAccountAccessToken());
+        e.setAmOrganizationId(c.amOrganizationId());
         e.setEnvironmentId(c.environmentId());
         e.setDefaultDomainId(c.defaultDomainId());
         e.setDefaultDomainHrid(c.defaultDomainHrid());

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/test/java/io/gravitee/apim/plugin/gamma/api/identity/ApimAmConnectionRepositoryTest.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/test/java/io/gravitee/apim/plugin/gamma/api/identity/ApimAmConnectionRepositoryTest.java
@@ -81,6 +81,7 @@ class ApimAmConnectionRepositoryTest {
         AmConnection connection = new AmConnection(
             "https://am.example.com",
             "plain-token",
+            "am-org-1",
             "env-1",
             "dom-1",
             "dom-hrid-1",
@@ -99,6 +100,7 @@ class ApimAmConnectionRepositoryTest {
         assertThat(sent.getOrganizationId()).isEqualTo("org-1");
         assertThat(sent.getBaseUrl()).isEqualTo("https://am.example.com");
         assertThat(sent.getServiceAccountAccessToken()).isEqualTo("plain-token");
+        assertThat(sent.getAmOrganizationId()).isEqualTo("am-org-1");
         assertThat(sent.getEnvironmentId()).isEqualTo("env-1");
         assertThat(sent.getDefaultDomainId()).isEqualTo("dom-1");
         assertThat(sent.getDefaultDomainHrid()).isEqualTo("dom-hrid-1");
@@ -110,7 +112,7 @@ class ApimAmConnectionRepositoryTest {
 
     @Test
     void save_passes_null_token_through() {
-        AmConnection connection = new AmConnection("https://am.example.com", null, null, null, null, null);
+        AmConnection connection = new AmConnection("https://am.example.com", null, null, null, null, null, null);
         when(amConnectionService.save(eq("org-1"), any())).thenReturn(new AmConnectionEntity());
 
         repository().save("org-1", connection);
@@ -125,6 +127,7 @@ class ApimAmConnectionRepositoryTest {
         AmConnection connection = new AmConnection(
             "https://am.example.com",
             "plain-token",
+            "am-org-1",
             "env-1",
             "dom-1",
             "dom-hrid-1",


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-860

## Description

Two related changes to the AM connection.

First, the connection now persists the AM environment id (the APIM half of GMA-595). AM addresses domains as `organizations/{org}/environments/{env}/domains/{domain}`, but we only stored the domain, so a consumer couldn't build the path. I threaded `environmentId` through everywhere the existing `defaultDomainId` already lives: the repository model, the mongo and jdbc mappings (plus a liquibase changeset for the new column), the rest-api model and service, the shared `AmConnection` in the gamma plugin api, and the platform save/read use cases and UI. It's nullable, same as the domain.

Second, a fix so verifying the connection actually checks the AM organization you entered. The `/_test` endpoint was dropping `amOrganizationId` from the request body, and the tester was probing the APIM org instead of the connection's org, so a junk org still reported "connection succeeded". Now the org is carried through the test path and the tester probes it, and Save rejects a blank org up front.

Tests: added unit coverage for the tester (probes the configured org, fails fast on a blank org, surfaces AM's status when the org is rejected), the resource wiring (`/_test` and save both forward the org), the test use case, and save validation.

## Additional context

Two gamma modules consume the updated `AmConnection` and depend on this being merged and published first:
- gravitee-io/gravitee-gamma-module-aim#455
- gravitee-io/gravitee-gamma-module-authz#49

## Demo

https://github.com/user-attachments/assets/037a5ba5-468c-4fbc-8c7b-68b70510a0ff



