### PR TITLE
fix(gamma): handle `gammaBaseURL` in API bootstrap response

### DIFF
--- a/gravitee-gamma/gamma-ui-shared/src/api/apimClient.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/api/apimClient.ts
@@ -53,9 +53,10 @@ async function resolveBootstrap(): Promise<ApimBootstrap> {
             }
             const bootstrap = (await bootstrapRes.json()) as Record<string, unknown>;
 
+            const bootstrapGamma = typeof bootstrap.gammaBaseURL === 'string' ? bootstrap.gammaBaseURL.trim() : '';
             _bootstrap = {
                 managementBaseURL: trimTrailingSlash(requireNonEmptyString(bootstrap.managementBaseURL, 'managementBaseURL')),
-                gammaBaseURL: gammaBase,
+                gammaBaseURL: bootstrapGamma ? trimTrailingSlash(bootstrapGamma) : gammaBase,
                 organizationId: requireNonEmptyString(bootstrap.organizationId, 'organizationId'),
             };
             return _bootstrap;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/testing/handlers/bootstrap.handlers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/testing/handlers/bootstrap.handlers.ts
@@ -22,6 +22,7 @@ export const bootstrapHandlers = [
     http.get(`${TEST_CONFIG.gammaBaseURL}/ui/bootstrap`, () =>
         HttpResponse.json({
             managementBaseURL: TEST_CONFIG.managementBaseURL,
+            gammaBaseURL: TEST_CONFIG.gammaBaseURL,
             organizationId: TEST_CONFIG.organizationId,
         }),
     ),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-819

Summary
The shared APIM bootstrap client (gamma-ui-shared/src/api/apimClient.ts) was deriving gammaBaseURL from /constants.json (the relative /gamma, proxied to the dev host) and ignoring the absolute gammaBaseURL returned by /ui/bootstrap. The relative URL resolves to the dev-proxy origin, which doesn't own the auth/XSRF cookie scope so gamma-scoped calls never receive Set-Cookie XSRF-TOKEN and 401.

This aligns the shared client with the pattern already used by AIM (management-api-client.ts): prefer bootstrap.gammaBaseURL, and fall back to the constants value only when the backend doesn't supply one (standalone / mock setups).

Because this client is shared by gravitee-gamma-module-apim and gravitee-gamma-module-platform, the single fix unblocks both most visibly the analytics / observability dashboards, whose base URL is built from this field via useObservabilityBaseUrl.


### Before

https://github.com/user-attachments/assets/6d3f8db8-cf79-45e7-93ae-b8e478ba0f2b

### After

https://github.com/user-attachments/assets/cf9e9367-5bf6-444e-a0ed-7bba75be05a2


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

