### PR TITLE
feat(rest-api): validate email.branded_senders and Email.from (APIM-14181)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/AbstractCommonSettingsEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/AbstractCommonSettingsEntity.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.common.util.MultiValueMap;
+import jakarta.validation.Valid;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -28,6 +29,8 @@ import io.gravitee.common.util.MultiValueMap;
 public abstract class AbstractCommonSettingsEntity {
 
     public static final String METADATA_READONLY = "readonly";
+
+    @Valid
     private Email email;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenderConfig.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenderConfig.java
@@ -16,6 +16,12 @@
 package io.gravitee.rest.api.model.settings;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.gravitee.rest.api.validator.NoDuplicates;
+import io.gravitee.rest.api.validator.ValidSenderAddress;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,12 +44,23 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BrandedSenderConfig {
 
+    /**
+     * RFC 1035 host name: dot-separated labels of letters/digits/hyphens (no leading or trailing
+     * hyphen, max 63 chars each), ending in an alphabetic TLD.
+     */
+    private static final String DOMAIN_PATTERN = "^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,}$";
+
     /** Recipient domains (e.g. {@code "graviteecustomer.com"}) this configuration applies to. */
-    private List<String> domains;
+    @NotEmpty
+    @NoDuplicates(ignoreCase = true, message = "must not contain duplicate domains")
+    private List<@NotBlank @Pattern(regexp = DOMAIN_PATTERN, message = "must be a valid domain name") String> domains;
 
     /** Branded {@code From} address used for emails sent to a matching recipient domain. */
+    @NotBlank
+    @ValidSenderAddress
     private String from;
 
     /** Subject prefix wrapper (e.g. {@code "[Gravitee Customer] %s"}) applied to matching emails. */
+    @Size(max = 255, message = "must be at most 255 characters")
     private String subject;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenders.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenders.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.rest.api.model.parameters.Key;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import lombok.CustomLog;
 
 /**
@@ -78,6 +79,7 @@ final class BrandedSenders {
     static String write(List<BrandedSenderConfig> configs) {
         final List<BrandedSenderConfig> value = configs == null ? new ArrayList<>() : configs;
         value.forEach(BrandedSenders::validateEntry);
+        value.forEach(BrandedSenders::normalizeDomains);
         try {
             final String json = MAPPER.writeValueAsString(value).replace(";", "\\u003b");
             if (json.length() > MAX_SERIALIZED_LENGTH) {
@@ -118,5 +120,25 @@ final class BrandedSenders {
         if (value != null && (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0)) {
             throw new IllegalArgumentException("'" + Key.EMAIL_BRANDED_SENDERS.key() + "' " + field + " must not contain line breaks");
         }
+    }
+
+    /**
+     * Canonicalises domains for storage: trims surrounding whitespace and lower-cases each entry
+     * (RFC 1035 host names are case-insensitive), so send-time matching can compare directly. Null
+     * entries are kept (not silently dropped) so the {@code @NotBlank} domain constraint rejects them
+     * loudly, the same way a blank entry is handled.
+     */
+    private static void normalizeDomains(BrandedSenderConfig config) {
+        if (config.getDomains() == null) {
+            return;
+        }
+        config.setDomains(config.getDomains().stream().map(BrandedSenders::normalizeDomain).toList());
+    }
+
+    private static String normalizeDomain(String domain) {
+        if (domain == null) {
+            return null;
+        }
+        return domain.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Email.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Email.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.rest.api.model.annotations.ParameterKey;
 import io.gravitee.rest.api.model.parameters.Key;
+import jakarta.validation.Valid;
 import java.util.List;
 
 /**
@@ -149,6 +150,7 @@ public class Email {
      * prefix (see {@link BrandedSenderConfig}). Never {@code null}; malformed stored values degrade to
      * an empty list (see {@link BrandedSenders#parse(String)}).
      */
+    @Valid
     @JsonProperty("brandedSenders")
     public List<BrandedSenderConfig> getBrandedSenders() {
         return BrandedSenders.parse(brandedSendersRaw);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/NoDuplicates.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/NoDuplicates.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.validator;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Validates that a {@code List<String>} contains no duplicate entries. A {@code null} list is
+ * considered valid, and {@code null} elements are ignored. Entries are compared after trimming
+ * surrounding whitespace; with {@link #ignoreCase()} enabled they are additionally compared
+ * case-insensitively (so {@code "Acme.com"} and {@code " acme.com "} count as duplicates).
+ *
+ * @author GraviteeSource Team
+ */
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RUNTIME)
+@Constraint(validatedBy = { NoDuplicatesValidator.class })
+@Documented
+public @interface NoDuplicates {
+    String message() default "must not contain duplicates";
+
+    boolean ignoreCase() default false;
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/NoDuplicatesValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/NoDuplicatesValidator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class NoDuplicatesValidator implements ConstraintValidator<NoDuplicates, List<String>> {
+
+    private boolean ignoreCase;
+
+    @Override
+    public void initialize(NoDuplicates constraint) {
+        this.ignoreCase = constraint.ignoreCase();
+    }
+
+    @Override
+    public boolean isValid(List<String> values, ConstraintValidatorContext context) {
+        if (values == null) {
+            return true;
+        }
+        final Set<String> seen = new HashSet<>();
+        for (final String value : values) {
+            if (value == null) {
+                continue;
+            }
+            final String trimmed = value.trim();
+            final String key;
+            if (ignoreCase) {
+                key = trimmed.toLowerCase(Locale.ROOT);
+            } else {
+                key = trimmed;
+            }
+            if (!seen.add(key)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/SenderAddressValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/SenderAddressValidator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class SenderAddressValidator implements ConstraintValidator<ValidSenderAddress, String> {
+
+    /**
+     * Pragmatic {@code local@domain.tld} check for a branded sender address. The domain is matched as
+     * RFC 1035 labels (each starts and ends alphanumeric, no empty or leading-dot labels, no consecutive
+     * dots) with a bounded label length. The label group is matched with a possessive quantifier
+     * ({@code ++}) so the engine runs iteratively — it can't backtrack super-linearly or recurse into a
+     * stack overflow on a large input — and it rejects shapes like {@code a..b.com} / {@code .a.com}.
+     */
+    private static final Pattern EMAIL = Pattern.compile(
+        "^[A-Za-z0-9._%+-]+@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)++[A-Za-z]{2,}$"
+    );
+
+    /** Optional {@code Display Name <addr>} wrapper; captures the angle-bracketed address. */
+    private static final Pattern PERSONAL_NAME = Pattern.compile("^.*<\\s*([^<>]+?)\\s*>$");
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isBlank()) {
+            return true;
+        }
+        final String trimmed = value.trim();
+        final Matcher personalName = PERSONAL_NAME.matcher(trimmed);
+        final String address;
+        if (personalName.matches()) {
+            address = personalName.group(1).trim();
+        } else {
+            address = trimmed;
+        }
+        return EMAIL.matcher(address).matches();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/ValidSenderAddress.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/ValidSenderAddress.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.validator;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Validates an email sender address. Accepts either a bare address ({@code user@example.com}) or the
+ * RFC&nbsp;822 personal-name form ({@code Name <user@example.com>}) that the SMTP send-path supports.
+ * A {@code null} or blank value is considered valid — combine with {@code @NotBlank} where a value is
+ * required.
+ *
+ * @author GraviteeSource Team
+ */
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RUNTIME)
+@Constraint(validatedBy = { SenderAddressValidator.class })
+@Documented
+public @interface ValidSenderAddress {
+    String message() default "must be a valid email address, optionally with a display name (e.g. \"Name <user@example.com>\")";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/BrandedSenderValidationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/BrandedSenderValidationTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Bean-validation coverage for the branded-sender constraints, including the {@code @Valid} cascade
+ * that enforces them end-to-end through the settings save graph
+ * ({@code settings entity -> email -> branded senders}).
+ *
+ * @author GraviteeSource Team
+ */
+class BrandedSenderValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    private static BrandedSenderConfig.BrandedSenderConfigBuilder validConfig() {
+        return BrandedSenderConfig.builder()
+            .domains(List.of("graviteecustomer.com"))
+            .from("noreply@graviteecustomer.com")
+            .subject("[Gravitee Customer] %s");
+    }
+
+    // --- BrandedSenderConfig ---
+
+    @Test
+    void should_accept_a_valid_configuration() {
+        assertThat(validator.validate(validConfig().build())).isEmpty();
+    }
+
+    @Test
+    void should_accept_from_with_display_name() {
+        assertThat(validator.validate(validConfig().from("Gravitee Customer <noreply@graviteecustomer.com>").build())).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "not-an-email", "user@a..b.com", "user@.example.com" })
+    void should_reject_malformed_from(String from) {
+        assertThat(validator.validate(validConfig().from(from).build())).isNotEmpty();
+    }
+
+    @Test
+    void should_reject_blank_from() {
+        assertThat(validator.validate(validConfig().from("   ").build())).isNotEmpty();
+    }
+
+    @Test
+    void should_reject_empty_domains() {
+        assertThat(validator.validate(validConfig().domains(List.of()).build())).isNotEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "not a domain", "-example.com", "example-.com", "localhost", "example.a", "example.123" })
+    void should_reject_invalid_domain(String domain) {
+        assertThat(validator.validate(validConfig().domains(List.of(domain)).build())).isNotEmpty();
+    }
+
+    @Test
+    void should_reject_blank_domain_entry() {
+        assertThat(validator.validate(validConfig().domains(Arrays.asList("graviteecustomer.com", "   ")).build())).isNotEmpty();
+    }
+
+    @Test
+    void should_reject_duplicate_domains_case_insensitively() {
+        var config = validConfig().domains(List.of("graviteecustomer.com", "GraviteeCustomer.com")).build();
+        assertThat(validator.validate(config)).anyMatch(v -> v.getMessage().contains("duplicate"));
+    }
+
+    @Test
+    void should_reject_null_domain_entry() {
+        assertThat(validator.validate(validConfig().domains(Arrays.asList("graviteecustomer.com", null)).build())).isNotEmpty();
+    }
+
+    @Test
+    void should_reject_display_name_with_invalid_inner_address() {
+        assertThat(validator.validate(validConfig().from("Gravitee <not-an-email>").build())).isNotEmpty();
+    }
+
+    @Test
+    void should_reject_subject_exceeding_max_length() {
+        assertThat(validator.validate(validConfig().subject("x".repeat(256)).build())).isNotEmpty();
+    }
+
+    // --- @Valid cascade through the real save graph (settings entity -> email -> branded senders) ---
+
+    @Test
+    void should_cascade_from_settings_entity_into_branded_senders() {
+        var settings = new PortalSettingsEntity();
+        settings.getEmail().setBrandedSenders(List.of(validConfig().from("not-an-email").build()));
+
+        assertThat(validator.validate(settings)).anyMatch(v -> v.getPropertyPath().toString().equals("email.brandedSenders[0].from"));
+    }
+
+    @Test
+    void should_cascade_into_branded_senders_when_validating_email() {
+        var email = new Email();
+        email.setBrandedSenders(List.of(validConfig().from("not-an-email").build()));
+
+        assertThat(validator.validate(email)).anyMatch(v -> v.getPropertyPath().toString().equals("brandedSenders[0].from"));
+    }
+
+    @Test
+    void should_accept_whitespace_domain_normalized_before_cascade() {
+        var email = new Email();
+        email.setBrandedSenders(List.of(validConfig().domains(List.of("  GraviteeCustomer.COM  ")).build()));
+
+        // setBrandedSenders trims + lower-cases at the write boundary, so the @Pattern cascade sees a
+        // clean value: surrounding whitespace is normalised, not rejected.
+        assertThat(validator.validate(email)).isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/EmailBrandedSendersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/EmailBrandedSendersTest.java
@@ -37,6 +37,31 @@ class EmailBrandedSendersTest {
     }
 
     @Test
+    void should_normalize_domains_to_trimmed_lowercase_on_write() {
+        var email = new Email();
+        var config = BrandedSenderConfig.builder()
+            .domains(List.of("  GraviteeCustomer.COM  "))
+            .from("noreply@graviteecustomer.com")
+            .subject("[Gravitee] %s")
+            .build();
+
+        email.setBrandedSenders(List.of(config));
+
+        assertThat(email.getBrandedSenders().get(0).getDomains()).containsExactly("graviteecustomer.com");
+    }
+
+    @Test
+    void should_handle_configuration_with_null_domains_on_write() {
+        var email = new Email();
+        var config = BrandedSenderConfig.builder().domains(null).from("noreply@graviteecustomer.com").subject("[Gravitee] %s").build();
+
+        // normalizeDomains must guard a null domains list — otherwise write() NPEs (HTTP 500 on save).
+        email.setBrandedSenders(List.of(config));
+
+        assertThat(email.getBrandedSenders()).containsExactly(config);
+    }
+
+    @Test
     void should_round_trip_single_configuration() {
         var email = new Email();
         var config = BrandedSenderConfig.builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/validator/NoDuplicatesValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/validator/NoDuplicatesValidatorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+class NoDuplicatesValidatorTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void should_accept_null_list() {
+        assertThat(validator.validate(new CaseSensitiveHolder(null))).isEmpty();
+        assertThat(validator.validate(new CaseInsensitiveHolder(null))).isEmpty();
+    }
+
+    @Test
+    void should_accept_distinct_values() {
+        assertThat(validator.validate(new CaseSensitiveHolder(List.of("a", "b", "c")))).isEmpty();
+    }
+
+    @Test
+    void should_ignore_a_single_null_element() {
+        assertThat(validator.validate(new CaseSensitiveHolder(Arrays.asList("a", null)))).isEmpty();
+    }
+
+    // --- ignoreCase = false (the default branch) ---
+
+    @Test
+    void should_reject_exact_duplicates_when_case_sensitive() {
+        assertThat(validator.validate(new CaseSensitiveHolder(List.of("a", "a")))).isNotEmpty();
+    }
+
+    @Test
+    void should_treat_case_differing_values_as_distinct_when_case_sensitive() {
+        assertThat(validator.validate(new CaseSensitiveHolder(List.of("a", "A")))).isEmpty();
+    }
+
+    @Test
+    void should_reject_whitespace_differing_duplicates_when_case_sensitive() {
+        // both branches trim before comparing, so "a" and " a " collide even when case-sensitive
+        assertThat(validator.validate(new CaseSensitiveHolder(List.of("a", " a ")))).isNotEmpty();
+    }
+
+    // --- ignoreCase = true ---
+
+    @Test
+    void should_reject_case_differing_duplicates_when_ignoring_case() {
+        assertThat(validator.validate(new CaseInsensitiveHolder(List.of("a", " A ")))).isNotEmpty();
+    }
+
+    static class CaseSensitiveHolder {
+
+        @NoDuplicates
+        final List<String> values;
+
+        CaseSensitiveHolder(List<String> values) {
+            this.values = values;
+        }
+    }
+
+    static class CaseInsensitiveHolder {
+
+        @NoDuplicates(ignoreCase = true)
+        final List<String> values;
+
+        CaseInsensitiveHolder(List<String> values) {
+            this.values = values;
+        }
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14178
## Description
Field validation for the new `email.branded_senders` configuration (APIM-14181), scoped to the
branded-sender path only.

- **`BrandedSenderConfig`**
  - `from`: `@NotBlank` + `@ValidSenderAddress` — a bare address (`user@example.com`) or the
    personal-name form (`Name <user@example.com>`) the SMTP send-path supports.
  - `domains`: `@NotEmpty`, `@NoDuplicates(ignoreCase)` (so `Acme.com`/`acme.com` collide), and each
    entry `@NotBlank` + a valid RFC-1035 host name.
- **`@Valid` cascade** added on `AbstractCommonSettingsEntity.email` and `Email.brandedSenders`, so the
  constraints actually fire end-to-end through the settings save path (the resource methods already
  carry `@Valid`; the nested cascade was the missing piece).
- **`email.from` is intentionally left unvalidated.** Turning on validation for that pre-existing field
  would 400 legacy stored values on the next settings save; validation is limited to the brand-new
  branded-sender data, which has no existing data and zero blast radius.
- Domains are trimmed + lower-cased at the write boundary so send-time matching can compare directly.

## New constraints (reusable, no new deps)
- `@ValidSenderAddress` / `SenderAddressValidator` — sender-address check that also accepts the
  `Name <addr>` form.
- `@NoDuplicates(ignoreCase)` / `NoDuplicatesValidator` — generic list-dedup constraint.

## Tests
- `BrandedSenderValidationTest` — field constraints (valid, display-name, invalid/blank from,
  empty/invalid/blank/duplicate domains) and the end-to-end `@Valid` cascade
  (`settings entity → email → branded senders`).
- `EmailBrandedSendersTest` — domain normalization round-trip (plus the existing serialization seam
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

