### PR TITLE
fix: normalize legacy SSL none configuration

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
@@ -67,6 +67,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class EndpointGroupsValidationServiceImpl extends TransactionalService implements EndpointGroupsValidationService {
 
+    private static final String HTTP_PROXY_TYPE = "http-proxy";
     private static final String LLM_PROXY_TYPE = "llm-proxy";
 
     private final EndpointConnectorPluginService endpointService;
@@ -114,7 +115,10 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
 
             if (endpointGroup.getSharedConfiguration() != null) {
                 endpointGroup.setSharedConfiguration(
-                    endpointService.validateSharedConfiguration(endpointConnector, endpointGroup.getSharedConfiguration())
+                    endpointService.validateSharedConfiguration(
+                        endpointConnector,
+                        normalizeSharedConfiguration(endpointConnector, endpointGroup.getSharedConfiguration())
+                    )
                 );
             }
             if (endpointGroup.getEndpoints() != null && !endpointGroups.isEmpty()) {
@@ -153,10 +157,19 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
                 endpointService.validateSharedConfiguration(endpointConnector, "{}");
             } else {
                 endpoint.setSharedConfigurationOverride(
-                    endpointService.validateSharedConfiguration(endpointConnector, endpoint.getSharedConfigurationOverride())
+                    endpointService.validateSharedConfiguration(
+                        endpointConnector,
+                        normalizeSharedConfiguration(endpointConnector, endpoint.getSharedConfigurationOverride())
+                    )
                 );
             }
         }
+    }
+
+    private String normalizeSharedConfiguration(ConnectorPluginEntity endpointConnector, String sharedConfiguration) {
+        return HTTP_PROXY_TYPE.equals(endpointConnector.getId())
+            ? HttpProxySharedConfigurationNormalizer.normalizeLegacySslNoneValues(sharedConfiguration)
+            : sharedConfiguration;
     }
 
     private void validateSharedConfigurationInheritance(AbstractEndpointGroup<?> endpointGroup, AbstractEndpoint endpoint) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/HttpProxySharedConfigurationNormalizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/HttpProxySharedConfigurationNormalizer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl.validation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+class HttpProxySharedConfigurationNormalizer {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String NONE = "NONE";
+
+    static String normalizeLegacySslNoneValues(String sharedConfiguration) {
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(sharedConfiguration);
+            if (!(root.path("ssl") instanceof ObjectNode sslObject)) {
+                return sharedConfiguration;
+            }
+
+            boolean normalized = normalizeLegacySslNoneValue(sslObject, "trustStore");
+            normalized |= normalizeLegacySslNoneValue(sslObject, "keyStore");
+            return normalized ? OBJECT_MAPPER.writeValueAsString(root) : sharedConfiguration;
+        } catch (JsonProcessingException ignored) {
+            return sharedConfiguration;
+        }
+    }
+
+    private static boolean normalizeLegacySslNoneValue(ObjectNode sslObject, String storeName) {
+        JsonNode store = sslObject.get(storeName);
+        if (!(store instanceof ObjectNode storeObject)) {
+            return false;
+        }
+
+        JsonNode type = storeObject.get("type");
+        if (type == null || !type.isTextual() || !type.asText().isEmpty()) {
+            return false;
+        }
+
+        storeObject.removeAll();
+        storeObject.put("type", NONE);
+        return true;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
@@ -68,6 +68,7 @@ public class EndpointGroupsValidationServiceImplTest {
 
     public static final String FIXED_HC_CONFIG = "{fixed}";
     public static final String HEALTH_CHECK_TYPE = "http-health-check";
+    public static final String HTTP_PROXY_ENDPOINT_TYPE = "http-proxy";
     public static final String NATIVE_ENDPOINT_TYPE = "native-friendly";
 
     @Mock
@@ -91,6 +92,11 @@ public class EndpointGroupsValidationServiceImplTest {
         httpEndpoint.setId("http");
         httpEndpoint.setSupportedApiType(ApiType.PROXY);
         lenient().when(endpointService.findById("http")).thenReturn(httpEndpoint);
+
+        var httpProxyEndpoint = new ConnectorPluginEntity();
+        httpProxyEndpoint.setId(HTTP_PROXY_ENDPOINT_TYPE);
+        httpProxyEndpoint.setSupportedApiType(ApiType.PROXY);
+        lenient().when(endpointService.findById(HTTP_PROXY_ENDPOINT_TYPE)).thenReturn(httpProxyEndpoint);
 
         var nativeFriendlyEndpoint = new ConnectorPluginEntity();
         nativeFriendlyEndpoint.setId(NATIVE_ENDPOINT_TYPE);
@@ -565,6 +571,48 @@ public class EndpointGroupsValidationServiceImplTest {
     }
 
     @Test
+    public void should_normalize_legacy_http_proxy_ssl_store_types_before_validating_shared_configuration() {
+        String legacySharedConfiguration =
+            "{\"ssl\":{\"trustStore\":{\"type\":\"\",\"path\":\"\"},\"keyStore\":{\"type\":\"\",\"content\":\"\"}}}";
+        String normalizedSharedConfiguration = "{\"ssl\":{\"trustStore\":{\"type\":\"NONE\"},\"keyStore\":{\"type\":\"NONE\"}}}";
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setName("my name");
+        endpointGroup.setType(HTTP_PROXY_ENDPOINT_TYPE);
+        endpointGroup.setSharedConfiguration(legacySharedConfiguration);
+        endpointGroup.setEndpoints(List.of());
+        Service discovery = new Service();
+        discovery.setEnabled(true);
+        EndpointGroupServices services = new EndpointGroupServices();
+        services.setDiscovery(discovery);
+        endpointGroup.setServices(services);
+
+        var endpointGroups = endpointGroupsValidationService.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(endpointGroup));
+
+        assertThat(endpointGroups.getFirst().getSharedConfiguration()).isEqualTo(normalizedSharedConfiguration);
+        verify(endpointService).validateSharedConfiguration(any(), eq(normalizedSharedConfiguration));
+    }
+
+    @Test
+    public void should_not_normalize_legacy_ssl_store_types_for_non_http_proxy_shared_configuration() {
+        String sharedConfiguration = "{\"ssl\":{\"trustStore\":{\"type\":\"\"},\"keyStore\":{\"type\":\"\"}}}";
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setName("my name");
+        endpointGroup.setType("http");
+        endpointGroup.setSharedConfiguration(sharedConfiguration);
+        endpointGroup.setEndpoints(List.of());
+        Service discovery = new Service();
+        discovery.setEnabled(true);
+        EndpointGroupServices services = new EndpointGroupServices();
+        services.setDiscovery(discovery);
+        endpointGroup.setServices(services);
+
+        var endpointGroups = endpointGroupsValidationService.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(endpointGroup));
+
+        assertThat(endpointGroups.getFirst().getSharedConfiguration()).isEqualTo(sharedConfiguration);
+        verify(endpointService).validateSharedConfiguration(any(), eq(sharedConfiguration));
+    }
+
+    @Test
     public void shouldValidateOverriddenSharedConfiguration() {
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("my name");
@@ -603,6 +651,35 @@ public class EndpointGroupsValidationServiceImplTest {
             .isEqualTo("overriddenSharedConfiguration");
         verify(endpointService).validateSharedConfiguration(any(), eq(endpointGroup.getSharedConfiguration()));
         verify(endpointService).validateSharedConfiguration(any(), eq(endpoint.getSharedConfigurationOverride()));
+    }
+
+    @Test
+    public void should_normalize_legacy_http_proxy_ssl_store_types_before_validating_shared_configuration_override() {
+        String legacySharedConfigurationOverride = "{\"ssl\":{\"keyStore\":{\"type\":\"\",\"content\":\"\"}}}";
+        String normalizedSharedConfigurationOverride = "{\"ssl\":{\"keyStore\":{\"type\":\"NONE\"}}}";
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setName("my name");
+        endpointGroup.setType(HTTP_PROXY_ENDPOINT_TYPE);
+        endpointGroup.setSharedConfiguration("{}");
+        Service discovery = new Service();
+        discovery.setEnabled(true);
+        EndpointGroupServices services = new EndpointGroupServices();
+        services.setDiscovery(discovery);
+        endpointGroup.setServices(services);
+
+        Endpoint endpoint = new Endpoint();
+        endpoint.setName("endpoint");
+        endpoint.setType(HTTP_PROXY_ENDPOINT_TYPE);
+        endpoint.setInheritConfiguration(false);
+        endpoint.setSharedConfigurationOverride(legacySharedConfigurationOverride);
+        endpointGroup.setEndpoints(List.of(endpoint));
+
+        var endpointGroups = endpointGroupsValidationService.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(endpointGroup));
+
+        assertThat(endpointGroups.getFirst().getEndpoints().getFirst().getSharedConfigurationOverride()).isEqualTo(
+            normalizedSharedConfigurationOverride
+        );
+        verify(endpointService).validateSharedConfiguration(any(), eq(normalizedSharedConfigurationOverride));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14599

## Description

Normalize legacy V4 HTTP proxy SSL store configuration before validating endpoint shared configuration.

Older API definitions can store `ssl.trustStore.type` and `ssl.keyStore.type` as an empty string for “None”, while the current shared configuration schema expects `NONE`. This PR converts those legacy empty values to `NONE` during backend validation so existing APIs can be saved or imported without manual definition edits.

## Additional context

Tested in Docker with:

`mvn -q prettier:write -pl gravitee-apim-rest-api/gravitee-apim-rest-api-service`

`mvn -q test -pl gravitee-apim-rest-api/gravitee-apim-rest-api-service -Dtest=EndpointConnectorPluginServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false -am`
