### PR TITLE
fix(authz-sync): change-gate to stop authz PDP commit churn

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
@@ -46,6 +46,7 @@ import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.Aut
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.NoopAuthzAppender;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.PlanAppender;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.SubscriptionAppender;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzAppliedRevisions;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzEnginePort;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzHostedScopes;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.EventBusAuthzEnginePort;
@@ -177,8 +178,18 @@ public class SyncConfiguration {
 
     @Bean
     @Conditional(GammaEnabledCondition.class)
-    public AuthzEnginePort authzEnginePort(io.vertx.rxjava3.core.Vertx vertx, AuthzHostedScopes authzHostedScopes) {
-        return new EventBusAuthzEnginePort(vertx, authzHostedScopes);
+    public AuthzAppliedRevisions authzAppliedRevisions() {
+        return new AuthzAppliedRevisions();
+    }
+
+    @Bean
+    @Conditional(GammaEnabledCondition.class)
+    public AuthzEnginePort authzEnginePort(
+        io.vertx.rxjava3.core.Vertx vertx,
+        AuthzHostedScopes authzHostedScopes,
+        AuthzAppliedRevisions authzAppliedRevisions
+    ) {
+        return new EventBusAuthzEnginePort(vertx, authzHostedScopes, authzAppliedRevisions);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzEntityDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzEntityDeployer.java
@@ -44,7 +44,8 @@ public class AuthzEntityDeployer implements Deployer<AuthzEntityReactorDeployabl
                     deployable.engineUid(),
                     deployable.attributes(),
                     deployable.parents(),
-                    deployable.targetPdpIds()
+                    deployable.targetPdpIds(),
+                    deployable.updatedAt()
                 )
             )
             .doOnComplete(() -> log.debug("Authz entity '{}' staged for next commit", deployable.entityId()))

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzPolicyDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzPolicyDeployer.java
@@ -44,7 +44,8 @@ public class AuthzPolicyDeployer implements Deployer<AuthzPolicyReactorDeployabl
                     deployable.docId(),
                     deployable.name(),
                     deployable.policyText(),
-                    deployable.targetPdpIds()
+                    deployable.targetPdpIds(),
+                    deployable.updatedAt()
                 )
             )
             .doOnComplete(() -> log.debug("Authz policy '{}' staged for next commit", deployable.docId()))

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
@@ -59,6 +59,7 @@ import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.Rep
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.SubscriptionAppender;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.apikey.ApiKeySynchronizer;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.apiproduct.ApiProductSynchronizer;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzAppliedRevisions;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzEnginePort;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzEntityMapper;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzEntitySynchronizer;
@@ -480,7 +481,8 @@ public class RepositorySyncConfiguration {
         io.vertx.rxjava3.core.Vertx vertx,
         AuthzHostedScopes authzHostedScopes,
         @Qualifier("syncFetcherExecutor") ThreadPoolExecutor syncFetcherExecutor,
-        @Qualifier("syncDeployerExecutor") ThreadPoolExecutor syncDeployerExecutor
+        @Qualifier("syncDeployerExecutor") ThreadPoolExecutor syncDeployerExecutor,
+        AuthzAppliedRevisions authzAppliedRevisions
     ) {
         return new AuthzPdpSynchronizer(
             eventsFetcher,
@@ -492,7 +494,8 @@ public class RepositorySyncConfiguration {
             vertx,
             authzHostedScopes,
             syncFetcherExecutor,
-            syncDeployerExecutor
+            syncDeployerExecutor,
+            authzAppliedRevisions
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzAppliedRevisions.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzAppliedRevisions.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Node-local record of which authz document is applied to which scope, at which {@code event.updatedAt}.
+ * The authz analogue of the deployed-API map that {@code ApiManagerImpl} uses to skip an unchanged redeploy.
+ */
+public class AuthzAppliedRevisions {
+
+    private static final String SEP = "\u001f";
+    private final ConcurrentMap<String, ConcurrentMap<String, Long>> revisions = new ConcurrentHashMap<>();
+
+    public boolean shouldApply(String environmentId, String scope, String docId, long updatedAt) {
+        ConcurrentMap<String, Long> scopeRevisions = revisions.get(scopeKey(environmentId, scope));
+        if (scopeRevisions == null) {
+            return true;
+        }
+        Long applied = scopeRevisions.get(docId);
+        return applied == null || updatedAt > applied;
+    }
+
+    public void markApplied(String environmentId, String scope, String docId, long updatedAt) {
+        revisions.computeIfAbsent(scopeKey(environmentId, scope), k -> new ConcurrentHashMap<>()).merge(docId, updatedAt, Math::max);
+    }
+
+    public void forget(String environmentId, String scope, String docId) {
+        ConcurrentMap<String, Long> scopeRevisions = revisions.get(scopeKey(environmentId, scope));
+        if (scopeRevisions != null) {
+            scopeRevisions.remove(docId);
+        }
+    }
+
+    public void forgetScope(String environmentId, String scope) {
+        revisions.remove(scopeKey(environmentId, scope));
+    }
+
+    private static String scopeKey(String environmentId, String scope) {
+        return environmentId + SEP + scope;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzAppliedRevisions.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzAppliedRevisions.java
@@ -25,9 +25,16 @@ import java.util.concurrent.ConcurrentMap;
 public class AuthzAppliedRevisions {
 
     private static final String SEP = "\u001f";
+    private static final String SCOPE_TAG_SEPARATOR = "@";
     private final ConcurrentMap<String, ConcurrentMap<String, Long>> revisions = new ConcurrentHashMap<>();
 
     public boolean shouldApply(String environmentId, String scope, String docId, long updatedAt) {
+        // A non-positive updatedAt is an unknown revision (the mappers default a missing event timestamp
+        // to 0): never gate it, otherwise a real change carrying no timestamp would be suppressed after the
+        // first apply. Such documents keep the pre-gate always-apply behaviour; they are simply not tracked.
+        if (updatedAt <= 0) {
+            return true;
+        }
         ConcurrentMap<String, Long> scopeRevisions = revisions.get(scopeKey(environmentId, scope));
         if (scopeRevisions == null) {
             return true;
@@ -37,6 +44,9 @@ public class AuthzAppliedRevisions {
     }
 
     public void markApplied(String environmentId, String scope, String docId, long updatedAt) {
+        if (updatedAt <= 0) {
+            return;
+        }
         revisions.computeIfAbsent(scopeKey(environmentId, scope), k -> new ConcurrentHashMap<>()).merge(docId, updatedAt, Math::max);
     }
 
@@ -47,8 +57,19 @@ public class AuthzAppliedRevisions {
         }
     }
 
-    public void forgetScope(String environmentId, String scope) {
-        revisions.remove(scopeKey(environmentId, scope));
+    /**
+     * Forget every revision bucket for an engine, i.e. the bare {@code targetPdpId} and all its
+     * {@code targetPdpId@<tag>} routing-scope variants. Called when a PDP is evicted: the engine address is
+     * derived from the {@code targetPdpId} alone, so on a catch-all node every tag-variant scope aliases to
+     * the one engine being torn down and its bucket is now stale — clearing only the bare id would leave a
+     * tagged bucket behind and gate out every doc when the scope is re-provisioned. Walks the outer map, but
+     * only on the (rare) evict path; the hot mutation path never touches it.
+     */
+    public void forgetEngine(String environmentId, String targetPdpId) {
+        String bareKey = scopeKey(environmentId, targetPdpId);
+        String taggedPrefix = bareKey + SCOPE_TAG_SEPARATOR;
+        revisions.remove(bareKey);
+        revisions.keySet().removeIf(k -> k.startsWith(taggedPrefix));
     }
 
     private static String scopeKey(String environmentId, String scope) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEnginePort.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEnginePort.java
@@ -26,12 +26,20 @@ public interface AuthzEnginePort {
         String uid,
         Map<String, Object> attributes,
         List<String> parents,
-        Set<String> targetPdpIds
+        Set<String> targetPdpIds,
+        long updatedAt
     );
 
     Completable removeEntity(String environmentId, String uid, Set<String> targetPdpIds);
 
-    Completable addOrUpdatePolicy(String environmentId, String docId, String name, String policyText, Set<String> targetPdpIds);
+    Completable addOrUpdatePolicy(
+        String environmentId,
+        String docId,
+        String name,
+        String policyText,
+        Set<String> targetPdpIds,
+        long updatedAt
+    );
 
     Completable removePolicy(String environmentId, String docId, Set<String> targetPdpIds);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapper.java
@@ -48,6 +48,7 @@ public class AuthzEntityMapper {
                     .parents(wire.getParents())
                     .environmentId(wire.getEnvironmentId())
                     .targetPdpIds(AuthzWire.targetPdpIdsOrEmpty(wire.getTargetPdpIds()))
+                    .updatedAt(event.getUpdatedAt() != null ? event.getUpdatedAt().getTime() : 0L)
                     .syncAction(SyncAction.DEPLOY)
                     .build();
             } catch (Exception e) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityReactorDeployable.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityReactorDeployable.java
@@ -35,6 +35,7 @@ import lombok.experimental.Accessors;
 public class AuthzEntityReactorDeployable implements AuthzScopedDeployable {
 
     private String entityId;
+    private long updatedAt;
     private String engineUid;
     private Kind kind;
     /** Engine type name (e.g. "User", "Doc"). Optional — null on legacy publishers, in which

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHostedScopes.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHostedScopes.java
@@ -69,6 +69,10 @@ public class AuthzHostedScopes {
         hosted.remove(key(environmentId, targetPdpId));
     }
 
+    public boolean isHosted(String environmentId, String targetPdpId) {
+        return hosted.contains(key(environmentId, targetPdpId));
+    }
+
     /** The named scopes (targetPdpIds) whose engine is provisioned on this node for the given environment.
      *  A wildcard ("*") document expands to these (plus the always-on default) so it is routed per-scope to
      *  exactly the engines this node hosts, rather than via a fire-and-forget broadcast. */

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizer.java
@@ -306,7 +306,9 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
                     pendingHydrationAttempts.remove(rk);
                     pendingEvicts.remove(rk);
                     hostedScopes.unmarkHosted(deployable.environmentId(), deployable.targetPdpId());
-                    revisions.forgetScope(deployable.environmentId(), deployable.targetPdpId());
+                    // Drop the bare id AND every tag-variant bucket: revisions are keyed by routing scope
+                    // (targetPdpId@tag), and on a catch-all node several tag variants alias to this one engine.
+                    revisions.forgetEngine(deployable.environmentId(), deployable.targetPdpId());
                 }
             })
             .onErrorResumeNext(t -> {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizer.java
@@ -103,6 +103,8 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
      *  actually live here, instead of routing blindly to every targetPdpId and hitting NO_HANDLERS. */
     private final AuthzHostedScopes hostedScopes;
 
+    private final AuthzAppliedRevisions revisions;
+
     private static String runtimeKey(AuthzPdpProvisionDeployable deployable) {
         return deployable.environmentId() + ":" + deployable.targetPdpId();
     }
@@ -117,7 +119,8 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
         Vertx vertx,
         AuthzHostedScopes hostedScopes,
         ThreadPoolExecutor syncFetcherExecutor,
-        ThreadPoolExecutor syncDeployerExecutor
+        ThreadPoolExecutor syncDeployerExecutor,
+        AuthzAppliedRevisions revisions
     ) {
         this.eventsFetcher = eventsFetcher;
         this.mapper = mapper;
@@ -129,6 +132,7 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
         this.hostedScopes = Objects.requireNonNull(hostedScopes, "hostedScopes must not be null");
         this.syncFetcherExecutor = syncFetcherExecutor;
         this.syncDeployerExecutor = syncDeployerExecutor;
+        this.revisions = Objects.requireNonNull(revisions, "revisions must not be null");
     }
 
     @Override
@@ -270,6 +274,8 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
         ConcurrentLinkedQueue<AuthzPdpProvisionDeployable> provisionedScopes
     ) {
         boolean provision = deployable.syncAction() == SyncAction.DEPLOY;
+        // raw membership, not serves(): gate on prior provision of this exact scope, not tag-serving
+        boolean wasHosted = hostedScopes.isHosted(deployable.environmentId(), deployable.targetPdpId());
         String op = provision ? OP_PROVISION : OP_EVICT;
         JsonObject command = new JsonObject()
             .put("op", op)
@@ -288,7 +294,9 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
                     pendingProvisionAttempts.remove(rk);
                     pendingEvicts.remove(rk);
                     hostedScopes.markHosted(deployable.environmentId(), deployable.targetPdpId());
-                    provisionedScopes.add(deployable);
+                    if (!wasHosted) {
+                        provisionedScopes.add(deployable);
+                    }
                 } else {
                     // Evict confirmed: drop any pending provision (evict wins), pending hydration and evict,
                     // and stop treating the scope as locally hosted.
@@ -298,6 +306,7 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
                     pendingHydrationAttempts.remove(rk);
                     pendingEvicts.remove(rk);
                     hostedScopes.unmarkHosted(deployable.environmentId(), deployable.targetPdpId());
+                    revisions.forgetScope(deployable.environmentId(), deployable.targetPdpId());
                 }
             })
             .onErrorResumeNext(t -> {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPolicyMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPolicyMapper.java
@@ -61,6 +61,7 @@ public class AuthzPolicyMapper {
                     .entityId(wire.getEntityId())
                     .environmentId(wire.getEnvironmentId())
                     .targetPdpIds(AuthzWire.targetPdpIdsOrEmpty(wire.getTargetPdpIds()))
+                    .updatedAt(event.getUpdatedAt() != null ? event.getUpdatedAt().getTime() : 0L)
                     .syncAction(SyncAction.DEPLOY)
                     .build();
             } catch (Exception e) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPolicyReactorDeployable.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPolicyReactorDeployable.java
@@ -33,6 +33,7 @@ import lombok.experimental.Accessors;
 public class AuthzPolicyReactorDeployable implements AuthzScopedDeployable {
 
     private String docId;
+    private long updatedAt;
     private String name;
     private String policyText;
     private Kind kind;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePort.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePort.java
@@ -57,13 +57,15 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
 
     private final Vertx vertx;
     private final AuthzHostedScopes hostedScopes;
+    private final AuthzAppliedRevisions revisions;
     private final DeliveryOptions deliveryOptions = new DeliveryOptions().setSendTimeout(REPLY_TIMEOUT_MS);
     private final Set<String> touched = ConcurrentHashMap.newKeySet();
     private final Map<String, Integer> commitAttempts = new ConcurrentHashMap<>();
 
-    public EventBusAuthzEnginePort(Vertx vertx, AuthzHostedScopes hostedScopes) {
+    public EventBusAuthzEnginePort(Vertx vertx, AuthzHostedScopes hostedScopes, AuthzAppliedRevisions revisions) {
         this.vertx = Objects.requireNonNull(vertx, "vertx must not be null");
         this.hostedScopes = Objects.requireNonNull(hostedScopes, "hostedScopes must not be null");
+        this.revisions = Objects.requireNonNull(revisions, "revisions must not be null");
     }
 
     private static String addressFor(String environmentId, String scope) {
@@ -88,7 +90,8 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
         String uid,
         Map<String, Object> attributes,
         List<String> parents,
-        Set<String> targetPdpIds
+        Set<String> targetPdpIds,
+        long updatedAt
     ) {
         JsonObject command = new JsonObject().put("op", OP_ADD_OR_UPDATE_ENTITY).put("uid", uid);
         if (attributes != null && !attributes.isEmpty()) {
@@ -97,27 +100,34 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
         if (parents != null && !parents.isEmpty()) {
             command.put("parents", new JsonArray(parents));
         }
-        return route(environmentId, command, targetPdpIds);
+        return routeGated(environmentId, command, targetPdpIds, uid, updatedAt);
     }
 
     @Override
     public Completable removeEntity(String environmentId, String uid, Set<String> targetPdpIds) {
-        return route(environmentId, new JsonObject().put("op", OP_REMOVE_ENTITY).put("uid", uid), targetPdpIds);
+        return routeForget(environmentId, new JsonObject().put("op", OP_REMOVE_ENTITY).put("uid", uid), targetPdpIds, uid);
     }
 
     @Override
-    public Completable addOrUpdatePolicy(String environmentId, String docId, String name, String policyText, Set<String> targetPdpIds) {
+    public Completable addOrUpdatePolicy(
+        String environmentId,
+        String docId,
+        String name,
+        String policyText,
+        Set<String> targetPdpIds,
+        long updatedAt
+    ) {
         JsonObject command = new JsonObject()
             .put("op", OP_ADD_OR_UPDATE_POLICY)
             .put("docId", docId)
             .put("name", name)
             .put("policyText", policyText);
-        return route(environmentId, command, targetPdpIds);
+        return routeGated(environmentId, command, targetPdpIds, docId, updatedAt);
     }
 
     @Override
     public Completable removePolicy(String environmentId, String docId, Set<String> targetPdpIds) {
-        return route(environmentId, new JsonObject().put("op", OP_REMOVE_POLICY).put("docId", docId), targetPdpIds);
+        return routeForget(environmentId, new JsonObject().put("op", OP_REMOVE_POLICY).put("docId", docId), targetPdpIds, docId);
     }
 
     @Override
@@ -174,14 +184,39 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
             });
     }
 
-    private Completable route(String environmentId, JsonObject command, Set<String> targetPdpIds) {
+    private Completable routeGated(String environmentId, JsonObject command, Set<String> targetPdpIds, String docId, long updatedAt) {
         if (targetPdpIds == null || targetPdpIds.isEmpty()) {
             return Completable.complete();
         }
         List<Completable> sends = new ArrayList<>();
         for (String scope : expandWildcard(environmentId, targetPdpIds)) {
-            // Only route to scopes this node hosts (default always served). A named scope whose engine
-            // lives on another node is skipped — sending would just hit NO_HANDLERS.
+            if (!hostedScopes.serves(environmentId, scope)) {
+                continue;
+            }
+            if (!revisions.shouldApply(environmentId, scope, docId, updatedAt)) {
+                continue;
+            }
+            String address = addressFor(environmentId, scope);
+            sends.add(
+                vertx
+                    .eventBus()
+                    .<JsonObject>rxRequest(address, command, deliveryOptions)
+                    .ignoreElement()
+                    .doOnComplete(() -> {
+                        revisions.markApplied(environmentId, scope, docId, updatedAt);
+                        touched.add(address);
+                    })
+            );
+        }
+        return Completable.merge(sends);
+    }
+
+    private Completable routeForget(String environmentId, JsonObject command, Set<String> targetPdpIds, String docId) {
+        if (targetPdpIds == null || targetPdpIds.isEmpty()) {
+            return Completable.complete();
+        }
+        List<Completable> sends = new ArrayList<>();
+        for (String scope : expandWildcard(environmentId, targetPdpIds)) {
             if (!hostedScopes.serves(environmentId, scope)) {
                 continue;
             }
@@ -191,7 +226,10 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
                     .eventBus()
                     .<JsonObject>rxRequest(address, command, deliveryOptions)
                     .ignoreElement()
-                    .doOnComplete(() -> touched.add(address))
+                    .doOnComplete(() -> {
+                        revisions.forget(environmentId, scope, docId);
+                        touched.add(address);
+                    })
             );
         }
         return Completable.merge(sends);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePort.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePort.java
@@ -61,6 +61,12 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
     private final DeliveryOptions deliveryOptions = new DeliveryOptions().setSendTimeout(REPLY_TIMEOUT_MS);
     private final Set<String> touched = ConcurrentHashMap.newKeySet();
     private final Map<String, Integer> commitAttempts = new ConcurrentHashMap<>();
+    // Revisions marked applied against an address but not yet sealed by a successful commit. Kept so that when
+    // a commit to that address is abandoned (past MAX_COMMIT_ATTEMPTS) the marks can be rolled back, otherwise
+    // the gate would suppress a re-stage forever and the scope would sit permanently uncommitted.
+    private final Map<String, Set<RevisionRef>> pendingByAddress = new ConcurrentHashMap<>();
+
+    private record RevisionRef(String environmentId, String scope, String docId) {}
 
     public EventBusAuthzEnginePort(Vertx vertx, AuthzHostedScopes hostedScopes, AuthzAppliedRevisions revisions) {
         this.vertx = Objects.requireNonNull(vertx, "vertx must not be null");
@@ -163,25 +169,54 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
     }
 
     private Completable commitOne(String address) {
-        JsonObject c = new JsonObject().put("op", OP_COMMIT);
-        return vertx
-            .eventBus()
-            .<JsonObject>rxRequest(address, c, deliveryOptions)
-            .flatMapCompletable(this::verifyCommitReply)
-            .doOnComplete(() -> commitAttempts.remove(address))
-            .onErrorComplete(t -> {
-                int attempts = commitAttempts.merge(address, 1, Integer::sum);
-                if (attempts > MAX_COMMIT_ATTEMPTS) {
-                    commitAttempts.remove(address);
-                    log.warn("Abandoning authz PDP commit to address [{}] after {} attempts", address, attempts - 1);
+        return Completable.defer(() -> {
+            // Take ownership of the revisions this commit is sealing (mirrors the touched snapshot): marks
+            // armed by a mutation that completes after this point stay pending for the next commit.
+            Set<RevisionRef> sealing = pendingByAddress.remove(address);
+            JsonObject c = new JsonObject().put("op", OP_COMMIT);
+            return vertx
+                .eventBus()
+                .<JsonObject>rxRequest(address, c, deliveryOptions)
+                .flatMapCompletable(this::verifyCommitReply)
+                // Commit sealed the generation: the marks are now durable, drop the snapshot without rolling back.
+                .doOnComplete(() -> commitAttempts.remove(address))
+                .onErrorComplete(t -> {
+                    int attempts = commitAttempts.merge(address, 1, Integer::sum);
+                    if (attempts > MAX_COMMIT_ATTEMPTS) {
+                        commitAttempts.remove(address);
+                        // Give up: the staged mutations were never sealed, so roll back their revision marks —
+                        // otherwise the gate suppresses the re-stage forever and the scope stays uncommitted.
+                        forgetPending(sealing);
+                        log.warn(
+                            "Abandoning authz PDP commit to address [{}] after {} attempts; rolled back {} unsealed revision(s) so they re-stage next cycle",
+                            address,
+                            attempts - 1,
+                            sealing == null ? 0 : sealing.size()
+                        );
+                        return true;
+                    }
+                    // Re-arm the address AND keep owning the unsealed marks so the next cycle's commit retries
+                    // and can still roll them back if it ultimately gives up.
+                    rearmPending(address, sealing);
+                    touched.add(address);
+                    log.warn("Authz PDP commit to address [{}] failed (attempt {}), will retry next cycle", address, attempts, t);
                     return true;
-                }
-                // Re-arm the address so a transient commit failure is retried next cycle, instead of
-                // leaving the scope's staged mutations unsealed until a later mutation touches it.
-                touched.add(address);
-                log.warn("Authz PDP commit to address [{}] failed (attempt {}), will retry next cycle", address, attempts, t);
-                return true;
-            });
+                });
+        });
+    }
+
+    private void forgetPending(Set<RevisionRef> refs) {
+        if (refs == null) {
+            return;
+        }
+        refs.forEach(r -> revisions.forget(r.environmentId(), r.scope(), r.docId()));
+    }
+
+    private void rearmPending(String address, Set<RevisionRef> refs) {
+        if (refs == null || refs.isEmpty()) {
+            return;
+        }
+        pendingByAddress.computeIfAbsent(address, k -> ConcurrentHashMap.newKeySet()).addAll(refs);
     }
 
     private Completable routeGated(String environmentId, JsonObject command, Set<String> targetPdpIds, String docId, long updatedAt) {
@@ -204,6 +239,9 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
                     .ignoreElement()
                     .doOnComplete(() -> {
                         revisions.markApplied(environmentId, scope, docId, updatedAt);
+                        pendingByAddress
+                            .computeIfAbsent(address, k -> ConcurrentHashMap.newKeySet())
+                            .add(new RevisionRef(environmentId, scope, docId));
                         touched.add(address);
                     })
             );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/NoopAuthzEnginePort.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/NoopAuthzEnginePort.java
@@ -28,7 +28,8 @@ public class NoopAuthzEnginePort implements AuthzEnginePort {
         String uid,
         Map<String, Object> attributes,
         List<String> parents,
-        Set<String> targetPdpIds
+        Set<String> targetPdpIds,
+        long updatedAt
     ) {
         return Completable.complete();
     }
@@ -39,7 +40,14 @@ public class NoopAuthzEnginePort implements AuthzEnginePort {
     }
 
     @Override
-    public Completable addOrUpdatePolicy(String environmentId, String docId, String name, String policyText, Set<String> targetPdpIds) {
+    public Completable addOrUpdatePolicy(
+        String environmentId,
+        String docId,
+        String name,
+        String policyText,
+        Set<String> targetPdpIds,
+        long updatedAt
+    ) {
         return Completable.complete();
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzEntityDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzEntityDeployerTest.java
@@ -169,7 +169,8 @@ class AuthzEntityDeployerTest {
             String uid,
             Map<String, Object> attributes,
             List<String> parents,
-            Set<String> targetPdpIds
+            Set<String> targetPdpIds,
+            long updatedAt
         ) {
             entityOps.add(new EntityOp("addOrUpdateEntity", uid, attributes, parents, targetPdpIds));
             return Completable.complete();
@@ -182,7 +183,14 @@ class AuthzEntityDeployerTest {
         }
 
         @Override
-        public Completable addOrUpdatePolicy(String environmentId, String docId, String name, String policyText, Set<String> targetPdpIds) {
+        public Completable addOrUpdatePolicy(
+            String environmentId,
+            String docId,
+            String name,
+            String policyText,
+            Set<String> targetPdpIds,
+            long updatedAt
+        ) {
             return Completable.complete();
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzPolicyDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzPolicyDeployerTest.java
@@ -216,7 +216,8 @@ class AuthzPolicyDeployerTest {
             String uid,
             Map<String, Object> attributes,
             List<String> parents,
-            Set<String> targetPdpIds
+            Set<String> targetPdpIds,
+            long updatedAt
         ) {
             return Completable.complete();
         }
@@ -227,7 +228,14 @@ class AuthzPolicyDeployerTest {
         }
 
         @Override
-        public Completable addOrUpdatePolicy(String environmentId, String docId, String name, String policyText, Set<String> targetPdpIds) {
+        public Completable addOrUpdatePolicy(
+            String environmentId,
+            String docId,
+            String name,
+            String policyText,
+            Set<String> targetPdpIds,
+            long updatedAt
+        ) {
             policyOps.add(new PolicyOp("addOrUpdatePolicy", docId, name, policyText, targetPdpIds));
             return Completable.complete();
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzAppliedRevisionsTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzAppliedRevisionsTest.java
@@ -48,20 +48,46 @@ class AuthzAppliedRevisionsTest {
     }
 
     @Test
-    void forgetScope_clears_only_that_scope() {
+    void forgetEngine_clears_only_that_engine() {
         revisions.markApplied("env", "scope-a", "doc", 100L);
         revisions.markApplied("env", "scope-b", "doc", 100L);
-        revisions.forgetScope("env", "scope-a");
+        revisions.forgetEngine("env", "scope-a");
         assertThat(revisions.shouldApply("env", "scope-a", "doc", 100L)).isTrue();
         assertThat(revisions.shouldApply("env", "scope-b", "doc", 100L)).isFalse();
     }
 
     @Test
-    void forgetScope_does_not_clear_a_prefix_sibling_scope() {
+    void forgetEngine_does_not_clear_a_prefix_sibling_scope() {
         revisions.markApplied("env", "scope", "doc", 100L);
         revisions.markApplied("env", "scope-b", "doc", 100L); // "scope" is a prefix of "scope-b"
-        revisions.forgetScope("env", "scope");
+        revisions.forgetEngine("env", "scope");
         assertThat(revisions.shouldApply("env", "scope", "doc", 100L)).isTrue(); // cleared
         assertThat(revisions.shouldApply("env", "scope-b", "doc", 100L)).isFalse(); // NOT cleared
+    }
+
+    @Test
+    void forgetEngine_clears_the_bare_id_and_every_tag_variant() {
+        // A catch-all node hosting several tag variants marks them under the routing scope (id@tag), all
+        // aliasing to the one engine addressed by the bare id. Evicting that engine must drop them all.
+        revisions.markApplied("env", "orders", "doc", 100L);
+        revisions.markApplied("env", "orders@eu", "doc", 100L);
+        revisions.markApplied("env", "orders@us", "doc", 100L);
+        revisions.forgetEngine("env", "orders");
+        assertThat(revisions.shouldApply("env", "orders", "doc", 100L)).isTrue();
+        assertThat(revisions.shouldApply("env", "orders@eu", "doc", 100L)).isTrue();
+        assertThat(revisions.shouldApply("env", "orders@us", "doc", 100L)).isTrue();
+    }
+
+    @Test
+    void an_unknown_timestamp_is_never_gated() {
+        // A missing event.updatedAt is mapped to 0: it must never be recorded nor gated, otherwise a real
+        // change carrying no timestamp would be suppressed after the first apply.
+        assertThat(revisions.shouldApply("env", "scope", "doc", 0L)).isTrue();
+        revisions.markApplied("env", "scope", "doc", 0L);
+        assertThat(revisions.shouldApply("env", "scope", "doc", 0L)).isTrue();
+        // A later real timestamp still applies and starts gating from there.
+        assertThat(revisions.shouldApply("env", "scope", "doc", 100L)).isTrue();
+        revisions.markApplied("env", "scope", "doc", 100L);
+        assertThat(revisions.shouldApply("env", "scope", "doc", 100L)).isFalse();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzAppliedRevisionsTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzAppliedRevisionsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AuthzAppliedRevisionsTest {
+
+    private final AuthzAppliedRevisions revisions = new AuthzAppliedRevisions();
+
+    @Test
+    void applies_when_absent_then_skips_same_or_older() {
+        assertThat(revisions.shouldApply("env", "scope", "doc", 100L)).isTrue();
+        revisions.markApplied("env", "scope", "doc", 100L);
+        assertThat(revisions.shouldApply("env", "scope", "doc", 100L)).isFalse();
+        assertThat(revisions.shouldApply("env", "scope", "doc", 90L)).isFalse();
+        assertThat(revisions.shouldApply("env", "scope", "doc", 101L)).isTrue();
+    }
+
+    @Test
+    void markApplied_is_monotonic() {
+        revisions.markApplied("env", "scope", "doc", 100L);
+        revisions.markApplied("env", "scope", "doc", 50L);
+        assertThat(revisions.shouldApply("env", "scope", "doc", 100L)).isFalse();
+        assertThat(revisions.shouldApply("env", "scope", "doc", 101L)).isTrue();
+    }
+
+    @Test
+    void forget_lets_the_same_revision_apply_again() {
+        revisions.markApplied("env", "scope", "doc", 100L);
+        revisions.forget("env", "scope", "doc");
+        assertThat(revisions.shouldApply("env", "scope", "doc", 100L)).isTrue();
+    }
+
+    @Test
+    void forgetScope_clears_only_that_scope() {
+        revisions.markApplied("env", "scope-a", "doc", 100L);
+        revisions.markApplied("env", "scope-b", "doc", 100L);
+        revisions.forgetScope("env", "scope-a");
+        assertThat(revisions.shouldApply("env", "scope-a", "doc", 100L)).isTrue();
+        assertThat(revisions.shouldApply("env", "scope-b", "doc", 100L)).isFalse();
+    }
+
+    @Test
+    void forgetScope_does_not_clear_a_prefix_sibling_scope() {
+        revisions.markApplied("env", "scope", "doc", 100L);
+        revisions.markApplied("env", "scope-b", "doc", 100L); // "scope" is a prefix of "scope-b"
+        revisions.forgetScope("env", "scope");
+        assertThat(revisions.shouldApply("env", "scope", "doc", 100L)).isTrue(); // cleared
+        assertThat(revisions.shouldApply("env", "scope-b", "doc", 100L)).isFalse(); // NOT cleared
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapperTest.java
@@ -211,6 +211,32 @@ class AuthzEntityMapperTest {
         assertThat(d.engineUid()).isEqualTo("Resource::\"custom.bookings\"");
     }
 
+    @Test
+    void toDeploy_carries_event_updatedAt() {
+        Event event = event(
+            "evt-upd-1",
+            "{\"entityId\": \"custom.bookings\", \"kind\": \"RESOURCE\", \"attributes\": {}, \"parents\": []}"
+        );
+        event.setUpdatedAt(new java.util.Date(1234L));
+
+        AuthzEntityReactorDeployable deployable = mapper.toDeploy(event).blockingGet();
+
+        assertThat(deployable.updatedAt()).isEqualTo(1234L);
+    }
+
+    @Test
+    void toDeploy_defaults_updatedAt_to_zero_when_event_has_none() {
+        Event event = event(
+            "evt-upd-2",
+            "{\"entityId\": \"custom.bookings\", \"kind\": \"RESOURCE\", \"attributes\": {}, \"parents\": []}"
+        );
+        event.setUpdatedAt(null);
+
+        AuthzEntityReactorDeployable deployable = mapper.toDeploy(event).blockingGet();
+
+        assertThat(deployable.updatedAt()).isZero();
+    }
+
     private static Event event(String id, String payload) {
         Event event = new Event();
         event.setId(id);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEventToEngineIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEventToEngineIntegrationTest.java
@@ -147,7 +147,8 @@ class AuthzEventToEngineIntegrationTest {
             String uid,
             Map<String, Object> attributes,
             List<String> parents,
-            Set<String> targetPdpIds
+            Set<String> targetPdpIds,
+            long updatedAt
         ) {
             ops.add("addOrUpdateEntity:" + uid);
             return Completable.complete();
@@ -160,7 +161,14 @@ class AuthzEventToEngineIntegrationTest {
         }
 
         @Override
-        public Completable addOrUpdatePolicy(String environmentId, String docId, String name, String policyText, Set<String> targetPdpIds) {
+        public Completable addOrUpdatePolicy(
+            String environmentId,
+            String docId,
+            String name,
+            String policyText,
+            Set<String> targetPdpIds,
+            long updatedAt
+        ) {
             ops.add("addOrUpdatePolicy:" + docId);
             return Completable.complete();
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHydrationPlacementTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHydrationPlacementTest.java
@@ -141,7 +141,8 @@ class AuthzHydrationPlacementTest {
             vertx,
             hostedScopes,
             executor(),
-            executor()
+            executor(),
+            new AuthzAppliedRevisions()
         );
     }
 
@@ -262,7 +263,8 @@ class AuthzHydrationPlacementTest {
             String uid,
             Map<String, Object> attributes,
             List<String> parents,
-            Set<String> targetPdpIds
+            Set<String> targetPdpIds,
+            long updatedAt
         ) {
             ops.add("addOrUpdateEntity:" + uid + ":" + new TreeSet<>(targetPdpIds));
             return Completable.complete();
@@ -275,7 +277,14 @@ class AuthzHydrationPlacementTest {
         }
 
         @Override
-        public Completable addOrUpdatePolicy(String environmentId, String docId, String name, String policyText, Set<String> targetPdpIds) {
+        public Completable addOrUpdatePolicy(
+            String environmentId,
+            String docId,
+            String name,
+            String policyText,
+            Set<String> targetPdpIds,
+            long updatedAt
+        ) {
             ops.add("addOrUpdatePolicy:" + docId);
             return Completable.complete();
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpHydrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpHydrationTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -73,6 +74,7 @@ class AuthzPdpHydrationTest {
     private AuthzEnginePort enginePort;
 
     private AuthzPdpSynchronizer synchronizer;
+    private AuthzAppliedRevisions revisions;
     private MessageConsumer<JsonObject> provisionConsumer;
 
     @BeforeEach
@@ -114,6 +116,7 @@ class AuthzPdpHydrationTest {
             executor(),
             executor()
         );
+        revisions = new AuthzAppliedRevisions();
         synchronizer = new AuthzPdpSynchronizer(
             fetcher,
             new AuthzPdpMapper(new ObjectMapper()),
@@ -125,7 +128,7 @@ class AuthzPdpHydrationTest {
             new AuthzHostedScopes(),
             executor(),
             executor(),
-            new AuthzAppliedRevisions()
+            revisions
         );
     }
 
@@ -282,6 +285,26 @@ class AuthzPdpHydrationTest {
 
         // 1 fresh attempt + MAX_PENDING_ATTEMPTS re-drives, then abandoned — not unbounded.
         verify(enginePort, times(AuthzPdpSynchronizer.MAX_PENDING_ATTEMPTS + 1)).commitScope("env-pdp", "scope-fail");
+    }
+
+    @Test
+    void evict_of_a_tagged_pdp_forgets_every_tag_variant_revision_so_a_reprovision_re_hydrates() throws InterruptedException {
+        // A prior hydration marked the tagged scope's docs under its routing scope (orders@eu). Forgetting
+        // only the bare id on evict would leave those marks in place, and a re-provision would then gate out
+        // every doc — engine empty while hydration looks successful. The evict must drop the tagged bucket.
+        revisions.markApplied("env-pdp", "orders@eu", "pol-1", 100L);
+        revisions.markApplied("env-pdp", "orders@eu", "ent-1", 100L);
+        assertThat(revisions.shouldApply("env-pdp", "orders@eu", "pol-1", 100L)).isFalse();
+
+        Event evict = pdpEvent("evt-u", EventType.UNPUBLISH_AUTHZ_PDP, "orders", "eu");
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
+            Flowable.just(List.of(evict))
+        );
+
+        synchronizer.synchronize(123L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        assertThat(revisions.shouldApply("env-pdp", "orders@eu", "pol-1", 100L)).isTrue();
+        assertThat(revisions.shouldApply("env-pdp", "orders@eu", "ent-1", 100L)).isTrue();
     }
 
     private static Event pdpEvent(String id, EventType type, String targetPdpId, String tag) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpHydrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpHydrationTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -82,8 +83,8 @@ class AuthzPdpHydrationTest {
         lenient().when(fetcher.bulkItems()).thenReturn(10);
         lenient().when(fetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.empty());
         lenient().when(gatewayConfiguration.shardingTags()).thenReturn(java.util.Optional.of(java.util.List.of()));
-        lenient().when(enginePort.addOrUpdatePolicy(any(), any(), any(), any(), any())).thenReturn(Completable.complete());
-        lenient().when(enginePort.addOrUpdateEntity(any(), any(), any(), any(), any())).thenReturn(Completable.complete());
+        lenient().when(enginePort.addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong())).thenReturn(Completable.complete());
+        lenient().when(enginePort.addOrUpdateEntity(any(), any(), any(), any(), any(), anyLong())).thenReturn(Completable.complete());
         lenient().when(enginePort.commit()).thenReturn(Completable.complete());
         lenient().when(enginePort.commitScope(any(), any())).thenReturn(Completable.complete());
         provisionConsumer = vertx
@@ -123,7 +124,8 @@ class AuthzPdpHydrationTest {
             vertx,
             new AuthzHostedScopes(),
             executor(),
-            executor()
+            executor(),
+            new AuthzAppliedRevisions()
         );
     }
 
@@ -158,10 +160,10 @@ class AuthzPdpHydrationTest {
 
         synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
 
-        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-1"), any(), any(), eq(Set.of("scope-1")));
-        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-2"), any(), any(), eq(Set.of("scope-1")));
-        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-3"), any(), any(), any());
-        verify(enginePort).addOrUpdateEntity(eq("env-pdp"), any(), any(), any(), eq(Set.of("scope-1")));
+        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-1"), any(), any(), eq(Set.of("scope-1")), anyLong());
+        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-2"), any(), any(), eq(Set.of("scope-1")), anyLong());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-3"), any(), any(), any(), anyLong());
+        verify(enginePort).addOrUpdateEntity(eq("env-pdp"), any(), any(), any(), eq(Set.of("scope-1")), anyLong());
         verify(enginePort, times(2)).commitScope("env-pdp", "scope-1");
     }
 
@@ -182,11 +184,11 @@ class AuthzPdpHydrationTest {
 
         synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
 
-        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-x"), any(), any(), eq(Set.of("scope-x")));
-        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-w"), any(), any(), eq(Set.of("scope-x")));
-        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-multi"), any(), any(), eq(Set.of("scope-x")));
-        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-other"), any(), any(), any());
-        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), eq(Set.of("scope-other")));
+        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-x"), any(), any(), eq(Set.of("scope-x")), anyLong());
+        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-w"), any(), any(), eq(Set.of("scope-x")), anyLong());
+        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-multi"), any(), any(), eq(Set.of("scope-x")), anyLong());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-other"), any(), any(), any(), anyLong());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), eq(Set.of("scope-other")), anyLong());
     }
 
     @Test
@@ -205,9 +207,9 @@ class AuthzPdpHydrationTest {
 
         synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-pdp", "env-other")).test().await().assertComplete();
 
-        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-own"), any(), any(), eq(Set.of("scope-shared")));
-        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-foreign"), any(), any(), any());
-        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-foreign-w"), any(), any(), any());
+        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-own"), any(), any(), eq(Set.of("scope-shared")), anyLong());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-foreign"), any(), any(), any(), anyLong());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-foreign-w"), any(), any(), any(), anyLong());
     }
 
     @Test
@@ -225,8 +227,8 @@ class AuthzPdpHydrationTest {
 
         synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-pdp", "env-other")).test().await().assertComplete();
 
-        verify(enginePort).addOrUpdateEntity(eq("env-pdp"), any(), any(), any(), eq(Set.of("scope-shared")));
-        verify(enginePort, times(1)).addOrUpdateEntity(any(), any(), any(), any(), any());
+        verify(enginePort).addOrUpdateEntity(eq("env-pdp"), any(), any(), any(), eq(Set.of("scope-shared")), anyLong());
+        verify(enginePort, times(1)).addOrUpdateEntity(any(), any(), any(), any(), any(), anyLong());
     }
 
     @Test
@@ -239,8 +241,8 @@ class AuthzPdpHydrationTest {
 
         synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
 
-        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any());
-        verify(enginePort, never()).addOrUpdateEntity(any(), any(), any(), any(), any());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong());
+        verify(enginePort, never()).addOrUpdateEntity(any(), any(), any(), any(), any(), anyLong());
         // the scope must still seal generation 0 so it does not stay cold forever (once per synchronizer)
         verify(enginePort, times(2)).commitScope("env-pdp", "scope-empty");
     }
@@ -254,8 +256,8 @@ class AuthzPdpHydrationTest {
 
         synchronizer.synchronize(123L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
 
-        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any());
-        verify(enginePort, never()).addOrUpdateEntity(any(), any(), any(), any(), any());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong());
+        verify(enginePort, never()).addOrUpdateEntity(any(), any(), any(), any(), any(), anyLong());
         verify(enginePort, never()).commitScope(any(), any());
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizerChaosTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizerChaosTest.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -102,8 +103,8 @@ class AuthzPdpSynchronizerChaosTest {
         lenient().when(fetcher.bulkItems()).thenReturn(10);
         lenient().when(fetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.empty());
         lenient().when(gatewayConfiguration.shardingTags()).thenReturn(java.util.Optional.of(java.util.List.of("eu")));
-        lenient().when(enginePort.addOrUpdatePolicy(any(), any(), any(), any(), any())).thenReturn(Completable.complete());
-        lenient().when(enginePort.addOrUpdateEntity(any(), any(), any(), any(), any())).thenReturn(Completable.complete());
+        lenient().when(enginePort.addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong())).thenReturn(Completable.complete());
+        lenient().when(enginePort.addOrUpdateEntity(any(), any(), any(), any(), any(), anyLong())).thenReturn(Completable.complete());
         lenient().when(enginePort.commit()).thenReturn(Completable.complete());
         lenient().when(enginePort.commitScope(any(), any())).thenReturn(Completable.complete());
         consumer = registerReplyingConsumer();
@@ -153,7 +154,8 @@ class AuthzPdpSynchronizerChaosTest {
             vertx,
             new AuthzHostedScopes(),
             executor(),
-            executor()
+            executor(),
+            new AuthzAppliedRevisions()
         );
     }
 
@@ -200,8 +202,8 @@ class AuthzPdpSynchronizerChaosTest {
         assertThat(received.peek().getString("op")).isEqualTo("provision");
         assertThat(received.peek().getString("targetPdpId")).isEqualTo("scope-1");
         assertThat(received.peek().getString("environmentId")).isEqualTo("env-1");
-        verify(enginePort).addOrUpdatePolicy(eq("env-1"), eq("pol-1"), any(), any(), eq(Set.of("scope-1@eu")));
-        verify(enginePort).addOrUpdateEntity(eq("env-1"), any(), any(), any(), eq(Set.of("scope-1@eu")));
+        verify(enginePort).addOrUpdatePolicy(eq("env-1"), eq("pol-1"), any(), any(), eq(Set.of("scope-1@eu")), anyLong());
+        verify(enginePort).addOrUpdateEntity(eq("env-1"), any(), any(), any(), eq(Set.of("scope-1@eu")), anyLong());
         verify(enginePort, times(2)).commitScope("env-1", "scope-1@eu");
     }
 
@@ -232,7 +234,7 @@ class AuthzPdpSynchronizerChaosTest {
 
         // Fail-closed: nothing relayed (no listener), nothing hydrated, no commit.
         assertThat(received).isEmpty();
-        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong());
         verify(enginePort, never()).commitScope(any(), any());
 
         // Cycle 2: PDP service is back and the AUTHZ_PDP window is now EMPTY.
@@ -244,7 +246,7 @@ class AuthzPdpSynchronizerChaosTest {
         assertThat(received)
             .extracting(m -> m.getString("op") + ":" + m.getString("environmentId") + ":" + m.getString("targetPdpId"))
             .containsExactly("provision:env-1:scope-cut");
-        verify(enginePort).addOrUpdatePolicy(eq("env-1"), eq("pol-1"), any(), any(), eq(Set.of("scope-cut@eu")));
+        verify(enginePort).addOrUpdatePolicy(eq("env-1"), eq("pol-1"), any(), any(), eq(Set.of("scope-cut@eu")), anyLong());
         verify(enginePort, times(2)).commitScope("env-1", "scope-cut@eu");
     }
 
@@ -298,11 +300,11 @@ class AuthzPdpSynchronizerChaosTest {
             .containsExactlyInAnyOrder("env-a:shared-scope", "env-b:shared-scope");
 
         // env-a policy lands ONLY under env-a; env-b policy lands ONLY under env-b.
-        verify(enginePort).addOrUpdatePolicy(eq("env-a"), eq("pol-a"), any(), any(), eq(Set.of("shared-scope@eu")));
-        verify(enginePort).addOrUpdatePolicy(eq("env-b"), eq("pol-b"), any(), any(), eq(Set.of("shared-scope@eu")));
+        verify(enginePort).addOrUpdatePolicy(eq("env-a"), eq("pol-a"), any(), any(), eq(Set.of("shared-scope@eu")), anyLong());
+        verify(enginePort).addOrUpdatePolicy(eq("env-b"), eq("pol-b"), any(), any(), eq(Set.of("shared-scope@eu")), anyLong());
         // No cross-tenant leak: env-a never sees pol-b, env-b never sees pol-a.
-        verify(enginePort, never()).addOrUpdatePolicy(eq("env-a"), eq("pol-b"), any(), any(), any());
-        verify(enginePort, never()).addOrUpdatePolicy(eq("env-b"), eq("pol-a"), any(), any(), any());
+        verify(enginePort, never()).addOrUpdatePolicy(eq("env-a"), eq("pol-b"), any(), any(), any(), anyLong());
+        verify(enginePort, never()).addOrUpdatePolicy(eq("env-b"), eq("pol-a"), any(), any(), any(), anyLong());
     }
 
     @Test
@@ -346,7 +348,7 @@ class AuthzPdpSynchronizerChaosTest {
             .extracting(m -> m.getString("op") + ":" + m.getString("targetPdpId"))
             .containsExactlyInAnyOrder("evict:scope-gone", "provision:scope-other");
         // Evict must not trigger any hydration.
-        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), eq(Set.of("scope-gone@eu")));
+        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), eq(Set.of("scope-gone@eu")), anyLong());
     }
 
     // ---------------------------------------------------------------------
@@ -444,7 +446,7 @@ class AuthzPdpSynchronizerChaosTest {
         synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
 
         assertThat(received).isEmpty();
-        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong());
         verify(enginePort, never()).commitScope(any(), any());
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizerGapsTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizerGapsTest.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -95,8 +96,8 @@ class AuthzPdpSynchronizerGapsTest {
         lenient().when(fetcher.bulkItems()).thenReturn(10);
         lenient().when(fetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.empty());
         lenient().when(gatewayConfiguration.shardingTags()).thenReturn(java.util.Optional.of(java.util.List.of("eu")));
-        lenient().when(enginePort.addOrUpdatePolicy(any(), any(), any(), any(), any())).thenReturn(Completable.complete());
-        lenient().when(enginePort.addOrUpdateEntity(any(), any(), any(), any(), any())).thenReturn(Completable.complete());
+        lenient().when(enginePort.addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong())).thenReturn(Completable.complete());
+        lenient().when(enginePort.addOrUpdateEntity(any(), any(), any(), any(), any(), anyLong())).thenReturn(Completable.complete());
         lenient().when(enginePort.commit()).thenReturn(Completable.complete());
         lenient().when(enginePort.commitScope(any(), any())).thenReturn(Completable.complete());
         consumer = registerReplyingConsumer();
@@ -146,7 +147,8 @@ class AuthzPdpSynchronizerGapsTest {
             vertx,
             new AuthzHostedScopes(),
             executor(),
-            executor()
+            executor(),
+            new AuthzAppliedRevisions()
         );
     }
 
@@ -234,8 +236,8 @@ class AuthzPdpSynchronizerGapsTest {
         synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
 
         assertThat(received).isEmpty();
-        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any());
-        verify(enginePort, never()).addOrUpdateEntity(any(), any(), any(), any(), any());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong());
+        verify(enginePort, never()).addOrUpdateEntity(any(), any(), any(), any(), any(), anyLong());
         verify(enginePort, never()).commitScope(any(), any());
     }
 
@@ -268,14 +270,14 @@ class AuthzPdpSynchronizerGapsTest {
         assertThat(received).allMatch(m -> "env-pdp".equals(m.getString("environmentId")));
 
         // scope-a hydration: own policy + wildcard, routed under scope-a only, env-namespaced
-        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-a"), any(), any(), eq(Set.of("scope-a@eu")));
-        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-w"), any(), any(), eq(Set.of("scope-a@eu")));
-        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-b"), any(), any(), eq(Set.of("scope-a@eu")));
+        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-a"), any(), any(), eq(Set.of("scope-a@eu")), anyLong());
+        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-w"), any(), any(), eq(Set.of("scope-a@eu")), anyLong());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-b"), any(), any(), eq(Set.of("scope-a@eu")), anyLong());
 
         // scope-b hydration: own policy + wildcard, routed under scope-b only, env-namespaced
-        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-b"), any(), any(), eq(Set.of("scope-b@eu")));
-        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-w"), any(), any(), eq(Set.of("scope-b@eu")));
-        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-a"), any(), any(), eq(Set.of("scope-b@eu")));
+        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-b"), any(), any(), eq(Set.of("scope-b@eu")), anyLong());
+        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-w"), any(), any(), eq(Set.of("scope-b@eu")), anyLong());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-a"), any(), any(), eq(Set.of("scope-b@eu")), anyLong());
 
         // one commit per provisioned scope, per synchronizer (policy + entity backfill)
         verify(enginePort, times(2)).commitScope("env-pdp", "scope-a@eu");
@@ -302,7 +304,7 @@ class AuthzPdpSynchronizerGapsTest {
         synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
 
         assertThat(received).isEmpty();
-        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong());
         verify(enginePort, never()).commitScope(any(), any());
     }
 
@@ -365,7 +367,7 @@ class AuthzPdpSynchronizerGapsTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(policy))
         );
-        when(enginePort.addOrUpdatePolicy(any(), any(), any(), any(), any())).thenReturn(
+        when(enginePort.addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong())).thenReturn(
             Completable.error(new RuntimeException("engine down"))
         );
 
@@ -404,7 +406,7 @@ class AuthzPdpSynchronizerGapsTest {
         synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
 
         // Relay failed, so the scope was not yet provisioned/hydrated.
-        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any());
+        verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong());
         verify(enginePort, never()).commitScope(any(), any());
 
         // Cycle 2: the PDP service is healthy again and the incremental event window is EMPTY
@@ -424,7 +426,7 @@ class AuthzPdpSynchronizerGapsTest {
         assertThat(received)
             .extracting(m -> m.getString("op") + ":" + m.getString("environmentId") + ":" + m.getString("targetPdpId"))
             .containsExactly("provision:env-pdp:scope-lost");
-        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-1"), any(), any(), eq(Set.of("scope-lost@eu")));
+        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-1"), any(), any(), eq(Set.of("scope-lost@eu")), anyLong());
         verify(enginePort, times(2)).commitScope("env-pdp", "scope-lost@eu");
     }
 
@@ -463,9 +465,9 @@ class AuthzPdpSynchronizerGapsTest {
         assertThat(received)
             .extracting(m -> m.getString("targetPdpId"))
             .contains("scope-good");
-        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-good"), any(), any(), eq(Set.of("scope-good@eu")));
+        verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-good"), any(), any(), eq(Set.of("scope-good@eu")), anyLong());
         // failed scope never hydrated (it stays in the pending set, not provisioned this cycle)
-        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-bad"), any(), any(), eq(Set.of("scope-bad@eu")));
+        verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-bad"), any(), any(), eq(Set.of("scope-bad@eu")), anyLong());
     }
 
     @Test
@@ -603,7 +605,7 @@ class AuthzPdpSynchronizerGapsTest {
         // The scope was hydrated again on cycle 2 and finally committed.
         // Cycle 1: policy backfill commit errors before the entity backfill runs (1 commitScope).
         // Cycle 2: healthy, policy backfill commits then entity backfill commits (2 commitScope) = 3 total.
-        verify(enginePort, times(2)).addOrUpdatePolicy(eq("env-pdp"), eq("pol-h"), any(), any(), eq(Set.of("scope-h@eu")));
+        verify(enginePort, times(2)).addOrUpdatePolicy(eq("env-pdp"), eq("pol-h"), any(), any(), eq(Set.of("scope-h@eu")), anyLong());
         verify(enginePort, times(3)).commitScope("env-pdp", "scope-h@eu");
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizerTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -72,6 +74,8 @@ class AuthzPdpSynchronizerTest {
     private AuthzEnginePort enginePort;
 
     private AuthzPdpSynchronizer synchronizer;
+    private AuthzHostedScopes hostedScopes;
+    private AuthzAppliedRevisions revisions;
     private final ConcurrentLinkedQueue<JsonObject> received = new ConcurrentLinkedQueue<>();
     private MessageConsumer<JsonObject> consumer;
 
@@ -118,6 +122,8 @@ class AuthzPdpSynchronizerTest {
             executor(),
             executor()
         );
+        hostedScopes = new AuthzHostedScopes();
+        revisions = new AuthzAppliedRevisions();
         return new AuthzPdpSynchronizer(
             fetcher,
             new AuthzPdpMapper(new ObjectMapper()),
@@ -126,9 +132,10 @@ class AuthzPdpSynchronizerTest {
             node,
             gatewayConfiguration,
             vertx,
-            new AuthzHostedScopes(),
+            hostedScopes,
             executor(),
-            executor()
+            executor(),
+            revisions
         );
     }
 
@@ -298,6 +305,29 @@ class AuthzPdpSynchronizerTest {
         synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
 
         assertThat(received).isEmpty();
+    }
+
+    @Test
+    void does_not_re_hydrate_a_scope_already_hosted() throws InterruptedException {
+        // Simulate "scope-1 was already provisioned in a prior cycle" by pre-marking it hosted.
+        hostedScopes.markHosted("env-1", "scope-1");
+
+        // A re-fetch of the same PUBLISH_AUTHZ_PDP event arrives (e.g. the event window overlaps).
+        Event publish = pdpEvent("evt-p", EventType.PUBLISH_AUTHZ_PDP, "scope-1", "eu");
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
+            Flowable.just(List.of(publish))
+        );
+
+        synchronizer.synchronize(100L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        // The relay message is still sent (provision idempotency), but hydration (stageScope) must be
+        // skipped because wasHosted was true at the start of relayProvisionOrEvict.
+        assertThat(received).hasSize(1);
+        assertThat(received.peek().getString("op")).isEqualTo("provision");
+        assertThat(hostedScopes.isHosted("env-1", "scope-1")).isTrue();
+        // stageScope always calls enginePort.commitScope as its final step; if it were invoked the
+        // scope would be re-hydrated. Verifying never() here proves Gate D held: no stageScope ran.
+        verify(enginePort, never()).commitScope(any(), any());
     }
 
     private void stubPdpFetch(Event... events) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPolicyMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPolicyMapperTest.java
@@ -146,6 +146,32 @@ class AuthzPolicyMapperTest {
         assertThat(mapper.toUndeploy(event).blockingGet()).isNull();
     }
 
+    @Test
+    void toDeploy_carries_event_updatedAt() {
+        io.gravitee.repository.management.model.Event event = event(
+            "evt-upd-1",
+            "{\"id\": \"doc-upd-1\", \"name\": \"n\", \"kind\": \"GLOBAL\", \"policyText\": \"permit(p,a,r);\"}"
+        );
+        event.setUpdatedAt(new java.util.Date(1234L));
+
+        AuthzPolicyReactorDeployable deployable = mapper.toDeploy(event).blockingGet();
+
+        assertThat(deployable.updatedAt()).isEqualTo(1234L);
+    }
+
+    @Test
+    void toDeploy_defaults_updatedAt_to_zero_when_event_has_none() {
+        io.gravitee.repository.management.model.Event event = event(
+            "evt-upd-2",
+            "{\"id\": \"doc-upd-2\", \"name\": \"n\", \"kind\": \"GLOBAL\", \"policyText\": \"permit(p,a,r);\"}"
+        );
+        event.setUpdatedAt(null);
+
+        AuthzPolicyReactorDeployable deployable = mapper.toDeploy(event).blockingGet();
+
+        assertThat(deployable.updatedAt()).isZero();
+    }
+
     private static Event event(String id, String payload) {
         Event event = new Event();
         event.setId(id);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePortScopeTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePortScopeTest.java
@@ -38,7 +38,7 @@ class EventBusAuthzEnginePortScopeTest {
     void setUp() {
         vertx = Vertx.vertx();
         // Addressing test: treat every scope as hosted so routing is exercised regardless of placement.
-        port = new EventBusAuthzEnginePort(vertx, HostedScopesFixtures.servingAll());
+        port = new EventBusAuthzEnginePort(vertx, HostedScopesFixtures.servingAll(), new AuthzAppliedRevisions());
     }
 
     @AfterEach
@@ -59,7 +59,7 @@ class EventBusAuthzEnginePortScopeTest {
     void scoped_policy_is_sent_to_its_env_namespaced_scope_address_only() {
         recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
         recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-b");
-        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("api-a")).blockingAwait();
+        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("api-a"), 1L).blockingAwait();
         assertThat(hits).containsExactly("service:authz-pdp:sync:scope:env-1:api-a");
     }
 
@@ -69,7 +69,7 @@ class EventBusAuthzEnginePortScopeTest {
         // must land on the base engine address ":scope:env-1:orders", NOT ":scope:env-1:orders@us".
         recordAndReplyOn("service:authz-pdp:sync:scope:env-1:orders");
         recordAndReplyOn("service:authz-pdp:sync:scope:env-1:orders@us");
-        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("orders@us")).blockingAwait();
+        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("orders@us"), 1L).blockingAwait();
         assertThat(hits).containsExactly("service:authz-pdp:sync:scope:env-1:orders");
     }
 
@@ -77,7 +77,7 @@ class EventBusAuthzEnginePortScopeTest {
     void same_scope_id_in_two_envs_does_not_co_mingle() {
         recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
         recordAndReplyOn("service:authz-pdp:sync:scope:env-2:api-a");
-        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("api-a")).blockingAwait();
+        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("api-a"), 1L).blockingAwait();
         assertThat(hits).containsExactly("service:authz-pdp:sync:scope:env-1:api-a");
     }
 
@@ -88,11 +88,11 @@ class EventBusAuthzEnginePortScopeTest {
         AuthzHostedScopes hosted = new AuthzHostedScopes();
         hosted.markHosted("env-1", "api-a");
         hosted.markHosted("env-1", "api-b");
-        EventBusAuthzEnginePort scopedPort = new EventBusAuthzEnginePort(vertx, hosted);
+        EventBusAuthzEnginePort scopedPort = new EventBusAuthzEnginePort(vertx, hosted, new AuthzAppliedRevisions());
         recordAndReplyOn("service:authz-pdp:sync");
         recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
         recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-b");
-        scopedPort.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("*")).blockingAwait();
+        scopedPort.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("*"), 1L).blockingAwait();
         assertThat(hits).containsExactlyInAnyOrder(
             "service:authz-pdp:sync",
             "service:authz-pdp:sync:scope:env-1:api-a",
@@ -106,31 +106,31 @@ class EventBusAuthzEnginePortScopeTest {
         // receive an env-1 wildcard document. env-1 hosts nothing extra, so only the default engine is hit.
         AuthzHostedScopes hosted = new AuthzHostedScopes();
         hosted.markHosted("env-2", "other");
-        EventBusAuthzEnginePort scopedPort = new EventBusAuthzEnginePort(vertx, hosted);
+        EventBusAuthzEnginePort scopedPort = new EventBusAuthzEnginePort(vertx, hosted, new AuthzAppliedRevisions());
         recordAndReplyOn("service:authz-pdp:sync");
         recordAndReplyOn("service:authz-pdp:sync:scope:env-2:other");
-        scopedPort.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("*")).blockingAwait();
+        scopedPort.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("*"), 1L).blockingAwait();
         assertThat(hits).containsExactly("service:authz-pdp:sync");
     }
 
     @Test
     void default_scope_is_sent_unicast_to_the_bare_sync_address() {
         recordAndReplyOn("service:authz-pdp:sync");
-        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("default")).blockingAwait();
+        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("default"), 1L).blockingAwait();
         assertThat(hits).containsExactly("service:authz-pdp:sync");
     }
 
     @Test
     void default_scope_ignores_environment_id() {
         recordAndReplyOn("service:authz-pdp:sync");
-        port.addOrUpdatePolicy("env-9", "p1", "n", "permit(principal, action, resource);", Set.of("default")).blockingAwait();
+        port.addOrUpdatePolicy("env-9", "p1", "n", "permit(principal, action, resource);", Set.of("default"), 1L).blockingAwait();
         assertThat(hits).containsExactly("service:authz-pdp:sync");
     }
 
     @Test
     void commit_to_default_scope_uses_unicast_request_reply() {
         recordAndReplyOn("service:authz-pdp:sync");
-        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("default")).blockingAwait();
+        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("default"), 1L).blockingAwait();
         hits.clear();
         port.commit().blockingAwait();
         assertThat(hits).containsExactly("service:authz-pdp:sync");
@@ -139,7 +139,7 @@ class EventBusAuthzEnginePortScopeTest {
     @Test
     void empty_scope_set_sends_nothing() {
         recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
-        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of()).blockingAwait();
+        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of(), 1L).blockingAwait();
         assertThat(hits).isEmpty();
     }
 
@@ -147,8 +147,8 @@ class EventBusAuthzEnginePortScopeTest {
     void commit_targets_every_touched_scope_then_clears() {
         recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
         recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-b");
-        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("api-a")).blockingAwait();
-        port.addOrUpdateEntity("env-1", "User::\"alice\"", java.util.Map.of(), java.util.List.of(), Set.of("api-b")).blockingAwait();
+        port.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("api-a"), 1L).blockingAwait();
+        port.addOrUpdateEntity("env-1", "User::\"alice\"", java.util.Map.of(), java.util.List.of(), Set.of("api-b"), 1L).blockingAwait();
         hits.clear();
         port.commit().blockingAwait();
         assertThat(hits).containsExactlyInAnyOrder("service:authz-pdp:sync:scope:env-1:api-a", "service:authz-pdp:sync:scope:env-1:api-b");

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePortTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePortTest.java
@@ -527,6 +527,70 @@ class EventBusAuthzEnginePortTest {
     }
 
     @Test
+    void a_committed_revision_stays_gated() {
+        // fakePluginConsumer (SCOPE_ADDRESS) replies with a commitGeneration to every op, so the commit
+        // succeeds. A successful commit must leave the revision marked — the re-apply is gated out.
+        port.addOrUpdatePolicy(ENV, "doc", "n", "permit();", Set.of(SCOPE), 100L).andThen(port.commit()).blockingAwait();
+        received.clear();
+
+        port.addOrUpdatePolicy(ENV, "doc", "n", "permit();", Set.of(SCOPE), 100L).blockingAwait();
+
+        long staged = received
+            .stream()
+            .filter(b -> "addOrUpdatePolicy".equals(b.getString("op")))
+            .count();
+        assertThat(staged).as("a successfully committed revision stays gated").isZero();
+    }
+
+    @Test
+    void an_abandoned_commit_rolls_back_the_revision_so_it_re_stages() {
+        // A mutation stages fine, but every commit to its address fails (reply carries no commitGeneration).
+        // After the attempt cap the commit is abandoned; the unsealed revision mark must be rolled back so
+        // the SAME revision re-stages next cycle instead of sitting permanently uncommitted.
+        String scope = "s-commit-fail";
+        String address = EventBusAuthzEnginePort.SCOPE_ADDRESS_PREFIX + ENV + ":" + scope;
+        ConcurrentLinkedQueue<JsonObject> got = new ConcurrentLinkedQueue<>();
+        MessageConsumer<JsonObject> consumer = vertx
+            .eventBus()
+            .<JsonObject>consumer(address, msg -> {
+                JsonObject body = msg.body();
+                got.add(body);
+                if ("commit".equals(body.getString("op"))) {
+                    msg.reply(new JsonObject()); // missing commitGeneration -> verifyCommitReply fails
+                } else {
+                    msg.reply(new JsonObject().put("commitGeneration", 1L));
+                }
+            });
+
+        port.addOrUpdatePolicy(ENV, "doc", "n", "permit();", Set.of(scope), 100L).blockingAwait();
+        for (int i = 0; i <= EventBusAuthzEnginePort.MAX_COMMIT_ATTEMPTS; i++) {
+            port.commit().blockingAwait();
+        }
+        assertThat(
+            got
+                .stream()
+                .filter(b -> "addOrUpdatePolicy".equals(b.getString("op")))
+                .count()
+        )
+            .as("mutation staged once before abandonment")
+            .isEqualTo(1);
+        got.clear();
+
+        port.addOrUpdatePolicy(ENV, "doc", "n", "permit();", Set.of(scope), 100L).blockingAwait();
+
+        assertThat(
+            got
+                .stream()
+                .filter(b -> "addOrUpdatePolicy".equals(b.getString("op")))
+                .count()
+        )
+            .as("an abandoned commit must roll back the mark so the same revision re-stages")
+            .isEqualTo(1);
+
+        consumer.unregister();
+    }
+
+    @Test
     void applies_a_newer_revision() {
         port.addOrUpdatePolicy(ENV, "doc", "n", "p", Set.of(SCOPE), 100L).blockingAwait();
         port.addOrUpdatePolicy(ENV, "doc", "n", "p", Set.of(SCOPE), 200L).blockingAwait();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePortTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePortTest.java
@@ -47,7 +47,11 @@ class EventBusAuthzEnginePortTest {
     void setUp() {
         vertx = Vertx.vertx();
         // These tests exercise routing/commit, not per-node sharding — treat every scope as hosted.
-        port = new EventBusAuthzEnginePort(io.vertx.rxjava3.core.Vertx.newInstance(vertx), HostedScopesFixtures.servingAll());
+        port = new EventBusAuthzEnginePort(
+            io.vertx.rxjava3.core.Vertx.newInstance(vertx),
+            HostedScopesFixtures.servingAll(),
+            new AuthzAppliedRevisions()
+        );
         fakePluginConsumer = vertx
             .eventBus()
             .<JsonObject>consumer(SCOPE_ADDRESS, msg -> {
@@ -78,7 +82,8 @@ class EventBusAuthzEnginePortTest {
                 "Resource::\"api.bookings\"",
                 Map.of("region", "eu", "active", true),
                 List.of("Resource::\"api.parent\""),
-                Set.of(SCOPE)
+                Set.of(SCOPE),
+                1L
             )
             .subscribe(
                 () -> {
@@ -100,7 +105,7 @@ class EventBusAuthzEnginePortTest {
     @Test
     void addOrUpdateEntity_omits_attributes_field_when_empty(VertxTestContext ctx) {
         port
-            .addOrUpdateEntity(ENV, "Resource::\"api.x\"", Map.of(), List.of(), Set.of(SCOPE))
+            .addOrUpdateEntity(ENV, "Resource::\"api.x\"", Map.of(), List.of(), Set.of(SCOPE), 1L)
             .subscribe(
                 () -> {
                     ctx.verify(() -> {
@@ -135,7 +140,8 @@ class EventBusAuthzEnginePortTest {
     void tag_scoped_default_routes_to_the_default_engine_on_a_matching_node(VertxTestContext ctx) {
         EventBusAuthzEnginePort tagPort = new EventBusAuthzEnginePort(
             io.vertx.rxjava3.core.Vertx.newInstance(vertx),
-            new AuthzHostedScopes(Set.of("us"))
+            new AuthzHostedScopes(Set.of("us")),
+            new AuthzAppliedRevisions()
         );
         ConcurrentLinkedQueue<JsonObject> defaultReceived = new ConcurrentLinkedQueue<>();
         vertx
@@ -146,7 +152,7 @@ class EventBusAuthzEnginePortTest {
             });
 
         tagPort
-            .addOrUpdatePolicy(ENV, "doc-1", "p", "permit(principal, action, resource);", Set.of("default@us"))
+            .addOrUpdatePolicy(ENV, "doc-1", "p", "permit(principal, action, resource);", Set.of("default@us"), 1L)
             .subscribe(
                 () -> {
                     ctx.verify(() -> {
@@ -164,7 +170,8 @@ class EventBusAuthzEnginePortTest {
     void tag_scoped_default_is_skipped_on_a_node_without_that_tag(VertxTestContext ctx) {
         EventBusAuthzEnginePort tagPort = new EventBusAuthzEnginePort(
             io.vertx.rxjava3.core.Vertx.newInstance(vertx),
-            new AuthzHostedScopes(Set.of("eu"))
+            new AuthzHostedScopes(Set.of("eu")),
+            new AuthzAppliedRevisions()
         );
         ConcurrentLinkedQueue<JsonObject> defaultReceived = new ConcurrentLinkedQueue<>();
         vertx
@@ -176,7 +183,7 @@ class EventBusAuthzEnginePortTest {
 
         // The node carries tag "eu", not "us" — "default@us" is not served here, so routing is a no-op.
         tagPort
-            .addOrUpdatePolicy(ENV, "doc-1", "p", "permit(principal, action, resource);", Set.of("default@us"))
+            .addOrUpdatePolicy(ENV, "doc-1", "p", "permit(principal, action, resource);", Set.of("default@us"), 1L)
             .subscribe(
                 () -> {
                     ctx.verify(() -> assertThat(defaultReceived).isEmpty());
@@ -200,7 +207,7 @@ class EventBusAuthzEnginePortTest {
             });
 
         port
-            .addOrUpdatePolicy(ENV, "doc-1", "p", "permit(principal, action, resource);", Set.of("*"))
+            .addOrUpdatePolicy(ENV, "doc-1", "p", "permit(principal, action, resource);", Set.of("*"), 1L)
             .subscribe(
                 () -> {
                     ctx.verify(() -> {
@@ -218,7 +225,7 @@ class EventBusAuthzEnginePortTest {
     @Test
     void addOrUpdatePolicy_publishes_op_docId_name_policyText(VertxTestContext ctx) {
         port
-            .addOrUpdatePolicy(ENV, "p-1", "Allow read", "permit(principal, action, resource);", Set.of(SCOPE))
+            .addOrUpdatePolicy(ENV, "p-1", "Allow read", "permit(principal, action, resource);", Set.of(SCOPE), 1L)
             .subscribe(
                 () -> {
                     ctx.verify(() -> {
@@ -254,7 +261,7 @@ class EventBusAuthzEnginePortTest {
     @Test
     void commit_publishes_just_op(VertxTestContext ctx) {
         port
-            .addOrUpdatePolicy(ENV, "p-1", "Allow read", "permit(principal, action, resource);", Set.of(SCOPE))
+            .addOrUpdatePolicy(ENV, "p-1", "Allow read", "permit(principal, action, resource);", Set.of(SCOPE), 1L)
             .andThen(port.commit())
             .subscribe(
                 () -> {
@@ -276,7 +283,7 @@ class EventBusAuthzEnginePortTest {
         // before the commit lands. A per-address NO_HANDLERS must NOT fail the commit — a scope that
         // was evicted between stage and commit cannot be allowed to wedge the whole sync cycle.
         port
-            .addOrUpdatePolicy(ENV, "p-1", "Allow read", "permit(principal, action, resource);", Set.of(SCOPE))
+            .addOrUpdatePolicy(ENV, "p-1", "Allow read", "permit(principal, action, resource);", Set.of(SCOPE), 1L)
             .subscribe(
                 () -> {
                     fakePluginConsumer.unregister();
@@ -296,8 +303,8 @@ class EventBusAuthzEnginePortTest {
             .<JsonObject>consumer(deadAddress, msg -> msg.reply(new JsonObject().put("commitGeneration", 1L)));
 
         port
-            .addOrUpdatePolicy(ENV, "p-dead", "x", "permit();", Set.of(deadScope))
-            .andThen(port.addOrUpdatePolicy(ENV, "p-live", "x", "permit();", Set.of(SCOPE)))
+            .addOrUpdatePolicy(ENV, "p-dead", "x", "permit();", Set.of(deadScope), 1L)
+            .andThen(port.addOrUpdatePolicy(ENV, "p-live", "x", "permit();", Set.of(SCOPE), 1L))
             .subscribe(
                 () -> {
                     deadConsumer.unregister();
@@ -328,14 +335,14 @@ class EventBusAuthzEnginePortTest {
         // next commit would seal a generation the engine never received the mutation for (fail-open).
         String missingScope = "scope-without-consumer";
         port
-            .addOrUpdatePolicy(ENV, "p-1", "Allow read", "permit();", Set.of(missingScope))
+            .addOrUpdatePolicy(ENV, "p-1", "Allow read", "permit();", Set.of(missingScope), 1L)
             .subscribe(
                 () -> ctx.failNow("Expected the stage to fail with NO_HANDLERS"),
                 stageError -> {
                     // Now commit: the failed address must not be among the committed ones. Only the
                     // healthy SCOPE address (which we DID stage successfully below) should be committed.
                     port
-                        .addOrUpdatePolicy(ENV, "p-2", "Allow read", "permit();", Set.of(SCOPE))
+                        .addOrUpdatePolicy(ENV, "p-2", "Allow read", "permit();", Set.of(SCOPE), 1L)
                         .andThen(port.commit())
                         .subscribe(
                             () -> {
@@ -365,7 +372,7 @@ class EventBusAuthzEnginePortTest {
         // never replies. The commit must give up at the configured timeout (not 30s) and, because a
         // wedged scope must not fail the whole cycle, complete rather than propagate the timeout.
         port
-            .addOrUpdatePolicy(ENV, "p-1", "Allow read", "permit(principal, action, resource);", Set.of(SCOPE))
+            .addOrUpdatePolicy(ENV, "p-1", "Allow read", "permit(principal, action, resource);", Set.of(SCOPE), 1L)
             .subscribe(
                 () -> {
                     fakePluginConsumer.unregister();
@@ -407,7 +414,7 @@ class EventBusAuthzEnginePortTest {
             });
 
         // Arm scope A by staging a mutation (do NOT commit it).
-        port.addOrUpdatePolicy(ENV, "p-a", "n", "permit();", Set.of(SCOPE)).blockingAwait();
+        port.addOrUpdatePolicy(ENV, "p-a", "n", "permit();", Set.of(SCOPE), 1L).blockingAwait();
         received.clear();
 
         // commitScope for scope B must seal ONLY scope B, not drain scope A's armed address.
@@ -429,7 +436,7 @@ class EventBusAuthzEnginePortTest {
     @Test
     void commit_stops_re_arming_a_permanently_dead_address_after_the_attempt_cap() {
         // Arm scope A, then kill its consumer so every commit fails fast with NO_HANDLERS.
-        port.addOrUpdatePolicy(ENV, "p-a", "n", "permit();", Set.of(SCOPE)).blockingAwait();
+        port.addOrUpdatePolicy(ENV, "p-a", "n", "permit();", Set.of(SCOPE), 1L).blockingAwait();
         fakePluginConsumer.unregister();
         received.clear();
 
@@ -455,7 +462,11 @@ class EventBusAuthzEnginePortTest {
     void route_skips_a_named_scope_not_hosted_on_this_node() {
         AuthzHostedScopes hosted = new AuthzHostedScopes();
         hosted.markHosted(ENV, "scope-here");
-        EventBusAuthzEnginePort scopedPort = new EventBusAuthzEnginePort(io.vertx.rxjava3.core.Vertx.newInstance(vertx), hosted);
+        EventBusAuthzEnginePort scopedPort = new EventBusAuthzEnginePort(
+            io.vertx.rxjava3.core.Vertx.newInstance(vertx),
+            hosted,
+            new AuthzAppliedRevisions()
+        );
 
         ConcurrentLinkedQueue<JsonObject> here = new ConcurrentLinkedQueue<>();
         ConcurrentLinkedQueue<JsonObject> elsewhere = new ConcurrentLinkedQueue<>();
@@ -472,7 +483,7 @@ class EventBusAuthzEnginePortTest {
                 msg.reply(new JsonObject());
             });
 
-        scopedPort.addOrUpdatePolicy(ENV, "p", "n", "permit();", Set.of("scope-here", "scope-elsewhere")).blockingAwait();
+        scopedPort.addOrUpdatePolicy(ENV, "p", "n", "permit();", Set.of("scope-here", "scope-elsewhere"), 1L).blockingAwait();
 
         hereConsumer.unregister();
         elsewhereConsumer.unregister();
@@ -484,7 +495,8 @@ class EventBusAuthzEnginePortTest {
     void route_always_serves_the_default_scope_even_when_nothing_is_hosted() {
         EventBusAuthzEnginePort scopedPort = new EventBusAuthzEnginePort(
             io.vertx.rxjava3.core.Vertx.newInstance(vertx),
-            new AuthzHostedScopes()
+            new AuthzHostedScopes(),
+            new AuthzAppliedRevisions()
         );
 
         ConcurrentLinkedQueue<JsonObject> def = new ConcurrentLinkedQueue<>();
@@ -495,9 +507,104 @@ class EventBusAuthzEnginePortTest {
                 msg.reply(new JsonObject());
             });
 
-        scopedPort.addOrUpdatePolicy(ENV, "p", "n", "permit();", Set.of("default")).blockingAwait();
+        scopedPort.addOrUpdatePolicy(ENV, "p", "n", "permit();", Set.of("default"), 1L).blockingAwait();
 
         defConsumer.unregister();
         assertThat(def).as("the default scope is always served regardless of hosting").hasSize(1);
+    }
+
+    @Test
+    void skips_a_second_apply_of_the_same_revision() {
+        // Uses the fakePluginConsumer registered in setUp() on SCOPE_ADDRESS.
+        port.addOrUpdatePolicy(ENV, "doc", "name", "permit(...);", Set.of(SCOPE), 100L).blockingAwait();
+        port.addOrUpdatePolicy(ENV, "doc", "name", "permit(...);", Set.of(SCOPE), 100L).blockingAwait();
+
+        long addOrUpdateCount = received
+            .stream()
+            .filter(b -> "addOrUpdatePolicy".equals(b.getString("op")))
+            .count();
+        assertThat(addOrUpdateCount).as("second call with same revision must be suppressed").isEqualTo(1);
+    }
+
+    @Test
+    void applies_a_newer_revision() {
+        port.addOrUpdatePolicy(ENV, "doc", "n", "p", Set.of(SCOPE), 100L).blockingAwait();
+        port.addOrUpdatePolicy(ENV, "doc", "n", "p", Set.of(SCOPE), 200L).blockingAwait();
+
+        long addOrUpdateCount = received
+            .stream()
+            .filter(b -> "addOrUpdatePolicy".equals(b.getString("op")))
+            .count();
+        assertThat(addOrUpdateCount).as("newer revision must be applied").isEqualTo(2);
+    }
+
+    @Test
+    void a_scope_not_served_is_not_recorded_as_applied() {
+        // This test uses a distinct port with a controlled AuthzHostedScopes.
+        // "scope-remote" is on a different address than SCOPE_ADDRESS so it won't clash with fakePluginConsumer.
+        AuthzHostedScopes controlled = new AuthzHostedScopes();
+        EventBusAuthzEnginePort controlledPort = new EventBusAuthzEnginePort(
+            io.vertx.rxjava3.core.Vertx.newInstance(vertx),
+            controlled,
+            new AuthzAppliedRevisions()
+        );
+
+        String remoteScope = "scope-remote";
+        String remoteAddress = EventBusAuthzEnginePort.SCOPE_ADDRESS_PREFIX + ENV + ":" + remoteScope;
+        ConcurrentLinkedQueue<JsonObject> remoteReceived = new ConcurrentLinkedQueue<>();
+        MessageConsumer<JsonObject> remoteConsumer = vertx
+            .eventBus()
+            .<JsonObject>consumer(remoteAddress, msg -> {
+                remoteReceived.add(msg.body());
+                msg.reply(new JsonObject().put("commitGeneration", 1L));
+            });
+
+        // First call: scope not served — must not send and must not record as applied
+        controlledPort.addOrUpdatePolicy(ENV, "doc", "n", "p", Set.of(remoteScope), 100L).blockingAwait();
+        assertThat(remoteReceived).as("not-served scope must not receive a message").isEmpty();
+
+        // Now the node starts serving "scope-remote"
+        controlled.markHosted(ENV, remoteScope);
+
+        // Same revision must now be applied (not gated out) because it was never recorded
+        controlledPort.addOrUpdatePolicy(ENV, "doc", "n", "p", Set.of(remoteScope), 100L).blockingAwait();
+        assertThat(remoteReceived).as("revision must be applied exactly once, on the served attempt").hasSize(1);
+
+        remoteConsumer.unregister();
+    }
+
+    @Test
+    void remove_forgets_so_a_later_readd_of_same_revision_applies() {
+        port.addOrUpdatePolicy(ENV, "doc", "n", "p", Set.of(SCOPE), 100L).blockingAwait();
+        port.removePolicy(ENV, "doc", Set.of(SCOPE)).blockingAwait();
+        port.addOrUpdatePolicy(ENV, "doc", "n", "p", Set.of(SCOPE), 100L).blockingAwait();
+
+        long addOrUpdateCount = received
+            .stream()
+            .filter(b -> "addOrUpdatePolicy".equals(b.getString("op")))
+            .count();
+        assertThat(addOrUpdateCount).as("re-add after remove must apply again").isEqualTo(2);
+    }
+
+    @Test
+    void entity_skips_a_second_apply_of_the_same_revision_and_sends_again_for_newer() {
+        String uid = "Resource::\"api.bookings\"";
+
+        port.addOrUpdateEntity(ENV, uid, Map.of(), List.of(), Set.of(SCOPE), 100L).blockingAwait();
+        port.addOrUpdateEntity(ENV, uid, Map.of(), List.of(), Set.of(SCOPE), 100L).blockingAwait();
+
+        long firstCount = received
+            .stream()
+            .filter(b -> "addOrUpdateEntity".equals(b.getString("op")))
+            .count();
+        assertThat(firstCount).as("second call with same revision must be suppressed").isEqualTo(1);
+
+        port.addOrUpdateEntity(ENV, uid, Map.of(), List.of(), Set.of(SCOPE), 200L).blockingAwait();
+
+        long totalCount = received
+            .stream()
+            .filter(b -> "addOrUpdateEntity".equals(b.getString("op")))
+            .count();
+        assertThat(totalCount).as("newer revision must be applied").isEqualTo(2);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/NoopAuthzEnginePortTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/NoopAuthzEnginePortTest.java
@@ -26,9 +26,9 @@ class NoopAuthzEnginePortTest {
 
     @Test
     void every_op_completes_without_error_so_deployer_chains_run_silently_when_gamma_disabled() {
-        port.addOrUpdateEntity("env-1", "Resource::\"api.x\"", Map.of(), List.of(), Set.of("api-x")).test().assertComplete();
+        port.addOrUpdateEntity("env-1", "Resource::\"api.x\"", Map.of(), List.of(), Set.of("api-x"), 1L).test().assertComplete();
         port.removeEntity("env-1", "Resource::\"api.x\"", Set.of("api-x")).test().assertComplete();
-        port.addOrUpdatePolicy("env-1", "doc-1", "n", "permit(...);", Set.of("api-x")).test().assertComplete();
+        port.addOrUpdatePolicy("env-1", "doc-1", "n", "permit(...);", Set.of("api-x"), 1L).test().assertComplete();
         port.removePolicy("env-1", "doc-1", Set.of("api-x")).test().assertComplete();
         port.commit().test().assertComplete();
     }


### PR DESCRIPTION
## Issue

[AUTHZ-18](https://gravitee.atlassian.net/browse/AUTHZ-18)

## Description

**Problem:** the authz PDP sync path re-applies re-fetched-but-unchanged events on every sync cycle, causing "commit churn": the PDP engine rebuilds its immutable snapshot and bumps its commit generation every ~5s for ~30s after any authz change (and emits empty `0 policies / 0 docs / 0 entities` commits when a PDP is provisioned).

**Root cause:** the APIM sync mechanism intentionally re-delivers recently-changed events from `events_latest` within a rolling window. This is harmless for APIs because `ApiManagerImpl.register` change-gates on `deployedAt`/`revision` and skips an unchanged redeploy. The authz path had **no such gate** — it re-staged and committed unconditionally. Same sync mechanism as APIs; authz simply lacked the change-gate.

**Fix:** give authz the same change-gate, keyed on `event.updatedAt`. Two gates + one node-local store, entirely in `gravitee-apim-gateway-services-sync`. **No change to the PDP engine.**

- **`AuthzAppliedRevisions`** (new, node-local): records which doc is applied to which scope at which `updatedAt`; `shouldApply` (strictly-newer), `markApplied` (monotonic), `forget`/`forgetScope`.
- **Gate C** — `EventBusAuthzEnginePort`: per-scope routing splits into `routeGated` (add/update: `serves` guard → `shouldApply` → send → `markApplied`) and `routeForget` (remove → `forget`). A gated scope does not arm `touched`, so the existing conditional `commit()` short-circuits.
- **Gate D** — `AuthzPdpSynchronizer`: hydrate a scope only on its first provision (capture `wasHosted` before the relay), not on every re-fetched `PUBLISH_AUTHZ_PDP`; `forgetScope` on evict.
- `event.updatedAt` plumbed via the mappers/deployables and threaded through `AuthzEnginePort`.

## Additional context

**Testing**
- Unit: `AuthzAppliedRevisions`, both gate paths in `EventBusAuthzEnginePort` (skip-same / apply-newer / not-served-not-recorded / remove-forgets, policy + entity), Gate D no-re-hydration (`does_not_re_hydrate_a_scope_already_hosted`, asserts `commitScope` never called), prefix-sibling `forgetScope` guard, mapper `updatedAt`. Full authz sync suite green.
- Live (fresh gateway with the rebuilt sync plugin): empty PDP → 1 provision then silence (was `g0→g14`); policy update across 5 scopes → 5 applies (one per scope) then silence (was 5×/~5s for ~30s); a genuine content change still propagates.

**Operational assessment (adversarial review)**
- **No regression** — only behavioural delta is fewer redundant applies/commits; the eval/authorization decision path is untouched.
- **Throughput** — strictly less sync-side work; O(1) `ConcurrentHashMap` per event, no lock contention, eval path unaffected.
- **Startup** — cold boot applies everything (empty map) and Gate D hydrates every scope on first provision; no engine left empty, no new blocking I/O (marginally faster).
- **No lost events** in normal operation — the gate is monotonic, restart re-applies everything (node-local transient map), `forget` restores appliability, and late-provisioned scopes are covered by hydration backfill. The only theoretical hole (two distinct edits of the same doc sharing a millisecond `updatedAt`) is unreachable under a forward clock, because `events_latest` coalesces to the latest version and a same-`updatedAt` collision would require a sync poll (~5s) between the two writes.

**Design & plan:** `docs/superpowers/specs/2026-07-01-authz-sync-change-gate-design.md`, `docs/superpowers/plans/2026-07-01-authz-sync-change-gate.md`.


[AUTHZ-18]: https://gravitee.atlassian.net/browse/AUTHZ-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ