### PR TITLE
feat(platform-gamma): added meta data ui

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -46,6 +46,7 @@ jest.mock('../shared/console-settings', () => ({
 
 jest.mock('../shared/hooks/useEnvironmentPermissions', () => ({
     useEnvironmentPermissions: jest.fn(),
+    useEnvironmentPermissionsReady: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock('../pages/ApplicationsPage', () => ({

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -32,7 +32,8 @@ import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
 import { retryTransientRequest } from '../shared/api/queryRetry';
 import { ConsoleSettingsProvider } from '../shared/console-settings';
-import { useEnvironmentPermissions } from '../shared/hooks/useEnvironmentPermissions';
+import { useHasPermission } from '../shared/gamma-modules-sdk';
+import { useEnvironmentPermissions, useEnvironmentPermissionsReady } from '../shared/hooks/useEnvironmentPermissions';
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -43,11 +44,31 @@ const queryClient = new QueryClient({
 
 const APPLICATION_DETAIL_TABS = flattenApplicationDetailNavItems(APPLICATION_NAV_GROUPS);
 
+function MetadataGuard() {
+    const permissionsReady = useEnvironmentPermissionsReady();
+    const canRead = useHasPermission({ anyOf: ['environment-metadata-r'] });
+    if (!permissionsReady) return null;
+    if (!canRead) return <Navigate to="applications" replace />;
+    return <MetadataPage />;
+}
+
 function ModuleLayout() {
     useEnvironmentPermissions();
 
+    const permissionsReady = useEnvironmentPermissionsReady();
+    const canReadMetadata = useHasPermission({ anyOf: ['environment-metadata-r'] });
+
     const navigate = useNavigate();
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
+
+    const visibleNavGroups = useMemo(
+        () =>
+            NAV_GROUPS.map(group => ({
+                ...group,
+                items: group.items.filter(item => item.key !== 'metadata' || !permissionsReady || canReadMetadata),
+            })).filter(group => group.items.length > 0),
+        [permissionsReady, canReadMetadata],
+    );
 
     const breadcrumbs = useMemo(
         () => buildLinearBreadcrumbs(navigate, [{ label: PLATFORM_ROUTE_CONFIG.routes[activeNavKey].label }]),
@@ -56,10 +77,10 @@ function ModuleLayout() {
 
     useLayoutConfig(
         {
-            navigation: <SidebarNavigation groups={NAV_GROUPS} activeItemKey={activeNavKey} onItemSelect={navigateToKey} />,
+            navigation: <SidebarNavigation groups={visibleNavGroups} activeItemKey={activeNavKey} onItemSelect={navigateToKey} />,
             breadcrumbs,
         },
-        [activeNavKey, breadcrumbs, navigateToKey],
+        [activeNavKey, breadcrumbs, navigateToKey, visibleNavGroups],
     );
 
     return <Outlet />;
@@ -87,7 +108,7 @@ export function AppRoutes() {
                             </Route>
                         </Route>
                         <Route path="access-management" element={<AccessManagementPage />} />
-                        <Route path="metadata" element={<MetadataPage />} />
+                        <Route path="metadata" element={<MetadataGuard />} />
                     </Route>
                 </Routes>
             </ConsoleSettingsProvider>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -28,6 +28,7 @@ import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../feat
 import { AccessManagementPage } from '../pages/AccessManagementPage';
 import { ApplicationDetailSubscriptionPage } from '../pages/ApplicationDetailSubscriptionPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
+import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
 import { retryTransientRequest } from '../shared/api/queryRetry';
 import { ConsoleSettingsProvider } from '../shared/console-settings';
@@ -86,6 +87,7 @@ export function AppRoutes() {
                             </Route>
                         </Route>
                         <Route path="access-management" element={<AccessManagementPage />} />
+                        <Route path="metadata" element={<MetadataPage />} />
                     </Route>
                 </Routes>
             </ConsoleSettingsProvider>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import type { NavGroup } from '@gravitee/graphene-core';
-import { AppWindowIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
+import { AppWindowIcon, DatabaseIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
 
 import { ROUTES } from './routes';
 
@@ -22,6 +22,10 @@ export const NAV_GROUPS: NavGroup[] = [
     {
         label: 'Overview',
         items: [{ key: 'applications', title: ROUTES.applications.label, icon: AppWindowIcon }],
+    },
+    {
+        label: 'APIs & Assets',
+        items: [{ key: 'metadata', title: ROUTES.metadata.label, icon: DatabaseIcon }],
     },
     {
         label: 'System & Security',

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -15,7 +15,7 @@
  */
 import type { ModuleRouteConfig } from '@gravitee/gamma-modules-sdk/routing';
 
-export const ROUTE_KEYS: readonly string[] = ['applications', 'access-management'];
+export const ROUTE_KEYS: readonly string[] = ['applications', 'access-management', 'metadata'];
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
 const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
@@ -23,6 +23,7 @@ const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
 export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: string }> = {
     applications: { path: 'applications', label: 'Applications' },
     'access-management': { path: 'access-management', label: 'Access Management' },
+    metadata: { path: 'metadata', label: 'Metadata' },
 };
 
 export const PLATFORM_ROUTE_CONFIG: ModuleRouteConfig<RouteKey> = {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataDeleteSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataDeleteSheet.spec.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { MetadataDeleteSheet } from './MetadataDeleteSheet';
+import type { Metadata } from '../types/metadata';
+import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
+
+const METADATA: Metadata = { key: 'support-email', name: 'Support Email', format: 'MAIL', value: 'help@example.com' };
+
+function renderSheet(open: boolean, metadata: Metadata | undefined = METADATA) {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    render(<MetadataDeleteSheet open={open} metadata={metadata} onClose={onClose} onConfirm={onConfirm} isDeleting={false} />);
+    return { onClose, onConfirm };
+}
+
+describe('MetadataDeleteSheet', () => {
+    it('does not show sheet content when closed', () => {
+        renderSheet(false);
+        expect(querySheetHeading('Delete Metadata')).toBeNull();
+    });
+
+    it('shows the sheet title when open', () => {
+        renderSheet(true);
+        expect(screen.getByRole('heading', { name: 'Delete Metadata' })).not.toBeNull();
+    });
+
+    it('shows the metadata name and key in the confirmation text', () => {
+        renderSheet(true);
+        expect(screen.queryByText('Support Email')).not.toBeNull();
+        expect(screen.queryByText('support-email')).not.toBeNull();
+    });
+
+    it('invokes onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet(true);
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes onConfirm when Delete is clicked', () => {
+        const { onConfirm } = renderSheet(true);
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables both buttons while deleting', () => {
+        const onClose = jest.fn();
+        const onConfirm = jest.fn();
+        render(<MetadataDeleteSheet open={true} metadata={METADATA} onClose={onClose} onConfirm={onConfirm} isDeleting={true} />);
+        expect((screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement).disabled).toBe(true);
+        expect((screen.getByRole('button', { name: 'Deleting…' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataDeleteSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataDeleteSheet.spec.tsx
@@ -16,8 +16,8 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { MetadataDeleteSheet } from './MetadataDeleteSheet';
-import type { Metadata } from '../types/metadata';
 import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
+import type { Metadata } from '../types/metadata';
 
 const METADATA: Metadata = { key: 'support-email', name: 'Support Email', format: 'MAIL', value: 'help@example.com' };
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataDeleteSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataDeleteSheet.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from '@gravitee/graphene-core';
+import { useCallback } from 'react';
+
+import type { Metadata } from '../types/metadata';
+
+export function MetadataDeleteSheet({
+    open,
+    metadata,
+    onClose,
+    onConfirm,
+    isDeleting,
+}: Readonly<{
+    open: boolean;
+    metadata: Metadata | undefined;
+    onClose: () => void;
+    onConfirm: () => void;
+    isDeleting: boolean;
+}>) {
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>Delete Metadata</SheetTitle>
+                    <SheetDescription>This action cannot be undone.</SheetDescription>
+                </SheetHeader>
+
+                <div className="flex-1 px-1 py-4">
+                    <p className="text-sm text-muted-foreground">
+                        Are you sure you want to delete <span className="font-medium text-foreground">{metadata?.name}</span>
+                        {metadata?.key ? (
+                            <>
+                                {' '}
+                                <span className="font-mono text-xs bg-muted px-1 py-0.5 rounded">{metadata.key}</span>
+                            </>
+                        ) : null}
+                        ? APIs that inherit this key will lose its default value.
+                    </p>
+                </div>
+
+                <SheetFooter className="shrink-0 flex-row justify-end gap-2 border-t pt-4">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting}>
+                        {isDeleting ? 'Deleting…' : 'Delete'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataFormatBadge.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataFormatBadge.spec.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { MetadataFormatBadge } from './MetadataFormatBadge';
+import type { MetadataFormat } from '../types/metadata';
+
+describe('MetadataFormatBadge', () => {
+    it.each<[MetadataFormat, string]>([
+        ['STRING', 'String'],
+        ['NUMERIC', 'Numeric'],
+        ['BOOLEAN', 'Boolean'],
+        ['DATE', 'Date'],
+        ['MAIL', 'Mail'],
+        ['URL', 'URL'],
+    ])('renders label "%s" for format %s', (format, expectedLabel) => {
+        render(<MetadataFormatBadge format={format} />);
+        expect(screen.queryByText(expectedLabel)).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataFormatBadge.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataFormatBadge.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Badge, cn } from '@gravitee/graphene-core';
+
+import type { MetadataFormat } from '../types/metadata';
+
+const FORMAT_CONFIG: Record<MetadataFormat, { label: string; className: string }> = {
+    STRING: { label: 'String', className: 'bg-blue-100 text-blue-700 border-transparent' },
+    NUMERIC: { label: 'Numeric', className: 'bg-purple-100 text-purple-700 border-transparent' },
+    BOOLEAN: { label: 'Boolean', className: 'bg-amber-100 text-amber-700 border-transparent' },
+    DATE: { label: 'Date', className: 'bg-green-100 text-green-700 border-transparent' },
+    MAIL: { label: 'Mail', className: 'bg-pink-100 text-pink-700 border-transparent' },
+    URL: { label: 'URL', className: 'bg-cyan-100 text-cyan-700 border-transparent' },
+};
+
+export function MetadataFormatBadge({ format }: Readonly<{ format: MetadataFormat }>) {
+    const config = FORMAT_CONFIG[format] ?? { label: format, className: '' };
+    return <Badge className={cn('font-normal text-xs', config.className)}>{config.label}</Badge>;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataSheet.spec.tsx
@@ -16,8 +16,8 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { MetadataSheet } from './MetadataSheet';
-import type { Metadata } from '../types/metadata';
 import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
+import type { Metadata } from '../types/metadata';
 
 const EXISTING_METADATA: Metadata = { key: 'support-email', name: 'Support Email', format: 'MAIL', value: 'help@example.com' };
 
@@ -57,35 +57,34 @@ describe('MetadataSheet', () => {
     });
 
     describe('create mode', () => {
-        it('renders an empty form', () => {
+        it('renders an empty name field', () => {
             renderSheet({ mode: 'create' });
-            expect((screen.getByLabelText(/Key/i) as HTMLInputElement).value).toBe('');
             expect((screen.getByLabelText(/Name/i) as HTMLInputElement).value).toBe('');
         });
 
-        it('enables the key field', () => {
+        it('defaults format to STRING', () => {
             renderSheet({ mode: 'create' });
-            expect((screen.getByLabelText(/Key/i) as HTMLInputElement).disabled).toBe(false);
+            expect(screen.queryAllByText('String').length).toBeGreaterThan(0);
         });
 
-        it('keeps Add disabled until both key and name are filled', () => {
+        it('keeps Add disabled until name and value are filled', () => {
             renderSheet({ mode: 'create' });
             const addBtn = screen.getByRole('button', { name: 'Add' }) as HTMLButtonElement;
             expect(addBtn.disabled).toBe(true);
 
-            fireEvent.change(screen.getByLabelText(/Key/i), { target: { value: 'my-key' } });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Metadata' } });
             expect(addBtn.disabled).toBe(true);
 
-            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Key' } });
+            fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: 'some-value' } });
             expect(addBtn.disabled).toBe(false);
         });
 
-        it('submits the form with trimmed values', () => {
+        it('submits the form with trimmed name and value and no key', () => {
             const { onSubmit } = renderSheet({ mode: 'create' });
-            fireEvent.change(screen.getByLabelText(/Key/i), { target: { value: '  my-key  ' } });
-            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: '  My Key  ' } });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: '  My Metadata  ' } });
+            fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: '  some value  ' } });
             fireEvent.click(screen.getByRole('button', { name: 'Add' }));
-            expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ key: 'my-key', name: 'My Key' }));
+            expect(onSubmit).toHaveBeenCalledWith({ name: 'My Metadata', format: 'STRING', value: 'some value' });
         });
 
         it('shows "Adding…" label while saving', () => {
@@ -95,15 +94,27 @@ describe('MetadataSheet', () => {
     });
 
     describe('edit mode', () => {
-        it('pre-fills the form with existing metadata', () => {
+        it('shows the key as a disabled read-only field', () => {
             renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
-            expect((screen.getByLabelText(/Key/i) as HTMLInputElement).value).toBe('support-email');
-            expect((screen.getByLabelText(/Name/i) as HTMLInputElement).value).toBe('Support Email');
+            const keyInput = screen.getByLabelText(/Key/i) as HTMLInputElement;
+            expect(keyInput.value).toBe('support-email');
+            expect(keyInput.disabled).toBe(true);
         });
 
-        it('disables the key field', () => {
+        it('does not show the key field in create mode', () => {
+            renderSheet({ mode: 'create' });
+            expect(screen.queryByLabelText(/Key/i)).toBeNull();
+        });
+
+        it('pre-fills name and value from existing metadata', () => {
             renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
-            expect((screen.getByLabelText(/Key/i) as HTMLInputElement).disabled).toBe(true);
+            expect((screen.getByLabelText(/Name/i) as HTMLInputElement).value).toBe('Support Email');
+            expect((screen.getByLabelText(/Value/i) as HTMLInputElement).value).toBe('help@example.com');
+        });
+
+        it('shows a hint that format cannot be changed in edit mode', () => {
+            renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
+            expect(screen.queryByText('Format cannot be changed after creation.')).not.toBeNull();
         });
 
         it('shows Update button', () => {
@@ -111,7 +122,31 @@ describe('MetadataSheet', () => {
             expect(screen.queryByRole('button', { name: 'Update' })).not.toBeNull();
         });
 
-        it('submits updated values', () => {
+        it('disables Update when nothing has changed', () => {
+            renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
+            expect((screen.getByRole('button', { name: 'Update' }) as HTMLButtonElement).disabled).toBe(true);
+        });
+
+        it('enables Update after changing the name', () => {
+            renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'New Name' } });
+            expect((screen.getByRole('button', { name: 'Update' }) as HTMLButtonElement).disabled).toBe(false);
+        });
+
+        it('enables Update after changing the value', () => {
+            renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
+            fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: 'new@example.com' } });
+            expect((screen.getByRole('button', { name: 'Update' }) as HTMLButtonElement).disabled).toBe(false);
+        });
+
+        it('re-disables Update when name is reverted to original', () => {
+            renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'New Name' } });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Support Email' } });
+            expect((screen.getByRole('button', { name: 'Update' }) as HTMLButtonElement).disabled).toBe(true);
+        });
+
+        it('submits updated values including the original key', () => {
             const { onSubmit } = renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
             fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Updated Name' } });
             fireEvent.click(screen.getByRole('button', { name: 'Update' }));
@@ -129,6 +164,60 @@ describe('MetadataSheet', () => {
             const { onClose } = renderSheet({ mode: 'create' });
             fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
             expect(onClose).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('format-specific validation', () => {
+        it('renders a Select (not an input) for BOOLEAN format value field', () => {
+            const booleanMetadata: Metadata = { key: 'debug', name: 'Debug Mode', format: 'BOOLEAN', value: 'true' };
+            renderSheet({ mode: 'edit', metadata: booleanMetadata });
+            expect(screen.queryByRole('combobox', { name: /Value/i })).not.toBeNull();
+        });
+
+        it('disables Update when NUMERIC value is not a valid number', () => {
+            const numericMetadata: Metadata = { key: 'retries', name: 'Max Retries', format: 'NUMERIC', value: '3' };
+            renderSheet({ mode: 'edit', metadata: numericMetadata });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Max Retries Updated' } });
+            const updateBtn = screen.getByRole('button', { name: 'Update' }) as HTMLButtonElement;
+            expect(updateBtn.disabled).toBe(false);
+
+            fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: 'not-a-number' } });
+            expect(updateBtn.disabled).toBe(true);
+        });
+
+        it('disables Update when MAIL value is not a valid email', () => {
+            renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Changed' } });
+            const updateBtn = screen.getByRole('button', { name: 'Update' }) as HTMLButtonElement;
+            expect(updateBtn.disabled).toBe(false);
+
+            fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: 'not-an-email' } });
+            expect(updateBtn.disabled).toBe(true);
+        });
+
+        it('disables Update when MAIL value is missing domain extension', () => {
+            renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Changed' } });
+            fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: 'user@nodomain' } });
+            expect((screen.getByRole('button', { name: 'Update' }) as HTMLButtonElement).disabled).toBe(true);
+        });
+
+        it('disables Update when URL value is not a valid URL', () => {
+            const urlMetadata: Metadata = { key: 'docs', name: 'Docs URL', format: 'URL', value: 'https://docs.example.com' };
+            renderSheet({ mode: 'edit', metadata: urlMetadata });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Docs URL Updated' } });
+            const updateBtn = screen.getByRole('button', { name: 'Update' }) as HTMLButtonElement;
+            expect(updateBtn.disabled).toBe(false);
+
+            fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: 'not a url !!' } });
+            expect(updateBtn.disabled).toBe(true);
+        });
+
+        it('disables Add when value is empty for STRING format', () => {
+            renderSheet({ mode: 'create' });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Metadata' } });
+            const addBtn = screen.getByRole('button', { name: 'Add' }) as HTMLButtonElement;
+            expect(addBtn.disabled).toBe(true);
         });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataSheet.spec.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { MetadataSheet } from './MetadataSheet';
+import type { Metadata } from '../types/metadata';
+import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
+
+const EXISTING_METADATA: Metadata = { key: 'support-email', name: 'Support Email', format: 'MAIL', value: 'help@example.com' };
+
+function renderSheet({
+    open = true,
+    mode,
+    metadata,
+    isSaving = false,
+}: {
+    open?: boolean;
+    mode: 'create' | 'edit';
+    metadata?: Metadata;
+    isSaving?: boolean;
+}) {
+    const onClose = jest.fn();
+    const onSubmit = jest.fn();
+    render(<MetadataSheet open={open} mode={mode} metadata={metadata} onClose={onClose} onSubmit={onSubmit} isSaving={isSaving} />);
+    return { onClose, onSubmit };
+}
+
+describe('MetadataSheet', () => {
+    describe('visibility', () => {
+        it('does not show sheet content when closed', () => {
+            renderSheet({ open: false, mode: 'create' });
+            expect(querySheetHeading('Add Global Metadata')).toBeNull();
+        });
+
+        it('shows create title when mode is create', () => {
+            renderSheet({ mode: 'create' });
+            expect(screen.getByRole('heading', { name: 'Add Global Metadata' })).not.toBeNull();
+        });
+
+        it('shows edit title when mode is edit', () => {
+            renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
+            expect(screen.getByRole('heading', { name: 'Edit Metadata' })).not.toBeNull();
+        });
+    });
+
+    describe('create mode', () => {
+        it('renders an empty form', () => {
+            renderSheet({ mode: 'create' });
+            expect((screen.getByLabelText(/Key/i) as HTMLInputElement).value).toBe('');
+            expect((screen.getByLabelText(/Name/i) as HTMLInputElement).value).toBe('');
+        });
+
+        it('enables the key field', () => {
+            renderSheet({ mode: 'create' });
+            expect((screen.getByLabelText(/Key/i) as HTMLInputElement).disabled).toBe(false);
+        });
+
+        it('keeps Add disabled until both key and name are filled', () => {
+            renderSheet({ mode: 'create' });
+            const addBtn = screen.getByRole('button', { name: 'Add' }) as HTMLButtonElement;
+            expect(addBtn.disabled).toBe(true);
+
+            fireEvent.change(screen.getByLabelText(/Key/i), { target: { value: 'my-key' } });
+            expect(addBtn.disabled).toBe(true);
+
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Key' } });
+            expect(addBtn.disabled).toBe(false);
+        });
+
+        it('submits the form with trimmed values', () => {
+            const { onSubmit } = renderSheet({ mode: 'create' });
+            fireEvent.change(screen.getByLabelText(/Key/i), { target: { value: '  my-key  ' } });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: '  My Key  ' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+            expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ key: 'my-key', name: 'My Key' }));
+        });
+
+        it('shows "Adding…" label while saving', () => {
+            renderSheet({ mode: 'create', isSaving: true });
+            expect(screen.queryByRole('button', { name: 'Adding…' })).not.toBeNull();
+        });
+    });
+
+    describe('edit mode', () => {
+        it('pre-fills the form with existing metadata', () => {
+            renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
+            expect((screen.getByLabelText(/Key/i) as HTMLInputElement).value).toBe('support-email');
+            expect((screen.getByLabelText(/Name/i) as HTMLInputElement).value).toBe('Support Email');
+        });
+
+        it('disables the key field', () => {
+            renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
+            expect((screen.getByLabelText(/Key/i) as HTMLInputElement).disabled).toBe(true);
+        });
+
+        it('shows Update button', () => {
+            renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
+            expect(screen.queryByRole('button', { name: 'Update' })).not.toBeNull();
+        });
+
+        it('submits updated values', () => {
+            const { onSubmit } = renderSheet({ mode: 'edit', metadata: EXISTING_METADATA });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Updated Name' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+            expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ key: 'support-email', name: 'Updated Name' }));
+        });
+
+        it('shows "Updating…" label while saving', () => {
+            renderSheet({ mode: 'edit', metadata: EXISTING_METADATA, isSaving: true });
+            expect(screen.queryByRole('button', { name: 'Updating…' })).not.toBeNull();
+        });
+    });
+
+    describe('cancel', () => {
+        it('invokes onClose when Cancel is clicked', () => {
+            const { onClose } = renderSheet({ mode: 'create' });
+            fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataSheet.tsx
@@ -32,7 +32,7 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@gravitee/graphene-core';
-import { useCallback, useEffect, useState, type FormEvent } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 
 import type { Metadata, MetadataFormat, NewMetadataPayload, UpdateMetadataPayload } from '../types/metadata';
 
@@ -47,14 +47,26 @@ const FORMAT_LABELS: Record<MetadataFormat, string> = {
     URL: 'URL',
 };
 
+const MAIL_REGEX =
+    /^((\${.+})|(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,})))$/;
+const URL_REGEX = /^((\$\{.+\})|(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})\b([-a-zA-Z0-9()@:%_+.~#?&//=]*))$/;
+
 interface MetadataForm {
-    key: string;
     name: string;
     format: MetadataFormat;
     value: string;
 }
 
-const EMPTY_FORM: MetadataForm = { key: '', name: '', format: 'STRING', value: '' };
+const EMPTY_FORM: MetadataForm = { name: '', format: 'STRING', value: '' };
+
+function isValueValid(format: MetadataFormat, value: string): boolean {
+    if (format === 'BOOLEAN') return value === 'true' || value === 'false';
+    if (!value.trim()) return false;
+    if (format === 'NUMERIC') return !isNaN(Number(value));
+    if (format === 'MAIL') return MAIL_REGEX.test(value);
+    if (format === 'URL') return URL_REGEX.test(value);
+    return true;
+}
 
 export type MetadataSheetMode = 'create' | 'edit';
 
@@ -74,13 +86,17 @@ export function MetadataSheet({
     isSaving: boolean;
 }>) {
     const [form, setForm] = useState<MetadataForm>(EMPTY_FORM);
+    const [initialForm, setInitialForm] = useState<MetadataForm | null>(null);
 
     useEffect(() => {
         if (!open) return;
         if (mode === 'edit' && metadata) {
-            setForm({ key: metadata.key, name: metadata.name, format: metadata.format, value: metadata.value ?? '' });
+            const initial = { name: metadata.name, format: metadata.format, value: metadata.value ?? '' };
+            setForm(initial);
+            setInitialForm(initial);
         } else {
             setForm(EMPTY_FORM);
+            setInitialForm(null);
         }
     }, [open, mode, metadata]);
 
@@ -95,12 +111,28 @@ export function MetadataSheet({
         setForm(prev => ({ ...prev, [key]: value }));
     }
 
-    const isValid = form.key.trim() !== '' && form.name.trim() !== '';
+    function handleFormatChange(newFormat: MetadataFormat) {
+        // Reset value on format change; BOOLEAN defaults to 'false'
+        setForm(prev => ({ ...prev, format: newFormat, value: newFormat === 'BOOLEAN' ? 'false' : '' }));
+    }
+
+    const isValid = form.name.trim() !== '' && isValueValid(form.format, form.value);
+
+    const hasChanged = useMemo(() => {
+        if (mode === 'create') return true;
+        if (!initialForm) return false;
+        return form.name !== initialForm.name || form.value !== initialForm.value;
+    }, [mode, form, initialForm]);
 
     function handleSubmit(e: FormEvent) {
         e.preventDefault();
-        if (!isValid) return;
-        onSubmit({ key: form.key.trim(), name: form.name.trim(), format: form.format, value: form.value.trim() });
+        if (!isValid || !hasChanged) return;
+        const base = { name: form.name.trim(), format: form.format, value: form.value.trim() };
+        if (mode === 'edit' && metadata) {
+            onSubmit({ ...base, key: metadata.key } satisfies UpdateMetadataPayload);
+        } else {
+            onSubmit(base satisfies NewMetadataPayload);
+        }
     }
 
     return (
@@ -111,29 +143,18 @@ export function MetadataSheet({
                     <SheetDescription>
                         {mode === 'create'
                             ? 'Define a new metadata key that will be inherited by all APIs in this environment.'
-                            : 'Update the metadata value. The key cannot be changed after creation.'}
+                            : 'Update the metadata value. Format cannot be changed after creation.'}
                     </SheetDescription>
                 </SheetHeader>
 
                 <ScrollArea className="flex-1 min-h-0">
                     <form id="metadata-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-1 py-4">
-                        <Field orientation="vertical" className="gap-1.5">
-                            <FieldLabel htmlFor="metadata-key">
-                                Key{' '}
-                                <span className="text-destructive" aria-hidden>
-                                    *
-                                </span>
-                            </FieldLabel>
-                            <Input
-                                id="metadata-key"
-                                value={form.key}
-                                onChange={e => setField('key', e.target.value)}
-                                placeholder="e.g. support-email"
-                                disabled={mode === 'edit' || isSaving}
-                                required
-                            />
-                            {mode === 'edit' && <p className="text-xs text-muted-foreground">The key is fixed and cannot be changed.</p>}
-                        </Field>
+                        {mode === 'edit' && metadata && (
+                            <Field orientation="vertical" className="gap-1.5">
+                                <FieldLabel htmlFor="metadata-key">Key</FieldLabel>
+                                <Input id="metadata-key" value={metadata.key} disabled readOnly />
+                            </Field>
+                        )}
 
                         <Field orientation="vertical" className="gap-1.5">
                             <FieldLabel htmlFor="metadata-name">
@@ -153,11 +174,16 @@ export function MetadataSheet({
                         </Field>
 
                         <Field orientation="vertical" className="gap-1.5">
-                            <FieldLabel htmlFor="metadata-format">Format</FieldLabel>
+                            <FieldLabel htmlFor="metadata-format">
+                                Format{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
                             <Select
                                 value={form.format}
-                                onValueChange={val => setField('format', val as MetadataFormat)}
-                                disabled={isSaving}
+                                onValueChange={val => handleFormatChange(val as MetadataFormat)}
+                                disabled={mode === 'edit' || isSaving}
                             >
                                 <SelectTrigger id="metadata-format">
                                     <SelectValue />
@@ -170,18 +196,55 @@ export function MetadataSheet({
                                     ))}
                                 </SelectContent>
                             </Select>
+                            {mode === 'edit' && <p className="text-xs text-muted-foreground">Format cannot be changed after creation.</p>}
                         </Field>
 
                         <Field orientation="vertical" className="gap-1.5">
-                            <FieldLabel htmlFor="metadata-value">Default Value</FieldLabel>
-                            <Input
-                                id="metadata-value"
-                                value={form.value}
-                                onChange={e => setField('value', e.target.value)}
-                                placeholder="Default value (optional)"
-                                disabled={isSaving}
-                            />
-                            <p className="text-xs text-muted-foreground">APIs can override this. Leave blank to have no default.</p>
+                            <FieldLabel htmlFor="metadata-value">
+                                Value{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            {form.format === 'BOOLEAN' ? (
+                                <Select value={form.value} onValueChange={val => setField('value', val)} disabled={isSaving}>
+                                    <SelectTrigger id="metadata-value">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="true">true</SelectItem>
+                                        <SelectItem value="false">false</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            ) : (
+                                <Input
+                                    id="metadata-value"
+                                    value={form.value}
+                                    onChange={e => setField('value', e.target.value)}
+                                    type={
+                                        form.format === 'NUMERIC'
+                                            ? 'number'
+                                            : form.format === 'DATE'
+                                              ? 'date'
+                                              : form.format === 'MAIL'
+                                                ? 'email'
+                                                : form.format === 'URL'
+                                                  ? 'url'
+                                                  : 'text'
+                                    }
+                                    placeholder={
+                                        form.format === 'NUMERIC'
+                                            ? 'e.g. 123'
+                                            : form.format === 'MAIL'
+                                              ? 'e.g. john@doe.com'
+                                              : form.format === 'URL'
+                                                ? 'e.g. https://gravitee.io'
+                                                : undefined
+                                    }
+                                    disabled={isSaving}
+                                    required
+                                />
+                            )}
                         </Field>
                     </form>
                 </ScrollArea>
@@ -190,7 +253,7 @@ export function MetadataSheet({
                     <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
                         Cancel
                     </Button>
-                    <Button type="submit" form="metadata-form" disabled={!isValid || isSaving}>
+                    <Button type="submit" form="metadata-form" disabled={!isValid || !hasChanged || isSaving}>
                         {isSaving ? (mode === 'create' ? 'Adding…' : 'Updating…') : mode === 'create' ? 'Add' : 'Update'}
                     </Button>
                 </SheetFooter>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataSheet.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Field,
+    FieldLabel,
+    Input,
+    ScrollArea,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+} from '@gravitee/graphene-core';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+
+import type { Metadata, MetadataFormat, NewMetadataPayload, UpdateMetadataPayload } from '../types/metadata';
+
+const METADATA_FORMATS: MetadataFormat[] = ['STRING', 'NUMERIC', 'BOOLEAN', 'DATE', 'MAIL', 'URL'];
+
+const FORMAT_LABELS: Record<MetadataFormat, string> = {
+    STRING: 'String',
+    NUMERIC: 'Numeric',
+    BOOLEAN: 'Boolean',
+    DATE: 'Date',
+    MAIL: 'Mail',
+    URL: 'URL',
+};
+
+interface MetadataForm {
+    key: string;
+    name: string;
+    format: MetadataFormat;
+    value: string;
+}
+
+const EMPTY_FORM: MetadataForm = { key: '', name: '', format: 'STRING', value: '' };
+
+export type MetadataSheetMode = 'create' | 'edit';
+
+export function MetadataSheet({
+    open,
+    mode,
+    metadata,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    mode: MetadataSheetMode;
+    metadata?: Metadata;
+    onClose: () => void;
+    onSubmit: (data: NewMetadataPayload | UpdateMetadataPayload) => void;
+    isSaving: boolean;
+}>) {
+    const [form, setForm] = useState<MetadataForm>(EMPTY_FORM);
+
+    useEffect(() => {
+        if (!open) return;
+        if (mode === 'edit' && metadata) {
+            setForm({ key: metadata.key, name: metadata.name, format: metadata.format, value: metadata.value ?? '' });
+        } else {
+            setForm(EMPTY_FORM);
+        }
+    }, [open, mode, metadata]);
+
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    function setField<K extends keyof MetadataForm>(key: K, value: MetadataForm[K]) {
+        setForm(prev => ({ ...prev, [key]: value }));
+    }
+
+    const isValid = form.key.trim() !== '' && form.name.trim() !== '';
+
+    function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        if (!isValid) return;
+        onSubmit({ key: form.key.trim(), name: form.name.trim(), format: form.format, value: form.value.trim() });
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>{mode === 'create' ? 'Add Global Metadata' : 'Edit Metadata'}</SheetTitle>
+                    <SheetDescription>
+                        {mode === 'create'
+                            ? 'Define a new metadata key that will be inherited by all APIs in this environment.'
+                            : 'Update the metadata value. The key cannot be changed after creation.'}
+                    </SheetDescription>
+                </SheetHeader>
+
+                <ScrollArea className="flex-1 min-h-0">
+                    <form id="metadata-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-1 py-4">
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="metadata-key">
+                                Key{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            <Input
+                                id="metadata-key"
+                                value={form.key}
+                                onChange={e => setField('key', e.target.value)}
+                                placeholder="e.g. support-email"
+                                disabled={mode === 'edit' || isSaving}
+                                required
+                            />
+                            {mode === 'edit' && <p className="text-xs text-muted-foreground">The key is fixed and cannot be changed.</p>}
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="metadata-name">
+                                Name{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            <Input
+                                id="metadata-name"
+                                value={form.name}
+                                onChange={e => setField('name', e.target.value)}
+                                placeholder="e.g. Support Email"
+                                disabled={isSaving}
+                                required
+                            />
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="metadata-format">Format</FieldLabel>
+                            <Select
+                                value={form.format}
+                                onValueChange={val => setField('format', val as MetadataFormat)}
+                                disabled={isSaving}
+                            >
+                                <SelectTrigger id="metadata-format">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {METADATA_FORMATS.map(fmt => (
+                                        <SelectItem key={fmt} value={fmt}>
+                                            {FORMAT_LABELS[fmt]}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="metadata-value">Default Value</FieldLabel>
+                            <Input
+                                id="metadata-value"
+                                value={form.value}
+                                onChange={e => setField('value', e.target.value)}
+                                placeholder="Default value (optional)"
+                                disabled={isSaving}
+                            />
+                            <p className="text-xs text-muted-foreground">APIs can override this. Leave blank to have no default.</p>
+                        </Field>
+                    </form>
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-row justify-end gap-2 border-t pt-4">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="submit" form="metadata-form" disabled={!isValid || isSaving}>
+                        {isSaving ? (mode === 'create' ? 'Adding…' : 'Updating…') : mode === 'create' ? 'Add' : 'Update'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataTable.spec.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { MetadataTable } from './MetadataTable';
+import type { Metadata } from '../types/metadata';
+
+const METADATA: Metadata[] = [
+    { key: 'support-email', name: 'Support Email', format: 'MAIL', value: 'help@example.com' },
+    { key: 'api-version', name: 'API Version', format: 'STRING', value: '1.0' },
+    { key: 'max-retries', name: 'Max Retries', format: 'NUMERIC', value: '3' },
+];
+
+function renderTable(overrides: Partial<{ canWrite: boolean; metadata: Metadata[] }> = {}) {
+    const onEdit = jest.fn();
+    const onDelete = jest.fn();
+    render(
+        <MetadataTable
+            metadata={overrides.metadata ?? METADATA}
+            canWrite={overrides.canWrite ?? true}
+            onEdit={onEdit}
+            onDelete={onDelete}
+        />,
+    );
+    return { onEdit, onDelete };
+}
+
+describe('MetadataTable', () => {
+    describe('rendering', () => {
+        it('renders all metadata rows', () => {
+            renderTable();
+            expect(screen.queryByText('Support Email')).not.toBeNull();
+            expect(screen.queryByText('API Version')).not.toBeNull();
+            expect(screen.queryByText('Max Retries')).not.toBeNull();
+        });
+
+        it('shows the empty message when there is no metadata', () => {
+            renderTable({ metadata: [] });
+            expect(screen.queryByText('No global metadata defined for this environment.')).not.toBeNull();
+        });
+    });
+
+    describe('search filtering', () => {
+        it('filters rows by name', () => {
+            renderTable();
+            fireEvent.change(screen.getByPlaceholderText('Search by key or name…'), { target: { value: 'version' } });
+            expect(screen.queryByText('API Version')).not.toBeNull();
+            expect(screen.queryByText('Support Email')).toBeNull();
+        });
+
+        it('filters rows by key', () => {
+            renderTable();
+            fireEvent.change(screen.getByPlaceholderText('Search by key or name…'), { target: { value: 'max-retries' } });
+            expect(screen.queryByText('Max Retries')).not.toBeNull();
+            expect(screen.queryByText('Support Email')).toBeNull();
+        });
+
+        it('shows the no-match message when search has no results', () => {
+            renderTable();
+            fireEvent.change(screen.getByPlaceholderText('Search by key or name…'), { target: { value: 'zzznomatch' } });
+            expect(screen.queryByText('No metadata matches your search.')).not.toBeNull();
+        });
+
+        it('is case-insensitive', () => {
+            renderTable();
+            fireEvent.change(screen.getByPlaceholderText('Search by key or name…'), { target: { value: 'SUPPORT' } });
+            expect(screen.queryByText('Support Email')).not.toBeNull();
+        });
+    });
+
+    describe('write permissions', () => {
+        it('hides the actions column when canWrite is false', () => {
+            renderTable({ canWrite: false });
+            expect(screen.queryByRole('button', { name: 'Metadata actions' })).toBeNull();
+        });
+
+        it('shows one action button per row when canWrite is true', () => {
+            renderTable();
+            expect(screen.getAllByRole('button', { name: 'Metadata actions' }).length).toBe(METADATA.length);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataTable.spec.tsx
@@ -24,13 +24,14 @@ const METADATA: Metadata[] = [
     { key: 'max-retries', name: 'Max Retries', format: 'NUMERIC', value: '3' },
 ];
 
-function renderTable(overrides: Partial<{ canWrite: boolean; metadata: Metadata[] }> = {}) {
+function renderTable(overrides: Partial<{ canEdit: boolean; canDelete: boolean; metadata: Metadata[] }> = {}) {
     const onEdit = jest.fn();
     const onDelete = jest.fn();
     render(
         <MetadataTable
             metadata={overrides.metadata ?? METADATA}
-            canWrite={overrides.canWrite ?? true}
+            canEdit={overrides.canEdit ?? true}
+            canDelete={overrides.canDelete ?? true}
             onEdit={onEdit}
             onDelete={onDelete}
         />,
@@ -50,6 +51,12 @@ describe('MetadataTable', () => {
         it('shows the empty message when there is no metadata', () => {
             renderTable({ metadata: [] });
             expect(screen.queryByText('No global metadata defined for this environment.')).not.toBeNull();
+        });
+
+        it('renders "Value" as the column header (not "Default Value")', () => {
+            renderTable();
+            expect(screen.queryByRole('columnheader', { name: 'Value' })).not.toBeNull();
+            expect(screen.queryByRole('columnheader', { name: 'Default Value' })).toBeNull();
         });
     });
 
@@ -81,13 +88,23 @@ describe('MetadataTable', () => {
         });
     });
 
-    describe('write permissions', () => {
-        it('hides the actions column when canWrite is false', () => {
-            renderTable({ canWrite: false });
+    describe('permissions', () => {
+        it('hides the actions column when both canEdit and canDelete are false', () => {
+            renderTable({ canEdit: false, canDelete: false });
             expect(screen.queryByRole('button', { name: 'Metadata actions' })).toBeNull();
         });
 
-        it('shows one action button per row when canWrite is true', () => {
+        it('shows one action button per row when canEdit is true', () => {
+            renderTable({ canEdit: true, canDelete: false });
+            expect(screen.getAllByRole('button', { name: 'Metadata actions' }).length).toBe(METADATA.length);
+        });
+
+        it('shows one action button per row when canDelete is true', () => {
+            renderTable({ canEdit: false, canDelete: true });
+            expect(screen.getAllByRole('button', { name: 'Metadata actions' }).length).toBe(METADATA.length);
+        });
+
+        it('shows one action button per row when both canEdit and canDelete are true', () => {
             renderTable();
             expect(screen.getAllByRole('button', { name: 'Metadata actions' }).length).toBe(METADATA.length);
         });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataTable.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    DataTable,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+    Input,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useMemo, useState } from 'react';
+
+import { MetadataFormatBadge } from './MetadataFormatBadge';
+import type { Metadata } from '../types/metadata';
+
+const NON_SORTABLE = { enableSorting: false } as const;
+
+type ColCell<T> = { row: { original: T } };
+
+function buildColumns({
+    canWrite,
+    onEdit,
+    onDelete,
+}: {
+    canWrite: boolean;
+    onEdit: (metadata: Metadata) => void;
+    onDelete: (metadata: Metadata) => void;
+}): DataTableProps<Metadata>['columns'] {
+    const columns: DataTableProps<Metadata>['columns'] = [
+        {
+            id: 'key',
+            accessorKey: 'key',
+            header: 'Key',
+            ...NON_SORTABLE,
+            cell: ({ row }: ColCell<Metadata>) => (
+                <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">{row.original.key}</span>
+            ),
+        },
+        {
+            id: 'name',
+            accessorKey: 'name',
+            header: 'Name',
+            ...NON_SORTABLE,
+            cell: ({ row }: ColCell<Metadata>) => <span className="text-sm font-medium">{row.original.name}</span>,
+        },
+        {
+            id: 'format',
+            accessorKey: 'format',
+            header: 'Format',
+            ...NON_SORTABLE,
+            cell: ({ row }: ColCell<Metadata>) => <MetadataFormatBadge format={row.original.format} />,
+        },
+        {
+            id: 'value',
+            accessorKey: 'value',
+            header: 'Default Value',
+            ...NON_SORTABLE,
+            cell: ({ row }: ColCell<Metadata>) =>
+                row.original.value ? (
+                    <span className="text-sm">{row.original.value}</span>
+                ) : (
+                    <span className="text-sm text-muted-foreground">—</span>
+                ),
+        },
+    ];
+
+    if (canWrite) {
+        columns.push({
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            size: 56,
+            enableSorting: false,
+            enableHiding: false,
+            cell: ({ row }: ColCell<Metadata>) => (
+                <div className="flex justify-end">
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" size="icon" className="size-8" aria-label="Metadata actions">
+                                <MoreHorizontalIcon className="size-4" aria-hidden />
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            <DropdownMenuItem onSelect={() => onEdit(row.original)}>
+                                <PencilIcon className="size-4 mr-2" aria-hidden />
+                                Edit
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem variant="destructive" onSelect={() => onDelete(row.original)}>
+                                <Trash2Icon className="size-4 mr-2" aria-hidden />
+                                Delete
+                            </DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </div>
+            ),
+        });
+    }
+
+    return columns;
+}
+
+export function MetadataTable({
+    metadata,
+    canWrite,
+    onEdit,
+    onDelete,
+}: Readonly<{
+    metadata: Metadata[];
+    canWrite: boolean;
+    onEdit: (metadata: Metadata) => void;
+    onDelete: (metadata: Metadata) => void;
+}>) {
+    const [search, setSearch] = useState('');
+
+    const filtered = useMemo(() => {
+        const query = search.trim().toLowerCase();
+        if (!query) return metadata;
+        return metadata.filter(m => m.key.toLowerCase().includes(query) || m.name.toLowerCase().includes(query));
+    }, [metadata, search]);
+
+    const columns = useMemo(() => buildColumns({ canWrite, onEdit, onDelete }), [canWrite, onEdit, onDelete]);
+
+    return (
+        <div className="space-y-3">
+            <div className="relative max-w-sm">
+                <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
+                <Input className="pl-10" placeholder="Search by key or name…" value={search} onChange={e => setSearch(e.target.value)} />
+            </div>
+
+            <DataTable
+                columns={columns}
+                data={filtered}
+                emptyMessage={search.trim() ? 'No metadata matches your search.' : 'No global metadata defined for this environment.'}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataTable.tsx
@@ -17,6 +17,7 @@
 import {
     Button,
     DataTable,
+    DataTableColumnHeader,
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
@@ -29,18 +30,34 @@ import { MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon } from '@gravite
 import { useMemo, useState } from 'react';
 
 import { MetadataFormatBadge } from './MetadataFormatBadge';
+import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+import type { TableSortingState } from '../../applications/utils/tableSort';
 import type { Metadata } from '../types/metadata';
 
-const NON_SORTABLE = { enableSorting: false } as const;
+const DEFAULT_PAGE_SIZE = 10;
 
-type ColCell<T> = { row: { original: T } };
+const SORTABLE_IDS = new Set(['key', 'name', 'format', 'value']);
+
+function sortMetadata(items: Metadata[], sorting: TableSortingState): Metadata[] {
+    const active = sorting[0];
+    if (!active?.id || !SORTABLE_IDS.has(active.id)) return items;
+    const direction = active.desc ? -1 : 1;
+    return [...items].sort((a, b) => {
+        const av = active.id === 'key' ? a.key : active.id === 'name' ? a.name : active.id === 'format' ? a.format : (a.value ?? '');
+        const bv = active.id === 'key' ? b.key : active.id === 'name' ? b.name : active.id === 'format' ? b.format : (b.value ?? '');
+        return av.localeCompare(bv) * direction;
+    });
+}
 
 function buildColumns({
-    canWrite,
+    canEdit,
+    canDelete,
     onEdit,
     onDelete,
 }: {
-    canWrite: boolean;
+    canEdit: boolean;
+    canDelete: boolean;
     onEdit: (metadata: Metadata) => void;
     onDelete: (metadata: Metadata) => void;
 }): DataTableProps<Metadata>['columns'] {
@@ -48,8 +65,7 @@ function buildColumns({
         {
             id: 'key',
             accessorKey: 'key',
-            header: 'Key',
-            ...NON_SORTABLE,
+            header: ({ column }: ColHeader<Metadata>) => <DataTableColumnHeader column={column} title="Key" />,
             cell: ({ row }: ColCell<Metadata>) => (
                 <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">{row.original.key}</span>
             ),
@@ -57,22 +73,19 @@ function buildColumns({
         {
             id: 'name',
             accessorKey: 'name',
-            header: 'Name',
-            ...NON_SORTABLE,
+            header: ({ column }: ColHeader<Metadata>) => <DataTableColumnHeader column={column} title="Name" />,
             cell: ({ row }: ColCell<Metadata>) => <span className="text-sm font-medium">{row.original.name}</span>,
         },
         {
             id: 'format',
             accessorKey: 'format',
-            header: 'Format',
-            ...NON_SORTABLE,
+            header: ({ column }: ColHeader<Metadata>) => <DataTableColumnHeader column={column} title="Format" />,
             cell: ({ row }: ColCell<Metadata>) => <MetadataFormatBadge format={row.original.format} />,
         },
         {
             id: 'value',
             accessorKey: 'value',
-            header: 'Default Value',
-            ...NON_SORTABLE,
+            header: ({ column }: ColHeader<Metadata>) => <DataTableColumnHeader column={column} title="Value" />,
             cell: ({ row }: ColCell<Metadata>) =>
                 row.original.value ? (
                     <span className="text-sm">{row.original.value}</span>
@@ -82,7 +95,7 @@ function buildColumns({
         },
     ];
 
-    if (canWrite) {
+    if (canEdit || canDelete) {
         columns.push({
             id: 'actions',
             header: () => <span className="sr-only">Actions</span>,
@@ -98,15 +111,19 @@ function buildColumns({
                             </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                            <DropdownMenuItem onSelect={() => onEdit(row.original)}>
-                                <PencilIcon className="size-4 mr-2" aria-hidden />
-                                Edit
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem variant="destructive" onSelect={() => onDelete(row.original)}>
-                                <Trash2Icon className="size-4 mr-2" aria-hidden />
-                                Delete
-                            </DropdownMenuItem>
+                            {canEdit && (
+                                <DropdownMenuItem onSelect={() => onEdit(row.original)}>
+                                    <PencilIcon className="size-4 mr-2" aria-hidden />
+                                    Edit
+                                </DropdownMenuItem>
+                            )}
+                            {canEdit && canDelete && <DropdownMenuSeparator />}
+                            {canDelete && (
+                                <DropdownMenuItem variant="destructive" onSelect={() => onDelete(row.original)}>
+                                    <Trash2Icon className="size-4 mr-2" aria-hidden />
+                                    Delete
+                                </DropdownMenuItem>
+                            )}
                         </DropdownMenuContent>
                     </DropdownMenu>
                 </div>
@@ -119,16 +136,21 @@ function buildColumns({
 
 export function MetadataTable({
     metadata,
-    canWrite,
+    canEdit,
+    canDelete,
     onEdit,
     onDelete,
 }: Readonly<{
     metadata: Metadata[];
-    canWrite: boolean;
+    canEdit: boolean;
+    canDelete: boolean;
     onEdit: (metadata: Metadata) => void;
     onDelete: (metadata: Metadata) => void;
 }>) {
     const [search, setSearch] = useState('');
+    const [sorting, setSorting] = useState<TableSortingState>([]);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
 
     const filtered = useMemo(() => {
         const query = search.trim().toLowerCase();
@@ -136,18 +158,58 @@ export function MetadataTable({
         return metadata.filter(m => m.key.toLowerCase().includes(query) || m.name.toLowerCase().includes(query));
     }, [metadata, search]);
 
-    const columns = useMemo(() => buildColumns({ canWrite, onEdit, onDelete }), [canWrite, onEdit, onDelete]);
+    const sorted = useMemo(() => sortMetadata(filtered, sorting), [filtered, sorting]);
+
+    const totalCount = sorted.length;
+
+    const paginatedData = useMemo(() => {
+        const start = (page - 1) * pageSize;
+        return sorted.slice(start, start + pageSize);
+    }, [sorted, page, pageSize]);
+
+    const columns = useMemo(() => buildColumns({ canEdit, canDelete, onEdit, onDelete }), [canEdit, canDelete, onEdit, onDelete]);
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function handleSortingChange(updater: TableSortingState | ((prev: TableSortingState) => TableSortingState)) {
+        setSorting(prev => (typeof updater === 'function' ? updater(prev) : updater));
+        setPage(1);
+    }
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
 
     return (
         <div className="space-y-3">
             <div className="relative max-w-sm">
                 <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
-                <Input className="pl-10" placeholder="Search by key or name…" value={search} onChange={e => setSearch(e.target.value)} />
+                <Input
+                    className="pl-10"
+                    placeholder="Search by key or name…"
+                    value={search}
+                    onChange={e => handleSearchChange(e.target.value)}
+                />
             </div>
 
             <DataTable
                 columns={columns}
-                data={filtered}
+                data={paginatedData}
+                sorting={sorting}
+                onSortingChange={handleSortingChange}
+                serverSide
+                pagination={{
+                    page,
+                    pageSize,
+                    totalCount,
+                    pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                    onPageChange: setPage,
+                    onPageSizeChange: handlePageSizeChange,
+                }}
                 emptyMessage={search.trim() ? 'No metadata matches your search.' : 'No global metadata defined for this environment.'}
             />
         </div>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/hooks/useEnvironmentMetadata.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/hooks/useEnvironmentMetadata.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { listEnvironmentMetadata } from '../services/metadata';
+import { metadataKeys } from '../utils/queryKeys';
+
+export function useEnvironmentMetadata() {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: metadataKeys.list(env?.id ?? ''),
+        queryFn: () => listEnvironmentMetadata(env!.id),
+        enabled: Boolean(env),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/hooks/useMetadataMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/hooks/useMetadataMutations.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { createEnvironmentMetadata, deleteEnvironmentMetadata, updateEnvironmentMetadata } from '../services/metadata';
+import type { NewMetadataPayload, UpdateMetadataPayload } from '../types/metadata';
+import { metadataKeys } from '../utils/queryKeys';
+
+export function useCreateMetadata() {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (data: NewMetadataPayload) => createEnvironmentMetadata(env!.id, data),
+        onSuccess: () => {
+            if (env?.id) {
+                void queryClient.invalidateQueries({ queryKey: metadataKeys.list(env.id) });
+            }
+        },
+    });
+}
+
+export function useUpdateMetadata() {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (data: UpdateMetadataPayload) => updateEnvironmentMetadata(env!.id, data),
+        onSuccess: () => {
+            if (env?.id) {
+                void queryClient.invalidateQueries({ queryKey: metadataKeys.list(env.id) });
+            }
+        },
+    });
+}
+
+export function useDeleteMetadata() {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (key: string) => deleteEnvironmentMetadata(env!.id, key),
+        onSuccess: () => {
+            if (env?.id) {
+                void queryClient.invalidateQueries({ queryKey: metadataKeys.list(env.id) });
+            }
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/hooks/useMetadataMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/hooks/useMetadataMutations.ts
@@ -21,44 +21,28 @@ import { createEnvironmentMetadata, deleteEnvironmentMetadata, updateEnvironment
 import type { NewMetadataPayload, UpdateMetadataPayload } from '../types/metadata';
 import { metadataKeys } from '../utils/queryKeys';
 
-export function useCreateMetadata() {
+function useMetadataMutation<TData>(mutationFn: (envId: string, data: TData) => Promise<unknown>) {
     const env = useEnvironment();
     const queryClient = useQueryClient();
 
     return useMutation({
-        mutationFn: (data: NewMetadataPayload) => createEnvironmentMetadata(env!.id, data),
+        mutationFn: (data: TData) => mutationFn(env!.id, data),
         onSuccess: () => {
             if (env?.id) {
                 void queryClient.invalidateQueries({ queryKey: metadataKeys.list(env.id) });
             }
         },
     });
+}
+
+export function useCreateMetadata() {
+    return useMetadataMutation<NewMetadataPayload>(createEnvironmentMetadata);
 }
 
 export function useUpdateMetadata() {
-    const env = useEnvironment();
-    const queryClient = useQueryClient();
-
-    return useMutation({
-        mutationFn: (data: UpdateMetadataPayload) => updateEnvironmentMetadata(env!.id, data),
-        onSuccess: () => {
-            if (env?.id) {
-                void queryClient.invalidateQueries({ queryKey: metadataKeys.list(env.id) });
-            }
-        },
-    });
+    return useMetadataMutation<UpdateMetadataPayload>(updateEnvironmentMetadata);
 }
 
 export function useDeleteMetadata() {
-    const env = useEnvironment();
-    const queryClient = useQueryClient();
-
-    return useMutation({
-        mutationFn: (key: string) => deleteEnvironmentMetadata(env!.id, key),
-        onSuccess: () => {
-            if (env?.id) {
-                void queryClient.invalidateQueries({ queryKey: metadataKeys.list(env.id) });
-            }
-        },
-    });
+    return useMetadataMutation<string>(deleteEnvironmentMetadata);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/services/metadata.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/services/metadata.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createEnvironmentMetadata, deleteEnvironmentMetadata, listEnvironmentMetadata, updateEnvironmentMetadata } from './metadata';
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonV1Env: jest.fn(),
+}));
+
+const mockApimFetchJsonV1Env = jest.mocked(apimFetchJsonV1Env);
+
+describe('metadata service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonV1Env.mockResolvedValue(undefined);
+    });
+
+    describe('listEnvironmentMetadata', () => {
+        it('calls GET on the configuration/metadata resource', async () => {
+            await listEnvironmentMetadata('env-1');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/metadata');
+        });
+    });
+
+    describe('createEnvironmentMetadata', () => {
+        it('calls POST with the serialized payload', async () => {
+            const payload = { key: 'support-email', name: 'Support Email', format: 'MAIL' as const, value: 'help@example.com' };
+            await createEnvironmentMetadata('env-1', payload);
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/metadata', {
+                method: 'POST',
+                body: JSON.stringify(payload),
+            });
+        });
+    });
+
+    describe('updateEnvironmentMetadata', () => {
+        it('calls PUT with the serialized payload', async () => {
+            const payload = { key: 'support-email', name: 'Support Email', format: 'MAIL' as const, value: 'new@example.com' };
+            await updateEnvironmentMetadata('env-1', payload);
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/metadata', {
+                method: 'PUT',
+                body: JSON.stringify(payload),
+            });
+        });
+    });
+
+    describe('deleteEnvironmentMetadata', () => {
+        it('calls DELETE on the keyed resource path', async () => {
+            await deleteEnvironmentMetadata('env-1', 'support-email');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/metadata/support-email', {
+                method: 'DELETE',
+            });
+        });
+
+        it('URL-encodes the key in the path', async () => {
+            await deleteEnvironmentMetadata('env-1', 'key with spaces');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/metadata/key%20with%20spaces', {
+                method: 'DELETE',
+            });
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/services/metadata.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/services/metadata.spec.ts
@@ -37,7 +37,7 @@ describe('metadata service', () => {
 
     describe('createEnvironmentMetadata', () => {
         it('calls POST with the serialized payload', async () => {
-            const payload = { key: 'support-email', name: 'Support Email', format: 'MAIL' as const, value: 'help@example.com' };
+            const payload = { name: 'Support Email', format: 'MAIL' as const, value: 'help@example.com' };
             await createEnvironmentMetadata('env-1', payload);
             expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/metadata', {
                 method: 'POST',

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/services/metadata.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/services/metadata.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { Metadata, NewMetadataPayload, UpdateMetadataPayload } from '../types/metadata';
+
+export async function listEnvironmentMetadata(environmentId: string): Promise<Metadata[]> {
+    return apimFetchJsonV1Env<Metadata[]>(environmentId, '/configuration/metadata');
+}
+
+export async function createEnvironmentMetadata(environmentId: string, data: NewMetadataPayload): Promise<Metadata> {
+    return apimFetchJsonV1Env<Metadata>(environmentId, '/configuration/metadata', {
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+}
+
+export async function updateEnvironmentMetadata(environmentId: string, data: UpdateMetadataPayload): Promise<Metadata> {
+    return apimFetchJsonV1Env<Metadata>(environmentId, '/configuration/metadata', {
+        method: 'PUT',
+        body: JSON.stringify(data),
+    });
+}
+
+export async function deleteEnvironmentMetadata(environmentId: string, key: string): Promise<void> {
+    return apimFetchJsonV1Env<void>(environmentId, `/configuration/metadata/${encodeURIComponent(key)}`, {
+        method: 'DELETE',
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/types/metadata.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/types/metadata.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type MetadataFormat = 'STRING' | 'NUMERIC' | 'BOOLEAN' | 'DATE' | 'MAIL' | 'URL';
+
+export interface Metadata {
+    key: string;
+    name: string;
+    format: MetadataFormat;
+    value: string;
+}
+
+export interface NewMetadataPayload {
+    key: string;
+    name: string;
+    format: MetadataFormat;
+    value: string;
+}
+
+export interface UpdateMetadataPayload {
+    key: string;
+    name: string;
+    format: MetadataFormat;
+    value: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/types/metadata.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/types/metadata.ts
@@ -24,7 +24,6 @@ export interface Metadata {
 }
 
 export interface NewMetadataPayload {
-    key: string;
     name: string;
     format: MetadataFormat;
     value: string;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/utils/queryKeys.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const metadataKeys = {
+    all: ['environment-metadata'] as const,
+    list: (envId: string) => [...metadataKeys.all, 'list', envId] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.spec.tsx
@@ -36,12 +36,14 @@ jest.mock('../shared/notify', () => ({
 jest.mock('../features/metadata/components/MetadataTable', () => ({
     MetadataTable: ({
         metadata,
-        canWrite,
+        canEdit,
+        canDelete,
         onEdit,
         onDelete,
     }: {
         metadata: Metadata[];
-        canWrite: boolean;
+        canEdit: boolean;
+        canDelete: boolean;
         onEdit: (m: Metadata) => void;
         onDelete: (m: Metadata) => void;
     }) => (
@@ -49,15 +51,15 @@ jest.mock('../features/metadata/components/MetadataTable', () => ({
             {metadata.map(m => (
                 <div key={m.key} data-testid={`row-${m.key}`}>
                     <span>{m.name}</span>
-                    {canWrite && (
-                        <>
-                            <button type="button" onClick={() => onEdit(m)}>
-                                Edit {m.name}
-                            </button>
-                            <button type="button" onClick={() => onDelete(m)}>
-                                Delete {m.name}
-                            </button>
-                        </>
+                    {canEdit && (
+                        <button type="button" onClick={() => onEdit(m)}>
+                            Edit {m.name}
+                        </button>
+                    )}
+                    {canDelete && (
+                        <button type="button" onClick={() => onDelete(m)}>
+                            Delete {m.name}
+                        </button>
                     )}
                 </div>
             ))}
@@ -85,8 +87,9 @@ function makeQueryResult(overrides: Partial<ReturnType<typeof useEnvironmentMeta
     } as ReturnType<typeof useEnvironmentMetadata>;
 }
 
-function makeMutation(mutateAsync = jest.fn()): ReturnType<typeof useCreateMetadata> {
-    return { mutateAsync, isPending: false } as unknown as ReturnType<typeof useCreateMetadata>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeMutation(mutateAsync = jest.fn()): any {
+    return { mutateAsync, isPending: false };
 }
 
 function renderPage() {
@@ -119,7 +122,7 @@ describe('MetadataPage', () => {
 
         it('hides the Add Global Metadata button when user cannot create', () => {
             mockUseHasPermission.mockImplementation(
-                ({ anyOf }) => anyOf.includes('environment-metadata-u') || anyOf.includes('environment-metadata-d'),
+                ({ anyOf }) => !!(anyOf?.includes('environment-metadata-u') || anyOf?.includes('environment-metadata-d')),
             );
             renderPage();
             expect(screen.queryByRole('button', { name: /Add Global Metadata/i })).toBeNull();
@@ -147,14 +150,14 @@ describe('MetadataPage', () => {
             expect(screen.queryByText('API Version')).not.toBeNull();
         });
 
-        it('hides action buttons when user has no write permissions', () => {
+        it('hides action buttons when user has no permissions', () => {
             mockUseHasPermission.mockReturnValue(false);
             renderPage();
             expect(screen.queryByRole('button', { name: /Edit /i })).toBeNull();
             expect(screen.queryByRole('button', { name: /Delete /i })).toBeNull();
         });
 
-        it('shows action buttons when user has write permissions', () => {
+        it('shows action buttons when user has edit and delete permissions', () => {
             renderPage();
             expect(screen.getAllByRole('button', { name: /Edit /i }).length).toBe(STUB_METADATA.length);
             expect(screen.getAllByRole('button', { name: /Delete /i }).length).toBe(STUB_METADATA.length);
@@ -181,12 +184,12 @@ describe('MetadataPage', () => {
             renderPage();
 
             fireEvent.click(screen.getByRole('button', { name: /Add Global Metadata/i }));
-            fireEvent.change(screen.getByLabelText(/Key/i), { target: { value: 'my-key' } });
-            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Key' } });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Metadata' } });
+            fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: 'some-value' } });
             fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
             await waitFor(() => {
-                expect(mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ key: 'my-key', name: 'My Key' }));
+                expect(mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ name: 'My Metadata', value: 'some-value' }));
                 expect(notify.success).toHaveBeenCalledWith('Metadata created successfully');
             });
         });
@@ -198,8 +201,8 @@ describe('MetadataPage', () => {
             renderPage();
 
             fireEvent.click(screen.getByRole('button', { name: /Add Global Metadata/i }));
-            fireEvent.change(screen.getByLabelText(/Key/i), { target: { value: 'my-key' } });
-            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Key' } });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Metadata' } });
+            fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: 'some-value' } });
             fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
             await waitFor(() => {
@@ -219,17 +222,16 @@ describe('MetadataPage', () => {
             expect(screen.queryByRole('heading', { name: 'Edit Metadata' })).not.toBeNull();
         });
 
-        it('pre-fills the form with the selected metadata', () => {
+        it('pre-fills the form with the selected metadata name', () => {
             renderPage();
             openEditSheet();
-            expect((screen.getByLabelText(/Key/i) as HTMLInputElement).value).toBe('support-email');
             expect((screen.getByLabelText(/Name/i) as HTMLInputElement).value).toBe('Support Email');
         });
 
-        it('disables the key field in edit mode', () => {
+        it('shows a hint that format cannot be changed in edit mode', () => {
             renderPage();
             openEditSheet();
-            expect((screen.getByLabelText(/Key/i) as HTMLInputElement).disabled).toBe(true);
+            expect(screen.queryByText('Format cannot be changed after creation.')).not.toBeNull();
         });
 
         it('calls updateMutation and shows success toast on submit', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.spec.tsx
@@ -1,0 +1,303 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { MetadataPage } from './MetadataPage';
+import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
+import { useCreateMetadata, useDeleteMetadata, useUpdateMetadata } from '../features/metadata/hooks/useMetadataMutations';
+import type { Metadata } from '../features/metadata/types/metadata';
+import { notify } from '../shared/notify';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+jest.mock('../features/metadata/hooks/useEnvironmentMetadata');
+jest.mock('../features/metadata/hooks/useMetadataMutations');
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+
+// Stub MetadataTable to avoid Radix UI pointer-event complexity in jsdom.
+// Exposes Edit/Delete buttons that wire directly to the page's callbacks.
+jest.mock('../features/metadata/components/MetadataTable', () => ({
+    MetadataTable: ({
+        metadata,
+        canWrite,
+        onEdit,
+        onDelete,
+    }: {
+        metadata: Metadata[];
+        canWrite: boolean;
+        onEdit: (m: Metadata) => void;
+        onDelete: (m: Metadata) => void;
+    }) => (
+        <div>
+            {metadata.map(m => (
+                <div key={m.key} data-testid={`row-${m.key}`}>
+                    <span>{m.name}</span>
+                    {canWrite && (
+                        <>
+                            <button type="button" onClick={() => onEdit(m)}>
+                                Edit {m.name}
+                            </button>
+                            <button type="button" onClick={() => onDelete(m)}>
+                                Delete {m.name}
+                            </button>
+                        </>
+                    )}
+                </div>
+            ))}
+        </div>
+    ),
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseEnvironmentMetadata = jest.mocked(useEnvironmentMetadata);
+const mockUseCreateMetadata = jest.mocked(useCreateMetadata);
+const mockUseUpdateMetadata = jest.mocked(useUpdateMetadata);
+const mockUseDeleteMetadata = jest.mocked(useDeleteMetadata);
+
+const STUB_METADATA: Metadata[] = [
+    { key: 'support-email', name: 'Support Email', format: 'MAIL', value: 'support@example.com' },
+    { key: 'version', name: 'API Version', format: 'STRING', value: '1.0' },
+];
+
+function makeQueryResult(overrides: Partial<ReturnType<typeof useEnvironmentMetadata>> = {}): ReturnType<typeof useEnvironmentMetadata> {
+    return {
+        data: STUB_METADATA,
+        isLoading: false,
+        isError: false,
+        ...overrides,
+    } as ReturnType<typeof useEnvironmentMetadata>;
+}
+
+function makeMutation(mutateAsync = jest.fn()): ReturnType<typeof useCreateMetadata> {
+    return { mutateAsync, isPending: false } as unknown as ReturnType<typeof useCreateMetadata>;
+}
+
+function renderPage() {
+    return render(<MetadataPage />);
+}
+
+describe('MetadataPage', () => {
+    beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseEnvironmentMetadata.mockReturnValue(makeQueryResult());
+        mockUseCreateMetadata.mockReturnValue(makeMutation());
+        mockUseUpdateMetadata.mockReturnValue(makeMutation());
+        mockUseDeleteMetadata.mockReturnValue(makeMutation());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('page header', () => {
+        it('renders the page title', () => {
+            renderPage();
+            expect(screen.queryByRole('heading', { name: 'Metadata' })).not.toBeNull();
+        });
+
+        it('shows the Add Global Metadata button when user can create', () => {
+            renderPage();
+            expect(screen.queryByRole('button', { name: /Add Global Metadata/i })).not.toBeNull();
+        });
+
+        it('hides the Add Global Metadata button when user cannot create', () => {
+            mockUseHasPermission.mockImplementation(
+                ({ anyOf }) => anyOf.includes('environment-metadata-u') || anyOf.includes('environment-metadata-d'),
+            );
+            renderPage();
+            expect(screen.queryByRole('button', { name: /Add Global Metadata/i })).toBeNull();
+        });
+    });
+
+    describe('loading and error states', () => {
+        it('shows skeleton rows while data is loading', () => {
+            mockUseEnvironmentMetadata.mockReturnValue(makeQueryResult({ data: undefined, isLoading: true }));
+            const { container } = renderPage();
+            expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+        });
+
+        it('shows an error message when the query fails', () => {
+            mockUseEnvironmentMetadata.mockReturnValue(makeQueryResult({ data: undefined, isError: true }));
+            renderPage();
+            expect(screen.queryByText('Failed to load metadata. Please refresh and try again.')).not.toBeNull();
+        });
+    });
+
+    describe('data table', () => {
+        it('renders metadata rows in the table', () => {
+            renderPage();
+            expect(screen.queryByText('Support Email')).not.toBeNull();
+            expect(screen.queryByText('API Version')).not.toBeNull();
+        });
+
+        it('hides action buttons when user has no write permissions', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            renderPage();
+            expect(screen.queryByRole('button', { name: /Edit /i })).toBeNull();
+            expect(screen.queryByRole('button', { name: /Delete /i })).toBeNull();
+        });
+
+        it('shows action buttons when user has write permissions', () => {
+            renderPage();
+            expect(screen.getAllByRole('button', { name: /Edit /i }).length).toBe(STUB_METADATA.length);
+            expect(screen.getAllByRole('button', { name: /Delete /i }).length).toBe(STUB_METADATA.length);
+        });
+    });
+
+    describe('create sheet', () => {
+        it('opens the create sheet when Add Global Metadata is clicked', () => {
+            renderPage();
+            fireEvent.click(screen.getByRole('button', { name: /Add Global Metadata/i }));
+            expect(screen.queryByRole('heading', { name: 'Add Global Metadata' })).not.toBeNull();
+        });
+
+        it('closes the sheet when Cancel is clicked', () => {
+            renderPage();
+            fireEvent.click(screen.getByRole('button', { name: /Add Global Metadata/i }));
+            fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+            expect(screen.queryByRole('heading', { name: 'Add Global Metadata' })).toBeNull();
+        });
+
+        it('calls createMutation and shows success toast on submit', async () => {
+            const mutateAsync = jest.fn().mockResolvedValue({});
+            mockUseCreateMetadata.mockReturnValue(makeMutation(mutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: /Add Global Metadata/i }));
+            fireEvent.change(screen.getByLabelText(/Key/i), { target: { value: 'my-key' } });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Key' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+            await waitFor(() => {
+                expect(mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ key: 'my-key', name: 'My Key' }));
+                expect(notify.success).toHaveBeenCalledWith('Metadata created successfully');
+            });
+        });
+
+        it('shows an error toast when create fails', async () => {
+            const error = new Error('create failed');
+            const mutateAsync = jest.fn().mockRejectedValue(error);
+            mockUseCreateMetadata.mockReturnValue(makeMutation(mutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: /Add Global Metadata/i }));
+            fireEvent.change(screen.getByLabelText(/Key/i), { target: { value: 'my-key' } });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Key' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+            await waitFor(() => {
+                expect(notify.error).toHaveBeenCalledWith(error, 'Failed to create metadata');
+            });
+        });
+    });
+
+    describe('edit sheet', () => {
+        function openEditSheet() {
+            fireEvent.click(screen.getByRole('button', { name: `Edit ${STUB_METADATA[0].name}` }));
+        }
+
+        it('opens the edit sheet when Edit is clicked for a row', () => {
+            renderPage();
+            openEditSheet();
+            expect(screen.queryByRole('heading', { name: 'Edit Metadata' })).not.toBeNull();
+        });
+
+        it('pre-fills the form with the selected metadata', () => {
+            renderPage();
+            openEditSheet();
+            expect((screen.getByLabelText(/Key/i) as HTMLInputElement).value).toBe('support-email');
+            expect((screen.getByLabelText(/Name/i) as HTMLInputElement).value).toBe('Support Email');
+        });
+
+        it('disables the key field in edit mode', () => {
+            renderPage();
+            openEditSheet();
+            expect((screen.getByLabelText(/Key/i) as HTMLInputElement).disabled).toBe(true);
+        });
+
+        it('calls updateMutation and shows success toast on submit', async () => {
+            const mutateAsync = jest.fn().mockResolvedValue({});
+            mockUseUpdateMetadata.mockReturnValue(makeMutation(mutateAsync));
+            renderPage();
+            openEditSheet();
+
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Updated Name' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+
+            await waitFor(() => {
+                expect(mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ name: 'Updated Name' }));
+                expect(notify.success).toHaveBeenCalledWith('Metadata updated successfully');
+            });
+        });
+    });
+
+    describe('delete sheet', () => {
+        function openDeleteSheet() {
+            fireEvent.click(screen.getByRole('button', { name: `Delete ${STUB_METADATA[0].name}` }));
+        }
+
+        it('opens the delete sheet when Delete is clicked for a row', () => {
+            renderPage();
+            openDeleteSheet();
+            expect(screen.queryByRole('heading', { name: 'Delete Metadata' })).not.toBeNull();
+        });
+
+        it('shows the metadata name in the delete confirmation', () => {
+            renderPage();
+            openDeleteSheet();
+            expect(screen.queryAllByText(STUB_METADATA[0].name).length).toBeGreaterThan(0);
+        });
+
+        it('calls deleteMutation and shows success toast on confirm', async () => {
+            const mutateAsync = jest.fn().mockResolvedValue({});
+            mockUseDeleteMetadata.mockReturnValue(makeMutation(mutateAsync));
+            renderPage();
+            openDeleteSheet();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+            await waitFor(() => {
+                expect(mutateAsync).toHaveBeenCalledWith('support-email');
+                expect(notify.success).toHaveBeenCalledWith('Metadata deleted successfully');
+            });
+        });
+
+        it('shows an error toast when delete fails', async () => {
+            const error = new Error('delete failed');
+            const mutateAsync = jest.fn().mockRejectedValue(error);
+            mockUseDeleteMetadata.mockReturnValue(makeMutation(mutateAsync));
+            renderPage();
+            openDeleteSheet();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+            await waitFor(() => {
+                expect(notify.error).toHaveBeenCalledWith(error, 'Failed to delete metadata');
+            });
+        });
+
+        it('closes the sheet when Cancel is clicked', () => {
+            renderPage();
+            openDeleteSheet();
+            fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+            expect(screen.queryByRole('heading', { name: 'Delete Metadata' })).toBeNull();
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.tsx
@@ -30,8 +30,9 @@ import { notify } from '../shared/notify';
 type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'edit'; metadata: Metadata } | { type: 'delete'; metadata: Metadata };
 
 export function MetadataPage() {
-    const canWrite = useHasPermission({ anyOf: ['environment-metadata-u', 'environment-metadata-c', 'environment-metadata-d'] });
     const canCreate = useHasPermission({ anyOf: ['environment-metadata-c'] });
+    const canEdit = useHasPermission({ anyOf: ['environment-metadata-u'] });
+    const canDelete = useHasPermission({ anyOf: ['environment-metadata-d'] });
 
     const { data: metadata = [], isLoading, isError } = useEnvironmentMetadata();
     const createMutation = useCreateMetadata();
@@ -105,7 +106,8 @@ export function MetadataPage() {
             ) : (
                 <MetadataTable
                     metadata={metadata}
-                    canWrite={canWrite}
+                    canEdit={canEdit}
+                    canDelete={canDelete}
                     onEdit={m => setSheet({ type: 'edit', metadata: m })}
                     onDelete={m => setSheet({ type: 'delete', metadata: m })}
                 />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Button, Skeleton } from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+
+import { MetadataDeleteSheet } from '../features/metadata/components/MetadataDeleteSheet';
+import { MetadataSheet } from '../features/metadata/components/MetadataSheet';
+import { MetadataTable } from '../features/metadata/components/MetadataTable';
+import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
+import { useCreateMetadata, useDeleteMetadata, useUpdateMetadata } from '../features/metadata/hooks/useMetadataMutations';
+import type { Metadata, NewMetadataPayload, UpdateMetadataPayload } from '../features/metadata/types/metadata';
+import { notify } from '../shared/notify';
+
+type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'edit'; metadata: Metadata } | { type: 'delete'; metadata: Metadata };
+
+export function MetadataPage() {
+    const canWrite = useHasPermission({ anyOf: ['environment-metadata-u', 'environment-metadata-c', 'environment-metadata-d'] });
+    const canCreate = useHasPermission({ anyOf: ['environment-metadata-c'] });
+
+    const { data: metadata = [], isLoading, isError } = useEnvironmentMetadata();
+    const createMutation = useCreateMetadata();
+    const updateMutation = useUpdateMetadata();
+    const deleteMutation = useDeleteMetadata();
+
+    const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
+
+    function closeSheet() {
+        setSheet({ type: 'closed' });
+    }
+
+    async function handleCreate(data: NewMetadataPayload | UpdateMetadataPayload) {
+        try {
+            await createMutation.mutateAsync(data as NewMetadataPayload);
+            notify.success('Metadata created successfully');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to create metadata');
+        }
+    }
+
+    async function handleUpdate(data: NewMetadataPayload | UpdateMetadataPayload) {
+        try {
+            await updateMutation.mutateAsync(data as UpdateMetadataPayload);
+            notify.success('Metadata updated successfully');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to update metadata');
+        }
+    }
+
+    async function handleDelete() {
+        if (sheet.type !== 'delete') return;
+        try {
+            await deleteMutation.mutateAsync(sheet.metadata.key);
+            notify.success('Metadata deleted successfully');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to delete metadata');
+        }
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-start justify-between">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Metadata</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Create global metadata to retrieve custom information about your APIs across the environment.
+                    </p>
+                </div>
+                {canCreate && (
+                    <Button className="shrink-0" onClick={() => setSheet({ type: 'create' })}>
+                        <PlusIcon className="size-4" aria-hidden />
+                        Add Global Metadata
+                    </Button>
+                )}
+            </div>
+
+            {isLoading ? (
+                <div className="space-y-2">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                        <Skeleton key={i} className="h-12 w-full rounded-md" />
+                    ))}
+                </div>
+            ) : isError ? (
+                <div className="flex items-center justify-center p-8">
+                    <p className="text-sm text-muted-foreground">Failed to load metadata. Please refresh and try again.</p>
+                </div>
+            ) : (
+                <MetadataTable
+                    metadata={metadata}
+                    canWrite={canWrite}
+                    onEdit={m => setSheet({ type: 'edit', metadata: m })}
+                    onDelete={m => setSheet({ type: 'delete', metadata: m })}
+                />
+            )}
+
+            <MetadataSheet
+                open={sheet.type === 'create' || sheet.type === 'edit'}
+                mode={sheet.type === 'edit' ? 'edit' : 'create'}
+                metadata={sheet.type === 'edit' ? sheet.metadata : undefined}
+                onClose={closeSheet}
+                onSubmit={sheet.type === 'edit' ? handleUpdate : handleCreate}
+                isSaving={createMutation.isPending || updateMutation.isPending}
+            />
+
+            <MetadataDeleteSheet
+                open={sheet.type === 'delete'}
+                metadata={sheet.type === 'delete' ? sheet.metadata : undefined}
+                onClose={closeSheet}
+                onConfirm={handleDelete}
+                isDeleting={deleteMutation.isPending}
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-3

## Description

Added the Environment Metadata UI to gravitee-gamma-module-platform. This includes a MetadataPage wired into the sidebar navigation under a new "APIs & Assets" group, with a DataTable for listing, client-side search by key/name, and a Sheet for create/edit (shared component with a mode prop) and a separate confirmation Sheet for delete. Write actions (Create, Edit, Delete) are hidden for read-only users via permission checks. All new components, services, and page logic are covered by unit tests.


## Additional context


https://github.com/user-attachments/assets/4b7eb1dc-e01b-4778-b4e6-f224a299a598



