### PR TITLE
fix(gamma-observability): serialize log timestamp as epoch millis

### DIFF
--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/LogDetailDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/LogDetailDto.java
@@ -19,13 +19,19 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.gravitee.gamma.rest.core.observability.logs.model.HttpPayload;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogDetail;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogEntryWarning;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
 /**
  * Wire shape for the merged log detail returned by {@code GET /observability/logs/{requestId}}.
  * Null fields are omitted to keep the payload lean.
+ *
+ * <p>{@code timestampEpochMs} is emitted as a plain JSON number (ms since epoch), consistent with
+ * {@link LogEntryDto} and {@link io.gravitee.gamma.rest.resources.tracing.dto.TraceSummaryDto}. The
+ * numeric field type bypasses Jackson's {@code Instant} serialization (the parent rest-api
+ * ObjectMapper has {@code WRITE_DATES_AS_TIMESTAMPS} enabled), which would otherwise emit a fractional
+ * {@code <epoch_seconds>.<nanos>} value that JS code misinterprets as milliseconds. Kept as a boxed
+ * {@code Long} so a missing timestamp is omitted (via {@code NON_NULL}) rather than serialised as 0.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record LogDetailDto(
@@ -33,7 +39,7 @@ public record LogDetailDto(
     String apiId,
     String transactionId,
     String clientIdentifier,
-    Instant timestamp,
+    Long timestampEpochMs,
     Boolean requestEnded,
     String method,
     String uri,
@@ -80,7 +86,7 @@ public record LogDetailDto(
             detail.apiId(),
             detail.transactionId(),
             detail.clientIdentifier(),
-            detail.timestamp(),
+            detail.timestamp() != null ? detail.timestamp().toEpochMilli() : null,
             detail.requestEnded(),
             detail.method(),
             detail.uri(),

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/LogEntryDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/LogEntryDto.java
@@ -18,20 +18,28 @@ package io.gravitee.gamma.rest.resources.observability.logs.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogEntryWarning;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
 /**
  * Wire shape for one light log row returned by {@code POST /observability/logs/search}. Null
  * fields are omitted from the JSON to keep the payload lean.
+ *
+ * <p>{@code timestampEpochMs} is emitted as a plain JSON number (ms since epoch) so the consumer can
+ * pass it directly to {@code new Date(value)} without parsing. The numeric field type bypasses
+ * Jackson's {@code Instant} handling entirely — the parent rest-api ObjectMapper has
+ * {@code WRITE_DATES_AS_TIMESTAMPS} enabled, which would otherwise serialise Instant as a fractional
+ * {@code <epoch_seconds>.<nanos>} value that JS code misinterprets as milliseconds. Kept as a boxed
+ * {@code Long} so a missing timestamp is omitted (via {@code NON_NULL}) rather than serialised as
+ * {@code 0} (which the UI would render as 1970). Mirrors the {@code startTimeEpochMs} convention of
+ * {@link io.gravitee.gamma.rest.resources.tracing.dto.TraceSummaryDto}.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record LogEntryDto(
     String apiId,
     String apiName,
     String apiType,
-    Instant timestamp,
+    Long timestampEpochMs,
     String requestId,
     String method,
     String clientIdentifier,
@@ -69,7 +77,7 @@ public record LogEntryDto(
             entry.apiId(),
             entry.apiName(),
             entry.apiType(),
-            entry.timestamp(),
+            entry.timestamp() != null ? entry.timestamp().toEpochMilli() : null,
             entry.requestId(),
             entry.method(),
             entry.clientIdentifier(),

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/observability/logs/LogsResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/observability/logs/LogsResourceTest.java
@@ -112,6 +112,11 @@ class LogsResourceTest extends AbstractResourceTest {
             assertThat(body.get("data").get(0).get("apiId").asText()).isEqualTo("api-1");
             assertThat(body.get("data").get(0).get("apiName").asText()).isEqualTo("Petstore");
             assertThat(body.get("data").get(0).get("status").asInt()).isEqualTo(200);
+            // timestamp is emitted as integer epoch millis (not a fractional Instant) so the UI can pass it to new Date()
+            assertThat(body.get("data").get(0).get("timestampEpochMs").isIntegralNumber()).isTrue();
+            assertThat(body.get("data").get(0).get("timestampEpochMs").asLong()).isEqualTo(
+                Instant.parse("2026-06-10T10:00:00Z").toEpochMilli()
+            );
             assertThat(body.get("pagination").get("totalCount").asLong()).isEqualTo(1L);
             assertThat(body.get("pagination").get("page").asInt()).isEqualTo(1);
         }
@@ -207,6 +212,8 @@ class LogsResourceTest extends AbstractResourceTest {
             assertThat(body.get("requestId").asText()).isEqualTo(REQUEST_ID);
             assertThat(body.get("apiId").asText()).isEqualTo(API_ID);
             assertThat(body.get("status").asInt()).isEqualTo(200);
+            assertThat(body.get("timestampEpochMs").isIntegralNumber()).isTrue();
+            assertThat(body.get("timestampEpochMs").asLong()).isEqualTo(Instant.parse("2026-06-10T14:32:01Z").toEpochMilli());
             assertThat(body.get("planName").asText()).isEqualTo("Gold");
             assertThat(body.get("entrypointRequest").get("method").asText()).isEqualTo("GET");
             assertThat(body.get("entrypointResponse").get("body").asText()).isEqualTo("{\"id\":42}");


### PR DESCRIPTION
## Summary
The Gamma `/observability/logs` endpoints serialized the log timestamp as a `java.time.Instant`. With the parent rest-api ObjectMapper's `WRITE_DATES_AS_TIMESTAMPS` enabled, Jackson emitted it as a fractional `<epoch_seconds>.<nanos>` number, which the web consumer misread as milliseconds — so the AIM Logs screen showed `01/21/1970`. This changes the wire field to a plain `long timestampEpochMs`, mirroring `TraceSummaryDto.startTimeEpochMs`.

Frontend counterpart: gravitee-io/gamma-lib-observability#63 (same branch) — the two must ship together.

Jira: [GMA-910](https://gravitee.atlassian.net/browse/GMA-910)

## Changes
- `LogEntryDto`: `Instant timestamp` → `long timestampEpochMs` (via `Instant.toEpochMilli()`), with the same javadoc rationale as `TraceSummaryDto`.
- `LogDetailDto`: same change.
- `LogsResourceTest`: assert the emitted `timestampEpochMs` is an integer epoch-millis value on both search and detail.
- The core `LogEntry`/`LogDetail` models and the Elasticsearch adapter keep `Instant` — conversion happens only at the DTO boundary.

## Non-regression / scope
- Confined to the Gamma `/observability/logs` DTOs. The legacy APIM v2 logs endpoint (`/environments/{envId}/logs/search`) uses its own DTOs and is not touched.
- Breaking change to the Gamma logs JSON contract; the only consumer (`@gravitee/gamma-lib-observability`) is updated in the paired PR.

## API changes

| Endpoint | Method | Change | Response example |
|----------|--------|--------|------------------|
| `/observability/logs/search` | POST | `timestamp` (Instant, `1786424793.793`) → `timestampEpochMs` (long) | `{ "data": [{ "timestampEpochMs": 1786424793793, ... }] }` |
| `/observability/logs/{requestId}` | GET | same field change | `{ "timestampEpochMs": 1786424793793, ... }` |

## Test plan
- [ ] `mvn -pl gravitee-gamma/gravitee-gamma-rest-api test -Dtest=LogsResourceTest` — green
- [ ] With the stack running, `POST /observability/logs/search` returns `timestampEpochMs` as an integer (~13 digits), no fractional/Instant value.
- [ ] `GET /observability/logs/{requestId}` — same.
- [ ] AIM Logs screen (with gamma-lib-observability#63) shows the real timestamp instead of 1970.


[GMA-910]: https://gravitee.atlassian.net/browse/GMA-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ