### PR TITLE
fix(rest-api): bump swagger-parser to fix recursive OpenAPI import

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/parser/OAIParser.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/parser/OAIParser.java
@@ -64,10 +64,13 @@ public class OAIParser extends AbstractDescriptorParser<OAIDescriptor> {
             }
         }
 
-        parseResult = parser.readLocation(path, null, options);
-
-        if (tmp != null) {
-            deleteTempFile(tmp);
+        try {
+            parseResult = parser.readLocation(path, null, options);
+        } finally {
+            // Always clean up the temp file, even when the parser throws on an invalid descriptor.
+            if (tmp != null) {
+                deleteTempFile(tmp);
+            }
         }
 
         /* Hack due to swagger v1 converting issue

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/converter/oai/OAIToImportDefinitionConverterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/converter/oai/OAIToImportDefinitionConverterTest.java
@@ -740,6 +740,31 @@ class OAIToImportDefinitionConverterTest {
         }
     }
 
+    @Nested
+    class RecursiveSchemas {
+
+        @Test
+        void should_import_recursive_spec_with_repeated_property_names_without_stackoverflow() throws IOException {
+            // Given
+            var apiInput = toOpenApi("io/gravitee/rest/api/management/service/openapi-recursive-schemas.yml");
+
+            // When
+            var result = OAIToImportDefinitionConverter.INSTANCE.toImportDefinition(apiInput, null);
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(result).isNotNull();
+                softly.assertThat(result.getApiExport()).isNotNull();
+                var flowPaths = ((List<Flow>) result.getApiExport().getFlows()).stream()
+                    .flatMap(flow -> flow.getSelectors().stream())
+                    .filter(HttpSelector.class::isInstance)
+                    .map(selector -> ((HttpSelector) selector).getPath())
+                    .toList();
+                softly.assertThat(flowPaths).contains("/primary", "/secondary");
+            });
+        }
+    }
+
     protected OpenAPI toOpenApi(String file) throws IOException {
         var resource = Resources.getResource(file);
         var content = Resources.toString(resource, Charsets.UTF_8);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/openapi-recursive-schemas.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/openapi-recursive-schemas.yml
@@ -1,0 +1,70 @@
+# Minimal recursive spec: the self-referencing schema "Node" (oneOf -> Node),
+# reached via requestBodies/responses, overflows the parser stack while fully resolving
+# $refs (resolveFully). Some $ref targets are intentionally left dangling and are needed
+# to reproduce the failure. Guards against a regression of
+# https://github.com/swagger-api/swagger-parser/issues/1751
+openapi: 3.0.1
+info:
+  title: Recursive schema repro
+  version: "1.0"
+paths:
+  /secondary:
+    post:
+      responses:
+        "201":
+          $ref: "#/components/responses/CreatedRoot"
+  /primary:
+    post:
+      requestBody:
+        $ref: "#/components/requestBodies/RootInputBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/CreatedRoot"
+components:
+  schemas:
+    NodeOrRef:
+      oneOf:
+        - $ref: "#/components/schemas/Node"
+    Node:
+      oneOf:
+        - $ref: "#/components/schemas/Node"
+    Root:
+      allOf:
+        - type: object
+          properties:
+            child:
+                $ref: "#/components/schemas/AbsentA"
+            element:
+                $ref: "#/components/schemas/Element"
+            attribute:
+                $ref: "#/components/schemas/Notice"
+    Element:
+      allOf:
+        - type: object
+          properties:
+            child:
+                $ref: "#/components/schemas/NodeOrRef"
+    RootInput:
+      allOf:
+        - type: object
+          properties:
+            element:
+                $ref: "#/components/schemas/AbsentB"
+    Notice:
+      allOf:
+        - type: object
+          properties:
+            element:
+                $ref: "#/components/schemas/AbsentC"
+  requestBodies:
+    RootInputBody:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/RootInput"
+  responses:
+    CreatedRoot:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Root"

--- a/pom.xml
+++ b/pom.xml
@@ -146,9 +146,9 @@
         <resilience4j-rxjava3.version>2.3.0</resilience4j-rxjava3.version>
         <!-- !! Transitive dependency !! need to remove when swagger parser will include a version higher than 1.7.15.1 -->
         <rhino.version>1.7.15.1</rhino.version>
-        <swagger-core.version>2.2.29</swagger-core.version>
-        <swagger-jaxrs2.version>2.2.29</swagger-jaxrs2.version>
-        <swagger-parser.version>2.1.25</swagger-parser.version>
+        <swagger-core.version>2.2.52</swagger-core.version>
+        <swagger-jaxrs2.version>2.2.52</swagger-jaxrs2.version>
+        <swagger-parser.version>2.1.45</swagger-parser.version>
         <wiremock.version>3.12.1</wiremock.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <xmlbeans.version>5.3.0</xmlbeans.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13054

## Description

Importing certain valid OpenAPI specs (recursive / self-referencing schemas) crashed with a `StackOverflowError` thrown by swagger-parser in `ResolverFully.resolveSchema`. This was a bug in swagger-parser itself ([#1751](https://github.com/swagger-api/swagger-parser/issues/1751)), now fixed upstream.

- Bump `swagger-parser` 2.1.25 → **2.1.45** (and `swagger-core`/`swagger-jaxrs2` 2.2.29 → **2.2.52**, the aligned versions). The fixed parser detects cycles by object identity and stops instead of recursing infinitely.
- Add a regression test importing a minimal recursive spec. Verified **red on  2.1.25 / green on 2.1.45**.

### Additionnal
A second, independent commit wraps the parse call in `try/finally` so the temp file is always cleaned up (pre-existing leak when the parser throws, it can be dropped).