### PR TITLE
feat(gateway): populate applicationName and enrich v4 Log with error/subscription context

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/InvokerAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/InvokerAdapter.java
@@ -125,6 +125,7 @@ public class InvokerAdapter implements HttpInvoker, Invoker, io.gravitee.gateway
                     return ctx.interruptWith(((InterruptionFailureException) throwable).getExecutionFailure());
                 } else {
                     ctx.withLogger(log).error("An error occurred when invoking the backend.", throwable);
+                    ctx.metrics().setErrorMessage(throwable.getMessage());
                     return ctx.interruptWith(
                         new ExecutionFailure(HttpStatusCode.BAD_GATEWAY_502).key(GATEWAY_CLIENT_CONNECTION_ERROR).cause(throwable)
                     );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/AbstractFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/AbstractFailureProcessor.java
@@ -78,6 +78,10 @@ public abstract class AbstractFailureProcessor implements Processor {
         final HttpBaseResponse response = ctx.response();
 
         ctx.metrics().setErrorKey(executionFailure.key());
+        String message = executionFailure.message();
+        if (message != null && !message.isBlank()) {
+            ctx.metrics().setErrorMessage(message);
+        }
         response.status(executionFailure.statusCode());
         response.reason(HttpResponseStatus.valueOf(executionFailure.statusCode()).reasonPhrase());
         // In case of client error we don't want to force close the connection

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessor.java
@@ -166,6 +166,10 @@ public class ResponseTemplateBasedFailureProcessor extends AbstractFailureProces
         context.response().headers().set(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
         if (template.isPropagateErrorKeyToLogs()) {
             context.metrics().setErrorKey(executionFailure.key());
+            String message = executionFailure.message();
+            if (message != null && !message.isBlank()) {
+                context.metrics().setErrorMessage(message);
+            }
         }
 
         if (template.getBody() != null && !template.getBody().isEmpty()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
@@ -142,6 +142,7 @@ public class SubscriptionProcessor implements Processor {
                 subscription.setStatus(ACCEPTED.name());
                 ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_SUBSCRIPTION, subscription);
             }
+            metrics.setApplicationName(subscription.getApplicationName());
             if (subscription.getApiProductId() != null) {
                 ctx.setAttribute(ATTR_API_PRODUCT, subscription.getApiProductId());
                 metrics.setApiProductId(subscription.getApiProductId());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/InvokerAdapterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/InvokerAdapterTest.java
@@ -129,6 +129,7 @@ class InvokerAdapterTest {
     @Test
     void shouldInterruptWith502WhenExceptionOccurs() {
         when(ctx.response()).thenReturn(response);
+        when(ctx.metrics()).thenReturn(metrics);
         when(ctx.interruptWith(any(ExecutionFailure.class))).thenAnswer(i ->
             Completable.error(new InterruptionFailureException(i.getArgument(0)))
         );
@@ -146,6 +147,7 @@ class InvokerAdapterTest {
             return true;
         });
         verify(response).chunks(Flowable.empty());
+        verify(metrics).setErrorMessage(any(String.class));
     }
 
     @Test
@@ -310,6 +312,7 @@ class InvokerAdapterTest {
         when(adaptedExecutionContext.getDelegate()).thenReturn(ctx);
         when(adaptedExecutionContext.request()).thenReturn(adaptedRequest);
         when(ctx.response()).thenReturn(response);
+        when(ctx.metrics()).thenReturn(metrics);
         when(ctx.interruptWith(any(ExecutionFailure.class))).thenAnswer(i ->
             Completable.error(new InterruptionFailureException(i.getArgument(0)))
         );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/error/SimpleFailureProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/error/SimpleFailureProcessorTest.java
@@ -255,6 +255,43 @@ class SimpleFailureProcessorTest extends AbstractProcessorTest {
         });
     }
 
+    @Test
+    void should_set_error_message_on_metrics_when_failure_has_message() {
+        ExecutionFailure executionFailure = new ExecutionFailure(HttpResponseStatus.INTERNAL_SERVER_ERROR.code())
+            .key("SOME_ERROR")
+            .message("Something went wrong");
+        spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
+
+        simpleFailureProcessor.execute(spyCtx).test().assertResult();
+
+        assertThat(spyCtx.metrics().getErrorKey()).isEqualTo("SOME_ERROR");
+        assertThat(spyCtx.metrics().getErrorMessage()).isEqualTo("Something went wrong");
+    }
+
+    @Test
+    void should_set_null_error_message_on_metrics_when_failure_has_blank_message() {
+        ExecutionFailure executionFailure = new ExecutionFailure(HttpResponseStatus.INTERNAL_SERVER_ERROR.code())
+            .key("SOME_ERROR")
+            .message("   ");
+        spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
+
+        simpleFailureProcessor.execute(spyCtx).test().assertResult();
+
+        assertThat(spyCtx.metrics().getErrorKey()).isEqualTo("SOME_ERROR");
+        assertThat(spyCtx.metrics().getErrorMessage()).isNull();
+    }
+
+    @Test
+    void should_set_null_error_message_on_metrics_when_failure_has_no_message() {
+        ExecutionFailure executionFailure = new ExecutionFailure(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()).key("SOME_ERROR");
+        spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
+
+        simpleFailureProcessor.execute(spyCtx).test().assertResult();
+
+        assertThat(spyCtx.metrics().getErrorKey()).isEqualTo("SOME_ERROR");
+        assertThat(spyCtx.metrics().getErrorMessage()).isNull();
+    }
+
     private void configureMemoryAppender() {
         Logger logger = (Logger) LoggerFactory.getLogger(AbstractFailureProcessor.class);
         memoryAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessorTest.java
@@ -185,6 +185,26 @@ class SubscriptionProcessorTest extends AbstractProcessorTest {
 
             assertThat(spyCtx.metrics().getApiProductId()).isEqualTo("pre-existing");
         }
+
+        @Test
+        void should_set_application_name_on_metrics_when_subscription_has_application_name() {
+            var subscription = new Subscription();
+            subscription.setApplicationName("my-application");
+            spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_SUBSCRIPTION, subscription);
+
+            cut.execute(spyCtx).test().assertComplete();
+
+            assertThat(spyCtx.metrics().getApplicationName()).isEqualTo("my-application");
+        }
+
+        @Test
+        void should_set_null_application_name_on_metrics_when_subscription_has_no_application_name() {
+            spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_SUBSCRIPTION, new Subscription());
+
+            cut.execute(spyCtx).test().assertComplete();
+
+            assertThat(spyCtx.metrics().getApplicationName()).isNull();
+        }
     }
 
     @Nested

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessor.java
@@ -95,6 +95,12 @@ public class ReporterProcessor implements Processor {
                             log.setApiName(metrics.getApiName());
                             log.setApiProductId(metrics.getApiProductId());
                             log.setRequestEnded(metrics.isRequestEnded());
+                            log.setApplicationId(metrics.getApplicationId());
+                            log.setApplicationName(metrics.getApplicationName());
+                            log.setPlanId(metrics.getPlanId());
+                            log.setSubscriptionId(metrics.getSubscriptionId());
+                            log.setErrorKey(metrics.getErrorKey());
+                            log.setErrorMessage(metrics.getErrorMessage());
                             reporterService.report(log);
                         }
                     } else {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessorTest.java
@@ -147,6 +147,50 @@ class ReporterProcessorTest extends AbstractProcessorTest {
         }
 
         @Test
+        void should_set_subscription_and_error_context_on_log() {
+            // Given
+            when(reactableApi.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);
+            ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API, reactableApi);
+            ctx.metrics().setApplicationId("app-id");
+            ctx.metrics().setApplicationName("my-app");
+            ctx.metrics().setPlanId("plan-id");
+            ctx.metrics().setSubscriptionId("sub-id");
+            ctx.metrics().setErrorKey("GATEWAY_CLIENT_CONNECTION_REFUSED");
+            ctx.metrics().setErrorMessage("Connection refused");
+            ctx.metrics().setLog(Log.builder().build());
+
+            // When
+            reporterProcessor.execute(ctx).test().assertResult();
+
+            // Then
+            Log log = ctx.metrics().getLog();
+            assertThat(log.getApplicationId()).isEqualTo("app-id");
+            assertThat(log.getApplicationName()).isEqualTo("my-app");
+            assertThat(log.getPlanId()).isEqualTo("plan-id");
+            assertThat(log.getSubscriptionId()).isEqualTo("sub-id");
+            assertThat(log.getErrorKey()).isEqualTo("GATEWAY_CLIENT_CONNECTION_REFUSED");
+            assertThat(log.getErrorMessage()).isEqualTo("Connection refused");
+        }
+
+        @Test
+        void should_set_null_error_fields_on_log_when_no_error() {
+            // Given
+            when(reactableApi.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);
+            ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API, reactableApi);
+            ctx.metrics().setApplicationId("app-id");
+            ctx.metrics().setLog(Log.builder().build());
+
+            // When
+            reporterProcessor.execute(ctx).test().assertResult();
+
+            // Then
+            Log log = ctx.metrics().getLog();
+            assertThat(log.getApplicationId()).isEqualTo("app-id");
+            assertThat(log.getErrorKey()).isNull();
+            assertThat(log.getErrorMessage()).isNull();
+        }
+
+        @Test
         void should_attribute_endpoint_component_when_translating_error_with_endpoint() {
             // Given
             when(reactableApi.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es7x/index/v4-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es7x/index/v4-log.ftl
@@ -22,6 +22,24 @@
   <#if log.getClientIdentifier()??>
   ,"client-identifier":"${log.getClientIdentifier()}"
   </#if>
+  <#if log.getApplicationId()??>
+  ,"application-id":"${log.getApplicationId()}"
+  </#if>
+  <#if log.getApplicationName()??>
+  ,"application-name":"${log.getApplicationName()?j_string}"
+  </#if>
+  <#if log.getPlanId()??>
+  ,"plan-id":"${log.getPlanId()}"
+  </#if>
+  <#if log.getSubscriptionId()??>
+  ,"subscription-id":"${log.getSubscriptionId()}"
+  </#if>
+  <#if log.getErrorKey()??>
+  ,"error-key":"${log.getErrorKey()}"
+  </#if>
+  <#if log.getErrorMessage()??>
+  ,"error-message":"${log.getErrorMessage()?j_string}"
+  </#if>
   ,"request-ended":"${log.isRequestEnded()?c}"
   <#if log.getEntrypointRequest()??>
   ,"entrypoint-request": {

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es7x/index/v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es7x/index/v4-metrics.ftl
@@ -48,6 +48,9 @@
   <#if metrics.getApplicationId()??>
   ,"application-id":"${metrics.getApplicationId()}"
   </#if>
+  <#if metrics.getApplicationName()??>
+  ,"application-name":"${metrics.getApplicationName()?j_string}"
+  </#if>
   <#if metrics.getSubscriptionId()??>
   ,"subscription-id":"${metrics.getSubscriptionId()}"
   </#if>

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es8x/index/v4-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es8x/index/v4-log.ftl
@@ -22,6 +22,24 @@
   <#if log.getClientIdentifier()??>
   ,"client-identifier":"${log.getClientIdentifier()}"
   </#if>
+  <#if log.getApplicationId()??>
+  ,"application-id":"${log.getApplicationId()}"
+  </#if>
+  <#if log.getApplicationName()??>
+  ,"application-name":"${log.getApplicationName()?j_string}"
+  </#if>
+  <#if log.getPlanId()??>
+  ,"plan-id":"${log.getPlanId()}"
+  </#if>
+  <#if log.getSubscriptionId()??>
+  ,"subscription-id":"${log.getSubscriptionId()}"
+  </#if>
+  <#if log.getErrorKey()??>
+  ,"error-key":"${log.getErrorKey()}"
+  </#if>
+  <#if log.getErrorMessage()??>
+  ,"error-message":"${log.getErrorMessage()?j_string}"
+  </#if>
   ,"request-ended":"${log.isRequestEnded()?c}"
   <#if log.getEntrypointRequest()??>
   ,"entrypoint-request": {

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es8x/index/v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es8x/index/v4-metrics.ftl
@@ -48,6 +48,9 @@
   <#if metrics.getApplicationId()??>
   ,"application-id":"${metrics.getApplicationId()}"
   </#if>
+  <#if metrics.getApplicationName()??>
+  ,"application-name":"${metrics.getApplicationName()?j_string}"
+  </#if>
   <#if metrics.getSubscriptionId()??>
   ,"subscription-id":"${metrics.getSubscriptionId()}"
   </#if>

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es9x/index/v4-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es9x/index/v4-log.ftl
@@ -22,6 +22,24 @@
   <#if log.getClientIdentifier()??>
   ,"client-identifier":"${log.getClientIdentifier()}"
   </#if>
+  <#if log.getApplicationId()??>
+  ,"application-id":"${log.getApplicationId()}"
+  </#if>
+  <#if log.getApplicationName()??>
+  ,"application-name":"${log.getApplicationName()?j_string}"
+  </#if>
+  <#if log.getPlanId()??>
+  ,"plan-id":"${log.getPlanId()}"
+  </#if>
+  <#if log.getSubscriptionId()??>
+  ,"subscription-id":"${log.getSubscriptionId()}"
+  </#if>
+  <#if log.getErrorKey()??>
+  ,"error-key":"${log.getErrorKey()}"
+  </#if>
+  <#if log.getErrorMessage()??>
+  ,"error-message":"${log.getErrorMessage()?j_string}"
+  </#if>
   ,"request-ended":"${log.isRequestEnded()?c}"
   <#if log.getEntrypointRequest()??>
   ,"entrypoint-request": {

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es9x/index/v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es9x/index/v4-metrics.ftl
@@ -48,6 +48,9 @@
   <#if metrics.getApplicationId()??>
   ,"application-id":"${metrics.getApplicationId()}"
   </#if>
+  <#if metrics.getApplicationName()??>
+  ,"application-name":"${metrics.getApplicationName()?j_string}"
+  </#if>
   <#if metrics.getSubscriptionId()??>
   ,"subscription-id":"${metrics.getSubscriptionId()}"
   </#if>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <gravitee-plugin.version>5.1.4</gravitee-plugin.version>
         <gravitee-plugin-common-configurations.version>1.4.0</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>2.5.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>2.6.0</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
         <gravitee-resource-cache-provider-api.version>2.2.0</gravitee-resource-cache-provider-api.version>


### PR DESCRIPTION
## Summary

  - Populate applicationName on metrics from the resolved subscription in SubscriptionProcessor
  - Enrich V4 Log with applicationId, applicationName, planId, subscriptionId, errorKey, errorMessage in ReporterProcessor
  - Update ES FTL templates (es7x/es8x/es9x) to include new fields in v4-metrics and v4-log indices
  - Bump gravitee-reporter-api to 2.6.0

##  Testing

  - SubscriptionProcessorTest: +2 new for applicationName
  - ReporterProcessorTest: +2 new for log error/subscription context

##  Related

  - https://gravitee.atlassian.net/browse/APIM-14595

