### PR TITLE
fix(http-proxy): release pool slot when client aborts the request

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ClientAbortPropagationV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ClientAbortPropagationV4IntegrationTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayDynamicConfig;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import io.vertx.rxjava3.core.http.HttpClientResponse;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage that a client abort releases the upstream connection-pool slot held (or awaited) by the aborted
+ * request instead of burning it until the endpoint read timeout fires.
+ *
+ * The API under test uses a single-connection pool so one leaked slot is directly observable as latency on the next
+ * request. Aborts are raw TCP socket closes, matching what the gateway sees when a real caller gives up.
+ *
+ * Without abort propagation, an aborted-while-queued request is still granted the connection once it frees up and
+ * holds it idle until the read timeout (8s here) — the mechanism behind pool-collapse incidents where abandoned
+ * requests shed no load and the collapse outlives the backend recovery.
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ClientAbortPropagationV4IntegrationTest extends AbstractGatewayTest {
+
+    private static final String BACKEND_PATH = "/endpoint";
+    private static final long PROBE_LATENCY_BUDGET_MS = 2500;
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Test
+    @DeployApi("/apis/v4/http/clientabort/api-client-abort-single-connection.json")
+    void should_release_pool_slot_when_queued_request_is_aborted(HttpClient httpClient, GatewayDynamicConfig.HttpConfig gateway)
+        throws Exception {
+        // First backend call is slow (3s) to keep the single connection busy; every later call answers immediately, so
+        // any latency observed on the probe is pool-acquisition wait, not backend time.
+        stubSlowThenFastBackend(3000);
+
+        // Occupies the only upstream connection for ~3s.
+        var slowRequest = httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(HttpClientRequest::rxSend)
+            .doOnSuccess(response -> assertThat(response.statusCode()).isEqualTo(200))
+            .flatMap(HttpClientResponse::rxBody)
+            .test();
+        Thread.sleep(500);
+
+        // Aborted while QUEUED for the connection: it must never be granted the slot (nor reach the backend).
+        abortClientRequest(gateway.httpPort(), 300);
+
+        slowRequest.awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+        // The slot just freed by the slow request must be immediately available to the probe. Without abort
+        // propagation the aborted request is granted the slot and holds it idle until the 8s read timeout.
+        assertProbeAcquiresSlotWithin(httpClient, PROBE_LATENCY_BUDGET_MS);
+
+        // The aborted request must not have been dispatched to the backend: slow request + probe only.
+        wiremock.verify(2, getRequestedFor(urlPathEqualTo(BACKEND_PATH)));
+    }
+
+    @Test
+    @DeployApi("/apis/v4/http/clientabort/api-client-abort-single-connection.json")
+    void should_release_pool_slot_when_in_flight_request_is_aborted(HttpClient httpClient, GatewayDynamicConfig.HttpConfig gateway)
+        throws Exception {
+        stubSlowThenFastBackend(6000);
+
+        // Dispatched to the backend (single connection acquired), then aborted while the backend is still answering.
+        abortClientRequest(gateway.httpPort(), 500);
+
+        // The abort must release the connection: the probe must not wait for the backend's 6s answer to the aborted
+        // request (nor for the 8s read timeout).
+        assertProbeAcquiresSlotWithin(httpClient, PROBE_LATENCY_BUDGET_MS);
+    }
+
+    private void stubSlowThenFastBackend(int slowDelayMillis) {
+        wiremock.stubFor(
+            get(BACKEND_PATH)
+                .inScenario("single-slot")
+                .whenScenarioStateIs(STARTED)
+                .willReturn(ok("slow").withFixedDelay(slowDelayMillis))
+                .willSetStateTo("fast")
+        );
+        wiremock.stubFor(get(BACKEND_PATH).inScenario("single-slot").whenScenarioStateIs("fast").willReturn(ok("fast")));
+    }
+
+    /**
+     * Sends a request as a raw TCP client and closes the socket after the given delay — a genuine client abort, seen
+     * by the gateway as the downstream connection closing mid-request.
+     */
+    private void abortClientRequest(int gatewayPort, long holdMillis) throws Exception {
+        try (Socket socket = new Socket("localhost", gatewayPort)) {
+            socket.getOutputStream().write("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n".getBytes(StandardCharsets.UTF_8));
+            socket.getOutputStream().flush();
+            Thread.sleep(holdMillis);
+        }
+        // Leaves the gateway a beat to observe the close before the test moves on.
+        Thread.sleep(200);
+    }
+
+    private void assertProbeAcquiresSlotWithin(HttpClient httpClient, long budgetMillis) {
+        long probeStart = System.currentTimeMillis();
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(HttpClientRequest::rxSend)
+            .doOnSuccess(response -> assertThat(response.statusCode()).isEqualTo(200))
+            .flatMap(HttpClientResponse::rxBody)
+            .test()
+            .awaitDone(15, TimeUnit.SECONDS)
+            .assertComplete();
+        long probeLatency = System.currentTimeMillis() - probeStart;
+        assertThat(probeLatency)
+            .as("probe latency — the pool slot of the aborted request must be released, not held until the read timeout")
+            .isLessThan(budgetMillis);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/clientabort/api-client-abort-single-connection.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/clientabort/api-client-abort-single-connection.json
@@ -1,0 +1,65 @@
+{
+  "id": "my-api-v4-client-abort",
+  "name": "my-api-v4-client-abort",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 8000,
+              "idleTimeout": 30000,
+              "maxConcurrentConnections": 1
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "GET"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -69,6 +69,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.CustomLog;
 
 /**
@@ -150,11 +151,14 @@ public class HttpConnector implements ProxyConnector {
             ctx.metrics().setEndpoint(absoluteUri);
             ObservableHttpClientRequest observableHttpClientRequest = new ObservableHttpClientRequest(options);
             Span httpRequestSpan = ctx.getTracer().startSpanFrom(observableHttpClientRequest);
-            return httpClientFactory
-                .getOrBuildHttpClient(ctx, configuration, sharedConfiguration)
-                .rxRequest(options)
-                // rxRequest resolves once a connection/stream is acquired from the pool: from here on, a request-level
-                // timeout is a backend read timeout, not a connection-acquisition timeout (APIM-12769).
+            // Tracks the upstream request between pool acquisition and the response head so that disposing the chain
+            // (typically a client abort) releases the pooled connection instead of holding it until the request
+            // timeout fires. From the response head onward, cancellation is handled by the response chunks'
+            // doOnCancel (see getEndpointResponseChunks).
+            final AtomicReference<HttpClientRequest> pendingUpstreamRequest = new AtomicReference<>();
+            return acquireUpstreamRequest(ctx, options, pendingUpstreamRequest, absoluteUri)
+                // The upstream request resolves once a connection/stream is acquired from the pool: from here on, a
+                // request-level timeout is a backend read timeout, not a connection-acquisition timeout (APIM-12769).
                 .doOnSuccess(acquiredRequest -> ctx.setInternalAttribute(ATTR_INTERNAL_UPSTREAM_CONNECTION_ACQUIRED, Boolean.TRUE))
                 .map(this::customizeHttpClientRequest)
                 .flatMap(httpClientRequest -> {
@@ -162,6 +166,10 @@ public class HttpConnector implements ProxyConnector {
                     return sendEndpointRequestChunks(httpClientRequest, request);
                 })
                 .doOnSuccess(endpointResponse -> {
+                    // The response chunks' doOnCancel owns cancellation from here; reset() being a no-op on a
+                    // completed stream makes the race with a concurrent disposal benign.
+                    pendingUpstreamRequest.set(null);
+
                     response.status(endpointResponse.statusCode());
 
                     copyHeaders(endpointResponse.headers(), response.headers());
@@ -182,9 +190,65 @@ public class HttpConnector implements ProxyConnector {
                     ctx.getTracer().endWithResponse(httpRequestSpan, observableHttpClientResponse);
                 })
                 .doOnError(throwable -> ctx.getTracer().endOnError(httpRequestSpan, throwable))
-                .ignoreElement();
+                .ignoreElement()
+                .doOnDispose(() -> resetPendingUpstreamRequest(ctx, pendingUpstreamRequest, absoluteUri));
         } catch (Exception e) {
             return Completable.error(e);
+        }
+    }
+
+    /**
+     * Acquires an upstream request from the client's connection pool, releasing it immediately when the chain has
+     * already been disposed (client abort while the request was queued in the pool). The rx bridge cannot do this by
+     * itself: disposing {@code rxRequest}'s Single only drops the observer, so a connection granted afterwards would
+     * silently hold its pool slot until the request timeout fires — under sustained abort/retry load this keeps the
+     * pool collapsed long after the backend has recovered.
+     */
+    private Single<HttpClientRequest> acquireUpstreamRequest(
+        final HttpExecutionContext ctx,
+        final RequestOptions options,
+        final AtomicReference<HttpClientRequest> pendingUpstreamRequest,
+        final String absoluteUri
+    ) {
+        return Single.create(emitter ->
+            httpClientFactory
+                .getOrBuildHttpClient(ctx, configuration, sharedConfiguration)
+                .getDelegate()
+                .request(options)
+                .onComplete(asyncRequest -> {
+                    if (asyncRequest.succeeded()) {
+                        final HttpClientRequest upstreamRequest = HttpClientRequest.newInstance(asyncRequest.result());
+                        // Publish the request before checking for disposal so a concurrent disposal either sees it
+                        // (doOnDispose resets it) or is detected right below; getAndSet(null) makes the double reset
+                        // a no-op.
+                        pendingUpstreamRequest.set(upstreamRequest);
+                        if (emitter.isDisposed()) {
+                            resetPendingUpstreamRequest(ctx, pendingUpstreamRequest, absoluteUri);
+                        } else {
+                            emitter.onSuccess(upstreamRequest);
+                        }
+                    } else {
+                        emitter.tryOnError(asyncRequest.cause());
+                    }
+                })
+        );
+    }
+
+    private void resetPendingUpstreamRequest(
+        final HttpExecutionContext ctx,
+        final AtomicReference<HttpClientRequest> pendingUpstreamRequest,
+        final String absoluteUri
+    ) {
+        final HttpClientRequest upstreamRequest = pendingUpstreamRequest.getAndSet(null);
+        if (upstreamRequest != null) {
+            try {
+                ctx.withLogger(log).debug("Downstream request has been disposed, releasing upstream request to [{}]", absoluteUri);
+                // Reset closes the upstream connection/stream so its pool slot is released right away instead of
+                // being held until the request timeout; no-op if the request already completed.
+                upstreamRequest.reset();
+            } catch (Exception e) {
+                ctx.withLogger(log).debug("Can't properly reset endpoint request to backend [{}]", absoluteUri, e);
+            }
         }
     }
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
@@ -59,6 +59,8 @@ import io.netty.handler.timeout.ReadTimeoutException;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.vertx.core.Future;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.impl.NoStackTraceTimeoutException;
 import io.vertx.rxjava3.core.http.HttpClient;
@@ -439,6 +441,9 @@ class HttpProxyEndpointConnectorTest {
         private HttpClient mockHttpClient;
 
         @Mock
+        private io.vertx.core.http.HttpClient mockDelegateHttpClient;
+
+        @Mock
         private WebSocketClient mockWebSocketClient;
 
         @BeforeEach
@@ -450,6 +455,7 @@ class HttpProxyEndpointConnectorTest {
         private void injectSpyIntoEndpointConnector(HttpProxyEndpointConnector cut) {
             spyHttpClientFactory = spy((HttpClientFactory) ReflectionTestUtils.getField(cut, "httpClientFactory"));
             lenient().doReturn(mockHttpClient).when(spyHttpClientFactory).getOrBuildHttpClient(any(), any(), any());
+            lenient().when(mockHttpClient.getDelegate()).thenReturn(mockDelegateHttpClient);
             ReflectionTestUtils.setField(cut, "httpClientFactory", spyHttpClientFactory);
             spyGrpcHttpClientFactory = spy((GrpcHttpClientFactory) ReflectionTestUtils.getField(cut, "grpcHttpClientFactory"));
             lenient().doReturn(mockHttpClient).when(spyGrpcHttpClientFactory).getOrBuildHttpClient(any(), any(), any());
@@ -468,7 +474,7 @@ class HttpProxyEndpointConnectorTest {
             injectSpyIntoEndpointConnector(cut);
 
             // We don't want to test the request itself just that the correct factory is used
-            when(mockHttpClient.rxRequest(any())).thenThrow(new IllegalStateException());
+            when(mockDelegateHttpClient.request(any(RequestOptions.class))).thenReturn(Future.failedFuture(new IllegalStateException()));
             cut.connect(ctx).onErrorComplete(IllegalStateException.class::isInstance).test().assertComplete();
 
             ArgumentCaptor<HttpProxyEndpointConnectorSharedConfiguration> sharedConfigurationCaptor = ArgumentCaptor.forClass(
@@ -500,7 +506,7 @@ class HttpProxyEndpointConnectorTest {
             injectSpyIntoEndpointConnector(cut);
 
             // We don't want to test the request itself just that the correct factory is used
-            when(mockHttpClient.rxRequest(any())).thenThrow(new IllegalStateException());
+            when(mockDelegateHttpClient.request(any(RequestOptions.class))).thenReturn(Future.failedFuture(new IllegalStateException()));
             cut.connect(ctx).onErrorComplete(IllegalStateException.class::isInstance).test().assertComplete();
 
             ArgumentCaptor<HttpProxyEndpointConnectorSharedConfiguration> sharedConfigurationCaptor = ArgumentCaptor.forClass(
@@ -539,7 +545,7 @@ class HttpProxyEndpointConnectorTest {
         @Test
         void should_use_http_client_factory() {
             // We don't want to test the request itself just that the correct factory is used
-            when(mockHttpClient.rxRequest(any())).thenThrow(new IllegalStateException());
+            when(mockDelegateHttpClient.request(any(RequestOptions.class))).thenReturn(Future.failedFuture(new IllegalStateException()));
             cut
                 .connect(ctx)
                 .onErrorComplete(throwable -> throwable instanceof IllegalStateException)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14605

## Description

On a v4 HTTP proxy API, a client abort never reached the upstream request handled by the http-proxy endpoint connector: disposing the reactive chain only drops the rx bridge's observer, so an aborted request kept holding (or was later granted) its connection-pool slot until the request timeout fired. Aborted requests shed no load — under sustained abort/retry traffic against a slow backend the endpoint pool stays collapsed even after the backend recovers.

This PR propagates disposal to the upstream request in the window between pool acquisition and the response head (post-head cancellation was already handled by the response chunks' `doOnCancel`):

- the acquired `HttpClientRequest` is tracked and `reset()` on disposal, releasing its pool slot immediately;
- acquisition goes through the client's `Future` directly, so a connection granted *after* disposal (client aborted while queued in the pool) is reset on the spot instead of being held idle until the timeout;
- at the response head the tracking is dropped and the existing chunk-level cancellation takes over (`reset()` is a no-op on a completed stream, making the disposal race benign).

`GrpcConnector` inherits the fix. `WebSocketConnector` has the same flaw and is left as a follow-up.

## Additional context

New acceptance tests (`ClientAbortPropagationV4IntegrationTest`, single-connection pool + raw TCP aborts) fail on master and pass with this change:
- a request aborted while queued must not consume the slot freed by the previous request (and must never be dispatched to the backend);
- a request aborted while in flight must release its connection immediately.

Verified no regression on the connect-vs-read timeout classification (APIM-12769): `ConnectionFailureV4IntegrationTest` and all `HttpRequestTimeout*` suites green (28 tests), plus the http-proxy plugin unit tests.

Related: gravitee-io/issues#10984 (stale keep-alive reuse — the same `keepAlive: false` workaround masks both defects).
