### PR TITLE
fix(console): return 404 instead of 500 when API missing during permission check

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
@@ -1803,6 +1804,14 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 }
                 return emptyMap();
             });
+        } catch (UncheckedExecutionException e) {
+            // Guava wraps unchecked exceptions thrown inside the cache loader (e.g. ApiNotFoundException) in an
+            // UncheckedExecutionException. Unwrap it so the original exception reaches the REST layer and is mapped
+            // to its proper HTTP status (e.g. 404) instead of falling through to a generic 500.
+            if (e.getCause() instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw e;
         } catch (ExecutionException e) {
             log.error("Error getting user permissions from cache", e);
             // Fallback: compute without cache

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberPermissionsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberPermissionsTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.verify;
@@ -28,6 +29,7 @@ import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import java.util.Collections;
 import java.util.Map;
 import lombok.SneakyThrows;
@@ -135,5 +137,19 @@ public class MembershipService_GetUserMemberPermissionsTest {
 
         verify(membershipService, times(2)).getUserMember(EXECUTION_CONTEXT, MembershipReferenceType.API, REFERENCE_ID, USER_ID);
         verify(commandRepository).create(any());
+    }
+
+    @Test
+    public void should_propagate_api_not_found_exception_when_api_does_not_exist() {
+        // getUserMember throws when the referenced API no longer exists. The exception is a RuntimeException,
+        // so Guava's cache wraps it in an UncheckedExecutionException. getUserMemberPermissions must unwrap it
+        // and propagate the original ApiNotFoundException so the REST layer maps it to 404 (not 500).
+        doThrow(new ApiNotFoundException(REFERENCE_ID))
+            .when(membershipService)
+            .getUserMember(EXECUTION_CONTEXT, MembershipReferenceType.API, REFERENCE_ID, USER_ID);
+
+        assertThatThrownBy(() ->
+            membershipService.getUserMemberPermissions(EXECUTION_CONTEXT, MembershipReferenceType.API, REFERENCE_ID, USER_ID)
+        ).isInstanceOf(ApiNotFoundException.class);
     }
 }


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-14609
## Description

Fix: Added a catch (UncheckedExecutionException) that unwraps and rethrows the original exception, so ApiNotFoundException reaches the mapper and returns 404 — which GKO already handles gracefully. Applies to every permission-checked endpoint on a missing reference, not just DELETE.

Test: Added should_propagate_api_not_found_exception_when_api_does_not_exist (red→green); existing cache tests still pass.
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

