### PR TITLE
feat: add dedicated ENVIRONMENT_KAFKA_EXPLORER permission (ESM-94)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
@@ -75,6 +75,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
             "IDENTITY_PROVIDER_ACTIVATION",
             "INSTANCE",
             "INTEGRATION",
+            "KAFKA_EXPLORER",
             "MESSAGE",
             "METADATA",
             "NOTIFICATION",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
@@ -60,7 +60,8 @@ public enum EnvironmentPermission implements Permission {
     AUTHZ_POLICIES("AUTHZ_POLICIES", 4800),
     AUTHZ_PDP("AUTHZ_PDP", 4900),
     AUTHZ_SCHEMA("AUTHZ_SCHEMA", 5000),
-    AI_CATALOG("AI_CATALOG", 5100);
+    AI_CATALOG("AI_CATALOG", 5100),
+    KAFKA_EXPLORER("KAFKA_EXPLORER", 5200);
 
     String name;
     int mask;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -101,6 +101,7 @@ public enum RolePermission {
     ENVIRONMENT_AUTHZ_PDP(RoleScope.ENVIRONMENT, EnvironmentPermission.AUTHZ_PDP),
     ENVIRONMENT_AUTHZ_SCHEMA(RoleScope.ENVIRONMENT, EnvironmentPermission.AUTHZ_SCHEMA),
     ENVIRONMENT_AI_CATALOG(RoleScope.ENVIRONMENT, EnvironmentPermission.AI_CATALOG),
+    ENVIRONMENT_KAFKA_EXPLORER(RoleScope.ENVIRONMENT, EnvironmentPermission.KAFKA_EXPLORER),
 
     ORGANIZATION_USERS(RoleScope.ORGANIZATION, OrganizationPermission.USER),
     ORGANIZATION_USERS_TOKEN(RoleScope.ORGANIZATION, OrganizationPermission.USER_TOKEN),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
@@ -65,6 +65,7 @@ public interface DefaultRoleEntityDefinition {
             .put(EnvironmentPermission.TENANT.getName(), new char[] { READ.getId() })
             .put(EnvironmentPermission.PLATFORM.getName(), new char[] { READ.getId() })
             .put(EnvironmentPermission.CLUSTER.getName(), new char[] { READ.getId() })
+            .put(EnvironmentPermission.KAFKA_EXPLORER.getName(), new char[] { READ.getId() })
             .build()
     );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/KafkaExplorerPermissionUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/KafkaExplorerPermissionUpgrader.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.UpdateRoleEntity;
+import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * One-shot upgrader that seeds the new {@code KAFKA_EXPLORER} environment permission on existing installations.
+ * <ul>
+ *   <li>Every non-system {@code ENVIRONMENT} role that carries {@code CLUSTER} ACLs gets the same ACLs copied to
+ *       {@code KAFKA_EXPLORER} ({@code putIfAbsent} — pre-existing values are preserved), so users who could use
+ *       the Kafka explorer through {@code ENVIRONMENT_CLUSTER} keep their access when endpoints switch to the
+ *       dedicated permission.</li>
+ *   <li>System roles are refreshed via {@code createOrUpdateSystemRoles} so ADMIN gains the new permission.</li>
+ * </ul>
+ * Idempotent — re-running after a successful upgrade is a no-op.
+ * Order: {@link UpgraderOrder#KAFKA_EXPLORER_PERMISSION_UPGRADER}.
+ */
+@CustomLog
+@Component
+public class KafkaExplorerPermissionUpgrader implements Upgrader {
+
+    private static final String CLUSTER_PERMISSION = EnvironmentPermission.CLUSTER.getName();
+    private static final String KAFKA_EXPLORER_PERMISSION = EnvironmentPermission.KAFKA_EXPLORER.getName();
+
+    private final RoleService roleService;
+    private final OrganizationRepository organizationRepository;
+
+    @Autowired
+    public KafkaExplorerPermissionUpgrader(RoleService roleService, @Lazy OrganizationRepository organizationRepository) {
+        this.roleService = roleService;
+        this.organizationRepository = organizationRepository;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return wrapException(() -> {
+            organizationRepository
+                .findAll()
+                .forEach(organization -> {
+                    ExecutionContext executionContext = new ExecutionContext(organization);
+                    String organizationId = executionContext.getOrganizationId();
+                    log.info("Applying Kafka explorer permission for organization {}", organizationId);
+                    roleService
+                        .findByScope(RoleScope.ENVIRONMENT, organizationId)
+                        .stream()
+                        .filter(role -> !role.isSystem())
+                        .forEach(role -> copyClusterAcls(executionContext, role));
+                    roleService.createOrUpdateSystemRoles(executionContext, organizationId);
+                });
+            return true;
+        });
+    }
+
+    private void copyClusterAcls(ExecutionContext executionContext, RoleEntity role) {
+        Map<String, char[]> actualPermissions = role.getPermissions();
+        if (
+            actualPermissions == null ||
+            !actualPermissions.containsKey(CLUSTER_PERMISSION) ||
+            actualPermissions.containsKey(KAFKA_EXPLORER_PERMISSION)
+        ) {
+            return;
+        }
+
+        Map<String, char[]> expectedPermissions = new HashMap<>(actualPermissions);
+        expectedPermissions.put(KAFKA_EXPLORER_PERMISSION, actualPermissions.get(CLUSTER_PERMISSION).clone());
+
+        UpdateRoleEntity expectedRole = UpdateRoleEntity.from(role);
+        expectedRole.setPermissions(expectedPermissions);
+
+        roleService.update(executionContext, expectedRole);
+        log.info("Copied CLUSTER ACLs to KAFKA_EXPLORER on role: {}", role.getName());
+    }
+
+    @Override
+    public int getOrder() {
+        return UpgraderOrder.KAFKA_EXPLORER_PERMISSION_UPGRADER;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -81,4 +81,5 @@ public class UpgraderOrder {
     public static final int GAMMA_IDENTITY_ROLES_UPGRADER = 956;
     public static final int GAMMA_AUTHZ_ROLES_UPGRADER = 957;
     public static final int AI_CATALOG_ROLES_UPGRADER = 958;
+    public static final int KAFKA_EXPLORER_PERMISSION_UPGRADER = 959;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/KafkaExplorerPermissionUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/KafkaExplorerPermissionUpgraderTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.model.permissions.RoleScope.ENVIRONMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Organization;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.UpdateRoleEntity;
+import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
+public class KafkaExplorerPermissionUpgraderTest {
+
+    private static final String CLUSTER = EnvironmentPermission.CLUSTER.getName();
+    private static final String KAFKA_EXPLORER = EnvironmentPermission.KAFKA_EXPLORER.getName();
+    private static final char[] CLUSTER_ACLS = { 'C', 'R', 'U', 'D' };
+    private static final String ORG_A = "org-a";
+    private static final String ORG_B = "org-b";
+
+    @InjectMocks
+    KafkaExplorerPermissionUpgrader upgrader;
+
+    @Mock
+    RoleService roleService;
+
+    @Mock
+    OrganizationRepository organizationRepository;
+
+    @Test
+    public void should_copy_cluster_acls_when_role_has_cluster_permission() throws TechnicalException, UpgraderException {
+        String orgId = GraviteeContext.getDefaultOrganization();
+        mockOrganizations(orgId);
+
+        RoleEntity role = roleWithPermissions("role-id", Map.of(CLUSTER, CLUSTER_ACLS));
+        when(roleService.findByScope(ENVIRONMENT, orgId)).thenReturn(List.of(role));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<UpdateRoleEntity> updated = ArgumentCaptor.forClass(UpdateRoleEntity.class);
+        verify(roleService).update(any(ExecutionContext.class), updated.capture());
+
+        Map<String, char[]> permissions = updated.getValue().getPermissions();
+        assertThat(permissions.get(KAFKA_EXPLORER)).isEqualTo(CLUSTER_ACLS);
+        assertThat(permissions.get(CLUSTER)).isEqualTo(CLUSTER_ACLS);
+
+        verify(roleService).createOrUpdateSystemRoles(any(ExecutionContext.class), eq(orgId));
+    }
+
+    @Test
+    public void should_not_update_role_without_cluster_permission() throws TechnicalException, UpgraderException {
+        String orgId = GraviteeContext.getDefaultOrganization();
+        mockOrganizations(orgId);
+
+        RoleEntity role = roleWithPermissions("role-id", Map.of(EnvironmentPermission.API.getName(), CLUSTER_ACLS));
+        when(roleService.findByScope(ENVIRONMENT, orgId)).thenReturn(List.of(role));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(roleService, never()).update(any(), any());
+        verify(roleService).createOrUpdateSystemRoles(any(ExecutionContext.class), eq(orgId));
+    }
+
+    @Test
+    public void should_preserve_existing_kafka_explorer_acls() throws TechnicalException, UpgraderException {
+        String orgId = GraviteeContext.getDefaultOrganization();
+        mockOrganizations(orgId);
+
+        char[] customAcls = { 'R' };
+        RoleEntity role = roleWithPermissions("role-id", Map.of(CLUSTER, CLUSTER_ACLS, KAFKA_EXPLORER, customAcls));
+        when(roleService.findByScope(ENVIRONMENT, orgId)).thenReturn(List.of(role));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(roleService, never()).update(any(), any());
+        verify(roleService).createOrUpdateSystemRoles(any(ExecutionContext.class), eq(orgId));
+    }
+
+    @Test
+    public void should_skip_system_roles() throws TechnicalException, UpgraderException {
+        String orgId = GraviteeContext.getDefaultOrganization();
+        mockOrganizations(orgId);
+
+        RoleEntity systemRole = roleWithPermissions("admin-id", Map.of(CLUSTER, CLUSTER_ACLS));
+        systemRole.setSystem(true);
+        when(roleService.findByScope(ENVIRONMENT, orgId)).thenReturn(List.of(systemRole));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(roleService, never()).update(any(), any());
+        verify(roleService).createOrUpdateSystemRoles(any(ExecutionContext.class), eq(orgId));
+    }
+
+    @Test
+    public void should_ignore_role_with_null_permissions() throws TechnicalException, UpgraderException {
+        String orgId = GraviteeContext.getDefaultOrganization();
+        mockOrganizations(orgId);
+
+        RoleEntity role = new RoleEntity();
+        role.setId("role-id");
+        role.setName("no-permissions");
+        role.setPermissions(null);
+        when(roleService.findByScope(ENVIRONMENT, orgId)).thenReturn(List.of(role));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(roleService, never()).update(any(), any());
+        verify(roleService).createOrUpdateSystemRoles(any(ExecutionContext.class), eq(orgId));
+    }
+
+    @Test
+    public void should_process_each_organization() throws TechnicalException, UpgraderException {
+        Organization orgA = mock(Organization.class);
+        when(orgA.getId()).thenReturn(ORG_A);
+        Organization orgB = mock(Organization.class);
+        when(orgB.getId()).thenReturn(ORG_B);
+        when(organizationRepository.findAll()).thenReturn(Set.of(orgA, orgB));
+
+        List.of(ORG_A, ORG_B).forEach(orgId ->
+            when(roleService.findByScope(ENVIRONMENT, orgId)).thenReturn(
+                List.of(roleWithPermissions("role-" + orgId, Map.of(CLUSTER, CLUSTER_ACLS)))
+            )
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(roleService, times(2)).update(any(ExecutionContext.class), any(UpdateRoleEntity.class));
+        verify(roleService, times(2)).createOrUpdateSystemRoles(any(ExecutionContext.class), any(String.class));
+    }
+
+    @Test
+    public void throws_UpgraderException_when_organization_repository_throws_RuntimeException() throws TechnicalException {
+        assertThrows(UpgraderException.class, () -> {
+            when(organizationRepository.findAll()).thenThrow(new RuntimeException("OrganizationRepository connection failure"));
+            upgrader.upgrade();
+        });
+    }
+
+    @Test
+    public void throws_UpgraderException_when_role_service_throws_RuntimeException() throws TechnicalException {
+        assertThrows(UpgraderException.class, () -> {
+            String orgId = GraviteeContext.getDefaultOrganization();
+            mockOrganizations(orgId);
+
+            when(roleService.findByScope(ENVIRONMENT, orgId)).thenReturn(
+                List.of(roleWithPermissions("role-id", Map.of(CLUSTER, CLUSTER_ACLS)))
+            );
+            doThrow(new RuntimeException("RoleService update failure"))
+                .when(roleService)
+                .update(any(ExecutionContext.class), any(UpdateRoleEntity.class));
+
+            upgrader.upgrade();
+        });
+    }
+
+    private void mockOrganizations(String... ids) throws TechnicalException {
+        Set<Organization> orgs = new HashSet<>();
+        Arrays.stream(ids).forEach(id -> {
+            Organization org = mock(Organization.class);
+            when(org.getId()).thenReturn(id);
+            orgs.add(org);
+        });
+
+        when(organizationRepository.findAll()).thenReturn(orgs);
+    }
+
+    private static RoleEntity roleWithPermissions(String id, Map<String, char[]> permissions) {
+        RoleEntity role = new RoleEntity();
+        role.setId(id);
+        role.setName(id);
+        role.setPermissions(new HashMap<>(permissions));
+        return role;
+    }
+}


### PR DESCRIPTION
## Description

Introduces a dedicated `KAFKA_EXPLORER` environment permission so Kafka explorer access (browse/tail messages, and the upcoming explorer connections CRUD in the gamma ESM module) can be granted independently from cluster management rights (`ENVIRONMENT_CLUSTER`).

### Changes
- `EnvironmentPermission.KAFKA_EXPLORER` (mask 5200) + `RolePermission.ENVIRONMENT_KAFKA_EXPLORER`
- `KafkaExplorerPermissionUpgrader` (one-shot, idempotent, modeled on `NativeApiLogPermissionUpgrader`):
  - copies existing `CLUSTER` ACLs to `KAFKA_EXPLORER` on every non-system `ENVIRONMENT` role (`putIfAbsent` — pre-existing values preserved), so current explorer users keep access when the ESM module endpoints switch to the dedicated permission
  - refreshes system roles so ADMIN gains the new permission
- Unit tests for the upgrader

### Context
Part of the Kafka Explorer Connection work (ESM-94). The entity/CRUD/persistence live entirely in the `gravitee-gamma-module-esm` module; this permission is the only APIM-side change required.

