### PR TITLE
chore(master): bump gravitee-policy-kafka-message-filtering from 1.0.0 to 1.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
         <gravitee-policy-kafka-topic-mapping.version>2.0.1</gravitee-policy-kafka-topic-mapping.version>
         <gravitee-policy-kafka-acl.version>3.0.2</gravitee-policy-kafka-acl.version>
         <gravitee-policy-kafka-transform-key.version>1.0.0</gravitee-policy-kafka-transform-key.version>
-        <gravitee-policy-kafka-message-filtering.version>1.0.0</gravitee-policy-kafka-message-filtering.version>
+        <gravitee-policy-kafka-message-filtering.version>1.1.1</gravitee-policy-kafka-message-filtering.version>
         <gravitee-policy-kafka-message-encryption-decryption.version>1.0.0</gravitee-policy-kafka-message-encryption-decryption.version>
         <gravitee-policy-kafka-rules.version>1.1.2</gravitee-policy-kafka-rules.version>
         <gravitee-policy-offloading.version>1.1.0</gravitee-policy-offloading.version>


### PR DESCRIPTION
## Summary

Bumps on `master`:

- **[gravitee-policy-kafka-message-filtering](https://github.com/gravitee-io/gravitee-policy-kafka-message-filtering)** `1.0.0` -> `1.1.1`
