### PR TITLE
chore(deps): bump gravitee-expression-language to 4.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-common-mcp.version>1.2.0</gravitee-common-mcp.version>
         <gravitee-connector-api.version>2.0.0</gravitee-connector-api.version>
         <gravitee-exchange.version>3.0.0</gravitee-exchange.version>
-        <gravitee-expression-language.version>4.3.0</gravitee-expression-language.version>
+        <gravitee-expression-language.version>4.4.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>6.3.0</gravitee-gateway-api.version>
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>


### PR DESCRIPTION
## Issue

[APIM-14528](https://gravitee.atlassian.net/browse/APIM-14528)

## Purpose

Response template bodies substitute EL expressions as raw strings with no automatic JSON escaping, causing silent corruption when substituted values contain `"`, `\`, or control characters. The `gravitee-expression-language` library now ships a `#jsonEscape` helper (mirroring the existing `#xmlEscape`) that template authors can use to guarantee valid JSON output. This PR adopts that library version in APIM.

## Summary of changes

Bumps `gravitee-expression-language` from `4.3.0` to `4.4.0` in `pom.xml`. No gateway or REST API production code changes are required — the new `#jsonEscape` EL function is available to template authors as soon as this dependency version lands.

[APIM-14528]: https://gravitee.atlassian.net/browse/APIM-14528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ