### PR TITLE
fix: redis resources cannot be disabled

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceManagerImpl.java
@@ -63,9 +63,10 @@ public class ResourceManagerImpl extends LegacyResourceManagerImpl {
         if (legacyMode) {
             super.initialize();
         } else {
-            // Unlike v4 resource, v2 Resource enabled flag has never been used. Keep this unchanged to avoid unexpected behavior or breaking changes.
             reactable
                 .dependencies(Resource.class)
+                .stream()
+                .filter(Resource::isEnabled)
                 .forEach(resource -> {
                     log.debug("Loading resource {} for {}", resource.getName(), reactable);
                     final io.gravitee.resource.api.Resource resourceInstance = resourceLoader.load(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/test/java/io/gravitee/gateway/resource/internal/ResourceManagerImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/test/java/io/gravitee/gateway/resource/internal/ResourceManagerImplTest.java
@@ -151,18 +151,16 @@ class ResourceManagerImplTest {
     }
 
     @Test
-    void should_not_ignore_when_resource_is_disabled() {
+    void should_ignore_when_resource_is_disabled() {
         final Resource resource = buildResource();
-        final ResourcePlugin resourcePlugin = mock(ResourcePlugin.class);
         resource.setEnabled(false);
 
-        when(resourcePlugin.resource()).thenReturn(Fake.class);
         when(reactable.dependencies(Resource.class)).thenReturn(Set.of(resource));
-        when(resourcePluginManager.get(resource.getType())).thenReturn(resourcePlugin);
+
         cut.initialize();
 
-        assertThat(cut.containsResource(resource.getName())).isTrue();
-        assertThat(cut.getResource(resource.getName())).isExactlyInstanceOf(Fake.class);
+        assertThat(cut.containsResource(resource.getName())).isFalse();
+        verifyNoInteractions(resourcePluginManager, resourceClassLoaderFactory, resourceConfigurationFactory, applicationContext);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14000

## Description
When a cache-redis resource was disabled in the Console (enabled: false) and the API was redeployed, the gateway still loaded, initialized, and used the resource. The Cache policy continued to read/write Redis as if the resource were still enabled.

**Root cause**
On v2 APIs with execution_mode: v3, resources are managed by ResourceManagerImpl, which loaded all declared resources and ignored the enabled flag. v4 APIs already filter disabled resources via DefaultResourceManager.

**Solution**
Filter resources with Resource::isEnabled before loading them in ResourceManagerImpl.initialize(), matching v4 behavior.

Also updated the unit test to assert that disabled resources are skipped and not registered in the resource manager.

**Before **Fix:****
<img width="1130" height="426" alt="image" src="https://github.com/user-attachments/assets/e0eac19f-23b5-4ad1-b079-0f1fa203b1e2" />

**After fix:**
<img width="1690" height="312" alt="image" src="https://github.com/user-attachments/assets/4c5a5a40-a261-458f-9652-e2fb05e83227" />

<img width="1533" height="312" alt="image" src="https://github.com/user-attachments/assets/e91a0b1b-563a-464b-8421-4556f36035da" />


