### PR TITLE
chore: bump authz to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
 
         <!-- Gamma plugins -->
         <gravitee-gamma-module-aim.version>1.1.0-alpha.2</gravitee-gamma-module-aim.version>
-        <gravitee-gamma-module-authz.version>1.2.0</gravitee-gamma-module-authz.version>
+        <gravitee-gamma-module-authz.version>1.4.0</gravitee-gamma-module-authz.version>
         <gravitee-gamma-module-edge.version>1.1.0</gravitee-gamma-module-edge.version>
         <gravitee-gamma-module-esm.version>1.0.0</gravitee-gamma-module-esm.version>
 


### PR DESCRIPTION
Bumps the gravitee-gamma-module-authz plugin from 1.2.0 to 1.4.0 in the root pom.