### PR TITLE
fix(console): settings 2nd-level menu not full height

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/settings-navigation/settings-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/settings-navigation/settings-navigation.component.scss
@@ -55,7 +55,7 @@ $textColor: map.get(gio.$mat-dove-palette, default);
   &__submenu {
     z-index: 70;
     display: block;
-    height: auto;
+    height: 100%;
     color: $textColor;
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14540

## Description

The secondary navigation menu on the Settings page was not stretching to full height — it only extended as far as the menu items, leaving the sidebar column visually incomplete.

Root cause: `.settings-navigation__submenu` had `height: auto`, which sizes the `<gio-submenu>` element to its content rather than the available container height.

Fix: changed `height: auto` → `height: 100%` so the submenu fills the full sidebar column, matching the behavior of other navigation sidebars (API, application, integrations).
