### PR TITLE
feat(repository): add IdP claim whitelist & DCR mapping storage (APIM-13956)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ClientRegistrationProvider.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ClientRegistrationProvider.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.management.model;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class ClientRegistrationProvider {
@@ -86,6 +87,11 @@ public class ClientRegistrationProvider {
     private String renewClientSecretMethod;
 
     private String softwareId;
+
+    /**
+     * Mapping of persisted IdP claim name to the DCR request field path it should be injected into.
+     */
+    private Map<String, String> claimMappings;
 
     private String trustStoreType;
 
@@ -243,6 +249,14 @@ public class ClientRegistrationProvider {
 
     public void setSoftwareId(String softwareId) {
         this.softwareId = softwareId;
+    }
+
+    public Map<String, String> getClaimMappings() {
+        return claimMappings;
+    }
+
+    public void setClaimMappings(Map<String, String> claimMappings) {
+        this.claimMappings = claimMappings;
     }
 
     public String getTrustStoreType() {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/IdentityProvider.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/IdentityProvider.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.management.model;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -78,6 +79,11 @@ public class IdentityProvider {
      * Identity provider user profile mapping
      */
     private Map<String, String> userProfileMapping;
+
+    /**
+     * Names of the IdP claims allowed to be persisted on the user at login, for later use (e.g. DCR injection).
+     */
+    private List<String> persistedClaimsWhitelist;
 
     private Boolean emailRequired;
 
@@ -187,6 +193,14 @@ public class IdentityProvider {
 
     public void setUserProfileMapping(Map<String, String> userProfileMapping) {
         this.userProfileMapping = userProfileMapping;
+    }
+
+    public List<String> getPersistedClaimsWhitelist() {
+        return persistedClaimsWhitelist;
+    }
+
+    public void setPersistedClaimsWhitelist(List<String> persistedClaimsWhitelist) {
+        this.persistedClaimsWhitelist = persistedClaimsWhitelist;
     }
 
     public Boolean getEmailRequired() {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClientRegistrationProviderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClientRegistrationProviderRepository.java
@@ -17,6 +17,9 @@ package io.gravitee.repository.jdbc.management;
 
 import static java.lang.String.format;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
 import io.gravitee.repository.management.api.ClientRegistrationProviderRepository;
@@ -26,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import lombok.CustomLog;
@@ -43,6 +47,8 @@ public class JdbcClientRegistrationProviderRepository
     implements ClientRegistrationProviderRepository {
 
     private final String CLIENT_REGISTRATION_PROVIDER_SCOPES;
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
     JdbcClientRegistrationProviderRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
         super(tablePrefix, "client_registration_providers");
@@ -77,7 +83,36 @@ public class JdbcClientRegistrationProviderRepository
             .addColumn("key_password", Types.NVARCHAR, String.class)
             .addColumn("created_at", Types.TIMESTAMP, Date.class)
             .addColumn("updated_at", Types.TIMESTAMP, Date.class)
+            .addColumn(
+                "claim_mappings",
+                Types.NCLOB,
+                Map.class,
+                JdbcClientRegistrationProviderRepository::serializeClaimMappings,
+                JdbcClientRegistrationProviderRepository::deserializeClaimMappings
+            )
             .build();
+    }
+
+    private static String serializeClaimMappings(Map claimMappings) {
+        if (claimMappings == null) {
+            return null;
+        }
+        try {
+            return JSON_MAPPER.writeValueAsString(claimMappings);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalArgumentException("Failed to serialize client registration provider claim mappings", ex);
+        }
+    }
+
+    private static Map deserializeClaimMappings(String json) {
+        if (json == null || json.isEmpty()) {
+            return null;
+        }
+        try {
+            return JSON_MAPPER.readValue(json, new TypeReference<Map<String, String>>() {});
+        } catch (JsonProcessingException ex) {
+            throw new IllegalArgumentException("Failed to deserialize client registration provider claim mappings", ex);
+        }
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcIdentityProviderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcIdentityProviderRepository.java
@@ -91,8 +91,20 @@ public class JdbcIdentityProviderRepository extends JdbcAbstractRepository<Ident
             identityProvider.setGroupMappings(convert(rs.getString("group_mappings"), String.class, true));
             identityProvider.setRoleMappings(convert(rs.getString("role_mappings"), String.class, true));
             identityProvider.setUserProfileMapping(convert(rs.getString("user_profile_mapping"), String.class, false));
+            identityProvider.setPersistedClaimsWhitelist(convertList(rs.getString("persisted_claims_whitelist")));
 
             return identityProvider;
+        }
+
+        private List<String> convertList(String sList) {
+            if (sList != null && !sList.isEmpty()) {
+                try {
+                    return JSON_MAPPER.readValue(sList, new TypeReference<List<String>>() {});
+                } catch (IOException e) {
+                    log.warn("Failed to deserialize persisted_claims_whitelist for an identity provider row", e);
+                }
+            }
+            return null;
         }
 
         private <T, C> Map<String, T> convert(String sMap, Class<C> valueType, boolean array) {
@@ -146,6 +158,7 @@ public class JdbcIdentityProviderRepository extends JdbcAbstractRepository<Ident
             stmt.setString(idx++, convert(identityProvider.getGroupMappings()));
             stmt.setString(idx++, convert(identityProvider.getRoleMappings()));
             stmt.setString(idx++, convert(identityProvider.getUserProfileMapping()));
+            stmt.setString(idx++, convert(identityProvider.getPersistedClaimsWhitelist()));
 
             for (Object id : ids) {
                 stmt.setObject(idx++, id);
@@ -179,6 +192,7 @@ public class JdbcIdentityProviderRepository extends JdbcAbstractRepository<Ident
         builder.append(", group_mappings");
         builder.append(", role_mappings");
         builder.append(", user_profile_mapping");
+        builder.append(", persisted_claims_whitelist");
         builder.append(" ) values ( ");
         first = true;
         for (int i = 0; i < getOrm().getColumns().size(); i++) {
@@ -188,6 +202,7 @@ public class JdbcIdentityProviderRepository extends JdbcAbstractRepository<Ident
             first = false;
             builder.append("?");
         }
+        builder.append(", ?");
         builder.append(", ?");
         builder.append(", ?");
         builder.append(", ?");
@@ -214,6 +229,7 @@ public class JdbcIdentityProviderRepository extends JdbcAbstractRepository<Ident
         builder.append(", group_mappings = ?");
         builder.append(", role_mappings = ?");
         builder.append(", user_profile_mapping = ?");
+        builder.append(", persisted_claims_whitelist = ?");
 
         builder.append(" where id = ?");
         builder.append(" and organization_id = ?");

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/01_add_persisted_claims_whitelist_to_identity_providers.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/01_add_persisted_claims_whitelist_to_identity_providers.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_add_persisted_claims_whitelist_to_identity_providers
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}identity_providers
+            columns:
+              - column: { name: persisted_claims_whitelist, type: nclob, constraints: { nullable: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/02_add_claim_mappings_to_client_registration_providers.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/02_add_claim_mappings_to_client_registration_providers.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_add_claim_mappings_to_client_registration_providers
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}client_registration_providers
+            columns:
+              - column: { name: claim_mappings, type: nclob, constraints: { nullable: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -387,3 +387,7 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/20_add_tokenbucket_table.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/21_add_am_organization_id_to_am_connections.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/01_add_persisted_claims_whitelist_to_identity_providers.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/02_add_claim_mappings_to_client_registration_providers.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoClientRegistrationProviderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoClientRegistrationProviderRepository.java
@@ -96,6 +96,7 @@ public class MongoClientRegistrationProviderRepository implements ClientRegistra
             clientRegistrationProviderMongo.setRenewClientSecretMethod(clientRegistrationProvider.getRenewClientSecretMethod());
             clientRegistrationProviderMongo.setRenewClientSecretEndpoint(clientRegistrationProvider.getRenewClientSecretEndpoint());
             clientRegistrationProviderMongo.setSoftwareId(clientRegistrationProvider.getSoftwareId());
+            clientRegistrationProviderMongo.setClaimMappings(clientRegistrationProvider.getClaimMappings());
             clientRegistrationProviderMongo.setTrustStoreType(clientRegistrationProvider.getTrustStoreType());
             clientRegistrationProviderMongo.setTrustStorePath(clientRegistrationProvider.getTrustStorePath());
             clientRegistrationProviderMongo.setTrustStorePassword(clientRegistrationProvider.getTrustStorePassword());

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoIdentityProviderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoIdentityProviderRepository.java
@@ -89,6 +89,7 @@ public class MongoIdentityProviderRepository implements IdentityProviderReposito
             identityProviderMongo.setGroupMappings(providerMongo.getGroupMappings());
             identityProviderMongo.setRoleMappings(providerMongo.getRoleMappings());
             identityProviderMongo.setUserProfileMapping(identityProvider.getUserProfileMapping());
+            identityProviderMongo.setPersistedClaimsWhitelist(identityProvider.getPersistedClaimsWhitelist());
             identityProviderMongo.setEmailRequired(identityProvider.getEmailRequired());
             identityProviderMongo.setSyncMappings(identityProvider.getSyncMappings());
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ClientRegistrationProviderMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ClientRegistrationProviderMongo.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.mongodb.management.internal.model;
 
 import java.util.List;
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -80,6 +81,8 @@ public class ClientRegistrationProviderMongo extends DeprecatedAuditable {
     private String renewClientSecretMethod;
 
     private String softwareId;
+
+    private Map<String, String> claimMappings;
 
     private String trustStoreType;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/IdentityProviderMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/IdentityProviderMongo.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.mongodb.management.internal.model;
 
+import java.util.List;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -52,6 +53,8 @@ public class IdentityProviderMongo extends DeprecatedAuditable {
     private Map<String, String[]> roleMappings;
 
     private Map<String, String> userProfileMapping;
+
+    private List<String> persistedClaimsWhitelist;
 
     private Boolean emailRequired;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClientRegistrationProviderRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClientRegistrationProviderRepositoryTest.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.model.ClientRegistrationProvider;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Assertions;
@@ -145,6 +146,39 @@ public class ClientRegistrationProviderRepositoryTest extends AbstractManagement
             clientRegistrationProviderSaved.getScopes().size(),
             "Invalid client registration provider scopes."
         );
+    }
+
+    @Test
+    public void should_persist_and_read_claim_mappings() throws Exception {
+        final ClientRegistrationProvider clientRegistrationProvider = new ClientRegistrationProvider();
+        clientRegistrationProvider.setId("dcr-claim-mappings");
+        clientRegistrationProvider.setEnvironmentId("envId");
+        clientRegistrationProvider.setName("DCR with claim mappings");
+        clientRegistrationProvider.setDiscoveryEndpoint("http://localhost:8092/oidc/.well-known/openid-configuration");
+        clientRegistrationProvider.setInitialAccessTokenType(ClientRegistrationProvider.InitialAccessTokenType.INITIAL_ACCESS_TOKEN);
+        clientRegistrationProvider.setScopes(Arrays.asList("openid"));
+        clientRegistrationProvider.setCreatedAt(new Date(1000000000000L));
+        clientRegistrationProvider.setUpdatedAt(new Date(1486771200000L));
+        clientRegistrationProvider.setClaimMappings(Map.of("org_id", "metadata.organization"));
+
+        clientRegistrationProviderRepository.create(clientRegistrationProvider);
+
+        Optional<ClientRegistrationProvider> optional = clientRegistrationProviderRepository.findById("dcr-claim-mappings");
+        Assertions.assertTrue(optional.isPresent(), "Client registration provider saved not found");
+        Assertions.assertEquals(
+            Map.of("org_id", "metadata.organization"),
+            optional.get().getClaimMappings(),
+            "Invalid saved claim mappings."
+        );
+
+        // The claim mappings must also survive an update (refreshed, not dropped)
+        final ClientRegistrationProvider toUpdate = optional.get();
+        toUpdate.setClaimMappings(Map.of("tenant", "metadata.tenant"));
+        clientRegistrationProviderRepository.update(toUpdate);
+
+        Optional<ClientRegistrationProvider> updated = clientRegistrationProviderRepository.findById("dcr-claim-mappings");
+        Assertions.assertTrue(updated.isPresent(), "Client registration provider updated not found");
+        Assertions.assertEquals(Map.of("tenant", "metadata.tenant"), updated.get().getClaimMappings(), "Invalid updated claim mappings.");
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/IdentityProviderRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/IdentityProviderRepositoryTest.java
@@ -164,6 +164,41 @@ public class IdentityProviderRepositoryTest extends AbstractManagementRepository
     }
 
     @Test
+    public void should_persist_and_read_persisted_claims_whitelist() throws Exception {
+        final IdentityProvider identityProvider = new IdentityProvider();
+        identityProvider.setId("idp-claims-whitelist");
+        identityProvider.setOrganizationId("DEFAULT");
+        identityProvider.setName("Whitelist IdP");
+        identityProvider.setType(IdentityProviderType.OIDC);
+        identityProvider.setCreatedAt(new Date(1000000000000L));
+        identityProvider.setUpdatedAt(new Date(1439032010883L));
+        identityProvider.setPersistedClaimsWhitelist(List.of("org_id", "tenant"));
+
+        identityProviderRepository.create(identityProvider);
+
+        Optional<IdentityProvider> optional = identityProviderRepository.findById("idp-claims-whitelist");
+        Assertions.assertTrue(optional.isPresent(), "Identity provider saved not found");
+        Assertions.assertEquals(
+            List.of("org_id", "tenant"),
+            optional.get().getPersistedClaimsWhitelist(),
+            "Invalid saved persisted claims whitelist."
+        );
+
+        // The whitelist must also survive an update (refreshed, not dropped)
+        final IdentityProvider toUpdate = optional.get();
+        toUpdate.setPersistedClaimsWhitelist(List.of("department"));
+        identityProviderRepository.update(toUpdate);
+
+        Optional<IdentityProvider> updated = identityProviderRepository.findById("idp-claims-whitelist");
+        Assertions.assertTrue(updated.isPresent(), "Identity provider updated not found");
+        Assertions.assertEquals(
+            List.of("department"),
+            updated.get().getPersistedClaimsWhitelist(),
+            "Invalid updated persisted claims whitelist."
+        );
+    }
+
+    @Test
     public void shouldUpdate() throws Exception {
         Optional<IdentityProvider> optional = identityProviderRepository.findById("idp-1");
         Assertions.assertTrue(optional.isPresent(), "Identity provider to update not found");


### PR DESCRIPTION
## What

First (foundational) story of epic **APIM-13949** — *Tenant/User context propagation in DCR via IdP claims*. This PR adds the **repository-layer storage** the rest of the feature builds on:

- `IdentityProvider.persistedClaimsWhitelist` (`List<String>`) — claim names allowed to be persisted on a user at login.
- `ClientRegistrationProvider.claimMappings` (`Map<String,String>`) — persisted-claim → DCR-request-field-path mapping.

Both fields are **optional / nullable** — existing installations are unaffected until configured.

## How

- **Mongo**: fields added to the `*Mongo` models; `update()` setters wired (they are field-by-field manual, not mapper-based).
- **JDBC**: `IdentityProvider` reuses its serialized-column pattern (`persisted_claims_whitelist` nclob); `ClientRegistrationProvider` gets a serialized `claim_mappings` nclob column.
- **Liquibase**: `v4_13_0` changelogs for both columns, registered in `master.yml`.

## Tests

Repository round-trip tests (create **and update**) for both fields, green on **MongoDB and JDBC** (Testcontainers).

## Notes

- Ref: **APIM-13956** (epic **APIM-13949**).
- Base of a stacked series; subsequent PRs (User `idpClaims` storage, REST config, login persistence, DCR injection, docs) build on this one and should be reviewed/merged after it.
- No UI (per product decision on APIM-13954); configuration is via the Management REST API.
