### PR TITLE
fix(console): auto-scroll to newly created portal nav item

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -1265,6 +1265,54 @@ describe('FlatTreeComponent', () => {
     }));
   });
 
+  describe('auto-scroll to selected node', () => {
+    let scrolledNodeIds: string[];
+    let originalScrollIntoView: typeof Element.prototype.scrollIntoView;
+
+    beforeEach(() => {
+      scrolledNodeIds = [];
+      originalScrollIntoView = Element.prototype.scrollIntoView;
+      Element.prototype.scrollIntoView = jest.fn(function (this: HTMLElement) {
+        scrolledNodeIds.push(this.getAttribute('data-node-id') ?? '');
+      });
+    });
+
+    afterEach(() => {
+      Element.prototype.scrollIntoView = originalScrollIntoView;
+    });
+
+    it('should scroll the newly selected root item into view', async () => {
+      const links = [makeItem('p1', 'PAGE', 'Page 1', 0), makeItem('p2', 'PAGE', 'Page 2', 1)];
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      fixture.componentRef.setInput('selectedId', 'p2');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(scrolledNodeIds).toContain('p2');
+    });
+
+    it('should scroll a nested item into view once its ancestors are expanded', async () => {
+      const nestedLinks = [
+        makeItem('f1', 'FOLDER', 'Folder 1', 0),
+        makeItem('f2', 'FOLDER', 'Folder 2', 0, 'f1'),
+        makeItem('p1', 'PAGE', 'Page 1', 0, 'f2'),
+      ];
+      fixture.componentRef.setInput('links', nestedLinks);
+      fixture.componentRef.setInput('selectedId', 'p1');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(scrolledNodeIds).toContain('p1');
+    });
+  });
+
   function createDropEvent(itemData: any, isPointerOverContainer = true): CdkDragDrop<SectionNode[]> {
     return {
       item: { data: itemData },

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -13,7 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, computed, effect, ElementRef, inject, input, output, signal, viewChild } from '@angular/core';
+import {
+  afterNextRender,
+  Component,
+  computed,
+  effect,
+  ElementRef,
+  inject,
+  Injector,
+  input,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
 import { MatTree, MatTreeModule } from '@angular/material/tree';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
@@ -101,6 +113,8 @@ interface DropIntent {
 })
 export class FlatTreeComponent {
   private readonly permissionService = inject(GioPermissionService);
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly injector = inject(Injector);
 
   links = input<PortalNavigationItem[] | null>(null);
   selectedId = input<string | null>(null);
@@ -266,6 +280,7 @@ export class FlatTreeComponent {
 
         if (this.expandAncestorsOfSelectedNode(selectedId, nodes, tree)) {
           this.selectedIdToReveal.set(null);
+          this.scrollNodeIntoView(selectedId);
         }
       });
     });
@@ -465,6 +480,16 @@ export class FlatTreeComponent {
 
   private isWithinSubtree(nodeId: string, root: SectionNode): boolean {
     return (root.children ?? []).some(child => child.id === nodeId || this.isWithinSubtree(nodeId, child));
+  }
+
+  private scrollNodeIntoView(nodeId: string): void {
+    afterNextRender(
+      () => {
+        const row = this.host.nativeElement.querySelector<HTMLElement>(`mat-tree-node[data-node-id="${nodeId}"]`);
+        row?.scrollIntoView({ block: 'nearest' });
+      },
+      { injector: this.injector },
+    );
   }
 
   private expandAncestorsOfSelectedNode(selectedId: string, nodes: SectionNode[], tree: MatTree<SectionNode, string>): boolean {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14544

## Description

### Cause
`FlatTreeComponent`'s reveal effect only expanded the selected node's ancestors (logical reveal) but never scrolled its row into the scrollable container's viewport.

  ### Fix
After the ancestors are expanded, scroll the selected row into view via `afterNextRender` + `scrollIntoView({ block: 'nearest' })`:
- `'nearest'` is a no-op when the row is already visible (a plain click won't jump the view).
- Triggered only when `selectedId` changes, so no spurious scroll on data refresh (publish / move / delete).


https://github.com/user-attachments/assets/e7cb777a-f01c-4755-924a-9a5f3f07366f
