### PR TITLE
feat(opentelemetry): allow disabling V2 API tracing independently of V4

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
@@ -122,6 +122,7 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
     public static final String HANDLERS_REQUEST_HEADERS_X_FORWARDED_PREFIX_PROPERTY = "handlers.request.headers.x-forwarded-prefix";
     public static final String REPORTERS_LOGGING_EXCLUDED_RESPONSE_TYPES_PROPERTY = "reporters.logging.excluded_response_types";
     public static final String PENDING_REQUESTS_TIMEOUT_PROPERTY = "api.pending_requests_timeout";
+    public static final String TRACING_V2_ENABLED_PROPERTY = "services.opentelemetry.tracing.v2.enabled";
 
     /** OTel {@code gravitee.module} resource-attribute value identifying this reactor. */
     private static final String MODULE = "apim";
@@ -313,8 +314,7 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
 
                     final io.gravitee.gateway.reactive.policy.PolicyChainFactory policyChainFactory = createPolicyChainFactory(
                         api,
-                        policyManager,
-                        openTelemetryConfiguration
+                        policyManager
                     );
 
                     FlowChainFactory flowChainFactory = createFlowChainFactory(
@@ -388,12 +388,8 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
         );
     }
 
-    protected HttpPolicyChainFactory createPolicyChainFactory(
-        Api api,
-        io.gravitee.gateway.reactive.policy.PolicyManager policyManager,
-        OpenTelemetryConfiguration openTelemetryConfiguration
-    ) {
-        return new HttpPolicyChainFactory(api.getId(), policyManager, openTelemetryConfiguration.isTracesEnabled());
+    protected HttpPolicyChainFactory createPolicyChainFactory(Api api, io.gravitee.gateway.reactive.policy.PolicyManager policyManager) {
+        return new HttpPolicyChainFactory(api.getId(), policyManager, isV2TracingEnabled());
     }
 
     protected FlowChainFactory createFlowChainFactory(
@@ -460,6 +456,9 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
     }
 
     private TracingContext createTracingContext(final Api api, final String apiType) {
+        if (!isV2TracingEnabled()) {
+            return TracingContext.noop();
+        }
         Tracer tracer = openTelemetryFactory.createTracer(
             node.id(),
             node.application(),
@@ -468,7 +467,18 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
             instrumenterTracerFactories,
             TracerResourceAttributes.of(MODULE, api.getId(), api.getName(), apiType, api.getOrganizationId(), api.getEnvironmentId())
         );
-        return new TracingContext(tracer, openTelemetryConfiguration.isTracesEnabled(), openTelemetryConfiguration.isVerboseEnabled());
+        return new TracingContext(tracer, true, openTelemetryConfiguration.isVerboseEnabled());
+    }
+
+    /**
+     * V2 APIs (legacy and emulated) have no per-API tracing opt-in, unlike V4 (which gates on
+     * {@code analytics.tracing.enabled}). So when OTel is enabled gateway-wide, every V2 API would be
+     * traced. This independent switch — {@code services.opentelemetry.tracing.v2.enabled} (default
+     * {@code true}) — lets an operator turn V2 tracing off without affecting V4. It is a gateway
+     * concern: gravitee-node stays unaware of API versions and only answers {@code isTracesEnabled()}.
+     */
+    private boolean isV2TracingEnabled() {
+        return openTelemetryConfiguration.isTracesEnabled() && configuration.getProperty(TRACING_V2_ENABLED_PROPERTY, Boolean.class, true);
     }
 
     public PolicyChainFactory policyChainFactory(PolicyManager policyManager) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactoryTest.java
@@ -18,12 +18,14 @@ package io.gravitee.gateway.handlers.api;
 import static io.gravitee.gateway.handlers.api.ApiReactorHandlerFactory.CLASSLOADER_LEGACY_ENABLED_PROPERTY;
 import static io.gravitee.gateway.handlers.api.ApiReactorHandlerFactory.HANDLERS_REQUEST_HEADERS_X_FORWARDED_PREFIX_PROPERTY;
 import static io.gravitee.gateway.handlers.api.ApiReactorHandlerFactory.PENDING_REQUESTS_TIMEOUT_PROPERTY;
+import static io.gravitee.gateway.handlers.api.ApiReactorHandlerFactory.TRACING_V2_ENABLED_PROPERTY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.event.EventManager;
@@ -127,6 +129,7 @@ public class ApiReactorHandlerFactoryTest {
         when(configuration.getProperty(HANDLERS_REQUEST_HEADERS_X_FORWARDED_PREFIX_PROPERTY, Boolean.class, false)).thenReturn(false);
         when(configuration.getProperty(CLASSLOADER_LEGACY_ENABLED_PROPERTY, Boolean.class, false)).thenReturn(false);
         when(configuration.getProperty(PENDING_REQUESTS_TIMEOUT_PROPERTY, Long.class, 10_000L)).thenReturn(10_000L);
+        when(configuration.getProperty(TRACING_V2_ENABLED_PROPERTY, Boolean.class, true)).thenReturn(true);
         when(openTelemetryConfiguration.isTracesEnabled()).thenReturn(false);
         when(applicationContext.getBean(GatewayConfiguration.class)).thenReturn(gatewayConfiguration);
         when(applicationContext.getBean(ApiTemplateVariableProviderFactory.class)).thenReturn(apiTemplateVariableProviderFactory);
@@ -197,6 +200,7 @@ public class ApiReactorHandlerFactoryTest {
         // carries the per-API identity flatly under the OTel gravitee.* keys so consumers can filter
         // without parsing service names.
         when(api.enabled()).thenReturn(true);
+        when(openTelemetryConfiguration.isTracesEnabled()).thenReturn(true);
         io.gravitee.definition.model.Api definition = mock(io.gravitee.definition.model.Api.class);
         when(definition.getProxy()).thenReturn(mock(io.gravitee.definition.model.Proxy.class));
         when(api.getDefinition()).thenReturn(definition);
@@ -215,6 +219,23 @@ public class ApiReactorHandlerFactoryTest {
             .containsEntry("gravitee.api.type", "API_V2_EMULATED")
             .containsEntry("gravitee.org.id", "org-id")
             .containsEntry("gravitee.env.id", "env-id");
+    }
+
+    @Test
+    public void shouldNotBuildTracerWhenV2TracingDisabled() {
+        // OTel is enabled gateway-wide, but V2 tracing is turned off via services.opentelemetry.tracing.v2.enabled:
+        // the v2 factory must short-circuit and never build a tracer (V2 has no per-API opt-in, unlike V4).
+        when(api.enabled()).thenReturn(true);
+        when(openTelemetryConfiguration.isTracesEnabled()).thenReturn(true);
+        when(configuration.getProperty(TRACING_V2_ENABLED_PROPERTY, Boolean.class, true)).thenReturn(false);
+        io.gravitee.definition.model.Api definition = mock(io.gravitee.definition.model.Api.class);
+        when(definition.getProxy()).thenReturn(mock(io.gravitee.definition.model.Proxy.class));
+        when(api.getDefinition()).thenReturn(definition);
+        stubApiIdentityForTracing();
+
+        apiContextHandlerFactory.create(api);
+
+        verifyNoInteractions(openTelemetryFactory);
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/handlers/api/DebugApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/handlers/api/DebugApiReactorHandlerFactory.java
@@ -56,7 +56,6 @@ import io.gravitee.gateway.security.core.AuthenticationHandlerSelector;
 import io.gravitee.gateway.security.core.SecurityPolicyResolver;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
-import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import java.util.List;
 import org.springframework.context.ApplicationContext;
@@ -152,11 +151,7 @@ public class DebugApiReactorHandlerFactory extends ApiReactorHandlerFactory {
     }
 
     @Override
-    protected HttpPolicyChainFactory createPolicyChainFactory(
-        Api api,
-        io.gravitee.gateway.reactive.policy.PolicyManager policyManager,
-        OpenTelemetryConfiguration openTelemetryConfiguration
-    ) {
+    protected HttpPolicyChainFactory createPolicyChainFactory(Api api, io.gravitee.gateway.reactive.policy.PolicyManager policyManager) {
         return new DebugPolicyChainFactory(api.getId(), policyManager, false);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -754,6 +754,13 @@ services:
 #    exporter:
 #      endpoint: http://localhost:4317
 #      protocol: grpc
+#    tracing:
+#      v2:
+#        # Whether tracing applies to V2 APIs (legacy and V4-emulation engine).
+#        # V2 APIs have no per-API tracing opt-in, so when opentelemetry.enabled is true they are all
+#        # traced. Set to false to disable tracing for every V2 API while keeping it on for V4 APIs.
+#        # Default: true.
+#        enabled: true
 #    # Kafka Native API tracing configuration
 #    # tracedApiKeys restricts per-request spans to specific Kafka protocol types.
 #    # When omitted or empty, all protocol types are traced.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2070,6 +2070,12 @@ gateway:
 #   opentelemetry:
 #      enabled: false
 #      verbose: false
+#      tracing:
+#        v2:
+#          # Whether tracing applies to V2 APIs (legacy and V4-emulation engine). V2 APIs have no
+#          # per-API tracing opt-in, so when enabled is true they are all traced. Set to false to
+#          # disable tracing for every V2 API while keeping it on for V4 APIs. Default: true.
+#          enabled: true
 #      extraAttributes:
 #        - deployment.environment.name: production
 #      exporter:


### PR DESCRIPTION
## Problem

V2 APIs (legacy + emulated) have **no per-API tracing opt-in**, unlike V4 (which gates on `analytics.tracing.enabled`). So `services.opentelemetry.enabled=true` traces **every** V2 API on the gateway — a large, unintended span volume in deployments that mix V2 and V4 (notably Cloud, where OTel is enabled for V4 message/native observability).

## Change

Add a gateway-side flag **`services.opentelemetry.tracing.v2.enabled`** (default `true`, back-compatible). When `false`:
- the V2 reactor builds a no-op `TracingContext` (no per-API tracer allocated), and
- the V2 policy chain is not traced.

V4 is unaffected — still gated per-API on `analytics.tracing.enabled`.

The flag is read in `ApiReactorHandlerFactory` via the gateway `Configuration`. **gravitee-node stays version-agnostic** (only answers `isTracesEnabled()`); the V2-vs-V4 decision lives in the gateway, mirroring the existing V4 `analytics.tracing` gate.

## Tests

- `ApiReactorHandlerFactoryTest#shouldNotBuildTracerWhenV2TracingDisabled` — with OTel on and the flag off, no tracer is built (`verifyNoInteractions(openTelemetryFactory)`).
- Existing identity test updated to enable OTel (the factory now short-circuits to noop when tracing is disabled, so the tracer is only built when enabled).
