### PR TITLE
fix: enable automation API by default

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1017,7 +1017,7 @@ api:
       #      - apim.example.com
       #    secretName: api-custom-cert
     automation:
-      enabled: false
+      enabled: true
       path: /automation
       ingressClassName: ""
       pathType: Prefix


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14586

## Description

Automation is now live as used in various products:
* GKO requires automation API in 4.12
* Terraform is GA and requires it too

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

