### PR TITLE
chore: bump gravitee-policy-traffic-shadowing to 3.0.3

### DIFF
--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-9.1.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.1.1.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-9.1.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.1.1.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-9.2.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.2.1.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-9.2.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.2.1.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -510,8 +510,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.1.1.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.1.1.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.2.1.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.2.1.zip
 
 api:
   enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
     <gravitee-policy-retry.version>4.1.1</gravitee-policy-retry.version>
     <gravitee-policy-role-based-access-control.version>2.1.0</gravitee-policy-role-based-access-control.version>
     <gravitee-policy-ssl-enforcement.version>1.7.0</gravitee-policy-ssl-enforcement.version>
-    <gravitee-policy-traffic-shadowing.version>3.0.2</gravitee-policy-traffic-shadowing.version>
+    <gravitee-policy-traffic-shadowing.version>3.0.3</gravitee-policy-traffic-shadowing.version>
     <gravitee-policy-transform-avro-json.version>5.2.0</gravitee-policy-transform-avro-json.version>
     <gravitee-policy-transform-avro-protobuf.version>1.0.9</gravitee-policy-transform-avro-protobuf.version>
     <gravitee-policy-transform-protobuf-json.version>2.0.1</gravitee-policy-transform-protobuf-json.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14291

**Purpose**

Bump the traffic-shadowing policy to 3.0.3 on the 4.12.x maintenance branch to pick up a bug fix.

**Summary of changes**

- Updated `gravitee-policy-traffic-shadowing.version` from 3.0.2 to 3.0.3 in root pom.xml.
- 3.0.3 fixes: strip client Host header from shadow request headers (#60).

**Out of scope**

No other dependency or code changes.

**Testing**

- Built & ran the policy's own test suite (`mvn clean install`) — 11 tests passing.
- Verified `gravitee-apim-integration-tests` resolves and compiles against 3.0.3.
- Verified `gravitee-apim-distribution` resolves the 3.0.3 zip artifact.
- Ran full `mvn clean install -DskipTests -Dbundle=dev` build — BUILD SUCCESS.