### PR TITLE
Revert "fix: enable automation API by default"

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1017,7 +1017,7 @@ api:
       #      - apim.example.com
       #    secretName: api-custom-cert
     automation:
-      enabled: true
+      enabled: false
       path: /automation
       ingressClassName: ""
       pathType: Prefix


### PR DESCRIPTION
Reverts gravitee-io/gravitee-api-management#18337

This change is a breaking change and needs to be discussed before released.