### PR TITLE
fix(gamma-console): emit a single <base> tag and route under the deploy sub-path

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/rspack.config.prod.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/rspack.config.prod.ts
@@ -56,7 +56,8 @@ export default {
             tsConfig: './tsconfig.app.json',
             main: './src/main.ts',
             index: './src/index.html',
-            baseHref: '/',
+            // baseHref:false disables HtmlRspackPlugin's <base> injection. NxAppRspackPlugin otherwise defaults baseHref to '/', which injects a <base> on top of the one already in index.html -> duplicate <base> (GMA-838). index.html's <base> stays the only one and is rewritten at runtime by nginx (GAMMA_CONSOLE_BASE_HREF).
+            baseHref: false,
             assets: ['./src/favicon.ico', './src/assets', './src/constants.json'],
             styles: [],
             outputHashing: process.env['NODE_ENV'] === 'production' ? 'all' : 'none',

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/rspack.config.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/rspack.config.ts
@@ -67,7 +67,8 @@ export default {
             tsConfig: './tsconfig.app.json',
             main: './src/main.ts',
             index: './src/index.html',
-            baseHref: '/',
+            // baseHref:false disables HtmlRspackPlugin's <base> injection. NxAppRspackPlugin otherwise defaults baseHref to '/', which injects a <base> on top of the one already in index.html -> duplicate <base> (GMA-838). index.html's <base> stays the only one and is rewritten at runtime by nginx (GAMMA_CONSOLE_BASE_HREF).
+            baseHref: false,
             assets: ['./src/favicon.ico', './src/assets', './src/constants.json'],
             styles: [],
             outputHashing: process.env['NODE_ENV'] === 'production' ? 'all' : 'none',

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/bootstrap.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/bootstrap.tsx
@@ -23,12 +23,13 @@ import { BrowserRouter } from 'react-router-dom';
 import { AppRoutes } from './app/AppRoutes';
 import { runApplicationBootstrap } from './bootstrap-initialize';
 import { ErrorBoundary } from './shared/components/ErrorBoundary';
+import { resolveRouterBasename } from './shared/config/resolve-router-basename';
 
 runApplicationBootstrap().then(() => {
     const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
     root.render(
         <StrictMode>
-            <BrowserRouter>
+            <BrowserRouter basename={resolveRouterBasename()}>
                 <ThemeProvider defaultMode="system">
                     {/* Single app-wide Toaster so toast() calls from federated module remotes render. */}
                     <Toaster position="bottom-right" richColors closeButton />

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/resolve-router-basename.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/resolve-router-basename.spec.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { resolveRouterBasename } from './resolve-router-basename';
+
+describe('resolveRouterBasename', () => {
+    it('returns "/" for a root deployment', () => {
+        expect(resolveRouterBasename('http://gamma.localhost/')).toBe('/');
+    });
+
+    it('strips the trailing slash of a sub-path deployment', () => {
+        expect(resolveRouterBasename('http://gamma.localhost/gravitee-gamma/')).toBe('/gravitee-gamma');
+    });
+
+    it('keeps a sub-path that already has no trailing slash', () => {
+        expect(resolveRouterBasename('http://gamma.localhost/gravitee-gamma')).toBe('/gravitee-gamma');
+    });
+
+    it('handles a nested sub-path', () => {
+        expect(resolveRouterBasename('http://gamma.localhost/foo/bar/')).toBe('/foo/bar');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/resolve-router-basename.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/resolve-router-basename.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * React Router basename derived from the document base href.
+ *
+ * `<base href>` is set at runtime by nginx from `GAMMA_CONSOLE_BASE_HREF` so the console can be served
+ * under a sub-path (e.g. `/gravitee-gamma/`). React Router does not read `<base href>` itself, so we
+ * derive the basename to keep client-side routes under the same path as the assets. It expects a
+ * leading slash and no trailing one, so `/gravitee-gamma/` becomes `/gravitee-gamma` and root stays `/`.
+ */
+export function resolveRouterBasename(baseURI: string = document.baseURI): string {
+    return new URL(baseURI).pathname.replace(/\/$/, '') || '/';
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/rspack.config.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/rspack.config.ts
@@ -41,7 +41,8 @@ export default {
             tsConfig: './tsconfig.app.json',
             main: './src/main/ui/index.tsx',
             index: './src/main/ui/index.html',
-            baseHref: '/',
+            // baseHref:false so HtmlRspackPlugin does not inject a <base> that duplicates index.html's (GMA-838).
+            baseHref: false,
             outputHashing: process.env['NODE_ENV'] === 'production' ? 'all' : 'none',
             optimization: process.env['NODE_ENV'] === 'production',
         }),

--- a/gravitee-gamma/gravitee-gamma-module-platform/rspack.config.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/rspack.config.ts
@@ -41,7 +41,8 @@ export default {
             tsConfig: './tsconfig.app.json',
             main: './src/main/ui/index.tsx',
             index: './src/main/ui/index.html',
-            baseHref: '/',
+            // baseHref:false so HtmlRspackPlugin does not inject a <base> that duplicates index.html's (GMA-838).
+            baseHref: false,
             outputHashing: process.env['NODE_ENV'] === 'production' ? 'all' : 'none',
             optimization: process.env['NODE_ENV'] === 'production',
         }),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-887

## What
Sub-path deployments (GAMMA_CONSOLE_BASE_HREF=/gravitee-gamma/) were broken: the served page had two conflicting <base> tags, and client-side routes stayed at the root instead of following the sub-path. Both are fixed so the console works end to end under a sub-path.

Root cause
NxAppRspackPlugin defaults baseHref to / (baseHref ?? '/'), so HtmlRspackPlugin injected a <base> on top of the one already in index.html. nginx rewrites only the first occurrence, leaving a stray <base href="/">.

Separately, <BrowserRouter> had no basename, so React Router routed at the root and ignored the base href.

### Changes
- Set baseHref: false in the console rspack configs so HtmlRspackPlugin no longer injects a second <base>. The single <base> from index.html is kept and rewritten at runtime by nginx.
- Derive the React Router basename from <base href> (resolveRouterBasename) so client-side routes live under the same sub-path as the assets. Added a unit test covering root, sub-path (with and without trailing slash) and nested cases.
- Apply baseHref: false to module-apim and module-platform for consistency (same latent duplication).

### Testing

Tested using the docker compose in the sdk project


https://github.com/user-attachments/assets/5361529b-08d3-41ea-8138-57171e213e7b


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

