### PR TITLE
feat(console): configurable From address for notification emails

### DIFF
--- a/gravitee-apim-console-webui/src/entities/brandedSender.ts
+++ b/gravitee-apim-console-webui/src/entities/brandedSender.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** A single branded-sender rule: recipient domains that map to a specific From address and Subject prefix. */
+export interface BrandedSender {
+  domains: string[];
+  from: string;
+  subject: string;
+}

--- a/gravitee-apim-console-webui/src/entities/consoleSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/consoleSettings.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { BrandedSender } from './brandedSender';
+
 export interface ConsoleSettings {
   email?: ConsoleSettingsEmail;
   metadata?: ConsoleSettingsMetadata;
@@ -47,6 +49,7 @@ export interface ConsoleSettingsEmail extends DisableableFeature {
   protocol?: string;
   subject?: string;
   from?: string;
+  brandedSenders?: BrandedSender[];
   properties?: {
     auth?: boolean;
     startTlsEnable?: boolean;

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -116,6 +116,7 @@ export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration
         startTlsEnable: false,
         sslTrust: 'testssl',
       },
+      brandedSenders: [],
     },
     api: {
       labelsDictionary: ['test'],

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { BrandedSender } from '../brandedSender';
+
 /**
  * TODO: to complete, contains only one part used in the Ui console
  */
@@ -225,6 +227,7 @@ export interface PortalSettingsEmail {
   protocol: string;
   subject: string;
   from: string;
+  brandedSenders?: BrandedSender[];
   properties: {
     auth: boolean;
     startTlsEnable: boolean;

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -735,6 +735,12 @@
             <input formControlName="sslTrust" matInput type="text" />
           </mat-form-field>
         </div>
+
+        <branded-senders
+          formControlName="brandedSenders"
+          [defaultFrom]="portalForm.get('email.from')?.value ?? ''"
+          [defaultSubject]="portalForm.get('email.subject')?.value ?? ''"
+        ></branded-senders>
       </mat-card-content>
     </mat-card>
 

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -646,6 +646,71 @@ describe('PortalSettingsComponent', () => {
     });
   });
 
+  describe('branded senders', () => {
+    beforeEach(async () => {
+      await init();
+    });
+
+    it('should render the branded senders control enabled when emailing is on and not read-only', async () => {
+      const settings = fakePortalSettings();
+      settings.email.enabled = true;
+      expectPortalSettingsGetRequest(settings);
+
+      const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      expect(await addConfigurationButton.isDisabled()).toBe(false);
+    });
+
+    it('should disable branded senders when emailing is off', async () => {
+      const settings = fakePortalSettings();
+      settings.email.enabled = false;
+      expectPortalSettingsGetRequest(settings);
+
+      const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      expect(await addConfigurationButton.isDisabled()).toBe(true);
+    });
+
+    it('should disable branded senders when email.branded_senders is read-only', async () => {
+      const settings = fakePortalSettings();
+      settings.email.enabled = true;
+      settings.metadata.readonly.push('email.branded_senders');
+      expectPortalSettingsGetRequest(settings);
+
+      const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      expect(await addConfigurationButton.isDisabled()).toBe(true);
+    });
+
+    it('should round-trip branded senders from a populated GET through save at env scope', async () => {
+      const settings = fakePortalSettings();
+      settings.email.enabled = true;
+      settings.email.brandedSenders = [{ domains: ['example.com'], from: 'noreply@example.com', subject: '[Example] %s' }];
+      expectPortalSettingsGetRequest(settings);
+
+      const domainsInput = await loader.getHarness(GioFormTagsInputHarness.with({ selector: '[formControlName="domains"]' }));
+      await domainsInput.addTag('example.org');
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body.email.brandedSenders).toEqual([
+        { domains: ['example.com', 'example.org'], from: 'noreply@example.com', subject: '[Example] %s' },
+      ]);
+    });
+  });
+
+  describe('branded senders permissions', () => {
+    it('should disable branded senders when the user lacks environment-settings update permission', async () => {
+      await init([]);
+      const settings = fakePortalSettings();
+      settings.email.enabled = true;
+      expectPortalSettingsGetRequest(settings);
+
+      const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      expect(await addConfigurationButton.isDisabled()).toBe(true);
+    });
+  });
+
   function expectPortalSettingsGetRequest(portalSettings: PortalSettings) {
     httpTestingController
       .expectOne({

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -15,8 +15,8 @@
  */
 import { Component, DestroyRef, OnInit, inject, Inject } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { combineLatest, Observable, of, Subject } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
+import { combineLatest, EMPTY, Observable, of, Subject } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GioLicenseService } from '@gravitee/ui-particles-angular';
 import { isEmpty } from 'lodash';
@@ -24,6 +24,7 @@ import { isEmpty } from 'lodash';
 import { PortalSettingsService } from '../../../services-ngx/portal-settings.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { PortalSettings } from '../../../entities/portal/portalSettings';
+import { BrandedSender } from '../../../entities/brandedSender';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import { CorsUtil } from '../../../shared/utils';
 import { Constants } from '../../../entities/Constants';
@@ -161,6 +162,7 @@ interface PortalForm {
     protocol: FormControl<string>;
     subject: FormControl<string>;
     from: FormControl<string>;
+    brandedSenders: FormControl<BrandedSender[]>;
     properties: FormGroup<{
       auth: FormControl<boolean>;
       startTlsEnable: FormControl<boolean>;
@@ -588,6 +590,10 @@ export class PortalSettingsComponent implements OnInit {
           value: this.settings.email.from,
           disabled: this.isReadonly('email.from') || !this.settings.email.enabled,
         }),
+        brandedSenders: new FormControl({
+          value: this.settings.email.brandedSenders ?? [],
+          disabled: this.isReadonly('email.branded_senders') || !this.settings.email.enabled,
+        }),
         properties: new FormGroup({
           auth: new FormControl({
             value: this.settings.email.properties.auth,
@@ -800,6 +806,10 @@ export class PortalSettingsComponent implements OnInit {
       .save(updatedSettingsPayload)
       .pipe(
         tap(() => this.snackBarService.success('Settings successfully updated!')),
+        catchError(({ error }) => {
+          this.snackBarService.error(error?.message ?? 'An error occurred while saving the settings.');
+          return EMPTY;
+        }),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(() => this.ngOnInit());

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.module.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.module.ts
@@ -41,6 +41,7 @@ import { MatSelectModule } from '@angular/material/select';
 
 import { PortalSettingsComponent } from './portal-settings.component';
 
+import { BrandedSendersComponent } from '../../../shared/components/branded-senders/branded-senders.component';
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
 
@@ -72,6 +73,7 @@ import { GioPermissionModule } from '../../../shared/components/gio-permission/g
     MatOptionModule,
     MatSelectModule,
     GioTopBarLinkModule,
+    BrandedSendersComponent,
   ],
 })
 export class PortalSettingsModule {}

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
@@ -435,6 +435,12 @@
             </mat-form-field>
           </ng-container>
         </ng-container>
+
+        <branded-senders
+          formControlName="brandedSenders"
+          [defaultFrom]="formSettings.get('email.from')?.value ?? ''"
+          [defaultSubject]="formSettings.get('email.subject')?.value ?? ''"
+        ></branded-senders>
       </mat-card-content>
     </mat-card>
     <gio-save-bar [form]="formSettings" [formInitialValues]="formInitialValues"> </gio-save-bar>

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
@@ -31,8 +31,10 @@ import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { OrgSettingsGeneralComponent } from './org-settings-general.component';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { OrganizationSettingsModule } from '../organization-settings.module';
 import { ConsoleSettings } from '../../../entities/consoleSettings';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 
 describe('ConsoleSettingsComponent', () => {
   let fixture: ComponentFixture<OrgSettingsGeneralComponent>;
@@ -44,6 +46,7 @@ describe('ConsoleSettingsComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, OrganizationSettingsModule, MatIconTestingModule],
+      providers: [{ provide: GioTestingPermissionProvider, useValue: ['organization-settings-u'] }],
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {
@@ -503,6 +506,126 @@ describe('ConsoleSettingsComponent', () => {
         MatSlideToggleHarness.with({ name: 'emailPropertiesStartTlsEnable' }),
       );
       expect(await propertiesStartTlsEnableSlideToggle.isDisabled()).toEqual(false);
+    });
+
+    it('should enable and disable the branded senders control together with email.enabled', async () => {
+      expectConsoleSettingsGetRequest({
+        email: { enabled: true },
+        metadata: { readonly: [] },
+      });
+
+      const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      expect(await addConfigurationButton.isDisabled()).toEqual(false);
+
+      const emailEnabledSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'emailEnabled' }));
+      await emailEnabledSlideToggle.uncheck();
+      expect(await addConfigurationButton.isDisabled()).toEqual(true);
+
+      await emailEnabledSlideToggle.check();
+      expect(await addConfigurationButton.isDisabled()).toEqual(false);
+    });
+
+    it('should keep branded senders disabled when email.branded_senders is read-only, even after toggling email on', async () => {
+      expectConsoleSettingsGetRequest({
+        email: { enabled: true },
+        metadata: { readonly: ['email.branded_senders'] },
+      });
+
+      const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      expect(await addConfigurationButton.isDisabled()).toEqual(true);
+
+      // Toggling email off then on must not re-enable a system-provided (read-only) setting: this guards the
+      // camelCase form-path vs. snake_case parameter-key divergence in the enable/disable sync.
+      const emailEnabledSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'emailEnabled' }));
+      await emailEnabledSlideToggle.uncheck();
+      await emailEnabledSlideToggle.check();
+      expect(await addConfigurationButton.isDisabled()).toEqual(true);
+    });
+
+    it('should disable branded senders on initial load when email is disabled', async () => {
+      expectConsoleSettingsGetRequest({
+        email: { enabled: false },
+        metadata: { readonly: [] },
+      });
+
+      const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      expect(await addConfigurationButton.isDisabled()).toEqual(true);
+    });
+
+    it('should round-trip branded senders from a populated GET through save', async () => {
+      expectConsoleSettingsGetRequest({
+        email: {
+          enabled: true,
+          brandedSenders: [{ domains: ['example.com'], from: 'noreply@example.com', subject: '[Example] %s' }],
+        },
+        metadata: { readonly: [] },
+      });
+
+      const domainsField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Recipient domains' }));
+      await (await domainsField.getControl(GioFormTagsInputHarness))!.addTag('example.org');
+
+      const saveButton = await loader.getHarness(GioSaveBarHarness);
+      await saveButton.clickSubmit();
+
+      expectConsoleSettingsSendRequest({
+        email: {
+          brandedSenders: [{ domains: ['example.com', 'example.org'], from: 'noreply@example.com', subject: '[Example] %s' }],
+        },
+      });
+    });
+
+    it('should surface a snackbar error when saving fails', async () => {
+      const snackBarService = TestBed.inject(SnackBarService);
+      const errorSpy = jest.spyOn(snackBarService, 'error');
+
+      expectConsoleSettingsGetRequest({
+        email: {
+          enabled: true,
+          brandedSenders: [{ domains: ['example.com'], from: 'noreply@example.com', subject: '[Example] %s' }],
+        },
+        metadata: { readonly: [] },
+      });
+
+      const domainsField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Recipient domains' }));
+      await (await domainsField.getControl(GioFormTagsInputHarness))!.addTag('example.org');
+
+      const saveButton = await loader.getHarness(GioSaveBarHarness);
+      await saveButton.clickSubmit();
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/settings`);
+      req.flush({ message: 'Payload too large' }, { status: 400, statusText: 'Bad Request' });
+
+      expect(errorSpy).toHaveBeenCalledWith('Payload too large');
+    });
+  });
+
+  describe('permissions', () => {
+    beforeEach(() => {
+      // The root beforeEach grants organization-settings-u; re-create the component without it to exercise the
+      // read-only path (the previously-created instance and its HTTP controller are discarded by the reset).
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [NoopAnimationsModule, GioTestingModule, OrganizationSettingsModule, MatIconTestingModule],
+        providers: [{ provide: GioTestingPermissionProvider, useValue: [] }],
+      })
+        .overrideProvider(InteractivityChecker, {
+          useValue: {
+            isFocusable: () => true,
+          },
+        })
+        .compileComponents();
+
+      fixture = TestBed.createComponent(OrgSettingsGeneralComponent);
+      loader = TestbedHarnessEnvironment.loader(fixture);
+      httpTestingController = TestBed.inject(HttpTestingController);
+      fixture.detectChanges();
+    });
+
+    it('should disable the form including branded senders when lacking organization-settings-u', async () => {
+      expectConsoleSettingsGetRequest({ email: { enabled: true }, metadata: { readonly: [] } });
+
+      const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      expect(await addConfigurationButton.isDisabled()).toEqual(true);
     });
   });
 

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { Subject } from 'rxjs';
-import { takeUntil, tap } from 'rxjs/operators';
+import { EMPTY, Subject } from 'rxjs';
+import { catchError, takeUntil, tap } from 'rxjs/operators';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { get } from 'lodash';
@@ -26,6 +26,7 @@ import { ConsoleSettingsService } from '../../../services-ngx/console-settings.s
 import { ConsoleSettings } from '../../../entities/consoleSettings';
 import { CorsUtil } from '../../../shared/utils';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 
 @Component({
   selector: 'org-settings-general',
@@ -56,6 +57,7 @@ export class OrgSettingsGeneralComponent implements OnInit, OnDestroy {
     private readonly consoleSettingsService: ConsoleSettingsService,
     private readonly matDialog: MatDialog,
     private readonly snackBarService: SnackBarService,
+    private readonly permissionService: GioPermissionService,
   ) {}
 
   ngOnInit(): void {
@@ -100,6 +102,14 @@ export class OrgSettingsGeneralComponent implements OnInit, OnDestroy {
             protocol: [toFormState(this.settings, 'email.protocol')],
             subject: [toFormState(this.settings, 'email.subject')],
             from: [toFormState(this.settings, 'email.from')],
+            // Unlike the other email fields (hidden by *ngIf when email is off), branded-senders is always rendered,
+            // so it must be disabled at init when email is disabled — not only when the setting is read-only.
+            brandedSenders: [
+              {
+                value: get(this.settings, 'email.brandedSenders', []),
+                disabled: isReadonlySetting(this.settings, 'email.branded_senders') || !get(this.settings, 'email.enabled'),
+              },
+            ],
             properties: this.fb.group({
               auth: [toFormState(this.settings, 'email.properties.auth')],
               startTlsEnable: [toFormState(this.settings, 'email.properties.startTlsEnable')],
@@ -121,29 +131,37 @@ export class OrgSettingsGeneralComponent implements OnInit, OnDestroy {
             this.formSettings.get('management.automaticValidation.enabled').disable();
           });
 
-        // Disable all `email` group if `email.enabled` is not checked without impacting the already readonly properties
-        const controlKeys = [
-          'host',
-          'port',
-          'username',
-          'password',
-          'protocol',
-          'subject',
-          'from',
-          'properties.auth',
-          'properties.startTlsEnable',
-          'properties.sslTrust',
+        // Disable all `email` group if `email.enabled` is not checked without impacting the already readonly properties.
+        // `readonlyKey` overrides the parameter key when it differs from the control path (e.g. brandedSenders / branded_senders).
+        const emailControls: { name: string; readonlyKey?: string }[] = [
+          { name: 'host' },
+          { name: 'port' },
+          { name: 'username' },
+          { name: 'password' },
+          { name: 'protocol' },
+          { name: 'subject' },
+          { name: 'from' },
+          { name: 'properties.auth' },
+          { name: 'properties.startTlsEnable' },
+          { name: 'properties.sslTrust' },
+          { name: 'brandedSenders', readonlyKey: 'email.branded_senders' },
         ];
         // eslint-disable-next-line rxjs/no-nested-subscribe
         this.formSettings.get('email.enabled').valueChanges.subscribe(checked => {
-          controlKeys
-            .filter(k => !isReadonlySetting(this.settings, `email.${k}`))
-            .forEach(k => {
-              return checked ? this.formSettings.get(`email.${k}`).enable() : this.formSettings.get(`email.${k}`).disable();
+          emailControls
+            .filter(({ name, readonlyKey }) => !isReadonlySetting(this.settings, readonlyKey ?? `email.${name}`))
+            .forEach(({ name }) => {
+              return checked ? this.formSettings.get(`email.${name}`).enable() : this.formSettings.get(`email.${name}`).disable();
             });
         });
 
         this.formInitialValues = this.formSettings.getRawValue();
+
+        // A user without organization-settings update permission can view but not change any setting, including the
+        // branded-senders add/edit/delete controls. Disable the whole form (the Portal settings form does the same).
+        if (!this.permissionService.hasAnyMatching(['organization-settings-u'])) {
+          this.formSettings.disable({ emitEvent: false });
+        }
       });
   }
 
@@ -278,6 +296,10 @@ export class OrgSettingsGeneralComponent implements OnInit, OnDestroy {
       .save(updatedSettingsPayload)
       .pipe(
         tap(() => this.snackBarService.success('Configuration successfully saved!')),
+        catchError(({ error }) => {
+          this.snackBarService.error(error?.message ?? 'An error occurred while saving the configuration.');
+          return EMPTY;
+        }),
         takeUntil(this.unsubscribe$),
       )
       .subscribe(() => this.ngOnInit());

--- a/gravitee-apim-console-webui/src/organization/configuration/organization-settings.module.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/organization-settings.module.ts
@@ -89,6 +89,7 @@ import { OrgSettingsPlatformPoliciesConfigComponent } from './policies/config/or
 import { OrgNavigationComponent } from './navigation/org-navigation.component';
 import { OrgSettingsPlatformPoliciesStudioModule } from './policies/studio/org-settings-platform-policies-studio.module';
 
+import { BrandedSendersComponent } from '../../shared/components/branded-senders/branded-senders.component';
 import { GioTableOfContentsModule } from '../../shared/components/gio-table-of-contents/gio-table-of-contents.module';
 import { GioPermissionModule } from '../../shared/components/gio-permission/gio-permission.module';
 import { GioFormColorInputModule } from '../../shared/components/gio-form-color-input/gio-form-color-input.module';
@@ -154,6 +155,7 @@ import { GioTooltipOnEllipsisModule } from '../../shared/components/gio-tooltip-
     MatMenu,
     MatMenuItem,
     MatMenuTrigger,
+    BrandedSendersComponent,
   ],
   declarations: [
     OrgNavigationComponent,

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.html
@@ -1,0 +1,124 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="branded-senders">
+  <!-- Default notification email (read-only, for context) -->
+  <h3 class="branded-senders__title">Default notification email</h3>
+  <p class="branded-senders__subtitle">Used when no branded rule matches the recipient's email domain.</p>
+
+  <mat-form-field class="branded-senders__field">
+    <mat-label>Default From</mat-label>
+    <mat-icon
+      matPrefix
+      class="branded-senders__lock"
+      matTooltip="Read-only preview of the Default From configured in the Email settings above"
+    >
+      lock
+    </mat-icon>
+    <input matInput [value]="defaultFrom()" disabled aria-label="Default From" />
+  </mat-form-field>
+
+  <mat-form-field class="branded-senders__field">
+    <mat-label>Default subject prefix</mat-label>
+    <mat-icon
+      matPrefix
+      class="branded-senders__lock"
+      matTooltip="Read-only preview of the Default subject prefix configured in the Email settings above"
+    >
+      lock
+    </mat-icon>
+    <input matInput [value]="defaultSubject()" disabled aria-label="Default subject prefix" />
+    <mat-hint>%s is replaced with the email's subject.</mat-hint>
+  </mat-form-field>
+
+  <!-- Branded notification email (editable rules) -->
+  <h3 class="branded-senders__title">Branded notification email</h3>
+  <p class="branded-senders__subtitle">
+    Add one or more rules. When a recipient's domain matches a rule, that rule's <strong>From</strong> and <strong>Subject</strong> prefix
+    are used instead of the defaults above.
+  </p>
+
+  @for (group of configurations.controls; track $index) {
+    <mat-card [formGroup]="group" class="branded-senders__card">
+      <div class="branded-senders__card__header">
+        <span class="branded-senders__card__header__title">Configuration {{ $index + 1 }}</span>
+        <button
+          mat-icon-button
+          type="button"
+          aria-label="Delete configuration"
+          [disabled]="isDisabled()"
+          (click)="removeConfiguration($index)"
+        >
+          <mat-icon>delete</mat-icon>
+        </button>
+      </div>
+
+      <mat-form-field class="branded-senders__field">
+        <mat-label>Recipient domains</mat-label>
+        <gio-form-tags-input formControlName="domains" [addOnBlur]="true" placeholder="example.com, eu.example.com"></gio-form-tags-input>
+        <mat-hint>Match is case-insensitive on the part after &#64; in the recipient address.</mat-hint>
+        @if (group.controls.domains.hasError('required')) {
+          <mat-error>At least one domain is required.</mat-error>
+        }
+        @if (group.controls.domains.hasError('invalidDomains')) {
+          <mat-error>Invalid domain(s): {{ group.controls.domains.getError('invalidDomains').join(', ') }}</mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field class="branded-senders__field">
+        <mat-label>From</mat-label>
+        <input matInput formControlName="from" placeholder="noreply@example.com" aria-label="From" />
+        @if (group.controls.from.hasError('required')) {
+          <mat-error>From is required.</mat-error>
+        }
+        @if (group.controls.from.hasError('invalidSenderAddress')) {
+          <mat-error>Enter a valid email address, optionally with a display name.</mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field class="branded-senders__field">
+        <mat-label>Subject prefix</mat-label>
+        <input matInput formControlName="subject" placeholder="[Example] %s" aria-label="Subject prefix" />
+        @if (group.controls.subject.hasError('maxlength')) {
+          <mat-error>Must be at most {{ subjectMaxLength }} characters.</mat-error>
+        }
+      </mat-form-field>
+    </mat-card>
+  }
+
+  @if (configurations.hasError('duplicateDomains')) {
+    <p class="branded-senders__error">
+      Each domain may only be used in one configuration. Used more than once: {{ configurations.getError('duplicateDomains').join(', ') }}.
+    </p>
+  }
+
+  @if (configurations.hasError('maxSerializedLength')) {
+    <p class="branded-senders__error">These configurations are too large to save. Remove some domains or configurations and try again.</p>
+  }
+
+  <button
+    mat-raised-button
+    color="primary"
+    type="button"
+    class="branded-senders__add"
+    [disabled]="isDisabled()"
+    (click)="addConfiguration()"
+  >
+    <mat-icon>add</mat-icon>
+    Add configuration
+  </button>
+</div>

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.scss
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$foreground: map.get(gio.$mat-theme, foreground);
+$typography: map.get(gio.$mat-theme, typography);
+$warn: map.get(gio.$mat-theme, warn);
+
+// Mirrors the Schedulers/CORS settings sections (org-settings-general.component.scss).
+.branded-senders {
+  display: block;
+
+  &__title {
+    @include mat.m2-typography-level($typography, subtitle-1);
+    margin: 24px 0 4px;
+  }
+
+  &__subtitle {
+    margin: 0 0 16px;
+    color: mat.m2-get-color-from-palette($foreground, secondary-text);
+  }
+
+  &__field {
+    width: 100%;
+  }
+
+  &__lock {
+    color: mat.m2-get-color-from-palette($foreground, disabled);
+  }
+
+  &__card {
+    margin-bottom: 16px;
+    padding: 16px;
+
+    &__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 8px;
+
+      &__title {
+        @include mat.m2-typography-level($typography, subtitle-2);
+      }
+    }
+  }
+
+  &__error {
+    @include mat.m2-typography-level($typography, caption);
+    margin: 4px 0 8px;
+    color: mat.m2-get-color-from-palette($warn);
+  }
+
+  &__add {
+    margin-top: 8px;
+  }
+}

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.spec.ts
@@ -1,0 +1,354 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatFormFieldHarness } from '@angular/material/form-field/testing';
+import { MatTooltipHarness } from '@angular/material/tooltip/testing';
+import { GioFormTagsInputHarness } from '@gravitee/ui-particles-angular';
+
+import { BrandedSendersComponent } from './branded-senders.component';
+
+import { BrandedSender } from '../../../entities/brandedSender';
+import { GioTestingModule } from '../../testing';
+
+@Component({
+  standalone: true,
+  imports: [ReactiveFormsModule, BrandedSendersComponent],
+  template: `
+    <form [formGroup]="form">
+      <branded-senders formControlName="brandedSenders" [defaultFrom]="defaultFrom" [defaultSubject]="defaultSubject" />
+    </form>
+  `,
+})
+class TestHostComponent {
+  defaultFrom = '';
+  defaultSubject = '';
+  form = new FormGroup({
+    brandedSenders: new FormControl<BrandedSender[]>([], { nonNullable: true }),
+  });
+}
+
+describe('BrandedSendersComponent', () => {
+  let component: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+  let loader: HarnessLoader;
+
+  const control = () => component.form.controls.brandedSenders;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent, GioTestingModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  describe('default section', () => {
+    it('should display the default from and subject as read-only fields', async () => {
+      component.defaultFrom = 'noreply@example.com';
+      component.defaultSubject = '[Example] %s';
+      fixture.detectChanges();
+
+      const defaultFromField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Default From' }));
+      const defaultFromInput = (await defaultFromField.getControl(MatInputHarness))!;
+      expect(await defaultFromInput.getValue()).toBe('noreply@example.com');
+      expect(await defaultFromInput.isDisabled()).toBe(true);
+
+      const defaultSubjectField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Default subject prefix' }));
+      const defaultSubjectInput = (await defaultSubjectField.getControl(MatInputHarness))!;
+      expect(await defaultSubjectInput.getValue()).toBe('[Example] %s');
+      expect(await defaultSubjectInput.isDisabled()).toBe(true);
+    });
+
+    it('should explain, via each lock tooltip, that the default fields are a read-only preview', async () => {
+      const tooltips = await loader.getAllHarnesses(MatTooltipHarness);
+      const messages: string[] = [];
+      for (const tooltip of tooltips) {
+        await tooltip.show();
+        messages.push(await tooltip.getTooltipText());
+        await tooltip.hide();
+      }
+
+      expect(messages).toContain('Read-only preview of the Default From configured in the Email settings above');
+      expect(messages).toContain('Read-only preview of the Default subject prefix configured in the Email settings above');
+    });
+  });
+
+  describe('rendering the form control value', () => {
+    it('should render a configuration provided through the form control', async () => {
+      control().setValue([{ domains: ['example.com'], from: 'noreply@example.com', subject: '[Example] %s' }]);
+      fixture.detectChanges();
+
+      const domainsField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Recipient domains' }));
+      const domainsInput = (await domainsField.getControl(GioFormTagsInputHarness))!;
+      expect(await domainsInput.getTags()).toEqual(['example.com']);
+
+      const fromField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'From' }));
+      expect(await (await fromField.getControl(MatInputHarness))!.getValue()).toBe('noreply@example.com');
+
+      const subjectField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Subject prefix' }));
+      expect(await (await subjectField.getControl(MatInputHarness))!.getValue()).toBe('[Example] %s');
+    });
+
+    it('should render no configurations when the form control value is null', async () => {
+      control().setValue(null as unknown as BrandedSender[]);
+      fixture.detectChanges();
+
+      const deleteButtons = await loader.getAllHarnesses(MatButtonHarness.with({ selector: '[aria-label="Delete configuration"]' }));
+      expect(deleteButtons.length).toBe(0);
+    });
+  });
+
+  describe('adding and removing configurations', () => {
+    it('should add an empty configuration when "Add configuration" is clicked', async () => {
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      await addButton.click();
+
+      expect(control().value).toEqual([{ domains: [], from: '', subject: '' }]);
+    });
+
+    it('should remove a configuration when its delete button is clicked', async () => {
+      control().setValue([{ domains: ['example.com'], from: 'noreply@example.com', subject: '' }]);
+      fixture.detectChanges();
+
+      const deleteButton = await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Delete configuration"]' }));
+      await deleteButton.click();
+
+      expect(control().value).toEqual([]);
+    });
+
+    it('should remove the correct configuration when one of several is deleted', async () => {
+      control().setValue([
+        { domains: ['a.com'], from: 'a@a.com', subject: 'A' },
+        { domains: ['b.com'], from: 'b@b.com', subject: 'B' },
+        { domains: ['c.com'], from: 'c@c.com', subject: 'C' },
+      ]);
+      fixture.detectChanges();
+
+      const deleteButtons = await loader.getAllHarnesses(MatButtonHarness.with({ selector: '[aria-label="Delete configuration"]' }));
+      await deleteButtons[1].click();
+
+      expect(control().value).toEqual([
+        { domains: ['a.com'], from: 'a@a.com', subject: 'A' },
+        { domains: ['c.com'], from: 'c@c.com', subject: 'C' },
+      ]);
+    });
+  });
+
+  describe('propagating edits', () => {
+    it('should propagate field edits back to the form control', async () => {
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      await addButton.click();
+
+      const domainsField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Recipient domains' }));
+      await (await domainsField.getControl(GioFormTagsInputHarness))!.addTag('example.com');
+
+      const fromField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'From' }));
+      await (await fromField.getControl(MatInputHarness))!.setValue('noreply@example.com');
+
+      const subjectField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Subject prefix' }));
+      await (await subjectField.getControl(MatInputHarness))!.setValue('[Example] %s');
+
+      expect(control().value).toEqual([{ domains: ['example.com'], from: 'noreply@example.com', subject: '[Example] %s' }]);
+    });
+
+    it('should normalize domains (trim + lowercase) and trim the from address when propagating', async () => {
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      await addButton.click();
+
+      const domainsField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Recipient domains' }));
+      await (await domainsField.getControl(GioFormTagsInputHarness))!.addTag('Example.COM');
+
+      const fromField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'From' }));
+      await (await fromField.getControl(MatInputHarness))!.setValue('  noreply@example.com  ');
+
+      expect(control().value).toEqual([{ domains: ['example.com'], from: 'noreply@example.com', subject: '' }]);
+    });
+  });
+
+  describe('disabled state', () => {
+    it('should disable every field when the form control is disabled', async () => {
+      control().setValue([{ domains: ['example.com'], from: 'noreply@example.com', subject: '' }]);
+      control().disable();
+      fixture.detectChanges();
+
+      const domainsField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Recipient domains' }));
+      expect(await (await domainsField.getControl(GioFormTagsInputHarness))!.isDisabled()).toBe(true);
+
+      const fromField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'From' }));
+      expect(await (await fromField.getControl(MatInputHarness))!.isDisabled()).toBe(true);
+
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      expect(await addButton.isDisabled()).toBe(true);
+    });
+
+    it('should stay disabled when the value is rewritten while disabled (e.g. a save-bar Discard)', async () => {
+      control().setValue([{ domains: ['example.com'], from: 'noreply@example.com', subject: '' }]);
+      control().disable();
+      fixture.detectChanges();
+
+      // A later writeValue rebuilds the fields; without re-applying the disabled state they would silently re-enable.
+      control().setValue([{ domains: ['example.org'], from: 'noreply@example.org', subject: '' }]);
+      fixture.detectChanges();
+
+      const fromField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'From' }));
+      expect(await (await fromField.getControl(MatInputHarness))!.isDisabled()).toBe(true);
+    });
+
+    it('should re-enable every field and the add button when the control is re-enabled', async () => {
+      control().setValue([{ domains: ['example.com'], from: 'noreply@example.com', subject: '' }]);
+      control().disable();
+      fixture.detectChanges();
+
+      control().enable();
+      fixture.detectChanges();
+
+      const fromField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'From' }));
+      expect(await (await fromField.getControl(MatInputHarness))!.isDisabled()).toBe(false);
+
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      expect(await addButton.isDisabled()).toBe(false);
+    });
+  });
+
+  describe('validation', () => {
+    it('should be valid with no configurations', () => {
+      control().setValue([]);
+      fixture.detectChanges();
+      expect(control().valid).toBe(true);
+    });
+
+    it('should be valid with a well-formed configuration', () => {
+      control().setValue([{ domains: ['example.com', 'example.org'], from: 'noreply@example.com', subject: '[Example] %s' }]);
+      fixture.detectChanges();
+      expect(control().valid).toBe(true);
+    });
+
+    it('should accept a from address that uses a display name', () => {
+      control().setValue([{ domains: ['example.com'], from: 'Example Team <noreply@example.com>', subject: '' }]);
+      fixture.detectChanges();
+      expect(control().valid).toBe(true);
+    });
+
+    it('should be invalid when a configuration has no domains', () => {
+      control().setValue([{ domains: [], from: 'noreply@example.com', subject: '' }]);
+      fixture.detectChanges();
+      expect(control().invalid).toBe(true);
+    });
+
+    it('should be invalid when a configuration has a malformed domain', () => {
+      control().setValue([{ domains: ['not a domain'], from: 'noreply@example.com', subject: '' }]);
+      fixture.detectChanges();
+      expect(control().invalid).toBe(true);
+    });
+
+    it('should be invalid when the from address is empty', () => {
+      control().setValue([{ domains: ['example.com'], from: '', subject: '' }]);
+      fixture.detectChanges();
+      expect(control().invalid).toBe(true);
+    });
+
+    it('should be invalid when the from address is malformed', () => {
+      control().setValue([{ domains: ['example.com'], from: 'not-an-email', subject: '' }]);
+      fixture.detectChanges();
+      expect(control().invalid).toBe(true);
+    });
+
+    it('should be invalid when the subject prefix exceeds the maximum length', () => {
+      control().setValue([{ domains: ['example.com'], from: 'noreply@example.com', subject: 'x'.repeat(256) }]);
+      fixture.detectChanges();
+      expect(control().invalid).toBe(true);
+    });
+
+    it('should accept domains regardless of case and surrounding whitespace', () => {
+      control().setValue([{ domains: ['  Example.COM  '], from: 'noreply@example.com', subject: '' }]);
+      fixture.detectChanges();
+      expect(control().valid).toBe(true);
+    });
+
+    it('should accept an ACE/punycode IDN TLD', () => {
+      control().setValue([{ domains: ['example.xn--p1ai'], from: 'noreply@example.xn--p1ai', subject: '' }]);
+      fixture.detectChanges();
+      expect(control().valid).toBe(true);
+    });
+
+    it('should accept a sender address with an uppercase ACE/punycode IDN TLD', () => {
+      control().setValue([{ domains: ['example.xn--p1ai'], from: 'noreply@example.XN--P1AI', subject: '' }]);
+      fixture.detectChanges();
+      expect(control().valid).toBe(true);
+    });
+
+    it('should be invalid when the aggregate serialized size exceeds the backend cap', () => {
+      const tooMany = Array.from({ length: 60 }, (_unused, index) => ({
+        domains: [`example${index}.com`],
+        from: `noreply@example${index}.com`,
+        subject: `[Example ${index}] %s`,
+      }));
+      control().setValue(tooMany);
+      fixture.detectChanges();
+
+      expect(control().invalid).toBe(true);
+      expect(fixture.nativeElement.querySelector('.branded-senders__error')?.textContent).toContain('too large to save');
+    });
+
+    it('should be invalid when the same domain is used across configurations', () => {
+      control().setValue([
+        { domains: ['example.com'], from: 'noreply@example.com', subject: '' },
+        { domains: ['EXAMPLE.com', 'example.org'], from: 'noreply@example.org', subject: '' },
+      ]);
+      fixture.detectChanges();
+
+      expect(control().invalid).toBe(true);
+      expect(fixture.nativeElement.querySelector('.branded-senders__error')?.textContent).toContain('example.com');
+    });
+  });
+
+  describe('inline error messages', () => {
+    it('should show an inline error for an invalid domain', async () => {
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      await addButton.click();
+
+      const domainsField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Recipient domains' }));
+      await (await domainsField.getControl(GioFormTagsInputHarness))!.addTag('invalid', 'blur');
+
+      expect(await domainsField.getTextErrors()).toEqual(['Invalid domain(s): invalid']);
+    });
+
+    it('should show an inline error when the from address is malformed', async () => {
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      await addButton.click();
+
+      const fromField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'From' }));
+      const fromInput = (await fromField.getControl(MatInputHarness))!;
+      await fromInput.setValue('not-an-email');
+      await fromInput.blur();
+
+      expect(await fromField.getTextErrors()).toEqual(['Enter a valid email address, optionally with a display name.']);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.stories.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.stories.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+
+import { BrandedSendersComponent } from './branded-senders.component';
+
+import { BrandedSender } from '../../../entities/brandedSender';
+
+export default {
+  title: 'Shared / Branded senders',
+  component: BrandedSendersComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [ReactiveFormsModule, BrandedSendersComponent],
+    }),
+  ],
+} as Meta;
+
+const defaults = {
+  defaultFrom: 'noreply@example.com',
+  defaultSubject: '[Example] %s',
+};
+
+const template = `<branded-senders [formControl]="control" [defaultFrom]="defaultFrom" [defaultSubject]="defaultSubject" />`;
+
+export const Empty: StoryObj = {
+  render: () => ({
+    template,
+    props: { control: new FormControl<BrandedSender[]>([]), ...defaults },
+  }),
+};
+
+export const Prefilled: StoryObj = {
+  render: () => ({
+    template,
+    props: {
+      control: new FormControl<BrandedSender[]>([
+        { domains: ['example.com', 'eu.example.com'], from: 'noreply@example.com', subject: '[Example] %s' },
+        { domains: ['example.org'], from: 'Partner Team <noreply@example.org>', subject: '[Partner] %s' },
+      ]),
+      ...defaults,
+    },
+  }),
+};
+
+export const Disabled: StoryObj = {
+  render: () => ({
+    template,
+    props: {
+      control: new FormControl<BrandedSender[]>({
+        value: [{ domains: ['example.com'], from: 'noreply@example.com', subject: '[Example] %s' }],
+        disabled: true,
+      }),
+      ...defaults,
+    },
+  }),
+};

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  ErrorHandler,
+  forwardRef,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  AbstractControl,
+  ControlValueAccessor,
+  FormArray,
+  FormControl,
+  FormGroup,
+  NG_VALIDATORS,
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validator,
+  ValidatorFn,
+  Validators,
+} from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatIconModule } from '@angular/material/icon';
+import { GioFormTagsInputModule } from '@gravitee/ui-particles-angular';
+
+import { BrandedSender } from '../../../entities/brandedSender';
+
+type BrandedSenderForm = FormGroup<{
+  domains: FormControl<string[]>;
+  from: FormControl<string>;
+  subject: FormControl<string>;
+}>;
+
+const SUBJECT_MAX_LENGTH = 255;
+// The backend persists the whole list as one serialized parameter with a hard cap (BrandedSenders.MAX_SERIALIZED_LENGTH).
+// Mirror it here as an aggregate guard so many individually-valid configurations can't silently overflow it at save time.
+const MAX_SERIALIZED_LENGTH = 4000;
+
+// Client-side format checks so the admin gets a helpful inline error (RFC 1035 host name, and a bare address or a
+// "Name <addr>" sender). These are UX-only and intentionally lenient — the backend only rejects null entries and
+// CR/LF, so this is NOT a mirror of backend validation. The final label allows either an alphabetic TLD or an
+// ACE/punycode IDN TLD (e.g. `xn--p1ai`), which contains digits and hyphens. The `i` flag keeps hostnames
+// case-insensitive (RFC 4343) so e.g. an `XN--P1AI` TLD is accepted the same in a bare domain and in a sender address.
+const TLD = '(?:[a-zA-Z]{2,}|xn--[a-zA-Z0-9-]{1,59})';
+const DOMAIN_PATTERN = new RegExp(String.raw`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+${TLD}$`, 'i');
+const EMAIL_PATTERN = new RegExp(String.raw`^[A-Za-z0-9._%+-]+@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+${TLD}$`, 'i');
+
+/** Rejects a `string[]` where any entry is not a valid, dot-separated host name (case-insensitive). */
+const domainsValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+  const domains: string[] = control.value ?? [];
+  const invalid = domains.filter(domain => !DOMAIN_PATTERN.test((domain ?? '').trim().toLowerCase()));
+  return invalid.length > 0 ? { invalidDomains: invalid } : null;
+};
+
+/** Accepts a bare address (`user@example.com`) or the personal-name form (`Name <user@example.com>`). */
+const senderAddressValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+  const value: string = (control.value ?? '').trim();
+  if (value === '') {
+    return null; // emptiness is handled by Validators.required
+  }
+  const personalName = /^.*<([^<>]+)>$/.exec(value);
+  const address = personalName ? personalName[1].trim() : value;
+  return EMAIL_PATTERN.test(address) ? null : { invalidSenderAddress: true };
+};
+
+/**
+ * Rejects the whole list when its serialized size would exceed the backend's aggregate cap. This is a fail-fast UX
+ * guard only — the backend stays the authority (and its rejection is surfaced by the save error handler). It mirrors
+ * the backend escaping each ";" to a 6-char sequence before measuring, so the estimate stays conservative.
+ */
+const serializedSizeValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+  const json = JSON.stringify(control.value ?? []);
+  // Each ";" is escaped to a 6-char sequence server-side (net +5 chars), so count them into the estimate.
+  const serializedLength = json.length + (json.match(/;/g)?.length ?? 0) * 5;
+  return serializedLength > MAX_SERIALIZED_LENGTH
+    ? { maxSerializedLength: { max: MAX_SERIALIZED_LENGTH, actual: serializedLength } }
+    : null;
+};
+
+/** Rejects the list when the same domain is used in more than one configuration (cross-config uniqueness). */
+const duplicateDomainsValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+  const configurations: BrandedSender[] = control.value ?? [];
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  const trackDomain = (domain: string) => {
+    const normalized = (domain ?? '').trim().toLowerCase();
+    if (normalized === '') {
+      return;
+    }
+    if (seen.has(normalized)) {
+      duplicates.add(normalized);
+    }
+    seen.add(normalized);
+  };
+  configurations.forEach(configuration => (configuration.domains ?? []).forEach(trackDomain));
+  return duplicates.size > 0 ? { duplicateDomains: [...duplicates] } : null;
+};
+
+@Component({
+  selector: 'branded-senders',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatTooltipModule,
+    MatIconModule,
+    GioFormTagsInputModule,
+  ],
+  templateUrl: './branded-senders.component.html',
+  styleUrl: './branded-senders.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => BrandedSendersComponent), multi: true },
+    { provide: NG_VALIDATORS, useExisting: forwardRef(() => BrandedSendersComponent), multi: true },
+  ],
+})
+export class BrandedSendersComponent implements ControlValueAccessor, Validator {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly changeDetector = inject(ChangeDetectorRef);
+  private readonly errorHandler = inject(ErrorHandler);
+
+  /** The default sender/subject shown read-only for context (the `EMAIL_FROM` / `EMAIL_SUBJECT` fallback). */
+  readonly defaultFrom = input('');
+  readonly defaultSubject = input('');
+
+  protected readonly subjectMaxLength = SUBJECT_MAX_LENGTH;
+  protected readonly configurations = new FormArray<BrandedSenderForm>([], [serializedSizeValidator, duplicateDomainsValidator]);
+  protected readonly isDisabled = signal(false);
+
+  private _onChange: (value: BrandedSender[]) => void = () => undefined;
+  private _onTouched: () => void = () => undefined;
+
+  // A CVA propagates its value on every form change; this subscription is the bridge to _onChange. A throw in the
+  // callback is caught so it can't terminate this long-lived stream (which would silently stop propagating edits to
+  // the parent control); it is reported via Angular's ErrorHandler instead.
+  private readonly _propagateValue = this.configurations.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+    try {
+      this._onChange(this.snapshot());
+    } catch (error) {
+      this.errorHandler.handleError(error);
+    }
+  });
+
+  // --- ControlValueAccessor ---
+
+  writeValue(value: BrandedSender[] | null): void {
+    this.configurations.clear({ emitEvent: false });
+    (value ?? []).forEach(brandedSender => this.configurations.push(this.newConfiguration(brandedSender), { emitEvent: false }));
+    // Freshly-built controls are always enabled; Angular only calls setDisabledState() once at setup, so a later
+    // writeValue (e.g. a save-bar Discard/reset) would otherwise re-enable a control that must stay disabled.
+    if (this.isDisabled()) {
+      this.configurations.disable({ emitEvent: false });
+    }
+    // The FormArray is not a signal, so a programmatic value change must be flagged for OnPush re-render.
+    this.changeDetector.markForCheck();
+  }
+
+  registerOnChange(fn: (value: BrandedSender[]) => void): void {
+    this._onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.isDisabled.set(isDisabled);
+    if (isDisabled) {
+      this.configurations.disable({ emitEvent: false });
+    } else {
+      this.configurations.enable({ emitEvent: false });
+    }
+  }
+
+  // --- Validator ---
+
+  validate(): ValidationErrors | null {
+    return this.configurations.valid ? null : { brandedSenders: 'invalid' };
+  }
+
+  // --- Template actions ---
+
+  protected addConfiguration(): void {
+    this.configurations.push(this.newConfiguration());
+    this._onTouched();
+  }
+
+  protected removeConfiguration(index: number): void {
+    this.configurations.removeAt(index);
+    this._onTouched();
+  }
+
+  private newConfiguration(brandedSender?: BrandedSender): BrandedSenderForm {
+    return new FormGroup({
+      domains: new FormControl<string[]>(brandedSender?.domains ?? [], {
+        nonNullable: true,
+        validators: [Validators.required, domainsValidator],
+      }),
+      from: new FormControl<string>(brandedSender?.from ?? '', {
+        nonNullable: true,
+        validators: [Validators.required, senderAddressValidator],
+      }),
+      subject: new FormControl<string>(brandedSender?.subject ?? '', {
+        nonNullable: true,
+        validators: [Validators.maxLength(SUBJECT_MAX_LENGTH)],
+      }),
+    });
+  }
+
+  private snapshot(): BrandedSender[] {
+    // Persist the normalized form the validators accept, so what is stored matches what was validated and reaches
+    // send-time domain matching without stray whitespace (domains are matched case-insensitively, hence lowercased).
+    return this.configurations.controls.map(group => ({
+      domains: group.controls.domains.value.map(domain => domain.trim().toLowerCase()),
+      from: group.controls.from.value.trim(),
+      subject: group.controls.subject.value,
+    }));
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14190
https://gravitee.atlassian.net/browse/APIM-14191
## Description

What
Adds the classic console UI (Org + Portal settings → Email) for per-tenant branded notification senders: a read-only "Default notification email" section plus repeatable "Configuration N" cards, each with recipient domains (chips), a From address, and a Subject prefix. When a recipient's domain matches a rule, that rule's From/Subject is used instead of the EMAIL_FROM/EMAIL_SUBJECT defaults.

Details
- New standalone BrandedSendersComponent (src/shared/components/branded-senders/) — CVA + Validator, OnPush, signals, typed forms, gio-form-tags-input for domains.
- Wired into Org (org-settings-general) and Portal (portal-settings) email settings; brandedSenders added inline to the ConsoleSettingsEmail / PortalSettingsEmail entities.
- Client-side validation mirrors the backend rules (RFC-1035 domains, bare or Name <addr> From, 255-char subject cap).
- Harness-based spec (14 tests) + Shared / Branded senders stories.

Notes for reviewers
- Depends on the branded-senders persistence model (14179/14180), already merged to master — so this is functional standalone.
- Stricter server-side validation (14181, PR #18336) is still in review; the component enforces the same rules client-side in the meantime.
- Classic console only (gamma out of scope).

Covers S3 (APIM-14190) + S4 (APIM-14191).
## Additional context

https://github.com/user-attachments/assets/3a00e273-2153-4502-9cac-7b29afc7b10c


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

Documentation summary — Branded notification senders

  New capability
  Administrators can configure per-domain "branded" senders for outbound subscription/notification emails: a custom From address and Subject prefix that apply when a recipient's email domain matches a configured rule. Without a match, emails use the existing global default sender/subject, so this is purely additive. Configurable at both Organization and Environment (Portal) scope.

  Where to configure
  - Organization scope: Organization Settings → Console → Email
  - Environment scope: Environment/Portal Settings → Email
  - In both, a new "Branded notification email" section appears below the existing "Default notification email" section (which shows the system default From / Subject prefix as read-only, locked fields for reference).

  How to configure
  Each rule is a "Configuration" card with:
  - Recipient domains — one or more domains entered as chips (e.g. example.com, eu.example.com).
  - From — the branded sender address for matching recipients.
  - Subject prefix — a template applied to the notification's title; use %s where the title should appear (e.g. [Example] %s).
  Use + Add configuration to add rules and the trash icon to remove them. Changes are saved with the page's save bar.

  How matching works at send time
  - A recipient's domain (the part after @) is matched against each configuration's domains — case-insensitive and whitespace-tolerant.
  - First match wins if a domain somehow appears in more than one rule.
  - When a single notification goes to recipients across different domains, it is split so each recipient receives an email from the correct branded sender (recipients on non-matching domains get the default sender).
  - No match → the default From / Subject are used, unchanged.

  Scope & inheritance
  Values resolve Environment → Organization → system default: an environment uses its own branded senders if set, otherwise inherits the organization's, otherwise the system default.

Values resolve Environment → Organization → system default: an environment uses its own branded senders if set, otherwise inherits the organization's, otherwise the system default.

Validation rules (enforced inline in the UI and on save)
- Domain: valid host name (RFC 1035); IDN/punycode xn-- TLDs are accepted.
- From: a bare address (noreply@example.com) or a display-name form (Example Team <noreply@example.com>).
- Subject prefix: up to 255 characters.
- No duplicate domains across configurations.
- The total configuration set has a size limit; very large sets are rejected with an inline error.

Permissions
Editing requires ORGANIZATION_SETTINGS[U] (Org scope) or ENVIRONMENT_SETTINGS[U] (Environment scope). Users without the update permission see the settings form (including Add/Delete) disabled/read-only.

Known limitation (note for docs writer — deferred to a follow-up)
At Environment scope, the UI does not yet visually indicate whether displayed configurations are the environment's own overrides or values inherited from the Organization, and deleting an environment override does not visibly restore the inherited value. Tracked separately; consider documenting the current behavior (env values shown are the effective/resolved set) and revisiting once the "Inherited from Org" indicator ships.

Internal behavior — exclude from user docs
(For reviewers, not the published doc: multi-recipient notifications are delivered via Bcc; an explicit caller-provided From bypasses branding; a self-send to the configured address is not branded; the sender's copy from "copy to sender" uses the default identity. These are implementation details, not user-facing configuration.)
