### PR TITLE
chore: bump gravitee-policy-groovy to 4.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <gravitee-policy-generate-http-signature.version>1.3.0</gravitee-policy-generate-http-signature.version>
         <gravitee-policy-generate-jwt.version>1.8.0</gravitee-policy-generate-jwt.version>
         <gravitee-policy-geoip-filtering.version>2.2.2</gravitee-policy-geoip-filtering.version>
-        <gravitee-policy-groovy.version>4.3.2</gravitee-policy-groovy.version>
+        <gravitee-policy-groovy.version>4.3.5</gravitee-policy-groovy.version>
         <gravitee-policy-html-json.version>1.6.3</gravitee-policy-html-json.version>
         <gravitee-policy-http-signature.version>1.7.0</gravitee-policy-http-signature.version>
         <gravitee-policy-interrupt.version>1.1.1</gravitee-policy-interrupt.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Bump `gravitee-policy-groovy` from `4.3.2` to `4.3.5` to pull in the default-schema-resolution fix.

The groovy policy manifest previously declared only `native_kafka.schema`, leaving the default `schema` property unset. `gravitee-plugin-core` then fell back to `getFirstFile()` (`dir.listFiles()[0]`, no ordering guarantee); with two files in `schemas/`, APIM could serve `schema-form-native-kafka.json` for proxy/message APIs, hiding fields like `readContent` from the policy studio form. The fix declares `schema=schema-form.json` explicitly.

## Additional context

- Policy fix PR: gravitee-io/gravitee-policy-groovy#133 (targets groovy `4.3.x`, releases `4.3.5`)
- **Depends on groovy `4.3.5` being released** before this can build green.
- Same bump needed on APIM `4.10.x`, `4.11.x`, `master` (also on groovy `4.3.2`). `4.8.x` is unaffected (groovy `3.0.3`, single schema file).
