### PR TITLE
chore(4.12.x): bump gravitee-reactor-native-kafka from 7.0.0-alpha.25 to 7.0.0-alpha.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
         <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>7.0.0-alpha.25</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>7.0.0-alpha.27</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>3.0.0-alpha.12</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>3.0.0-alpha.7</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.3</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Summary

Bumps on `4.12.x`:

- **[gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka)** `7.0.0-alpha.25` -> `7.0.0-alpha.27`
