### PR TITLE
fix: bump gravitee-reactor-a2a-proxy version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,7 @@
         <gravitee-reactor-native-kafka.version>7.0.0</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>3.0.0</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>3.0.0</gravitee-reactor-llm-proxy.version>
-        <gravitee-reactor-a2a-proxy.version>1.0.3</gravitee-reactor-a2a-proxy.version>
+        <gravitee-reactor-a2a-proxy.version>2.0.0</gravitee-reactor-a2a-proxy.version>
         <gravitee-reactor-edge.version>1.0.0</gravitee-reactor-edge.version>
         <gravitee-resource-ai-vector-store-redis.version>2.0.0</gravitee-resource-ai-vector-store-redis.version>
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

bump gravitee-reactor-a2a-proxy version to 2.0.0 (fix vertx 5 compatibility)

