### PR TITLE
chore(deps)!: bump gravitee-policy-json-validation to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <gravitee-policy-javascript.version>1.4.0</gravitee-policy-javascript.version>
         <gravitee-policy-json-threat-protection.version>2.1.0</gravitee-policy-json-threat-protection.version>
         <gravitee-policy-json-to-json.version>3.0.1</gravitee-policy-json-to-json.version>
-        <gravitee-policy-json-validation.version>2.1.4</gravitee-policy-json-validation.version>
+        <gravitee-policy-json-validation.version>3.0.0</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.3</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>2.0.0</gravitee-policy-jws.version>
         <gravitee-policy-jwt.version>7.0.4</gravitee-policy-jwt.version>


### PR DESCRIPTION
## Purpose

Bumps `gravitee-policy-json-validation` from 2.1.4 to 3.0.0 to pick up new capabilities and a fix for a long-standing error-key mix-up in the policy's response-scope handling.

## Summary of changes

- Updated `gravitee-policy-json-validation.version` in `pom.xml` from `2.1.4` to `3.0.0`.

### Breaking changes

- ⚠️ BREAKING: response-scope JSON validation now emits `JSON_INVALID_RESPONSE_PAYLOAD` for payload (schema) failures and `JSON_INVALID_RESPONSE_FORMAT` for parse/format failures (previously swapped). APIs whose response templates were authored against the old, swapped keys must update them.

## Manual testing

Verified locally against a running gateway built from this branch, using a local mock backend, covering both scopes (request/response) and both failure classes (schema violation vs. malformed JSON).

**Pass-through / basic validation:**

| Case | Result |
|---|---|
| Request scope, valid JSON matching schema | 200, forwarded to backend |
| Request scope, valid JSON failing schema | 400, configured `errorMessage` |
| Response scope, valid JSON matching schema | 200, passed through unchanged |

**Error-key routing** — confirms the breaking-change fix: each of the four failure combinations (request/response × schema-violation/malformed) routes to its own distinct error key, not the swapped/collapsed behavior from 2.1.4.

Test API configured with one `response_templates` entry per key, each returning a unique marker body:

```yaml
JSON_INVALID_PAYLOAD:          -> {"templated": "request-schema-violation"}
JSON_INVALID_FORMAT:           -> {"templated": "request-parse-failure"}
JSON_INVALID_RESPONSE_PAYLOAD: -> {"templated": "schema-violation"}
JSON_INVALID_RESPONSE_FORMAT:  -> {"templated": "parse-failure"}
```

| Scope | Input sent | Failure type | Expected key | Result |
|---|---|---|---|---|
| Request | `{"foo":"bar"}` (valid JSON, missing required field) | schema violation | `JSON_INVALID_PAYLOAD` | ✅ matched |
| Request | `not-json-at-all` (unparseable) | parse failure | `JSON_INVALID_FORMAT` | ✅ matched |
| Response | backend returns `{"wrong":"shape"}` | schema violation | `JSON_INVALID_RESPONSE_PAYLOAD` | ✅ matched |
| Response | backend returns `not-json-at-all` | parse failure | `JSON_INVALID_RESPONSE_FORMAT` | ✅ matched |

**Default behavior** (no `response_templates` configured):

| Case | Status | Body |
|---|---|---|
| Request scope, schema violation | 400 | `{"message":"{\"error\":\"Bad request\"}","http_status_code":400}` |
| Request scope, malformed body | 400 | `{"message":"{\"error\":\"Bad request\"}","http_status_code":400}` |
| Response scope, schema violation | 500 | `{"message":"{\"error\":\"Invalid response\"}","http_status_code":500}` |
| Response scope, malformed body | 500 | `{"message":"{\"error\":\"Invalid response\"}","http_status_code":500}` |

Without `response_templates` keyed on the specific error keys, schema violations and malformed bodies are indistinguishable to the client (same status, same body) in both directions. The breaking change above is only observable to APIs that already differentiate `response_templates` by these keys — everything else keeps its existing behavior after the upgrade.
