### PR TITLE
fix(reporter): use JSON escaping for webhook jsonAdditionalMetrics

### DIFF
--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es7x/index/v4-message-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es7x/index/v4-message-metrics.ftl
@@ -103,7 +103,7 @@
     </#if>
     <#if (metrics.jsonAdditionalMetrics())??>
       <#list metrics.jsonAdditionalMetrics() as propKey, propValue>
-        <#assign additionalMetrics = additionalMetrics + ['"' + propKey + '":"' + propValue?js_string + '"']>
+        <#assign additionalMetrics = additionalMetrics + ['"' + propKey + '":"' + propValue?j_string + '"']>
       </#list>
     </#if>
       ${additionalMetrics?join(',')}

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es8x/index/v4-message-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es8x/index/v4-message-metrics.ftl
@@ -103,7 +103,7 @@
     </#if>
     <#if (metrics.jsonAdditionalMetrics())??>
       <#list metrics.jsonAdditionalMetrics() as propKey, propValue>
-        <#assign additionalMetrics = additionalMetrics + ['"' + propKey + '":"' + propValue?js_string + '"']>
+        <#assign additionalMetrics = additionalMetrics + ['"' + propKey + '":"' + propValue?j_string + '"']>
       </#list>
     </#if>
       ${additionalMetrics?join(',')}

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es9x/index/v4-message-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/resources/freemarker/es9x/index/v4-message-metrics.ftl
@@ -103,7 +103,7 @@
     </#if>
     <#if (metrics.jsonAdditionalMetrics())??>
       <#list metrics.jsonAdditionalMetrics() as propKey, propValue>
-        <#assign additionalMetrics = additionalMetrics + ['"' + propKey + '":"' + propValue?js_string + '"']>
+        <#assign additionalMetrics = additionalMetrics + ['"' + propKey + '":"' + propValue?j_string + '"']>
       </#list>
     </#if>
       ${additionalMetrics?join(',')}

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/java/io/gravitee/apim/reporter/common/formatter/elasticsearch/ElasticsearchFormatterTest.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/java/io/gravitee/apim/reporter/common/formatter/elasticsearch/ElasticsearchFormatterTest.java
@@ -55,6 +55,7 @@ class ElasticsearchFormatterTest extends AbstractFormatterTest {
             "v4 metrics with warnings, v4.metric.Metrics, v4/metrics-with-warnings.json, elasticsearch/v4/metrics-with-warnings.json",
             "v4 metrics with additional, v4.metric.Metrics, v4/metrics-with-additional.json, elasticsearch/v4/metrics-with-additional.json",
             "message metrics with additional, v4.metric.MessageMetrics, v4/message-metrics-with-additional.json, elasticsearch/v4/message-metrics-with-additional.json",
+            "message metrics with apostrophe in json additional, v4.metric.MessageMetrics, v4/message-metrics-with-apostrophe-in-json-additional.json, elasticsearch/v4/message-metrics-with-apostrophe-in-json-additional.json",
             "api event metrics, v4.metric.event.ApiEventMetrics, v4/api-event-metrics.json, elasticsearch/v4/api-event-metrics.json",
             "application event metrics, v4.metric.event.ApplicationEventMetrics, v4/application-event-metrics.json, elasticsearch/v4/application-event-metrics.json",
             "topic event metrics, v4.metric.event.TopicEventMetrics, v4/topic-event-metrics.json, elasticsearch/v4/topic-event-metrics.json",

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/resources/io/gravitee/reporter/common/formatter/expected/elasticsearch/v4/message-metrics-with-apostrophe-in-json-additional.json
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/resources/io/gravitee/reporter/common/formatter/expected/elasticsearch/v4/message-metrics-with-apostrophe-in-json-additional.json
@@ -1,0 +1,24 @@
+{
+  "gateway": "gateway-id",
+  "_id": "10e949d4-fa38-4ff4-a139-1358bbacd127-entrypoint",
+  "type": "v4-message-metrics",
+  "date": "2023.08.23",
+  "@timestamp": "2023-08-23T13:12:01.153Z",
+  "request-id": "1d1d007b-7891-45d0-9d00-7b789175d0a2",
+  "api-id": "be926300-20aa-4109-9263-0020aa31096c",
+  "api-name": "API Name",
+  "org-id": "7e3c7b4c-91c1-4f79-9c2e-3c2d6cfbf890",
+  "env-id": "d4f0f9d2-b2c4-4d8a-a3a0-5324fdad0e73",
+  "client-identifier": "b6cf5bd6081fb775fc3f89927e582d7e945f955c35b73a07879d75bb4ea96a01",
+  "correlation-id": "10e949d4-fa38-4ff4-a139-1358bbacd127",
+  "operation": "subscribe",
+  "connector-type": "entrypoint",
+  "connector-id": "webhook",
+  "content-length": 4,
+  "count": 1,
+  "count-increment": 1,
+  "gateway-latency-ms": 0,
+  "additional-metrics": {
+    "json_webhook_resp-headers": "{\"header\":\"it's a test\"}"
+  }
+}

--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/resources/io/gravitee/reporter/common/formatter/given/v4/message-metrics-with-apostrophe-in-json-additional.json
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/test/resources/io/gravitee/reporter/common/formatter/given/v4/message-metrics-with-apostrophe-in-json-additional.json
@@ -1,0 +1,24 @@
+{
+  "timestamp": 1692796321153,
+  "requestId": "1d1d007b-7891-45d0-9d00-7b789175d0a2",
+  "apiId": "be926300-20aa-4109-9263-0020aa31096c",
+  "apiName": "API Name",
+  "organizationId": "7e3c7b4c-91c1-4f79-9c2e-3c2d6cfbf890",
+  "environmentId": "d4f0f9d2-b2c4-4d8a-a3a0-5324fdad0e73",
+  "clientIdentifier": "b6cf5bd6081fb775fc3f89927e582d7e945f955c35b73a07879d75bb4ea96a01",
+  "correlationId": "10e949d4-fa38-4ff4-a139-1358bbacd127",
+  "parentCorrelationId": null,
+  "operation": "SUBSCRIBE",
+  "connectorType": "ENTRYPOINT",
+  "connectorId": "webhook",
+  "contentLength": 4,
+  "count": 1,
+  "errorCount": -1,
+  "countIncrement": 1,
+  "errorCountIncrement": -1,
+  "error": false,
+  "gatewayLatencyMs": 0,
+  "additionalMetrics": [
+    { "name": "json_webhook_resp-headers", "value": "{\"header\":\"it's a test\"}" }
+  ]
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14557

## Description

Replace ?js_string with ?j_string when serializing jsonAdditionalMetrics in v4-message-metrics.ftl (es7x, es8x, es9x). JavaScript escaping emits invalid \' sequences in JSON, causing Elasticsearch to reject webhook callback metrics when captured headers contain apostrophes.

## Additional context
### Before Fix:

https://github.com/user-attachments/assets/dff61b91-6a93-4d58-9567-6980e817efe0

### After Fix:

https://github.com/user-attachments/assets/1b09f707-f587-4e4a-aa46-4c1c4193189f


