### PR TITLE
chore: bump gravitee-reactor-authz to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <gravitee-reactor-mcp-proxy.version>3.0.0-alpha.12</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>3.0.0-alpha.7</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.3</gravitee-reactor-a2a-proxy.version>
-        <gravitee-reactor-authz.version>1.0.0-alpha.1</gravitee-reactor-authz.version>
+        <gravitee-reactor-authz.version>1.0.0</gravitee-reactor-authz.version>
         <gravitee-reactor-edge.version>1.0.0-alpha.10</gravitee-reactor-edge.version>
         <gravitee-resource-ai-vector-store-redis.version>2.0.0</gravitee-resource-ai-vector-store-redis.version>
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>


### PR DESCRIPTION
Bumps the bundled `gravitee-reactor-authz` (reactor + AuthZEN entrypoint) from `1.0.0-alpha.1` to `1.0.0`.

`1.0.0` is the first release that ships the AuthZEN metadata endpoint `GET /<path>/.well-known/authzen-configuration` (`AuthzenEntrypointConnector` routes it to `writeMetadata`). The bundled `alpha.1` predates it, so PDP AuthZEN endpoints currently 404 on `.well-known/authzen-configuration` while `/access/v1/evaluation` works.

One-line version-property bump; both `gravitee-entrypoint-authz` and `gravitee-reactor-authz` are pulled into the distribution via `${gravitee-reactor-authz.version}`.