### PR TITLE
feat(rest-api): expose email.branded_senders in gravitee.yml for on-prem configuration

### DIFF
--- a/docker/quick-setup/kafka-console/docker-compose.yml
+++ b/docker/quick-setup/kafka-console/docker-compose.yml
@@ -127,6 +127,9 @@ services:
             - gravitee_email_port=1025
             - gravitee_email_subject="TEST"
             - gravitee_email_from="user@my.domain"
+            # Branded senders (optional): JSON array of {domains, from, subject}; overrides From/Subject for
+            # emails to matching recipient domains and locks the field in the console. Uncomment to enable.
+            # - gravitee_email_branded_senders=[{"domains":["example.com"],"from":"noreply@example.com","subject":"[Example] %s"}]
             - gravitee_kafka_console_enabled=true
             - gravitee_kafka_console_server_host=kafkaConsole
             - gravitee_kafka_console_server_port=8080

--- a/docker/quick-setup/mongodb/docker-compose.yml
+++ b/docker/quick-setup/mongodb/docker-compose.yml
@@ -124,6 +124,9 @@ services:
             - gravitee_email_port=1025
             - gravitee_email_subject="TEST"
             - gravitee_email_from="user@my.domain"
+            # Branded senders (optional): JSON array of {domains, from, subject}; overrides From/Subject for
+            # emails to matching recipient domains and locks the field in the console. Uncomment to enable.
+            # - gravitee_email_branded_senders=[{"domains":["example.com"],"from":"noreply@example.com","subject":"[Example] %s"}]
             - 'license.key=${LICENSE_KEY}'
         networks:
             - storage

--- a/docker/quick-setup/native-kafka-mesh/docker-compose.yml
+++ b/docker/quick-setup/native-kafka-mesh/docker-compose.yml
@@ -154,6 +154,9 @@ services:
             - gravitee_email_port=1025
             - gravitee_email_subject="TEST"
             - gravitee_email_from="user@my.domain"
+            # Branded senders (optional): JSON array of {domains, from, subject}; overrides From/Subject for
+            # emails to matching recipient domains and locks the field in the console. Uncomment to enable.
+            # - gravitee_email_branded_senders=[{"domains":["example.com"],"from":"noreply@example.com","subject":"[Example] %s"}]
             # Pre-seed the Entrypoints & Sharding Tags → Default Kafka Domain pattern.
             # Maps Key.PORTAL_KAFKA_DOMAIN (isOverridable=true, scope SYSTEM). The `{apiHost}`
             # placeholder is substituted with the API's host prefix at runtime, so an API with

--- a/docker/quick-setup/native-kafka/docker-compose.yml
+++ b/docker/quick-setup/native-kafka/docker-compose.yml
@@ -156,6 +156,9 @@ services:
             - gravitee_email_port=1025
             - gravitee_email_subject="TEST"
             - gravitee_email_from="user@my.domain"
+            # Branded senders (optional): JSON array of {domains, from, subject}; overrides From/Subject for
+            # emails to matching recipient domains and locks the field in the console. Uncomment to enable.
+            # - gravitee_email_branded_senders=[{"domains":["example.com"],"from":"noreply@example.com","subject":"[Example] %s"}]
         networks:
             - storage
             - frontend

--- a/docker/quick-setup/systemProxy/docker-compose.yml
+++ b/docker/quick-setup/systemProxy/docker-compose.yml
@@ -132,6 +132,9 @@ services:
             - gravitee_email_port=1025
             - gravitee_email_subject="TEST"
             - gravitee_email_from="user@my.domain"
+            # Branded senders (optional): JSON array of {domains, from, subject}; overrides From/Subject for
+            # emails to matching recipient domains and locks the field in the console. Uncomment to enable.
+            # - gravitee_email_branded_senders=[{"domains":["example.com"],"from":"noreply@example.com","subject":"[Example] %s"}]
             - gravitee_httpClient_proxy_http_host=mitmproxy
             - gravitee_httpClient_proxy_http_port=8080
             - gravitee_httpClient_proxy_https_host=mitmproxy

--- a/docker/quick-setup/tcp/docker-compose.yml
+++ b/docker/quick-setup/tcp/docker-compose.yml
@@ -159,6 +159,9 @@ services:
             - gravitee_email_port=1025
             - gravitee_email_subject="TEST"
             - gravitee_email_from="user@my.domain"
+            # Branded senders (optional): JSON array of {domains, from, subject}; overrides From/Subject for
+            # emails to matching recipient domains and locks the field in the console. Uncomment to enable.
+            # - gravitee_email_branded_senders=[{"domains":["example.com"],"from":"noreply@example.com","subject":"[Example] %s"}]
         networks:
             - storage
             - frontend

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenders.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenders.java
@@ -149,7 +149,7 @@ public final class BrandedSenders {
      * {@code ';'} here is inside a free-text {@code from} / {@code subject}. Jackson decodes the escape
      * back to {@code ';'} transparently on read.</p>
      */
-    static String write(List<BrandedSenderConfig> configs) {
+    public static String write(List<BrandedSenderConfig> configs) {
         final List<BrandedSenderConfig> value = configs == null ? new ArrayList<>() : configs;
         value.forEach(BrandedSenders::validateEntry);
         value.forEach(BrandedSenders::normalizeDomains);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/BrandedSendersEnvironmentReader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/BrandedSendersEnvironmentReader.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.settings.BrandedSenderConfig;
+import io.gravitee.rest.api.model.settings.BrandedSenders;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.stereotype.Component;
+
+/**
+ * Reconstructs the {@code email.branded_senders} parameter value from the native yaml list of objects an
+ * on-prem operator writes in {@code gravitee.yml}:
+ *
+ * <pre>
+ * email:
+ *   branded_senders:
+ *     - domains: [example.com]
+ *       from: noreply@example.com
+ *       subject: "[Example] %s"
+ * </pre>
+ *
+ * <p>Spring flattens such a list into indexed properties ({@code email.branded_senders[0].from},
+ * {@code email.branded_senders[0].domains[0]}, …), so {@code environment.getProperty("email.branded_senders")}
+ * returns {@code null} and the value cannot be read as a single string. This reader walks the indexed
+ * properties into a typed {@link BrandedSenderConfig} list and serialises it with {@link BrandedSenders#write(List)},
+ * yielding the same JSON string form the console persists — including the {@code ';'} escaping the parameter
+ * read path relies on and the size guard.</p>
+ *
+ * <p>The equivalent flat JSON string / env-var form ({@code gravitee_email_branded_senders=[{…}]}) is accepted
+ * too and routed through the same {@link BrandedSenders#parse(String)} + {@link BrandedSenders#write(List)}
+ * normalisation, so both forms get the same escaping, CR/LF validation and size guard and behave identically.
+ * It is used by {@code ParameterServiceImpl} to seed the value at SYSTEM scope.</p>
+ *
+ * @author GraviteeSource Team
+ */
+@Component
+@CustomLog
+public class BrandedSendersEnvironmentReader {
+
+    private static final String PREFIX = Key.EMAIL_BRANDED_SENDERS.key();
+
+    private final ConfigurableEnvironment environment;
+
+    @Autowired
+    public BrandedSendersEnvironmentReader(ConfigurableEnvironment environment) {
+        this.environment = environment;
+    }
+
+    /**
+     * Reads the branded-sender configurations, accepting either the native yaml list or the flat JSON string /
+     * env-var form, and normalising both through {@link BrandedSenders#write(List)} so they share the same
+     * {@code ';'}-escaping, CR/LF validation and size guard. Returns {@link Optional#empty()} when none are
+     * declared (so the caller falls through to the env / org / default value), or when the declared value is
+     * invalid or oversized — a broken on-prem config is logged and ignored rather than breaking the whole
+     * settings response, and (crucially) leaves the console field editable rather than locked on a value that
+     * is not actually in effect.
+     */
+    public Optional<String> read() {
+        List<BrandedSenderConfig> configurations = readConfigurations();
+        if (configurations.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(BrandedSenders.write(configurations));
+        } catch (IllegalArgumentException e) {
+            // write() signals invalid/oversized operator config only via IllegalArgumentException; catching that
+            // (not RuntimeException) so an unrelated future bug surfaces instead of being mislabelled as bad config.
+            // Source-neutral: read() serves both the native yaml list and the flat env-var / JSON form.
+            log.error("Ignoring invalid '{}' branded-senders configuration", PREFIX, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Whether a <em>valid</em> branded-sender configuration is declared (in either storage form). Used to mark the
+     * console field read-only, so an operator who seeds the value in {@code gravitee.yml} sees the same
+     * "system-controlled" lock the flat form already gets — but only when the value is actually applied. A present
+     * but invalid config yields {@code false} here (matching {@link #read()}), so the field stays editable and the
+     * problem is logged rather than silently locked on the default.
+     */
+    public boolean isConfigured() {
+        return read().isPresent();
+    }
+
+    private List<BrandedSenderConfig> readConfigurations() {
+        // Flat JSON string / env-var form (e.g. gravitee_email_branded_senders): parse it here so read()'s
+        // write() gives it the identical ';'-escaping, CR/LF validation and size guard as the native yaml list —
+        // the two accepted forms then behave the same.
+        String flat = environment.getProperty(PREFIX);
+        if (flat != null && !flat.isBlank()) {
+            return BrandedSenders.parse(flat);
+        }
+
+        // Native yaml list, flattened by Spring into indexed properties.
+        List<BrandedSenderConfig> configurations = new ArrayList<>();
+        int index = 0;
+        while (hasEntry(index)) {
+            String entryPrefix = PREFIX + "[" + index + "]";
+            List<String> domains = readList(entryPrefix + ".domains");
+            if (domains.isEmpty()) {
+                log.warn("Branding entry '{}[{}]' has no 'domains'; it will never match a recipient", PREFIX, index);
+            }
+            configurations.add(
+                BrandedSenderConfig.builder()
+                    .domains(domains.isEmpty() ? null : domains)
+                    .from(environment.getProperty(entryPrefix + ".from"))
+                    .subject(environment.getProperty(entryPrefix + ".subject"))
+                    .build()
+            );
+            index++;
+        }
+        return configurations;
+    }
+
+    /**
+     * Whether an entry exists at {@code index}. Checks every field (not just {@code from} / {@code domains}) so an
+     * incomplete middle entry does not prematurely terminate the loop and silently drop the valid entries after it;
+     * a truly empty index ends the list.
+     */
+    private boolean hasEntry(int index) {
+        String entryPrefix = PREFIX + "[" + index + "]";
+        return (
+            environment.getProperty(entryPrefix + ".from") != null ||
+            environment.getProperty(entryPrefix + ".subject") != null ||
+            environment.getProperty(entryPrefix + ".domains") != null ||
+            environment.getProperty(entryPrefix + ".domains[0]") != null
+        );
+    }
+
+    private List<String> readList(String listKey) {
+        List<String> values = new ArrayList<>();
+        int index = 0;
+        String value;
+        while ((value = environment.getProperty(listKey + "[" + index + "]")) != null) {
+            values.add(value);
+            index++;
+        }
+        if (values.isEmpty()) {
+            // A scalar `domains: example.com` (rather than a list) binds to the bare key, not to domains[0].
+            String scalar = environment.getProperty(listKey);
+            if (scalar != null && !scalar.isBlank()) {
+                values.add(scalar);
+            }
+        }
+        return values;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -75,6 +75,9 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
     private ConfigurableEnvironment environment;
 
     @Autowired
+    private BrandedSendersEnvironmentReader brandedSendersEnvironmentReader;
+
+    @Autowired
     private NewsletterService newsletterService;
 
     @Autowired
@@ -192,7 +195,14 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
                     f.setAccessible(true);
                     try {
                         List<String> values = parameterMap.get(parameterKey.value().key());
-                        if (environment.containsProperty(parameterKey.value().key())) {
+                        // branded_senders needs its own presence check: containsProperty is false for a native yaml
+                        // list (flattened into indexed properties), and true for a flat value even when that value is
+                        // invalid and never applied. isConfigured() covers both forms and is true only when a valid
+                        // value is actually seeded, so the field locks exactly when its value is in effect.
+                        boolean systemConfigured = parameterKey.value() == Key.EMAIL_BRANDED_SENDERS
+                            ? brandedSendersEnvironmentReader.isConfigured()
+                            : environment.containsProperty(parameterKey.value().key());
+                        if (systemConfigured) {
                             configEntity.getMetadata().add(PortalSettingsEntity.METADATA_READONLY, parameterKey.value().key());
                         }
                         final String defaultValue = parameterKey.value().defaultValue();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ParameterServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ParameterServiceImpl.java
@@ -97,6 +97,9 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
     private ConfigurableEnvironment environment;
 
     @Inject
+    private BrandedSendersEnvironmentReader brandedSendersEnvironmentReader;
+
+    @Inject
     private EventManager eventManager;
 
     @Inject
@@ -447,9 +450,21 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
             parameter.setReferenceType(ParameterReferenceType.valueOf(referenceType.name()));
             parameter.setValue(value);
 
-            if (environment.containsProperty(key.key()) && key.isOverridable()) {
-                parameter.setValue(toSemicolonSeparatedString(key, environment.getProperty(key.key())));
-                return parameter;
+            // A system-overridden value must not be persisted to org/env storage: return the effective value
+            // without writing. This mirrors getSystemParameter() — branded_senders is resolved through the reader
+            // (both the native yaml list, for which containsProperty is false, and the flat form), every other key
+            // through containsProperty — so a console save cannot leave a stale org/env value behind a locked field.
+            if (key.isOverridable()) {
+                if (key == Key.EMAIL_BRANDED_SENDERS) {
+                    Optional<String> systemValue = brandedSendersEnvironmentReader.read();
+                    if (systemValue.isPresent()) {
+                        parameter.setValue(systemValue.get());
+                        return parameter;
+                    }
+                } else if (environment.containsProperty(key.key())) {
+                    parameter.setValue(toSemicolonSeparatedString(key, environment.getProperty(key.key())));
+                    return parameter;
+                }
             }
 
             if (updateMode) {
@@ -678,13 +693,27 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
     }
 
     private Optional<Parameter> getSystemParameter(Key key) {
-        if (environment.containsProperty(key.key()) && key.isOverridable()) {
-            final Parameter parameter = new Parameter();
-            parameter.setKey(key.key());
-            parameter.setValue(toSemicolonSeparatedString(key, environment.getProperty(key.key())));
-            return Optional.of(parameter);
+        if (!key.isOverridable()) {
+            return Optional.empty();
+        }
+        // email.branded_senders accepts a native yaml list (flattened into indexed properties, so containsProperty
+        // is false) or a flat JSON string / env var. Both are routed through the reader (parse -> write) so they get
+        // the same ';'-escaping, CR/LF validation and size guard and behave identically — hence this is handled
+        // before the generic verbatim branch below (which would otherwise store the flat form unescaped).
+        if (key == Key.EMAIL_BRANDED_SENDERS) {
+            return brandedSendersEnvironmentReader.read().map(value -> systemParameter(key, value));
+        }
+        if (environment.containsProperty(key.key())) {
+            return Optional.of(systemParameter(key, toSemicolonSeparatedString(key, environment.getProperty(key.key()))));
         }
         return Optional.empty();
+    }
+
+    private Parameter systemParameter(Key key, String value) {
+        final Parameter parameter = new Parameter();
+        parameter.setKey(key.key());
+        parameter.setValue(value);
+        return parameter;
     }
 
     private String getDefaultParameterValue(Key key) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/BrandedSendersEnvironmentReaderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/BrandedSendersEnvironmentReaderTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.model.settings.BrandedSenderConfig;
+import io.gravitee.rest.api.model.settings.BrandedSenders;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Covers the reconstruction of the {@code email.branded_senders} JSON parameter value from the native
+ * yaml list of objects an on-prem operator writes in {@code gravitee.yml}.
+ *
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class BrandedSendersEnvironmentReaderTest {
+
+    @Mock
+    private ConfigurableEnvironment environment;
+
+    private BrandedSendersEnvironmentReader reader;
+
+    private void stub(String key, String value) {
+        when(environment.getProperty(key)).thenReturn(value);
+    }
+
+    private BrandedSendersEnvironmentReader reader() {
+        return new BrandedSendersEnvironmentReader(environment);
+    }
+
+    @Test
+    void should_read_a_single_configuration_from_indexed_yaml_properties() {
+        reader = reader();
+        stub("email.branded_senders[0].domains[0]", "example.com");
+        stub("email.branded_senders[0].from", "noreply@example.com");
+        stub("email.branded_senders[0].subject", "[Example] %s");
+
+        var result = reader.read();
+
+        assertThat(result).isPresent();
+        assertThat(BrandedSenders.parse(result.get())).containsExactly(
+            BrandedSenderConfig.builder().domains(List.of("example.com")).from("noreply@example.com").subject("[Example] %s").build()
+        );
+    }
+
+    @Test
+    void should_read_multiple_configurations_each_with_multiple_domains() {
+        reader = reader();
+        stub("email.branded_senders[0].domains[0]", "example.com");
+        stub("email.branded_senders[0].domains[1]", "example.org");
+        stub("email.branded_senders[0].from", "noreply@example.com");
+        stub("email.branded_senders[0].subject", "[Example] %s");
+        stub("email.branded_senders[1].domains[0]", "sample.net");
+        stub("email.branded_senders[1].from", "noreply@sample.net");
+
+        var result = reader.read();
+
+        assertThat(result).isPresent();
+        assertThat(BrandedSenders.parse(result.get())).containsExactly(
+            BrandedSenderConfig.builder()
+                .domains(List.of("example.com", "example.org"))
+                .from("noreply@example.com")
+                .subject("[Example] %s")
+                .build(),
+            BrandedSenderConfig.builder().domains(List.of("sample.net")).from("noreply@sample.net").build()
+        );
+    }
+
+    @Test
+    void should_return_empty_when_no_configuration_is_declared() {
+        reader = reader();
+
+        assertThat(reader.read()).isEmpty();
+    }
+
+    @Test
+    void should_escape_semicolons_so_the_parameter_read_path_does_not_truncate() {
+        reader = reader();
+        stub("email.branded_senders[0].domains[0]", "example.com");
+        stub("email.branded_senders[0].from", "noreply@example.com");
+        stub("email.branded_senders[0].subject", "[a; b] %s");
+
+        var result = reader.read();
+
+        assertThat(result).isPresent();
+        // The value is stored as a single parameter whose read path splits on ';'; the serialiser must leave no
+        // literal ';' in the value, and a round-trip must still recover the original subject.
+        assertThat(result.get()).doesNotContain(";");
+        assertThat(BrandedSenders.parse(result.get()).get(0).getSubject()).isEqualTo("[a; b] %s");
+    }
+
+    @Test
+    void should_ignore_an_invalid_configuration_rather_than_fail() {
+        reader = reader();
+        stub("email.branded_senders[0].domains[0]", "example.com");
+        // A CR/LF in a header-bound field is rejected by the serialiser (header-injection defence); the reader
+        // logs and returns empty so a broken on-prem config cannot break the whole settings response.
+        stub("email.branded_senders[0].from", "noreply@example.com\r\nBcc: evil@example.org");
+
+        assertThat(reader.read()).isEmpty();
+        // ...and it must report "not configured" so the console field stays editable rather than locked on a
+        // value that is not actually applied.
+        assertThat(reader.isConfigured()).isFalse();
+    }
+
+    @Test
+    void should_read_the_flat_json_string_form() {
+        reader = reader();
+        stub("email.branded_senders", "[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]");
+
+        var result = reader.read();
+
+        assertThat(result).isPresent();
+        assertThat(BrandedSenders.parse(result.get())).containsExactly(
+            BrandedSenderConfig.builder().domains(List.of("example.com")).from("noreply@example.com").subject("[Example] %s").build()
+        );
+        assertThat(reader.isConfigured()).isTrue();
+    }
+
+    @Test
+    void should_escape_semicolons_in_the_flat_form_too() {
+        reader = reader();
+        // AC2 promises the flat / env-var form works too; it must get the same ';'-escaping as the native path so a
+        // ';' in a subject does not truncate the value at the parameter read path.
+        stub("email.branded_senders", "[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[a; b] %s\"}]");
+
+        var result = reader.read();
+
+        assertThat(result).isPresent();
+        assertThat(result.get()).doesNotContain(";");
+        assertThat(BrandedSenders.parse(result.get()).get(0).getSubject()).isEqualTo("[a; b] %s");
+    }
+
+    @Test
+    void should_ignore_an_invalid_flat_form() {
+        reader = reader();
+        // CR/LF smuggled into the flat form is caught by the same serialiser validation and left editable + logged.
+        stub(
+            "email.branded_senders",
+            "[{\"domains\":[\"example.com\"],\"from\":\"a@example.com\\r\\nBcc: evil@example.org\",\"subject\":\"[X] %s\"}]"
+        );
+
+        assertThat(reader.read()).isEmpty();
+        assertThat(reader.isConfigured()).isFalse();
+    }
+
+    @Test
+    void should_read_a_scalar_domains_value() {
+        reader = reader();
+        // A common yaml habit: `domains: example.com` (scalar) rather than a list; it binds to the bare key, not
+        // domains[0], and must not be silently dropped.
+        stub("email.branded_senders[0].domains", "example.com");
+        stub("email.branded_senders[0].from", "noreply@example.com");
+
+        var result = reader.read();
+
+        assertThat(result).isPresent();
+        assertThat(BrandedSenders.parse(result.get())).containsExactly(
+            BrandedSenderConfig.builder().domains(List.of("example.com")).from("noreply@example.com").build()
+        );
+    }
+
+    @Test
+    void should_keep_later_entries_when_a_middle_entry_is_incomplete() {
+        reader = reader();
+        stub("email.branded_senders[0].domains[0]", "first.com");
+        stub("email.branded_senders[0].from", "noreply@first.com");
+        // An incomplete middle entry (only a subject) must not terminate the loop and drop the valid entry after it.
+        stub("email.branded_senders[1].subject", "[Incomplete] %s");
+        stub("email.branded_senders[2].domains[0]", "third.com");
+        stub("email.branded_senders[2].from", "noreply@third.com");
+
+        var result = reader.read();
+
+        assertThat(result).isPresent();
+        var configurations = BrandedSenders.parse(result.get());
+        assertThat(configurations).hasSize(3);
+        assertThat(configurations).anySatisfy(config -> assertThat(config.getFrom()).isEqualTo("noreply@third.com"));
+    }
+
+    @Test
+    void should_report_configured_when_a_native_list_is_present() {
+        reader = reader();
+        stub("email.branded_senders[0].from", "noreply@example.com");
+
+        assertThat(reader.isConfigured()).isTrue();
+    }
+
+    @Test
+    void should_report_configured_from_domains_only() {
+        reader = reader();
+        stub("email.branded_senders[0].domains[0]", "example.com");
+
+        assertThat(reader.isConfigured()).isTrue();
+    }
+
+    @Test
+    void should_not_report_configured_when_absent() {
+        reader = reader();
+
+        assertThat(reader.isConfigured()).isFalse();
+    }
+
+    @Test
+    void should_parse_real_yaml_the_way_spring_flattens_it() {
+        // Guards against the hand-stubbed indexed-key shape drifting from Spring's real yaml-list flattening: load
+        // actual yaml through the same SnakeYAML mechanism gravitee-node uses, then read it back end to end.
+        String yaml = """
+            email:
+              branded_senders:
+                - domains:
+                    - example.com
+                    - example.org
+                  from: noreply@example.com
+                  subject: "[Example] %s"
+                - domains: [sample.net]
+                  from: noreply@sample.net
+            """;
+        YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+        factory.setResources(new ByteArrayResource(yaml.getBytes(StandardCharsets.UTF_8)));
+        MockEnvironment realEnvironment = new MockEnvironment();
+        factory.getObject().forEach((key, value) -> realEnvironment.setProperty(key.toString(), value.toString()));
+
+        // The reader's assumption made explicit: Spring flattens the list to indexed properties.
+        assertThat(realEnvironment.getProperty("email.branded_senders[0].from")).isEqualTo("noreply@example.com");
+        assertThat(realEnvironment.getProperty("email.branded_senders[0].domains[1]")).isEqualTo("example.org");
+
+        var result = new BrandedSendersEnvironmentReader(realEnvironment).read();
+
+        assertThat(result).isPresent();
+        assertThat(BrandedSenders.parse(result.get())).containsExactly(
+            BrandedSenderConfig.builder()
+                .domains(List.of("example.com", "example.org"))
+                .from("noreply@example.com")
+                .subject("[Example] %s")
+                .build(),
+            BrandedSenderConfig.builder().domains(List.of("sample.net")).from("noreply@sample.net").build()
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
@@ -119,6 +119,9 @@ class ConfigServiceTest {
     private ConfigurableEnvironment environment;
 
     @Mock
+    private BrandedSendersEnvironmentReader brandedSendersEnvironmentReader;
+
+    @Mock
     private NewsletterService newsletterService;
 
     @Mock
@@ -269,6 +272,47 @@ class ConfigServiceTest {
         assertThat(portalSettings.getLogging().getMessageSampling().getTemporal().getLimit())
             .as("sampling temporal limit")
             .isEqualTo("PT1S");
+    }
+
+    @Test
+    void shouldMarkBrandedSendersReadonlyWhenConfiguredAsNativeYamlList() {
+        // A native yaml list is flattened into indexed properties, so environment.containsProperty is false for it;
+        // the reader's presence check must still lock the field, matching how a flat / env-var value already does.
+        when(
+            mockParameterService.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                any(List.class),
+                any(Function.class),
+                eq("DEFAULT"),
+                eq(ParameterReferenceType.ENVIRONMENT)
+            )
+        ).thenReturn(new HashMap<>());
+        when(brandedSendersEnvironmentReader.isConfigured()).thenReturn(true);
+
+        PortalSettingsEntity portalSettings = configService.getPortalSettings(GraviteeContext.getExecutionContext());
+
+        assertThat(portalSettings.getMetadata().get(PortalSettingsEntity.METADATA_READONLY)).contains(Key.EMAIL_BRANDED_SENDERS.key());
+    }
+
+    @Test
+    void shouldNotMarkBrandedSendersReadonlyWhenNotConfigured() {
+        // A present-but-invalid config yields isConfigured() == false; the field must stay editable rather than
+        // being locked on a value that is not actually in effect.
+        when(
+            mockParameterService.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                any(List.class),
+                any(Function.class),
+                eq("DEFAULT"),
+                eq(ParameterReferenceType.ENVIRONMENT)
+            )
+        ).thenReturn(new HashMap<>());
+        when(brandedSendersEnvironmentReader.isConfigured()).thenReturn(false);
+
+        PortalSettingsEntity portalSettings = configService.getPortalSettings(GraviteeContext.getExecutionContext());
+
+        List<String> readonly = portalSettings.getMetadata().get(PortalSettingsEntity.METADATA_READONLY);
+        assertThat(readonly == null ? List.<String>of() : readonly).doesNotContain(Key.EMAIL_BRANDED_SENDERS.key());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ParameterServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ParameterServiceTest.java
@@ -79,6 +79,9 @@ public class ParameterServiceTest {
     private ConfigurableEnvironment environment;
 
     @Mock
+    private BrandedSendersEnvironmentReader brandedSendersEnvironmentReader;
+
+    @Mock
     private EventManager eventManager;
 
     @Mock
@@ -97,6 +100,79 @@ public class ParameterServiceTest {
     public void init() {
         GraviteeContext.getCurrentParameters().clear();
         when(node.id()).thenReturn("test-node-id");
+    }
+
+    @Test
+    public void shouldServeBrandedSendersFromYamlAsSystemParameter() throws TechnicalException {
+        final String json = "[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]";
+        when(brandedSendersEnvironmentReader.read()).thenReturn(of(json));
+
+        final List<String> values = parameterService.findAll(
+            GraviteeContext.getExecutionContext(),
+            EMAIL_BRANDED_SENDERS,
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        // A gravitee.yml value is served at SYSTEM scope and wins over the console (env/org) value.
+        assertEquals(List.of(json), values);
+        verifyNoInteractions(parameterRepository);
+    }
+
+    @Test
+    public void shouldFallBackToDefaultWhenNoBrandedSendersInYaml() throws TechnicalException {
+        when(brandedSendersEnvironmentReader.read()).thenReturn(empty());
+        when(parameterRepository.findById(eq(EMAIL_BRANDED_SENDERS.key()), any(), eq(ParameterReferenceType.ORGANIZATION))).thenReturn(
+            empty()
+        );
+
+        final List<String> values = parameterService.findAll(
+            GraviteeContext.getExecutionContext(),
+            EMAIL_BRANDED_SENDERS,
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ORGANIZATION
+        );
+
+        assertEquals(List.of(EMAIL_BRANDED_SENDERS.defaultValue()), values);
+    }
+
+    @Test
+    public void shouldRouteFlatBrandedSendersThroughTheReaderNotVerbatim() throws TechnicalException {
+        // Even when the flat property is present, the value must come from the reader (normalised via parse -> write)
+        // rather than the raw environment string, so the flat and native forms behave identically.
+        final String normalized = "[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\",\"subject\":\"[Example] %s\"}]";
+        lenient().when(environment.containsProperty(EMAIL_BRANDED_SENDERS.key())).thenReturn(true);
+        lenient().when(environment.getProperty(EMAIL_BRANDED_SENDERS.key())).thenReturn("raw-unescaped-value");
+        when(brandedSendersEnvironmentReader.read()).thenReturn(of(normalized));
+
+        final List<String> values = parameterService.findAll(
+            GraviteeContext.getExecutionContext(),
+            EMAIL_BRANDED_SENDERS,
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        assertEquals(List.of(normalized), values);
+    }
+
+    @Test
+    public void shouldNotPersistBrandedSendersSaveWhenConfiguredInYaml() throws TechnicalException {
+        // A yaml-configured (system-controlled) branded_senders must short-circuit save() and NOT be persisted to
+        // org/env storage; otherwise a stale value would survive once the yaml entry is removed. containsProperty is
+        // false for the native list, so save() must resolve it through the reader, mirroring getSystemParameter().
+        final String systemValue = "[{\"domains\":[\"example.com\"],\"from\":\"noreply@example.com\"}]";
+        when(brandedSendersEnvironmentReader.read()).thenReturn(of(systemValue));
+        when(parameterRepository.findById(eq(EMAIL_BRANDED_SENDERS.key()), any(), eq(ParameterReferenceType.ORGANIZATION))).thenReturn(
+            empty()
+        );
+
+        final Parameter result = parameterService.save(
+            GraviteeContext.getExecutionContext(),
+            EMAIL_BRANDED_SENDERS,
+            "[{\"domains\":[\"other.com\"],\"from\":\"x@other.com\"}]",
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ORGANIZATION
+        );
+
+        assertEquals(systemValue, result.getValue());
+        verify(parameterRepository, never()).create(any());
+        verify(parameterRepository, never()).update(any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -595,6 +595,18 @@ email:
   subject: "[Gravitee.io] %s"
   port: 587
   from: noreply@my.domain
+  # Branded senders (optional): override the "from" address and subject for notification emails sent to
+  # specific recipient domains. Each entry applies its "from"/"subject" when the recipient's domain matches
+  # one of "domains"; recipients on any other domain keep the default "from"/"subject" above. "subject"
+  # wraps the email subject, where "%s" is replaced by the original subject.
+  # A value set here applies to all organizations/environments and locks the field in the console (like the
+  # other email settings above); leave it commented to manage branded senders from the console UI instead.
+#  branded_senders:
+#    - domains:
+#        - example.com
+#        - example.org
+#      from: noreply@example.com
+#      subject: "[Example] %s"
 #  username: user@my.domain
 #  password: password
 #  properties:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14192
## Description
Exposes `email.branded_senders` in `gravitee.yml` so on-prem operators can configure branded senders without the console (APIM-14192 / S5 of the branded-senders epic).

Operators write a **native yaml list**; a load-time adapter reconstructs it into the `email.branded_senders` JSON parameter value:

```yaml
email:
  branded_senders:
    - domains: [example.com]
      from: noreply@example.com
      subject: "[Example] %s"
```

The flat JSON-string form (and the `gravitee_email_branded_senders` env var) is also accepted; both forms are normalised through the same `parse` → `write` path, so they get identical `;`-escaping, CR/LF validation and size guard.

### Behaviour (matches existing `email.*` convention)
- A value in `gravitee.yml` seeds `email.branded_senders` at SYSTEM scope and takes precedence over the console (Org/Env) value — same as `email.from` / `email.subject` / `email.host`.
- When a **valid** value is set in `gravitee.yml`, the console marks the branded-senders field read-only (both flat and native-list forms), like `email.host` / `email.port` today. A present-but-invalid value is logged and ignored, and the field stays editable rather than locking on a value that isn't in effect.
- Shipped commented out, so by default the console fully controls branded senders.

### Changes
- **`BrandedSendersEnvironmentReader`** (new) — reconstructs the native yaml list (and normalises the flat/env form) into the JSON parameter value via `BrandedSenders.write`, reusing validation, `;`-escaping and the size guard.
- **`ParameterServiceImpl.getSystemParameter`** — routes `email.branded_senders` (both forms) through the reader so the value is escaped/validated consistently and yaml wins.
- **`ConfigServiceImpl`** — marks the field read-only via `isConfigured()` (valid-value check), covering both storage forms.
- **`BrandedSenders.write`** made public (symmetric with the public `parse`).
- Shipped `gravitee.yml` + 6 docker quick-setup compose files: commented examples.

### Tests
`BrandedSendersEnvironmentReaderTest` (13), plus 5 new cases in `ParameterServiceTest` and 2 in `ConfigServiceTest` — covering both storage forms, `;`-escaping, scalar `domains`, incomplete/invalid entries, the read-only valid-value gate, and the non-overridable-key path. No regressions in the existing suites.


### Additional Context
getSystemParameter / ConfigServiceImpl special-case EMAIL_BRANDED_SENDERS with an explicit branch rather than a Map<Key, …> reader registry is a deliberate choice. With a single key needing custom reconstruction, an inline, commented branch is clearer than a strategy abstraction, and matches how this legacy service module already handles per-key logic. 

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

