### PR TITLE
APIM-12483-Client-certificate-is-not-sent-while-creating-a-backend-to-backend-application-in-classic-portal

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation-step2/application-creation-step2.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation-step2/application-creation-step2.component.html
@@ -67,7 +67,7 @@
         </gv-switch>
       </div>
     </div>
-    <div class="step-grid-column" formGroupName="oauth">
+    <div class="step-grid-column">
       <ng-container formGroupName="oauth">
         <div class="form-control" *ngIf="requiresRedirectUris" formArrayName="redirect_uris">
           <gv-input


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12483

## Description

The tls formGroupName container was nested inside a div with formGroupName="oauth", causing Angular to resolve client_certificate against oauthForm.oauth.tls instead of oauthForm.tls. The field rendered in the UI but was disconnected from the form model, so the certificate value was never included in the request payload.

Remove formGroupName="oauth" from the second step-grid-column div so that the tls container correctly resolves to oauthForm.tls.

## Additional context

### Before Fix:
https://github.com/user-attachments/assets/6b4fdee9-25b5-4496-812b-53dd7ef94f86


### After Fix:
https://github.com/user-attachments/assets/f2438264-583a-48c3-a4c0-261dbfc2e598
