### PR TITLE
fix(reporter): add JSON escaping for warning messages in FreeMarker templates

### DIFF
--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es7x/index/request.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es7x/index/request.ftl
@@ -104,7 +104,7 @@
       "key":"${warning.getKey()}"
       </#if>
       <#if warning.getMessage()??>
-      ,"message":"${warning.getMessage()}"
+      ,"message":"${warning.getMessage()?j_string}"
       </#if>
       <#if warning.getComponentType()??>
       ,"component-type":"${warning.getComponentType()}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es7x/index/v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es7x/index/v4-metrics.ftl
@@ -136,7 +136,7 @@
   <#list metrics.getWarnings() as warning>
     {
       "key":"${warning.getKey()}",
-      "message":"${warning.getMessage()}",
+      "message":"${warning.getMessage()?j_string}",
       "component-type":"${warning.getComponentType()}",
       "component-name":"${warning.getComponentName()}"
     }<#sep>,

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es8x/index/request.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es8x/index/request.ftl
@@ -104,7 +104,7 @@
       "key":"${warning.getKey()}"
       </#if>
       <#if warning.getMessage()??>
-      ,"message":"${warning.getMessage()}"
+      ,"message":"${warning.getMessage()?j_string}"
       </#if>
       <#if warning.getComponentType()??>
       ,"component-type":"${warning.getComponentType()}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es8x/index/v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es8x/index/v4-metrics.ftl
@@ -136,7 +136,7 @@
   <#list metrics.getWarnings() as warning>
     {
       "key":"${warning.getKey()}",
-      "message":"${warning.getMessage()}",
+      "message":"${warning.getMessage()?j_string}",
       "component-type":"${warning.getComponentType()}",
       "component-name":"${warning.getComponentName()}"
     }<#sep>,

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es9x/index/request.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es9x/index/request.ftl
@@ -104,7 +104,7 @@
       "key":"${warning.getKey()}"
       </#if>
       <#if warning.getMessage()??>
-      ,"message":"${warning.getMessage()}"
+      ,"message":"${warning.getMessage()?j_string}"
       </#if>
       <#if warning.getComponentType()??>
       ,"component-type":"${warning.getComponentType()}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es9x/index/v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es9x/index/v4-metrics.ftl
@@ -136,7 +136,7 @@
   <#list metrics.getWarnings() as warning>
     {
       "key":"${warning.getKey()}",
-      "message":"${warning.getMessage()}",
+      "message":"${warning.getMessage()?j_string}",
       "component-type":"${warning.getComponentType()}",
       "component-name":"${warning.getComponentName()}"
     }<#sep>,

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/java/io/gravitee/apim/reporter/common/formatter/elasticsearch/ElasticsearchFormatterTest.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/java/io/gravitee/apim/reporter/common/formatter/elasticsearch/ElasticsearchFormatterTest.java
@@ -53,6 +53,7 @@ class ElasticsearchFormatterTest extends AbstractFormatterTest {
             "v4 metrics with null transaction id, v4.metric.Metrics, v4/metrics-with-null-transaction-id.json, elasticsearch/v4/metrics-with-null-transaction-id.json",
             "message metrics, v4.metric.MessageMetrics, v4/message-metrics.json, elasticsearch/v4/message-metrics.json",
             "message log, v4.log.MessageLog, v4/message-log.json, elasticsearch/v4/message-log.json",
+            "v4 metrics with warnings, v4.metric.Metrics, v4/metrics-with-warnings.json, elasticsearch/v4/metrics-with-warnings.json",
             "v4 metrics with additional, v4.metric.Metrics, v4/metrics-with-additional.json, elasticsearch/v4/metrics-with-additional.json",
             "message metrics with additional, v4.metric.MessageMetrics, v4/message-metrics-with-additional.json, elasticsearch/v4/message-metrics-with-additional.json",
             "api event metrics, v4.metric.event.ApiEventMetrics, v4/api-event-metrics.json, elasticsearch/v4/api-event-metrics.json",

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/resources/io/gravitee/reporter/common/formatter/expected/elasticsearch/v4/metrics-with-warnings.json
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/resources/io/gravitee/reporter/common/formatter/expected/elasticsearch/v4/metrics-with-warnings.json
@@ -1,0 +1,44 @@
+{
+  "type": "v4-metrics",
+  "date": "2023.08.18",
+  "_id": "076aea69-6024-4590-aaea-6960247590a0",
+  "gateway": "gateway-id",
+  "@timestamp": "2023-08-18T11:46:53.844Z",
+  "request-id": "076aea69-6024-4590-aaea-6960247590a0",
+  "client-identifier": "318e47e5-349c-4fa4-8e47-e5349c3fa444",
+  "transaction-id": "076aea69-6024-4590-aaea-6960247590a0",
+  "api-id": "5f67b38f-0700-4557-a7b3-8f0700855779",
+  "api-name": "API Name",
+  "api-product-id": "my-product-id",
+  "org-id": "7e3c7b4c-91c1-4f79-9c2e-3c2d6cfbf890",
+  "env-id": "d4f0f9d2-b2c4-4d8a-a3a0-5324fdad0e73",
+  "plan-id": "8463511c-fbed-4ca9-a351-1cfbed9ca99d",
+  "application-id": "91f077b0-1204-49e4-b077-b0120419e4f6",
+  "subscription-id": "318e47e5-349c-4fa4-8e47-e5349c3fa444",
+  "http-method": 3,
+  "local-address": "127.0.0.1",
+  "remote-address": "127.0.0.1",
+  "host": "localhost:8082",
+  "uri": "/test-v4",
+  "path-info": "",
+  "user-agent": "",
+  "request-ended": "true",
+  "entrypoint-id": "http-get",
+  "endpoint": "https://api.gravitee.io/echo",
+  "endpoint-response-time-ms": 137,
+  "status": 200,
+  "response-content-length": 274,
+  "gateway-response-time-ms": 144,
+  "gateway-latency-ms": 7,
+  "warnings": [
+    {
+      "key": "RATE_LIMIT_NOT_APPLIED",
+      "message": "Request bypassed rate limit policy due to internal error (Cannot invoke \"io.reactivex.rxjava3.core.Single.map(io.reactivex.rxjava3.functions.Function)\" because the return value of \"io.gravitee.repository.ratelimit.api.RateLimitRepository.incrementAndGet(String, long, java.util.function.Supplier)\" is null)",
+      "component-type": "POLICY",
+      "component-name": "rate-limit"
+    }
+  ],
+  "custom": {
+    "zone": "europe-north1-a"
+  }
+}

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/resources/io/gravitee/reporter/common/formatter/given/v4/metrics-with-warnings.json
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/resources/io/gravitee/reporter/common/formatter/given/v4/metrics-with-warnings.json
@@ -1,0 +1,53 @@
+{
+  "timestamp": 1692359213844,
+  "enabled": true,
+  "requestId": "076aea69-6024-4590-aaea-6960247590a0",
+  "transactionId": "076aea69-6024-4590-aaea-6960247590a0",
+  "apiId": "5f67b38f-0700-4557-a7b3-8f0700855779",
+  "apiName": "API Name",
+  "apiProductId": "my-product-id",
+  "organizationId": "7e3c7b4c-91c1-4f79-9c2e-3c2d6cfbf890",
+  "environmentId": "d4f0f9d2-b2c4-4d8a-a3a0-5324fdad0e73",
+  "apiType": "proxy",
+  "planId": "8463511c-fbed-4ca9-a351-1cfbed9ca99d",
+  "applicationId": "91f077b0-1204-49e4-b077-b0120419e4f6",
+  "subscriptionId": "318e47e5-349c-4fa4-8e47-e5349c3fa444",
+  "clientIdentifier": "318e47e5-349c-4fa4-8e47-e5349c3fa444",
+  "tenant": null,
+  "zone": null,
+  "httpMethod": "GET",
+  "localAddress": "127.0.0.1",
+  "remoteAddress": "127.0.0.1",
+  "host": "localhost:8082",
+  "uri": "/test-v4",
+  "pathInfo": "",
+  "mappedPath": null,
+  "userAgent": "curl/7.88.1",
+  "requestContentLength": -1,
+  "requestEnded": true,
+  "entrypointId": "http-get",
+  "endpoint": "https://api.gravitee.io/echo",
+  "endpointResponseTimeMs": 137,
+  "status": 200,
+  "responseContentLength": 274,
+  "gatewayResponseTimeMs": 144,
+  "gatewayLatencyMs": 7,
+  "user": null,
+  "securityType": null,
+  "securityToken": null,
+  "errorMessage": null,
+  "errorKey": null,
+  "warnings": [
+    {
+      "key": "RATE_LIMIT_NOT_APPLIED",
+      "message": "Request bypassed rate limit policy due to internal error (Cannot invoke \"io.reactivex.rxjava3.core.Single.map(io.reactivex.rxjava3.functions.Function)\" because the return value of \"io.gravitee.repository.ratelimit.api.RateLimitRepository.incrementAndGet(String, long, java.util.function.Supplier)\" is null)",
+      "componentType": "POLICY",
+      "componentName": "rate-limit"
+    }
+  ],
+  "customMetrics": {
+    "zone": "europe-north1-a",
+    "otherField": null
+  },
+  "log": null
+}


### PR DESCRIPTION
##  Issue

  https://gravitee.atlassian.net/browse/APIM-14495

##  Purpose

  Fix silent loss of Elasticsearch metrics when warning messages contain double quotes.

##  Summary of changes

  - Add ?j_string escaping to warning.getMessage() in v4-metrics.ftl and request.ftl (es7x, es8x, es9x)
  - Add test case v4 metrics with warnings to ElasticsearchFormatterTest with a warning containing double quotes

##  Out of scope

  - Other warning fields (key, componentType, componentName) are programmatic identifiers and don't need escaping

 ## Testing

  - New parameterized test in ElasticsearchFormatterTest verifies proper JSON escaping of warning messages containing double quotes
  - Verified the test fails without the fix and passes with it
  - Manually reproduced on local Docker stack: confirmed bulk error before fix and successful ES indexing after fix

##  Related PRs/tickets

  https://gravitee.atlassian.net/browse/APIM-14495

##  Demo

**Before Fix:**

https://github.com/user-attachments/assets/94f062db-1313-4d77-9b47-9eb357031b79

**After Fix:**

https://github.com/user-attachments/assets/5edd0667-6558-479d-93e8-b4dc98e90524