### PR TITLE
chore(deps): bump gravitee-service-authz-pdp to 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
         <gravitee-gamma-module-esm.version>1.0.0</gravitee-gamma-module-esm.version>
 
         <!-- Authz plugins -->
-        <gravitee-service-authz-pdp.version>1.0.0</gravitee-service-authz-pdp.version>
+        <gravitee-service-authz-pdp.version>1.0.1</gravitee-service-authz-pdp.version>
         <gravitee-policy-authz-pep.version>1.1.0</gravitee-policy-authz-pep.version>
         <gravitee-policy-authz-pdp-authzen.version>1.0.0</gravitee-policy-authz-pdp-authzen.version>
     </properties>


### PR DESCRIPTION
## Issue

_No linked Jira issue — authz plugin version bump._

## Description

Bump `gravitee-service-authz-pdp` **1.0.0 → 1.0.1**.

Release [1.0.1](https://github.com/gravitee-io/gravitee-service-authz-pdp/releases/tag/1.0.1) (2026-07-01) contains:
- **fix:** default blank resource type in PDP request evaluator — a request with no `resourceType` (e.g. a principal-only PEP eval) built a malformed `null::""` resource, so even an unconstrained `permit(principal, action, resource)` returned `NOT_APPLICABLE`. The evaluator now defaults a blank resource type to `Resource`, mirroring how the action type is defaulted.

## Additional context

Single-line change to the `gravitee-service-authz-pdp.version` property; the distribution pulls the plugin via `${gravitee-service-authz-pdp.version}`.
