### PR TITLE
feat(rest-api): add email.branded_senders config list and BrandedSenderConfig DTO (APIM-14179, APIM-14180)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -387,6 +387,7 @@ public enum Key {
     EMAIL_PROTOCOL("email.protocol", "smtp", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM)), true),
     EMAIL_SUBJECT("email.subject", "[Gravitee.io] %s", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM)), true),
     EMAIL_FROM("email.from", "noreply@my.domain", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM)), true),
+    EMAIL_BRANDED_SENDERS("email.branded_senders", "[]", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM)), true),
     EMAIL_PROPERTIES_AUTH_ENABLED("email.properties.auth", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM)), true),
     EMAIL_PROPERTIES_STARTTLS_ENABLE(
         "email.properties.starttls.enable",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenderConfig.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenderConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.settings;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A single branded-sender configuration: the {@code from} address and {@code subject} prefix to
+ * apply when an outbound notification email targets one of {@code domains}.
+ *
+ * <p>Persisted as part of a JSON-serialised list under the {@code email.branded_senders} parameter
+ * (see {@link Email#getBrandedSenders()}).</p>
+ *
+ * @author GraviteeSource Team
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BrandedSenderConfig {
+
+    /** Recipient domains (e.g. {@code "graviteecustomer.com"}) this configuration applies to. */
+    private List<String> domains;
+
+    /** Branded {@code From} address used for emails sent to a matching recipient domain. */
+    private String from;
+
+    /** Subject prefix wrapper (e.g. {@code "[Gravitee Customer] %s"}) applied to matching emails. */
+    private String subject;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenders.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenders.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.settings;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.rest.api.model.parameters.Key;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.CustomLog;
+
+/**
+ * Serialises / deserialises the branded-sender configuration list to and from the single
+ * {@code email.branded_senders} parameter value, keeping the storage-format concerns out of the
+ * {@link Email} settings model so that it stays a plain data holder.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+final class BrandedSenders {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Maximum length of the serialised {@code email.branded_senders} JSON value. Mirrors the JDBC
+     * {@code parameters.value} column (nvarchar(4000)); a longer value would be truncated on save.
+     */
+    static final int MAX_SERIALIZED_LENGTH = 4000;
+
+    private BrandedSenders() {}
+
+    /**
+     * Deserialises the stored value. Never {@code null}: a malformed value (e.g. a hand-edited DB row
+     * or a partial migration) is logged and treated as an empty list, so a corrupt parameter cannot
+     * break the whole settings response. Invalid input is rejected loudly on the write path instead
+     * (see {@link #write(List)}).
+     */
+    static List<BrandedSenderConfig> parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return new ArrayList<>();
+        }
+        try {
+            var parsed = MAPPER.readValue(raw, new TypeReference<List<BrandedSenderConfig>>() {});
+            // A stored JSON literal `null` deserialises to a Java null; coerce to empty to honour the
+            // never-null contract.
+            return parsed != null ? parsed : new ArrayList<>();
+        } catch (JsonProcessingException e) {
+            log.error("Ignoring malformed '{}' configuration [{}]; returning an empty list", Key.EMAIL_BRANDED_SENDERS.key(), raw, e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Serialises the configurations into the parameter value, guarding against exceeding
+     * {@link #MAX_SERIALIZED_LENGTH}, the storage column limit.
+     *
+     * <p>Any {@code ';'} in the serialised JSON is replaced with its JSON unicode escape so the stored
+     * value contains no literal {@code ';'}. The value is persisted as a single {@code ParameterService}
+     * parameter whose read path splits on {@code ';'} (the parameter separator) and keeps only the first
+     * fragment; since JSON structure never uses {@code ';'} (only {@code , : &#123; &#125; [ ] "}), every
+     * {@code ';'} here is inside a free-text {@code from} / {@code subject}. Jackson decodes the escape
+     * back to {@code ';'} transparently on read.</p>
+     */
+    static String write(List<BrandedSenderConfig> configs) {
+        final List<BrandedSenderConfig> value = configs == null ? new ArrayList<>() : configs;
+        value.forEach(BrandedSenders::validateEntry);
+        try {
+            final String json = MAPPER.writeValueAsString(value).replace(";", "\\u003b");
+            if (json.length() > MAX_SERIALIZED_LENGTH) {
+                throw new IllegalArgumentException(
+                    "'" +
+                        Key.EMAIL_BRANDED_SENDERS.key() +
+                        "' configuration exceeds the maximum supported size of " +
+                        MAX_SERIALIZED_LENGTH +
+                        " characters"
+                );
+            }
+            return json;
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Unable to serialise '" + Key.EMAIL_BRANDED_SENDERS.key() + "' configuration", e);
+        }
+    }
+
+    /**
+     * Validates a single configuration entry before serialisation. Rejects a {@code null} entry (which
+     * would otherwise persist as a JSON {@code null} and surface as a null element on read), and rejects
+     * CR/LF in any header-bound field as defence-in-depth against email header injection (OWASP A05):
+     * {@code from} and {@code subject} flow into email headers downstream, where a line break could
+     * smuggle additional headers. Domains are checked too; none of these fields legitimately contains a
+     * line break.
+     */
+    private static void validateEntry(BrandedSenderConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("'" + Key.EMAIL_BRANDED_SENDERS.key() + "' must not contain null entries");
+        }
+        rejectLineBreak("from", config.getFrom());
+        rejectLineBreak("subject", config.getSubject());
+        if (config.getDomains() != null) {
+            config.getDomains().forEach(domain -> rejectLineBreak("domain", domain));
+        }
+    }
+
+    private static void rejectLineBreak(String field, String value) {
+        if (value != null && (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0)) {
+            throw new IllegalArgumentException("'" + Key.EMAIL_BRANDED_SENDERS.key() + "' " + field + " must not contain line breaks");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Email.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Email.java
@@ -15,9 +15,12 @@
  */
 package io.gravitee.rest.api.model.settings;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.rest.api.model.annotations.ParameterKey;
 import io.gravitee.rest.api.model.parameters.Key;
+import java.util.List;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -49,6 +52,16 @@ public class Email {
 
     @ParameterKey(Key.EMAIL_FROM)
     private String from;
+
+    /**
+     * Raw JSON storage for the branded-sender configurations, persisted via {@link ParameterKey}
+     * under {@code email.branded_senders}. Exposed to the API as the typed {@code brandedSenders}
+     * list (see {@link #getBrandedSenders()}); this raw form is internal and kept out of the JSON
+     * surface.
+     */
+    @ParameterKey(Key.EMAIL_BRANDED_SENDERS)
+    @JsonIgnore
+    private String brandedSendersRaw = "[]";
 
     private EmailProperties properties;
 
@@ -118,6 +131,36 @@ public class Email {
 
     public void setFrom(String from) {
         this.from = from;
+    }
+
+    @JsonIgnore
+    public String getBrandedSendersRaw() {
+        return brandedSendersRaw;
+    }
+
+    @JsonIgnore
+    public void setBrandedSendersRaw(String brandedSendersRaw) {
+        this.brandedSendersRaw = brandedSendersRaw;
+    }
+
+    /**
+     * Returns the branded-sender configurations deserialised from the {@code email.branded_senders}
+     * parameter. Each entry maps a set of recipient domains to a {@code From} address and subject
+     * prefix (see {@link BrandedSenderConfig}). Never {@code null}; malformed stored values degrade to
+     * an empty list (see {@link BrandedSenders#parse(String)}).
+     */
+    @JsonProperty("brandedSenders")
+    public List<BrandedSenderConfig> getBrandedSenders() {
+        return BrandedSenders.parse(brandedSendersRaw);
+    }
+
+    /**
+     * Serialises the branded-sender configurations into the {@code email.branded_senders} parameter
+     * value; invalid or oversized input is rejected (see {@link BrandedSenders#write(List)}).
+     */
+    @JsonProperty("brandedSenders")
+    public void setBrandedSenders(List<BrandedSenderConfig> brandedSenders) {
+        this.brandedSendersRaw = BrandedSenders.write(brandedSenders);
     }
 
     public EmailProperties getProperties() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/EmailBrandedSendersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/EmailBrandedSendersTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the JSON serialise / deserialise seam between the typed {@code brandedSenders} list and
+ * the raw {@code email.branded_senders} parameter value.
+ *
+ * @author GraviteeSource Team
+ */
+class EmailBrandedSendersTest {
+
+    @Test
+    void should_default_to_empty_list() {
+        assertThat(new Email().getBrandedSenders()).isEmpty();
+    }
+
+    @Test
+    void should_round_trip_single_configuration() {
+        var email = new Email();
+        var config = BrandedSenderConfig.builder()
+            .domains(List.of("graviteecustomer.com"))
+            .from("noreply.integration@graviteecustomer.com")
+            .subject("[Gravitee Customer] %s")
+            .build();
+
+        email.setBrandedSenders(List.of(config));
+
+        assertThat(email.getBrandedSenders()).containsExactly(config);
+    }
+
+    @Test
+    void should_round_trip_multiple_configurations() {
+        var email = new Email();
+        var customer = BrandedSenderConfig.builder()
+            .domains(List.of("graviteecustomer.com"))
+            .from("noreply@graviteecustomer.com")
+            .subject("[Gravitee Customer] %s")
+            .build();
+        var partner = BrandedSenderConfig.builder()
+            .domains(List.of("graviteepartner.com", "graviteepartner.co.uk"))
+            .from("noreply@graviteepartner.com")
+            .subject("[Gravitee Partner] %s")
+            .build();
+
+        email.setBrandedSenders(List.of(customer, partner));
+
+        assertThat(email.getBrandedSenders()).containsExactly(customer, partner);
+    }
+
+    @Test
+    void should_return_empty_list_when_set_with_null() {
+        var email = new Email();
+        email.setBrandedSenders(null);
+        assertThat(email.getBrandedSenders()).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_list_when_stored_value_is_json_null() {
+        var email = new Email();
+        email.setBrandedSendersRaw("null");
+        assertThat(email.getBrandedSenders()).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_list_when_raw_value_is_blank() {
+        var email = new Email();
+        email.setBrandedSendersRaw("   ");
+        assertThat(email.getBrandedSenders()).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_list_when_stored_json_is_malformed() {
+        var email = new Email();
+        email.setBrandedSendersRaw("not-json");
+
+        // A corrupt stored value (hand-edited row, partial migration) must not break the settings
+        // response — read degrades to an empty list rather than throwing.
+        assertThat(email.getBrandedSenders()).isEmpty();
+    }
+
+    @Test
+    void should_survive_parameter_service_semicolon_split_when_value_contains_semicolon() {
+        var email = new Email();
+        var config = BrandedSenderConfig.builder()
+            .domains(List.of("graviteecustomer.com"))
+            .from("noreply@graviteecustomer.com")
+            .subject("[Gravitee]; verify %s") // free-text semicolon
+            .build();
+
+        email.setBrandedSenders(List.of(config));
+
+        // ParameterService persists the value as one string but splits on ';' on read, keeping only the
+        // first fragment. The stored form must therefore contain no literal ';'.
+        var stored = email.getBrandedSendersRaw();
+        assertThat(stored).doesNotContain(";");
+
+        // Simulate ParameterServiceImpl.splitValue + ConfigServiceImpl.getFirstValueOrDefault, then reload.
+        var afterParameterServiceRoundTrip = stored.split(";", -1)[0];
+        assertThat(afterParameterServiceRoundTrip).isEqualTo(stored);
+
+        var reloaded = new Email();
+        reloaded.setBrandedSendersRaw(afterParameterServiceRoundTrip);
+        assertThat(reloaded.getBrandedSenders()).containsExactly(config);
+    }
+
+    @Test
+    void should_throw_when_configuration_exceeds_max_length() {
+        var email = new Email();
+        var oversized = IntStream.range(0, 200)
+            .mapToObj(i ->
+                BrandedSenderConfig.builder()
+                    .domains(List.of("domain" + i + ".example.com"))
+                    .from("noreply@domain" + i + ".example.com")
+                    .subject("[Brand" + i + "] %s")
+                    .build()
+            )
+            .toList();
+
+        assertThatThrownBy(() -> email.setBrandedSenders(oversized))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("maximum supported size");
+    }
+
+    @Test
+    void should_reject_line_breaks_in_from() {
+        var email = new Email();
+        var config = BrandedSenderConfig.builder()
+            .domains(List.of("graviteecustomer.com"))
+            .from("noreply@graviteecustomer.com\r\nBcc: evil@graviteepartner.com")
+            .subject("[Gravitee] %s")
+            .build();
+
+        assertThatThrownBy(() -> email.setBrandedSenders(List.of(config)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("line breaks");
+    }
+
+    @Test
+    void should_reject_line_breaks_in_subject() {
+        var email = new Email();
+        var config = BrandedSenderConfig.builder()
+            .domains(List.of("graviteecustomer.com"))
+            .from("noreply@graviteecustomer.com")
+            .subject("[Gravitee] %s\nInjected-Header: x")
+            .build();
+
+        assertThatThrownBy(() -> email.setBrandedSenders(List.of(config)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("line breaks");
+    }
+
+    @Test
+    void should_reject_line_breaks_in_domain() {
+        var email = new Email();
+        var config = BrandedSenderConfig.builder()
+            .domains(List.of("graviteecustomer.com\r\nevil.com"))
+            .from("noreply@graviteecustomer.com")
+            .subject("[Gravitee] %s")
+            .build();
+
+        assertThatThrownBy(() -> email.setBrandedSenders(List.of(config)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("line breaks");
+    }
+
+    @Test
+    void should_reject_null_entry_in_list() {
+        var email = new Email();
+        var configs = new ArrayList<BrandedSenderConfig>();
+        configs.add(
+            BrandedSenderConfig.builder()
+                .domains(List.of("graviteecustomer.com"))
+                .from("noreply@graviteecustomer.com")
+                .subject("[Gravitee] %s")
+                .build()
+        );
+        configs.add(null);
+
+        assertThatThrownBy(() -> email.setBrandedSenders(configs))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("null entries");
+    }
+}


### PR DESCRIPTION
## What
Backend data-model foundation for the configurable branded "From" / subject feature (epic APIM-14125).

- **APIM-14179** — register `EMAIL_BRANDED_SENDERS` (`email.branded_senders`) in `Key.java`, default `"[]"`, scopes `{ENVIRONMENT, ORGANIZATION, SYSTEM}`.
- **APIM-14180** — `BrandedSenderConfig` DTO (`domains`, `from`, `subject`) + `brandedSenders` on the `Email` settings model.

## How
Option A storage: the list of configs is JSON-serialised into a single `String` parameter, so it rides the existing `ParameterService` cascade / `ConfigService` plumbing (no new repository entity). A `@JsonIgnore` raw field holds the JSON; typed `getBrandedSenders()/setBrandedSenders()` accessors expose it, with a 4000-char guard matching the JDBC `parameters.value` column.

## Tests
7/7 unit tests cover default/empty, single & multi-config round-trip, null, blank, malformed JSON, and the size guard.
