### PR TITLE
fix(gamma): get gamma console urls from gamma-console key in standalo…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImpl.java
@@ -106,7 +106,7 @@ public class InstallationAccessQueryServiceImpl implements InstallationAccessQue
         if (!installationTypeDomainService.isMultiTenant()) {
             consoleUrls.putAll(loadUrls("console", "orgId"));
             portalUrls.putAll(loadUrls("portal", "envId"));
-            gammaUrls.putAll(loadUrls("gamma", "orgId"));
+            gammaUrls.putAll(loadUrls("gamma-console", "orgId"));
 
             // Handle legacy urls
             handleEnvironmentUrls();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImplTest.java
@@ -212,6 +212,16 @@ class InstallationAccessQueryServiceImplTest {
     }
 
     @Test
+    void should_build_gamma_url_for_DEFAULT_organization_when_installation_is_not_multi_tenant() {
+        when(installationTypeDomainService.isMultiTenant()).thenReturn(false);
+        environment.withProperty("installation.standalone.gamma-console.url", "http://gamma.url");
+
+        cut.afterPropertiesSet();
+        assertThat(cut.getGammaUrl(DEFAULT_ORGANIZATION_ID)).isEqualTo("http://gamma.url");
+        assertThat(cut.getGammaUrls(DEFAULT_ORGANIZATION_ID)).containsOnly("http://gamma.url");
+    }
+
+    @Test
     void should_use_console_api_url_when_installation_is_not_multi_tenant_and_console_url_is_defined() {
         when(installationTypeDomainService.isMultiTenant()).thenReturn(false);
         setValue("consoleApiUrl", "http://console.api.url");
@@ -256,6 +266,21 @@ class InstallationAccessQueryServiceImplTest {
         assertThat(cut.getPortalUrls("envId")).containsOnly("http://envId.portal.url");
         assertThat(cut.getPortalUrl("envId1")).isEqualTo("http://envId1.portal.url");
         assertThat(cut.getPortalUrls("envId1")).containsOnly("http://envId1.portal.url");
+    }
+
+    @Test
+    void should_build_gamma_urls_when_installation_is_not_multi_tenant() {
+        when(installationTypeDomainService.isMultiTenant()).thenReturn(false);
+        environment.withProperty("installation.standalone.gamma-console.urls[0].orgId", "orgId");
+        environment.withProperty("installation.standalone.gamma-console.urls[0].url", "http://orgId.gamma.url");
+        environment.withProperty("installation.standalone.gamma-console.urls[1].orgId", "orgId1");
+        environment.withProperty("installation.standalone.gamma-console.urls[1].url", "http://orgId1.gamma.url");
+
+        cut.afterPropertiesSet();
+        assertThat(cut.getGammaUrl("orgId")).isEqualTo("http://orgId.gamma.url");
+        assertThat(cut.getGammaUrls("orgId")).containsOnly("http://orgId.gamma.url");
+        assertThat(cut.getGammaUrl("orgId1")).isEqualTo("http://orgId1.gamma.url");
+        assertThat(cut.getGammaUrls("orgId1")).containsOnly("http://orgId1.gamma.url");
     }
 
     @Test


### PR DESCRIPTION
 ## Summary

 In standalone mode, Gamma console URLs were loaded from the `installation.standalone.gamma.*` property keys, while the rest of the platform (access points, config schema) uses `gamma-console` as the canonical identifier for that
  UI. As a result, per-organization Gamma console URLs configured under `installation.standalone.gamma-console.*` were silently ignored and `getGammaUrl(...)` always fell back to the default `http://localhost:4200`, breaking
  redirection to the Gamma console.
  
 This PR aligns the standalone loader with the `gamma-console` naming so the configured URLs are picked up correctly.


https://github.com/user-attachments/assets/29df3e10-4156-460c-b951-67baaddad18b



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

