### PR TITLE
fix(kafka): refresh deployed cluster on version bump

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/cluster/ReactableCluster.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/cluster/ReactableCluster.java
@@ -35,4 +35,5 @@ public abstract class ReactableCluster implements Serializable {
     private String environmentId;
     private String organizationId;
     private Date deployedAt;
+    private Integer version;
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-cluster/src/main/java/io/gravitee/gateway/handlers/cluster/manager/impl/ClusterManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-cluster/src/main/java/io/gravitee/gateway/handlers/cluster/manager/impl/ClusterManagerImpl.java
@@ -59,13 +59,21 @@ public class ClusterManagerImpl implements ClusterManager {
      * {@code version} (bumped on every redeploy) is the authoritative discriminator: {@code deployedAt}
      * is only second-resolution in the event payload, so two redeploys within the same wall-clock second
      * carry an equal {@code deployedAt} and a {@code deployedAt}-only comparison would silently drop the
-     * second update. Falls back to {@code deployedAt} when versions are absent (older events).
+     * second update. A versioned side always supersedes an unversioned one (version was introduced
+     * later, so its presence implies a newer producer). Falls back to {@code deployedAt} only when
+     * both versions are absent (older events).
      */
     private static boolean isNewer(ReactableCluster current, ReactableCluster candidate) {
         if (candidate.getVersion() != null && current.getVersion() != null) {
             return candidate.getVersion() > current.getVersion();
         }
-        // Fallback for events without a version: compare deployedAt.
+        if (candidate.getVersion() != null) {
+            return true;
+        }
+        if (current.getVersion() != null) {
+            return false;
+        }
+        // Fallback for events where both versions are absent: compare deployedAt.
         if (candidate.getDeployedAt() == null) {
             return false;
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-cluster/src/main/java/io/gravitee/gateway/handlers/cluster/manager/impl/ClusterManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-cluster/src/main/java/io/gravitee/gateway/handlers/cluster/manager/impl/ClusterManagerImpl.java
@@ -65,10 +65,14 @@ public class ClusterManagerImpl implements ClusterManager {
         if (candidate.getVersion() != null && current.getVersion() != null) {
             return candidate.getVersion() > current.getVersion();
         }
-        return (
-            candidate.getDeployedAt() != null &&
-            (current.getDeployedAt() == null || current.getDeployedAt().before(candidate.getDeployedAt()))
-        );
+        // Fallback for events without a version: compare deployedAt.
+        if (candidate.getDeployedAt() == null) {
+            return false;
+        }
+        if (current.getDeployedAt() == null) {
+            return true;
+        }
+        return current.getDeployedAt().before(candidate.getDeployedAt());
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-cluster/src/main/java/io/gravitee/gateway/handlers/cluster/manager/impl/ClusterManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-cluster/src/main/java/io/gravitee/gateway/handlers/cluster/manager/impl/ClusterManagerImpl.java
@@ -39,10 +39,7 @@ public class ClusterManagerImpl implements ClusterManager {
         ReactableCluster deployedCluster = get(cluster.getId());
 
         boolean clusterToDeploy = deployedCluster == null;
-        boolean clusterToUpdate =
-            !clusterToDeploy &&
-            cluster.getDeployedAt() != null &&
-            (deployedCluster.getDeployedAt() == null || deployedCluster.getDeployedAt().before(cluster.getDeployedAt()));
+        boolean clusterToUpdate = !clusterToDeploy && isNewer(deployedCluster, cluster);
 
         if (clusterToDeploy) {
             deploy(cluster);
@@ -55,6 +52,23 @@ public class ClusterManagerImpl implements ClusterManager {
         }
 
         return false;
+    }
+
+    /**
+     * Whether {@code candidate} supersedes the currently-deployed {@code current}. The monotonic
+     * {@code version} (bumped on every redeploy) is the authoritative discriminator: {@code deployedAt}
+     * is only second-resolution in the event payload, so two redeploys within the same wall-clock second
+     * carry an equal {@code deployedAt} and a {@code deployedAt}-only comparison would silently drop the
+     * second update. Falls back to {@code deployedAt} when versions are absent (older events).
+     */
+    private static boolean isNewer(ReactableCluster current, ReactableCluster candidate) {
+        if (candidate.getVersion() != null && current.getVersion() != null) {
+            return candidate.getVersion() > current.getVersion();
+        }
+        return (
+            candidate.getDeployedAt() != null &&
+            (current.getDeployedAt() == null || current.getDeployedAt().before(candidate.getDeployedAt()))
+        );
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-cluster/src/test/java/io/gravitee/gateway/handlers/cluster/manager/impl/ClusterManagerImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-cluster/src/test/java/io/gravitee/gateway/handlers/cluster/manager/impl/ClusterManagerImplTest.java
@@ -91,6 +91,38 @@ class ClusterManagerImplTest {
     }
 
     @Test
+    void should_update_cluster_when_version_advances_within_same_deployed_at_second() {
+        // Two redeploys landing in the same wall-clock second carry an identical (second-resolution)
+        // deployedAt, but the monotonic version still advances. The update must not be dropped.
+        Date sameSecond = new Date(1_698_000_000L);
+        ReactableCluster oldCluster = KafkaClusterReactableCluster.builder().id("cluster-1").deployedAt(sameSecond).version(1).build();
+        cut.register(oldCluster);
+
+        ReactableCluster newCluster = KafkaClusterReactableCluster.builder().id("cluster-1").deployedAt(sameSecond).version(2).build();
+
+        boolean result = cut.register(newCluster);
+
+        assertThat(result).isTrue();
+        verify(eventManager).publishEvent(ClusterEvent.UPDATE, newCluster);
+        assertThat(cut.get("cluster-1")).isEqualTo(newCluster);
+    }
+
+    @Test
+    void should_not_update_cluster_when_version_unchanged() {
+        // Idempotent re-delivery of the same event (same version) must not republish an update.
+        Date sameSecond = new Date(1_698_000_000L);
+        ReactableCluster cluster = KafkaClusterReactableCluster.builder().id("cluster-1").deployedAt(sameSecond).version(1).build();
+        cut.register(cluster);
+
+        ReactableCluster redelivered = KafkaClusterReactableCluster.builder().id("cluster-1").deployedAt(sameSecond).version(1).build();
+
+        boolean result = cut.register(redelivered);
+
+        assertThat(result).isFalse();
+        verify(eventManager, never()).publishEvent(eq(ClusterEvent.UPDATE), any());
+    }
+
+    @Test
     void should_undeploy_cluster() {
         ReactableCluster cluster = KafkaClusterReactableCluster.builder().id("cluster-1").deployedAt(new Date()).build();
         cut.register(cluster);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-cluster/src/test/java/io/gravitee/gateway/handlers/cluster/manager/impl/ClusterManagerImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-cluster/src/test/java/io/gravitee/gateway/handlers/cluster/manager/impl/ClusterManagerImplTest.java
@@ -123,6 +123,38 @@ class ClusterManagerImplTest {
     }
 
     @Test
+    void should_update_cluster_when_candidate_has_version_and_current_does_not() {
+        // Transition case: the deployed cluster comes from an old event without version, the new
+        // event carries one. Even with an equal (second-resolution) deployedAt, the versioned
+        // candidate must win — falling back to deployedAt would silently drop the update.
+        Date sameSecond = new Date(1_698_000_000L);
+        ReactableCluster oldCluster = KafkaClusterReactableCluster.builder().id("cluster-1").deployedAt(sameSecond).build();
+        cut.register(oldCluster);
+
+        ReactableCluster newCluster = KafkaClusterReactableCluster.builder().id("cluster-1").deployedAt(sameSecond).version(1).build();
+
+        boolean result = cut.register(newCluster);
+
+        assertThat(result).isTrue();
+        verify(eventManager).publishEvent(ClusterEvent.UPDATE, newCluster);
+        assertThat(cut.get("cluster-1")).isEqualTo(newCluster);
+    }
+
+    @Test
+    void should_not_update_cluster_when_candidate_has_no_version_and_current_does() {
+        // A versioned deployment must never be superseded by an unversioned (older-producer) event.
+        ReactableCluster versioned = KafkaClusterReactableCluster.builder().id("cluster-1").deployedAt(new Date(1000)).version(1).build();
+        cut.register(versioned);
+
+        ReactableCluster unversioned = KafkaClusterReactableCluster.builder().id("cluster-1").deployedAt(new Date(5000)).build();
+
+        boolean result = cut.register(unversioned);
+
+        assertThat(result).isFalse();
+        verify(eventManager, never()).publishEvent(eq(ClusterEvent.UPDATE), any());
+    }
+
+    @Test
     void should_undeploy_cluster() {
         ReactableCluster cluster = KafkaClusterReactableCluster.builder().id("cluster-1").deployedAt(new Date()).build();
         cut.register(cluster);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ClusterMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ClusterMapper.java
@@ -64,11 +64,13 @@ public class ClusterMapper {
                 String organizationId = (String) payload.get("organizationId");
                 Object deployedAtRaw = payload.get("deployedAt");
                 Date deployedAt = deployedAtRaw != null ? new Date(((Number) deployedAtRaw).longValue() * 1000) : null;
+                Object versionRaw = payload.get("version");
+                Integer version = versionRaw != null ? ((Number) versionRaw).intValue() : null;
 
                 if ("KAFKA_CLUSTER".equals(type)) {
-                    return buildKafkaCluster(id, crossId, name, environmentId, organizationId, deployedAt, payload);
+                    return buildKafkaCluster(id, crossId, name, environmentId, organizationId, deployedAt, version, payload);
                 } else if ("KAFKA_VIRTUAL_CLUSTER".equals(type)) {
-                    return buildKafkaVirtualCluster(id, crossId, name, environmentId, organizationId, deployedAt, payload);
+                    return buildKafkaVirtualCluster(id, crossId, name, environmentId, organizationId, deployedAt, version, payload);
                 } else {
                     log.warn("Cluster type [{}] is not deployable yet, skipping cluster [{}].", type, id);
                     return null;
@@ -88,6 +90,7 @@ public class ClusterMapper {
         String environmentId,
         String organizationId,
         Date deployedAt,
+        Integer version,
         Map<String, Object> payload
     ) {
         List<KafkaClusterReactableCluster.KafkaClusterConnection> connections = Collections.emptyList();
@@ -117,6 +120,7 @@ public class ClusterMapper {
             .environmentId(environmentId)
             .organizationId(organizationId)
             .deployedAt(deployedAt)
+            .version(version)
             .connections(connections)
             .build();
     }
@@ -129,6 +133,7 @@ public class ClusterMapper {
         String environmentId,
         String organizationId,
         Date deployedAt,
+        Integer version,
         Map<String, Object> payload
     ) {
         List<KafkaVirtualClusterReactableCluster.KafkaVirtualClusterBackend> backends = Collections.emptyList();
@@ -156,6 +161,7 @@ public class ClusterMapper {
             .environmentId(environmentId)
             .organizationId(organizationId)
             .deployedAt(deployedAt)
+            .version(version)
             .backends(backends)
             .build();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ClusterMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ClusterMapperTest.java
@@ -169,6 +169,30 @@ class ClusterMapperTest {
     }
 
     @Test
+    void should_map_version_from_payload() {
+        Event event = new Event();
+        event.setId("event-id");
+        event.setPayload(
+            """
+            {
+                "id": "cluster-id",
+                "crossId": "my-kafka-cluster",
+                "name": "My Kafka Cluster",
+                "type": "KAFKA_CLUSTER",
+                "environmentId": "env-1",
+                "deployedAt": 1698000,
+                "version": 3,
+                "configuration": { "connections": [] }
+            }
+            """
+        );
+
+        ReactableCluster result = cut.to(event).blockingGet();
+
+        assertThat(result.getVersion()).isEqualTo(3);
+    }
+
+    @Test
     void should_return_null_on_invalid_payload() {
         Event event = new Event();
         event.setId("event-id");


### PR DESCRIPTION
## Problem

A native Kafka Service bound to a Virtual Cluster (VC) keeps serving a **stale** VC→backend
binding after the VC's composition changes: the Kafka client gets an **empty topic list with no
error**, and the only workaround is a Stop/Start (or redeploy) of the Kafka Service.

## Root cause

The data-plane reactor already re-resolves VC backends and invalidates its cached endpoint on
`ClusterEvent` — verified, it self-heals. The gap is in how the **management plane propagates a
cluster redeploy to the gateway**:

- Cluster redeploy events serialize `deployedAt` at **epoch-second** resolution
  (`ClusterMapper` rebuilds it as `new Date(seconds * 1000)`).
- `ClusterManagerImpl.register` gated updates on a **strict** `deployedAt.before(...)` comparison.

So two cluster deploys landing in the **same wall-clock second** carry an equal `deployedAt`, and
the second one is classified as neither a deploy nor an update → **no `ClusterEvent` is published**
→ the reactor's cluster registry and endpoint cache never refresh → stale binding. Rapid/scripted
deploys (e.g. the ESM SDK docker stack) trigger this reliably.

## Fix

Use the monotonic cluster `version` (already bumped on every `Cluster.deploy()`) as the
authoritative discriminator for "is this newer", falling back to `deployedAt` when `version` is
absent (older events). `version` is mapped through the gateway sync `ClusterMapper` and carried on
`ReactableCluster`.

- `ReactableCluster`: add `version` field
- `ClusterMapper`: parse + set `version` (KAFKA_CLUSTER and KAFKA_VIRTUAL_CLUSTER)
- `ClusterManagerImpl.register`: compare by `version`, fall back to `deployedAt`

## Tests (TDD — written failing first)

- `ClusterManagerImplTest`: update fires when version advances within the same `deployedAt` second;
  no update on identical version (idempotent re-delivery). Existing `deployedAt` tests stay green
  via the fallback.
- `ClusterMapperTest`: `version` is mapped from the payload.

Verified green: definition-model 72, cluster handler 8, sync cluster tests 17.

## Scope / notes

- Robustly fixes same-second / rapid redeploys (version is precision-proof). A purely manual
  redeploy >1s apart already advanced `deployedAt`; version-based comparison is the correct robust
  fix regardless.
- The `403` on `POST /apis/{id}/deployments` reported alongside the bug is **out of scope** here.
