### PR TITLE
feat(rest-api): apply branded sender From/Subject at email send time

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenders.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenders.java
@@ -22,6 +22,8 @@ import io.gravitee.rest.api.model.parameters.Key;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.CustomLog;
 
 /**
@@ -32,7 +34,7 @@ import lombok.CustomLog;
  * @author GraviteeSource Team
  */
 @CustomLog
-final class BrandedSenders {
+public final class BrandedSenders {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -50,7 +52,7 @@ final class BrandedSenders {
      * break the whole settings response. Invalid input is rejected loudly on the write path instead
      * (see {@link #write(List)}).
      */
-    static List<BrandedSenderConfig> parse(String raw) {
+    public static List<BrandedSenderConfig> parse(String raw) {
         if (raw == null || raw.isBlank()) {
             return new ArrayList<>();
         }
@@ -63,6 +65,77 @@ final class BrandedSenders {
             log.error("Ignoring malformed '{}' configuration [{}]; returning an empty list", Key.EMAIL_BRANDED_SENDERS.key(), raw, e);
             return new ArrayList<>();
         }
+    }
+
+    /**
+     * Resolves the branded-sender configuration to apply for an outbound email by matching the recipient's
+     * domain (the part after {@code '@'}, compared case-insensitively) against each configuration's domains,
+     * returning the first match. Returns {@link Optional#empty()} when the stored value is blank/malformed,
+     * the recipient has no parseable domain, or no configuration matches — in which case the caller keeps the
+     * default {@code EMAIL_FROM} / {@code EMAIL_SUBJECT}. When more than one configuration lists the same
+     * domain, the first is used (the console UI rejects cross-configuration duplicates, but a hand-edited
+     * value could still contain them).
+     */
+    public static Optional<BrandedSenderConfig> resolve(String raw, String recipientEmail) {
+        return match(parse(raw), recipientEmail);
+    }
+
+    /**
+     * Matches an already-parsed configuration list against a recipient, so a caller sending to many recipients
+     * can {@link #parse(String)} once and match per recipient rather than re-deserialising the value each time.
+     * Same semantics as {@link #resolve(String, String)}.
+     */
+    public static Optional<BrandedSenderConfig> match(List<BrandedSenderConfig> configs, String recipientEmail) {
+        final String domain = extractDomain(recipientEmail);
+        if (domain == null) {
+            return Optional.empty();
+        }
+        return configs
+            .stream()
+            .filter(config -> matchesDomain(config, domain))
+            .findFirst();
+    }
+
+    private static boolean matchesDomain(BrandedSenderConfig config, String domain) {
+        if (config == null || config.getDomains() == null) {
+            return false;
+        }
+        return config.getDomains().stream().filter(Objects::nonNull).map(BrandedSenders::normalizeDomain).anyMatch(domain::equals);
+    }
+
+    /**
+     * Extracts the lower-cased domain from a recipient address, accepting both a bare address
+     * ({@code user@example.com}) and the personal-name form ({@code Name <user@example.com>}). Returns
+     * {@code null} when no domain can be extracted, or when the string is a multi-address list
+     * ({@code a@x.com, b@y.com}) — matching such a value on a single domain would brand every address for
+     * one tenant, so it falls through to the default sender instead.
+     */
+    private static String extractDomain(String recipientEmail) {
+        if (recipientEmail == null) {
+            return null;
+        }
+        final String trimmed = recipientEmail.trim();
+        // A single recipient carries exactly one '@'. Zero means there is no domain to match; more than one
+        // means the value is really an address list — either the bare form ("a@x.com, b@y.com") or the
+        // personal-name form ("Jane <jane@x.com>, John <john@y.com>"). Matching such a value on a single
+        // domain would brand every address for one tenant, so it falls through to the default sender instead.
+        // This count is taken on the whole value (before any bracket stripping) so a trailing "Name <addr>"
+        // pair cannot hide the earlier addresses from the check.
+        final int firstAt = trimmed.indexOf('@');
+        if (firstAt < 0 || firstAt != trimmed.lastIndexOf('@')) {
+            return null;
+        }
+        String address = trimmed;
+        final int lt = address.lastIndexOf('<');
+        final int gt = address.lastIndexOf('>');
+        if (lt >= 0 && gt > lt) {
+            address = address.substring(lt + 1, gt);
+        }
+        final int at = address.lastIndexOf('@');
+        if (at < 0 || at == address.length() - 1) {
+            return null;
+        }
+        return normalizeDomain(address.substring(at + 1));
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/EmailBrandedSendersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/EmailBrandedSendersTest.java
@@ -227,4 +227,135 @@ class EmailBrandedSendersTest {
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("null entries");
     }
+
+    @Test
+    void should_resolve_configuration_matching_recipient_domain() {
+        var config = BrandedSenderConfig.builder()
+            .domains(List.of("example.com"))
+            .from("noreply@example.com")
+            .subject("[Example] %s")
+            .build();
+        var raw = BrandedSenders.write(List.of(config));
+
+        assertThat(BrandedSenders.resolve(raw, "developer@example.com")).hasValueSatisfying(matched -> {
+            assertThat(matched.getFrom()).isEqualTo("noreply@example.com");
+            assertThat(matched.getSubject()).isEqualTo("[Example] %s");
+        });
+    }
+
+    @Test
+    void should_match_recipient_domain_case_insensitively() {
+        var raw = BrandedSenders.write(
+            List.of(BrandedSenderConfig.builder().domains(List.of("example.com")).from("noreply@example.com").build())
+        );
+
+        assertThat(BrandedSenders.resolve(raw, "Developer@EXAMPLE.COM")).hasValueSatisfying(matched ->
+            assertThat(matched.getFrom()).isEqualTo("noreply@example.com")
+        );
+    }
+
+    @Test
+    void should_return_empty_for_a_multi_address_recipient_string() {
+        var raw = BrandedSenders.write(
+            List.of(BrandedSenderConfig.builder().domains(List.of("example.org")).from("noreply@example.org").build())
+        );
+
+        // "a@example.com, b@example.org" must not brand both recipients for example.org's tenant.
+        assertThat(BrandedSenders.resolve(raw, "alice@example.com, bob@example.org")).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_for_a_multi_address_personal_name_recipient_string() {
+        var raw = BrandedSenders.write(
+            List.of(BrandedSenderConfig.builder().domains(List.of("example.org")).from("noreply@example.org").build())
+        );
+
+        // Comma-joined personal-name list where only the LAST address's domain (example.org) matches the
+        // config; it must not brand the whole recipient group by that trailing recipient's domain.
+        assertThat(BrandedSenders.resolve(raw, "Jane Developer <jane@example.com>, John Support <john@example.org>")).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_when_a_parsed_configuration_has_null_domains() {
+        // A hand-edited / legacy stored value can omit the "domains" key entirely; parse() does not run
+        // write()'s validation, so such a config reaches the match path with a null domains list. It must be
+        // skipped (never NPE) rather than matched.
+        assertThat(BrandedSenders.resolve("[{\"from\":\"noreply@example.com\"}]", "developer@example.com")).isEmpty();
+    }
+
+    @Test
+    void should_resolve_from_a_personal_name_recipient() {
+        var raw = BrandedSenders.write(
+            List.of(BrandedSenderConfig.builder().domains(List.of("example.com")).from("noreply@example.com").build())
+        );
+
+        assertThat(BrandedSenders.resolve(raw, "Jane Developer <jane@example.com>")).hasValueSatisfying(matched ->
+            assertThat(matched.getFrom()).isEqualTo("noreply@example.com")
+        );
+    }
+
+    @Test
+    void should_return_empty_when_no_configuration_matches_the_recipient_domain() {
+        var raw = BrandedSenders.write(
+            List.of(BrandedSenderConfig.builder().domains(List.of("example.com")).from("noreply@example.com").build())
+        );
+
+        assertThat(BrandedSenders.resolve(raw, "developer@example.org")).isEmpty();
+    }
+
+    @Test
+    void should_return_the_first_configuration_when_several_list_the_same_domain() {
+        var raw = BrandedSenders.write(
+            List.of(
+                BrandedSenderConfig.builder().domains(List.of("example.com")).from("first@example.com").build(),
+                BrandedSenderConfig.builder().domains(List.of("example.com")).from("second@example.com").build()
+            )
+        );
+
+        assertThat(BrandedSenders.resolve(raw, "developer@example.com")).hasValueSatisfying(matched ->
+            assertThat(matched.getFrom()).isEqualTo("first@example.com")
+        );
+    }
+
+    @Test
+    void should_return_empty_for_a_blank_or_malformed_value() {
+        assertThat(BrandedSenders.resolve(null, "developer@example.com")).isEmpty();
+        assertThat(BrandedSenders.resolve("   ", "developer@example.com")).isEmpty();
+        assertThat(BrandedSenders.resolve("not-json", "developer@example.com")).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_when_the_recipient_has_no_domain() {
+        var raw = BrandedSenders.write(
+            List.of(BrandedSenderConfig.builder().domains(List.of("example.com")).from("noreply@example.com").build())
+        );
+
+        assertThat(BrandedSenders.resolve(raw, null)).isEmpty();
+        assertThat(BrandedSenders.resolve(raw, "not-an-email")).isEmpty();
+    }
+
+    @Test
+    void should_accept_a_subject_prefix_with_a_literal_percent_on_write() {
+        var email = new Email();
+        // The subject is substituted literally at send time (not String.format), so a stray '%' is safe to store.
+        var config = BrandedSenderConfig.builder()
+            .domains(List.of("example.com"))
+            .from("noreply@example.com")
+            .subject("100% off %s")
+            .build();
+
+        email.setBrandedSenders(List.of(config));
+
+        assertThat(email.getBrandedSenders().get(0).getSubject()).isEqualTo("100% off %s");
+    }
+
+    @Test
+    void should_accept_a_subject_prefix_without_a_placeholder_on_write() {
+        var email = new Email();
+        var config = BrandedSenderConfig.builder().domains(List.of("example.com")).from("noreply@example.com").subject("[Example]").build();
+
+        email.setBrandedSenders(List.of(config));
+
+        assertThat(email.getBrandedSenders().get(0).getSubject()).isEqualTo("[Example]");
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EmailServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EmailServiceImpl.java
@@ -15,15 +15,16 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static io.gravitee.rest.api.model.parameters.Key.EMAIL_BRANDED_SENDERS;
 import static io.gravitee.rest.api.model.parameters.Key.EMAIL_ENABLED;
 import static io.gravitee.rest.api.model.parameters.Key.EMAIL_FROM;
 import static io.gravitee.rest.api.model.parameters.Key.EMAIL_SUBJECT;
-import static java.lang.String.format;
-import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.model.settings.BrandedSenderConfig;
+import io.gravitee.rest.api.model.settings.BrandedSenders;
 import io.gravitee.rest.api.service.EmailNotification;
 import io.gravitee.rest.api.service.EmailService;
 import io.gravitee.rest.api.service.ParameterService;
@@ -38,10 +39,13 @@ import jakarta.mail.internet.InternetAddress;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -67,6 +71,8 @@ import org.springframework.stereotype.Component;
 public class EmailServiceImpl extends TransactionalService implements EmailService {
 
     private static final Duration REGEX_TIMEOUT = Duration.ofSeconds(2);
+    private static final String SUBJECT_PLACEHOLDER = "%s";
+    private static final String POSITIONAL_SUBJECT_PLACEHOLDER = "%1$s";
 
     private final GraviteeJavaMailManager mailManager;
     private final NotificationTemplateService notificationTemplateService;
@@ -118,11 +124,6 @@ public class EmailServiceImpl extends TransactionalService implements EmailServi
         if (Boolean.parseBoolean(mailParameters.get(EMAIL_ENABLED)) && emailNotification.hasRecipients()) {
             try {
                 JavaMailSender mailSender = mailManager.getOrCreateMailSender(executionContext, referenceId, referenceType);
-                final MimeMessageHelper mailMessage = new MimeMessageHelper(
-                    mailSender.createMimeMessage(),
-                    true,
-                    StandardCharsets.UTF_8.name()
-                );
 
                 String emailSubject = notificationTemplateService.resolveTemplateWithParam(
                     executionContext.getOrganizationId(),
@@ -136,53 +137,15 @@ public class EmailServiceImpl extends TransactionalService implements EmailServi
                 );
                 content = content.replaceAll("&lt;br /&gt;", "<br />");
 
-                final String from = isNull(emailNotification.getFrom()) || emailNotification.getFrom().isEmpty()
-                    ? mailParameters.get(EMAIL_FROM)
-                    : emailNotification.getFrom();
-
-                InternetAddress configuredFrom = new InternetAddress(from);
-                if (isEmpty(configuredFrom.getPersonal())) {
-                    if (isEmpty(emailNotification.getFromName())) {
-                        mailMessage.setFrom(from);
-                    } else {
-                        mailMessage.setFrom(from, emailNotification.getFromName());
-                    }
-                } else {
-                    mailMessage.setFrom(configuredFrom);
+                // Group every recipient (to + bcc + copyToSender) by the branded sender its domain resolves to,
+                // then send one message per (From, Subject) group, so recipients on different branded domains each
+                // get their own sender identity. The common case — no configuration, or all recipients resolving to
+                // the same sender — yields a single group, i.e. a single message identical to before.
+                // Per-group send fault-isolation and idempotency (best-effort vs all-or-nothing, retry, per-group
+                // logging) are deferred to APIM-14632 (F2) to keep this PR scoped; this keeps today's fail-fast.
+                for (RecipientGroup group : buildRecipientGroups(emailNotification, mailParameters)) {
+                    sendGroupedMessage(mailSender, emailNotification, emailSubject, content, group);
                 }
-
-                String sender = emailNotification.getFrom();
-                if (!isEmpty(emailNotification.getReplyTo())) {
-                    mailMessage.setReplyTo(emailNotification.getReplyTo());
-                    sender = emailNotification.getReplyTo();
-                }
-
-                if (Arrays.equals(DEFAULT_MAIL_TO, emailNotification.getTo())) {
-                    mailMessage.setTo(mailParameters.get(Key.EMAIL_FROM));
-                } else if (emailNotification.getTo() != null && emailNotification.getTo().length > 0) {
-                    mailMessage.setTo(emailNotification.getTo());
-                }
-
-                if (emailNotification.getBcc() != null && emailNotification.getBcc().length > 0) {
-                    mailMessage.setBcc(emailNotification.getBcc());
-                }
-
-                if (emailNotification.isCopyToSender() && sender != null) {
-                    mailMessage.addBcc(sender);
-                }
-
-                mailMessage.setSubject(format(mailParameters.get(EMAIL_SUBJECT), emailSubject));
-
-                final String html = addResourcesInMessage(mailMessage, content);
-
-                log.debug(
-                    "Sending an email to {} recipient(s)\nSubject: {}\nMessage: {}",
-                    emailNotification.recipientsCount(),
-                    emailSubject,
-                    html
-                );
-
-                mailSender.send(mailMessage.getMimeMessage());
             } catch (final Exception ex) {
                 throw new TechnicalManagementException("Error while sending email notification", ex);
             }
@@ -248,13 +211,211 @@ public class EmailServiceImpl extends TransactionalService implements EmailServi
         return matcher.group(1).toLowerCase();
     }
 
+    private void sendGroupedMessage(
+        JavaMailSender mailSender,
+        EmailNotification emailNotification,
+        String emailSubject,
+        String content,
+        RecipientGroup group
+    ) throws Exception {
+        final MimeMessageHelper mailMessage = new MimeMessageHelper(mailSender.createMimeMessage(), true, StandardCharsets.UTF_8.name());
+
+        final InternetAddress configuredFrom = new InternetAddress(group.from());
+        if (isEmpty(configuredFrom.getPersonal())) {
+            if (isEmpty(emailNotification.getFromName())) {
+                mailMessage.setFrom(group.from());
+            } else {
+                mailMessage.setFrom(group.from(), emailNotification.getFromName());
+            }
+        } else {
+            mailMessage.setFrom(configuredFrom);
+        }
+
+        if (!isEmpty(emailNotification.getReplyTo())) {
+            mailMessage.setReplyTo(emailNotification.getReplyTo());
+        }
+        if (!group.to().isEmpty()) {
+            mailMessage.setTo(group.to().toArray(new String[0]));
+        }
+        if (!group.bcc().isEmpty()) {
+            mailMessage.setBcc(group.bcc().toArray(new String[0]));
+        }
+
+        mailMessage.setSubject(applySubject(group.subjectTemplate(), emailSubject));
+
+        final String html = addResourcesInMessage(mailMessage, content);
+
+        log.debug("Sending an email to {} recipient(s)\nSubject: {}\nMessage: {}", group.recipientCount(), emailSubject, html);
+
+        mailSender.send(mailMessage.getMimeMessage());
+    }
+
+    /**
+     * Splits the recipients into groups that share the same resolved {@code (From, Subject)}. Each recipient's
+     * domain (from {@code to}, {@code bcc}, and — when {@code copyToSender} is set — the reply-to/sender) is
+     * matched against the branded-sender configuration; a match yields that config's {@code from} / {@code subject},
+     * otherwise the default {@code EMAIL_FROM} / {@code EMAIL_SUBJECT}.
+     *
+     * <p>An explicit caller-provided {@code From} is a deliberate override and keeps today's single, unbranded
+     * message. The publisher broadcast ({@link EmailService#DEFAULT_MAIL_TO}) is <em>not</em> exempt: its real
+     * recipients live in {@code bcc} and are branded like any other, while the sentinel {@code to} is replaced
+     * with the placeholder {@code EMAIL_FROM} address on the default-identity message (as before) so the
+     * no-configuration case stays byte-identical to today.</p>
+     */
+    private List<RecipientGroup> buildRecipientGroups(EmailNotification emailNotification, Map<Key, String> mailParameters) {
+        final String defaultFrom = mailParameters.get(EMAIL_FROM);
+        final String defaultSubject = mailParameters.get(EMAIL_SUBJECT);
+
+        // copyToSender copies the reply-to (or, failing that, the explicit from) to the sender.
+        String sender = emailNotification.getFrom();
+        if (!isEmpty(emailNotification.getReplyTo())) {
+            sender = emailNotification.getReplyTo();
+        }
+        final boolean copyToSender = emailNotification.isCopyToSender() && sender != null;
+        final List<String> bcc = new ArrayList<>();
+        if (emailNotification.getBcc() != null) {
+            bcc.addAll(Arrays.asList(emailNotification.getBcc()));
+        }
+
+        final boolean selfSend = Arrays.equals(DEFAULT_MAIL_TO, emailNotification.getTo());
+
+        // An explicit caller-provided From is a deliberate override: keep today's single, unbranded message.
+        if (!isEmpty(emailNotification.getFrom())) {
+            return List.of(explicitFromGroup(emailNotification, defaultFrom, defaultSubject, sender, copyToSender, selfSend, bcc));
+        }
+
+        // Branding path: parse the configuration once, then match each recipient against the parsed list.
+        final List<BrandedSenderConfig> configurations = BrandedSenders.parse(mailParameters.get(EMAIL_BRANDED_SENDERS));
+        final Map<GroupKey, RecipientGroup> groups = new LinkedHashMap<>();
+        // On a self-send the "to" is the DEFAULT_MAIL_TO sentinel, not real addresses, so it is not matched;
+        // the placeholder recipient is added to the default-identity group at the end.
+        if (!selfSend && emailNotification.getTo() != null) {
+            for (String recipient : emailNotification.getTo()) {
+                groupRecipient(groups, configurations, recipient, true, defaultFrom, defaultSubject);
+            }
+        }
+        for (String recipient : bcc) {
+            groupRecipient(groups, configurations, recipient, false, defaultFrom, defaultSubject);
+        }
+        // The sender's own copy uses the default identity rather than being branded by the sender's domain,
+        // which could otherwise differ from what the recipients received.
+        if (copyToSender) {
+            defaultGroup(groups, defaultFrom, defaultSubject).bcc().add(sender);
+        }
+        if (selfSend) {
+            addSelfSendPlaceholderRecipient(groups, defaultFrom, defaultSubject);
+        }
+        return new ArrayList<>(groups.values());
+    }
+
+    /**
+     * Builds the single, unbranded group used when the caller supplies an explicit {@code From} (a deliberate
+     * override). A self-send keeps its {@code EMAIL_FROM} placeholder recipient; {@code copyToSender} adds the
+     * sender to the {@code bcc}.
+     */
+    private RecipientGroup explicitFromGroup(
+        EmailNotification emailNotification,
+        String defaultFrom,
+        String defaultSubject,
+        String sender,
+        boolean copyToSender,
+        boolean selfSend,
+        List<String> bcc
+    ) {
+        final List<String> to = new ArrayList<>();
+        if (selfSend) {
+            to.add(defaultFrom);
+        } else if (emailNotification.getTo() != null) {
+            to.addAll(Arrays.asList(emailNotification.getTo()));
+        }
+        if (copyToSender) {
+            bcc.add(sender);
+        }
+        return new RecipientGroup(emailNotification.getFrom(), defaultSubject, to, bcc);
+    }
+
+    /**
+     * Restores today's placeholder {@code "To: <default from>"} on a self-send (publisher broadcast). It is
+     * attached to the default-identity group only when one already exists (or no branded group does), so that
+     * when every recipient resolved to a brand we do not emit a spurious message addressed only to ourselves.
+     */
+    private void addSelfSendPlaceholderRecipient(Map<GroupKey, RecipientGroup> groups, String defaultFrom, String defaultSubject) {
+        if (groups.isEmpty()) {
+            defaultGroup(groups, defaultFrom, defaultSubject);
+        }
+        final RecipientGroup defaultGroup = groups.get(new GroupKey(defaultFrom, defaultSubject));
+        if (defaultGroup != null) {
+            defaultGroup.to().add(defaultFrom);
+        }
+    }
+
+    private void groupRecipient(
+        Map<GroupKey, RecipientGroup> groups,
+        List<BrandedSenderConfig> configurations,
+        String recipient,
+        boolean isTo,
+        String defaultFrom,
+        String defaultSubject
+    ) {
+        final Optional<BrandedSenderConfig> branded = BrandedSenders.match(configurations, recipient);
+        // Optional.map already drops a null from/subject, so the filtered value is non-null here.
+        final String from = branded
+            .map(BrandedSenderConfig::getFrom)
+            .filter(value -> !value.isBlank())
+            .orElse(defaultFrom);
+        final String subject = branded
+            .map(BrandedSenderConfig::getSubject)
+            .filter(value -> !value.isBlank())
+            .orElse(defaultSubject);
+        final RecipientGroup group = groups.computeIfAbsent(new GroupKey(from, subject), key ->
+            new RecipientGroup(from, subject, new ArrayList<>(), new ArrayList<>())
+        );
+        if (isTo) {
+            group.to().add(recipient);
+        } else {
+            group.bcc().add(recipient);
+        }
+    }
+
+    private RecipientGroup defaultGroup(Map<GroupKey, RecipientGroup> groups, String defaultFrom, String defaultSubject) {
+        return groups.computeIfAbsent(new GroupKey(defaultFrom, defaultSubject), key ->
+            new RecipientGroup(defaultFrom, defaultSubject, new ArrayList<>(), new ArrayList<>())
+        );
+    }
+
+    /**
+     * Applies the subject template to the resolved email title by substituting the {@code "%s"} placeholder — and
+     * the positional {@code "%1$s"} form that a pre-existing {@code EMAIL_SUBJECT} may use, which {@link String#format}
+     * used to honour before this substitution replaced it.
+     * Deliberately not {@link String#format}: the template is admin-controlled (via {@code EMAIL_SUBJECT}) or
+     * branded-config text, so a stray {@code '%'}, a width specifier, or {@code %n} must be treated as literal text
+     * rather than a format directive that could throw, allocate, or inject a newline into the Subject header.
+     */
+    private static String applySubject(String template, String title) {
+        // The two placeholders are disjoint substrings, so replacing them independently (positional first) is safe.
+        return template.replace(POSITIONAL_SUBJECT_PLACEHOLDER, title).replace(SUBJECT_PLACEHOLDER, title);
+    }
+
+    private record GroupKey(String from, String subjectTemplate) {}
+
+    private record RecipientGroup(String from, String subjectTemplate, List<String> to, List<String> bcc) {
+        int recipientCount() {
+            return to.size() + bcc.size();
+        }
+    }
+
     private Map<Key, String> getMailSenderConfiguration(
         ExecutionContext executionContext,
         String referenceId,
         ParameterReferenceType referenceType
     ) {
         return parameterService
-            .findAll(Arrays.asList(EMAIL_ENABLED, EMAIL_SUBJECT, EMAIL_FROM), referenceId, referenceType, executionContext)
+            .findAll(
+                Arrays.asList(EMAIL_ENABLED, EMAIL_SUBJECT, EMAIL_FROM, EMAIL_BRANDED_SENDERS),
+                referenceId,
+                referenceType,
+                executionContext
+            )
             .entrySet()
             .stream()
             .collect(Collectors.toMap(e -> Key.findByKey(e.getKey()), e -> e.getValue().isEmpty() ? "" : e.getValue().get(0)));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EmailServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EmailServiceTest.java
@@ -16,22 +16,27 @@
 package io.gravitee.rest.api.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.EmailService;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.NotificationTemplateService;
 import io.gravitee.rest.api.service.spring.GraviteeJavaMailManager;
 import jakarta.activation.DataSource;
@@ -254,6 +259,511 @@ public class EmailServiceTest {
         service.sendEmailNotification(EXECUTION_CONTEXT, anEmailNotification().to().bcc().build());
 
         verify(mailSender, never()).send(any(MimeMessage.class));
+    }
+
+    @Test
+    public void should_wrap_a_send_time_failure_in_a_technical_management_exception() throws Exception {
+        // A failure at send time (e.g. the SMTP transport throwing) must surface as a
+        // TechnicalManagementException, not be swallowed — otherwise a failed delivery would pass silently.
+        stubTemplateResolution("Test email title");
+        doThrow(new RuntimeException("SMTP down")).when(mailSender).send(any(MimeMessage.class));
+
+        assertThatThrownBy(() -> service.sendEmailNotification(EXECUTION_CONTEXT, anEmailNotification().build()))
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessageContaining("Error while sending email notification");
+    }
+
+    @Test
+    public void should_apply_branded_sender_when_recipient_domain_matches() throws Exception {
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Test email title");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).to("developer@example.com").build()
+        );
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getFrom()).isEqualTo("noreply@example.com");
+        assertThat(parsed.getSubject()).isEqualTo("[Example] Test email title");
+    }
+
+    @Test
+    public void should_keep_the_default_sender_when_no_branded_configuration_matches() throws Exception {
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Test email title");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).to("developer@example.org").build()
+        );
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getFrom()).isEqualTo("default@gravitee.io");
+        assertThat(parsed.getSubject()).isEqualTo("[Gravitee.io] Test email title");
+    }
+
+    @Test
+    public void should_not_brand_when_an_explicit_from_is_provided() throws Exception {
+        // An explicit caller-provided From is a deliberate override; branding (From and Subject) is skipped so
+        // these paths stay identical to today.
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Test email title");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).from("explicit@gravitee.io").to("developer@example.com").build()
+        );
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getFrom()).isEqualTo("explicit@gravitee.io");
+        assertThat(parsed.getSubject()).isEqualTo("[Gravitee.io] Test email title");
+    }
+
+    @Test
+    public void should_send_one_message_per_group_when_recipients_resolve_to_different_configs() throws Exception {
+        stubMailParameters(
+            "[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}," +
+                "{\"domains\":[\"example.org\"],\"from\":\"noreply@example.org\",\"subject\":\"[Partner] %s\"}]"
+        );
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com", "bob@example.org").build()
+        );
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender, times(2)).send(captor.capture());
+
+        assertThat(captor.getAllValues())
+            .extracting(this::parse)
+            .extracting(EmailServiceTest::from, EmailServiceTest::subject, EmailServiceTest::recipients)
+            .containsExactlyInAnyOrder(
+                tuple("noreply@example.com", "[Example] Approved", List.of("alice@example.com")),
+                tuple("noreply@example.org", "[Partner] Approved", List.of("bob@example.org"))
+            );
+    }
+
+    @Test
+    public void should_brand_a_multi_recipient_notification_delivered_over_bcc() throws Exception {
+        // EmailNotifierServiceImpl routes 2+ recipients to BCC with an empty "to"; branding must still apply.
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).bcc("alice@example.com", "carol@example.com").build()
+        );
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getFrom()).isEqualTo("noreply@example.com");
+        assertThat(parsed.getSubject()).isEqualTo("[Example] Approved");
+        assertThat(parsed.getBcc()).containsExactly(new InternetAddress("alice@example.com"), new InternetAddress("carol@example.com"));
+    }
+
+    @Test
+    public void should_send_a_single_message_when_all_recipients_resolve_to_the_same_config() throws Exception {
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com", "bob@example.com").build()
+        );
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getFrom()).isEqualTo("noreply@example.com");
+        assertThat(parsed.getSubject()).isEqualTo("[Example] Approved");
+        assertThat(parsed.getTo()).containsExactly(new InternetAddress("alice@example.com"), new InternetAddress("bob@example.com"));
+    }
+
+    @Test
+    public void should_send_a_single_default_message_when_no_branded_configuration_is_set() throws Exception {
+        // Backwards-compat common case: no email.branded_senders at all -> one default, unbranded message.
+        when(parameterService.findAll(anyList(), anyString(), any(ParameterReferenceType.class), any(ExecutionContext.class))).thenReturn(
+            Map.of(
+                "email.enabled",
+                List.of("true"),
+                "email.subject",
+                List.of("[Gravitee.io] %s"),
+                "email.from",
+                List.of("default@gravitee.io")
+            )
+        );
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com", "bob@example.org").build()
+        );
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getFrom()).isEqualTo("default@gravitee.io");
+        assertThat(parsed.getSubject()).isEqualTo("[Gravitee.io] Approved");
+    }
+
+    @Test
+    public void should_use_the_default_subject_when_a_matching_config_has_a_blank_subject() throws Exception {
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(EXECUTION_CONTEXT, new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com").build());
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getFrom()).isEqualTo("noreply@example.com");
+        assertThat(parsed.getSubject()).isEqualTo("[Gravitee.io] Approved");
+    }
+
+    @Test
+    public void should_use_the_default_from_when_a_matching_config_has_a_blank_from() throws Exception {
+        // A matched config with a blank From falls back to the default From but keeps its branded subject.
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(EXECUTION_CONTEXT, new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com").build());
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getFrom()).isEqualTo("default@gravitee.io");
+        assertThat(parsed.getSubject()).isEqualTo("[Example] Approved");
+    }
+
+    @Test
+    public void should_group_across_to_and_bcc_by_brand_without_leaking_recipients() throws Exception {
+        // A To recipient on brand A and a Bcc recipient on brand B must not end up in the same message.
+        stubMailParameters(
+            "[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}," +
+                "{\"domains\":[\"example.org\"],\"from\":\"noreply@example.org\",\"subject\":\"[Partner] %s\"}]"
+        );
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com").bcc("bob@example.org").build()
+        );
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender, times(2)).send(captor.capture());
+
+        // Each tuple is (From, To, Bcc). The example.org group is Bcc-only, so it has no To header — a missing
+        // To for Bcc-only messages is intentional (matches the pre-existing all-Bcc notification behaviour).
+        assertThat(captor.getAllValues())
+            .extracting(this::parse)
+            .extracting(EmailServiceTest::from, EmailServiceTest::recipients, EmailServiceTest::bccRecipients)
+            .containsExactlyInAnyOrder(
+                tuple("noreply@example.com", List.of("alice@example.com"), List.of()),
+                tuple("noreply@example.org", List.of(), List.of("bob@example.org"))
+            );
+    }
+
+    @Test
+    public void should_not_brand_a_self_send() throws Exception {
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).to(EmailService.DEFAULT_MAIL_TO).build()
+        );
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getFrom()).isEqualTo("default@gravitee.io");
+        assertThat(parsed.getTo()).containsExactly(new InternetAddress("default@gravitee.io"));
+        assertThat(parsed.getSubject()).isEqualTo("[Gravitee.io] Approved");
+    }
+
+    @Test
+    public void should_send_the_copy_to_sender_with_the_default_identity_not_a_brand() throws Exception {
+        // The recipient (alice@example.com) is branded; the sender's copy (bob@example.com) must not inherit that
+        // brand — it goes out as a separate default-identity message.
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com").replyTo("bob@example.com").copyToSender(true).build()
+        );
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender, times(2)).send(captor.capture());
+
+        // The branded message goes To alice with the brand From; the sender copy is Bcc bob with the default From
+        // (and no To header — intentional for this Bcc-only copy, matching the pre-existing all-Bcc behaviour).
+        assertThat(captor.getAllValues())
+            .extracting(this::parse)
+            .extracting(EmailServiceTest::from, EmailServiceTest::recipients, EmailServiceTest::bccRecipients)
+            .containsExactlyInAnyOrder(
+                tuple("noreply@example.com", List.of("alice@example.com"), List.of()),
+                tuple("default@gravitee.io", List.of(), List.of("bob@example.com"))
+            );
+    }
+
+    @Test
+    public void should_honour_a_branded_from_with_a_display_name() throws Exception {
+        stubMailParameters(
+            "[{\"domains\":[\"example.com\"],\"from\":\"Example Team <noreply@example.com>\",\"subject\":\"[Example] %s\"}]"
+        );
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(EXECUTION_CONTEXT, new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com").build());
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        InternetAddress from = (InternetAddress) captor.getValue().getFrom()[0];
+        assertThat(from.getAddress()).isEqualTo("noreply@example.com");
+        assertThat(from.getPersonal()).isEqualTo("Example Team");
+    }
+
+    @Test
+    public void should_treat_a_percent_in_the_subject_as_literal_text() throws Exception {
+        // Subject is substituted literally (not String.format): a stray '%' must neither throw nor be interpreted.
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"100% off %s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(EXECUTION_CONTEXT, new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com").build());
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getFrom()).isEqualTo("noreply@example.com");
+        assertThat(parsed.getSubject()).isEqualTo("100% off Approved");
+    }
+
+    @Test
+    public void should_not_expand_a_percent_n_in_the_subject_into_a_newline() throws Exception {
+        // %n must stay literal — String.format would expand it to a platform newline, injecting into the header.
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example]%n %s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(EXECUTION_CONTEXT, new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com").build());
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getSubject()).isEqualTo("[Example]%n Approved").doesNotContain("\n").doesNotContain("\r");
+    }
+
+    @Test
+    public void should_apply_the_notification_from_name_over_a_branded_bare_from() throws Exception {
+        // A branded From with no display name, combined with a caller-supplied fromName, must stamp that name
+        // onto the branded address (the setFrom(from, fromName) branch of sendGroupedMessage).
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com").fromName("Gravitee Team").build()
+        );
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        InternetAddress from = (InternetAddress) captor.getValue().getFrom()[0];
+        assertThat(from.getAddress()).isEqualTo("noreply@example.com");
+        assertThat(from.getPersonal()).isEqualTo("Gravitee Team");
+    }
+
+    @Test
+    public void should_set_the_reply_to_header_on_a_branded_message() throws Exception {
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com").replyTo("support@example.com").build()
+        );
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        assertThat(captor.getValue().getReplyTo()).containsExactly(new InternetAddress("support@example.com"));
+    }
+
+    @Test
+    public void should_brand_bcc_subscribers_of_a_publisher_broadcast() throws Exception {
+        // MessageServiceImpl broadcasts publisher->subscribers with to(DEFAULT_MAIL_TO).bcc(subscribers); those
+        // Bcc subscribers are real external recipients and must be branded by domain, not sent unbranded.
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder()
+                .template(TEMPLATE)
+                .to(EmailService.DEFAULT_MAIL_TO)
+                .bcc("alice@example.com", "bob@example.org")
+                .build()
+        );
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender, times(2)).send(captor.capture());
+
+        // alice@example.com -> branded group, Bcc-only (no To). bob@example.org -> default group, which also
+        // carries the placeholder "To: <default from>" that stands in for the DEFAULT_MAIL_TO sentinel.
+        assertThat(captor.getAllValues())
+            .extracting(this::parse)
+            .extracting(EmailServiceTest::from, EmailServiceTest::recipients, EmailServiceTest::bccRecipients)
+            .containsExactlyInAnyOrder(
+                tuple("noreply@example.com", List.of(), List.of("alice@example.com")),
+                tuple("default@gravitee.io", List.of("default@gravitee.io"), List.of("bob@example.org"))
+            );
+    }
+
+    @Test
+    public void should_send_a_single_unbranded_broadcast_when_no_configuration_is_set() throws Exception {
+        // Backwards-compat: a DEFAULT_MAIL_TO broadcast with no branded config stays one message — To the
+        // placeholder default-from address, all subscribers in Bcc — identical to before this feature.
+        when(parameterService.findAll(anyList(), anyString(), any(ParameterReferenceType.class), any(ExecutionContext.class))).thenReturn(
+            Map.of(
+                "email.enabled",
+                List.of("true"),
+                "email.subject",
+                List.of("[Gravitee.io] %s"),
+                "email.from",
+                List.of("default@gravitee.io")
+            )
+        );
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder()
+                .template(TEMPLATE)
+                .to(EmailService.DEFAULT_MAIL_TO)
+                .bcc("alice@example.com", "bob@example.org")
+                .build()
+        );
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getFrom()).isEqualTo("default@gravitee.io");
+        assertThat(parsed.getSubject()).isEqualTo("[Gravitee.io] Approved");
+        assertThat(parsed.getTo()).containsExactly(new InternetAddress("default@gravitee.io"));
+        assertThat(parsed.getBcc()).containsExactly(new InternetAddress("alice@example.com"), new InternetAddress("bob@example.org"));
+    }
+
+    @Test
+    public void should_substitute_a_positional_placeholder_in_the_subject() throws Exception {
+        // A pre-existing subject template using the positional %1$s form (previously handled by String.format)
+        // must still receive the title rather than shipping the literal placeholder.
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Acme] %1$s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(EXECUTION_CONTEXT, new EmailNotificationBuilder().template(TEMPLATE).to("alice@example.com").build());
+
+        MimeMessageParser parsed = captureSentMessage();
+        assertThat(parsed.getSubject()).isEqualTo("[Acme] Approved");
+    }
+
+    @Test
+    public void should_not_emit_a_placeholder_only_default_message_when_every_broadcast_recipient_is_branded() throws Exception {
+        // DEFAULT_MAIL_TO broadcast where every subscriber resolves to the same brand -> exactly one branded,
+        // Bcc-only message; the placeholder default self-send must be suppressed (no spurious second message).
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder()
+                .template(TEMPLATE)
+                .to(EmailService.DEFAULT_MAIL_TO)
+                .bcc("alice@example.com", "carol@example.com")
+                .build()
+        );
+
+        MimeMessageParser parsed = captureSentMessage(); // captureSentMessage verifies exactly one send happened
+        assertThat(parsed.getFrom()).isEqualTo("noreply@example.com");
+        assertThat(parsed.getTo()).isEmpty();
+        assertThat(parsed.getBcc()).containsExactly(new InternetAddress("alice@example.com"), new InternetAddress("carol@example.com"));
+    }
+
+    @Test
+    public void should_merge_the_copy_to_sender_into_an_existing_default_group() throws Exception {
+        // The recipient resolves to the default identity and the sender copy joins that SAME default group, so a
+        // single default-identity message carries both (as opposed to the split case covered above).
+        stubMailParameters("[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+        stubTemplateResolution("Approved");
+
+        service.sendEmailNotification(
+            EXECUTION_CONTEXT,
+            new EmailNotificationBuilder().template(TEMPLATE).to("dave@example.org").replyTo("boss@example.org").copyToSender(true).build()
+        );
+
+        MimeMessageParser parsed = captureSentMessage(); // exactly one message
+        assertThat(parsed.getFrom()).isEqualTo("default@gravitee.io");
+        assertThat(parsed.getTo()).containsExactly(new InternetAddress("dave@example.org"));
+        assertThat(parsed.getBcc()).containsExactly(new InternetAddress("boss@example.org"));
+    }
+
+    private void stubMailParameters(String brandedSendersJson) {
+        when(parameterService.findAll(anyList(), anyString(), any(ParameterReferenceType.class), any(ExecutionContext.class))).thenReturn(
+            Map.of(
+                "email.enabled",
+                List.of("true"),
+                "email.subject",
+                List.of("[Gravitee.io] %s"),
+                "email.from",
+                List.of("default@gravitee.io"),
+                "email.branded_senders",
+                List.of(brandedSendersJson)
+            )
+        );
+    }
+
+    private MimeMessageParser parse(MimeMessage message) {
+        try {
+            return new MimeMessageParser(message).parse();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String from(MimeMessageParser parser) {
+        try {
+            return parser.getFrom();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String subject(MimeMessageParser parser) {
+        try {
+            return parser.getSubject();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static List<String> recipients(MimeMessageParser parser) {
+        try {
+            return parser.getTo().stream().map(Object::toString).toList();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static List<String> bccRecipients(MimeMessageParser parser) {
+        try {
+            return parser.getBcc().stream().map(Object::toString).toList();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void stubTemplateResolution(String title) {
+        when(
+            notificationTemplateService.resolveTemplateWithParam(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq("API.API_STARTED.EMAIL.TITLE"),
+                anyMap()
+            )
+        ).thenReturn(title);
+        when(
+            notificationTemplateService.resolveTemplateWithParam(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq("API.API_STARTED.EMAIL"),
+                anyMap()
+            )
+        ).thenReturn("<html><body>Hello</body></html>");
+    }
+
+    private MimeMessageParser captureSentMessage() throws Exception {
+        ArgumentCaptor<MimeMessage> mimeMessageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(mimeMessageCaptor.capture());
+        return new MimeMessageParser(mimeMessageCaptor.getValue()).parse();
     }
 
     @NotNull


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14184
## Description

What
Implements S2 of the branded-sender epic (APIM-14125): outbound subscription/notification emails use a per-tenant branded From/Subject when a recipient's domain matches a configured rule, falling back to the default EMAIL_FROM/EMAIL_SUBJECT otherwise. This is the runtime behavior that makes the S1 data model + S3/S4 config UI take effect.

How
- BrandedSenders.resolve(rawParamValue, recipientEmail) (model) — parses the stored email.branded_senders config, extracts the recipient domain (handles bare user@x.com and Name <user@x.com>), and returns the first domain-matching config (case-insensitive, whitespace-tolerant).
- EmailServiceImpl — reads EMAIL_BRANDED_SENDERS alongside the other mail params and, per the ticket's multi-recipient AC (option a), groups every recipient (to + bcc + copyToSender) by its resolved (From, Subject) and sends one MimeMessage per group.

Behavior / decisions
- Per-recipient grouping — recipients on different branded domains each get their own sender identity in separate SMTP sends. The common case (no config, or all recipients resolving to the same sender) yields a single group → single message, byte-identical to today — no regression.
- Matching covers BCC recipients too — important because EmailNotifierServiceImpl routes 2+ recipients to BCC with an empty to.
- Exact domain match (each full domain is stored separately); case-insensitive.
- Explicit caller from (rare, deliberate) → no branding (From and Subject both left as today). Branding applies only on the default-sender path — which is the notification path this epic targets.
- Self-send (DEFAULT_MAIL_TO) → unbranded, as today.
- Purely additive: no match / blank / malformed config → unchanged default behavior.

Tests
- Model (EmailBrandedSendersTest): +7 resolve cases (match, case-insensitivity, personal-name form, no-match, first-match-wins, blank/malformed, no-domain).
- Service (EmailServiceTest): branded applies From+Subject; no-match keeps defaults; explicit-from → unbranded; two different-domain recipients → two sends; multi-recipient BCC gets branded; all-same-config → single send.

Depends on: S1 (data model, merged). Related: S3/S4 config UI (PR #18365).
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

Documentation notes

Feature: domain-matched branded senders (send-time)

Outbound notification emails can now use a per-tenant From and Subject when the recipient's email domain matches a configured rule. Rules are stored in the email.branded_senders setting at the environment/organization scope (the configuration UI ships in #18365).

- Matched branding: when a recipient's domain matches a rule, that rule's from and subject are used for the message to that recipient. Example: with a rule for airtel.com → noreply@airtel.com / [Airtel] %s, a notification to alice@airtel.com is sent from noreply@airtel.com with subject [Airtel] Subscription approved.
- Multi-recipient splitting: if a single notification's recipients span multiple branded domains, it is now delivered as multiple separate emails — one per matched (From, Subject) group — instead of a single message. Operators reading SMTP/notification logs should expect more than one send for one notification in this case. When all recipients resolve to the same sender (the common case, including all "no match → default"), it remains a single send.
- Fallback (additive & safe): no match, or a blank/malformed configuration, falls through to today's default EMAIL_FROM / EMAIL_SUBJECT — behavior is unchanged when the feature is unconfigured.
- Matching rules: domain match is case-insensitive and whitespace-tolerant, uses an exact domain match (no subdomain wildcards), and is first-match-wins if more than one rule lists the same domain.

