### PR TITLE
fix(helm): render http.requestTimeout with gateway.servers

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.8.31
+
+- fix gateway requestTimeout ignored when gateway.servers is configured (APIM-14276)
+
 ### 4.8.13
 
 - Improve redis rate limit configuration to allow username for acl configuration [issues/10966](https://github.com/gravitee-io/issues/issues/10966).

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -271,6 +271,38 @@ Usage:
 {{- end }}
 
 {{/*
+API processing timeout read by gateway from http.requestTimeout.
+When gateway.servers is used, derive from the first HTTP server entry, else gateway.http.
+*/}}
+{{- define "gateway.httpRequestTimeout" -}}
+{{- $result := .Values.gateway.http.requestTimeout -}}
+{{- $found := false -}}
+{{- range .Values.gateway.servers -}}
+{{- if and (not $found) (eq .type "http") (hasKey . "requestTimeout") -}}
+{{- $result = .requestTimeout -}}
+{{- $found = true -}}
+{{- end -}}
+{{- end -}}
+{{- printf "%v" (int $result) -}}
+{{- end -}}
+
+{{/*
+API processing timeout grace delay read by gateway from http.requestTimeoutGraceDelay.
+When gateway.servers is used, derive from the first HTTP server entry, else gateway.http.
+*/}}
+{{- define "gateway.httpRequestTimeoutGraceDelay" -}}
+{{- $result := .Values.gateway.http.requestTimeoutGraceDelay -}}
+{{- $found := false -}}
+{{- range .Values.gateway.servers -}}
+{{- if and (not $found) (eq .type "http") (hasKey . "requestTimeoutGraceDelay") -}}
+{{- $result = .requestTimeoutGraceDelay -}}
+{{- $found = true -}}
+{{- end -}}
+{{- end -}}
+{{- printf "%v" (int $result) -}}
+{{- end -}}
+
+{{/*
 Management API Docker images tag.
 */}}
 {{- define "api.dockerTag" -}}

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -45,10 +45,10 @@ data:
         instances: {{ $server.instances }}
         {{- end }}
         {{- if $server.requestTimeout }}
-        requestTimeout: {{ $server.requestTimeout }}
+        requestTimeout: {{ int $server.requestTimeout }}
         {{- end }}
         {{- if $server.requestTimeoutGraceDelay }}
-        requestTimeoutGraceDelay: {{ $server.requestTimeoutGraceDelay }}
+        requestTimeoutGraceDelay: {{ int $server.requestTimeoutGraceDelay }}
         {{- end }}
         {{- if $server.maxHeaderSize }}
         maxHeaderSize: {{ $server.maxHeaderSize }}
@@ -107,6 +107,9 @@ data:
         haproxy: {{ toYaml $server.haproxy | nindent 10 }}
         {{- end }}
     {{- end }}
+    http:
+      requestTimeout: {{ include "gateway.httpRequestTimeout" . }}
+      requestTimeoutGraceDelay: {{ include "gateway.httpRequestTimeoutGraceDelay" . }}
     {{- else }}
     http:
       port: {{ .Values.gateway.service.internalPort }}

--- a/helm/tests/gateway/configmap_servers_request_timeout_test.yaml
+++ b/helm/tests/gateway/configmap_servers_request_timeout_test.yaml
@@ -1,0 +1,53 @@
+suite: Test Gateway configmap requestTimeout with servers
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Renders http requestTimeout when servers mode is used
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        servers:
+          - type: http
+            port: 8082
+            requestTimeout: 3600000
+            requestTimeoutGraceDelay: 30
+            websocket:
+              enabled: true
+              subProtocols: v10.stomp, v11.stomp
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            servers:
+              - type: http
+                port: 8082
+                host: 0.0.0.0
+                requestTimeout: 3600000
+                requestTimeoutGraceDelay: 30
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            http:
+              requestTimeout: 3600000
+              requestTimeoutGraceDelay: 30
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: 3\.6e\+06
+
+  - it: Falls back to gateway.http requestTimeout when servers omit it
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        http:
+          requestTimeout: 60000
+          requestTimeoutGraceDelay: 60
+        servers:
+          - type: http
+            port: 8082
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            http:
+              requestTimeout: 60000
+              requestTimeoutGraceDelay: 60

--- a/helm/tests/gateway/configmap_test.yaml
+++ b/helm/tests/gateway/configmap_test.yaml
@@ -48,6 +48,12 @@ tests:
               - type: tcp
                 port: 9092
                 host: 0.0.0.0
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            http:
+              requestTimeout: 30000
+              requestTimeoutGraceDelay: 30
 
   - it: add service heartbeat default values
     template: gateway/gateway-configmap.yaml


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14276

When gateway.servers is configured (e.g. websocket subProtocols), Helm rendered only servers[].requestTimeout in gravitee.yml. Gateway reads API processing timeout from http.requestTimeout only, so it silently fell back to 30s.

## Description

- Emit root http.requestTimeout and http.requestTimeoutGraceDelay alongside servers: in gateway-configmap.yaml
- Add helpers to derive values from first HTTP server entry, falling back to gateway.http.*
- Cast server timeout values with int to avoid scientific notation (3.6e+06) in generated YAML
- Add helm unittest coverage for servers mode + fallback behavior

## Additional context

Done via gravitee-local-tooling and unit-tests.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

