### PR TITLE
fix(console): Adding a tooltip for long user roles

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/organization-settings.module.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/organization-settings.module.ts
@@ -95,6 +95,7 @@ import { GioFormColorInputModule } from '../../shared/components/gio-form-color-
 import { GioGoBackButtonModule } from '../../shared/components/gio-go-back-button/gio-go-back-button.module';
 import { GioTableWrapperModule } from '../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { GioUsersSelectorModule } from '../../shared/components/gio-users-selector/gio-users-selector.module';
+import { GioTooltipOnEllipsisModule } from '../../shared/components/gio-tooltip-on-ellipsis/gio-tooltip-on-ellipsis.module';
 
 @NgModule({
   imports: [
@@ -143,6 +144,7 @@ import { GioUsersSelectorModule } from '../../shared/components/gio-users-select
     GioClipboardModule,
     GioTableWrapperModule,
     GioUsersSelectorModule,
+    GioTooltipOnEllipsisModule,
     GioFormJsonSchemaModule,
     GioLicenseModule,
     GioMenuModule,

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-add-group-dialog.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-add-group-dialog.component.html
@@ -40,40 +40,120 @@
 
           <mat-form-field>
             <mat-label>API Role</mat-label>
-            <mat-select formControlName="apiRole" aria-label="API role">
+            <mat-select
+              #apiRoleSelect="matSelect"
+              formControlName="apiRole"
+              aria-label="API role"
+              panelClass="org-settings-user-detail__role-select-panel"
+            >
+              <mat-select-trigger>
+                <span
+                  class="org-settings-user-detail__role-trigger"
+                  gioTooltipOnEllipsis
+                  matTooltipClass="org-settings-user-detail__role-tooltip"
+                  >{{ apiRoleSelect.triggerValue }}</span
+                >
+              </mat-select-trigger>
               <mat-option>-- None --</mat-option>
               @for (apiRole of apiRoles(); track apiRole.name) {
-                <mat-option [disabled]="apiRole.system" [value]="apiRole.name">{{ apiRole.name }}</mat-option>
+                <mat-option
+                  [disabled]="apiRole.system"
+                  [value]="apiRole.name"
+                  class="org-settings-user-detail__role-option"
+                  gioTooltipOnEllipsis
+                  matTooltipClass="org-settings-user-detail__role-tooltip"
+                  >{{ apiRole.name }}</mat-option
+                >
               }
             </mat-select>
           </mat-form-field>
 
           <mat-form-field>
             <mat-label>API Product Role</mat-label>
-            <mat-select formControlName="apiProductRole" aria-label="API Product role">
+            <mat-select
+              #apiProductRoleSelect="matSelect"
+              formControlName="apiProductRole"
+              aria-label="API Product role"
+              panelClass="org-settings-user-detail__role-select-panel"
+            >
+              <mat-select-trigger>
+                <span
+                  class="org-settings-user-detail__role-trigger"
+                  gioTooltipOnEllipsis
+                  matTooltipClass="org-settings-user-detail__role-tooltip"
+                  >{{ apiProductRoleSelect.triggerValue }}</span
+                >
+              </mat-select-trigger>
               <mat-option>-- None --</mat-option>
               @for (apiProductRole of apiProductRoles(); track apiProductRole.name) {
-                <mat-option [disabled]="apiProductRole.system" [value]="apiProductRole.name">{{ apiProductRole.name }}</mat-option>
+                <mat-option
+                  [disabled]="apiProductRole.system"
+                  [value]="apiProductRole.name"
+                  class="org-settings-user-detail__role-option"
+                  gioTooltipOnEllipsis
+                  matTooltipClass="org-settings-user-detail__role-tooltip"
+                  >{{ apiProductRole.name }}</mat-option
+                >
               }
             </mat-select>
           </mat-form-field>
 
           <mat-form-field>
             <mat-label>Application Role</mat-label>
-            <mat-select formControlName="applicationRole" aria-label="Application role">
+            <mat-select
+              #applicationRoleSelect="matSelect"
+              formControlName="applicationRole"
+              aria-label="Application role"
+              panelClass="org-settings-user-detail__role-select-panel"
+            >
+              <mat-select-trigger>
+                <span
+                  class="org-settings-user-detail__role-trigger"
+                  gioTooltipOnEllipsis
+                  matTooltipClass="org-settings-user-detail__role-tooltip"
+                  >{{ applicationRoleSelect.triggerValue }}</span
+                >
+              </mat-select-trigger>
               <mat-option>-- None --</mat-option>
               @for (applicationRole of applicationRoles(); track applicationRole.name) {
-                <mat-option [disabled]="applicationRole.system" [value]="applicationRole.name">{{ applicationRole.name }}</mat-option>
+                <mat-option
+                  [disabled]="applicationRole.system"
+                  [value]="applicationRole.name"
+                  class="org-settings-user-detail__role-option"
+                  gioTooltipOnEllipsis
+                  matTooltipClass="org-settings-user-detail__role-tooltip"
+                  >{{ applicationRole.name }}</mat-option
+                >
               }
             </mat-select>
           </mat-form-field>
 
           <mat-form-field>
             <mat-label>Integration Role</mat-label>
-            <mat-select formControlName="integrationRole" aria-label="Integration role">
+            <mat-select
+              #integrationRoleSelect="matSelect"
+              formControlName="integrationRole"
+              aria-label="Integration role"
+              panelClass="org-settings-user-detail__role-select-panel"
+            >
+              <mat-select-trigger>
+                <span
+                  class="org-settings-user-detail__role-trigger"
+                  gioTooltipOnEllipsis
+                  matTooltipClass="org-settings-user-detail__role-tooltip"
+                  >{{ integrationRoleSelect.triggerValue }}</span
+                >
+              </mat-select-trigger>
               <mat-option>-- None --</mat-option>
               @for (integrationRole of integrationRoles(); track integrationRole.name) {
-                <mat-option [disabled]="integrationRole.system" [value]="integrationRole.name">{{ integrationRole.name }}</mat-option>
+                <mat-option
+                  [disabled]="integrationRole.system"
+                  [value]="integrationRole.name"
+                  class="org-settings-user-detail__role-option"
+                  gioTooltipOnEllipsis
+                  matTooltipClass="org-settings-user-detail__role-tooltip"
+                  >{{ integrationRole.name }}</mat-option
+                >
               }
             </mat-select>
           </mat-form-field>

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-add-group-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-add-group-dialog.component.scss
@@ -7,6 +7,18 @@
 
   mat-form-field {
     flex: 1 1 auto;
+    min-width: 0;
+
+    .mat-mdc-text-field-wrapper,
+    .mat-mdc-form-field-infix,
+    .mat-mdc-select-value,
+    .mat-mdc-select-value-text {
+      min-width: 0;
+    }
+
+    .mat-mdc-select-value-text {
+      overflow: hidden;
+    }
   }
 
   &__checkbox-field {

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.html
@@ -71,14 +71,31 @@
                     <mat-form-field>
                       <mat-label>API role</mat-label>
                       <mat-select
+                        #apiRoleSelect="matSelect"
                         [id]="group.id"
                         [aria-label]="'API roles for ' + group.id"
                         formControlName="API"
                         [disabled]="isApiRolePrimaryOwner(group.id)"
+                        panelClass="org-settings-user-detail__role-select-panel"
                       >
+                        <mat-select-trigger>
+                          <span
+                            class="org-settings-user-detail__role-trigger"
+                            gioTooltipOnEllipsis
+                            matTooltipClass="org-settings-user-detail__role-tooltip"
+                            >{{ apiRoleSelect.triggerValue }}</span
+                          >
+                        </mat-select-trigger>
                         <mat-option>-- None --</mat-option>
                         @for (role of apiRoles(); track role.name) {
-                          <mat-option [disabled]="role.system" [value]="role.name">{{ role.name }}</mat-option>
+                          <mat-option
+                            [disabled]="role.system"
+                            [value]="role.name"
+                            class="org-settings-user-detail__role-option"
+                            gioTooltipOnEllipsis
+                            matTooltipClass="org-settings-user-detail__role-tooltip"
+                            >{{ role.name }}</mat-option
+                          >
                         }
                       </mat-select>
                     </mat-form-field>
@@ -91,10 +108,31 @@
                   <td mat-cell *matCellDef="let group" [formGroupName]="group.id">
                     <mat-form-field>
                       <mat-label>API Product role</mat-label>
-                      <mat-select [id]="group.id" [aria-label]="'API Product roles for ' + group.id" formControlName="API_PRODUCT">
+                      <mat-select
+                        #apiProductRoleSelect="matSelect"
+                        [id]="group.id"
+                        [aria-label]="'API Product roles for ' + group.id"
+                        formControlName="API_PRODUCT"
+                        panelClass="org-settings-user-detail__role-select-panel"
+                      >
+                        <mat-select-trigger>
+                          <span
+                            class="org-settings-user-detail__role-trigger"
+                            gioTooltipOnEllipsis
+                            matTooltipClass="org-settings-user-detail__role-tooltip"
+                            >{{ apiProductRoleSelect.triggerValue }}</span
+                          >
+                        </mat-select-trigger>
                         <mat-option>-- None --</mat-option>
                         @for (role of apiProductRoles(); track role.name) {
-                          <mat-option [disabled]="role.system" [value]="role.name">{{ role.name }}</mat-option>
+                          <mat-option
+                            [disabled]="role.system"
+                            [value]="role.name"
+                            class="org-settings-user-detail__role-option"
+                            gioTooltipOnEllipsis
+                            matTooltipClass="org-settings-user-detail__role-tooltip"
+                            >{{ role.name }}</mat-option
+                          >
                         }
                       </mat-select>
                     </mat-form-field>
@@ -107,10 +145,31 @@
                   <td mat-cell *matCellDef="let group" [formGroupName]="group.id">
                     <mat-form-field>
                       <mat-label>Application role</mat-label>
-                      <mat-select [id]="group.id" [aria-label]="'Application roles for ' + group.id" formControlName="APPLICATION">
+                      <mat-select
+                        #applicationRoleSelect="matSelect"
+                        [id]="group.id"
+                        [aria-label]="'Application roles for ' + group.id"
+                        formControlName="APPLICATION"
+                        panelClass="org-settings-user-detail__role-select-panel"
+                      >
+                        <mat-select-trigger>
+                          <span
+                            class="org-settings-user-detail__role-trigger"
+                            gioTooltipOnEllipsis
+                            matTooltipClass="org-settings-user-detail__role-tooltip"
+                            >{{ applicationRoleSelect.triggerValue }}</span
+                          >
+                        </mat-select-trigger>
                         <mat-option>-- None --</mat-option>
                         @for (role of applicationRoles(); track role.name) {
-                          <mat-option [disabled]="role.system" [value]="role.name">{{ role.name }}</mat-option>
+                          <mat-option
+                            [disabled]="role.system"
+                            [value]="role.name"
+                            class="org-settings-user-detail__role-option"
+                            gioTooltipOnEllipsis
+                            matTooltipClass="org-settings-user-detail__role-tooltip"
+                            >{{ role.name }}</mat-option
+                          >
                         }
                       </mat-select>
                     </mat-form-field>
@@ -123,10 +182,31 @@
                   <td mat-cell *matCellDef="let group" [formGroupName]="group.id">
                     <mat-form-field>
                       <mat-label>Integration role</mat-label>
-                      <mat-select [id]="group.id" [aria-label]="'Integration roles for ' + group.id" formControlName="INTEGRATION">
+                      <mat-select
+                        #integrationRoleSelect="matSelect"
+                        [id]="group.id"
+                        [aria-label]="'Integration roles for ' + group.id"
+                        formControlName="INTEGRATION"
+                        panelClass="org-settings-user-detail__role-select-panel"
+                      >
+                        <mat-select-trigger>
+                          <span
+                            class="org-settings-user-detail__role-trigger"
+                            gioTooltipOnEllipsis
+                            matTooltipClass="org-settings-user-detail__role-tooltip"
+                            >{{ integrationRoleSelect.triggerValue }}</span
+                          >
+                        </mat-select-trigger>
                         <mat-option>-- None --</mat-option>
                         @for (role of integrationRoles(); track role.name) {
-                          <mat-option [disabled]="role.system" [value]="role.name">{{ role.name }}</mat-option>
+                          <mat-option
+                            [disabled]="role.system"
+                            [value]="role.name"
+                            class="org-settings-user-detail__role-option"
+                            gioTooltipOnEllipsis
+                            matTooltipClass="org-settings-user-detail__role-tooltip"
+                            >{{ role.name }}</mat-option
+                          >
                         }
                       </mat-select>
                     </mat-form-field>

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.scss
@@ -52,6 +52,18 @@ $border-color: mat.m2-get-color-from-palette($foreground, divider);
     .mat-mdc-cell.mat-column-integrationRole {
       mat-form-field {
         max-width: 160px;
+        min-width: 0;
+
+        .mat-mdc-text-field-wrapper,
+        .mat-mdc-form-field-infix,
+        .mat-mdc-select-value,
+        .mat-mdc-select-value-text {
+          min-width: 0;
+        }
+
+        .mat-mdc-select-value-text {
+          overflow: hidden;
+        }
       }
     }
 

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.html
@@ -123,24 +123,20 @@
         >
           <mat-select-trigger>
             <span
-              #roleTriggerEl
               class="org-settings-user-detail__role-trigger"
-              [matTooltip]="organizationRoleSelect.triggerValue"
+              gioTooltipOnEllipsis
               matTooltipClass="org-settings-user-detail__role-tooltip"
-              [matTooltipDisabled]="roleTriggerEl.offsetWidth >= roleTriggerEl.scrollWidth"
               >{{ organizationRoleSelect.triggerValue }}</span
             >
           </mat-select-trigger>
-          <mat-option *ngFor="let role of organizationRoles$ | async" [value]="role.id">
-            <span
-              #roleOptionEl
-              class="org-settings-user-detail__role-option"
-              [matTooltip]="role.name"
-              matTooltipClass="org-settings-user-detail__role-tooltip"
-              [matTooltipDisabled]="roleOptionEl.offsetWidth >= roleOptionEl.scrollWidth"
-              >{{ role.name }}</span
-            >
-          </mat-option>
+          <mat-option
+            *ngFor="let role of organizationRoles$ | async"
+            [value]="role.id"
+            class="org-settings-user-detail__role-option"
+            gioTooltipOnEllipsis
+            matTooltipClass="org-settings-user-detail__role-tooltip"
+            >{{ role.name }}</mat-option
+          >
         </mat-select>
       </mat-form-field>
     </mat-card-content>
@@ -191,24 +187,20 @@
                 >
                   <mat-select-trigger>
                     <span
-                      #roleTriggerEl
                       class="org-settings-user-detail__role-trigger"
-                      [matTooltip]="environmentRoleSelect.triggerValue"
+                      gioTooltipOnEllipsis
                       matTooltipClass="org-settings-user-detail__role-tooltip"
-                      [matTooltipDisabled]="roleTriggerEl.offsetWidth >= roleTriggerEl.scrollWidth"
                       >{{ environmentRoleSelect.triggerValue }}</span
                     >
                   </mat-select-trigger>
-                  <mat-option *ngFor="let role of environmentRoles$ | async" [value]="role.id">
-                    <span
-                      #roleOptionEl
-                      class="org-settings-user-detail__role-option"
-                      [matTooltip]="role.name"
-                      matTooltipClass="org-settings-user-detail__role-tooltip"
-                      [matTooltipDisabled]="roleOptionEl.offsetWidth >= roleOptionEl.scrollWidth"
-                      >{{ role.name }}</span
-                    >
-                  </mat-option>
+                  <mat-option
+                    *ngFor="let role of environmentRoles$ | async"
+                    [value]="role.id"
+                    class="org-settings-user-detail__role-option"
+                    gioTooltipOnEllipsis
+                    matTooltipClass="org-settings-user-detail__role-tooltip"
+                    >{{ role.name }}</mat-option
+                  >
                 </mat-select>
               </mat-form-field>
             </td>

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.scss
@@ -7,9 +7,6 @@
 $background: map-get(gio.$mat-theme, background);
 $typography: map.get(gio.$mat-theme, typography);
 
-// Ellipsis tooltip theming for the role selects. Kept in the component (not the
-// global stylesheet); it can still reach the matTooltip overlay because this
-// component uses ViewEncapsulation.None.
 $role-tooltip-background-color: var(--gio-oem-palette--background, #{mat.m2-get-color-from-palette(gio.$mat-space-palette, default)});
 $role-tooltip-text-color: mat.m2-get-color-from-palette(gio.$mat-basic-palette, white);
 $role-tooltip-max-width: 160px;
@@ -17,8 +14,6 @@ $role-tooltip-font-size: 11px;
 $role-tooltip-line-height: 16px;
 $role-tooltip-padding: 4px 8px;
 
-// ViewEncapsulation.None makes these styles global, so `:host` would not match.
-// Target the component element directly instead.
 org-settings-user-detail {
   @include gio-layout.gio-responsive-margin-container;
 
@@ -101,9 +96,9 @@ org-settings-user-detail {
     flex-direction: column;
   }
 
-  // Selected value shown in the closed role selects: truncate with ellipsis.
   &__role-trigger {
     display: block;
+    min-width: 0;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -123,20 +118,25 @@ org-settings-user-detail {
   }
 }
 
-// Role select options render in a CDK overlay (outside the component element).
-// With ViewEncapsulation.None these styles are global, targeted via the unique `panelClass`.
-.org-settings-user-detail__role-select-panel .org-settings-user-detail__role-option {
-  display: block;
-  // Caps how far the auto-sized panel can grow; beyond this the option text is
-  // truncated with an ellipsis, which is what enables the overflow tooltip.
-  max-width: 280px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+@at-root {
+  .cdk-overlay-container .mat-mdc-select-panel.org-settings-user-detail__role-select-panel {
+    max-width: 280px;
+
+    .mat-mdc-option.org-settings-user-detail__role-option {
+      min-width: 0;
+    }
+
+    .mat-mdc-option .mdc-list-item__primary-text {
+      display: block;
+      min-width: 0;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
 }
 
-// Themed ellipsis tooltip for the role selects, applied via `matTooltipClass`.
-// Reaches the matTooltip overlay because this component uses ViewEncapsulation.None.
 .org-settings-user-detail__role-tooltip {
   --mdc-plain-tooltip-container-color: #{$role-tooltip-background-color};
   --mdc-plain-tooltip-supporting-text-color: #{$role-tooltip-text-color};

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.ts
@@ -69,8 +69,6 @@ interface TokenDS {
   templateUrl: './org-settings-user-detail.component.html',
   styleUrls: ['./org-settings-user-detail.component.scss'],
   standalone: false,
-  // Styles are global so the role-select tooltip/option theming can reach the
-  // mat-select panel and matTooltip, both rendered in a CDK overlay outside this component.
   encapsulation: ViewEncapsulation.None,
 })
 export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {

--- a/gravitee-apim-console-webui/src/shared/components/gio-tooltip-on-ellipsis/gio-tooltip-on-ellipsis.directive.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-tooltip-on-ellipsis/gio-tooltip-on-ellipsis.directive.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AfterViewInit, Directive, ElementRef, Inject, NgZone, Optional, ViewContainerRef, DOCUMENT } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, HostListener, Inject, NgZone, Optional, ViewContainerRef, DOCUMENT } from '@angular/core';
 import { MAT_TOOLTIP_DEFAULT_OPTIONS, MAT_TOOLTIP_SCROLL_STRATEGY, MatTooltip, MatTooltipDefaultOptions } from '@angular/material/tooltip';
 import { Overlay, ScrollDispatcher } from '@angular/cdk/overlay';
 import { Platform } from '@angular/cdk/platform';
@@ -33,7 +33,7 @@ export class GioTooltipOnEllipsisDirective extends MatTooltip implements AfterVi
   private isEllipsis = false;
 
   override get message(): string {
-    return this.nativeElement?.innerHTML;
+    return this.nativeElement?.textContent?.trim() ?? '';
   }
 
   override get disabled(): boolean {
@@ -42,9 +42,27 @@ export class GioTooltipOnEllipsisDirective extends MatTooltip implements AfterVi
 
   override ngAfterViewInit(): void {
     super.ngAfterViewInit();
-    if (this.nativeElement.offsetWidth < this.nativeElement.scrollWidth) {
-      this.isEllipsis = true;
+    this.isEllipsis = this.hasVisibleOverflow(this.nativeElement);
+  }
+
+  @HostListener('mouseenter')
+  onMouseEnter(): void {
+    this.isEllipsis = this.hasVisibleOverflow(this.nativeElement);
+  }
+
+  private hasVisibleOverflow(element: HTMLElement): boolean {
+    if (element.offsetWidth < element.scrollWidth) {
+      return true;
     }
+
+    const primaryText =
+      element.querySelector<HTMLElement>('.mdc-list-item__primary-text') ?? element.closest<HTMLElement>('.mdc-list-item__primary-text');
+
+    if (primaryText && primaryText !== element) {
+      return primaryText.offsetWidth < primaryText.scrollWidth;
+    }
+
+    return false;
   }
 
   constructor(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14453

## Description

Adding a tooltip for long roles in the user details screen. 


## Additional context

Pre fix behaviour: 

<img width="3016" height="1546" alt="image" src="https://github.com/user-attachments/assets/bf7fbac6-7059-4d31-a1e7-d8923e7ba389" />


Post fix behaviour:

<img width="1432" height="782" alt="image" src="https://github.com/user-attachments/assets/4aa3a35d-7af2-405d-afbe-a453ef74d638" />

