### PR TITLE
fix(gateway-authz): keep wildcard-targeted docs on tagged PDP engines

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AbstractAuthzReactorSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AbstractAuthzReactorSynchronizer.java
@@ -191,7 +191,15 @@ public abstract class AbstractAuthzReactorSynchronizer<D extends AuthzScopedDepl
         // hosted on this node, so an unhosted target is simply not routed; eviction is the placement delta.
         Set<String> target = deployable.targetPdpIds();
         Set<String> dropped = new LinkedHashSet<>(placement.applied(rk));
-        dropped.removeAll(target);
+        if (target.contains(WILDCARD)) {
+            // A wildcard targets every hosted scope, so it can never narrow a previously-applied scope
+            // away. Computing dropped = applied − {"*"} would flag every concretely-applied scope — e.g. a
+            // scope recorded by the hydration backfill, which never equals the literal "*" — as removed and
+            // (ungated) evict the document from the very scopes it must stay on. A wildcard drops nothing.
+            dropped.clear();
+        } else {
+            dropped.removeAll(target);
+        }
         deployable.removedTargetPdpIds(dropped);
         return deployer
             .deploy(deployable)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHydrationPlacementTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHydrationPlacementTest.java
@@ -187,6 +187,41 @@ class AuthzHydrationPlacementTest {
         assertThat(entityPlacement.applied(ENV + ":" + ENTITY_ID)).containsExactly("scope-a");
     }
 
+    @Test
+    void a_scope_hydrated_with_an_entity_is_NOT_evicted_when_a_later_wildcard_publish_widens_it() throws InterruptedException {
+        // Cycle 1: provision scope-b and hydrate it with the entity (targets scope-b only). Records
+        // scope-b as the concrete applied placement — exactly the state a tagged node reaches after
+        // hydrating a wildcard document into the scope it hosts.
+        Event pdpPublish = pdpEvent("evt-pdp", "scope-b");
+        Event entityForScopeB = entityEvent("scope-b");
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
+            Flowable.just(List.of(pdpPublish))
+        );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(Flowable.empty());
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_ENTITY_ID), any(), any())).thenReturn(
+            Flowable.just(List.of(entityForScopeB))
+        );
+
+        pdpSynchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of(ENV)).test().await().assertComplete();
+
+        assertThat(entityPlacement.applied(ENV + ":" + ENTITY_ID)).containsExactly("scope-b");
+
+        // Cycle 2: the entity is re-published targeting the "*" wildcard (a WIDENING, not a narrowing).
+        // The synchronizer must NOT evict scope-b: dropped = applied − {"*"} would wrongly flag the
+        // concretely-hydrated scope-b (which never equals the literal "*") and, since the eviction is
+        // ungated, wipe the document from the scope it must stay on. A wildcard drops nothing.
+        port.ops.clear();
+        Event entityWidenedToWildcard = entityEvent("*");
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_ENTITY_ID), any(), any())).thenReturn(
+            Flowable.just(List.of(entityWidenedToWildcard))
+        );
+
+        entitySynchronizer.synchronize(1L, Instant.now().toEpochMilli(), Set.of(ENV)).test().await().assertComplete();
+
+        assertThat(port.ops).noneMatch(op -> op.startsWith("removeEntity:"));
+        assertThat(port.ops).contains("addOrUpdateEntity:" + ENGINE_UID + ":[*]");
+    }
+
     private static ThreadPoolExecutor executor() {
         return new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
     }


### PR DESCRIPTION
## Problem

On a multi-gateway setup, a policy or entity targeting the `*` wildcard is
**evicted from a tagged node's scoped engines**, so the tagged node returns
`No applicable policy` for requests the untagged catch-all permits — a silent,
per-node authorization divergence. Restarting the node does not recover it.

## Root cause

`AbstractAuthzReactorSynchronizer.deploy()` computes the eviction delta as
`dropped = placement.applied(rk) − deployable.targetPdpIds()` using the **raw**
target set. For a wildcard document the raw target is the literal `{"*"}`, while
`placement.applied` holds **concrete** scope names recorded by the hydration
backfill (`backfillOne` → `AuthzScopePlacement.addScope`, e.g. `us-prod`). Since
no concrete scope equals the string `"*"`, `dropped` becomes the entire applied
set, so the deployer issues an **ungated** `removePolicy`/`removeEntity`
(`routeForget` has no revision gate) while the re-add is revision-gated (skipped
as already-applied) and wildcard-expanded against a possibly-incomplete
`hostedFor`. Net: the scope is evicted and not re-added.

The catch-all node survives only because its `hostedFor` reliably contains the
scope so the concurrent re-add wins — a fragile accident.

## Fix

A wildcard is the widest possible target and can never *narrow* a previously
applied scope away, so it must drop nothing:

```java
if (target.contains(WILDCARD)) {
    dropped.clear();
} else {
    dropped.removeAll(target);
}
```

Only transitions **to** `*` (a widening) stop producing a bogus eviction; every
genuine narrowing (`["a","b"]→["a"]`, `["*"]→["a"]`) still takes the `else`
branch and evicts correctly.

## Tests

- New `AuthzHydrationPlacementTest#a_scope_hydrated_with_an_entity_is_NOT_evicted_when_a_later_wildcard_publish_widens_it`
  — hydrate a concrete scope, then re-publish targeting `*`; asserts no
  `removeEntity` and an add carrying `[*]`. Red without the fix.
- Existing narrowing/retarget regressions (`…_narrows_it_away`,
  `AuthzPolicySynchronizerTest#retarget_evicts_dropped_scope_via_placement`)
  still pass.
- Full `gravitee-apim-gateway-services-sync` suite green (628 tests).

Verified live on a 3-gateway stack (untagged catch-all + `eu` + `us`): with the
fix a `*`-targeted policy applies and **persists** on the tagged node's engine
across sync cycles (`PERMIT`), where before it was hydrated then evicted to an
empty snapshot (`No applicable policy`).
