### PR TITLE
feat(home): handle missing module license on the homepage (GMA-795)

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/bootstrap-initialize.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/bootstrap-initialize.spec.ts
@@ -13,18 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { licenseService } from '@gravitee/gamma-modules-sdk';
+
 import { runApplicationBootstrap } from './bootstrap-initialize';
 import { useAuthStore } from './features/auth/auth.store';
 import { useEnvironmentStore } from './features/environment/environment.store';
 import * as permissionSync from './features/permissions/permission-sync';
-import { TEST_ENVIRONMENTS, TEST_MANAGEMENT_BASE } from './testing/factories';
-import { trackHandler, respondWithError } from './testing/helpers';
+import { TEST_ENVIRONMENTS, TEST_MANAGEMENT_BASE, TEST_MANAGEMENT_V2_ORGANIZATION_BASE } from './testing/factories';
+import { trackHandler, respondWith, respondWithError } from './testing/helpers';
 
 describe('runApplicationBootstrap', () => {
     let startSyncSpy: jest.SpyInstance;
 
     beforeEach(() => {
         startSyncSpy = jest.spyOn(permissionSync, 'startPermissionSync').mockReturnValue(jest.fn());
+        licenseService.setLicense(null);
     });
 
     afterEach(() => {
@@ -40,10 +43,12 @@ describe('runApplicationBootstrap', () => {
         expect(useAuthStore.getState().user).toBeNull();
         expect(envListTracker.callCount).toBe(0);
         expect(useEnvironmentStore.getState().initialized).toBe(false);
+        expect(licenseService.getLicense()).toBeNull();
     });
 
-    it('should load environments when a session is already present', async () => {
+    it('should load environments and the organization license when a session is already present', async () => {
         const envListTracker = trackHandler('get', `${TEST_MANAGEMENT_BASE}/environments`, TEST_ENVIRONMENTS);
+        respondWith('get', `${TEST_MANAGEMENT_V2_ORGANIZATION_BASE}/license`, { tier: 'enterprise', packs: [], features: [] });
 
         await runApplicationBootstrap();
 
@@ -51,5 +56,6 @@ describe('runApplicationBootstrap', () => {
         expect(envListTracker.callCount).toBe(1);
         expect(useEnvironmentStore.getState().environments).toEqual(TEST_ENVIRONMENTS);
         expect(useEnvironmentStore.getState().initialized).toBe(true);
+        expect(licenseService.getLicense()?.tier).toBe('enterprise');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/bootstrap-initialize.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/bootstrap-initialize.ts
@@ -16,6 +16,7 @@
 import { useAuthStore } from './features/auth';
 import { useEnvironmentStore } from './features/environment';
 import { startEnvironmentSync } from './features/environment/environment-sync';
+import { loadOrganizationLicense } from './features/license/load-organization-license';
 import { startPermissionSync } from './features/permissions/permission-sync';
 import { useBootstrapStore } from './shared/config/bootstrap.store';
 
@@ -34,6 +35,9 @@ export async function runApplicationBootstrap(): Promise<void> {
     await useAuthStore.getState().initialize();
     if (useAuthStore.getState().user) {
         await useEnvironmentStore.getState().initialize(config.organizationId);
+        await loadOrganizationLicense().catch((error: unknown) => {
+            console.error('Failed to load organization license', error);
+        });
     }
 
     // If we just completed an OAuth callback, redirect to the intended URL

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/license/load-organization-license.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/license/load-organization-license.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { licenseService } from '@gravitee/gamma-modules-sdk';
+import type { License } from '@gravitee/gamma-modules-sdk/types';
+
+import { loadOrganizationLicense } from './load-organization-license';
+import { TEST_MANAGEMENT_V2_ORGANIZATION_BASE } from '../../testing/factories';
+import { resetAllStores, respondWith, respondWithError, seedBootstrap } from '../../testing/helpers';
+
+const LICENSE: License = {
+    tier: 'enterprise',
+    packs: ['apim-kafka'],
+    features: ['apim-native-kafka-reactor'],
+    scope: 'ORGANIZATION',
+    isExpired: false,
+};
+
+describe('loadOrganizationLicense', () => {
+    beforeEach(() => {
+        resetAllStores();
+        seedBootstrap();
+        licenseService.setLicense(null);
+    });
+
+    it('should fetch the organization license and push it to licenseService', async () => {
+        respondWith('get', `${TEST_MANAGEMENT_V2_ORGANIZATION_BASE}/license`, LICENSE);
+
+        await loadOrganizationLicense();
+
+        expect(licenseService.getLicense()).toEqual(LICENSE);
+        expect(licenseService.hasFeature('apim-native-kafka-reactor')).toBe(true);
+        expect(licenseService.hasPack('apim-kafka')).toBe(true);
+        expect(licenseService.isExpired()).toBe(false);
+    });
+
+    it('should reject and leave the license unset when the request fails', async () => {
+        respondWithError('get', `${TEST_MANAGEMENT_V2_ORGANIZATION_BASE}/license`, 500);
+
+        await expect(loadOrganizationLicense()).rejects.toThrow();
+        expect(licenseService.getLicense()).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/license/load-organization-license.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/license/load-organization-license.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { licenseService } from '@gravitee/gamma-modules-sdk';
+import type { License } from '@gravitee/gamma-modules-sdk/types';
+
+import { managementV2OrganizationApi } from '../../shared/api/api-client';
+
+/**
+ * Fetches the current organization license and pushes it to the SDK licenseService
+ * singleton so federated modules can gate features via useHasFeature() / useHasPack().
+ *
+ * The organization is fixed for the lifetime of the control plane session, so this is
+ * loaded once at bootstrap.
+ */
+export async function loadOrganizationLicense(): Promise<void> {
+    const license = await managementV2OrganizationApi.get<License>('/license');
+    licenseService.setLicense(license);
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.spec.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { HomePage } from './HomePage';
@@ -111,12 +111,32 @@ describe('HomePage', () => {
         expect(screen.queryByText('Coming soon')).toBeNull();
     });
 
-    it('should render the Agent Management card without any CTA when aim is missing from /modules', async () => {
+    it('should render an "Upgrade to access" CTA instead of a link when aim is missing from /modules', async () => {
         renderHome(ALL_MODULES.filter(m => m.id !== 'aim'));
 
         const card = screen.getByRole('group', { name: 'Agent Management' });
         expect(within(card).queryByText('Open')).toBeNull();
         expect(within(card).queryByText('Add Integration')).toBeNull();
+        expect(within(card).getByRole('button', { name: /upgrade to access/i })).toBeTruthy();
+    });
+
+    it('should keep core modules (API Management) accessible and never locked, even when absent from /modules', () => {
+        renderHome(ALL_MODULES.filter(m => m.id !== 'apim'));
+
+        const heading = screen.getByRole('heading', { level: 3, name: 'API Management' });
+        const link = heading.closest('a');
+        expect(link).not.toBeNull();
+        expect(within(link!).queryByRole('button', { name: /upgrade to access/i })).toBeNull();
+    });
+
+    it('should open the upgrade dialog when the "Upgrade to access" CTA is clicked', async () => {
+        renderHome(ALL_MODULES.filter(m => m.id !== 'aim'));
+
+        const card = screen.getByRole('group', { name: 'Agent Management' });
+        fireEvent.click(within(card).getByRole('button', { name: /upgrade to access/i }));
+
+        const dialog = await screen.findByRole('dialog');
+        expect(within(dialog).getByRole('link', { name: /request an enterprise license/i })).toBeTruthy();
     });
 
     it('should greet the user by first name when available', () => {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.spec.tsx
@@ -192,6 +192,10 @@ describe('HomePage', () => {
             expect(within(appsSection).getByText('Register an application')).toBeTruthy();
             expect(within(appsSection).getByText('Create your first policy')).toBeTruthy();
         });
+
+        // Agent Management empty-state CTA links to the aim module home, not a removed sub-route.
+        const aimCta = within(appsSection).getByText('Add Integration').closest('a');
+        expect(aimCta?.getAttribute('href')).toBe('/environments/env-1/aim');
     });
 
     it('should show metric view with Open CTA when module has data', async () => {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.tsx
@@ -149,7 +149,7 @@ export function HomePage({ modules, loading, error, onRetry }: HomePageProps) {
                 ) : (
                     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
                         {APPLICATIONS.map(app => {
-                            const to = isAvailable(app.moduleId) ? buildModulePath(envHrid, app.moduleId) : null;
+                            const to = isAvailable(app.moduleId) || !app.upgrade ? buildModulePath(envHrid, app.moduleId) : null;
                             return (
                                 <ApplicationCard key={app.title} app={app} to={to} metrics={to ? moduleMetrics[app.moduleId] : undefined} />
                             );

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.tsx
@@ -66,21 +66,26 @@ export function HomePage({ modules, loading, error, onRetry }: HomePageProps) {
 
     const moduleMetrics: Partial<Record<ModuleId, CardMetrics>> = {
         apim: {
-            primary: { value: apiCount, label: pluralize(apiCount, 'API', 'APIs') },
+            primary: { value: apiCount.value, label: pluralize(apiCount.value, 'API', 'APIs') },
+            loading: apiCount.loading,
         },
         aim: {
-            primary: { value: agentCount, label: pluralize(agentCount, 'agent', 'agents') },
-            secondary: { value: mcpServerCount, label: pluralize(mcpServerCount, 'MCP server', 'MCP servers') },
+            primary: { value: agentCount.value, label: pluralize(agentCount.value, 'agent', 'agents') },
+            secondary: { value: mcpServerCount.value, label: pluralize(mcpServerCount.value, 'MCP server', 'MCP servers') },
+            loading: agentCount.loading,
         },
         platform: {
-            primary: { value: appCount, label: pluralize(appCount, 'active app', 'active apps') },
+            primary: { value: appCount.value, label: pluralize(appCount.value, 'active app', 'active apps') },
+            loading: appCount.loading,
         },
         authz: {
-            primary: { value: policyCount, label: pluralize(policyCount, 'policy deployed', 'policies deployed') },
-            secondary: { value: principalCount, label: pluralize(principalCount, 'principal', 'principals') },
+            primary: { value: policyCount.value, label: pluralize(policyCount.value, 'policy deployed', 'policies deployed') },
+            secondary: { value: principalCount.value, label: pluralize(principalCount.value, 'principal', 'principals') },
+            loading: policyCount.loading,
         },
         edge: {
-            primary: { value: deviceCount, label: pluralize(deviceCount, 'active device (24h)', 'active devices (24h)') },
+            primary: { value: deviceCount.value, label: pluralize(deviceCount.value, 'active device (24h)', 'active devices (24h)') },
+            loading: deviceCount.loading,
         },
     };
 

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/ApplicationCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/ApplicationCard.tsx
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { Card, CardContent } from '@gravitee/graphene-core';
-import { ArrowRightIcon } from '@gravitee/graphene-core/icons';
+import { Button, Card, CardContent } from '@gravitee/graphene-core';
+import { ArrowRightIcon, ZapIcon } from '@gravitee/graphene-core/icons';
 import { useId, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { type Application } from './applications';
+import { UpgradeDialog } from './UpgradeDialog';
 
 export interface MetricLine {
     readonly value: number | null;
@@ -48,10 +49,11 @@ function MetricsSkeleton() {
 }
 
 /**
- * Three visual states:
+ * Four visual states:
  *  - **Metrics view** (`to !== null` and has data): live stats + "Open" CTA.
  *  - **Empty state** (`to !== null` but no data): description + module-specific CTA.
- *  - **Unavailable** (`to === null`): description, no CTA.
+ *  - **Locked** (`to === null`): description + "Upgrade to access" CTA opening the upgrade dialog.
+ *    A module is locked when it is absent from `/modules`, i.e. not covered by the organization license.
  */
 export function ApplicationCard({
     app,
@@ -65,6 +67,7 @@ export function ApplicationCard({
     const { Icon, title, description, emptyState } = app;
     const titleId = useId();
     const [isHovered, setIsHovered] = useState(false);
+    const [upgradeOpen, setUpgradeOpen] = useState(false);
 
     const hasData = metrics?.primary.value !== null && metrics?.primary.value !== undefined && metrics.primary.value > 0;
     const isEmptyState = to !== null && !hasData && metrics?.primary.value !== null;
@@ -109,14 +112,28 @@ export function ApplicationCard({
                     />
                 </p>
             )}
+            {to === null && app.upgrade && (
+                <Button
+                    variant="outline"
+                    size="sm"
+                    className="mt-auto self-start rounded-full border-primary px-4 text-primary hover:bg-primary/10 hover:text-primary"
+                    onClick={() => setUpgradeOpen(true)}
+                >
+                    <ZapIcon aria-hidden />
+                    Upgrade to access
+                </Button>
+            )}
         </CardContent>
     );
 
     if (to === null) {
         return (
-            <Card role="group" aria-labelledby={titleId} aria-disabled className="h-full">
-                {inner}
-            </Card>
+            <>
+                <Card role="group" aria-labelledby={titleId} className="h-full">
+                    {inner}
+                </Card>
+                {app.upgrade && <UpgradeDialog app={app} open={upgradeOpen} onOpenChange={setUpgradeOpen} />}
+            </>
         );
     }
 

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/ApplicationCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/ApplicationCard.tsx
@@ -75,7 +75,7 @@ export function ApplicationCard({
     const hasData = metrics?.primary.value !== null && metrics?.primary.value !== undefined && metrics.primary.value > 0;
     const isEmptyState = to !== null && !hasData && !isLoading;
     const ctaLabel = isEmptyState ? emptyState.cta : 'Open';
-    const ctaTarget = isEmptyState ? `${to}/${emptyState.ctaPath}` : to;
+    const ctaTarget = isEmptyState && emptyState.ctaPath ? `${to}/${emptyState.ctaPath}` : to;
 
     const inner = (
         <CardContent className="flex h-full flex-col gap-3">

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/ApplicationCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/ApplicationCard.tsx
@@ -30,6 +30,8 @@ export interface MetricLine {
 export interface CardMetrics {
     readonly primary: MetricLine;
     readonly secondary?: MetricLine;
+    /** True while the count is still being fetched. Once settled, a `null` value means "no data". */
+    readonly loading: boolean;
 }
 
 const HOVER_RING = `0 0 0 1px color-mix(in oklab, var(--color-muted-foreground) 40%, transparent), 0 4px 16px 0 rgb(0 0 0 / 0.08)`;
@@ -69,8 +71,9 @@ export function ApplicationCard({
     const [isHovered, setIsHovered] = useState(false);
     const [upgradeOpen, setUpgradeOpen] = useState(false);
 
+    const isLoading = metrics?.loading === true;
     const hasData = metrics?.primary.value !== null && metrics?.primary.value !== undefined && metrics.primary.value > 0;
-    const isEmptyState = to !== null && !hasData && metrics?.primary.value !== null;
+    const isEmptyState = to !== null && !hasData && !isLoading;
     const ctaLabel = isEmptyState ? emptyState.cta : 'Open';
     const ctaTarget = isEmptyState ? `${to}/${emptyState.ctaPath}` : to;
 
@@ -94,7 +97,7 @@ export function ApplicationCard({
                         </p>
                     )}
                 </div>
-            ) : metrics && metrics.primary.value === null ? (
+            ) : isLoading ? (
                 <MetricsSkeleton />
             ) : (
                 <p className="text-xs text-muted-foreground">{description}</p>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/UpgradeDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/UpgradeDialog.spec.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { APPLICATIONS, REQUEST_ENTERPRISE_LICENSE_URL } from './applications';
+import { UpgradeDialog } from './UpgradeDialog';
+
+const ESM_APP = APPLICATIONS.find(a => a.moduleId === 'esm')!;
+const ESM_FEATURES = ESM_APP.upgrade!.features;
+
+describe('UpgradeDialog', () => {
+    it('should render the module title, description and every feature when open', () => {
+        render(<UpgradeDialog app={ESM_APP} open onOpenChange={() => {}} />);
+
+        expect(screen.getByRole('heading', { name: ESM_APP.title })).toBeTruthy();
+        expect(screen.getByText(ESM_APP.description)).toBeTruthy();
+        ESM_FEATURES.forEach(feature => {
+            expect(screen.getByText(feature)).toBeTruthy();
+        });
+    });
+
+    it('should point the "Request an enterprise license" CTA to the configured URL', () => {
+        render(<UpgradeDialog app={ESM_APP} open onOpenChange={() => {}} />);
+
+        const cta = screen.getByRole('link', { name: /request an enterprise license/i });
+        expect(cta.getAttribute('href')).toBe(REQUEST_ENTERPRISE_LICENSE_URL);
+    });
+
+    it('should not render its content when closed', () => {
+        render(<UpgradeDialog app={ESM_APP} open={false} onOpenChange={() => {}} />);
+
+        expect(screen.queryByText(ESM_FEATURES[0])).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/UpgradeDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/UpgradeDialog.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+import { CircleCheckIcon } from '@gravitee/graphene-core/icons';
+
+import { type Application, REQUEST_ENTERPRISE_LICENSE_URL } from './applications';
+
+/**
+ * Upgrade dialog shown when a user interacts with a module that is not available
+ * for the current organization license. Presents the module value proposition and
+ * a "Request an enterprise license" call to action.
+ */
+export function UpgradeDialog({
+    app,
+    open,
+    onOpenChange,
+}: {
+    readonly app: Application;
+    readonly open: boolean;
+    readonly onOpenChange: (open: boolean) => void;
+}) {
+    const { Icon, title, description, upgrade } = app;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="w-96 gap-0 overflow-hidden p-0">
+                <div className="flex flex-col items-center gap-3 bg-primary/10 px-6 pt-10 pb-8 text-center">
+                    <div className="flex size-12 items-center justify-center rounded-xl bg-background ring-1 ring-foreground/10">
+                        <Icon className="size-8" aria-hidden />
+                    </div>
+                    <DialogHeader className="gap-1.5">
+                        <DialogTitle className="text-center text-xl font-semibold">{title}</DialogTitle>
+                        <DialogDescription className="text-center">{description}</DialogDescription>
+                    </DialogHeader>
+                </div>
+
+                <ul className="flex flex-col gap-2.5 px-6 py-5">
+                    {upgrade?.features.map(feature => (
+                        <li key={feature} className="flex items-start gap-2.5 text-sm">
+                            <CircleCheckIcon className="mt-0.5 size-4 shrink-0 text-success" aria-hidden />
+                            <span>{feature}</span>
+                        </li>
+                    ))}
+                </ul>
+
+                <div className="px-6 pb-6">
+                    <Button asChild variant="outline" className="w-full rounded-full">
+                        <a href={REQUEST_ENTERPRISE_LICENSE_URL} target="_blank" rel="noreferrer">
+                            Request an enterprise license
+                        </a>
+                    </Button>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/applications.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/applications.ts
@@ -32,7 +32,22 @@ export interface Application {
         readonly cta: string;
         readonly ctaPath: string;
     };
+    /**
+     * Upsell content shown in the upgrade dialog. Present only for license-gated modules.
+     * Core modules that always ship with the installation (e.g. API Management, Platform) omit it
+     * and are therefore never rendered in the locked state.
+     */
+    readonly upgrade?: {
+        readonly features: readonly string[];
+    };
 }
+
+/**
+ * Destination of the "Request an enterprise license" CTA in the upgrade dialog.
+ * Aligned with the classic console (`gio-license-data` / `bootstrapApplication`), which links to
+ * the self-hosted trial page. Gamma can also run self-hosted with a restricted license.
+ */
+export const REQUEST_ENTERPRISE_LICENSE_URL = 'https://gravitee.io/self-hosted-trial';
 
 /**
  * Static catalog of application cards. Each entry references the backend plugin id
@@ -47,6 +62,13 @@ export const APPLICATIONS: readonly Application[] = [
         Icon: MODULE_ICONS['aim'],
         accent: 'highlight',
         emptyState: { cta: 'Add Integration', ctaPath: 'import/models' },
+        upgrade: {
+            features: [
+                'Catalog and secure LLM, MCP, and A2A proxies',
+                'Govern agent access with fine-grained policies',
+                'Observe agent traffic and usage in real time',
+            ],
+        },
     },
     {
         title: 'API Management',
@@ -71,6 +93,13 @@ export const APPLICATIONS: readonly Application[] = [
         Icon: MODULE_ICONS['authz'],
         accent: 'success',
         emptyState: { cta: 'Create your first policy', ctaPath: 'policies/new' },
+        upgrade: {
+            features: [
+                'Model relationship-based access control (ReBAC)',
+                'Define fine-grained policies, tuples, and scopes',
+                'Enforce authorization decisions at the edge',
+            ],
+        },
     },
     {
         title: 'Event Stream Management',
@@ -79,6 +108,13 @@ export const APPLICATIONS: readonly Application[] = [
         Icon: MODULE_ICONS['esm'],
         accent: 'muted',
         emptyState: { cta: 'Register a cluster', ctaPath: 'clusters' },
+        upgrade: {
+            features: [
+                'Register and sync Kafka clusters in minutes',
+                'Expose streams as governed APIs for external consumers',
+                'Observe real-time data flows across topics and agents',
+            ],
+        },
     },
     {
         title: 'Edge Management',
@@ -87,6 +123,13 @@ export const APPLICATIONS: readonly Application[] = [
         Icon: MODULE_ICONS['edge'],
         accent: 'highlight',
         emptyState: { cta: 'Open Edge Management', ctaPath: '' },
+        upgrade: {
+            features: [
+                'Configure proxy, DNS, and Shadow AI controls',
+                'Monitor devices and proxied traffic in real time',
+                'Govern AI usage across your edge fleet',
+            ],
+        },
     },
 ];
 

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/applications.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/applications.ts
@@ -61,7 +61,7 @@ export const APPLICATIONS: readonly Application[] = [
         moduleId: 'aim',
         Icon: MODULE_ICONS['aim'],
         accent: 'highlight',
-        emptyState: { cta: 'Add Integration', ctaPath: 'import/models' },
+        emptyState: { cta: 'Add Integration', ctaPath: '' },
         upgrade: {
             features: [
                 'Catalog and secure LLM, MCP, and A2A proxies',

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/useModuleMetrics.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/useModuleMetrics.ts
@@ -13,16 +13,67 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useEnvironmentStore } from '../../features/environment/environment.store';
 import { gammaApi, managementApi, managementV2EnvironmentApi } from '../../shared/api/api-client';
 
 interface CountHookOptions {
-    /** When `false`, the hook does not fetch and returns `null`. Use this to gate the
+    /** When `false`, the hook does not fetch and settles with a `null` value. Use this to gate the
      *  call on module availability — avoids 403/404 noise on license-restricted
      *  deployments. Defaults to `true`. */
     readonly enabled?: boolean;
+}
+
+/**
+ * Result of a card count hook.
+ *
+ * `loading` distinguishes "still fetching" from "settled" so the card can tell a genuine loading
+ * state apart from a settled-without-value one (e.g. the endpoint returned an error on a
+ * license-restricted deployment). A settled `null` means "no value to show" — the card falls back
+ * to its description rather than showing a perpetual skeleton.
+ */
+export interface CountResult {
+    readonly value: number | null;
+    readonly loading: boolean;
+}
+
+/**
+ * Shared engine for the card counts: manages the value/loading state and runs the provided
+ * fetcher when enabled. The fetcher is read through a ref so the effect only re-runs on
+ * `enabled`/`environmentId` changes, not on every render.
+ */
+function useCount(enabled: boolean, fetcher: (environmentId: string) => Promise<number | null>): CountResult {
+    const environmentId = useEnvironmentStore(s => s.environmentId);
+    const [result, setResult] = useState<CountResult>({ value: null, loading: true });
+    const fetcherRef = useRef(fetcher);
+    fetcherRef.current = fetcher;
+
+    useEffect(() => {
+        if (!enabled || !environmentId) {
+            setResult({ value: null, loading: false });
+            return;
+        }
+
+        // Reset on every (re-)run so a stale value from a previous env can't flash through.
+        setResult({ value: null, loading: true });
+
+        let cancelled = false;
+        fetcherRef
+            .current(environmentId)
+            .then(value => {
+                if (!cancelled) setResult({ value, loading: false });
+            })
+            .catch(() => {
+                // Settle without a value — the card shows its description instead of a spinner.
+                if (!cancelled) setResult({ value: null, loading: false });
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [enabled, environmentId]);
+
+    return result;
 }
 
 /**
@@ -42,167 +93,71 @@ const V4_HTTP_PROXY_API_TYPES = ['V4_HTTP_PROXY'];
  * Scoped to V4 HTTP proxy APIs so the count matches the APIM module's list rather than every
  * API type in the environment.
  */
-export function useApiCount({ enabled = true }: CountHookOptions = {}): number | null {
-    const environmentId = useEnvironmentStore(s => s.environmentId);
-    const [count, setCount] = useState<number | null>(null);
-
-    useEffect(() => {
-        // Reset on every (re-)run so a stale value from a previous env/disabled state
-        // can't flash through while the new request is in flight.
-        setCount(null);
-        if (!enabled || !environmentId) return;
-
-        let cancelled = false;
+export function useApiCount({ enabled = true }: CountHookOptions = {}): CountResult {
+    return useCount(enabled, environmentId =>
         managementV2EnvironmentApi
             .post<{ pagination?: { totalCount?: number } }>(`/${encodeURIComponent(environmentId)}/apis/_search?page=1&perPage=1`, {
                 apiTypes: [...V4_HTTP_PROXY_API_TYPES],
             })
-            .then(res => {
-                if (!cancelled) setCount(res?.pagination?.totalCount ?? null);
-            })
-            .catch(() => {
-                /* silent — badge just won't render */
-            });
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, environmentId]);
-
-    return count;
+            .then(res => res?.pagination?.totalCount ?? null),
+    );
 }
 
 /**
  * Live count for the Agent Management card.
  *
- * Hits the AIM catalog endpoint with `perPage=1` — we only need the `total` from the
+ * Hits the AIM catalog endpoint with `perPage=1` — we only need the `totalCount` from the
  * paginated response. This goes through the gamma API directly, no localStorage or
  * domain-id dependency.
  */
-export function useAgentCount({ enabled = true }: CountHookOptions = {}): number | null {
-    const environmentId = useEnvironmentStore(s => s.environmentId);
-    const [count, setCount] = useState<number | null>(null);
-
-    useEffect(() => {
-        setCount(null);
-        if (!enabled || !environmentId) return;
-
-        let cancelled = false;
+export function useAgentCount({ enabled = true }: CountHookOptions = {}): CountResult {
+    return useCount(enabled, environmentId =>
         gammaApi
-            .get<{ pagination?: { totalCount?: number } }>(
-                `/environments/${encodeURIComponent(environmentId)}/modules/aim/catalog/agents?page=1&perPage=1`,
-            )
-            .then(res => {
-                if (!cancelled) setCount(res?.pagination?.totalCount ?? null);
-            })
-            .catch(() => {
-                /* silent — metric just won't render */
-            });
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, environmentId]);
-
-    return count;
+            .get<{
+                pagination?: { totalCount?: number };
+            }>(`/environments/${encodeURIComponent(environmentId)}/modules/aim/catalog/agents?page=1&perPage=1`)
+            .then(res => res?.pagination?.totalCount ?? null),
+    );
 }
 
 /** Active application count for the Platform card. */
-export function useActiveAppCount({ enabled = true }: CountHookOptions = {}): number | null {
-    const environmentId = useEnvironmentStore(s => s.environmentId);
-    const [count, setCount] = useState<number | null>(null);
-
-    useEffect(() => {
-        setCount(null);
-        if (!enabled || !environmentId) return;
-
-        let cancelled = false;
+export function useActiveAppCount({ enabled = true }: CountHookOptions = {}): CountResult {
+    return useCount(enabled, environmentId =>
         managementApi
-            .get<{ page?: { total_elements?: number } }>(
-                `/environments/${encodeURIComponent(environmentId)}/applications/_paged?status=ACTIVE&size=1`,
-            )
-            .then(res => {
-                if (!cancelled) setCount(res?.page?.total_elements ?? null);
-            })
-            .catch(() => {});
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, environmentId]);
-
-    return count;
+            .get<{
+                page?: { total_elements?: number };
+            }>(`/environments/${encodeURIComponent(environmentId)}/applications/_paged?status=ACTIVE&size=1`)
+            .then(res => res?.page?.total_elements ?? null),
+    );
 }
 
 /** Deployed policy count for the Authorization card. */
-export function useDeployedPolicyCount({ enabled = true }: CountHookOptions = {}): number | null {
-    const environmentId = useEnvironmentStore(s => s.environmentId);
-    const [count, setCount] = useState<number | null>(null);
-
-    useEffect(() => {
-        setCount(null);
-        if (!enabled || !environmentId) return;
-
-        let cancelled = false;
+export function useDeployedPolicyCount({ enabled = true }: CountHookOptions = {}): CountResult {
+    return useCount(enabled, environmentId =>
         gammaApi
             .get<{ total?: number }>(`/environments/${encodeURIComponent(environmentId)}/modules/authz/policies?perPage=1&status=DEPLOYED`)
-            .then(res => {
-                if (!cancelled) setCount(res?.total ?? null);
-            })
-            .catch(() => {});
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, environmentId]);
-
-    return count;
+            .then(res => res?.total ?? null),
+    );
 }
 
 /** Principal (user/group) count for the Authorization card. */
-export function usePrincipalCount({ enabled = true }: CountHookOptions = {}): number | null {
-    const environmentId = useEnvironmentStore(s => s.environmentId);
-    const [count, setCount] = useState<number | null>(null);
-
-    useEffect(() => {
-        setCount(null);
-        if (!enabled || !environmentId) return;
-
-        let cancelled = false;
+export function usePrincipalCount({ enabled = true }: CountHookOptions = {}): CountResult {
+    return useCount(enabled, environmentId =>
         gammaApi
             .get<{ total?: number }>(`/environments/${encodeURIComponent(environmentId)}/modules/authz/entities?perPage=1&kind=PRINCIPAL`)
-            .then(res => {
-                if (!cancelled) setCount(res?.total ?? null);
-            })
-            .catch(() => {});
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, environmentId]);
-
-    return count;
+            .then(res => res?.total ?? null),
+    );
 }
 
 /** MCP server count for the Agent Management card. */
-export function useMcpServerCount({ enabled = true }: CountHookOptions = {}): number | null {
-    const environmentId = useEnvironmentStore(s => s.environmentId);
-    const [count, setCount] = useState<number | null>(null);
-
-    useEffect(() => {
-        setCount(null);
-        if (!enabled || !environmentId) return;
-
-        let cancelled = false;
+export function useMcpServerCount({ enabled = true }: CountHookOptions = {}): CountResult {
+    return useCount(enabled, environmentId =>
         gammaApi
-            .get<{ total?: number }>(
-                `/environments/${encodeURIComponent(environmentId)}/modules/aim/catalog/items?kind=mcp-server&perPage=1`,
-            )
-            .then(res => {
-                if (!cancelled) setCount(res?.total ?? null);
-            })
-            .catch(() => {});
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, environmentId]);
-
-    return count;
+            .get<{
+                total?: number;
+            }>(`/environments/${encodeURIComponent(environmentId)}/modules/aim/catalog/items?kind=mcp-server&perPage=1`)
+            .then(res => res?.total ?? null),
+    );
 }
 
 const EDGE_DEVICE_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -220,19 +175,11 @@ const EDGE_DEVICE_WINDOW_MS = 24 * 60 * 60 * 1000;
  * and is capped at `limit: 100` buckets. Replace with a dedicated endpoint once the edge module
  * exposes one.
  */
-export function useDeviceCount({ enabled = true }: CountHookOptions = {}): number | null {
-    const environmentId = useEnvironmentStore(s => s.environmentId);
-    const [count, setCount] = useState<number | null>(null);
-
-    useEffect(() => {
-        setCount(null);
-        if (!enabled || !environmentId) return;
-
+export function useDeviceCount({ enabled = true }: CountHookOptions = {}): CountResult {
+    return useCount(enabled, environmentId => {
         const now = Date.now();
         const from = now - EDGE_DEVICE_WINDOW_MS;
-
-        let cancelled = false;
-        managementV2EnvironmentApi
+        return managementV2EnvironmentApi
             .post<{ metrics?: { name: string; buckets?: unknown[] }[] }>(`/${encodeURIComponent(environmentId)}/analytics/facets`, {
                 timeRange: { from: new Date(from).toISOString(), to: new Date(now).toISOString() },
                 filters: [{ name: 'EDGE_TYPE', operator: 'EQ', value: 'heartbeat' }],
@@ -240,18 +187,6 @@ export function useDeviceCount({ enabled = true }: CountHookOptions = {}): numbe
                 by: ['EDGE_CLIENT'],
                 limit: 100,
             })
-            .then(res => {
-                if (cancelled) return;
-                const buckets = res?.metrics?.find(m => m.name === 'EDGE_HEARTBEAT_COUNT')?.buckets ?? [];
-                setCount(buckets.length);
-            })
-            .catch(() => {
-                /* silent — metric just won't render */
-            });
-        return () => {
-            cancelled = true;
-        };
-    }, [enabled, environmentId]);
-
-    return count;
+            .then(res => res?.metrics?.find(m => m.name === 'EDGE_HEARTBEAT_COUNT')?.buckets?.length ?? null);
+    });
 }

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/api/api-client.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/api/api-client.spec.ts
@@ -13,8 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ApiError, gammaApi, managementApi, managementV2EnvironmentApi } from './api-client';
-import { TEST_GAMMA_BASE, TEST_MANAGEMENT_BASE, TEST_MANAGEMENT_V2_ENVIRONMENT_BASE } from '../../testing/factories';
+import { ApiError, gammaApi, managementApi, managementV2EnvironmentApi, managementV2OrganizationApi } from './api-client';
+import {
+    TEST_GAMMA_BASE,
+    TEST_MANAGEMENT_BASE,
+    TEST_MANAGEMENT_V2_ENVIRONMENT_BASE,
+    TEST_MANAGEMENT_V2_ORGANIZATION_BASE,
+} from '../../testing/factories';
 import { trackHandler, respondWithError } from '../../testing/helpers';
 
 describe('managementApi', () => {
@@ -90,5 +95,33 @@ describe('managementV2EnvironmentApi', () => {
         respondWithError('post', `${TEST_MANAGEMENT_V2_ENVIRONMENT_BASE}/env-1-id/apis/_search`, 403);
 
         await expect(managementV2EnvironmentApi.post('/env-1-id/apis/_search', {})).rejects.toThrow(ApiError);
+    });
+});
+
+describe('managementV2OrganizationApi', () => {
+    it('should resolve to the v2 organization url with the /organizations/{orgId} prefix', async () => {
+        const tracker = trackHandler('get', `${TEST_MANAGEMENT_V2_ORGANIZATION_BASE}/license`, { tier: 'enterprise' });
+
+        const res = await managementV2OrganizationApi.get<{ tier: string }>('/license');
+
+        expect(tracker.callCount).toBe(1);
+        expect(tracker.lastCall?.url).toBe(`${TEST_MANAGEMENT_V2_ORGANIZATION_BASE}/license`);
+        expect(res.tier).toBe('enterprise');
+    });
+
+    it('should send the same csrf header and X-Requested-With as managementApi', async () => {
+        localStorage.setItem('XSRF-TOKEN', 'my-csrf-token');
+        const tracker = trackHandler('get', `${TEST_MANAGEMENT_V2_ORGANIZATION_BASE}/license`, {});
+
+        await managementV2OrganizationApi.get('/license');
+
+        expect(tracker.lastCall?.headers.get('X-Xsrf-Token')).toBe('my-csrf-token');
+        expect(tracker.lastCall?.headers.get('X-Requested-With')).toBe('XMLHttpRequest');
+    });
+
+    it('should throw ApiError on non-2xx', async () => {
+        respondWithError('get', `${TEST_MANAGEMENT_V2_ORGANIZATION_BASE}/license`, 403);
+
+        await expect(managementV2OrganizationApi.get('/license')).rejects.toThrow(ApiError);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/api/api-client.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/api/api-client.ts
@@ -15,7 +15,7 @@
  */
 import { useBootstrapStore } from '../config/bootstrap.store';
 
-export type Backend = 'management' | 'gamma' | 'management-v2-environment';
+export type Backend = 'management' | 'gamma' | 'management-v2-environment' | 'management-v2-organization';
 
 function resolveBaseUrl(backend: Backend): string {
     const config = useBootstrapStore.getState().config;
@@ -28,6 +28,8 @@ function resolveBaseUrl(backend: Backend): string {
             return `${config.gammaBaseURL}/organizations/${config.organizationId}`;
         case 'management-v2-environment':
             return `${config.managementBaseURL}/v2/environments`;
+        case 'management-v2-organization':
+            return `${config.managementBaseURL}/v2/organizations/${config.organizationId}`;
     }
 }
 
@@ -102,3 +104,4 @@ function createClient(backend: Backend) {
 export const managementApi = createClient('management');
 export const gammaApi = createClient('gamma');
 export const managementV2EnvironmentApi = createClient('management-v2-environment');
+export const managementV2OrganizationApi = createClient('management-v2-organization');

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/license/index.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/license/index.ts
@@ -13,15 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Host barrel for `@gravitee/gamma-modules-sdk` — replaces the package stubs
- * with the real implementation via rspack alias + MF singleton.
- *
- * Only domains that need host override belong here (e.g. permissions, environment).
- * Standalone domains like routing live on their own subpath
- * (`@gravitee/gamma-modules-sdk/routing`) and are NOT re-exported here.
- */
-export * from './permissions/index';
-export * from './environment/index';
-export * from './license/index';
+export { LicenseService, licenseService } from './license-service';
+export { useHasFeature } from './useHasFeature';
+export { useHasPack } from './useHasPack';
+export type { License, ILicenseService, UseHasFeatureFn, UseHasPackFn } from '@gravitee/gamma-modules-sdk/types';

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/license/license-service.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/license/license-service.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ILicenseService, License } from '@gravitee/gamma-modules-sdk/types';
+
+type Listener = () => void;
+
+/**
+ * Real license store shared across Gamma host and federated modules.
+ * Populated by the host via startLicenseSync(); remotes consume via useHasFeature() / useHasPack().
+ */
+export class LicenseService implements ILicenseService {
+    private current: License | null = null;
+    private readonly listeners = new Set<Listener>();
+
+    setLicense(license: License | null): void {
+        this.current = license;
+        this.notify();
+    }
+
+    getLicense(): License | null {
+        return this.current;
+    }
+
+    hasFeature(feature: string): boolean {
+        return this.current?.features?.includes(feature) ?? false;
+    }
+
+    hasPack(pack: string): boolean {
+        return this.current?.packs?.includes(pack) ?? false;
+    }
+
+    isExpired(): boolean {
+        return this.current?.isExpired ?? false;
+    }
+
+    subscribe(listener: Listener): () => void {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
+    getSnapshot(): License | null {
+        return this.current;
+    }
+
+    private notify(): void {
+        this.listeners.forEach(l => l());
+    }
+}
+
+export const licenseService = new LicenseService();

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/license/useHasFeature.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/license/useHasFeature.ts
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { UseHasFeatureFn } from '@gravitee/gamma-modules-sdk/types';
+import { useSyncExternalStore } from 'react';
 
-/**
- * Host barrel for `@gravitee/gamma-modules-sdk` — replaces the package stubs
- * with the real implementation via rspack alias + MF singleton.
- *
- * Only domains that need host override belong here (e.g. permissions, environment).
- * Standalone domains like routing live on their own subpath
- * (`@gravitee/gamma-modules-sdk/routing`) and are NOT re-exported here.
- */
-export * from './permissions/index';
-export * from './environment/index';
-export * from './license/index';
+import { licenseService } from './license-service';
+
+export const useHasFeature: UseHasFeatureFn = (feature: string) => {
+    useSyncExternalStore(
+        cb => licenseService.subscribe(cb),
+        () => licenseService.getSnapshot(),
+        () => licenseService.getSnapshot(),
+    );
+    return licenseService.hasFeature(feature);
+};

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/license/useHasPack.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/license/useHasPack.ts
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { UseHasPackFn } from '@gravitee/gamma-modules-sdk/types';
+import { useSyncExternalStore } from 'react';
 
-/**
- * Host barrel for `@gravitee/gamma-modules-sdk` — replaces the package stubs
- * with the real implementation via rspack alias + MF singleton.
- *
- * Only domains that need host override belong here (e.g. permissions, environment).
- * Standalone domains like routing live on their own subpath
- * (`@gravitee/gamma-modules-sdk/routing`) and are NOT re-exported here.
- */
-export * from './permissions/index';
-export * from './environment/index';
-export * from './license/index';
+import { licenseService } from './license-service';
+
+export const useHasPack: UseHasPackFn = (pack: string) => {
+    useSyncExternalStore(
+        cb => licenseService.subscribe(cb),
+        () => licenseService.getSnapshot(),
+        () => licenseService.getSnapshot(),
+    );
+    return licenseService.hasPack(pack);
+};

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/factories.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/factories.ts
@@ -31,6 +31,9 @@ export const TEST_GAMMA_BASE = `${TEST_CONFIG.gammaBaseURL}/organizations/${TEST
 /** Base URL for the APIM v2 environment-scoped surface — paths are `/{envId}/...`. */
 export const TEST_MANAGEMENT_V2_ENVIRONMENT_BASE = `${TEST_CONFIG.managementBaseURL}/v2/environments`;
 
+/** Base URL for the APIM v2 organization-scoped surface — paths are `/license`, etc. */
+export const TEST_MANAGEMENT_V2_ORGANIZATION_BASE = `${TEST_CONFIG.managementBaseURL}/v2/organizations/${TEST_CONFIG.organizationId}`;
+
 export function buildUser(overrides: Partial<CurrentUser> = {}): CurrentUser {
     return {
         displayName: 'Test User',

--- a/gravitee-gamma/gravitee-gamma-module-apim/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "dependencies": {
         "@gravitee/gamma-lib-observability": "1.35.2",
-        "@gravitee/gamma-modules-sdk": "1.0.0-alpha.10",
+        "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/graphene-charts": "3.0.0",
         "@gravitee/graphene-core": "3.0.0",
         "@gravitee/graphene-policy-studio": "3.0.0",

--- a/gravitee-gamma/gravitee-gamma-module-platform/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-platform/package.json
@@ -2,7 +2,7 @@
     "name": "gravitee-gamma-module-platform",
     "private": true,
     "dependencies": {
-        "@gravitee/gamma-modules-sdk": "1.0.0-alpha.10",
+        "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/graphene-core": "^3.0.0",
         "@tanstack/react-query": "5.100.14",
         "react": "19.2.6",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
         "@angular/build": "20.3.14",
         "@angular/cli": "20.3.14",
         "@angular/compiler-cli": "20.3.16",
-        "@gravitee/gamma-modules-sdk": "1.0.0-alpha.10",
+        "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/ui-schematics": "17.8.0",
         "@module-federation/enhanced": "0.18.0",
         "@nx/angular": "21.6.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4589,16 +4589,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/gamma-modules-sdk@npm:1.0.0-alpha.10":
-  version: 1.0.0-alpha.10
-  resolution: "@gravitee/gamma-modules-sdk@npm:1.0.0-alpha.10"
+"@gravitee/gamma-modules-sdk@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@gravitee/gamma-modules-sdk@npm:1.2.0"
   dependencies:
     yaml: "npm:2.9.0"
   peerDependencies:
     react: ">=19"
     react-dom: ">=19"
     react-router-dom: ">=6"
-  checksum: 10c0/69bfb0f87c622f9d23b1cb2a413cb3d77c85f7d1120f3dd6d5eae94a0f5f4d14da3bdebe01129c96903d78278fab4c7b82fbf1affe1a5cc6a390a47408e408a7
+  checksum: 10c0/d4bf271b1bbda71d78c2a0862b2a3b16dfaae7892241a3c946687611ed105fd3345a1a5f194709ca0d2545a5e9cc64857d12c0fee60d19d452676658024c0bb4
   languageName: node
   linkType: hard
 
@@ -21535,7 +21535,7 @@ __metadata:
     "@fontsource/montserrat": "npm:5.2.5"
     "@fontsource/roboto": "npm:5.2.5"
     "@gravitee/gamma-lib-observability": "npm:1.35.2"
-    "@gravitee/gamma-modules-sdk": "npm:1.0.0-alpha.10"
+    "@gravitee/gamma-modules-sdk": "npm:1.2.0"
     "@gravitee/graphene-charts": "npm:3.0.0"
     "@gravitee/graphene-core": "npm:3.0.0"
     "@gravitee/graphene-policy-studio": "npm:3.0.0"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-795

### What
Wires the shared license contract into the Gamma host and uses it on the homepage: modules that are not covered by the current license are shown in a locked state instead of a dead card — a non-clickable card with a clear "Upgrade to access" CTA that opens an upgrade dialog.

Bumps @gravitee/gamma-modules-sdk to the pre-release that ships the license module.

### Why
A Gamma installation (cloud or self-hosted) can run with a restricted license that excludes some module packs. Those modules are absent from GET /organizations/{orgId}/modules, so their homepage cards were rendered inert with no explanation. Users now get a clear "upgrade needed" path, aligned with the classic console. Relates to GMA-795 (homepage) and lays the plumbing for GMA-901 (feature-level gating inside modules).

https://github.com/user-attachments/assets/81d0c230-9b71-4bc0-a9d6-6a6ba0e80ced


### Small fixes:
- AIM redirection is broken on home page as the route has changes recently, here we align the redirection with the new Paths
- Handle count failure gracefully on home page cards

### Linked PR
- https://github.com/gravitee-io/gravitee-gamma-modules-sdk/pull/22

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

