### PR TITLE
fix(console): resolve group member by id instead of a directory search

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.spec.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { of, throwError } from 'rxjs';
+import { of } from 'rxjs';
 
 import { EditMemberDialogComponent } from './edit-member-dialog.component';
 
@@ -626,51 +627,23 @@ describe('EditMemberDialogComponent', () => {
     });
   });
 
-  describe('error handling on submit (review #2 and #3)', () => {
-    it('surfaces a snackbar error and keeps the dialog open if the successor lookup returns no matching user', () => {
-      const editUser = mkMember('1', 'Member One', { API: 'PRIMARY_OWNER' });
-      const successor = mkMember('2', 'Member Two');
-      // Mock returns a list that does NOT contain the successor — find() will yield undefined.
-      setup(editUser, [editUser, successor], HYBRID_SETTINGS, [USERS[0]]);
+  it('sets Group Admin without any /search/users request, resolving the member by id', () => {
+    // Large-directory / LDAP scenario: GET /search/users would not return the member, so the dialog
+    // must resolve it from member.id alone — never via a directory search.
+    const editUser = mkMember('1', 'Alex River');
+    setup(editUser, [editUser], HYBRID_SETTINGS, []);
+    const httpTestingController = TestBed.inject(HttpTestingController);
 
-      component.editMemberForm.controls.defaultAPIRole.setValue('OWNER');
-      component.onChange();
-      component.selectPrimaryOwner({ option: { value: successor } } as any);
-      component.submit();
+    component.editMemberForm.controls.groupAdmin.setValue(true);
+    component.onChange();
+    component.submit();
 
-      expect(snackBarSpy.error).toHaveBeenCalledTimes(1);
-      expect(dialogRefSpy.close).not.toHaveBeenCalled();
-      expect(component.disableSubmit).toBe(false);
-    });
-
-    it('surfaces a snackbar error and keeps the dialog open if the demotion lookup returns no matching user', () => {
-      const editUser = mkMember('1', 'Member One', { API: 'OWNER' });
-      const apiPo = mkMember('2', 'Member Two', { API: 'PRIMARY_OWNER' });
-      setup(editUser, [editUser, apiPo], HYBRID_SETTINGS, [USERS[0]]); // USERS[0] has id '1' only
-
-      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
-      component.onChange();
-      component.submit();
-
-      expect(snackBarSpy.error).toHaveBeenCalledTimes(1);
-      expect(dialogRefSpy.close).not.toHaveBeenCalled();
-      expect(component.disableSubmit).toBe(false);
-    });
-
-    it('surfaces a snackbar error if the user search itself fails', () => {
-      const editUser = mkMember('1', 'Member One', { API: 'OWNER' });
-      const apiPo = mkMember('2', 'Member Two', { API: 'PRIMARY_OWNER' });
-      setup(editUser, [editUser, apiPo]);
-      // Replace the search after init so getUserDetails has already populated this.user.
-      usersSearchSpy.mockReturnValueOnce(throwError(() => new Error('network down')));
-
-      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
-      component.onChange();
-      component.submit();
-
-      expect(snackBarSpy.error).toHaveBeenCalledTimes(1);
-      expect(dialogRefSpy.close).not.toHaveBeenCalled();
-    });
+    httpTestingController.expectNone(req => req.url.includes('/search/users'));
+    expect(usersSearchSpy).not.toHaveBeenCalled();
+    const { memberships } = dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] };
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0].id).toBe('1');
+    expect(memberships[0].roles).toContainEqual({ name: 'ADMIN', scope: 'GROUP' });
   });
 
   describe('demoted membership shape (review #4)', () => {

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, DestroyRef, inject, Inject, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -25,11 +25,10 @@ import { CommonModule } from '@angular/common';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { MatInput } from '@angular/material/input';
-import { catchError, EMPTY, forkJoin, Observable, of, startWith } from 'rxjs';
+import { Observable, of, startWith } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
 import { MatChip, MatChipRemove, MatChipSet } from '@angular/material/chips';
 import { GioBannerModule, GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 
 import { Member, RoleName } from '../membershipState';
@@ -38,9 +37,6 @@ import { ApiPrimaryOwnerMode } from '../../../../../services/apiPrimaryOwnerMode
 import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
 import { Role } from '../../../../../entities/role/role';
 import { GroupMembership, GroupMembershipMemberRoleEntity } from '../../../../../entities/group/groupMember';
-import { SearchableUser } from '../../../../../entities/user/searchableUser';
-import { UsersService } from '../../../../../services-ngx/users.service';
-import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { EditMemberDialogData } from '../group.component';
 import { Group } from '../../../../../entities/group/group';
 
@@ -98,22 +94,17 @@ export class EditMemberDialogComponent implements OnInit {
   disabledAPIRoles = new Set<string>();
   disabledAPIProductRoles = new Set<string>();
 
-  private user: SearchableUser = null;
   private initialValues: any = null;
-  private destroyRef = inject(DestroyRef);
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: EditMemberDialogData,
-    private usersService: UsersService,
     private matDialogRef: MatDialogRef<EditMemberDialogComponent>,
     private permissionService: GioPermissionService,
     private settingsService: EnvironmentSettingsService,
-    private snackBarService: SnackBarService,
   ) {}
 
   ngOnInit(): void {
     this.initializeDataFromInput();
-    this.getUserDetails();
     this.initializeForm();
     this.initialValues = this.editMemberForm.getRawValue();
     this.initializeFilterFn();
@@ -154,16 +145,6 @@ export class EditMemberDialogComponent implements OnInit {
       distinctUntilChanged(),
       map((searchTerm: string) => this.filterMembers(searchTerm)),
     );
-  }
-
-  private getUserDetails() {
-    this.usersService
-      .search(this.member.displayName)
-      .pipe(
-        map((users: SearchableUser[]) => (this.user = users.length > 0 ? users.find(u => u.id === this.member.id) : undefined)),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
   }
 
   private disableControlsForUser() {
@@ -257,79 +238,38 @@ export class EditMemberDialogComponent implements OnInit {
     const apiProductPo = apiProductUpgrade ? this.findExistingPrimaryOwner('API_PRODUCT') : null;
     const sameOutgoing = !!(apiPo && apiProductPo && apiPo.id === apiProductPo.id);
 
-    const demotionLookups: Observable<GroupMembership>[] = [];
+    const demoted: GroupMembership[] = [];
     if (apiPo) {
       const scopes: ('API' | 'API_PRODUCT')[] = sameOutgoing ? ['API', 'API_PRODUCT'] : ['API'];
-      demotionLookups.push(this.demote(apiPo, scopes));
+      demoted.push(this.demote(apiPo, scopes));
     }
     if (apiProductPo && !sameOutgoing) {
-      demotionLookups.push(this.demote(apiProductPo, ['API_PRODUCT']));
+      demoted.push(this.demote(apiProductPo, ['API_PRODUCT']));
     }
 
-    const successorLookup: Observable<GroupMembership> | null =
+    const successor =
       apiDowngrade || apiProductDowngrade ? this.promoteSuccessor(this.selectedPrimaryOwner, apiDowngrade, apiProductDowngrade) : null;
 
-    if (demotionLookups.length === 0 && !successorLookup) {
-      this.memberships = [editMembership];
-      this.matDialogRef.close({ memberships: this.memberships });
-      return;
+    // Order: previous-PO demotion(s) → edit user → successor promotion.
+    this.memberships = successor ? [...demoted, editMembership, successor] : [...demoted, editMembership];
+    this.matDialogRef.close({ memberships: this.memberships });
+  }
+
+  private promoteSuccessor(successor: Member, apiDowngrade: boolean, apiProductDowngrade: boolean): GroupMembership {
+    const successorMembership = this.buildMembershipFromMember(successor);
+    if (apiDowngrade) {
+      this.setRole(successorMembership, 'API', RoleName.PRIMARY_OWNER);
     }
-
-    const allLookups = successorLookup ? [...demotionLookups, successorLookup] : demotionLookups;
-
-    forkJoin(allLookups)
-      .pipe(
-        catchError(() => {
-          this.handleTransferLookupFailure();
-          return EMPTY;
-        }),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe(resolved => {
-        // Order: previous-PO demotion(s) → edit user → successor promotion.
-        const demoted = resolved.slice(0, demotionLookups.length);
-        const successor = successorLookup ? resolved[resolved.length - 1] : null;
-        this.memberships = successor ? [...demoted, editMembership, successor] : [...demoted, editMembership];
-        this.matDialogRef.close({ memberships: this.memberships });
-      });
+    if (apiProductDowngrade) {
+      this.setRole(successorMembership, 'API_PRODUCT', RoleName.PRIMARY_OWNER);
+    }
+    return successorMembership;
   }
 
-  private promoteSuccessor(successor: Member, apiDowngrade: boolean, apiProductDowngrade: boolean): Observable<GroupMembership> {
-    return this.usersService.search(successor.displayName).pipe(
-      map(users => {
-        const successorUser = users.find(u => u.id === successor.id);
-        if (!successorUser) {
-          throw new Error(`Could not resolve user reference for member ${successor.id}`);
-        }
-        const successorMembership = this.buildMembershipFromMember(successor, successorUser.reference);
-        if (apiDowngrade) {
-          this.setRole(successorMembership, 'API', RoleName.PRIMARY_OWNER);
-        }
-        if (apiProductDowngrade) {
-          this.setRole(successorMembership, 'API_PRODUCT', RoleName.PRIMARY_OWNER);
-        }
-        return successorMembership;
-      }),
-    );
-  }
-
-  private demote(member: Member, scopes: ('API' | 'API_PRODUCT')[]): Observable<GroupMembership> {
-    return this.usersService.search(member.displayName).pipe(
-      map(users => {
-        const memberUser = users.find(u => u.id === member.id);
-        if (!memberUser) {
-          throw new Error(`Could not resolve user reference for member ${member.id}`);
-        }
-        const membership = this.buildMembershipFromMember(member, memberUser.reference);
-        scopes.forEach(scope => this.setRole(membership, scope, RoleName.OWNER));
-        return membership;
-      }),
-    );
-  }
-
-  private handleTransferLookupFailure(): void {
-    this.snackBarService.error('Could not resolve member references for the ownership transfer. Please try again.');
-    this.disableSubmit = false;
+  private demote(member: Member, scopes: ('API' | 'API_PRODUCT')[]): GroupMembership {
+    const membership = this.buildMembershipFromMember(member);
+    scopes.forEach(scope => this.setRole(membership, scope, RoleName.OWNER));
+    return membership;
   }
 
   private setGroupAdminRole(groupMembership: GroupMembership) {
@@ -340,8 +280,7 @@ export class EditMemberDialogComponent implements OnInit {
 
   private mapEditUserMembership(): GroupMembership {
     return {
-      id: this.user.id,
-      reference: this.user.reference,
+      id: this.member.id,
       roles: [
         { name: this.editMemberForm.controls.defaultAPIRole.value, scope: 'API' },
         { name: this.editMemberForm.controls.defaultAPIProductRole.value, scope: 'API_PRODUCT' },
@@ -352,14 +291,14 @@ export class EditMemberDialogComponent implements OnInit {
     };
   }
 
-  private buildMembershipFromMember(member: Member, reference: string): GroupMembership {
+  private buildMembershipFromMember(member: Member): GroupMembership {
     const roles: GroupMembershipMemberRoleEntity[] = [];
     Object.entries(member.roles).forEach(([scope, name]) => {
       if (name) {
         roles.push({ name, scope: scope as GroupMembershipMemberRoleEntity['scope'] });
       }
     });
-    return { id: member.id, reference, roles };
+    return { id: member.id, roles };
   }
 
   private setRole(membership: GroupMembership, scope: GroupMembershipMemberRoleEntity['scope'], name: string) {

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
@@ -546,7 +546,7 @@ describe('GroupComponent', () => {
       await groupAdminHarness.check();
       const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Save' }));
       await confirmButtonHarness.click();
-      expectAddOrUpdateMembership('1', 'testmember1', [
+      expectAddOrUpdateMembership('1', null, [
         { name: 'REVIEWER', scope: 'API' },
         { name: 'OWNER', scope: 'API_PRODUCT' },
         { name: 'USER', scope: 'APPLICATION' },
@@ -600,7 +600,6 @@ describe('GroupComponent', () => {
       expect(req.request.body).toEqual([
         {
           id: '2',
-          reference: 'testmember2',
           roles: [
             { name: 'OWNER', scope: 'API' },
             { name: 'OWNER', scope: 'API_PRODUCT' },
@@ -611,7 +610,6 @@ describe('GroupComponent', () => {
         },
         {
           id: '1',
-          reference: 'testmember1',
           roles: [
             { name: 'PRIMARY_OWNER', scope: 'API' },
             { name: 'OWNER', scope: 'API_PRODUCT' },
@@ -667,7 +665,6 @@ describe('GroupComponent', () => {
       expect(req.request.body).toEqual([
         {
           id: '2',
-          reference: 'testmember2',
           roles: [
             { name: 'OWNER', scope: 'API' },
             { name: 'OWNER', scope: 'API_PRODUCT' },
@@ -678,7 +675,6 @@ describe('GroupComponent', () => {
         },
         {
           id: '1',
-          reference: 'testmember1',
           roles: [
             { name: 'OWNER', scope: 'API' },
             { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
@@ -738,7 +734,6 @@ describe('GroupComponent', () => {
       expect(req.request.body).toEqual([
         {
           id: '2',
-          reference: 'testmember2',
           roles: [
             { name: 'OWNER', scope: 'API' },
             { name: 'OWNER', scope: 'API_PRODUCT' },
@@ -749,7 +744,6 @@ describe('GroupComponent', () => {
         },
         {
           id: '1',
-          reference: 'testmember1',
           roles: [
             { name: 'PRIMARY_OWNER', scope: 'API' },
             { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
@@ -813,7 +807,6 @@ describe('GroupComponent', () => {
       expect(req.request.body).toEqual([
         {
           id: '1',
-          reference: 'testmember1',
           roles: [
             { name: 'OWNER', scope: 'API' },
             { name: 'OWNER', scope: 'API_PRODUCT' },
@@ -824,7 +817,6 @@ describe('GroupComponent', () => {
         },
         {
           id: '2',
-          reference: 'testmember2',
           roles: [
             { name: 'PRIMARY_OWNER', scope: 'API' },
             { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
@@ -893,7 +885,6 @@ describe('GroupComponent', () => {
       expect(req.request.body).toEqual([
         {
           id: '2',
-          reference: 'testmember2',
           roles: [
             { name: 'USER', scope: 'API' },
             { name: 'OWNER', scope: 'API_PRODUCT' },
@@ -904,7 +895,6 @@ describe('GroupComponent', () => {
         },
         {
           id: '1',
-          reference: 'testmember1',
           roles: [
             { name: 'PRIMARY_OWNER', scope: 'API' },
             { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
@@ -952,7 +942,6 @@ describe('GroupComponent', () => {
       expect(req.request.body).toEqual([
         {
           id: '1',
-          reference: 'testmember1',
           roles: [
             { name: 'PRIMARY_OWNER', scope: 'API' },
             { name: 'OWNER', scope: 'API_PRODUCT' },
@@ -1019,7 +1008,6 @@ describe('GroupComponent', () => {
       expect(req.request.body).toEqual([
         {
           id: '1',
-          reference: 'testmember1',
           roles: [
             { name: 'OWNER', scope: 'API' },
             { name: 'OWNER', scope: 'API_PRODUCT' },
@@ -1030,7 +1018,6 @@ describe('GroupComponent', () => {
         },
         {
           id: '2',
-          reference: 'testmember2',
           roles: [
             { name: 'OWNER', scope: 'API' },
             { name: 'OWNER', scope: 'API_PRODUCT' },
@@ -1041,7 +1028,6 @@ describe('GroupComponent', () => {
         },
         {
           id: '3',
-          reference: 'testmember3',
           roles: [
             { name: 'PRIMARY_OWNER', scope: 'API' },
             { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
@@ -1098,7 +1084,6 @@ describe('GroupComponent', () => {
       expect(req.request.body).toEqual([
         {
           id: '1',
-          reference: 'testmember1',
           roles: [
             { name: 'OWNER', scope: 'API' },
             { name: 'OWNER', scope: 'API_PRODUCT' },
@@ -1109,7 +1094,6 @@ describe('GroupComponent', () => {
         },
         {
           id: '2',
-          reference: 'testmember2',
           roles: [
             { name: 'PRIMARY_OWNER', scope: 'API' },
             { name: 'OWNER', scope: 'API_PRODUCT' },
@@ -1168,7 +1152,6 @@ describe('GroupComponent', () => {
       expect(req.request.body).toEqual([
         {
           id: '1',
-          reference: 'testmember1',
           roles: [
             { name: 'OWNER', scope: 'API' },
             { name: 'OWNER', scope: 'API_PRODUCT' },
@@ -1179,7 +1162,6 @@ describe('GroupComponent', () => {
         },
         {
           id: '2',
-          reference: 'testmember2',
           roles: [
             { name: 'OWNER', scope: 'API' },
             { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
@@ -1609,7 +1591,7 @@ describe('GroupComponent', () => {
       await apiProductOptions[0].click();
       const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Save' }));
       await confirmButtonHarness.click();
-      expectAddOrUpdateMembership('1', 'testmember1', [
+      expectAddOrUpdateMembership('1', null, [
         { name: 'OWNER', scope: 'API' },
         { name: 'USER', scope: 'API_PRODUCT' },
         { name: 'OWNER', scope: 'APPLICATION' },
@@ -2174,18 +2156,14 @@ describe('GroupComponent', () => {
     });
   }
 
-  function expectAddOrUpdateMembership(id: string, reference: string, roles: GroupMembershipMemberRoleEntity[]) {
+  function expectAddOrUpdateMembership(id: string, reference: string | null, roles: GroupMembershipMemberRoleEntity[]) {
     const req = httpTestingController.expectOne({
       url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
       method: 'POST',
     });
-    const memberships: GroupMembership[] = [
-      {
-        id: id,
-        reference: reference,
-        roles: roles,
-      },
-    ];
+    // The edit flow resolves the member by id and sends no reference; the add flow (external users)
+    // still sends one. Omit reference from the expected payload when none is provided.
+    const memberships: GroupMembership[] = [reference != null ? { id, reference, roles } : { id, roles }];
     expect(req.request.body).toEqual(memberships);
   }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -1231,6 +1231,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
 
         Query<UserEntity> userQuery;
         if (query == null || query.isEmpty()) {
+            // Browsing with no search term: keep the alphabetical (lastname/firstname) order.
             userQuery = QueryBuilder.create(UserEntity.class)
                 .setQuery("*")
                 .setPage(pageable)
@@ -1240,11 +1241,9 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             // UserDocumentTransformation remove domain from email address for security reasons
             // remove it during search phase to provide results
             String sanitizedQuery = query.indexOf('@') > 0 ? query.substring(0, query.indexOf('@')) : query;
-            userQuery = QueryBuilder.create(UserEntity.class)
-                .setQuery(sanitizedQuery)
-                .setSort(new SortableImpl(UserDocumentTransformer.FIELD_LASTNAME_FIRSTNAME, true))
-                .setPage(pageable)
-                .build();
+            // No sort: let the search engine rank by relevance score (best matches first) so the most
+            // relevant users stay within bounded result windows such as the user picker's top 20.
+            userQuery = QueryBuilder.create(UserEntity.class).setQuery(sanitizedQuery).setPage(pageable).build();
         }
         SearchResult results = searchEngineService.search(executionContext, userQuery);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -66,6 +66,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -2584,6 +2585,26 @@ public class UserServiceTest {
         assertNotNull(first.getUpdatedAt());
         assertFalse(first.isPrimaryOwner());
         assertEquals(0, first.getNbActiveTokens());
+    }
+
+    @Test
+    public void shouldSearchUsers_rankTextQueryByRelevance_butBrowseAlphabetically() throws TechnicalException {
+        when(searchEngineService.search(eq(EXECUTION_CONTEXT), any())).thenReturn(
+            new io.gravitee.rest.api.service.impl.search.SearchResult(Collections.emptyList(), 0)
+        );
+
+        userService.search(EXECUTION_CONTEXT, "jean", new io.gravitee.rest.api.model.common.PageableImpl(1, 20));
+        userService.search(EXECUTION_CONTEXT, "", new io.gravitee.rest.api.model.common.PageableImpl(1, 20));
+
+        ArgumentCaptor<io.gravitee.rest.api.service.search.query.Query> queryCaptor = ArgumentCaptor.forClass(
+            io.gravitee.rest.api.service.search.query.Query.class
+        );
+        verify(searchEngineService, times(2)).search(eq(EXECUTION_CONTEXT), queryCaptor.capture());
+
+        // Text query: no sort so the search engine ranks by relevance score (best matches first).
+        assertNull(queryCaptor.getAllValues().get(0).getSort());
+        // No search term (browse): keep the alphabetical (lastname/firstname) sort.
+        assertNotNull(queryCaptor.getAllValues().get(1).getSort());
     }
 
     @Test


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14451
## Problem

Editing a group member (e.g. toggling **Group Admin**) re-resolved the member through `GET /search/users?q=<displayName>`, then read `.id`/`.reference` off the matching result.

In large directories (LDAP), the bounded search (~20 results) may not contain the member, so the resolved user stays `undefined` and **Save** throws `TypeError: Cannot read properties of undefined (reading 'id')` client-side — no request is sent and the dialog stays silently open.

Closes gravitee-io/issues#11544

## Root cause

The search exists to recover a `reference`, which the *Add members* flow needs for external users whose `id` is `null`. The *Edit* dialog reused the same payload shape and reconstructed `reference` via a second search — but a group member is **already registered in Gravitee**, so `member.id` is authoritative. The backend (`MembershipServiceImpl.findUserFromMembershipMember`) resolves by `id` first and only falls back to `reference` when `id` is absent. The search is therefore unnecessary here, and fragile.

## Fix

- Drop the directory search on edit; build the membership directly from `member.id` (no `reference`).
- Remove the same fragile lookup from the primary-owner `demote()` / `promoteSuccessor()` paths, fixing ownership transfer for the same directory users.
- `submit()` becomes synchronous (no more `forkJoin`/`catchError`); drop the now-unused `UsersService`, `SnackBarService`, and `DestroyRef` dependencies.

No on-screen user detail depended on the search — the only displayed field (`displayName`) comes from the `member` input.

## Tests

Replaced the old "error handling" suite (which asserted the fragile-search failure path) with a regression suite for #11544: with an empty search result, saving Group Admin, demotion, and successor promotion all succeed and never call the directory search. 39/39 tests pass.