### PR TITLE
Apim 14466 folder first item refresh fix2

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -1134,6 +1134,33 @@ describe('FlatTreeComponent', () => {
       expect(component.hasExpandedNode()).toBe(true);
     });
 
+    it('should not reveal the selected nested item again after a data refresh when it was manually collapsed', async () => {
+      fixture.componentRef.setInput('links', nestedLinks);
+      fixture.componentRef.setInput('selectedId', 'p1');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(await harness.getAllItemTitles()).toEqual(['Folder 1', 'Folder 2', 'Page 1']);
+
+      component.collapseAllNodes();
+      fixture.detectChanges();
+
+      expect(await harness.getAllItemTitles()).toEqual(['Folder 1']);
+      expect(component.hasExpandedNode()).toBe(false);
+
+      fixture.componentRef.setInput(
+        'links',
+        nestedLinks.map(link => ({ ...link })),
+      );
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(await harness.getAllItemTitles()).toEqual(['Folder 1']);
+      expect(component.hasExpandedNode()).toBe(false);
+    });
+
     it('should keep unrelated branches collapsed when revealing the selected nested item', async () => {
       const links = [
         makeItem('f1', 'FOLDER', 'Folder 1', 0),

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -202,6 +202,7 @@ export class FlatTreeComponent {
   contextMenuTrigger = viewChild('contextMenuTrigger', { read: MatMenuTrigger });
   contextMenuAnchor = viewChild('contextMenuTrigger', { read: ElementRef });
   contextMenuNode = signal<FlatTreeNode | null>(null);
+  private readonly selectedIdToReveal = signal<string | null>(null);
 
   canCreate: boolean;
   canUpdate: boolean;
@@ -242,19 +243,30 @@ export class FlatTreeComponent {
 
     effect(() => {
       const selectedId = this.selectedId();
+      this.selectedIdToReveal.set(selectedId);
+    });
+
+    effect(() => {
+      const selectedId = this.selectedIdToReveal();
+      if (!selectedId) {
+        return;
+      }
+
       const nodes = this.tree();
       const tree = this.treeBase();
 
-      if (!selectedId || nodes.length === 0 || !tree) {
+      if (nodes.length === 0 || !tree) {
         return;
       }
 
       queueMicrotask(() => {
-        if (this.selectedId() !== selectedId || this.tree() !== nodes || this.treeBase() !== tree) {
+        if (this.selectedIdToReveal() !== selectedId || this.tree() !== nodes || this.treeBase() !== tree) {
           return;
         }
 
-        this.expandAncestorsOfSelectedNode(selectedId, nodes, tree);
+        if (this.expandAncestorsOfSelectedNode(selectedId, nodes, tree)) {
+          this.selectedIdToReveal.set(null);
+        }
       });
     });
   }
@@ -455,15 +467,20 @@ export class FlatTreeComponent {
     return (root.children ?? []).some(child => child.id === nodeId || this.isWithinSubtree(nodeId, child));
   }
 
-  private expandAncestorsOfSelectedNode(selectedId: string, nodes: SectionNode[], tree: MatTree<SectionNode, string>): void {
+  private expandAncestorsOfSelectedNode(selectedId: string, nodes: SectionNode[], tree: MatTree<SectionNode, string>): boolean {
     const selectedPath = this.findPathToNode(selectedId, nodes);
 
-    if (!selectedPath || selectedPath.length <= 1) {
-      return;
+    if (!selectedPath) {
+      return false;
+    }
+
+    if (selectedPath.length <= 1) {
+      return true;
     }
 
     selectedPath.slice(0, -1).forEach(node => tree.expand(node));
     this.syncExpansionState();
+    return true;
   }
 
   private findPathToNode(selectedId: string, nodes: SectionNode[]): SectionNode[] | null {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14466

## Description

Fixes a side effect introduced by the selected portal navigation item reveal behavior.

When a nested navigation item was selected, collapsing its parent manually could be undone by an unrelated tree refresh, for example after publishing another item from the context menu. The tree refresh re-triggered the auto-reveal logic for the still-selected item and expanded its ancestors again.

## Changes

- Make selected item reveal a one-time pending action tied to `selectedId` changes.
- Keep retrying the reveal until the selected node exists in the refreshed tree.
- Clear the pending reveal after the selected node is found, so later data refreshes preserve the user’s manual collapsed/expanded state.
- Add a regression test covering manual collapse followed by a data refresh with the same selected item.
