### PR TITLE
feat(automation): use list order for portal navigation paths

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapper.java
@@ -66,6 +66,7 @@ public interface ApiMapper {
     ApiMapper INSTANCE = Mappers.getMapper(ApiMapper.class);
 
     @ValueMapping(source = "EDGE", target = MappingConstants.THROW_EXCEPTION)
+    @ValueMapping(source = "AUTHZ", target = MappingConstants.THROW_EXCEPTION)
     io.gravitee.apim.rest.api.automation.model.ApiType map(io.gravitee.rest.api.management.v2.rest.model.ApiType type);
 
     io.gravitee.rest.api.management.v2.rest.model.ApiType map(io.gravitee.apim.rest.api.automation.model.ApiType type);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
@@ -15,11 +15,14 @@
  */
 package io.gravitee.apim.rest.api.automation.mapper;
 
+import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.apim.rest.api.automation.model.Errors;
-import io.gravitee.apim.rest.api.automation.model.NavigationPath;
+import io.gravitee.apim.rest.api.automation.model.PortalNavigationPath;
 import io.gravitee.apim.rest.api.automation.model.PortalState;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import org.mapstruct.Mapper;
@@ -70,29 +73,35 @@ public interface PortalMapper {
     @Mapping(target = "navigation", ignore = true)
     void mapPortalToState(Portal portal, @MappingTarget PortalState state);
 
-    default List<io.gravitee.apim.core.portal.model.NavigationPath> toCoreNavigation(List<NavigationPath> navigation) {
+    default List<io.gravitee.apim.core.portal.model.NavigationPath> toCoreNavigation(List<PortalNavigationPath> navigation) {
         if (navigation == null) {
             return List.of();
         }
-        return navigation
-            .stream()
-            .filter(PortalMapper::isValidNavigationPath)
-            .map(n -> new io.gravitee.apim.core.portal.model.NavigationPath(n.getPath(), n.getDisplayName()))
-            .toList();
+
+        List<NavigationPath> list = new ArrayList<>();
+        for (int i = 0; i < navigation.size(); i++) {
+            PortalNavigationPath n = navigation.get(i);
+            if (isValidNavigationPath(n)) {
+                NavigationPath navigationPath = new NavigationPath(n.getPath(), n.getDisplayName(), i);
+                list.add(navigationPath);
+            }
+        }
+        return list;
     }
 
-    default List<NavigationPath> toApiNavigation(List<io.gravitee.apim.core.portal.model.NavigationPath> navigation) {
+    default List<PortalNavigationPath> toApiNavigation(List<io.gravitee.apim.core.portal.model.NavigationPath> navigation) {
         if (navigation == null) {
             return List.of();
         }
         return navigation
             .stream()
             .filter(Objects::nonNull)
-            .map(n -> new NavigationPath().path(n.path()).displayName(n.displayName()))
+            .sorted(Comparator.comparing(np -> np.order() == null ? 0 : np.order()))
+            .map(n -> new PortalNavigationPath().path(n.path()).displayName(n.displayName()))
             .toList();
     }
 
-    private static boolean isValidNavigationPath(NavigationPath n) {
-        return n != null && n.getPath() != null && !n.getPath().isBlank();
+    private static boolean isValidNavigationPath(PortalNavigationPath n) {
+        return n != null && !n.getPath().isBlank();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -1916,7 +1916,6 @@ components:
         - MESSAGE
       enum:
         - A2A_PROXY
-        - AUTHZ
         - LLM_PROXY
         - MCP_PROXY
         - MESSAGE
@@ -3145,7 +3144,7 @@ components:
 
     # Portal schemas
     NavigationPath:
-      description: A path entry in a portal or API navigation hierarchy.
+      description: A path entry in an API navigation hierarchy.
       type: object
       properties:
         path:
@@ -3172,6 +3171,27 @@ components:
             - 1
       required:
         - path
+    PortalNavigationPath:
+      description: A path entry in a Portal.
+      type: object
+      properties:
+        path:
+          type: string
+          description: |
+            A slash-separated path defining the navigation hierarchy.
+            Intermediate folders are implicitly created if not listed explicitly.
+          examples:
+            - /projects/alpha
+            - /projects/alpha/docs
+        displayName:
+          type: string
+          description: |
+            Optional human-friendly label for this path node.
+            Listing a path explicitly is the only way to attach a displayName.
+          examples:
+            - Alpha
+      required:
+        - path
     PortalSpec:
       description: Specification of a Portal resource. Represents a next-gen developer portal instance.
       type: object
@@ -3190,7 +3210,7 @@ components:
             Paths are ordered — the order in the list is preserved.
             Intermediate folders are implicitly created if not listed explicitly.
           items:
-            $ref: "#/components/schemas/NavigationPath"
+            $ref: "#/components/schemas/PortalNavigationPath"
       required:
         - hrid
         - name

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApisResourceTest.java
@@ -147,6 +147,19 @@ class ApisResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_reject_authz_api_type() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", false)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("api-with-authz-type.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+            }
+        }
+
+        @Test
         void should_return_state_from_hrid_and_have_spg_hrid_replaced() {
             var state = expectEntity("api-with-hrid-spg-hrid.json");
             SoftAssertions.assertSoftly(soft -> {
@@ -290,6 +303,19 @@ class ApisResourceTest extends AbstractResourceTest {
                     .request()
                     .accept(MediaType.APPLICATION_JSON_TYPE)
                     .put(Entity.json(readJSON("api-with-edge-type.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+            }
+        }
+
+        @Test
+        void should_reject_authz_api_type() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", dryRun)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("api-with-authz-type.json")))
             ) {
                 assertThat(response.getStatus()).isEqualTo(400);
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalResourceTest.java
@@ -27,6 +27,7 @@ import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal.use_case.DeletePortalUseCase;
 import io.gravitee.apim.core.portal.use_case.GetPortalUseCase;
+import io.gravitee.apim.rest.api.automation.model.PortalNavigationPath;
 import io.gravitee.apim.rest.api.automation.model.PortalState;
 import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
 import jakarta.inject.Inject;
@@ -83,16 +84,17 @@ class PortalResourceTest extends AbstractResourceTest {
         @Test
         void should_return_navigation_alongside_portal() {
             var persisted = Portal.of(PORTAL_ID, ENVIRONMENT, ORGANIZATION, "Default Portal");
-            var navigation = List.of(new NavigationPath("/projects", null), new NavigationPath("/projects/alpha", "Alpha"));
+            // order is inverted in the list to show that API returns it in the correct order
+            var navigation = List.of(new NavigationPath("/projects/alpha", "Alpha", 1), new NavigationPath("/projects", null));
             when(getPortalUseCase.execute(any())).thenReturn(new GetPortalUseCase.Output(persisted, navigation));
 
             try (var response = rootTarget(HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
                 assertThat(response.getStatus()).isEqualTo(200);
                 var state = response.readEntity(PortalState.class);
                 assertThat(state.getNavigation())
-                    .extracting(io.gravitee.apim.rest.api.automation.model.NavigationPath::getPath)
+                    .extracting(io.gravitee.apim.rest.api.automation.model.PortalNavigationPath::getPath)
                     .containsExactly("/projects", "/projects/alpha");
-                assertThat(state.getNavigation().get(1).getDisplayName()).isEqualTo("Alpha");
+                assertThat(state.getNavigation()).element(1).extracting(PortalNavigationPath::getDisplayName).isEqualTo("Alpha");
             }
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
@@ -27,6 +27,7 @@ import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal.use_case.CreateOrUpdatePortalUseCase;
 import io.gravitee.apim.core.portal.use_case.ValidatePortalUseCase;
+import io.gravitee.apim.rest.api.automation.model.PortalNavigationPath;
 import io.gravitee.apim.rest.api.automation.model.PortalState;
 import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
 import jakarta.inject.Inject;
@@ -107,9 +108,9 @@ class PortalsResourceTest extends AbstractResourceTest {
 
                 var state = response.readEntity(PortalState.class);
                 assertThat(state.getNavigation())
-                    .extracting(io.gravitee.apim.rest.api.automation.model.NavigationPath::getPath)
+                    .extracting(PortalNavigationPath::getPath)
                     .containsExactly("/projects/alpha", "/projects/alpha/docs");
-                assertThat(state.getNavigation().get(0).getDisplayName()).isEqualTo("Alpha");
+                assertThat(state.getNavigation()).first().extracting(PortalNavigationPath::getDisplayName).isEqualTo("Alpha");
             }
         }
 
@@ -184,9 +185,9 @@ class PortalsResourceTest extends AbstractResourceTest {
 
                 var state = response.readEntity(PortalState.class);
                 assertThat(state.getNavigation())
-                    .extracting(io.gravitee.apim.rest.api.automation.model.NavigationPath::getPath)
+                    .extracting(PortalNavigationPath::getPath)
                     .containsExactly("/projects", "/projects/alpha", "/projects/alpha/docs");
-                assertThat(state.getNavigation().get(1).getDisplayName()).isEqualTo("Alpha");
+                assertThat(state.getNavigation()).element(1).extracting(PortalNavigationPath::getDisplayName).isEqualTo("Alpha");
             }
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/api-with-authz-type.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/api-with-authz-type.json
@@ -1,0 +1,74 @@
+{
+    "name": "api-v4-edge",
+    "hrid": "api-hrid",
+    "description": "API v4 spec with forbidden AUTHZ type",
+    "version": "1.0",
+    "type": "AUTHZ",
+    "listeners": [
+        {
+            "type": "HTTP",
+            "paths": [
+                {
+                    "path": "/test-autz"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy",
+                    "qos": "AUTO"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "Default HTTP proxy group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "Default HTTP proxy",
+                    "type": "http-proxy",
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "https://api.gravitee.io/echo"
+                    },
+                    "secondary": false
+                }
+            ]
+        }
+    ],
+    "flowExecution": {
+        "mode": "DEFAULT",
+        "matchRequired": false
+    },
+    "state": "STARTED",
+    "lifecycleState": "PUBLISHED",
+    "visibility": "PUBLIC",
+    "flows": [],
+    "plans": [
+        {
+            "name": "Keyless plan",
+            "hrid": "KEY_LESS",
+            "description": "No authentication",
+            "type": "API",
+            "status": "PUBLISHED",
+            "validation": "AUTO",
+            "mode": "STANDARD",
+            "security": {
+                "type": "KEY_LESS"
+            },
+            "flows": [
+                {
+                    "enabled": true,
+                    "selectors": [
+                        {
+                            "type": "HTTP",
+                            "path": "/",
+                            "pathOperator": "STARTS_WITH"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14563

## Summary

- Introduce `PortalNavigationPath` schema for portal specs, without an `order` property — list position defines navigation order on write.
- Map list index to internal `NavigationPath.order` in `PortalMapper.toCoreNavigation`, and sort by stored order in `toApiNavigation` on read.
- Keep `NavigationPath` with `order` for API navigation hierarchies.
- Reject `AUTHZ` API type in the automation API (mapper + OpenAPI enum + tests).

## Test plan

- [x] `PortalResourceTest`, `PortalsResourceTest`, `ApisResourceTest` pass locally
- [x] PUT portal with navigation paths in a specific list order and verify round-trip order on GET
- [x] Confirm API navigation still accepts explicit `order` field