### PR TITLE
chore(deps): bump gravitee-gamma-module-authz to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
 
         <!-- Gamma plugins -->
         <gravitee-gamma-module-aim.version>1.1.0-alpha.2</gravitee-gamma-module-aim.version>
-        <gravitee-gamma-module-authz.version>1.1.0-alpha.1</gravitee-gamma-module-authz.version>
+        <gravitee-gamma-module-authz.version>1.2.0</gravitee-gamma-module-authz.version>
         <gravitee-gamma-module-edge.version>1.1.0</gravitee-gamma-module-edge.version>
         <gravitee-gamma-module-esm.version>1.0.0</gravitee-gamma-module-esm.version>
 


### PR DESCRIPTION
Bumps `gravitee-gamma-module-authz.version` from `1.1.0-alpha.1` to the released `1.2.0` on the 4.12.x line.

Single-line change in the root `pom.xml`; the distribution and standalone-distribution poms consume it via `${gravitee-gamma-module-authz.version}`, so no other edits are needed.

authz `1.2.0` is published (gravitee-gamma-module-authz#74 merged, tag/release `1.2.0`).