### PR TITLE
chore: bump gravitee-policy-authz-pep to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
 
         <!-- Authz plugins -->
         <gravitee-service-authz-pdp.version>1.0.0</gravitee-service-authz-pdp.version>
-        <gravitee-policy-authz-pep.version>1.0.0</gravitee-policy-authz-pep.version>
+        <gravitee-policy-authz-pep.version>1.1.0</gravitee-policy-authz-pep.version>
         <gravitee-policy-authz-pdp-authzen.version>1.0.0</gravitee-policy-authz-pdp-authzen.version>
     </properties>
 


### PR DESCRIPTION
Bumps the bundled `gravitee-policy-authz-pep` from `1.0.0` to `1.1.0`.

1.1.0 resolves the **action** entityId via the gateway `EntityResolver` (mirroring the resource resolution), so MCP FGA policies match the canonical tool id at runtime — see gravitee-io/gravitee-policy-authz-pep#15.

One-line version-property bump; the plugin is pulled into the distribution via `${gravitee-policy-authz-pep.version}`.