### PR TITLE
fix(console): Add panelWidth attribute to mat-select components for UI consistency

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.html
@@ -114,8 +114,33 @@
 
       <mat-form-field *ngIf="organizationRolesControl">
         <mat-label>Roles</mat-label>
-        <mat-select [formControl]="organizationRolesControl" aria-label="Organization role" multiple>
-          <mat-option *ngFor="let role of organizationRoles$ | async" [value]="role.id">{{ role.name }}</mat-option>
+        <mat-select
+          #organizationRoleSelect="matSelect"
+          [formControl]="organizationRolesControl"
+          aria-label="Organization role"
+          multiple
+          panelClass="org-settings-user-detail__role-select-panel"
+        >
+          <mat-select-trigger>
+            <span
+              #roleTriggerEl
+              class="org-settings-user-detail__role-trigger"
+              [matTooltip]="organizationRoleSelect.triggerValue"
+              matTooltipClass="org-settings-user-detail__role-tooltip"
+              [matTooltipDisabled]="roleTriggerEl.offsetWidth >= roleTriggerEl.scrollWidth"
+              >{{ organizationRoleSelect.triggerValue }}</span
+            >
+          </mat-select-trigger>
+          <mat-option *ngFor="let role of organizationRoles$ | async" [value]="role.id">
+            <span
+              #roleOptionEl
+              class="org-settings-user-detail__role-option"
+              [matTooltip]="role.name"
+              matTooltipClass="org-settings-user-detail__role-tooltip"
+              [matTooltipDisabled]="roleOptionEl.offsetWidth >= roleOptionEl.scrollWidth"
+              >{{ role.name }}</span
+            >
+          </mat-option>
         </mat-select>
       </mat-form-field>
     </mat-card-content>
@@ -157,12 +182,33 @@
               <mat-form-field>
                 <mat-label>Environment roles</mat-label>
                 <mat-select
+                  #environmentRoleSelect="matSelect"
                   [id]="environment.id"
                   [formControlName]="environment.id"
                   [aria-label]="'Environment roles for ' + environment.id"
                   multiple
+                  panelClass="org-settings-user-detail__role-select-panel"
                 >
-                  <mat-option *ngFor="let role of environmentRoles$ | async" [value]="role.id">{{ role.name }}</mat-option>
+                  <mat-select-trigger>
+                    <span
+                      #roleTriggerEl
+                      class="org-settings-user-detail__role-trigger"
+                      [matTooltip]="environmentRoleSelect.triggerValue"
+                      matTooltipClass="org-settings-user-detail__role-tooltip"
+                      [matTooltipDisabled]="roleTriggerEl.offsetWidth >= roleTriggerEl.scrollWidth"
+                      >{{ environmentRoleSelect.triggerValue }}</span
+                    >
+                  </mat-select-trigger>
+                  <mat-option *ngFor="let role of environmentRoles$ | async" [value]="role.id">
+                    <span
+                      #roleOptionEl
+                      class="org-settings-user-detail__role-option"
+                      [matTooltip]="role.name"
+                      matTooltipClass="org-settings-user-detail__role-tooltip"
+                      [matTooltipDisabled]="roleOptionEl.offsetWidth >= roleOptionEl.scrollWidth"
+                      >{{ role.name }}</span
+                    >
+                  </mat-option>
                 </mat-select>
               </mat-form-field>
             </td>
@@ -240,15 +286,34 @@
               <mat-form-field>
                 <mat-label>API role</mat-label>
                 <mat-select
+                  #apiRoleSelect="matSelect"
                   [id]="group.id"
                   [aria-label]="'API roles for ' + group.id"
                   formControlName="API"
                   [disabled]="isApiRolePrimaryOwner(group.id)"
+                  panelClass="org-settings-user-detail__role-select-panel"
                 >
+                  <mat-select-trigger>
+                    <span
+                      #roleTriggerEl
+                      class="org-settings-user-detail__role-trigger"
+                      [matTooltip]="apiRoleSelect.triggerValue"
+                      matTooltipClass="org-settings-user-detail__role-tooltip"
+                      [matTooltipDisabled]="roleTriggerEl.offsetWidth >= roleTriggerEl.scrollWidth"
+                      >{{ apiRoleSelect.triggerValue }}</span
+                    >
+                  </mat-select-trigger>
                   <mat-option>-- None --</mat-option>
-                  <mat-option *ngFor="let role of apiRoles$ | async" [disabled]="role.system" [value]="role.name">{{
-                    role.name
-                  }}</mat-option>
+                  <mat-option *ngFor="let role of apiRoles$ | async" [disabled]="role.system" [value]="role.name">
+                    <span
+                      #roleOptionEl
+                      class="org-settings-user-detail__role-option"
+                      [matTooltip]="role.name"
+                      matTooltipClass="org-settings-user-detail__role-tooltip"
+                      [matTooltipDisabled]="roleOptionEl.offsetWidth >= roleOptionEl.scrollWidth"
+                      >{{ role.name }}</span
+                    >
+                  </mat-option>
                 </mat-select>
               </mat-form-field>
             </td>
@@ -260,11 +325,34 @@
             <td mat-cell *matCellDef="let group" [formGroupName]="group.id">
               <mat-form-field>
                 <mat-label>Application role</mat-label>
-                <mat-select [id]="group.id" [aria-label]="'Application roles for ' + group.id" formControlName="APPLICATION">
+                <mat-select
+                  #applicationRoleSelect="matSelect"
+                  [id]="group.id"
+                  [aria-label]="'Application roles for ' + group.id"
+                  formControlName="APPLICATION"
+                  panelClass="org-settings-user-detail__role-select-panel"
+                >
+                  <mat-select-trigger>
+                    <span
+                      #roleTriggerEl
+                      class="org-settings-user-detail__role-trigger"
+                      [matTooltip]="applicationRoleSelect.triggerValue"
+                      matTooltipClass="org-settings-user-detail__role-tooltip"
+                      [matTooltipDisabled]="roleTriggerEl.offsetWidth >= roleTriggerEl.scrollWidth"
+                      >{{ applicationRoleSelect.triggerValue }}</span
+                    >
+                  </mat-select-trigger>
                   <mat-option>-- None --</mat-option>
-                  <mat-option *ngFor="let role of applicationRoles$ | async" [disabled]="role.system" [value]="role.name">{{
-                    role.name
-                  }}</mat-option>
+                  <mat-option *ngFor="let role of applicationRoles$ | async" [disabled]="role.system" [value]="role.name">
+                    <span
+                      #roleOptionEl
+                      class="org-settings-user-detail__role-option"
+                      [matTooltip]="role.name"
+                      matTooltipClass="org-settings-user-detail__role-tooltip"
+                      [matTooltipDisabled]="roleOptionEl.offsetWidth >= roleOptionEl.scrollWidth"
+                      >{{ role.name }}</span
+                    >
+                  </mat-option>
                 </mat-select>
               </mat-form-field>
             </td>
@@ -276,11 +364,34 @@
             <td mat-cell *matCellDef="let group" [formGroupName]="group.id">
               <mat-form-field>
                 <mat-label>Integration role</mat-label>
-                <mat-select [id]="group.id" [aria-label]="'Integration roles for ' + group.id" formControlName="INTEGRATION">
+                <mat-select
+                  #integrationRoleSelect="matSelect"
+                  [id]="group.id"
+                  [aria-label]="'Integration roles for ' + group.id"
+                  formControlName="INTEGRATION"
+                  panelClass="org-settings-user-detail__role-select-panel"
+                >
+                  <mat-select-trigger>
+                    <span
+                      #roleTriggerEl
+                      class="org-settings-user-detail__role-trigger"
+                      [matTooltip]="integrationRoleSelect.triggerValue"
+                      matTooltipClass="org-settings-user-detail__role-tooltip"
+                      [matTooltipDisabled]="roleTriggerEl.offsetWidth >= roleTriggerEl.scrollWidth"
+                      >{{ integrationRoleSelect.triggerValue }}</span
+                    >
+                  </mat-select-trigger>
                   <mat-option>-- None --</mat-option>
-                  <mat-option *ngFor="let role of integrationRoles$ | async" [disabled]="role.system" [value]="role.name">{{
-                    role.name
-                  }}</mat-option>
+                  <mat-option *ngFor="let role of integrationRoles$ | async" [disabled]="role.system" [value]="role.name">
+                    <span
+                      #roleOptionEl
+                      class="org-settings-user-detail__role-option"
+                      [matTooltip]="role.name"
+                      matTooltipClass="org-settings-user-detail__role-tooltip"
+                      [matTooltipDisabled]="roleOptionEl.offsetWidth >= roleOptionEl.scrollWidth"
+                      >{{ role.name }}</span
+                    >
+                  </mat-option>
                 </mat-select>
               </mat-form-field>
             </td>

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.scss
@@ -7,7 +7,19 @@
 $background: map-get(gio.$mat-theme, background);
 $typography: map.get(gio.$mat-theme, typography);
 
-:host {
+// Ellipsis tooltip theming for the role selects. Kept in the component (not the
+// global stylesheet); it can still reach the matTooltip overlay because this
+// component uses ViewEncapsulation.None.
+$role-tooltip-background-color: var(--gio-oem-palette--background, #{mat.m2-get-color-from-palette(gio.$mat-space-palette, default)});
+$role-tooltip-text-color: mat.m2-get-color-from-palette(gio.$mat-basic-palette, white);
+$role-tooltip-max-width: 160px;
+$role-tooltip-font-size: 11px;
+$role-tooltip-line-height: 16px;
+$role-tooltip-padding: 4px 8px;
+
+// ViewEncapsulation.None makes these styles global, so `:host` would not match.
+// Target the component element directly instead.
+org-settings-user-detail {
   @include gio-layout.gio-responsive-margin-container;
 
   display: flex;
@@ -120,6 +132,14 @@ $typography: map.get(gio.$mat-theme, typography);
     }
   }
 
+  // Selected value shown in the closed role selects: truncate with ellipsis.
+  &__role-trigger {
+    display: block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
   &__tokens {
     &__card {
       margin-bottom: 32px;
@@ -132,5 +152,35 @@ $typography: map.get(gio.$mat-theme, typography);
         margin-bottom: 16px;
       }
     }
+  }
+}
+
+// Role select options render in a CDK overlay (outside the component element).
+// With ViewEncapsulation.None these styles are global, targeted via the unique `panelClass`.
+.org-settings-user-detail__role-select-panel .org-settings-user-detail__role-option {
+  display: block;
+  // Caps how far the auto-sized panel can grow; beyond this the option text is
+  // truncated with an ellipsis, which is what enables the overflow tooltip.
+  max-width: 280px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+// Themed ellipsis tooltip for the role selects, applied via `matTooltipClass`.
+// Reaches the matTooltip overlay because this component uses ViewEncapsulation.None.
+.org-settings-user-detail__role-tooltip {
+  --mdc-plain-tooltip-container-color: #{$role-tooltip-background-color};
+  --mdc-plain-tooltip-supporting-text-color: #{$role-tooltip-text-color};
+
+  .mat-mdc-tooltip-surface {
+    max-width: $role-tooltip-max-width;
+    font-size: $role-tooltip-font-size;
+    line-height: $role-tooltip-line-height;
+    padding: $role-tooltip-padding;
+    white-space: normal;
+    overflow-wrap: break-word;
+    word-break: normal;
+    text-align: left !important;
   }
 }

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { AbstractControl, UntypedFormControl, UntypedFormGroup, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { combineLatest, EMPTY, from, Observable, of, Subject, zip } from 'rxjs';
@@ -95,6 +95,9 @@ interface TokenDS {
   templateUrl: './org-settings-user-detail.component.html',
   styleUrls: ['./org-settings-user-detail.component.scss'],
   standalone: false,
+  // Styles are global so the role-select tooltip/option theming can reach the
+  // mat-select panel and matTooltip, both rendered in a CDK overlay outside this component.
+  encapsulation: ViewEncapsulation.None,
 })
 export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
   user: UserVM;


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-14453

## Description

Updated the panelWidth attribute to mat-select components for UI consistency

## Additional context

Pre fix behaviour: 

<img width="3016" height="1546" alt="image" src="https://github.com/user-attachments/assets/bf7fbac6-7059-4d31-a1e7-d8923e7ba389" />


Post fix behaviour:

<img width="1432" height="782" alt="image" src="https://github.com/user-attachments/assets/4aa3a35d-7af2-405d-afbe-a453ef74d638" />



