### PR TITLE
chore(master): bump gravitee-policy-kafka-quota from 1.2.1 to 1.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>
         <gravitee-service-secrets.version>3.0.1</gravitee-service-secrets.version>
         <gravitee-policy-interops.version>1.1.3</gravitee-policy-interops.version>
-        <gravitee-policy-kafka-quota.version>1.2.1</gravitee-policy-kafka-quota.version>
+        <gravitee-policy-kafka-quota.version>1.2.2</gravitee-policy-kafka-quota.version>
         <gravitee-policy-kafka-topic-mapping.version>2.0.1</gravitee-policy-kafka-topic-mapping.version>
         <gravitee-policy-kafka-acl.version>3.0.2</gravitee-policy-kafka-acl.version>
         <gravitee-policy-kafka-transform-key.version>1.0.0</gravitee-policy-kafka-transform-key.version>


### PR DESCRIPTION
## Summary

Bumps on `master`:

- **[gravitee-policy-kafka-quota](https://github.com/gravitee-io/gravitee-policy-kafka-quota)** `1.2.1` -> `1.2.2`
