### PR TITLE
feat(repository): persist idpClaims on the user record (APIM-13955)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/User.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/User.java
@@ -16,6 +16,8 @@
 package io.gravitee.repository.management.model;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -71,6 +73,11 @@ public class User {
     private Boolean newsletterSubscribed;
     private Boolean isServiceAccount;
 
+    /**
+     * IdP claims captured at login (whitelisted on the identity provider), for later use such as DCR injection.
+     */
+    private Map<String, String> idpClaims;
+
     public User(User cloned) {
         this.id = cloned.id;
         this.organizationId = cloned.organizationId;
@@ -89,6 +96,7 @@ public class User {
         this.firstConnectionAt = cloned.firstConnectionAt;
         this.newsletterSubscribed = cloned.newsletterSubscribed;
         this.isServiceAccount = cloned.isServiceAccount;
+        this.idpClaims = cloned.idpClaims != null ? new HashMap<>(cloned.idpClaims) : null;
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcUserRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcUserRepository.java
@@ -17,6 +17,9 @@ package io.gravitee.repository.jdbc.management;
 
 import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
@@ -25,6 +28,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.UserCriteria;
 import io.gravitee.repository.management.model.User;
 import io.gravitee.repository.management.model.UserStatus;
+import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.sql.Types;
 import java.util.Arrays;
@@ -33,6 +37,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -46,8 +51,37 @@ public class JdbcUserRepository extends JdbcAbstractCrudRepository<User, String>
 
     private static final String STATUS_FIELD = "status";
 
+    private static final ObjectMapper JSON = new ObjectMapper();
+
     JdbcUserRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
         super(tablePrefix, "users");
+    }
+
+    private static String serializeIdpClaims(Map claims) {
+        if (claims == null) {
+            return null;
+        }
+        try {
+            return JSON.writeValueAsString(claims);
+        } catch (JsonProcessingException e) {
+            // The ORM's per-column writer swallows and mislabels a thrown exception ("Failed to invoke getter"),
+            // so log an accurate message here instead. Serializing a String map is effectively never expected to fail.
+            log.warn("Failed to serialize user idp_claims; storing null", e);
+            return null;
+        }
+    }
+
+    private static Map deserializeIdpClaims(String json) {
+        if (json == null || json.isEmpty()) {
+            return null;
+        }
+        try {
+            return JSON.readValue(json, new TypeReference<Map<String, String>>() {});
+        } catch (IOException e) {
+            // Let the ORM's setFromResultSet handler deal with it: it logs with the partially-built row (user id
+            // already set) and skips the column, so a corrupt/legacy value degrades to null without blocking the read.
+            throw new IllegalArgumentException("Failed to deserialize user idp_claims", e);
+        }
     }
 
     @Override
@@ -70,6 +104,13 @@ public class JdbcUserRepository extends JdbcAbstractCrudRepository<User, String>
             .addColumn("first_connection_at", Types.TIMESTAMP, Date.class)
             .addColumn("newsletter_subscribed", Types.BOOLEAN, Boolean.class)
             .addColumn("is_service_account", Types.BOOLEAN, Boolean.class)
+            .addColumn(
+                "idp_claims",
+                Types.NCLOB,
+                Map.class,
+                JdbcUserRepository::serializeIdpClaims,
+                JdbcUserRepository::deserializeIdpClaims
+            )
             .build();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/06_add_idp_claims_to_users.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/06_add_idp_claims_to_users.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_add_idp_claims_to_users
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}users
+            columns:
+              - column: { name: idp_claims, type: nclob, constraints: { nullable: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -397,3 +397,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_13_0/04_add_ai_workspace_components_table.yml
     - include:
         - file: liquibase/changelogs/v4_13_0/05_add_portal_categories_table.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/06_add_idp_claims_to_users.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoUserRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoUserRepository.java
@@ -24,8 +24,11 @@ import io.gravitee.repository.management.model.User;
 import io.gravitee.repository.mongodb.management.internal.model.UserMongo;
 import io.gravitee.repository.mongodb.management.internal.user.UserMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.Base64;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -56,6 +59,51 @@ public class MongoUserRepository implements UserRepository {
         this.mapper = mapper;
     }
 
+    /**
+     * Maps a domain user to its Mongo document, Base64-encoding the {@code idpClaims} keys. IdP claim names are
+     * externally controlled and OIDC namespaced claims contain dots, which MongoDB rejects as map keys; encoding
+     * the keys mirrors how {@code MongoIdentityProviderRepository} stores its group/role mapping keys.
+     */
+    private UserMongo toMongo(User user) {
+        UserMongo userMongo = mapper.map(user);
+        if (userMongo != null) {
+            userMongo.setIdpClaims(encodeClaimKeys(user.getIdpClaims()));
+        }
+        return userMongo;
+    }
+
+    private User toModel(UserMongo userMongo) {
+        User user = mapper.map(userMongo);
+        if (user != null) {
+            try {
+                user.setIdpClaims(decodeClaimKeys(userMongo.getIdpClaims()));
+            } catch (IllegalArgumentException e) {
+                // A non-Base64 key (e.g. from an out-of-band edit/import) must not make the user unreadable.
+                log.warn("Failed to decode idp_claims keys for user {}; ignoring stored claims", userMongo.getId(), e);
+                user.setIdpClaims(null);
+            }
+        }
+        return user;
+    }
+
+    private static Map<String, String> encodeClaimKeys(Map<String, String> claims) {
+        if (claims == null) {
+            return null;
+        }
+        Map<String, String> encoded = new HashMap<>(claims.size());
+        claims.forEach((key, value) -> encoded.put(new String(Base64.getEncoder().encode(key.getBytes())), value));
+        return encoded;
+    }
+
+    private static Map<String, String> decodeClaimKeys(Map<String, String> claims) {
+        if (claims == null) {
+            return null;
+        }
+        Map<String, String> decoded = new HashMap<>(claims.size());
+        claims.forEach((key, value) -> decoded.put(new String(Base64.getDecoder().decode(key)), value));
+        return decoded;
+    }
+
     @Override
     public Optional<User> findBySource(String source, String sourceId, String organizationId) {
         log.debug("Find user by name source[{}] user[{}]", source, sourceId);
@@ -71,7 +119,7 @@ public class MongoUserRepository implements UserRepository {
             String escapedSourceId = escaper.matcher(sourceId).replaceAll("\\\\$1");
             user = internalUserRepo.findBySourceAndSourceIdIgnoreCase(source, escapedSourceId, organizationId);
         }
-        User res = mapper.map(user);
+        User res = toModel(user);
 
         return Optional.ofNullable(res);
     }
@@ -91,7 +139,7 @@ public class MongoUserRepository implements UserRepository {
             users = internalUserRepo.findByEmailIgnoreCase(email, organizationId);
         }
 
-        return users.stream().map(mapper::map).toList();
+        return users.stream().map(this::toModel).toList();
     }
 
     @Override
@@ -99,7 +147,7 @@ public class MongoUserRepository implements UserRepository {
         log.debug("Find user by identifiers user [{}]", ids);
 
         Set<UserMongo> usersMongo = internalUserRepo.findByIds(ids);
-        Set<User> users = mapper.mapUsers(usersMongo);
+        Set<User> users = usersMongo.stream().map(this::toModel).collect(Collectors.toSet());
 
         log.debug("Find user by identifiers user [{}] - Done", ids);
         return users;
@@ -109,7 +157,7 @@ public class MongoUserRepository implements UserRepository {
     public Page<User> search(UserCriteria criteria, Pageable pageable) throws TechnicalException {
         log.debug("search users");
 
-        var users = internalUserRepo.search(criteria, pageable).map(mapper::map);
+        var users = internalUserRepo.search(criteria, pageable).map(this::toModel);
 
         log.debug("search users - Done");
         return users;
@@ -133,7 +181,7 @@ public class MongoUserRepository implements UserRepository {
         log.debug("Find user by ID [{}]", id);
 
         UserMongo user = internalUserRepo.findById(id).orElse(null);
-        User res = mapper.map(user);
+        User res = toModel(user);
 
         log.debug("Find user by ID [{}] - Done", id);
         return Optional.ofNullable(res);
@@ -143,7 +191,7 @@ public class MongoUserRepository implements UserRepository {
     public User create(User user) throws TechnicalException {
         log.debug("Create user [{}]", user.getId());
         try {
-            UserMongo userMongo = mapper.map(user);
+            UserMongo userMongo = toMongo(user);
 
             if (isEncryptionEnabled) {
                 if (userMongo.getSourceId() != null) {
@@ -156,7 +204,7 @@ public class MongoUserRepository implements UserRepository {
 
             UserMongo createdUserMongo = internalUserRepo.insert(userMongo);
 
-            User res = mapper.map(createdUserMongo);
+            User res = toModel(createdUserMongo);
 
             log.debug("Create user [{}] - Done", user.getId());
 
@@ -197,8 +245,9 @@ public class MongoUserRepository implements UserRepository {
         userMongo.setFirstConnectionAt(user.getFirstConnectionAt());
         userMongo.setNewsletterSubscribed(user.getNewsletterSubscribed());
         userMongo.setIsServiceAccount(user.getIsServiceAccount());
+        userMongo.setIdpClaims(encodeClaimKeys(user.getIdpClaims()));
         UserMongo userUpdated = internalUserRepo.save(userMongo);
-        return mapper.map(userUpdated);
+        return toModel(userUpdated);
     }
 
     @Override
@@ -209,10 +258,6 @@ public class MongoUserRepository implements UserRepository {
 
     @Override
     public Set<User> findAll() throws TechnicalException {
-        return internalUserRepo
-            .findAll()
-            .stream()
-            .map(userMongo -> mapper.map(userMongo))
-            .collect(Collectors.toSet());
+        return internalUserRepo.findAll().stream().map(this::toModel).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/UserMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/UserMongo.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.mongodb.management.internal.model;
 import static org.springframework.data.mongodb.core.EncryptionAlgorithms.AEAD_AES_256_CBC_HMAC_SHA_512_Deterministic;
 
 import java.util.Date;
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -70,4 +71,7 @@ public class UserMongo extends DeprecatedAuditable {
     private Date firstConnectionAt;
     private Boolean newsletterSubscribed;
     private Boolean isServiceAccount;
+
+    @ToString.Exclude // may carry PII from IdP claims — keep it out of logs
+    private Map<String, String> idpClaims;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/UserRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/UserRepositoryTest.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.management.model.User;
 import io.gravitee.repository.management.model.UserStatus;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -72,6 +73,69 @@ public class UserRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals(user.getLoginCount(), userFound.getLoginCount(), "Invalid saved user login count.");
         assertEquals(user.getFirstConnectionAt(), userFound.getFirstConnectionAt(), "Invalid saved user first connection at.");
         assertEquals(user.getNewsletterSubscribed(), false, "Invalid saved user newsletter.");
+    }
+
+    @Test
+    public void should_persist_and_read_idp_claims() throws Exception {
+        User user = new User();
+        user.setId("user-idp-claims");
+        user.setOrganizationId("DEFAULT");
+        user.setCreatedAt(new Date());
+        user.setUpdatedAt(user.getCreatedAt());
+        user.setEmail("user-idp-claims@gravitee.io");
+        user.setStatus(UserStatus.ACTIVE);
+        user.setSource("oidc");
+        user.setSourceId("user-idp-claims");
+        // include a dotted (OIDC-namespaced) claim key — MongoDB rejects dots in map keys unless handled
+        user.setIdpClaims(Map.of("org_id", "org_acme_12345", "https://acme.example/org", "org_ns"));
+
+        userRepository.create(user);
+
+        Optional<User> optional = userRepository.findById("user-idp-claims");
+        assertTrue(optional.isPresent(), "Unable to find saved user");
+        assertEquals(
+            Map.of("org_id", "org_acme_12345", "https://acme.example/org", "org_ns"),
+            optional.get().getIdpClaims(),
+            "Invalid saved idp claims."
+        );
+
+        // The claims must also survive an update (refreshed on each login, not dropped)
+        final User toUpdate = optional.get();
+        toUpdate.setIdpClaims(Map.of("org_id", "org_beta_67890"));
+        userRepository.update(toUpdate);
+
+        Optional<User> updated = userRepository.findById("user-idp-claims");
+        assertTrue(updated.isPresent(), "Unable to find updated user");
+        assertEquals(Map.of("org_id", "org_beta_67890"), updated.get().getIdpClaims(), "Invalid updated idp claims.");
+
+        // Updating with null clears the claims (not silently keeping the old value)
+        final User toClear = updated.get();
+        toClear.setIdpClaims(null);
+        userRepository.update(toClear);
+
+        Optional<User> cleared = userRepository.findById("user-idp-claims");
+        assertTrue(cleared.isPresent(), "Unable to find user after clearing claims");
+        assertNull(cleared.get().getIdpClaims(), "idp claims should be cleared when updated to null");
+    }
+
+    @Test
+    public void should_return_null_idp_claims_when_user_has_none() throws Exception {
+        User user = new User();
+        user.setId("user-without-idp-claims");
+        user.setOrganizationId("DEFAULT");
+        user.setCreatedAt(new Date());
+        user.setUpdatedAt(user.getCreatedAt());
+        user.setEmail("user-without-idp-claims@gravitee.io");
+        user.setStatus(UserStatus.ACTIVE);
+        user.setSource("oidc");
+        user.setSourceId("user-without-idp-claims");
+        // no idpClaims set
+
+        userRepository.create(user);
+
+        Optional<User> optional = userRepository.findById("user-without-idp-claims");
+        assertTrue(optional.isPresent(), "Unable to find saved user");
+        assertNull(optional.get().getIdpClaims(), "idp claims must be null when never set");
     }
 
     @Test


### PR DESCRIPTION
## What

Second story of epic **APIM-13949** — *Tenant/User context propagation in DCR via IdP claims*. Adds repository-layer storage for the IdP claims captured for a user at login:

- `User.idpClaims` (`Map<String,String>`) — claims persisted on the user record, later injected into DCR requests.

Optional / nullable — existing users are unaffected until claims are persisted (only social-IdP logins with a configured whitelist ever write it).

## How

- **Mongo**: field added to `UserMongo`; `MongoUserRepository.update()` setter wired (update is field-by-field manual).
- **JDBC**: `idp_claims` nclob column via the `JdbcObjectMapper` serialize/deserialize converter (covers all query paths, no N+1).
- **Liquibase**: `v4_13_0/03_add_idp_claims_to_users.yml`, registered in `master.yml`. No Mongo upgrader / backfill needed (schemaless; absent == feature-off default; all reads null-safe).

## Tests

`UserRepositoryTest` round-trip (create **and update**), green on MongoDB and JDBC (Testcontainers).

## Notes

- Ref: **APIM-13955** (epic **APIM-13949**).
- Builds on #18358 (merged). Next PRs (REST config, login persistence, DCR injection, docs) follow.
