### PR TITLE
feat(docker): add Chainguard (Wolfi) image variants for APIM components

### DIFF
--- a/.circleci/ci/src/commands/cmd-docker-login.ts
+++ b/.circleci/ci/src/commands/cmd-docker-login.ts
@@ -23,7 +23,12 @@ import { Command } from '@circleci/circleci-config-sdk/dist/src/lib/Components/C
 export class DockerLoginCommand {
   private static commandName = 'cmd-docker-login';
 
-  public static get(dynamicConfig: Config, environment: CircleCIEnvironment, isProd: boolean): ReusableCommand {
+  public static get(
+    dynamicConfig: Config,
+    environment: CircleCIEnvironment,
+    isProd: boolean,
+    commandName: string = DockerLoginCommand.commandName,
+  ): ReusableCommand {
     dynamicConfig.importOrb(orbs.keeper);
 
     const dockerRegistryUsernameSecretUrl = isProd ? config.secrets.dockerhubBotUserName : config.secrets.azureRegistryUsername;
@@ -56,6 +61,6 @@ export class DockerLoginCommand {
         }),
       );
     }
-    return new reusable.ReusableCommand(DockerLoginCommand.commandName, steps, undefined, `Login to ${dockerRegistryName}`);
+    return new reusable.ReusableCommand(commandName, steps, undefined, `Login to ${dockerRegistryName}`);
   }
 }

--- a/.circleci/ci/src/commands/cmd-docker-logout.ts
+++ b/.circleci/ci/src/commands/cmd-docker-logout.ts
@@ -19,7 +19,11 @@ import { CircleCIEnvironment } from '../pipelines';
 
 export class DockerLogoutCommand {
   private static commandName = 'cmd-docker-logout';
-  public static get(environment: CircleCIEnvironment, isProd: boolean): ReusableCommand {
+  public static get(
+    environment: CircleCIEnvironment,
+    isProd: boolean,
+    commandName: string = DockerLogoutCommand.commandName,
+  ): ReusableCommand {
     const dockerRegistryName = isProd ? 'Docker Hub' : 'Azure Container Registry';
     const dockerRegistry = isProd ? '' : ' graviteeio.azurecr.io';
 
@@ -43,6 +47,6 @@ export class DockerLogoutCommand {
         }),
       );
     }
-    return new reusable.ReusableCommand(DockerLogoutCommand.commandName, steps, undefined, name);
+    return new reusable.ReusableCommand(commandName, steps, undefined, name);
   }
 }

--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -173,7 +173,7 @@ const docker = {
   version: 'default',
 };
 
-export type Variant = 'alpine' | 'debian';
+export type Variant = 'alpine' | 'debian' | 'chainguard';
 export const config = {
   aqua,
   artifactoryUrl,

--- a/.circleci/ci/src/jobs/job-build-docker-image.ts
+++ b/.circleci/ci/src/jobs/job-build-docker-image.ts
@@ -167,6 +167,65 @@ export class BuildDockerBackendImageJob {
   }
 }
 
+export class BuildDockerChainguardImageJob {
+  private static jobName = 'job-build-docker-chainguard-image';
+
+  private static customParametersList = new parameters.CustomParametersList([
+    new parameters.CustomParameter('apim-project', 'string', '', 'the name of the project to build'),
+    new parameters.CustomParameter('apim-project-workdir', 'string', '', 'the directory of the project to build'),
+    new parameters.CustomParameter('docker-context', 'string', '', 'the name of context folder for docker build'),
+    new parameters.CustomParameter('docker-image-name', 'string', '', 'the name of the image'),
+  ]);
+
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment, isProd: boolean): reusable.ParameterizedJob {
+    dynamicConfig.importOrb(orbs.keeper);
+
+    const createDockerContextCommand = CreateDockerContextCommand.get();
+    dynamicConfig.addReusableCommand(createDockerContextCommand);
+
+    // Push registry follows isProd (Docker Hub when prod, azurecr otherwise), like
+    // the alpine/debian variants — only the '-chainguard' suffix and Dockerfile differ.
+    const dockerLoginCommand = DockerLoginCommand.get(dynamicConfig, environment, isProd);
+    dynamicConfig.addReusableCommand(dockerLoginCommand);
+    const dockerLogoutCommand = DockerLogoutCommand.get(environment, isProd);
+    dynamicConfig.addReusableCommand(dockerLogoutCommand);
+
+    // The chainguard base image (graviteeio.azurecr.io/*-chainguard) stays private, so
+    // when pushing the component to Docker Hub (isProd) we also need an azurecr login to
+    // pull the base. When !isProd the single azurecr login above already covers pull+push.
+    const azurecrPullLoginCommand = DockerLoginCommand.get(dynamicConfig, environment, false, 'cmd-docker-login-azurecr');
+    const azurecrPullLogoutCommand = DockerLogoutCommand.get(environment, false, 'cmd-docker-logout-azurecr');
+    if (isProd) {
+      dynamicConfig.addReusableCommand(azurecrPullLoginCommand);
+      dynamicConfig.addReusableCommand(azurecrPullLogoutCommand);
+    }
+
+    const parsedGraviteeioVersion = parse(environment.graviteeioVersion);
+    const dockerTags: string[] = dockerTagsArgument(environment, parsedGraviteeioVersion, isProd, 'chainguard');
+
+    return new reusable.ParameterizedJob(
+      BuildDockerChainguardImageJob.jobName,
+      BaseExecutor.create(),
+      BuildDockerChainguardImageJob.customParametersList,
+      [
+        new commands.Checkout(),
+        new commands.workspace.Attach({ at: '.' }),
+        new commands.SetupRemoteDocker({ version: config.docker.version }),
+        new reusable.ReusedCommand(createDockerContextCommand),
+        ...(isProd ? [new reusable.ReusedCommand(azurecrPullLoginCommand)] : []),
+        new reusable.ReusedCommand(dockerLoginCommand),
+        new commands.Run({
+          name: 'Build Chainguard docker image for << parameters.apim-project >>',
+          command: `${dockerBuildCommand(environment, dockerTags, isProd, 'chainguard')}`,
+          working_directory: '<< parameters.apim-project-workdir >>',
+        }),
+        new reusable.ReusedCommand(dockerLogoutCommand),
+        ...(isProd ? [new reusable.ReusedCommand(azurecrPullLogoutCommand)] : []),
+      ],
+    );
+  }
+}
+
 function aquaSetupCommands() {
   return [
     new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
@@ -201,7 +260,12 @@ function aquaSetupCommands() {
 function dockerBuildCommand(environment: CircleCIEnvironment, dockerTags: string[], isProd: boolean, variant?: Variant) {
   let command = 'docker buildx build';
 
-  const dockerfile = variant === 'debian' ? 'docker/Dockerfile.debian' : 'docker/Dockerfile';
+  let dockerfile = 'docker/Dockerfile';
+  if (variant === 'debian') {
+    dockerfile = 'docker/Dockerfile.debian';
+  } else if (variant === 'chainguard') {
+    dockerfile = 'docker/Dockerfile.chainguard';
+  }
 
   // Only publish if not dry run or not prod
   if (!isProd || !environment.isDryRun) {
@@ -227,7 +291,12 @@ function dockerTagsArgument(
   variant?: Variant,
 ): string[] {
   const tags: string[] = [];
-  const suffix = variant === 'debian' ? '-debian' : '';
+  let suffix = '';
+  if (variant === 'debian') {
+    suffix = '-debian';
+  } else if (variant === 'chainguard') {
+    suffix = '-chainguard';
+  }
   if (isProd) {
     const stub = `graviteeio/<< parameters.docker-image-name >>:`;
 

--- a/.circleci/ci/src/pipelines/config-factory.ts
+++ b/.circleci/ci/src/pipelines/config-factory.ts
@@ -28,6 +28,7 @@ export function initDynamicConfig(): Config {
     'pull_requests',
     'build_rpm',
     'build_docker_images',
+    'build_chainguard_images',
     'release_notes_apim',
     'bridge_compatibility_tests',
     'publish_docker_images',

--- a/.circleci/ci/src/pipelines/pipeline-build-chainguard-images.ts
+++ b/.circleci/ci/src/pipelines/pipeline-build-chainguard-images.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CircleCIEnvironment } from './circleci-environment';
+import { Config } from '@circleci/circleci-config-sdk';
+import { isBlank, validateGraviteeioVersion } from '../utils';
+import { BuildChainguardImagesWorkflow } from '../workflows';
+import { initDynamicConfig } from './config-factory';
+
+export function generateBuildChainguardImagesConfig(environment: CircleCIEnvironment): Config {
+  validateGraviteeioVersion(environment.graviteeioVersion);
+
+  if (isBlank(environment.branch)) {
+    throw new Error('A branch (CIRCLE_BRANCH) must be specified');
+  }
+
+  const dynamicConfig = initDynamicConfig();
+  const workflow = BuildChainguardImagesWorkflow.create(dynamicConfig, environment);
+  dynamicConfig.addWorkflow(workflow);
+  return dynamicConfig;
+}

--- a/.circleci/ci/src/pipelines/pipeline.ts
+++ b/.circleci/ci/src/pipelines/pipeline.ts
@@ -25,6 +25,7 @@ import { generateReleaseHelmConfig } from './pipeline-release-helm';
 import { generateReleaseConfig } from './pipeline-release';
 import { generateBuildRpmConfig } from './pipeline-build-rpm';
 import { generateBuildDockerImagesConfig } from './pipeline-build-docker-images';
+import { generateBuildChainguardImagesConfig } from './pipeline-build-chainguard-images';
 import { generatePullRequestsConfig } from './pipeline-pull-requests';
 import { generateFullReleaseConfig } from './pipeline-full-release';
 import { generateHelmTestsConfig } from './pipeline-helm-tests';
@@ -39,6 +40,8 @@ export function buildCIPipeline(environment: CircleCIEnvironment): Config | null
       return generateBuildRpmConfig(environment);
     case 'build_docker_images':
       return generateBuildDockerImagesConfig(environment);
+    case 'build_chainguard_images':
+      return generateBuildChainguardImagesConfig(environment);
     case 'release_helm':
       return generateReleaseHelmConfig(environment);
     case 'full_release':

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
@@ -148,6 +148,24 @@ commands:
           name: No logout from Docker Hub - Dry-Run
           command: echo "DRY RUN Mode. Build only"
     description: No logout from Docker Hub - Dry-Run
+  cmd-docker-login-azurecr:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Azure Container Registry
+          command: echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+    description: Login to Azure Container Registry
+  cmd-docker-logout-azurecr:
+    steps:
+      - run:
+          name: Logout from Azure Container Registry
+          command: docker logout graviteeio.azurecr.io
+    description: Logout from Azure Container Registry
 jobs:
   job-setup:
     docker:
@@ -411,6 +429,45 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
+      - cmd-docker-logout-azurecr
 workflows:
   build-docker-images:
     jobs:
@@ -486,6 +543,46 @@ workflows:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0-alpha.1 - Dry Run
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image for APIM 4.2.0-alpha.1
           requires:
             - Backend build
           apim-project: gravitee-apim-gateway

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
@@ -148,6 +148,24 @@ commands:
           name: Logout from Docker Hub
           command: docker logout
     description: Logout from Docker Hub
+  cmd-docker-login-azurecr:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Azure Container Registry
+          command: echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+    description: Login to Azure Container Registry
+  cmd-docker-logout-azurecr:
+    steps:
+      - run:
+          name: Logout from Azure Container Registry
+          command: docker logout graviteeio.azurecr.io
+    description: Logout from Azure Container Registry
 jobs:
   job-setup:
     docker:
@@ -411,6 +429,45 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
+      - cmd-docker-logout-azurecr
 workflows:
   build-docker-images:
     jobs:
@@ -486,6 +543,46 @@ workflows:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image for APIM 4.2.0-alpha.1
           requires:
             - Backend build
           apim-project: gravitee-apim-gateway

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
@@ -148,6 +148,24 @@ commands:
           name: No logout from Docker Hub - Dry-Run
           command: echo "DRY RUN Mode. Build only"
     description: No logout from Docker Hub - Dry-Run
+  cmd-docker-login-azurecr:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Azure Container Registry
+          command: echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+    description: Login to Azure Container Registry
+  cmd-docker-logout-azurecr:
+    steps:
+      - run:
+          name: Logout from Azure Container Registry
+          command: docker logout graviteeio.azurecr.io
+    description: Logout from Azure Container Registry
 jobs:
   job-setup:
     docker:
@@ -411,6 +429,45 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
+      - cmd-docker-logout-azurecr
 workflows:
   build-docker-images:
     jobs:
@@ -486,6 +543,46 @@ workflows:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0 - Dry Run
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image for APIM 4.2.0
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image for APIM 4.2.0
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image for APIM 4.2.0
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image for APIM 4.2.0
           requires:
             - Backend build
           apim-project: gravitee-apim-gateway

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
@@ -148,6 +148,24 @@ commands:
           name: Logout from Docker Hub
           command: docker logout
     description: Logout from Docker Hub
+  cmd-docker-login-azurecr:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Azure Container Registry
+          command: echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+    description: Login to Azure Container Registry
+  cmd-docker-logout-azurecr:
+    steps:
+      - run:
+          name: Logout from Azure Container Registry
+          command: docker logout graviteeio.azurecr.io
+    description: Logout from Azure Container Registry
 jobs:
   job-setup:
     docker:
@@ -411,6 +429,45 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2-chainguard -t graviteeio/<< parameters.docker-image-name >>:4-chainguard -t graviteeio/<< parameters.docker-image-name >>:latest-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
+      - cmd-docker-logout-azurecr
 workflows:
   build-docker-images:
     jobs:
@@ -486,6 +543,46 @@ workflows:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image for APIM 4.2.0
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image for APIM 4.2.0
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image for APIM 4.2.0
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image for APIM 4.2.0
           requires:
             - Backend build
           apim-project: gravitee-apim-gateway

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
@@ -148,6 +148,24 @@ commands:
           name: Logout from Docker Hub
           command: docker logout
     description: Logout from Docker Hub
+  cmd-docker-login-azurecr:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Azure Container Registry
+          command: echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+    description: Login to Azure Container Registry
+  cmd-docker-logout-azurecr:
+    steps:
+      - run:
+          name: Logout from Azure Container Registry
+          command: docker logout graviteeio.azurecr.io
+    description: Logout from Azure Container Registry
 jobs:
   job-setup:
     docker:
@@ -411,6 +429,45 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
+      - cmd-docker-logout-azurecr
 workflows:
   build-docker-images:
     jobs:
@@ -486,6 +543,46 @@ workflows:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image for APIM 4.2.0
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image for APIM 4.2.0
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image for APIM 4.2.0
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image for APIM 4.2.0
           requires:
             - Backend build
           apim-project: gravitee-apim-gateway

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -108,6 +108,24 @@ commands:
           name: Logout from Docker Hub
           command: docker logout
     description: Logout from Docker Hub
+  cmd-docker-login-azurecr:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Azure Container Registry
+          command: echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+    description: Login to Azure Container Registry
+  cmd-docker-logout-azurecr:
+    steps:
+      - run:
+          name: Logout from Azure Container Registry
+          command: docker logout graviteeio.azurecr.io
+    description: Logout from Azure Container Registry
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -429,6 +447,45 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
+      - cmd-docker-logout-azurecr
   job-backend-build-and-publish-on-download-website:
     docker:
       - image: cimg/openjdk:21.0.9-node
@@ -879,6 +936,46 @@ workflows:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image for APIM 4.2.0-alpha.1
           requires:
             - Backend build and publish on download website
           apim-project: gravitee-apim-gateway

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -108,6 +108,24 @@ commands:
           name: No logout from Docker Hub - Dry-Run
           command: echo "DRY RUN Mode. Build only"
     description: No logout from Docker Hub - Dry-Run
+  cmd-docker-login-azurecr:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Azure Container Registry
+          command: echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+    description: Login to Azure Container Registry
+  cmd-docker-logout-azurecr:
+    steps:
+      - run:
+          name: Logout from Azure Container Registry
+          command: docker logout graviteeio.azurecr.io
+    description: Logout from Azure Container Registry
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -429,6 +447,45 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
+      - cmd-docker-logout-azurecr
   job-backend-build-and-publish-on-download-website:
     docker:
       - image: cimg/openjdk:21.0.9-node
@@ -913,6 +970,46 @@ workflows:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0 - Dry Run
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image for APIM 4.2.0
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image for APIM 4.2.0
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image for APIM 4.2.0
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image for APIM 4.2.0
           requires:
             - Backend build and publish on download website
           apim-project: gravitee-apim-gateway

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -108,6 +108,24 @@ commands:
           name: Logout from Docker Hub
           command: docker logout
     description: Logout from Docker Hub
+  cmd-docker-login-azurecr:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Azure Container Registry
+          command: echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+    description: Login to Azure Container Registry
+  cmd-docker-logout-azurecr:
+    steps:
+      - run:
+          name: Logout from Azure Container Registry
+          command: docker logout graviteeio.azurecr.io
+    description: Logout from Azure Container Registry
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -429,6 +447,45 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2-chainguard -t graviteeio/<< parameters.docker-image-name >>:4-chainguard -t graviteeio/<< parameters.docker-image-name >>:latest-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
+      - cmd-docker-logout-azurecr
   job-backend-build-and-publish-on-download-website:
     docker:
       - image: cimg/openjdk:21.0.9-node
@@ -925,6 +982,46 @@ workflows:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image for APIM 4.2.0
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image for APIM 4.2.0
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image for APIM 4.2.0
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image for APIM 4.2.0
           requires:
             - Backend build and publish on download website
           apim-project: gravitee-apim-gateway

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -108,6 +108,24 @@ commands:
           name: Logout from Docker Hub
           command: docker logout
     description: Logout from Docker Hub
+  cmd-docker-login-azurecr:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Azure Container Registry
+          command: echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+    description: Login to Azure Container Registry
+  cmd-docker-logout-azurecr:
+    steps:
+      - run:
+          name: Logout from Azure Container Registry
+          command: docker logout graviteeio.azurecr.io
+    description: Logout from Azure Container Registry
   cmd-restore-maven-job-cache:
     parameters:
       jobName:
@@ -429,6 +447,45 @@ jobs:
           docker_image_to_scan: graviteeio/<< parameters.docker-image-name >>:4.2.0-debian
           scanner_url: https://82fb8f75da.cloud.aquasec.com
       - cmd-docker-logout
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
+      - cmd-docker-logout-azurecr
   job-backend-build-and-publish-on-download-website:
     docker:
       - image: cimg/openjdk:21.0.9-node
@@ -925,6 +982,46 @@ workflows:
           context:
             - cicd-orchestrator
           name: Build APIM Gateway docker image for APIM 4.2.0
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image for APIM 4.2.0
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image for APIM 4.2.0
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image for APIM 4.2.0
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image for APIM 4.2.0
           requires:
             - Backend build and publish on download website
           apim-project: gravitee-apim-gateway

--- a/.circleci/ci/src/workflows/index.ts
+++ b/.circleci/ci/src/workflows/index.ts
@@ -16,6 +16,7 @@
 export * from './workflow-bridge-compatibility-tests';
 export * from './workflow-build-rpm';
 export * from './workflow-build-docker-images';
+export * from './workflow-build-chainguard-images';
 export * from './workflow-full-release';
 export * from './workflow-repositories-tests';
 export * from './workflow-package-bundle';

--- a/.circleci/ci/src/workflows/workflow-build-chainguard-images.ts
+++ b/.circleci/ci/src/workflows/workflow-build-chainguard-images.ts
@@ -17,17 +17,14 @@ import { Config, Workflow, workflow } from '@circleci/circleci-config-sdk';
 import { CircleCIEnvironment } from '../pipelines';
 import {
   BackendBuildAndPublishOnDownloadWebsiteJob,
-  BuildDockerBackendImageJob,
   BuildDockerChainguardImageJob,
-  BuildDockerWebUiImageJob,
   ConsoleWebuiBuildJob,
-  GammaWebuiBuildJob,
   PortalWebuiBuildJob,
   SetupJob,
 } from '../jobs';
 import { config } from '../config';
 
-export class BuildDockerImagesWorkflow {
+export class BuildChainguardImagesWorkflow {
   static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
     const setupJob = SetupJob.create(dynamicConfig);
     dynamicConfig.addJob(setupJob);
@@ -35,15 +32,10 @@ export class BuildDockerImagesWorkflow {
     dynamicConfig.addJob(consoleWebuiBuildJob);
     const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(portalWebuiBuildJob);
-    const gammaWebuiBuildJob = GammaWebuiBuildJob.create(dynamicConfig, environment);
-    dynamicConfig.addJob(gammaWebuiBuildJob);
     const backendBuildJob = BackendBuildAndPublishOnDownloadWebsiteJob.create(dynamicConfig, environment, false);
     dynamicConfig.addJob(backendBuildJob);
-    const buildDockerWebUiImageJob = BuildDockerWebUiImageJob.create(dynamicConfig, environment, true);
-    dynamicConfig.addJob(buildDockerWebUiImageJob);
-    const buildDockerBackendImageJob = BuildDockerBackendImageJob.create(dynamicConfig, environment, true);
-    dynamicConfig.addJob(buildDockerBackendImageJob);
-    const buildDockerChainguardImageJob = BuildDockerChainguardImageJob.create(dynamicConfig, environment, true);
+    // isProd=false → azurecr with branch tags: this on-demand action is the test build.
+    const buildDockerChainguardImageJob = BuildDockerChainguardImageJob.create(dynamicConfig, environment, false);
     dynamicConfig.addJob(buildDockerChainguardImageJob);
 
     const jobs = [
@@ -54,9 +46,9 @@ export class BuildDockerImagesWorkflow {
         name: 'Build APIM Portal',
         requires: ['Setup'],
       }),
-      new workflow.WorkflowJob(buildDockerWebUiImageJob, {
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
         context: config.jobContext,
-        name: `Build APIM Portal docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
+        name: `Build APIM Portal chainguard docker image for APIM ${environment.graviteeioVersion}`,
         requires: ['Build APIM Portal'],
         'apim-project': config.components.portal.project,
         'apim-project-workdir': config.components.portal.workdir,
@@ -70,67 +62,6 @@ export class BuildDockerImagesWorkflow {
         name: 'Build APIM Console',
         requires: ['Setup'],
       }),
-      new workflow.WorkflowJob(buildDockerWebUiImageJob, {
-        context: config.jobContext,
-        name: `Build APIM Console docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
-        requires: ['Build APIM Console'],
-        'apim-project': config.components.console.project,
-        'apim-project-workdir': config.components.console.workdir,
-        'docker-context': '.',
-        'docker-image-name': config.components.console.image,
-      }),
-
-      // Gamma Console
-      new workflow.WorkflowJob(gammaWebuiBuildJob, {
-        context: config.jobContext,
-        name: 'Build Gamma Console',
-        requires: ['Setup'],
-      }),
-      new workflow.WorkflowJob(buildDockerWebUiImageJob, {
-        context: config.jobContext,
-        name: `Build Gamma Console docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
-        requires: ['Build Gamma Console'],
-        'apim-project': config.components.gamma.project,
-        'apim-project-workdir': config.components.gamma.workdir,
-        'docker-context': '.',
-        'docker-image-name': config.components.gamma.image,
-      }),
-
-      // APIM Backend
-      new workflow.WorkflowJob(backendBuildJob, {
-        context: config.jobContext,
-        name: 'Backend build',
-        requires: ['Setup'],
-      }),
-      new workflow.WorkflowJob(buildDockerBackendImageJob, {
-        context: config.jobContext,
-        name: `Build APIM Management API docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
-        requires: ['Backend build'],
-        'apim-project': config.components.managementApi.project,
-        'apim-project-workdir': config.components.managementApi.workdir,
-        'docker-context': 'gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target',
-        'docker-image-name': config.components.managementApi.image,
-      }),
-      new workflow.WorkflowJob(buildDockerBackendImageJob, {
-        context: config.jobContext,
-        name: `Build APIM Gateway docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
-        requires: ['Backend build'],
-        'apim-project': config.components.gateway.project,
-        'apim-project-workdir': config.components.gateway.workdir,
-        'docker-context': 'gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target',
-        'docker-image-name': config.components.gateway.image,
-      }),
-
-      // Chainguard component images (Docker Hub, <version>-chainguard)
-      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
-        context: config.jobContext,
-        name: `Build APIM Portal chainguard docker image for APIM ${environment.graviteeioVersion}`,
-        requires: ['Build APIM Portal'],
-        'apim-project': config.components.portal.project,
-        'apim-project-workdir': config.components.portal.workdir,
-        'docker-context': '.',
-        'docker-image-name': config.components.portal.image,
-      }),
       new workflow.WorkflowJob(buildDockerChainguardImageJob, {
         context: config.jobContext,
         name: `Build APIM Console chainguard docker image for APIM ${environment.graviteeioVersion}`,
@@ -139,6 +70,13 @@ export class BuildDockerImagesWorkflow {
         'apim-project-workdir': config.components.console.workdir,
         'docker-context': '.',
         'docker-image-name': config.components.console.image,
+      }),
+
+      // APIM Backend
+      new workflow.WorkflowJob(backendBuildJob, {
+        context: config.jobContext,
+        name: 'Backend build',
+        requires: ['Setup'],
       }),
       new workflow.WorkflowJob(buildDockerChainguardImageJob, {
         context: config.jobContext,
@@ -160,6 +98,6 @@ export class BuildDockerImagesWorkflow {
       }),
     ];
 
-    return new Workflow('build-docker-images', jobs);
+    return new Workflow('build-chainguard-images', jobs);
   }
 }

--- a/.circleci/ci/src/workflows/workflow-full-release.ts
+++ b/.circleci/ci/src/workflows/workflow-full-release.ts
@@ -17,6 +17,7 @@ import { Config, workflow, Workflow } from '@circleci/circleci-config-sdk';
 import {
   BackendBuildAndPublishOnDownloadWebsiteJob,
   BuildDockerBackendImageJob,
+  BuildDockerChainguardImageJob,
   BuildDockerWebUiImageJob,
   ConsoleWebuiBuildJob,
   GammaWebuiBuildJob,
@@ -58,6 +59,11 @@ export class FullReleaseWorkflow {
     dynamicConfig.addJob(buildDockerWebUiImageJob);
     const buildDockerBackendImageJob = BuildDockerBackendImageJob.create(dynamicConfig, environment, true);
     dynamicConfig.addJob(buildDockerBackendImageJob);
+
+    // Chainguard component images: published to Docker Hub (<version>-chainguard) like the
+    // alpine/debian variants; the private azurecr base is pulled via a second login.
+    const buildDockerChainguardImageJob = BuildDockerChainguardImageJob.create(dynamicConfig, environment, true);
+    dynamicConfig.addJob(buildDockerChainguardImageJob);
 
     const backendBuildAndPublishOnDownloadWebsiteJob = BackendBuildAndPublishOnDownloadWebsiteJob.create(dynamicConfig, environment, true);
     dynamicConfig.addJob(backendBuildAndPublishOnDownloadWebsiteJob);
@@ -161,6 +167,44 @@ export class FullReleaseWorkflow {
       new workflow.WorkflowJob(buildDockerBackendImageJob, {
         context: config.jobContext,
         name: `Build APIM Gateway docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
+        requires: ['Backend build and publish on download website'],
+        'apim-project': config.components.gateway.project,
+        'apim-project-workdir': config.components.gateway.workdir,
+        'docker-context': 'gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target',
+        'docker-image-name': config.components.gateway.image,
+      }),
+
+      // Chainguard component images (Docker Hub, <version>-chainguard)
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Portal chainguard docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build APIM Portal'],
+        'apim-project': config.components.portal.project,
+        'apim-project-workdir': config.components.portal.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.portal.image,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Console chainguard docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build APIM Console'],
+        'apim-project': config.components.console.project,
+        'apim-project-workdir': config.components.console.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.console.image,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Management API chainguard docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Backend build and publish on download website'],
+        'apim-project': config.components.managementApi.project,
+        'apim-project-workdir': config.components.managementApi.workdir,
+        'docker-context': 'gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target',
+        'docker-image-name': config.components.managementApi.image,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Gateway chainguard docker image for APIM ${environment.graviteeioVersion}`,
         requires: ['Backend build and publish on download website'],
         'apim-project': config.components.gateway.project,
         'apim-project-workdir': config.components.gateway.workdir,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ parameters:
                 pull_requests,
                 build_rpm,
                 build_docker_images,
+                build_chainguard_images,
                 release_notes_apim,
                 bridge_compatibility_tests,
                 publish_docker_images,

--- a/gravitee-apim-console-webui/docker/Dockerfile.chainguard
+++ b/gravitee-apim-console-webui/docker/Dockerfile.chainguard
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM graviteeio.azurecr.io/nginx:1.30-chainguard
+LABEL maintainer="contact@graviteesource.com"
+
+ENV CONSOLE_BASE_HREF="/"
+ENV MGMT_API_URL="http://localhost:8083/management"
+
+# The chainguard base image runs as the non-root nginx user; elevate to root for
+# the file setup below, then drop back to nginx at the end.
+USER root
+
+COPY ./dist /usr/share/nginx/html/
+
+COPY docker/config/constants.json /usr/share/nginx/html/constants.json
+COPY docker/config/default.conf /etc/nginx/conf.d/default.conf
+COPY docker/config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
+
+RUN chown -R nginx:root /usr/share/nginx /etc/nginx \
+    && chmod -R g=u /usr/share/nginx /etc/nginx
+
+COPY docker/config/check_ip_config.sh /check_ip_config.sh
+
+USER nginx
+CMD ["/bin/sh", "-c", "sh /check_ip_config.sh; sh /run.sh"]

--- a/gravitee-apim-gateway/docker/Dockerfile.chainguard
+++ b/gravitee-apim-gateway/docker/Dockerfile.chainguard
@@ -1,0 +1,41 @@
+#
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# First stage to share environment variable
+FROM graviteeio.azurecr.io/java:21-chainguard AS base
+ENV GRAVITEEIO_HOME=/opt/graviteeio-gateway
+# Wolfi is glibc-based: no libc6-compat and no musl ld-linux symlink needed.
+# jemalloc is installed (as in the alpine/debian variants) so deployments that set
+# LD_PRELOAD=/usr/lib/libjemalloc.so.2 keep the tuned memory allocator.
+USER root
+RUN apk add --no-cache libjemalloc2 \
+    && rm -rf /var/cache/apk/*
+
+# Second stage to add the folder and change the permissions and ownership
+FROM base AS builder
+COPY --chown=graviteeio:graviteeio ./distribution ${GRAVITEEIO_HOME}/
+USER root
+RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
+    chmod -R g=u ${GRAVITEEIO_HOME}
+
+# Third stage to build the final docker image. COPY preserves ownership & permissions
+FROM base
+LABEL maintainer="contact@graviteesource.com"
+COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
+WORKDIR ${GRAVITEEIO_HOME}
+EXPOSE 8082
+USER graviteeio
+ENTRYPOINT ["./bin/gravitee"]

--- a/gravitee-apim-portal-webui/docker/Dockerfile.chainguard
+++ b/gravitee-apim-portal-webui/docker/Dockerfile.chainguard
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM graviteeio.azurecr.io/nginx:1.30-chainguard
+LABEL maintainer="contact@graviteesource.com"
+
+EXPOSE 8080
+
+ENV ALLOWED_FRAME_ANCESTOR_URLS="'self'"
+ENV PORTAL_BASE_HREF="/"
+ENV PORTAL_API_URL="http://localhost:8083/portal"
+ENV DEFAULT_PORTAL="classic"
+
+# The chainguard base image runs as the non-root nginx user; elevate to root for
+# the file setup below, then drop back to nginx at the end.
+USER root
+
+COPY ./dist /usr/share/nginx/html/
+
+COPY docker/config/config.json /usr/share/nginx/html/assets/config.json
+COPY docker/config/config-next.json /usr/share/nginx/html/next/browser/assets/config.json
+COPY docker/config/default.conf /etc/nginx/conf.d/default.conf
+COPY docker/config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
+COPY docker/config/default-next.conf /etc/nginx/conf.d/default-next.conf
+COPY docker/config/default-next.no-ipv6.conf /etc/nginx/conf.d/default-next.no-ipv6.conf
+
+RUN chown -R nginx:root /usr/share/nginx /etc/nginx \
+    && chmod -R g=u /usr/share/nginx /etc/nginx
+
+COPY --chown=nginx:root docker/config/portal-next-run.sh /
+COPY --chown=nginx:root docker/config/check_ip_config.sh /
+
+USER nginx
+CMD ["/bin/sh", "-c", "sh /portal-next-run.sh; sh /check_ip_config.sh; sh /run.sh"]

--- a/gravitee-apim-rest-api/docker/Dockerfile.chainguard
+++ b/gravitee-apim-rest-api/docker/Dockerfile.chainguard
@@ -1,0 +1,35 @@
+#
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# First stage to share environment variable
+FROM graviteeio.azurecr.io/java:21-chainguard AS base
+ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
+
+# Second stage to add the folder and change the permissions and ownership
+FROM base AS builder
+COPY --chown=graviteeio:graviteeio ./distribution ${GRAVITEEIO_HOME}/
+USER root
+RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
+    chmod -R g=u ${GRAVITEEIO_HOME}
+
+# Third stage to build the final docker image. COPY preserves ownership & permissions
+FROM base
+LABEL maintainer="contact@graviteesource.com"
+COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
+WORKDIR ${GRAVITEEIO_HOME}
+EXPOSE 8083
+USER graviteeio
+ENTRYPOINT ["./bin/gravitee"]


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ESM-26

## Description

Adds Chainguard (Wolfi) based Docker image variants for the four APIM components (gateway, rest-api, console, portal). Additive — the existing `alpine` / `debian` / nginx images are left untouched.

Each component gets a `docker/Dockerfile.chainguard` built on the private `graviteeio.azurecr.io` Chainguard base images (`java:21-chainguard`, `nginx:1.30-chainguard`, produced by the companion gravitee-docker PR):

- **Backend** (gateway, rest-api): `FROM graviteeio.azurecr.io/java:21-chainguard`. Drops `jemalloc` / `libc6-compat` and the musl symlink (Wolfi is glibc); uses the shelled `-dev` base so the `bin/gravitee` launcher script runs.
- **Web UIs** (console, portal): `FROM graviteeio.azurecr.io/nginx:1.30-chainguard`. Run as the non-root `nginx` user (uid 65532), re-elevating to root only for the file setup (`chown`).

### CI

New on-demand action `build_chainguard_images` (added to both the static `.circleci/config.yml` and the dynamic `config-factory.ts` `gio_action` enums):

- `BuildDockerChainguardImageJob` builds each component from `docker/Dockerfile.chainguard` and pushes to `graviteeio.azurecr.io/<image>:<branch>-…-chainguard` (multi-arch `linux/amd64,linux/arm64`).
- Authenticates against **Azure CR only** (used for both pulling the base and pushing the component) — nothing is published to public Docker Hub, and no Aqua scan is wired.
- Pipeline + workflow `build-chainguard-images` reuse the existing Setup / Console / Portal / Backend build jobs to produce the `dist` / `distribution` artifacts, then run the four chainguard image jobs.

## Additional context

- Companion base-images PR (gravitee-docker): https://github.com/gravitee-io/gravitee-docker/pull/239 — must be built first so the `graviteeio.azurecr.io/{java,nginx}:*-chainguard` bases exist.
- Trigger end-to-end via the CircleCI API on a 4.12.x+ branch with `gio_action=build_chainguard_images` (and a `graviteeio_version`).
