### PR TITLE
chore(deps): bump released plugins to stable versions

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -2133,6 +2133,19 @@
                 </dependency>
                 <dependency>
                     <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-kafka-namespace</artifactId>
+                    <version>${gravitee-policy-kafka-namespace.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
                     <artifactId>gravitee-policy-transform-avro-json</artifactId>
                     <version>${gravitee-policy-transform-avro-json.version}</version>
                     <type>zip</type>

--- a/gravitee-apim-integration-tests/pom.xml
+++ b/gravitee-apim-integration-tests/pom.xml
@@ -594,7 +594,7 @@
         <dependency>
             <groupId>com.graviteesource.connector</groupId>
             <artifactId>gravitee-entrypoint-native-kafka</artifactId>
-            <version>${gravitee-entrypoint-native-kafka.version}</version>
+            <version>${gravitee-reactor-native-kafka.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- Endpoints -->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -10,7 +10,7 @@ info:
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0
-    version: "4.12.0-milestone.7-SNAPSHOT"
+    version: "4.12.0-SNAPSHOT"
 servers:
     - url: /portal/environments/{envId}
       description: The portal API for a given environment

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: apim
 # Also update CHANGELOG.md
-version: 4.12.0-milestone.7
-appVersion: 4.12.0-milestone.7
+version: 4.12.0
+appVersion: 4.12.0
 description: Official Gravitee.io Helm chart for API Management
 home: https://gravitee.io
 sources:

--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-9.0.0-alpha.18.zip  2>/dev/null || true ) && wget https://download.gravitee.io/pre-releases/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.0.0-alpha.18.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-9.0.0-alpha.18.zip  2>/dev/null || true ) && wget https://download.gravitee.io/pre-releases/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.0.0-alpha.18.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-9.1.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.1.1.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-9.1.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.1.1.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -510,8 +510,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/pre-releases/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.0.0-alpha.18.zip
-    - https://download.gravitee.io/pre-releases/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.0.0-alpha.18.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.1.1.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.1.1.zip
 
 api:
   enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <gravitee-reactor-llm-proxy.version>3.0.0</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.3</gravitee-reactor-a2a-proxy.version>
         <gravitee-reactor-authz.version>1.0.0</gravitee-reactor-authz.version>
-        <gravitee-reactor-edge.version>1.0.0-alpha.10</gravitee-reactor-edge.version>
+        <gravitee-reactor-edge.version>1.0.0</gravitee-reactor-edge.version>
         <gravitee-resource-ai-vector-store-redis.version>2.0.0</gravitee-resource-ai-vector-store-redis.version>
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>
         <gravitee-resource-ai-model-text-embedding.version>1.0.0</gravitee-resource-ai-model-text-embedding.version>

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,6 @@
         <gravitee-entrypoint-websocket.version>3.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-entrypoint-agent-to-agent.version>2.0.0</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp-tool-server.version>2.0.2</gravitee-entrypoint-mcp-tool-server.version>
-        <gravitee-entrypoint-native-kafka.version>7.0.0</gravitee-entrypoint-native-kafka.version>
         <gravitee-endpoint-jms.version>2.0.0</gravitee-endpoint-jms.version>
         <gravitee-endpoint-kafka.version>6.1.0</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>5.0.0</gravitee-endpoint-mqtt5.version>

--- a/pom.xml
+++ b/pom.xml
@@ -261,9 +261,9 @@
         <gravitee-fetcher-github.version>2.2.1</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>2.1.2</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>3.0.0</gravitee-fetcher-http.version>
-        <gravitee-notifier-email.version>3.0.0</gravitee-notifier-email.version>
-        <gravitee-notifier-slack.version>2.0.0</gravitee-notifier-slack.version>
-        <gravitee-notifier-webhook.version>2.0.0</gravitee-notifier-webhook.version>
+        <gravitee-notifier-email.version>4.0.1</gravitee-notifier-email.version>
+        <gravitee-notifier-slack.version>3.0.0</gravitee-notifier-slack.version>
+        <gravitee-notifier-webhook.version>3.0.0</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
         <gravitee-reporter-tcp.version>5.0.0</gravitee-reporter-tcp.version>
         <gravitee-reporter-cloud.version>4.0.0</gravitee-reporter-cloud.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0</gravitee-kubernetes.version>
-        <gravitee-node.version>9.1.0</gravitee-node.version>
+        <gravitee-node.version>9.1.1</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>2.0.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.4</gravitee-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <!-- Version properties -->
         <revision>4.12.0</revision>
-        <sha1>-milestone.7</sha1>
+        <sha1/>
         <changelist>-SNAPSHOT</changelist>
 
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin2

--- a/pom.xml
+++ b/pom.xml
@@ -340,10 +340,10 @@
         <gravitee-resource-ai-model-token-classification.version>2.0.0</gravitee-resource-ai-model-token-classification.version>
 
         <!-- Gamma plugins -->
-        <gravitee-gamma-module-aim.version>1.0.0-alpha.214</gravitee-gamma-module-aim.version>
-        <gravitee-gamma-module-authz.version>1.0.0-alpha.31</gravitee-gamma-module-authz.version>
-        <gravitee-gamma-module-edge.version>1.0.0-alpha.7</gravitee-gamma-module-edge.version>
-        <gravitee-gamma-module-esm.version>1.0.0-alpha.20</gravitee-gamma-module-esm.version>
+        <gravitee-gamma-module-aim.version>1.0.0</gravitee-gamma-module-aim.version>
+        <gravitee-gamma-module-authz.version>1.0.0</gravitee-gamma-module-authz.version>
+        <gravitee-gamma-module-edge.version>1.0.0</gravitee-gamma-module-edge.version>
+        <gravitee-gamma-module-esm.version>1.0.0</gravitee-gamma-module-esm.version>
 
         <!-- Authz plugins -->
         <gravitee-service-authz-pdp.version>1.0.0</gravitee-service-authz-pdp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,7 @@
         <gravitee-policy-kafka-message-filtering.version>1.0.0</gravitee-policy-kafka-message-filtering.version>
         <gravitee-policy-kafka-message-encryption-decryption.version>1.0.0</gravitee-policy-kafka-message-encryption-decryption.version>
         <gravitee-policy-kafka-rules.version>1.1.2</gravitee-policy-kafka-rules.version>
+        <gravitee-policy-kafka-namespace.version>1.0.0</gravitee-policy-kafka-namespace.version>
         <gravitee-policy-offloading.version>1.1.0</gravitee-policy-offloading.version>
         <gravitee-policy-token-ratelimit.version>1.0.0</gravitee-policy-token-ratelimit.version>
         <gravitee-policy-mcp-acl.version>1.0.4</gravitee-policy-mcp-acl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -199,13 +199,13 @@
         <gravitee-policy-html-json.version>1.6.3</gravitee-policy-html-json.version>
         <gravitee-policy-http-signature.version>1.7.0</gravitee-policy-http-signature.version>
         <gravitee-policy-interrupt.version>2.2.0</gravitee-policy-interrupt.version>
-        <gravitee-policy-ipfiltering.version>2.2.1</gravitee-policy-ipfiltering.version>
+        <gravitee-policy-ipfiltering.version>3.0.0</gravitee-policy-ipfiltering.version>
         <gravitee-policy-javascript.version>3.0.0</gravitee-policy-javascript.version>
         <gravitee-policy-js.version>1.0.1</gravitee-policy-js.version>
         <gravitee-policy-json-threat-protection.version>2.1.0</gravitee-policy-json-threat-protection.version>
         <gravitee-policy-json-to-json.version>3.1.0</gravitee-policy-json-to-json.version>
         <gravitee-policy-json-to-toon.version>1.0.2</gravitee-policy-json-to-toon.version>
-        <gravitee-policy-json-validation.version>2.2.0-alpha.4</gravitee-policy-json-validation.version>
+        <gravitee-policy-json-validation.version>3.0.0</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.3</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>2.0.0</gravitee-policy-jws.version>
         <gravitee-policy-jwt.version>8.0.0</gravitee-policy-jwt.version>
@@ -297,7 +297,7 @@
         <gravitee-entrypoint-websocket.version>3.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-entrypoint-agent-to-agent.version>2.0.0</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp-tool-server.version>2.0.2</gravitee-entrypoint-mcp-tool-server.version>
-        <gravitee-entrypoint-native-kafka.version>7.0.0-alpha.10</gravitee-entrypoint-native-kafka.version>
+        <gravitee-entrypoint-native-kafka.version>7.0.0</gravitee-entrypoint-native-kafka.version>
         <gravitee-endpoint-jms.version>2.0.0</gravitee-endpoint-jms.version>
         <gravitee-endpoint-kafka.version>6.1.0</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>5.0.0</gravitee-endpoint-mqtt5.version>
@@ -310,11 +310,11 @@
         <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>7.0.0-alpha.25</gravitee-reactor-native-kafka.version>
-        <gravitee-reactor-mcp-proxy.version>3.0.0-alpha.12</gravitee-reactor-mcp-proxy.version>
-        <gravitee-reactor-llm-proxy.version>3.0.0-alpha.7</gravitee-reactor-llm-proxy.version>
+        <gravitee-reactor-native-kafka.version>7.0.0</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-mcp-proxy.version>3.0.0</gravitee-reactor-mcp-proxy.version>
+        <gravitee-reactor-llm-proxy.version>3.0.0</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.3</gravitee-reactor-a2a-proxy.version>
-        <gravitee-reactor-authz.version>1.0.0-alpha.1</gravitee-reactor-authz.version>
+        <gravitee-reactor-authz.version>1.0.0</gravitee-reactor-authz.version>
         <gravitee-reactor-edge.version>1.0.0-alpha.10</gravitee-reactor-edge.version>
         <gravitee-resource-ai-vector-store-redis.version>2.0.0</gravitee-resource-ai-vector-store-redis.version>
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>


### PR DESCRIPTION
Bumps the 4.12.x dependency-train plugins to their released stable versions.

### Notifiers
- `gravitee-notifier-email`: 3.0.0 → 4.0.1
- `gravitee-notifier-slack`: 2.0.0 → 3.0.0
- `gravitee-notifier-webhook`: 2.0.0 → 3.0.0

### Reactors & policies (now released)
- `gravitee-policy-ipfiltering`: 2.2.1 → 3.0.0
- `gravitee-policy-json-validation`: 2.2.0-alpha.4 → 3.0.0
- `gravitee-reactor-native-kafka` / `gravitee-entrypoint-native-kafka`: 7.0.0-alpha.x → 7.0.0
- `gravitee-reactor-mcp-proxy`: 3.0.0-alpha.12 → 3.0.0
- `gravitee-reactor-llm-proxy`: 3.0.0-alpha.7 → 3.0.0
- `gravitee-reactor-authz`: 1.0.0-alpha.1 → 1.0.0
- `gravitee-reactor-edge`: 1.0.0-alpha.10 → 1.0.0

### Cleanup
- Drop the redundant `gravitee-entrypoint-native-kafka.version` property and reuse `gravitee-reactor-native-kafka.version` (same repo, released together).

After this, the only remaining pre-release versions in 4.12.x are the 4 gamma modules (aim / authz / edge / esm).