### PR TITLE
fix: preserve gateway distributed sync YAML newline

### DIFF
--- a/helm/templates/gateway/_gateway-distributed-sync-config.tpl
+++ b/helm/templates/gateway/_gateway-distributed-sync-config.tpl
@@ -5,7 +5,7 @@ Redis settings are expected from external gravitee.yml configuration.
 */}}
 {{- define "gateway.distributedSync.graviteeYaml" -}}
 {{- $ds := .Values.gateway.distributedSync -}}
-{{- if and (kindIs "map" $ds) $ds.type -}}
+{{- if and (kindIs "map" $ds) $ds.type }}
     distributed-sync:
       type: {{ $ds.type }}
       {{- if eq $ds.type "redis" }}

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -39,7 +39,7 @@ data:
     {{- end }}
 
     {{- if include "gateway.distributedSync.enabled" . }}
-    {{- include "gateway.distributedSync.graviteeYaml" . }}
+{{ include "gateway.distributedSync.graviteeYaml" . }}
     {{- end }}
     # Gateway HTTP server
     {{- if .Values.gateway.servers }}

--- a/helm/tests/gateway/configmap_hazelcast_cluster_test.yaml
+++ b/helm/tests/gateway/configmap_hazelcast_cluster_test.yaml
@@ -90,12 +90,22 @@ tests:
       gateway:
         cluster:
           type: hazelcast
+          hazelcast:
+            configPath: /opt/graviteeio-gateway/config/hazelcast-ext.xml
         distributedSync:
           type: redis
           redis:
             host: redis-shared
             port: 6379
     asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            config-path: /opt/graviteeio-gateway/config/hazelcast-ext\.xml
+            \s*distributed-sync:
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: "hazelcast-ext\\.xmldistributed-sync"
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14582

## Description

Fixes gateway Helm chart rendering when both `gateway.cluster.type=hazelcast` and `gateway.distributedSync.type=redis` are enabled.

The chart was trimming the newline before the `distributed-sync` block, producing invalid `gravitee.yml` like `config-path: /opt/graviteeio-gateway/config/hazelcast-ext.xmldistributed-sync:`.

This caused the gateway to fail at startup with a SnakeYAML parsing error.

The fix preserves the newline and root-level indentation before `distributed-sync`, and adds a regression test covering this exact rendering issue.

## Additional context

Reproduction values:

    gateway:
      cluster:
        type: hazelcast
        hazelcast:
          configPath: /opt/graviteeio-gateway/config/hazelcast-ext.xml
      distributedSync:
        type: redis
        redis:
          host: redis
          port: 6379

Validation:

    helm unittest -f 'tests/gateway/configmap_*_test.yaml' ./helm

Result: 129/129 gateway ConfigMap tests passing.

