### PR TITLE
ci: trigger SaaS chainguard docker images from full_release

### DIFF
--- a/.circleci/ci/src/jobs/job-trigger-saas-docker-images.ts
+++ b/.circleci/ci/src/jobs/job-trigger-saas-docker-images.ts
@@ -21,7 +21,10 @@ import { computeDockerTagSuffix } from '../utils';
 
 export class TriggerSaasDockerImagesJob {
   private static jobName: string = 'job-trigger-saas-docker-images';
-  public static create(environment: CircleCIEnvironment, distribution: 'dev' | 'prod'): Job {
+  public static create(environment: CircleCIEnvironment, distribution: 'dev' | 'prod', osDistribution: string = 'debian'): Job {
+    // Distinct job name per os-distribution so several SaaS triggers can coexist in a workflow.
+    const jobName =
+      osDistribution === 'debian' ? TriggerSaasDockerImagesJob.jobName : `${TriggerSaasDockerImagesJob.jobName}-${osDistribution}`;
     const steps: Command[] = [
       new commands.Run({
         name: 'Trigger SaaS Docker images pipeline',
@@ -33,7 +36,7 @@ export class TriggerSaasDockerImagesJob {
           environment.branch
         }", "sha1":"${computeDockerTagSuffix(environment.sha1)}", "release-version":"${environment.graviteeioVersion}", "dry-run":${
           environment.isDryRun
-        }, "os-distribution":"debian"}}' | jq -r '.id')
+        }, "os-distribution":"${osDistribution}"}}' | jq -r '.id')
 echo "Pipeline triggered with ID: $PIPELINE_ID"
 waitForPipelineCompletion() {
     while true; do
@@ -52,6 +55,6 @@ waitForPipelineCompletion() {
 waitForPipelineCompletion`,
       }),
     ];
-    return new Job(TriggerSaasDockerImagesJob.jobName, BaseExecutor.create(), steps);
+    return new Job(jobName, BaseExecutor.create(), steps);
   }
 }

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
@@ -572,6 +572,16 @@ workflows:
       - job-build-docker-chainguard-image:
           context:
             - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
           name: Build APIM Management API chainguard docker image for APIM 4.2.0-alpha.1
           requires:
             - Backend build

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
@@ -572,6 +572,16 @@ workflows:
       - job-build-docker-chainguard-image:
           context:
             - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
           name: Build APIM Management API chainguard docker image for APIM 4.2.0-alpha.1
           requires:
             - Backend build

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
@@ -572,6 +572,16 @@ workflows:
       - job-build-docker-chainguard-image:
           context:
             - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image for APIM 4.2.0
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
           name: Build APIM Management API chainguard docker image for APIM 4.2.0
           requires:
             - Backend build

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
@@ -572,6 +572,16 @@ workflows:
       - job-build-docker-chainguard-image:
           context:
             - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image for APIM 4.2.0
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
           name: Build APIM Management API chainguard docker image for APIM 4.2.0
           requires:
             - Backend build

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
@@ -572,6 +572,16 @@ workflows:
       - job-build-docker-chainguard-image:
           context:
             - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image for APIM 4.2.0
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
           name: Build APIM Management API chainguard docker image for APIM 4.2.0
           requires:
             - Backend build

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -990,6 +990,16 @@ workflows:
       - job-build-docker-chainguard-image:
           context:
             - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
           name: Build APIM Management API chainguard docker image for APIM 4.2.0-alpha.1
           requires:
             - Backend build and publish on download website
@@ -1046,6 +1056,7 @@ workflows:
           requires:
             - Build APIM Portal chainguard docker image for APIM 4.2.0-alpha.1
             - Build APIM Console chainguard docker image for APIM 4.2.0-alpha.1
+            - Build Gamma Console chainguard docker image for APIM 4.2.0-alpha.1
             - Build APIM Management API chainguard docker image for APIM 4.2.0-alpha.1
             - Build APIM Gateway chainguard docker image for APIM 4.2.0-alpha.1
       - job-nexus-staging:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -846,6 +846,31 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-trigger-saas-docker-images-chainguard:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger SaaS Docker images pipeline
+          command: |-
+            PIPELINE_ID=$(curl --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/cloud-distributions/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"project":"apim", "distribution":"prod", "branch-version":"4.2.x", "sha1":"784ff35", "release-version":"4.2.0-alpha.1", "dry-run":false, "os-distribution":"chainguard"}}' | jq -r '.id')
+            echo "Pipeline triggered with ID: $PIPELINE_ID"
+            waitForPipelineCompletion() {
+                while true; do
+                    STATUS=$(curl --request GET --url "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" --header "Circle-Token: ${CIRCLE_TOKEN}" | jq -r '.items[].status')
+                    echo "Current status: $STATUS"
+                    if [[ "$STATUS" == "success" ]]; then
+                        echo "Pipeline completed successfully."
+                        break
+                    elif [[ "$STATUS" == "failed" ]]; then
+                        echo "Pipeline failed."
+                        exit 1
+                    fi
+                    sleep 30
+                done
+            }  
+            waitForPipelineCompletion
   job-trigger-apim-api-docs-pipeline:
     docker:
       - image: cimg/base:stable
@@ -1013,6 +1038,16 @@ workflows:
             - Build APIM Console docker image for APIM 4.2.0-alpha.1
             - Build APIM Management API docker image for APIM 4.2.0-alpha.1
             - Build APIM Gateway docker image for APIM 4.2.0-alpha.1
+      - job-trigger-saas-docker-images-chainguard:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger SaaS Chainguard Docker images creation
+          requires:
+            - Build APIM Portal chainguard docker image for APIM 4.2.0-alpha.1
+            - Build APIM Console chainguard docker image for APIM 4.2.0-alpha.1
+            - Build APIM Management API chainguard docker image for APIM 4.2.0-alpha.1
+            - Build APIM Gateway chainguard docker image for APIM 4.2.0-alpha.1
       - job-nexus-staging:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -1024,6 +1024,16 @@ workflows:
       - job-build-docker-chainguard-image:
           context:
             - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image for APIM 4.2.0
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
           name: Build APIM Management API chainguard docker image for APIM 4.2.0
           requires:
             - Backend build and publish on download website
@@ -1080,6 +1090,7 @@ workflows:
           requires:
             - Build APIM Portal chainguard docker image for APIM 4.2.0
             - Build APIM Console chainguard docker image for APIM 4.2.0
+            - Build Gamma Console chainguard docker image for APIM 4.2.0
             - Build APIM Management API chainguard docker image for APIM 4.2.0
             - Build APIM Gateway chainguard docker image for APIM 4.2.0
       - job-nexus-staging:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -880,6 +880,31 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-trigger-saas-docker-images-chainguard:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger SaaS Docker images pipeline
+          command: |-
+            PIPELINE_ID=$(curl --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/cloud-distributions/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"project":"apim", "distribution":"prod", "branch-version":"4.2.x", "sha1":"784ff35", "release-version":"4.2.0", "dry-run":true, "os-distribution":"chainguard"}}' | jq -r '.id')
+            echo "Pipeline triggered with ID: $PIPELINE_ID"
+            waitForPipelineCompletion() {
+                while true; do
+                    STATUS=$(curl --request GET --url "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" --header "Circle-Token: ${CIRCLE_TOKEN}" | jq -r '.items[].status')
+                    echo "Current status: $STATUS"
+                    if [[ "$STATUS" == "success" ]]; then
+                        echo "Pipeline completed successfully."
+                        break
+                    elif [[ "$STATUS" == "failed" ]]; then
+                        echo "Pipeline failed."
+                        exit 1
+                    fi
+                    sleep 30
+                done
+            }  
+            waitForPipelineCompletion
   job-trigger-apim-api-docs-pipeline:
     docker:
       - image: cimg/base:stable
@@ -1047,6 +1072,16 @@ workflows:
             - Build APIM Console docker image for APIM 4.2.0 - Dry Run
             - Build APIM Management API docker image for APIM 4.2.0 - Dry Run
             - Build APIM Gateway docker image for APIM 4.2.0 - Dry Run
+      - job-trigger-saas-docker-images-chainguard:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger SaaS Chainguard Docker images creation
+          requires:
+            - Build APIM Portal chainguard docker image for APIM 4.2.0
+            - Build APIM Console chainguard docker image for APIM 4.2.0
+            - Build APIM Management API chainguard docker image for APIM 4.2.0
+            - Build APIM Gateway chainguard docker image for APIM 4.2.0
       - job-nexus-staging:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -1036,6 +1036,16 @@ workflows:
       - job-build-docker-chainguard-image:
           context:
             - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image for APIM 4.2.0
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
           name: Build APIM Management API chainguard docker image for APIM 4.2.0
           requires:
             - Backend build and publish on download website
@@ -1092,6 +1102,7 @@ workflows:
           requires:
             - Build APIM Portal chainguard docker image for APIM 4.2.0
             - Build APIM Console chainguard docker image for APIM 4.2.0
+            - Build Gamma Console chainguard docker image for APIM 4.2.0
             - Build APIM Management API chainguard docker image for APIM 4.2.0
             - Build APIM Gateway chainguard docker image for APIM 4.2.0
       - job-nexus-staging:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -892,6 +892,31 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-trigger-saas-docker-images-chainguard:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger SaaS Docker images pipeline
+          command: |-
+            PIPELINE_ID=$(curl --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/cloud-distributions/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"project":"apim", "distribution":"prod", "branch-version":"4.2.x", "sha1":"784ff35", "release-version":"4.2.0", "dry-run":false, "os-distribution":"chainguard"}}' | jq -r '.id')
+            echo "Pipeline triggered with ID: $PIPELINE_ID"
+            waitForPipelineCompletion() {
+                while true; do
+                    STATUS=$(curl --request GET --url "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" --header "Circle-Token: ${CIRCLE_TOKEN}" | jq -r '.items[].status')
+                    echo "Current status: $STATUS"
+                    if [[ "$STATUS" == "success" ]]; then
+                        echo "Pipeline completed successfully."
+                        break
+                    elif [[ "$STATUS" == "failed" ]]; then
+                        echo "Pipeline failed."
+                        exit 1
+                    fi
+                    sleep 30
+                done
+            }  
+            waitForPipelineCompletion
   job-trigger-apim-api-docs-pipeline:
     docker:
       - image: cimg/base:stable
@@ -1059,6 +1084,16 @@ workflows:
             - Build APIM Console docker image for APIM 4.2.0
             - Build APIM Management API docker image for APIM 4.2.0
             - Build APIM Gateway docker image for APIM 4.2.0
+      - job-trigger-saas-docker-images-chainguard:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger SaaS Chainguard Docker images creation
+          requires:
+            - Build APIM Portal chainguard docker image for APIM 4.2.0
+            - Build APIM Console chainguard docker image for APIM 4.2.0
+            - Build APIM Management API chainguard docker image for APIM 4.2.0
+            - Build APIM Gateway chainguard docker image for APIM 4.2.0
       - job-nexus-staging:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -1036,6 +1036,16 @@ workflows:
       - job-build-docker-chainguard-image:
           context:
             - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image for APIM 4.2.0
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
           name: Build APIM Management API chainguard docker image for APIM 4.2.0
           requires:
             - Backend build and publish on download website
@@ -1092,6 +1102,7 @@ workflows:
           requires:
             - Build APIM Portal chainguard docker image for APIM 4.2.0
             - Build APIM Console chainguard docker image for APIM 4.2.0
+            - Build Gamma Console chainguard docker image for APIM 4.2.0
             - Build APIM Management API chainguard docker image for APIM 4.2.0
             - Build APIM Gateway chainguard docker image for APIM 4.2.0
       - job-nexus-staging:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -892,6 +892,31 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-trigger-saas-docker-images-chainguard:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger SaaS Docker images pipeline
+          command: |-
+            PIPELINE_ID=$(curl --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/cloud-distributions/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"project":"apim", "distribution":"prod", "branch-version":"4.2.x", "sha1":"784ff35", "release-version":"4.2.0", "dry-run":false, "os-distribution":"chainguard"}}' | jq -r '.id')
+            echo "Pipeline triggered with ID: $PIPELINE_ID"
+            waitForPipelineCompletion() {
+                while true; do
+                    STATUS=$(curl --request GET --url "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" --header "Circle-Token: ${CIRCLE_TOKEN}" | jq -r '.items[].status')
+                    echo "Current status: $STATUS"
+                    if [[ "$STATUS" == "success" ]]; then
+                        echo "Pipeline completed successfully."
+                        break
+                    elif [[ "$STATUS" == "failed" ]]; then
+                        echo "Pipeline failed."
+                        exit 1
+                    fi
+                    sleep 30
+                done
+            }  
+            waitForPipelineCompletion
   job-trigger-apim-api-docs-pipeline:
     docker:
       - image: cimg/base:stable
@@ -1059,6 +1084,16 @@ workflows:
             - Build APIM Console docker image for APIM 4.2.0
             - Build APIM Management API docker image for APIM 4.2.0
             - Build APIM Gateway docker image for APIM 4.2.0
+      - job-trigger-saas-docker-images-chainguard:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger SaaS Chainguard Docker images creation
+          requires:
+            - Build APIM Portal chainguard docker image for APIM 4.2.0
+            - Build APIM Console chainguard docker image for APIM 4.2.0
+            - Build APIM Management API chainguard docker image for APIM 4.2.0
+            - Build APIM Gateway chainguard docker image for APIM 4.2.0
       - job-nexus-staging:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/workflows/workflow-build-chainguard-images.ts
+++ b/.circleci/ci/src/workflows/workflow-build-chainguard-images.ts
@@ -19,6 +19,7 @@ import {
   BackendBuildAndPublishOnDownloadWebsiteJob,
   BuildDockerChainguardImageJob,
   ConsoleWebuiBuildJob,
+  GammaWebuiBuildJob,
   PortalWebuiBuildJob,
   SetupJob,
 } from '../jobs';
@@ -32,6 +33,8 @@ export class BuildChainguardImagesWorkflow {
     dynamicConfig.addJob(consoleWebuiBuildJob);
     const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(portalWebuiBuildJob);
+    const gammaWebuiBuildJob = GammaWebuiBuildJob.create(dynamicConfig, environment);
+    dynamicConfig.addJob(gammaWebuiBuildJob);
     const backendBuildJob = BackendBuildAndPublishOnDownloadWebsiteJob.create(dynamicConfig, environment, false);
     dynamicConfig.addJob(backendBuildJob);
     // isProd=false → azurecr with branch tags: this on-demand action is the test build.
@@ -70,6 +73,22 @@ export class BuildChainguardImagesWorkflow {
         'apim-project-workdir': config.components.console.workdir,
         'docker-context': '.',
         'docker-image-name': config.components.console.image,
+      }),
+
+      // Gamma Console
+      new workflow.WorkflowJob(gammaWebuiBuildJob, {
+        context: config.jobContext,
+        name: 'Build Gamma Console',
+        requires: ['Setup'],
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
+        context: config.jobContext,
+        name: `Build Gamma Console chainguard docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build Gamma Console'],
+        'apim-project': config.components.gamma.project,
+        'apim-project-workdir': config.components.gamma.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.gamma.image,
       }),
 
       // APIM Backend

--- a/.circleci/ci/src/workflows/workflow-build-docker-images.ts
+++ b/.circleci/ci/src/workflows/workflow-build-docker-images.ts
@@ -142,6 +142,15 @@ export class BuildDockerImagesWorkflow {
       }),
       new workflow.WorkflowJob(buildDockerChainguardImageJob, {
         context: config.jobContext,
+        name: `Build Gamma Console chainguard docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build Gamma Console'],
+        'apim-project': config.components.gamma.project,
+        'apim-project-workdir': config.components.gamma.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.gamma.image,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
+        context: config.jobContext,
         name: `Build APIM Management API chainguard docker image for APIM ${environment.graviteeioVersion}`,
         requires: ['Backend build'],
         'apim-project': config.components.managementApi.project,

--- a/.circleci/ci/src/workflows/workflow-full-release.ts
+++ b/.circleci/ci/src/workflows/workflow-full-release.ts
@@ -89,6 +89,9 @@ export class FullReleaseWorkflow {
     const runTriggerSaasDockerImagesJob = TriggerSaasDockerImagesJob.create(environment, 'prod');
     dynamicConfig.addJob(runTriggerSaasDockerImagesJob);
 
+    const runTriggerSaasChainguardDockerImagesJob = TriggerSaasDockerImagesJob.create(environment, 'prod', 'chainguard');
+    dynamicConfig.addJob(runTriggerSaasChainguardDockerImagesJob);
+
     const triggerApimApiDocsPipelineJob = TriggerApimApiDocsPipelineJob.create(environment);
     dynamicConfig.addJob(triggerApimApiDocsPipelineJob);
 
@@ -242,6 +245,18 @@ export class FullReleaseWorkflow {
           `Build APIM Console docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
           `Build APIM Management API docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
           `Build APIM Gateway docker image for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
+        ],
+      }),
+
+      // Trigger SaaS Chainguard Docker images creation (built from the chainguard component images)
+      new workflow.WorkflowJob(runTriggerSaasChainguardDockerImagesJob, {
+        context: [...config.jobContext, 'keeper-orb-publishing'],
+        name: 'Trigger SaaS Chainguard Docker images creation',
+        requires: [
+          `Build APIM Portal chainguard docker image for APIM ${environment.graviteeioVersion}`,
+          `Build APIM Console chainguard docker image for APIM ${environment.graviteeioVersion}`,
+          `Build APIM Management API chainguard docker image for APIM ${environment.graviteeioVersion}`,
+          `Build APIM Gateway chainguard docker image for APIM ${environment.graviteeioVersion}`,
         ],
       }),
 

--- a/.circleci/ci/src/workflows/workflow-full-release.ts
+++ b/.circleci/ci/src/workflows/workflow-full-release.ts
@@ -198,6 +198,15 @@ export class FullReleaseWorkflow {
       }),
       new workflow.WorkflowJob(buildDockerChainguardImageJob, {
         context: config.jobContext,
+        name: `Build Gamma Console chainguard docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build Gamma Console'],
+        'apim-project': config.components.gamma.project,
+        'apim-project-workdir': config.components.gamma.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.gamma.image,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
+        context: config.jobContext,
         name: `Build APIM Management API chainguard docker image for APIM ${environment.graviteeioVersion}`,
         requires: ['Backend build and publish on download website'],
         'apim-project': config.components.managementApi.project,
@@ -255,6 +264,7 @@ export class FullReleaseWorkflow {
         requires: [
           `Build APIM Portal chainguard docker image for APIM ${environment.graviteeioVersion}`,
           `Build APIM Console chainguard docker image for APIM ${environment.graviteeioVersion}`,
+          `Build Gamma Console chainguard docker image for APIM ${environment.graviteeioVersion}`,
           `Build APIM Management API chainguard docker image for APIM ${environment.graviteeioVersion}`,
           `Build APIM Gateway chainguard docker image for APIM ${environment.graviteeioVersion}`,
         ],

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/docker/Dockerfile.chainguard
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/docker/Dockerfile.chainguard
@@ -1,0 +1,39 @@
+#
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM graviteeio.azurecr.io/nginx:1.30-chainguard
+LABEL maintainer="contact@graviteesource.com"
+
+ENV GAMMA_CONSOLE_BASE_HREF="/"
+ENV GAMMA_API_URL="http://localhost:8083/gamma"
+
+# The chainguard base image runs as the non-root nginx user; elevate to root for
+# the file setup below, then drop back to nginx at the end.
+USER root
+
+COPY ./dist /usr/share/nginx/html/
+
+COPY docker/config/constants.json /usr/share/nginx/html/constants.json
+COPY docker/config/default.conf /etc/nginx/conf.d/default.conf
+COPY docker/config/default.no-ipv6.conf /etc/nginx/conf.d/default.no-ipv6.conf
+
+RUN chown -R nginx:root /usr/share/nginx /etc/nginx \
+    && chmod -R g=u /usr/share/nginx /etc/nginx
+
+COPY docker/config/check_ip_config.sh /check_ip_config.sh
+
+USER nginx
+CMD ["/bin/sh", "-c", "sh /check_ip_config.sh; sh /run.sh"]


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ESM-26

## Description

Follow-up to the Chainguard component images: also build the **cloud/SaaS** chainguard images, and add the **gamma** control-plane UI to the chainguard set.

- `TriggerSaasDockerImagesJob` is parameterized with an `os-distribution` (default `debian`, distinct CircleCI job name per flavor). `full_release` now fires a **second** SaaS trigger with `os-distribution=chainguard`, gated on the chainguard component image jobs — so the `cloud-distributions` pipeline builds the SaaS images on top of the chainguard component images.
- **Gamma** now gets a chainguard variant too: `gravitee-gamma-control-plane-webui/docker/Dockerfile.chainguard` (nginx chainguard base, mirrors the console), a gamma chainguard docker job wired into `build_chainguard_images` / `build_docker_images` / `full_release`, and gamma added to the chainguard SaaS trigger requires.

## Additional context

- Companion PR in `cloud-distributions` (#48) adds the `chainguard` value to its `os-distribution` enum, makes the backend SaaS Dockerfiles work on the Wolfi base, and builds the gamma SaaS chainguard image.
- The base chainguard image stays private (azurecr); the component images are on Docker Hub, from which the SaaS build pulls.
