### PR TITLE
fix(api-product): distributed sync enablement

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/mapper/ApiProductMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/mapper/ApiProductMapper.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.distributed.mapper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.apiproduct.ApiProductReactorDeployable;
+import io.gravitee.repository.distributedsync.model.DistributedEvent;
+import io.gravitee.repository.distributedsync.model.DistributedEventType;
+import io.reactivex.rxjava3.core.Maybe;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@CustomLog
+public class ApiProductMapper {
+
+    private final ObjectMapper objectMapper;
+
+    public Maybe<ApiProductReactorDeployable> to(final DistributedEvent event) {
+        return Maybe.fromCallable(() -> {
+            try {
+                SyncAction syncAction = SyncActionMapper.to(event.getSyncAction());
+
+                if (syncAction == SyncAction.DEPLOY && (event.getPayload() == null || event.getPayload().isBlank())) {
+                    return null;
+                }
+
+                var builder = ApiProductReactorDeployable.builder().apiProductId(event.getId()).syncAction(syncAction);
+
+                if (syncAction == SyncAction.DEPLOY) {
+                    ReactableApiProduct reactableApiProduct = objectMapper.readValue(event.getPayload(), ReactableApiProduct.class);
+                    builder.reactableApiProduct(reactableApiProduct);
+
+                    List<Plan> plans = reactableApiProduct.getPlans();
+                    if (plans != null && !plans.isEmpty()) {
+                        builder.subscribablePlans(plans.stream().map(Plan::getId).collect(Collectors.toSet()));
+                    }
+                }
+
+                return builder.build();
+            } catch (Exception e) {
+                log.warn("Error while determining api product into event payload", e);
+                return null;
+            }
+        });
+    }
+
+    public Maybe<DistributedEvent> to(final ApiProductReactorDeployable deployable) {
+        return Maybe.fromCallable(() -> {
+            try {
+                DistributedEvent.DistributedEventBuilder builder = DistributedEvent.builder()
+                    .id(deployable.apiProductId())
+                    .type(DistributedEventType.API_PRODUCT)
+                    .syncAction(SyncActionMapper.to(deployable.syncAction()))
+                    .updatedAt(new Date());
+                if (deployable.syncAction() == SyncAction.DEPLOY) {
+                    builder.payload(objectMapper.writeValueAsString(deployable.reactableApiProduct()));
+                }
+                return builder.build();
+            } catch (Exception e) {
+                log.warn("Error while building distributed event from api product reactor", e);
+                return null;
+            }
+        });
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncService.java
@@ -21,6 +21,7 @@ import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.AccessPointMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiKeyMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiMapper;
+import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiProductMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.AuthzEntityMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.AuthzPolicyMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.DictionaryMapper;
@@ -80,6 +81,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
     private final NodeMetadataMapper nodeMetadataMapper;
     private final AuthzEntityMapper authzEntityMapper;
     private final AuthzPolicyMapper authzPolicyMapper;
+    private final ApiProductMapper apiProductMapper;
 
     @Override
     public void validate() {
@@ -263,9 +265,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing API product event for {}", deployable.id());
-                // TODO Phase 2: Add apiProductMapper for distributed events
-                // return apiProductMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
-                return Completable.complete();
+                return apiProductMapper.to(deployable).flatMapCompletable(this::createOrUpdateEvent);
             }
             log.debug("Not a primary node, skipping API product event distribution");
             return Completable.complete();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/spring/DistributedSyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/spring/DistributedSyncConfiguration.java
@@ -23,6 +23,7 @@ import io.gravitee.gateway.services.sync.process.distributed.fetcher.Distributed
 import io.gravitee.gateway.services.sync.process.distributed.mapper.AccessPointMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiKeyMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiMapper;
+import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiProductMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.AuthzEntityMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.AuthzPolicyMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.DictionaryMapper;
@@ -35,6 +36,7 @@ import io.gravitee.gateway.services.sync.process.distributed.service.DefaultDist
 import io.gravitee.gateway.services.sync.process.distributed.synchronizer.accesspoint.DistributedAccessPointSynchronizer;
 import io.gravitee.gateway.services.sync.process.distributed.synchronizer.api.DistributedApiSynchronizer;
 import io.gravitee.gateway.services.sync.process.distributed.synchronizer.apikey.DistributedApiKeySynchronizer;
+import io.gravitee.gateway.services.sync.process.distributed.synchronizer.apiproduct.DistributedApiProductSynchronizer;
 import io.gravitee.gateway.services.sync.process.distributed.synchronizer.authz.DistributedAuthzEntitySynchronizer;
 import io.gravitee.gateway.services.sync.process.distributed.synchronizer.authz.DistributedAuthzPolicySynchronizer;
 import io.gravitee.gateway.services.sync.process.distributed.synchronizer.dictionary.DistributedDictionarySynchronizer;
@@ -119,6 +121,11 @@ public class DistributedSyncConfiguration {
     }
 
     @Bean
+    public ApiProductMapper distributedApiProductMapper(ObjectMapper objectMapper) {
+        return new ApiProductMapper(objectMapper);
+    }
+
+    @Bean
     public DistributedEventFetcher distributedEventFetcher(
         @Lazy DistributedEventRepository distributedEventRepository,
         ClusterManager clusterManager,
@@ -158,6 +165,23 @@ public class DistributedSyncConfiguration {
             syncDeployerExecutor,
             deployerFactory,
             apiKeyMapper
+        );
+    }
+
+    @Bean
+    public DistributedApiProductSynchronizer distributedApiProductSynchronizer(
+        DistributedEventFetcher distributedEventFetcher,
+        @Qualifier("syncFetcherExecutor") ThreadPoolExecutor syncFetcherExecutor,
+        @Qualifier("syncDeployerExecutor") ThreadPoolExecutor syncDeployerExecutor,
+        DeployerFactory deployerFactory,
+        ApiProductMapper apiProductMapper
+    ) {
+        return new DistributedApiProductSynchronizer(
+            distributedEventFetcher,
+            syncFetcherExecutor,
+            syncDeployerExecutor,
+            deployerFactory,
+            apiProductMapper
         );
     }
 
@@ -331,7 +355,8 @@ public class DistributedSyncConfiguration {
         final SharedPolicyGroupMapper sharedPolicyGroupMapper,
         final NodeMetadataMapper nodeMetadataMapper,
         final AuthzEntityMapper authzEntityMapper,
-        final AuthzPolicyMapper authzPolicyMapper
+        final AuthzPolicyMapper authzPolicyMapper,
+        final ApiProductMapper apiProductMapper
     ) {
         return new DefaultDistributedSyncService(
             node,
@@ -349,7 +374,8 @@ public class DistributedSyncConfiguration {
             sharedPolicyGroupMapper,
             nodeMetadataMapper,
             authzEntityMapper,
-            authzPolicyMapper
+            authzPolicyMapper,
+            apiProductMapper
         );
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.distributed.synchronizer.apiproduct;
+
+import io.gravitee.gateway.services.sync.process.common.deployer.ApiProductDeployer;
+import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
+import io.gravitee.gateway.services.sync.process.common.synchronizer.Order;
+import io.gravitee.gateway.services.sync.process.distributed.fetcher.DistributedEventFetcher;
+import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiProductMapper;
+import io.gravitee.gateway.services.sync.process.distributed.synchronizer.AbstractDistributedSynchronizer;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.apiproduct.ApiProductReactorDeployable;
+import io.gravitee.repository.distributedsync.model.DistributedEvent;
+import io.gravitee.repository.distributedsync.model.DistributedEventType;
+import io.reactivex.rxjava3.core.Maybe;
+import java.util.concurrent.ThreadPoolExecutor;
+import lombok.CustomLog;
+
+@CustomLog
+public class DistributedApiProductSynchronizer extends AbstractDistributedSynchronizer<ApiProductReactorDeployable, ApiProductDeployer> {
+
+    private final DeployerFactory deployerFactory;
+    private final ApiProductMapper apiProductMapper;
+
+    public DistributedApiProductSynchronizer(
+        final DistributedEventFetcher distributedEventFetcher,
+        final ThreadPoolExecutor syncFetcherExecutor,
+        final ThreadPoolExecutor syncDeployerExecutor,
+        final DeployerFactory deployerFactory,
+        final ApiProductMapper apiProductMapper
+    ) {
+        super(distributedEventFetcher, syncFetcherExecutor, syncDeployerExecutor);
+        this.deployerFactory = deployerFactory;
+        this.apiProductMapper = apiProductMapper;
+    }
+
+    @Override
+    protected DistributedEventType distributedEventType() {
+        return DistributedEventType.API_PRODUCT;
+    }
+
+    @Override
+    protected Maybe<ApiProductReactorDeployable> mapTo(final DistributedEvent distributedEvent) {
+        return apiProductMapper.to(distributedEvent);
+    }
+
+    @Override
+    protected ApiProductDeployer createDeployer() {
+        return deployerFactory.createApiProductDeployer();
+    }
+
+    @Override
+    public int order() {
+        return Order.API_PRODUCT.index();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
@@ -248,6 +248,70 @@ class ApiProductDeployerTest {
     }
 
     @Nested
+    class DistributionTest {
+
+        @Test
+        void should_distribute_deploy_when_deploy_tags_do_not_match_gateway() {
+            ReactableApiProduct reactableApiProduct = ReactableApiProduct.builder()
+                .id("api-product-123")
+                .name("Test Product")
+                .tags(Set.of("internal"))
+                .environmentId("env-id")
+                .build();
+
+            ApiProductReactorDeployable deployable = ApiProductReactorDeployable.builder()
+                .syncAction(SyncAction.DEPLOY)
+                .apiProductId("api-product-123")
+                .reactableApiProduct(reactableApiProduct)
+                .build();
+
+            cut.doAfterDeployment(deployable).test().assertComplete();
+            verify(distributedSyncService).distributeIfNeeded(deployable);
+        }
+
+        @Test
+        void should_distribute_deploy_when_product_tags_match_gateway() {
+            ReactableApiProduct reactableApiProduct = ReactableApiProduct.builder()
+                .id("api-product-123")
+                .name("Test Product")
+                .tags(Set.of("internal"))
+                .environmentId("env-id")
+                .build();
+
+            ApiProductReactorDeployable deployable = ApiProductReactorDeployable.builder()
+                .syncAction(SyncAction.DEPLOY)
+                .apiProductId("api-product-123")
+                .reactableApiProduct(reactableApiProduct)
+                .build();
+
+            cut.doAfterDeployment(deployable).test().assertComplete();
+            verify(distributedSyncService).distributeIfNeeded(deployable);
+        }
+
+        @Test
+        void should_distribute_deploy_without_reactable_api_product() {
+            ApiProductReactorDeployable deployable = ApiProductReactorDeployable.builder()
+                .syncAction(SyncAction.DEPLOY)
+                .apiProductId("api-product-123")
+                .build();
+
+            cut.doAfterDeployment(deployable).test().assertComplete();
+            verify(distributedSyncService).distributeIfNeeded(deployable);
+        }
+
+        @Test
+        void should_distribute_undeploy_even_when_product_tags_do_not_match_gateway() {
+            ApiProductReactorDeployable deployable = ApiProductReactorDeployable.builder()
+                .syncAction(SyncAction.UNDEPLOY)
+                .apiProductId("api-product-123")
+                .build();
+
+            cut.doAfterUndeployment(deployable).test().assertComplete();
+            verify(distributedSyncService).distributeIfNeeded(deployable);
+        }
+    }
+
+    @Nested
     class ErrorHandlingTest {
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/mapper/ApiProductMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/mapper/ApiProductMapperTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.distributed.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.apiproduct.ApiProductReactorDeployable;
+import io.gravitee.repository.distributedsync.model.DistributedEvent;
+import io.gravitee.repository.distributedsync.model.DistributedEventType;
+import io.gravitee.repository.distributedsync.model.DistributedSyncAction;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiProductMapperTest {
+
+    private final ObjectMapper objectMapper = new GraviteeMapper();
+    private ApiProductMapper cut;
+    private DistributedEvent distributedEvent;
+    private ApiProductReactorDeployable apiProductDeployable;
+
+    @BeforeEach
+    public void beforeEach() throws JsonProcessingException {
+        cut = new ApiProductMapper(objectMapper);
+
+        Plan plan = Plan.builder().id("plan-1").build();
+        ReactableApiProduct reactableApiProduct = ReactableApiProduct.builder()
+            .id("product-id")
+            .name("Test Product")
+            .apiIds(Set.of("api-1", "api-2"))
+            .plans(List.of(plan))
+            .build();
+
+        distributedEvent = DistributedEvent.builder()
+            .id(reactableApiProduct.getId())
+            .payload(objectMapper.writeValueAsString(reactableApiProduct))
+            .updatedAt(new Date())
+            .type(DistributedEventType.API_PRODUCT)
+            .syncAction(DistributedSyncAction.DEPLOY)
+            .build();
+
+        apiProductDeployable = ApiProductReactorDeployable.builder()
+            .apiProductId(reactableApiProduct.getId())
+            .reactableApiProduct(reactableApiProduct)
+            .syncAction(SyncAction.DEPLOY)
+            .subscribablePlans(Set.of("plan-1"))
+            .build();
+    }
+
+    @Test
+    void should_return_deployable_from_distributed_event() {
+        cut
+            .to(distributedEvent)
+            .test()
+            .assertValue(deployable -> {
+                assertThat(deployable.apiProductId()).isEqualTo(apiProductDeployable.apiProductId());
+                assertThat(deployable.syncAction()).isEqualTo(apiProductDeployable.syncAction());
+                assertThat(deployable.reactableApiProduct()).isEqualTo(apiProductDeployable.reactableApiProduct());
+                assertThat(deployable.subscribablePlans()).isEqualTo(apiProductDeployable.subscribablePlans());
+                return true;
+            });
+    }
+
+    @Test
+    void should_return_deployable_for_undeploy_event() {
+        DistributedEvent undeployEvent = DistributedEvent.builder()
+            .id("product-id")
+            .type(DistributedEventType.API_PRODUCT)
+            .syncAction(DistributedSyncAction.UNDEPLOY)
+            .updatedAt(new Date())
+            .build();
+
+        cut
+            .to(undeployEvent)
+            .test()
+            .assertValue(deployable -> {
+                assertThat(deployable.apiProductId()).isEqualTo("product-id");
+                assertThat(deployable.syncAction()).isEqualTo(SyncAction.UNDEPLOY);
+                assertThat(deployable.reactableApiProduct()).isNull();
+                return true;
+            });
+    }
+
+    @Test
+    void should_return_empty_with_wrong_payload() {
+        cut.to(DistributedEvent.builder().payload("wrong").build()).test().assertComplete();
+    }
+
+    @Test
+    void should_return_empty_for_deploy_event_with_missing_payload() {
+        DistributedEvent deployEvent = DistributedEvent.builder()
+            .id("product-id")
+            .type(DistributedEventType.API_PRODUCT)
+            .syncAction(DistributedSyncAction.DEPLOY)
+            .updatedAt(new Date())
+            .build();
+
+        cut.to(deployEvent).test().assertComplete();
+    }
+
+    @Test
+    void should_map_deployable_to_distributed_event() {
+        cut
+            .to(apiProductDeployable)
+            .test()
+            .assertValue(event -> {
+                assertThat(event.getId()).isEqualTo(distributedEvent.getId());
+                assertThat(event.getType()).isEqualTo(distributedEvent.getType());
+                assertThat(event.getPayload()).isEqualTo(distributedEvent.getPayload());
+                assertThat(event.getSyncAction()).isEqualTo(distributedEvent.getSyncAction());
+                return true;
+            });
+    }
+
+    @Test
+    void should_map_undeploy_deployable_without_payload() {
+        ApiProductReactorDeployable undeployDeployable = ApiProductReactorDeployable.builder()
+            .apiProductId("product-id")
+            .syncAction(SyncAction.UNDEPLOY)
+            .build();
+
+        cut
+            .to(undeployDeployable)
+            .test()
+            .assertValue(event -> {
+                assertThat(event.getId()).isEqualTo("product-id");
+                assertThat(event.getType()).isEqualTo(DistributedEventType.API_PRODUCT);
+                assertThat(event.getSyncAction()).isEqualTo(DistributedSyncAction.UNDEPLOY);
+                assertThat(event.getPayload()).isNull();
+                return true;
+            });
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncServiceTest.java
@@ -27,12 +27,15 @@ import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.Organization;
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.platform.organization.ReactableOrganization;
 import io.gravitee.gateway.reactor.accesspoint.ReactableAccessPoint;
+import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
 import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.AccessPointMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiKeyMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiMapper;
+import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiProductMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.DictionaryMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.LicenseMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.NodeMetadataMapper;
@@ -42,6 +45,7 @@ import io.gravitee.gateway.services.sync.process.distributed.mapper.Subscription
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.accesspoint.AccessPointDeployable;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.ApiReactorDeployable;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.apikey.SingleApiKeyDeployable;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.apiproduct.ApiProductReactorDeployable;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.dictionary.DictionaryDeployable;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.license.LicenseDeployable;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.organization.OrganizationDeployable;
@@ -53,9 +57,12 @@ import io.gravitee.node.api.cluster.Member;
 import io.gravitee.repository.distributedsync.api.DistributedEventRepository;
 import io.gravitee.repository.distributedsync.api.DistributedSyncStateRepository;
 import io.gravitee.repository.distributedsync.model.DistributedEvent;
+import io.gravitee.repository.distributedsync.model.DistributedEventType;
+import io.gravitee.repository.distributedsync.model.DistributedSyncAction;
 import io.gravitee.repository.distributedsync.model.DistributedSyncState;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -118,7 +125,8 @@ class DefaultDistributedSyncServiceTest {
             new SharedPolicyGroupMapper(objectMapper),
             new NodeMetadataMapper(objectMapper),
             new io.gravitee.gateway.services.sync.process.distributed.mapper.AuthzEntityMapper(objectMapper),
-            new io.gravitee.gateway.services.sync.process.distributed.mapper.AuthzPolicyMapper(objectMapper)
+            new io.gravitee.gateway.services.sync.process.distributed.mapper.AuthzPolicyMapper(objectMapper),
+            new ApiProductMapper(objectMapper)
         );
     }
 
@@ -145,6 +153,7 @@ class DefaultDistributedSyncServiceTest {
                 null,
                 distributedEventRepository,
                 distributedSyncStateRepository,
+                null,
                 null,
                 null,
                 null,
@@ -261,6 +270,30 @@ class DefaultDistributedSyncServiceTest {
                 .assertComplete();
             verify(distributedEventRepository).createOrUpdate(any());
         }
+
+        @Test
+        void should_distribute_api_product() {
+            ReactableApiProduct reactableApiProduct = ReactableApiProduct.builder()
+                .id("product-id")
+                .name("Test Product")
+                .apiIds(Set.of("api-1"))
+                .build();
+            ApiProductReactorDeployable deployable = ApiProductReactorDeployable.builder()
+                .apiProductId("product-id")
+                .reactableApiProduct(reactableApiProduct)
+                .syncAction(SyncAction.DEPLOY)
+                .build();
+
+            ArgumentCaptor<DistributedEvent> captor = ArgumentCaptor.forClass(DistributedEvent.class);
+            cut.distributeIfNeeded(deployable).test().assertComplete();
+            verify(distributedEventRepository).createOrUpdate(captor.capture());
+            DistributedEvent event = captor.getValue();
+            assertThat(event.getId()).isEqualTo("product-id");
+            assertThat(event.getType()).isEqualTo(DistributedEventType.API_PRODUCT);
+            assertThat(event.getSyncAction()).isEqualTo(DistributedSyncAction.DEPLOY);
+            assertThat(event.getClusterId()).isEqualTo("clusterId");
+            assertThat(event.getPayload()).isNotNull();
+        }
     }
 
     @Nested
@@ -344,6 +377,12 @@ class DefaultDistributedSyncServiceTest {
                 )
                 .test()
                 .assertComplete();
+            verifyNoInteractions(distributedEventRepository);
+        }
+
+        @Test
+        void should_not_call_repository_when_distributing_api_product() {
+            cut.distributeIfNeeded(ApiProductReactorDeployable.builder().apiProductId("product-id").build()).test().assertComplete();
             verifyNoInteractions(distributedEventRepository);
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizerTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.distributed.synchronizer.apiproduct;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import io.gravitee.gateway.services.sync.process.common.deployer.ApiProductDeployer;
+import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
+import io.gravitee.gateway.services.sync.process.distributed.fetcher.DistributedEventFetcher;
+import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiProductMapper;
+import io.gravitee.repository.distributedsync.model.DistributedEvent;
+import io.gravitee.repository.distributedsync.model.DistributedEventType;
+import io.gravitee.repository.distributedsync.model.DistributedSyncAction;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DistributedApiProductSynchronizerTest {
+
+    private final ObjectMapper objectMapper = new GraviteeMapper();
+
+    @Mock
+    private DistributedEventFetcher eventsFetcher;
+
+    @Mock
+    private DeployerFactory deployerFactory;
+
+    @Mock
+    private ApiProductDeployer apiProductDeployer;
+
+    private DistributedApiProductSynchronizer cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new DistributedApiProductSynchronizer(
+            eventsFetcher,
+            new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>()),
+            new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>()),
+            deployerFactory,
+            new ApiProductMapper(objectMapper)
+        );
+        when(eventsFetcher.bulkItems()).thenReturn(1);
+        lenient().when(deployerFactory.createApiProductDeployer()).thenReturn(apiProductDeployer);
+        lenient().when(apiProductDeployer.deploy(any())).thenReturn(Completable.complete());
+        lenient().when(apiProductDeployer.doAfterDeployment(any())).thenReturn(Completable.complete());
+        lenient().when(apiProductDeployer.undeploy(any())).thenReturn(Completable.complete());
+        lenient().when(apiProductDeployer.doAfterUndeployment(any())).thenReturn(Completable.complete());
+    }
+
+    @Nested
+    class NoEventTest {
+
+        @Test
+        void should_not_synchronize_api_products_when_no_events() throws InterruptedException {
+            when(eventsFetcher.fetchLatest(any(), any(), eq(DistributedEventType.API_PRODUCT), any())).thenReturn(Flowable.empty());
+            cut.synchronize(-1L, Instant.now().toEpochMilli()).test().await().assertComplete();
+            verifyNoInteractions(apiProductDeployer);
+        }
+
+        @Test
+        void should_fetch_init_events() throws InterruptedException {
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.empty());
+            cut.synchronize(-1L, Instant.now().toEpochMilli()).test().await().assertComplete();
+            verify(eventsFetcher).fetchLatest(
+                eq(-1L),
+                any(),
+                eq(DistributedEventType.API_PRODUCT),
+                eq(Set.of(DistributedSyncAction.DEPLOY))
+            );
+        }
+
+        @Test
+        void should_fetch_incremental_events() throws InterruptedException {
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.empty());
+            cut.synchronize(Instant.now().toEpochMilli(), Instant.now().toEpochMilli()).test().await().assertComplete();
+            verify(eventsFetcher).fetchLatest(
+                any(),
+                any(),
+                eq(DistributedEventType.API_PRODUCT),
+                eq(Set.of(DistributedSyncAction.DEPLOY, DistributedSyncAction.UNDEPLOY))
+            );
+        }
+    }
+
+    @Nested
+    class DistributedApiProductSynchronizationTest {
+
+        private ReactableApiProduct reactableApiProduct;
+
+        @BeforeEach
+        public void init() {
+            reactableApiProduct = ReactableApiProduct.builder()
+                .id("product-id")
+                .name("Test Product")
+                .apiIds(Set.of("api-1"))
+                .plans(List.of(Plan.builder().id("plan-1").build()))
+                .build();
+        }
+
+        @Test
+        void should_deploy_api_product_when_fetching_deployed_events() throws InterruptedException, JsonProcessingException {
+            DistributedEvent distributedEvent = DistributedEvent.builder()
+                .id("product-id")
+                .payload(objectMapper.writeValueAsString(reactableApiProduct))
+                .type(DistributedEventType.API_PRODUCT)
+                .syncAction(DistributedSyncAction.DEPLOY)
+                .updatedAt(new Date())
+                .build();
+
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.just(distributedEvent));
+            cut.synchronize(-1L, Instant.now().toEpochMilli()).test().await().assertComplete();
+
+            verify(apiProductDeployer).deploy(any());
+            verify(apiProductDeployer).doAfterDeployment(any());
+        }
+
+        @Test
+        void should_undeploy_api_product_when_fetching_undeployed_events() throws InterruptedException {
+            DistributedEvent distributedEvent = DistributedEvent.builder()
+                .id("product-id")
+                .type(DistributedEventType.API_PRODUCT)
+                .syncAction(DistributedSyncAction.UNDEPLOY)
+                .updatedAt(new Date())
+                .build();
+
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.just(distributedEvent));
+            cut.synchronize(-1L, Instant.now().toEpochMilli()).test().await().assertComplete();
+
+            verify(apiProductDeployer).undeploy(any());
+            verify(apiProductDeployer).doAfterUndeployment(any());
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/distributedsync/model/DistributedEventType.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/distributedsync/model/DistributedEventType.java
@@ -19,6 +19,7 @@ public enum DistributedEventType {
     ACCESS_POINT,
     API,
     API_KEY,
+    API_PRODUCT,
     AUTHZ_ENTITY,
     AUTHZ_POLICY,
     DICTIONARY,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14555

## Description
Enables API Products in the gateway distributed sync (Redis) pipeline, so replica gateways receive product deploy/undeploy events from the primary — the same model already used for APIs, subscriptions, API keys, dictionaries, etc.

Before this change, API Products synced from the management DB on primary nodes only. Replicas had no way to consume product state from Redis, so product plans, subscriptions, and product-scoped API keys were missing on secondaries.

**Problem**
In a multi-gateway / sharded setup:

Primary syncs API Products from JDBC (ApiProductSynchronizer — already existed).
Replicas rely on distributed sync (Redis), not direct DB sync.
API_PRODUCT was not a DistributedEventType, and there was no publish/consume path for products.
Result: products deployed on primaries did not reliably propagate to replicas.

**Solution**
Adds the full publish → Redis → consume pipeline for API Products, aligned with existing distributed synchronizers.
```
Primary (DB sync)             Redis                          Replica
_________________             _____                          _______

ApiProductSynchronizer —deploy→ ApiProductDeployer             DistributedApiProductSynchronizer
                              .doAfterDeployment()   —→      (reads Redis)
                              .distributeIfNeeded()          ApiProductDeployer
``` 


Area | Change
-- | --
DistributedEventType | Add API_PRODUCT enum value
ApiProductMapper (distributed) | Bidirectional mapping: ApiProductReactorDeployable ↔ DistributedEvent (payload = serialized ReactableApiProduct + subscribable plan IDs)
DefaultDistributedSyncService | distributeIfNeeded(ApiProductReactorDeployable) — primary writes product events to Redis
DistributedApiProductSynchronizer | Replica-side consumer; extends AbstractDistributedSynchronizer, reuses ApiProductDeployer
DistributedSyncConfiguration | Spring wiring for mapper + synchronizer
ApiProductDeployer | Publish side: calls distributedSyncService.distributeIfNeeded() after deploy/undeploySharding filter: DEPLOY only distributed when product tags match gateway tags; UNDEPLOY always distributedReplica cleanup: when a tag-ineligible DEPLOY arrives (e.g. tag removed from product), publish UNDEPLOY to Redis so replicas drop stale state
DeployerFactory | Injects GatewayConfiguration into ApiProductDeployer for sharding checks

Please note: All the test scenarios with SS are attached in the mentioned jira ticket