### PR TITLE
fix(GKO-3022): accept case-insensitive enum values in Automation API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/pom.xml
@@ -230,7 +230,7 @@
                     <typeMappings>
                         <typeMapping>BigDecimal=Number</typeMapping>
                     </typeMappings>
-                    <additionalProperties>removeEnumValuePrefix=false</additionalProperties>
+                    <additionalProperties>removeEnumValuePrefix=false,useEnumCaseInsensitive=true</additionalProperties>
                     <instantiationTypes>map=java.util.LinkedHashMap</instantiationTypes>
                 </configuration>
                 <executions>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApisResourceTest.java
@@ -41,6 +41,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ApisResourceTest extends AbstractResourceTest {
 
@@ -81,6 +83,20 @@ class ApisResourceTest extends AbstractResourceTest {
                 soft.assertThat(state.getId()).isEqualTo("api-id");
                 soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
                 soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
+                soft.assertThat(state.getHrid()).isEqualTo("api-hrid");
+            });
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = { false, true })
+        void should_accept_lowercase_enum_values(boolean dryRun) {
+            when(validateApiCRDDomainService.validateAndSanitize(any(ValidateApiCRDDomainService.Input.class))).thenAnswer(call ->
+                Validator.Result.ofValue(call.getArgument(0))
+            );
+
+            var state = expectEntity("api-with-lowercase-flow-mode.json", dryRun, false);
+
+            SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(state.getHrid()).isEqualTo("api-hrid");
             });
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/api-with-lowercase-flow-mode.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/api-with-lowercase-flow-mode.json
@@ -1,0 +1,83 @@
+{
+    "name": "api-v4-with-apikey",
+    "hrid": "api-hrid",
+    "description": "API v4 CRD spec with unknown categories",
+    "version": "1.0",
+    "type": "PROXY",
+    "categories": [],
+    "listeners": [
+        {
+            "type": "HTTP",
+            "paths": [
+                {
+                    "path": "/test-hrid"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy",
+                    "qos": "AUTO"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "Default HTTP proxy group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "Default HTTP proxy",
+                    "type": "http-proxy",
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "https://api.gravitee.io/echo"
+                    },
+                    "secondary": false
+                }
+            ]
+        }
+    ],
+    "flowExecution": {
+        "mode": "default",
+        "matchRequired": false
+    },
+    "state": "STARTED",
+    "lifecycleState": "PUBLISHED",
+    "visibility": "PUBLIC",
+    "flows": [],
+    "pages": [
+        {
+            "hrid": "default-page",
+            "name": "Default page",
+            "type": "MARKDOWN",
+            "content": "Default page content"
+        }
+    ],
+    "plans": [
+        {
+            "name": "Keyless plan",
+            "hrid": "KEY_LESS",
+            "description": "No authentication",
+            "type": "API",
+            "status": "PUBLISHED",
+            "validation": "AUTO",
+            "mode": "STANDARD",
+            "security": {
+                "type": "KEY_LESS"
+            },
+            "flows": [
+                {
+                    "enabled": true,
+                    "selectors": [
+                        {
+                            "type": "HTTP",
+                            "path": "/",
+                            "pathOperator": "STARTS_WITH"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-3022

## Summary

- Enable OpenAPI generator `useEnumCaseInsensitive` for the Automation REST module so all generated enum deserializers accept lowercase variants (e.g. `default`, `best_match`) in addition to the canonical uppercase values.
- Add a regression test covering the reported `flowExecution.mode: default` case on `PUT /automation/.../apis` for both normal and dry-run reconciliation paths.

## Test plan

- [x] `mvn -pl gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest -Dtest=ApisResourceTest -DskipITs test`
- [ ] Verify GKO reconciliation succeeds for an existing `ApiV4Definition` CR with lowercase `flowExecution.mode: default`