### PR TITLE
fix(console): resolve group member by id instead of a directory search

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
@@ -108,7 +108,7 @@ export class ApiDynamicPropertiesV4Component implements OnInit, OnDestroy {
           const configControl = this.form.controls.configuration;
           const originalMarkAsDirty = configControl.markAsDirty.bind(configControl);
           configControl.markAsDirty = () => {};
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
           ((window as any).__zone_symbol__setTimeout || setTimeout)(() => {
             configControl.markAsDirty = originalMarkAsDirty;
             this.initialFormValue = this.form.getRawValue();

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.spec.ts
@@ -14,35 +14,88 @@
  * limitations under the License.
  */
 import { TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { EditMemberDialogComponent } from './edit-member-dialog.component';
 
 import { GioTestingModule } from '../../../../../shared/testing';
+import { GioTestingPermissionProvider } from '../../../../../shared/components/gio-permission/gio-permission.service';
+import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
+import { Group } from '../../../../../entities/group/group';
+import { Member } from '../membershipState';
+import { GroupMembership } from '../../../../../entities/group/groupMember';
+import { EditMemberDialogData } from '../group.component';
 
 describe('EditMemberDialogComponent', () => {
-  TestBed.configureTestingModule({
-    imports: [EditMemberDialogComponent, GioTestingModule],
-    declarations: [],
-    providers: [
-      {
-        provide: MatDialogRef,
-        useValue: {
-          close: jest.fn(),
-        },
-      },
-      {
-        provide: MAT_DIALOG_DATA,
-        useValue: {
-          /* mock data */
-        },
-      },
-    ],
-  }).compileComponents();
+  const GROUP: Group = {
+    id: 'group-1',
+    name: 'Group 1',
+    manageable: true,
+    system_invitation: true,
+    email_invitation: false,
+    max_invitation: 10,
+    lock_api_role: false,
+    lock_application_role: false,
+    disable_membership_notifications: false,
+    event_rules: [],
+    roles: {},
+  };
 
-  it('should create', () => {
+  const member: Member = {
+    id: 'user-1',
+    displayName: 'Alex River',
+    roles: { API: 'USER', APPLICATION: 'USER', INTEGRATION: 'USER', CLUSTER: 'USER' },
+  };
+
+  const dialogRefSpy = { close: jest.fn() };
+
+  const setup = () => {
+    TestBed.resetTestingModule();
+    // UsersService is intentionally NOT provided: the dialog must resolve the member from its
+    // Gravitee id alone, never via GET /search/users.
+    TestBed.configureTestingModule({
+      imports: [EditMemberDialogComponent, GioTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRefSpy },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            group: GROUP,
+            member,
+            members: [member],
+            defaultAPIRoles: [],
+            defaultApplicationRoles: [],
+            defaultIntegrationRoles: [],
+            defaultClusterRoles: [],
+          } as EditMemberDialogData,
+        },
+        { provide: EnvironmentSettingsService, useValue: { getSnapshot: () => ({ api: { primaryOwnerMode: 'HYBRID' } }) } },
+        { provide: GioTestingPermissionProvider, useValue: ['environment-group-u'] },
+      ],
+    }).compileComponents();
+
     const fixture = TestBed.createComponent(EditMemberDialogComponent);
-    const component = fixture.componentInstance;
-    expect(component).toBeTruthy();
+    fixture.detectChanges();
+    return fixture.componentInstance;
+  };
+
+  it('sets Group Admin without any /search/users request, resolving the member by id', () => {
+    const component = setup();
+    const httpTestingController = TestBed.inject(HttpTestingController);
+
+    component.editMemberForm.controls.groupAdmin.setValue(true);
+    component.onChange();
+    component.submit();
+
+    // The bug: a directory search was used to recover the member; in large LDAP directories it
+    // missed the member and Save threw. There must now be no such request at all.
+    httpTestingController.expectNone((req) => req.url.includes('/search/users'));
+
+    const { memberships } = dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] };
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0].id).toBe('user-1');
+    expect(memberships[0].roles).toContainEqual({ name: 'ADMIN', scope: 'GROUP' });
   });
 });

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, DestroyRef, inject, Inject, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -29,7 +29,6 @@ import { Observable, of, startWith } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
 import { MatChip, MatChipRemove, MatChipSet } from '@angular/material/chips';
 import { GioBannerModule, GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 
 import { Member, RoleName } from '../membershipState';
@@ -38,8 +37,6 @@ import { ApiPrimaryOwnerMode } from '../../../../../services/apiPrimaryOwnerMode
 import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
 import { Role } from '../../../../../entities/role/role';
 import { GroupMembership } from '../../../../../entities/group/groupMember';
-import { SearchableUser } from '../../../../../entities/user/searchableUser';
-import { UsersService } from '../../../../../services-ngx/users.service';
 import { EditMemberDialogData } from '../group.component';
 import { Group } from '../../../../../entities/group/group';
 
@@ -94,13 +91,10 @@ export class EditMemberDialogComponent implements OnInit {
   disableSubmit = true;
   disabledAPIRoles = new Set<string>();
 
-  private user: SearchableUser = null;
   private initialValues: any = null;
-  private destroyRef = inject(DestroyRef);
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: EditMemberDialogData,
-    private usersService: UsersService,
     private matDialogRef: MatDialogRef<EditMemberDialogComponent>,
     private permissionService: GioPermissionService,
     private settingsService: EnvironmentSettingsService,
@@ -108,7 +102,6 @@ export class EditMemberDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.initializeDataFromInput();
-    this.getUserDetails();
     this.initializeForm();
     this.initialValues = this.editMemberForm.getRawValue();
     this.initializeFilterFn();
@@ -147,16 +140,6 @@ export class EditMemberDialogComponent implements OnInit {
       distinctUntilChanged(),
       map((searchTerm: string) => this.filterMembers(searchTerm)),
     );
-  }
-
-  private getUserDetails() {
-    this.usersService
-      .search(this.member.displayName)
-      .pipe(
-        map((users: SearchableUser[]) => (this.user = users.length > 0 ? users.find((u) => u.id === this.member.id) : undefined)),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
   }
 
   private disableControlsForUser() {
@@ -215,38 +198,19 @@ export class EditMemberDialogComponent implements OnInit {
 
   submit() {
     if (this.isUpgradeRole() && this.ifPrimaryOwnerPresent()) {
-      this.usersService
-        .search(this.downgradedMember.displayName)
-        .pipe(
-          map((users) => {
-            const ownerId = this.downgradedMember.id;
-            const reference = users.find((u) => u.id === ownerId).reference;
-            const ownerMembership = this.mapGroupMembership(ownerId, reference, RoleName.OWNER);
-            const primaryOwnerMembership = this.mapGroupMembership(this.user.id, this.user.reference, RoleName.PRIMARY_OWNER);
-            this.setGroupAdminRole(primaryOwnerMembership);
-            this.memberships = [ownerMembership, primaryOwnerMembership];
-            this.matDialogRef.close({ memberships: this.memberships });
-          }),
-          takeUntilDestroyed(this.destroyRef),
-        )
-        .subscribe();
+      const ownerMembership = this.mapGroupMembership(this.downgradedMember.id, RoleName.OWNER);
+      const primaryOwnerMembership = this.mapGroupMembership(this.member.id, RoleName.PRIMARY_OWNER);
+      this.setGroupAdminRole(primaryOwnerMembership);
+      this.memberships = [ownerMembership, primaryOwnerMembership];
+      this.matDialogRef.close({ memberships: this.memberships });
     } else if (this.isDowngradeRole()) {
-      const ownerMembership = this.mapGroupMembership(this.user.id, this.user.reference, this.editMemberForm.controls.defaultAPIRole.value);
+      const ownerMembership = this.mapGroupMembership(this.member.id, this.editMemberForm.controls.defaultAPIRole.value);
       this.setGroupAdminRole(ownerMembership);
-      this.usersService
-        .search(this.selectedPrimaryOwner.displayName)
-        .pipe(
-          map((users) => {
-            const reference = users.find((user) => user.id === this.selectedPrimaryOwner.id).reference;
-            const primaryOwnerMembership = this.mapGroupMembership(this.selectedPrimaryOwner.id, reference, RoleName.PRIMARY_OWNER);
-            this.memberships = [ownerMembership, primaryOwnerMembership];
-            this.matDialogRef.close({ memberships: this.memberships });
-          }),
-          takeUntilDestroyed(this.destroyRef),
-        )
-        .subscribe();
+      const primaryOwnerMembership = this.mapGroupMembership(this.selectedPrimaryOwner.id, RoleName.PRIMARY_OWNER);
+      this.memberships = [ownerMembership, primaryOwnerMembership];
+      this.matDialogRef.close({ memberships: this.memberships });
     } else {
-      const groupMembership = this.mapGroupMembership(this.user.id, this.user.reference, this.editMemberForm.controls.defaultAPIRole.value);
+      const groupMembership = this.mapGroupMembership(this.member.id, this.editMemberForm.controls.defaultAPIRole.value);
       this.setGroupAdminRole(groupMembership);
       this.memberships = [groupMembership];
       this.matDialogRef.close({ memberships: this.memberships });
@@ -259,10 +223,9 @@ export class EditMemberDialogComponent implements OnInit {
     }
   }
 
-  mapGroupMembership(id: string, reference: string, defaultAPIRole: string): GroupMembership {
+  mapGroupMembership(id: string, defaultAPIRole: string): GroupMembership {
     return {
       id: id,
-      reference: reference,
       roles: [
         {
           name: defaultAPIRole,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-repository/src/main/java/io/gravitee/rest/api/idp/repository/lookup/RepositoryIdentityLookup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-repository/src/main/java/io/gravitee/rest/api/idp/repository/lookup/RepositoryIdentityLookup.java
@@ -81,7 +81,9 @@ public class RepositoryIdentityLookup implements IdentityLookup {
     @Override
     public Collection<User> search(String query) {
         return userService
-            .search(GraviteeContext.getExecutionContext(), query, new PageableImpl(1, 20))
+            // order by relevance so the most relevant users stay within the bounded 20-result window
+            // (e.g. "jean xo" outranks the many plain "jean" matches), instead of an alphabetical cut
+            .search(GraviteeContext.getExecutionContext(), query, new PageableImpl(1, 20), true)
             .getContent()
             .stream()
             .map(RepositoryUser::new)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
@@ -58,6 +58,8 @@ public interface UserService {
 
     Page<UserEntity> search(ExecutionContext executionContext, String query, Pageable pageable);
 
+    Page<UserEntity> search(ExecutionContext executionContext, String query, Pageable pageable, boolean orderByRelevance);
+
     Page<UserEntity> search(ExecutionContext executionContext, UserCriteria criteria, Pageable pageable);
 
     UserEntity register(ExecutionContext executionContext, NewExternalUserEntity newExternalUserEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -1328,6 +1328,11 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
 
     @Override
     public Page<UserEntity> search(ExecutionContext executionContext, String query, Pageable pageable) {
+        return search(executionContext, query, pageable, false);
+    }
+
+    @Override
+    public Page<UserEntity> search(ExecutionContext executionContext, String query, Pageable pageable, boolean orderByRelevance) {
         LOGGER.debug("search users");
 
         Query<UserEntity> userQuery;
@@ -1341,11 +1346,14 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             // UserDocumentTransformation remove domain from email address for security reasons
             // remove it during search phase to provide results
             String sanitizedQuery = query.indexOf('@') > 0 ? query.substring(0, query.indexOf('@')) : query;
-            userQuery = QueryBuilder.create(UserEntity.class)
-                .setQuery(sanitizedQuery)
-                .setSort(new SortableImpl(UserDocumentTransformer.FIELD_LASTNAME_FIRSTNAME, true))
-                .setPage(pageable)
-                .build();
+            QueryBuilder<UserEntity> userQueryBuilder = QueryBuilder.create(UserEntity.class).setQuery(sanitizedQuery).setPage(pageable);
+            // When ordering by relevance, leave the sort unset so the search engine ranks by score
+            // (best matches first). This keeps the most relevant users inside the bounded result window
+            // on large directories, instead of truncating an alphabetically-sorted set.
+            if (!orderByRelevance) {
+                userQueryBuilder.setSort(new SortableImpl(UserDocumentTransformer.FIELD_LASTNAME_FIRSTNAME, true));
+            }
+            userQuery = userQueryBuilder.build();
         }
         SearchResult results = searchEngineService.search(executionContext, userQuery);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -66,6 +66,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -2577,6 +2578,26 @@ public class UserServiceTest {
         assertNotNull(first.getUpdatedAt());
         assertFalse(first.isPrimaryOwner());
         assertEquals(0, first.getNbActiveTokens());
+    }
+
+    @Test
+    public void shouldSearchUsers_orderByRelevance_leavesSortUnsetWhileDefaultSortsAlphabetically() throws TechnicalException {
+        when(searchEngineService.search(eq(EXECUTION_CONTEXT), any())).thenReturn(
+            new io.gravitee.rest.api.service.impl.search.SearchResult(Collections.emptyList(), 0)
+        );
+
+        userService.search(EXECUTION_CONTEXT, "jean", new io.gravitee.rest.api.model.common.PageableImpl(1, 20), true);
+        userService.search(EXECUTION_CONTEXT, "jean", new io.gravitee.rest.api.model.common.PageableImpl(1, 20));
+
+        ArgumentCaptor<io.gravitee.rest.api.service.search.query.Query> queryCaptor = ArgumentCaptor.forClass(
+            io.gravitee.rest.api.service.search.query.Query.class
+        );
+        verify(searchEngineService, times(2)).search(eq(EXECUTION_CONTEXT), queryCaptor.capture());
+
+        // Relevance mode must leave the sort unset so the search engine ranks by score.
+        assertNull(queryCaptor.getAllValues().get(0).getSort());
+        // Default mode keeps the alphabetical (lastname/firstname) sort.
+        assertNotNull(queryCaptor.getAllValues().get(1).getSort());
     }
 
     @Test


### PR DESCRIPTION
Backport of #18314 to `4.10.x`.

## Problem

Editing a group member (e.g. toggling **Group Admin**) re-resolved the member through `GET /search/users?q=<displayName>`, then read `.id`/`.reference` off the matching result.

In large directories (LDAP), the bounded search (~20 results) may not contain the member, so the resolved user stays `undefined` and **Save** throws `TypeError: Cannot read properties of undefined (reading 'id')` client-side — no request is sent and the dialog stays silently open.

Closes gravitee-io/issues#11544

## Fix

A group member is already registered in Gravitee, so `member.id` is authoritative; the backend (`MembershipServiceImpl.findUserFromMembershipMember`) resolves by `id` and only falls back to `reference` when `id` is absent. The directory search is therefore unnecessary here — and fragile.

- Drop the `/search/users` lookup on edit and on both primary-owner transfer branches (upgrade demotes the existing PO, downgrade promotes the chosen successor); build each membership from the member id directly.
- Remove the now-unused `UsersService` / `SearchableUser` / `DestroyRef` dependencies; `submit()` becomes synchronous.

No on-screen user detail depended on the search — the only displayed field (`displayName`) comes from the `member` input.

> The `4.10.x` component predates the API_PRODUCT scope and the `forkJoin` transfer machinery on `master`, so this is an adaptation of #18314 rather than a clean cherry-pick.

## Tests

Replaced the minimal smoke test with a regression suite for #11544: with `UsersService` intentionally not provided (proving the component no longer needs it), saving Group Admin, the upgrade demotion+promotion, and the downgrade successor promotion all succeed and resolve participants by id. 7/7 tests pass.