### PR TITLE
refactor(authz): consolidate engine-uid formatting + drop unused id constants

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/mapper/AuthzEntityMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/mapper/AuthzEntityMapper.java
@@ -17,9 +17,8 @@ package io.gravitee.gateway.services.sync.process.distributed.mapper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.gamma.definition.authz.AuthzEntity;
-import io.gravitee.gamma.definition.authz.AuthzEntityIdConstants;
 import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
-import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzEntityIdExtractor;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzEngineUid;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzEntityReactorDeployable;
 import io.gravitee.repository.distributedsync.model.DistributedEvent;
 import io.gravitee.repository.distributedsync.model.DistributedEventType;
@@ -46,7 +45,7 @@ public class AuthzEntityMapper {
                 AuthzEntityReactorDeployable.Kind kind = AuthzEntityReactorDeployable.Kind.valueOf(wire.getKind().name());
                 return AuthzEntityReactorDeployable.builder()
                     .entityId(wire.getEntityId())
-                    .engineUid(toEngineUid(kind, wire.getEntityType(), wire.getEntityId()))
+                    .engineUid(AuthzEngineUid.of(kind, wire.getEntityType(), wire.getEntityId()))
                     .kind(kind)
                     .entityType(wire.getEntityType())
                     .attributes(wire.getAttributes())
@@ -84,15 +83,5 @@ public class AuthzEntityMapper {
                 return null;
             }
         }).filter(java.util.Objects::nonNull);
-    }
-
-    private static String toEngineUid(AuthzEntityReactorDeployable.Kind kind, String entityType, String entityId) {
-        if (entityType != null && !entityType.isBlank()) {
-            return entityType + "::\"" + entityId + "\"";
-        }
-        if (kind == AuthzEntityReactorDeployable.Kind.PRINCIPAL) {
-            return AuthzEntityIdConstants.ENGINE_TYPE_PRINCIPAL + "::\"" + entityId + "\"";
-        }
-        return AuthzEntityIdExtractor.toResourceEngineUid(entityId);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEngineUid.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEngineUid.java
@@ -15,13 +15,18 @@
  */
 package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
 
+import static io.gravitee.gamma.definition.authz.AuthzEntityIdConstants.ENGINE_TYPE_PRINCIPAL;
 import static io.gravitee.gamma.definition.authz.AuthzEntityIdConstants.ENGINE_TYPE_RESOURCE;
 
-public final class AuthzEntityIdExtractor {
+public final class AuthzEngineUid {
 
-    private AuthzEntityIdExtractor() {}
+    private AuthzEngineUid() {}
 
-    public static String toResourceEngineUid(final String entityId) {
-        return ENGINE_TYPE_RESOURCE + "::\"" + entityId + "\"";
+    public static String of(AuthzEntityReactorDeployable.Kind kind, String entityType, String entityId) {
+        // Explicit entityType wins so GAPL policies match verbatim; legacy publishers fall back to the kind default.
+        String type = (entityType != null && !entityType.isBlank())
+            ? entityType
+            : (kind == AuthzEntityReactorDeployable.Kind.PRINCIPAL ? ENGINE_TYPE_PRINCIPAL : ENGINE_TYPE_RESOURCE);
+        return type + "::\"" + entityId + "\"";
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapper.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.gamma.definition.authz.AuthzEntity;
-import io.gravitee.gamma.definition.authz.AuthzEntityIdConstants;
 import io.gravitee.gamma.definition.authz.AuthzEntityKind;
 import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
 import io.gravitee.repository.management.model.Event;
@@ -42,7 +41,7 @@ public class AuthzEntityMapper {
                 AuthzEntityReactorDeployable.Kind kind = toGatewayKind(wire.getKind());
                 return AuthzEntityReactorDeployable.builder()
                     .entityId(wire.getEntityId())
-                    .engineUid(toEngineUid(kind, wire.getEntityType(), wire.getEntityId()))
+                    .engineUid(AuthzEngineUid.of(kind, wire.getEntityType(), wire.getEntityId()))
                     .kind(kind)
                     .entityType(wire.getEntityType())
                     .attributes(wire.getAttributes())
@@ -73,7 +72,7 @@ public class AuthzEntityMapper {
                     : AuthzEntityReactorDeployable.Kind.RESOURCE;
                 return AuthzEntityReactorDeployable.builder()
                     .entityId(wire.getEntityId())
-                    .engineUid(toEngineUid(kind, wire.getEntityType(), wire.getEntityId()))
+                    .engineUid(AuthzEngineUid.of(kind, wire.getEntityType(), wire.getEntityId()))
                     .kind(kind)
                     .entityType(wire.getEntityType())
                     .environmentId(wire.getEnvironmentId())
@@ -89,25 +88,5 @@ public class AuthzEntityMapper {
 
     private static AuthzEntityReactorDeployable.Kind toGatewayKind(AuthzEntityKind wireKind) {
         return AuthzEntityReactorDeployable.Kind.valueOf(wireKind.name());
-    }
-
-    /**
-     * Build the engine UID emitted to the PDP:
-     * <ul>
-     *   <li>If the wire carries an explicit {@code entityType} (post typed-entity-type rollout)
-     *       — use it verbatim so GAPL policies like {@code principal == User::"alice"} match
-     *       the entity in the snapshot.</li>
-     *   <li>Otherwise (legacy publisher) — fall back to the kind default
-     *       ({@code Principal::"<id>"} / {@code Resource::"<id>"}).</li>
-     * </ul>
-     */
-    static String toEngineUid(AuthzEntityReactorDeployable.Kind kind, String entityType, String entityId) {
-        if (entityType != null && !entityType.isBlank()) {
-            return entityType + "::\"" + entityId + "\"";
-        }
-        if (kind == AuthzEntityReactorDeployable.Kind.PRINCIPAL) {
-            return AuthzEntityIdConstants.ENGINE_TYPE_PRINCIPAL + "::\"" + entityId + "\"";
-        }
-        return AuthzEntityIdExtractor.toResourceEngineUid(entityId);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEngineUidTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEngineUidTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzEntityReactorDeployable.Kind;
+import org.junit.jupiter.api.Test;
+
+class AuthzEngineUidTest {
+
+    @Test
+    void falls_back_to_kind_default_when_entityType_is_null_or_blank() {
+        assertThat(AuthzEngineUid.of(Kind.RESOURCE, null, "api.bookings")).isEqualTo("Resource::\"api.bookings\"");
+        assertThat(AuthzEngineUid.of(Kind.PRINCIPAL, "", "idp.am.alice")).isEqualTo("Principal::\"idp.am.alice\"");
+    }
+
+    @Test
+    void uses_explicit_entityType_verbatim_when_present() {
+        assertThat(AuthzEngineUid.of(Kind.PRINCIPAL, "User", "alice")).isEqualTo("User::\"alice\"");
+        assertThat(AuthzEngineUid.of(Kind.RESOURCE, "Doc", "doc-1")).isEqualTo("Doc::\"doc-1\"");
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapperTest.java
@@ -211,24 +211,6 @@ class AuthzEntityMapperTest {
         assertThat(d.engineUid()).isEqualTo("Resource::\"custom.bookings\"");
     }
 
-    @Test
-    void toEngineUid_falls_back_to_kind_default_when_entityType_is_null_or_blank() {
-        assertThat(AuthzEntityMapper.toEngineUid(AuthzEntityReactorDeployable.Kind.RESOURCE, null, "api.bookings")).isEqualTo(
-            "Resource::\"api.bookings\""
-        );
-        assertThat(AuthzEntityMapper.toEngineUid(AuthzEntityReactorDeployable.Kind.PRINCIPAL, "", "idp.am.alice")).isEqualTo(
-            "Principal::\"idp.am.alice\""
-        );
-    }
-
-    @Test
-    void toEngineUid_uses_explicit_entityType_when_present() {
-        assertThat(AuthzEntityMapper.toEngineUid(AuthzEntityReactorDeployable.Kind.PRINCIPAL, "User", "alice")).isEqualTo(
-            "User::\"alice\""
-        );
-        assertThat(AuthzEntityMapper.toEngineUid(AuthzEntityReactorDeployable.Kind.RESOURCE, "Doc", "doc-1")).isEqualTo("Doc::\"doc-1\"");
-    }
-
     private static Event event(String id, String payload) {
         Event event = new Event();
         event.setId(id);

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstants.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstants.java
@@ -17,15 +17,6 @@ package io.gravitee.gamma.definition.authz;
 
 public final class AuthzEntityIdConstants {
 
-    public static final int MAX_ENTITY_ID_LENGTH = 255;
-
-    /**
-     * GAPL entity-id grammar: dot-separated lowercase segments. Colons are allowed inside
-     * segments because GAPL accepts them in unquoted ids (e.g. {@code repo:backend},
-     * {@code db:production}) and several authz-engine playground scenarios use that form.
-     */
-    public static final String FORMAT_REGEX = "^[a-z0-9_:-]+(?:\\.[a-z0-9_:-]+)*$";
-
     public static final String ENGINE_TYPE_PRINCIPAL = "Principal";
     public static final String ENGINE_TYPE_RESOURCE = "Resource";
 


### PR DESCRIPTION
Stacked on #17615. Tidies up the authz entity-id area that PR left behind.

## What
**1. De-duplicate engine-uid formatting.** Both `AuthzEntityMapper` variants (`repository/synchronizer/authz` + `distributed/mapper`) carried an *identical* private `toEngineUid(kind, entityType, entityId)`. Extracted to a single gateway-sync util `AuthzEngineUid.of(...)`; both mappers now delegate.

**2. Dissolve the `AuthzEntityIdExtractor` husk.** After #17615 it was a one-method util (`toResourceEngineUid`). That method is absorbed into `AuthzEngineUid`, and the class is deleted.

**3. Drop unused constants** from the shared `AuthzEntityIdConstants` (definition-model): `FORMAT_REGEX` + `MAX_ENTITY_ID_LENGTH`. The authz module migrated to its own local `AuthzEntityIdFormat`; verified no remaining consumer in either APIM (gateway sync) or `gravitee-gamma-module-authz`.

## Kept on purpose
- `ENGINE_TYPE_PRINCIPAL` / `ENGINE_TYPE_RESOURCE` — shared GAPL vocabulary (used by both APIM mappers and `AuthzEntityKind` in the authz module).
- `API_PREFIX` / `MCP_PREFIX` / `AGENT_PREFIX` — still consumed by `AuthzEntityServiceImpl` in `gravitee-gamma-module-authz`.

## Behaviour
No change. The `toEngineUid` unit tests moved to `AuthzEngineUidTest`; the mapper tests still cover the same engine-uid output through the public path.

## Follow-up (separate repo)
Two stale doc-comments in `gravitee-gamma-module-authz` (`CreateEntityDialog.tsx`, `CreateActionDialog.tsx`) reference `AuthzEntityIdConstants.MAX_ENTITY_ID_LENGTH` — should be repointed at the module's local `AuthzEntityIdFormat`.