### PR TITLE
chore: bump up the gravitee reactor mcp proxy version to 3.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
     <gravitee-reactor-native-kafka.version>7.0.1</gravitee-reactor-native-kafka.version>
-    <gravitee-reactor-mcp-proxy.version>3.0.1</gravitee-reactor-mcp-proxy.version>
+    <gravitee-reactor-mcp-proxy.version>3.0.2</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>3.0.1</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.0.0</gravitee-reactor-a2a-proxy.version>
     <gravitee-reactor-authz.version>1.0.0</gravitee-reactor-authz.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-903

## Description

Bump up the MCP reactor to fix the well-known resource URL issue. 


