### PR TITLE
fix(reporter): FreeMarker errors on Kafka Protocol Mediation reports

### DIFF
--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/java/io/gravitee/apim/reporter/common/formatter/csv/v4/MessageLogFormatter.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/java/io/gravitee/apim/reporter/common/formatter/csv/v4/MessageLogFormatter.java
@@ -51,7 +51,7 @@ public class MessageLogFormatter extends SingleValueFormatter<MessageLog> {
         appendString(buffer, log.getConnectorId());
 
         try {
-            ReportableSanitizationUtil.removeMessageMetadataWithNullValues(log.getMessage());
+            ReportableSanitizationUtil.sanitizeMessageMetadata(log.getMessage());
             appendString(buffer, mapper.writeValueAsString(log.getMessage()));
         } catch (JsonProcessingException e) {
             MessageLogFormatter.log.error("Unable to process message", e);

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/java/io/gravitee/apim/reporter/common/formatter/elasticsearch/ElasticsearchFormatter.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/java/io/gravitee/apim/reporter/common/formatter/elasticsearch/ElasticsearchFormatter.java
@@ -293,7 +293,7 @@ public class ElasticsearchFormatter<T extends Reportable> extends AbstractFormat
 
         addCommonFields(data, log, esOptions);
 
-        ReportableSanitizationUtil.removeMessageMetadataWithNullValues(log.getMessage());
+        ReportableSanitizationUtil.sanitizeMessageMetadata(log.getMessage());
 
         data.put("log", log);
 

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/java/io/gravitee/apim/reporter/common/formatter/util/ReportableSanitizationUtil.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/java/io/gravitee/apim/reporter/common/formatter/util/ReportableSanitizationUtil.java
@@ -19,6 +19,7 @@ package io.gravitee.apim.reporter.common.formatter.util;
 import io.gravitee.reporter.api.http.Metrics;
 import io.gravitee.reporter.api.v4.common.Message;
 import io.gravitee.reporter.api.v4.metric.MessageMetrics;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -46,8 +47,42 @@ public final class ReportableSanitizationUtil {
         removeNullsFromMap(metrics, MessageMetrics::getCustomMetrics, MessageMetrics::setCustomMetrics);
     }
 
-    public static void removeMessageMetadataWithNullValues(Message message) {
-        removeNullsFromMap(message, Message::getMetadata, Message::setMetadata);
+    /**
+     * Sanitizes message metadata for serialization: drops null values and converts {@code byte[]}
+     * values (e.g. raw Kafka record keys/headers) into UTF-8 strings, since FreeMarker's
+     * {@code ?j_string} cannot render a byte array and would throw a NonStringException.
+     */
+    public static void sanitizeMessageMetadata(Message message) {
+        if (message == null) {
+            return;
+        }
+        final Map<String, Object> metadata = message.getMetadata();
+        if (metadata == null || metadata.isEmpty()) {
+            return;
+        }
+
+        // Only rewrite when something needs dropping (null) or normalizing (byte[])
+        boolean needsRewrite = false;
+        for (Object value : metadata.values()) {
+            if (value == null || value instanceof byte[]) {
+                needsRewrite = true;
+                break;
+            }
+        }
+        if (!needsRewrite) {
+            return;
+        }
+
+        Map<String, Object> cleanMap = new LinkedHashMap<>(metadata.size());
+        for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+            Object value = entry.getValue();
+            if (value == null) {
+                continue;
+            }
+            // ponytail: decode bytes as UTF-8 (Kafka keys/headers are usually text); switch to base64 if lossless binary is ever needed
+            cleanMap.put(entry.getKey(), value instanceof byte[] bytes ? new String(bytes, StandardCharsets.UTF_8) : value);
+        }
+        message.setMetadata(cleanMap);
     }
 
     private static <M, T> void removeNullsFromMap(M target, Function<M, Map<String, T>> getter, BiConsumer<M, Map<String, T>> setter) {

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/common/es/event/base-event-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/common/es/event/base-event-metrics.ftl
@@ -13,9 +13,16 @@
     ,"date": "${date}"
     </#if>
     ,"gw-id": "${metrics.getGatewayId()}"
+    <#-- org/env/api are @NonNull by contract but connection-level Kafka accumulators report before the API (and org/env) is resolved, so guard them to avoid FreeMarker InvalidReferenceException -->
+    <#if metrics.getOrganizationId()??>
     ,"org-id": "${metrics.getOrganizationId()}"
+    </#if>
+    <#if metrics.getEnvironmentId()??>
     ,"env-id": "${metrics.getEnvironmentId()}"
+    </#if>
+    <#if metrics.getApiId()??>
     ,"api-id": "${metrics.getApiId()}"
+    </#if>
     <#if metrics.getPlanId()??>
     ,"plan-id": "${metrics.getPlanId()}"
     </#if>

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/java/io/gravitee/apim/reporter/common/formatter/elasticsearch/ElasticsearchFormatterTest.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/java/io/gravitee/apim/reporter/common/formatter/elasticsearch/ElasticsearchFormatterTest.java
@@ -59,6 +59,7 @@ class ElasticsearchFormatterTest extends AbstractFormatterTest {
             "api event metrics, v4.metric.event.ApiEventMetrics, v4/api-event-metrics.json, elasticsearch/v4/api-event-metrics.json",
             "application event metrics, v4.metric.event.ApplicationEventMetrics, v4/application-event-metrics.json, elasticsearch/v4/application-event-metrics.json",
             "topic event metrics, v4.metric.event.TopicEventMetrics, v4/topic-event-metrics.json, elasticsearch/v4/topic-event-metrics.json",
+            "topic event metrics with null api, v4.metric.event.TopicEventMetrics, v4/topic-event-metrics-null-api.json, elasticsearch/v4/topic-event-metrics-null-api.json",
             "operation event metrics, v4.metric.event.OperationEventMetrics, v4/operation-event-metrics.json, elasticsearch/v4/operation-event-metrics.json",
         }
     )

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/java/io/gravitee/apim/reporter/common/formatter/util/ReportableSanitizationUtilTest.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/java/io/gravitee/apim/reporter/common/formatter/util/ReportableSanitizationUtilTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.reporter.common.formatter.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.reporter.api.v4.common.Message;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ReportableSanitizationUtilTest {
+
+    @Test
+    void should_convert_byte_array_metadata_to_utf8_string() {
+        var metadata = new LinkedHashMap<String, Object>();
+        metadata.put("key", "message".getBytes(StandardCharsets.UTF_8)); // raw Kafka record key
+        metadata.put("topic", "demo");
+        metadata.put("partition", 0);
+
+        var message = new Message();
+        message.setMetadata(metadata);
+
+        ReportableSanitizationUtil.sanitizeMessageMetadata(message);
+
+        assertThat(message.getMetadata()).containsEntry("key", "message").containsEntry("topic", "demo").containsEntry("partition", 0);
+    }
+
+    @Test
+    void should_drop_null_metadata_values() {
+        var metadata = new LinkedHashMap<String, Object>();
+        metadata.put("key", "message".getBytes(StandardCharsets.UTF_8));
+        metadata.put("nullMetadata", null);
+
+        var message = new Message();
+        message.setMetadata(metadata);
+
+        ReportableSanitizationUtil.sanitizeMessageMetadata(message);
+
+        assertThat(message.getMetadata()).containsOnlyKeys("key");
+    }
+
+    @Test
+    void should_be_noop_when_metadata_is_null_or_empty() {
+        var message = new Message();
+        message.setMetadata(null);
+        ReportableSanitizationUtil.sanitizeMessageMetadata(message);
+        assertThat(message.getMetadata()).isNull();
+
+        var empty = new Message();
+        empty.setMetadata(new LinkedHashMap<>());
+        ReportableSanitizationUtil.sanitizeMessageMetadata(empty);
+        assertThat(empty.getMetadata()).isEmpty();
+    }
+
+    @Test
+    void should_not_reallocate_when_nothing_to_sanitize() {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("topic", "demo");
+
+        var message = new Message();
+        message.setMetadata(metadata);
+
+        ReportableSanitizationUtil.sanitizeMessageMetadata(message);
+
+        assertThat(message.getMetadata()).isSameAs(metadata);
+    }
+}

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/resources/io/gravitee/reporter/common/formatter/expected/elasticsearch/v4/topic-event-metrics-null-api.json
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/resources/io/gravitee/reporter/common/formatter/expected/elasticsearch/v4/topic-event-metrics-null-api.json
@@ -1,0 +1,20 @@
+{
+  "type": "event-metrics",
+  "date": "2025.06.27",
+  "@timestamp": "2025-06-27T09:06:51.866Z",
+  "plan-id": "test_plan",
+  "app-id": "test_app",
+  "gw-id": "test_gateway",
+  "env-id": "test_env",
+  "org-id": "test_org",
+  "doc-type": "topic",
+  "topic": "test_topic",
+  "downstream-publish-messages-count-increment": 3112,
+  "downstream-publish-message-bytes-increment": 213123,
+  "upstream-publish-messages-count-increment": 13123,
+  "upstream-publish-message-bytes-increment": 213311,
+  "downstream-subscribe-messages-count-increment": 40593,
+  "downstream-subscribe-message-bytes-increment": 432421,
+  "upstream-subscribe-messages-count-increment": 34413,
+  "upstream-subscribe-message-bytes-increment": 2132131
+}

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/resources/io/gravitee/reporter/common/formatter/given/v4/topic-event-metrics-null-api.json
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/resources/io/gravitee/reporter/common/formatter/given/v4/topic-event-metrics-null-api.json
@@ -1,0 +1,17 @@
+{
+  "timestamp": 1751015211866,
+  "planId": "test_plan",
+  "applicationId": "test_app",
+  "gatewayId": "test_gateway",
+  "environmentId": "test_env",
+  "organizationId": "test_org",
+  "topic": "test_topic",
+  "downstreamPublishMessagesCountIncrement": 3112,
+  "downstreamPublishMessageBytesIncrement": 213123,
+  "upstreamPublishMessagesCountIncrement": 13123,
+  "upstreamPublishMessageBytesIncrement": 213311,
+  "downstreamSubscribeMessagesCountIncrement": 40593,
+  "downstreamSubscribeMessageBytesIncrement": 432421,
+  "upstreamSubscribeMessagesCountIncrement": 34413,
+  "upstreamSubscribeMessageBytesIncrement": 2132131
+}


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14581

Two FreeMarker template failures crash the reporter (SEVERE errors in the **gateway log**, reports dropped by the bulk processor) on **Kafka Protocol Mediation** traffic since 4.12. Both live in the new event/message reporter templates.

## 1. `byte[]` message metadata — the observed error

```
SEVERE: Error executing FreeMarker template
freemarker.core.NonStringException: For "?j_string" left-hand operand:
  Expected a string ... but this has evaluated to a sequence
  (byte[] wrapped into ...DefaultArrayAdapter$ByteArrayAdapter):
==> metadataValue  [in template "es8x/index/v4-message-log.ftl" at line 54]
WARN i.g.a.r.common.bulk.BulkProcessor - Unable to format incoming reportable
java.lang.IllegalArgumentException: Impossible to generate from template /es8x/index/v4-message-log.ftl
```

`Message.metadata` is a `Map<String, Object>`. For Kafka message logs the raw record **key/headers are `byte[]`**, and `v4-message-log.ftl:54` renders each value with `${metadataValue?j_string}` — `?j_string` accepts string/number/boolean/date but **not a byte array**, so it throws `NonStringException` and the whole message report is lost. The existing fixtures use string metadata (`key: "message"`), so tests never hit it.

**Fix:** sanitize message metadata before serialization — decode `byte[]` values as UTF-8 strings (matching how string Kafka keys already appear) alongside the existing null-value stripping. Applies to both the Elasticsearch and CSV message-log formatters (`removeMessageMetadataWithNullValues` → `sanitizeMessageMetadata`).

## 2. Null identity dimensions in event-metrics (related, defensive)

`base-event-metrics.ftl` renders `org-id`/`env-id`/`api-id` with unguarded `${...}`. `apiId` is `@org.jspecify.annotations.NonNull` (compile-time only, no runtime check), but connection/application-level Kafka accumulators are reported before an API is resolved, so `apiId` can be null → `InvalidReferenceException`. Guarded these three like the already-guarded `plan-id`/`app-id`.

## Tests
- `ReportableSanitizationUtilTest` — new: `byte[]` → UTF-8 string, null dropped, no-op/identity when nothing to sanitize.
- `ElasticsearchFormatterTest` — new `topic-event-metrics-null-api.json` fixture reproduces the null-apiId `InvalidReferenceException` before the fix.
- Full reporter-common suite green.

## Backport
`4.12.x` carries both unguarded templates and needs this cherry-picked.