### PR TITLE
fix(rest-api): fall back to console link when redirect URL isn't whitelisted

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/config/gravitee.yml
@@ -631,7 +631,8 @@ email:
 #  themes:
 #    path: ${gravitee.home}/themes
   # Allows domains to be used while generating some emails from the portal. ie. registration, forget password
-  # Empty whitelist means only the installation's own portal URL is allowed (see installation.standalone.portal.url below).
+  # Empty whitelist means only the installation's own portal URL is allowed (see installation.standalone.portal.url below);
+  # any other URL is ignored and the email falls back to the default link.
 #  whitelist:
 #    - https://portal.domain.com
 #    - https://private-portal.domain.com

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/config/gravitee.yml
@@ -631,7 +631,7 @@ email:
 #  themes:
 #    path: ${gravitee.home}/themes
   # Allows domains to be used while generating some emails from the portal. ie. registration, forget password
-  # Empty whitelist means all urls are allowed.
+  # Empty whitelist means only the installation's own portal URL is allowed (see installation.standalone.portal.url below).
 #  whitelist:
 #    - https://portal.domain.com
 #    - https://private-portal.domain.com

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -133,6 +133,7 @@ import io.gravitee.rest.api.service.exceptions.PasswordFormatInvalidException;
 import io.gravitee.rest.api.service.exceptions.ServiceAccountNotManageableException;
 import io.gravitee.rest.api.service.exceptions.StillPrimaryOwnerException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.exceptions.UrlForbiddenException;
 import io.gravitee.rest.api.service.exceptions.UserAlreadyFinalizedException;
 import io.gravitee.rest.api.service.exceptions.UserNotActiveException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
@@ -309,6 +310,21 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             portalWhitelist.add(whitelistUrl);
             i++;
         }
+    }
+
+    /**
+     * Registration confirmation and password reset links embed a signed token in the caller-supplied redirect
+     * URL. Without an explicit whitelist, that URL must be rejected outright rather than allowed by default,
+     * otherwise the token can be exfiltrated to an attacker-controlled domain.
+     */
+    private void checkPortalRedirectUrlAllowed(String url) {
+        if (url == null) {
+            return;
+        }
+        if (portalWhitelist.isEmpty()) {
+            throw new UrlForbiddenException();
+        }
+        UrlSanitizerUtils.checkAllowed(url, portalWhitelist, true);
     }
 
     @Override
@@ -835,9 +851,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     ) {
         final ReferenceContext currentContext = executionContext.getReferenceContext();
 
-        if (confirmationPageUrl != null) {
-            UrlSanitizerUtils.checkAllowed(confirmationPageUrl, portalWhitelist, true);
-        }
+        checkPortalRedirectUrlAllowed(confirmationPageUrl);
 
         checkUserRegistrationEnabled(executionContext);
         boolean autoRegistrationEnabled = isAutoRegistrationEnabled(executionContext, currentContext);
@@ -1425,7 +1439,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             throw new UserNotActiveException(sourceId);
         }
 
-        UrlSanitizerUtils.checkAllowed(resetPageUrl, portalWhitelist, true);
+        checkPortalRedirectUrlAllowed(resetPageUrl);
 
         UserEntity foundUser = this.findBySource(executionContext.getOrganizationId(), IDP_SOURCE_GRAVITEE, sourceId, false);
         if ("ACTIVE".equals(foundUser.getStatus())) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -138,6 +138,7 @@ import io.gravitee.rest.api.service.exceptions.PasswordFormatInvalidException;
 import io.gravitee.rest.api.service.exceptions.ServiceAccountNotManageableException;
 import io.gravitee.rest.api.service.exceptions.StillPrimaryOwnerException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.exceptions.UrlForbiddenException;
 import io.gravitee.rest.api.service.exceptions.UserAlreadyFinalizedException;
 import io.gravitee.rest.api.service.exceptions.UserNotActiveException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
@@ -308,6 +309,21 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             portalWhitelist.add(whitelistUrl);
             i++;
         }
+    }
+
+    /**
+     * Registration confirmation and password reset links embed a signed token in the caller-supplied redirect
+     * URL. Without an explicit whitelist, that URL must be rejected outright rather than allowed by default,
+     * otherwise the token can be exfiltrated to an attacker-controlled domain.
+     */
+    private void checkPortalRedirectUrlAllowed(String url) {
+        if (url == null) {
+            return;
+        }
+        if (portalWhitelist.isEmpty()) {
+            throw new UrlForbiddenException();
+        }
+        UrlSanitizerUtils.checkAllowed(url, portalWhitelist, true);
     }
 
     @Override
@@ -840,9 +856,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     ) {
         final ReferenceContext currentContext = executionContext.getReferenceContext();
 
-        if (confirmationPageUrl != null) {
-            UrlSanitizerUtils.checkAllowed(confirmationPageUrl, portalWhitelist, true);
-        }
+        checkPortalRedirectUrlAllowed(confirmationPageUrl);
 
         checkUserRegistrationEnabled(executionContext);
         boolean autoRegistrationEnabled = isAutoRegistrationEnabled(executionContext, currentContext);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -313,17 +313,26 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
 
     /**
      * Registration confirmation and password reset links embed a signed token in the caller-supplied redirect
-     * URL. Without an explicit whitelist, that URL must be rejected outright rather than allowed by default,
-     * otherwise the token can be exfiltrated to an attacker-controlled domain.
+     * URL. Without an explicit whitelist, that URL must only be accepted if it matches the installation's own
+     * resolved portal URL, otherwise the token can be exfiltrated to an attacker-controlled domain.
      */
-    private void checkPortalRedirectUrlAllowed(String url) {
-        if (url == null) {
+    private void checkPortalRedirectUrlAllowed(ExecutionContext executionContext, String url) {
+        if (url == null || url.isBlank()) {
             return;
         }
-        if (portalWhitelist.isEmpty()) {
+        List<String> effectiveWhitelist = portalWhitelist.isEmpty() ? fallbackPortalWhitelist(executionContext) : portalWhitelist;
+        if (effectiveWhitelist.isEmpty()) {
             throw new UrlForbiddenException();
         }
-        UrlSanitizerUtils.checkAllowed(url, portalWhitelist, true);
+        UrlSanitizerUtils.checkAllowed(url, effectiveWhitelist, true);
+    }
+
+    private List<String> fallbackPortalWhitelist(ExecutionContext executionContext) {
+        if (!executionContext.hasEnvironmentId()) {
+            return List.of();
+        }
+        String portalUrl = installationAccessQueryService.getPortalUrl(executionContext.getEnvironmentId());
+        return portalUrl == null ? List.of() : List.of(portalUrl);
     }
 
     @Override
@@ -856,7 +865,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     ) {
         final ReferenceContext currentContext = executionContext.getReferenceContext();
 
-        checkPortalRedirectUrlAllowed(confirmationPageUrl);
+        checkPortalRedirectUrlAllowed(executionContext, confirmationPageUrl);
 
         checkUserRegistrationEnabled(executionContext);
         boolean autoRegistrationEnabled = isAutoRegistrationEnabled(executionContext, currentContext);
@@ -1497,9 +1506,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
 
     @Override
     public void resetPassword(ExecutionContext executionContext, final String id, final String resetPageUrl) {
-        if (resetPageUrl != null && !resetPageUrl.isBlank()) {
-            UrlSanitizerUtils.checkAllowed(resetPageUrl, portalWhitelist, true);
-        }
+        checkPortalRedirectUrlAllowed(executionContext, resetPageUrl);
         doResetPassword(executionContext, id, resetPageUrl);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -313,26 +313,55 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
 
     /**
      * Registration confirmation and password reset links embed a signed token in the caller-supplied redirect
-     * URL. Without an explicit whitelist, that URL must only be accepted if it matches the installation's own
-     * resolved portal URL, otherwise the token can be exfiltrated to an attacker-controlled domain.
+     * URL. Without an explicit whitelist, that URL is only trusted when it matches the installation's own
+     * resolved portal URL; any other URL is dropped (returning {@code null}) so {@link #getTokenRegistrationParams}
+     * falls back to its default link instead of exfiltrating the token to an attacker-controlled domain.
+     * Only {@link #register} and the caller-facing {@link #resetPassword(ExecutionContext, String, String)}
+     * receive an externally-supplied redirect URL; other callers of {@code getTokenRegistrationParams} (gamma
+     * reset target, registration-approval flow) build their target page URL themselves from trusted installation
+     * configuration and must not be sanitized here.
      */
-    private void checkPortalRedirectUrlAllowed(ExecutionContext executionContext, String url) {
+    private String sanitizePortalRedirectUrl(ExecutionContext executionContext, String url) {
         if (url == null || url.isBlank()) {
-            return;
+            return null;
         }
-        List<String> effectiveWhitelist = portalWhitelist.isEmpty() ? fallbackPortalWhitelist(executionContext) : portalWhitelist;
+        String environmentId = executionContext.hasEnvironmentId() ? executionContext.getEnvironmentId() : null;
+        List<String> configuredWhitelist = portalWhitelist == null ? List.of() : portalWhitelist;
+        List<String> effectiveWhitelist = configuredWhitelist.isEmpty() ? fallbackPortalWhitelist(executionContext) : configuredWhitelist;
         if (effectiveWhitelist.isEmpty()) {
-            throw new UrlForbiddenException();
+            log.warn(
+                "Rejected redirect URL '{}' for environment {}: no 'portal.whitelist' is configured and no portal URL could be resolved for this environment. Falling back to the default link.",
+                url,
+                environmentId
+            );
+            return null;
         }
-        UrlSanitizerUtils.checkAllowed(url, effectiveWhitelist, true);
+        try {
+            UrlSanitizerUtils.checkAllowed(url, effectiveWhitelist, true);
+            return url;
+        } catch (UrlForbiddenException e) {
+            log.warn(
+                "Rejected redirect URL '{}' for environment {}: not part of the allowed whitelist {}. Falling back to the default link.",
+                url,
+                environmentId,
+                effectiveWhitelist
+            );
+            return null;
+        }
     }
 
     private List<String> fallbackPortalWhitelist(ExecutionContext executionContext) {
         if (!executionContext.hasEnvironmentId()) {
             return List.of();
         }
-        String portalUrl = installationAccessQueryService.getPortalUrl(executionContext.getEnvironmentId());
-        return portalUrl == null ? List.of() : List.of(portalUrl);
+        List<String> portalUrls = installationAccessQueryService.getPortalUrls(executionContext.getEnvironmentId());
+        if (portalUrls == null) {
+            return List.of();
+        }
+        return portalUrls
+            .stream()
+            .filter(portalUrl -> !isEmpty(portalUrl) && !DEFAULT_PORTAL_URL.equals(portalUrl))
+            .toList();
     }
 
     @Override
@@ -865,8 +894,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     ) {
         final ReferenceContext currentContext = executionContext.getReferenceContext();
 
-        checkPortalRedirectUrlAllowed(executionContext, confirmationPageUrl);
-
         checkUserRegistrationEnabled(executionContext);
         boolean autoRegistrationEnabled = isAutoRegistrationEnabled(executionContext, currentContext);
 
@@ -874,7 +901,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             executionContext,
             newExternalUserEntity,
             USER_REGISTRATION,
-            confirmationPageUrl,
+            sanitizePortalRedirectUrl(executionContext, confirmationPageUrl),
             autoRegistrationEnabled,
             false
         );
@@ -1506,8 +1533,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
 
     @Override
     public void resetPassword(ExecutionContext executionContext, final String id, final String resetPageUrl) {
-        checkPortalRedirectUrlAllowed(executionContext, resetPageUrl);
-        doResetPassword(executionContext, id, resetPageUrl);
+        doResetPassword(executionContext, id, sanitizePortalRedirectUrl(executionContext, resetPageUrl));
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -1287,6 +1287,7 @@ public class UserServiceTest {
     @Test
     public void shouldFailWhileResettingPassword() throws TechnicalException {
         assertThrows(UserNotFoundException.class, () -> {
+            setField(userService, "portalWhitelist", List.of("HTTP://MY-RESET-PAGE"));
             when(userRepository.findBySource(any(), any(), any())).thenReturn(Optional.empty());
             userService.resetPasswordFromSourceId(EXECUTION_CONTEXT, "my@email.com", "HTTP://MY-RESET-PAGE");
         });
@@ -1295,6 +1296,7 @@ public class UserServiceTest {
     @Test
     public void shouldFailWhileResettingPasswordWhenUserFoundIsNotActive() throws TechnicalException {
         assertThrows(UserNotActiveException.class, () -> {
+            setField(userService, "portalWhitelist", List.of("HTTP://MY-RESET-PAGE"));
             User user = new User();
             user.setId(USER_NAME);
             user.setSource("gravitee");
@@ -1308,6 +1310,7 @@ public class UserServiceTest {
     @Test
     public void shouldFailWhileResettingPasswordWhenUserFoundIsNotInternallyManaged() throws TechnicalException {
         assertThrows(UserNotInternallyManagedException.class, () -> {
+            setField(userService, "portalWhitelist", List.of("HTTP://MY-RESET-PAGE"));
             User user = new User();
             user.setId(USER_NAME);
             user.setSource("not gravitee");
@@ -1318,6 +1321,29 @@ public class UserServiceTest {
 
             userService.resetPasswordFromSourceId(EXECUTION_CONTEXT, "my@email.com", "HTTP://MY-RESET-PAGE");
         });
+    }
+
+    @Test
+    public void shouldRejectResetPageUrlWhenPortalWhitelistIsNotConfigured() throws TechnicalException {
+        setField(userService, "portalWhitelist", List.of());
+
+        assertThrows(UrlForbiddenException.class, () ->
+            userService.resetPasswordFromSourceId(EXECUTION_CONTEXT, "my@email.com", "https://attacker.example.com/reset")
+        );
+
+        verifyNoInteractions(emailService);
+    }
+
+    @Test
+    public void shouldRejectConfirmationPageUrlWhenPortalWhitelistIsNotConfigured() throws TechnicalException {
+        setField(userService, "portalWhitelist", List.of());
+        NewExternalUserEntity newExternalUserEntity = mock(NewExternalUserEntity.class);
+
+        assertThrows(UrlForbiddenException.class, () ->
+            userService.register(EXECUTION_CONTEXT, newExternalUserEntity, "https://attacker.example.com/confirm")
+        );
+
+        verifyNoInteractions(emailService);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService.DEFAULT_PORTAL_URL;
 import static io.gravitee.repository.management.model.User.AuditEvent.PASSWORD_CHANGED;
 import static io.gravitee.rest.api.service.common.JWTHelper.ACTION.RESET_PASSWORD;
 import static io.gravitee.rest.api.service.common.JWTHelper.ACTION.USER_REGISTRATION;
@@ -25,6 +26,7 @@ import static java.util.Optional.of;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.invokeMethod;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import com.auth0.jwt.JWT;
@@ -1287,7 +1289,6 @@ public class UserServiceTest {
     @Test
     public void shouldFailWhileResettingPassword() throws TechnicalException {
         assertThrows(UserNotFoundException.class, () -> {
-            setField(userService, "portalWhitelist", List.of("HTTP://MY-RESET-PAGE"));
             when(userRepository.findBySource(any(), any(), any())).thenReturn(Optional.empty());
             userService.resetPasswordFromSourceId(EXECUTION_CONTEXT, "my@email.com", "HTTP://MY-RESET-PAGE");
         });
@@ -1296,7 +1297,6 @@ public class UserServiceTest {
     @Test
     public void shouldFailWhileResettingPasswordWhenUserFoundIsNotActive() throws TechnicalException {
         assertThrows(UserNotActiveException.class, () -> {
-            setField(userService, "portalWhitelist", List.of("HTTP://MY-RESET-PAGE"));
             User user = new User();
             user.setId(USER_NAME);
             user.setSource("gravitee");
@@ -1310,7 +1310,6 @@ public class UserServiceTest {
     @Test
     public void shouldFailWhileResettingPasswordWhenUserFoundIsNotInternallyManaged() throws TechnicalException {
         assertThrows(UserNotInternallyManagedException.class, () -> {
-            setField(userService, "portalWhitelist", List.of("HTTP://MY-RESET-PAGE"));
             User user = new User();
             user.setId(USER_NAME);
             user.setSource("not gravitee");
@@ -1332,52 +1331,27 @@ public class UserServiceTest {
     }
 
     @Test
-    public void shouldRejectResetPageUrlWhenPortalWhitelistIsNotConfiguredAndNoFallbackPortalUrl() throws TechnicalException {
+    public void shouldNotBlockPasswordResetOnRedirectUrlNotMatchingWhitelist() throws TechnicalException {
         setField(userService, "portalWhitelist", List.of());
-        when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn(null);
+        when(installationAccessQueryService.getPortalUrls(ENVIRONMENT)).thenReturn(List.of());
         when(userRepository.findBySource(any(), any(), any())).thenReturn(Optional.of(activeGraviteeUser()));
 
-        assertThrows(UrlForbiddenException.class, () ->
+        // proceeds past the redirect URL and fails at the (unstubbed) user lookup inside doResetPassword,
+        // proving the mismatched URL itself is no longer rejected
+        assertThrows(UserNotFoundException.class, () ->
             userService.resetPasswordFromSourceId(EXECUTION_CONTEXT, "my@email.com", "https://attacker.example.com/reset")
         );
-
-        verifyNoInteractions(emailService);
     }
 
     @Test
-    public void shouldRejectConfirmationPageUrlWhenPortalWhitelistIsNotConfiguredAndNoFallbackPortalUrl() throws TechnicalException {
+    public void shouldNotBlockRegistrationOnRedirectUrlNotMatchingWhitelist() throws TechnicalException {
         setField(userService, "portalWhitelist", List.of());
-        when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn(null);
         NewExternalUserEntity newExternalUserEntity = mock(NewExternalUserEntity.class);
 
-        assertThrows(UrlForbiddenException.class, () ->
+        // proceeds past the redirect URL and fails because registration is disabled by default in this test setup,
+        // proving the mismatched URL itself is no longer rejected
+        assertThrows(UserRegistrationUnavailableException.class, () ->
             userService.register(EXECUTION_CONTEXT, newExternalUserEntity, "https://attacker.example.com/confirm")
-        );
-
-        verifyNoInteractions(emailService);
-    }
-
-    @Test
-    public void shouldRejectResetPageUrlWhenPortalWhitelistIsNotConfiguredAndUrlDoesNotMatchFallbackPortalUrl() throws TechnicalException {
-        setField(userService, "portalWhitelist", List.of());
-        when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn("https://portal.example.com");
-        when(userRepository.findBySource(any(), any(), any())).thenReturn(Optional.of(activeGraviteeUser()));
-
-        assertThrows(UrlForbiddenException.class, () ->
-            userService.resetPasswordFromSourceId(EXECUTION_CONTEXT, "my@email.com", "https://attacker.example.com/reset")
-        );
-
-        verifyNoInteractions(emailService);
-    }
-
-    @Test
-    public void shouldRejectResetPageUrlWhenPortalWhitelistIsNotConfiguredAndContextHasNoEnvironment() throws TechnicalException {
-        setField(userService, "portalWhitelist", List.of());
-        ExecutionContext organizationOnlyContext = new ExecutionContext(ORGANIZATION);
-        when(userRepository.findBySource(any(), any(), any())).thenReturn(Optional.of(activeGraviteeUser()));
-
-        assertThrows(UrlForbiddenException.class, () ->
-            userService.resetPasswordFromSourceId(organizationOnlyContext, "my@email.com", "https://attacker.example.com/reset")
         );
 
         verifyNoInteractions(emailService);
@@ -1385,24 +1359,105 @@ public class UserServiceTest {
     }
 
     @Test
-    public void shouldAllowResetPageUrlWhenPortalWhitelistIsNotConfiguredButUrlMatchesFallbackPortalUrl() throws TechnicalException {
-        assertThrows(UserNotFoundException.class, () -> {
-            setField(userService, "portalWhitelist", List.of());
-            when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn("https://portal.example.com");
-            when(userRepository.findBySource(any(), any(), any())).thenReturn(Optional.of(activeGraviteeUser()));
-            userService.resetPasswordFromSourceId(EXECUTION_CONTEXT, "my@email.com", "https://portal.example.com/reset");
-        });
+    public void shouldUseRedirectUrlWhenItMatchesConfiguredWhitelist() {
+        setField(userService, "portalWhitelist", List.of("https://portal.example.com"));
+
+        String sanitizedUrl = invokeMethod(userService, "sanitizePortalRedirectUrl", EXECUTION_CONTEXT, "https://portal.example.com/reset");
+
+        assertEquals("https://portal.example.com/reset", sanitizedUrl);
+        verify(installationAccessQueryService, never()).getPortalUrls(any());
     }
 
     @Test
-    public void shouldAllowConfirmationPageUrlWhenPortalWhitelistIsNotConfiguredButUrlMatchesFallbackPortalUrl() throws TechnicalException {
-        setField(userService, "portalWhitelist", List.of());
-        when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn("https://portal.example.com");
-        NewExternalUserEntity newExternalUserEntity = mock(NewExternalUserEntity.class);
+    public void shouldDropRedirectUrlWhenItDoesNotMatchConfiguredWhitelist() {
+        setField(userService, "portalWhitelist", List.of("https://portal.example.com"));
 
-        assertThrows(UserRegistrationUnavailableException.class, () ->
-            userService.register(EXECUTION_CONTEXT, newExternalUserEntity, "https://portal.example.com/confirm")
+        String sanitizedUrl = invokeMethod(
+            userService,
+            "sanitizePortalRedirectUrl",
+            EXECUTION_CONTEXT,
+            "https://attacker.example.com/reset"
         );
+
+        assertNull(sanitizedUrl);
+    }
+
+    @Test
+    public void shouldDropRedirectUrlWhenWhitelistIsEmptyAndNoPortalUrlIsResolvable() {
+        setField(userService, "portalWhitelist", List.of());
+        when(installationAccessQueryService.getPortalUrls(ENVIRONMENT)).thenReturn(List.of());
+
+        String sanitizedUrl = invokeMethod(
+            userService,
+            "sanitizePortalRedirectUrl",
+            EXECUTION_CONTEXT,
+            "https://attacker.example.com/reset"
+        );
+
+        assertNull(sanitizedUrl);
+    }
+
+    @Test
+    public void shouldDropRedirectUrlWhenExecutionContextHasNoEnvironment() {
+        setField(userService, "portalWhitelist", List.of());
+        ExecutionContext organizationOnlyContext = new ExecutionContext(ORGANIZATION);
+
+        String sanitizedUrl = invokeMethod(
+            userService,
+            "sanitizePortalRedirectUrl",
+            organizationOnlyContext,
+            "https://attacker.example.com/reset"
+        );
+
+        assertNull(sanitizedUrl);
+        verify(installationAccessQueryService, never()).getPortalUrls(any());
+    }
+
+    @Test
+    public void shouldDropRedirectUrlWhenFallbackPortalUrlIsStillTheDefaultSentinel() {
+        setField(userService, "portalWhitelist", List.of());
+        when(installationAccessQueryService.getPortalUrls(ENVIRONMENT)).thenReturn(List.of(DEFAULT_PORTAL_URL));
+
+        String sanitizedUrl = invokeMethod(
+            userService,
+            "sanitizePortalRedirectUrl",
+            EXECUTION_CONTEXT,
+            "https://attacker.example.com/reset"
+        );
+
+        assertNull(sanitizedUrl);
+    }
+
+    @Test
+    public void shouldUseRedirectUrlWhenItMatchesFallbackPortalUrlOnNestedPath() {
+        setField(userService, "portalWhitelist", List.of());
+        when(installationAccessQueryService.getPortalUrls(ENVIRONMENT)).thenReturn(List.of("https://portal.example.com"));
+
+        String sanitizedUrl = invokeMethod(
+            userService,
+            "sanitizePortalRedirectUrl",
+            EXECUTION_CONTEXT,
+            "https://portal.example.com/some/nested/path/reset"
+        );
+
+        assertEquals("https://portal.example.com/some/nested/path/reset", sanitizedUrl);
+    }
+
+    @Test
+    public void shouldUseRedirectUrlWhenItMatchesNonFirstFallbackPortalUrl() {
+        setField(userService, "portalWhitelist", List.of());
+        when(installationAccessQueryService.getPortalUrls(ENVIRONMENT)).thenReturn(
+            List.of("https://portal-one.example.com", "https://portal-two.example.com")
+        );
+
+        String sanitizedUrl = invokeMethod(
+            userService,
+            "sanitizePortalRedirectUrl",
+            EXECUTION_CONTEXT,
+            "https://portal-two.example.com/reset"
+        );
+
+        assertEquals("https://portal-two.example.com/reset", sanitizedUrl);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -1323,9 +1323,19 @@ public class UserServiceTest {
         });
     }
 
+    private static User activeGraviteeUser() {
+        User user = new User();
+        user.setId(USER_NAME);
+        user.setSource("gravitee");
+        user.setStatus(UserStatus.ACTIVE);
+        return user;
+    }
+
     @Test
-    public void shouldRejectResetPageUrlWhenPortalWhitelistIsNotConfigured() throws TechnicalException {
+    public void shouldRejectResetPageUrlWhenPortalWhitelistIsNotConfiguredAndNoFallbackPortalUrl() throws TechnicalException {
         setField(userService, "portalWhitelist", List.of());
+        when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn(null);
+        when(userRepository.findBySource(any(), any(), any())).thenReturn(Optional.of(activeGraviteeUser()));
 
         assertThrows(UrlForbiddenException.class, () ->
             userService.resetPasswordFromSourceId(EXECUTION_CONTEXT, "my@email.com", "https://attacker.example.com/reset")
@@ -1335,8 +1345,9 @@ public class UserServiceTest {
     }
 
     @Test
-    public void shouldRejectConfirmationPageUrlWhenPortalWhitelistIsNotConfigured() throws TechnicalException {
+    public void shouldRejectConfirmationPageUrlWhenPortalWhitelistIsNotConfiguredAndNoFallbackPortalUrl() throws TechnicalException {
         setField(userService, "portalWhitelist", List.of());
+        when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn(null);
         NewExternalUserEntity newExternalUserEntity = mock(NewExternalUserEntity.class);
 
         assertThrows(UrlForbiddenException.class, () ->
@@ -1344,6 +1355,54 @@ public class UserServiceTest {
         );
 
         verifyNoInteractions(emailService);
+    }
+
+    @Test
+    public void shouldRejectResetPageUrlWhenPortalWhitelistIsNotConfiguredAndUrlDoesNotMatchFallbackPortalUrl() throws TechnicalException {
+        setField(userService, "portalWhitelist", List.of());
+        when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn("https://portal.example.com");
+        when(userRepository.findBySource(any(), any(), any())).thenReturn(Optional.of(activeGraviteeUser()));
+
+        assertThrows(UrlForbiddenException.class, () ->
+            userService.resetPasswordFromSourceId(EXECUTION_CONTEXT, "my@email.com", "https://attacker.example.com/reset")
+        );
+
+        verifyNoInteractions(emailService);
+    }
+
+    @Test
+    public void shouldRejectResetPageUrlWhenPortalWhitelistIsNotConfiguredAndContextHasNoEnvironment() throws TechnicalException {
+        setField(userService, "portalWhitelist", List.of());
+        ExecutionContext organizationOnlyContext = new ExecutionContext(ORGANIZATION);
+        when(userRepository.findBySource(any(), any(), any())).thenReturn(Optional.of(activeGraviteeUser()));
+
+        assertThrows(UrlForbiddenException.class, () ->
+            userService.resetPasswordFromSourceId(organizationOnlyContext, "my@email.com", "https://attacker.example.com/reset")
+        );
+
+        verifyNoInteractions(emailService);
+        verifyNoInteractions(installationAccessQueryService);
+    }
+
+    @Test
+    public void shouldAllowResetPageUrlWhenPortalWhitelistIsNotConfiguredButUrlMatchesFallbackPortalUrl() throws TechnicalException {
+        assertThrows(UserNotFoundException.class, () -> {
+            setField(userService, "portalWhitelist", List.of());
+            when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn("https://portal.example.com");
+            when(userRepository.findBySource(any(), any(), any())).thenReturn(Optional.of(activeGraviteeUser()));
+            userService.resetPasswordFromSourceId(EXECUTION_CONTEXT, "my@email.com", "https://portal.example.com/reset");
+        });
+    }
+
+    @Test
+    public void shouldAllowConfirmationPageUrlWhenPortalWhitelistIsNotConfiguredButUrlMatchesFallbackPortalUrl() throws TechnicalException {
+        setField(userService, "portalWhitelist", List.of());
+        when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn("https://portal.example.com");
+        NewExternalUserEntity newExternalUserEntity = mock(NewExternalUserEntity.class);
+
+        assertThrows(UserRegistrationUnavailableException.class, () ->
+            userService.register(EXECUTION_CONTEXT, newExternalUserEntity, "https://portal.example.com/confirm")
+        );
     }
 
     @Test


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PORTAL-33

**Purpose**

Stop the caller-supplied redirect URL used in registration confirmation and password-reset emails from being trusted by default. Previously, when `portal.whitelist` was empty, any URL was accepted, letting an attacker redirect the signed confirmation/reset token to a domain they control.

**Summary of changes**

- `UserServiceImpl.sanitizePortalRedirectUrl` validates the redirect URL against `portal.whitelist`, falling back to the installation's own resolved portal URL(s) (`InstallationAccessQueryService.getPortalUrls`) when the whitelist is empty. A URL that doesn't match either is **dropped**, not rejected: the call proceeds normally and the email link falls back to the installation's console/portal URL, the same fallback `getTokenRegistrationParams` already uses today when no redirect URL is supplied at all.
- The check is a pre-check called only from the two entry points that actually receive a caller-supplied redirect URL: `register()` (`confirmationPageUrl`) and the caller-facing `resetPassword(ctx, id, resetPageUrl)`. It deliberately does **not** live inside `getTokenRegistrationParams` itself — that method is also used by the gamma password-reset target and the registration-approval flow, which build their target URL internally from trusted installation config (gamma console URL, resolved portal URL) rather than from caller input; routing those through the same whitelist check would incorrectly drop them (a gamma URL will never be in the portal whitelist).
- Every dropped URL is logged (`log.warn`) with the URL, environment, and effective whitelist, so operators can see it happening instead of silently mailing the fallback link.
- `fallbackPortalWhitelist` uses `getPortalUrls` (plural, includes non-overriding multi-tenant access points) and filters out the `DEFAULT_PORTAL_URL` sentinel, so an environment where the Portal URL setting was never configured is correctly treated as "no portal URL available" rather than matching on `http://localhost:4100`.
- `UrlSanitizerUtils.checkAllowed` itself is untouched — its existing default behavior is still needed by unrelated callers (OpenAPI/WSDL import, API duplication, page import).
- **Not a breaking change**: no install can have its registration/reset emails start failing because of this — worst case, the email link points at the console/portal instead of the caller-supplied page, which is the existing behavior for a `null` redirect URL.

**Out of scope**

- Any change to `UrlSanitizerUtils` shared semantics.
- Documentation for `portal.whitelist` configuration.
- A first-class Helm chart value for `portal.whitelist` (the existing `api.env` override already covers it).
- **Invitation emails** (`ApplicationInvitationsResource` → `ApplicationInvitationNotificationDomainServiceImpl`): they call `getTokenRegistrationParams` directly, bypassing `register()`/`resetPassword()` entirely, so covering them would mean sanitizing inside `getTokenRegistrationParams` itself — which is exactly what would break the gamma/registration-approval flows above. Same primitive (client-supplied `confirmation_page_url`), authenticated caller so less exposed. Tracked as a follow-up ticket rather than expanding this PR's scope.

**Testing**

- `UserServiceTest`: added tests directly on the private `sanitizePortalRedirectUrl` (via `ReflectionTestUtils.invokeMethod`, matching this file's existing convention for testing internal helpers) covering — URL preserved when it matches the configured whitelist or the fallback portal URL (including a nested path via `checkAllowed`'s `startsWith` matching) or a non-first entry in a multi-URL fallback list; URL dropped when it matches neither, when the whitelist is empty and no portal URL resolves, when the fallback resolves to the `DEFAULT_PORTAL_URL` sentinel, and when the `ExecutionContext` has no environment id. Also: `register()`/`resetPasswordFromSourceId()` no longer reject on a mismatched URL (they now fail downstream for unrelated reasons instead of `UrlForbiddenException`).
- Ran `UserServiceTest` (101 tests), `UrlSanitizerUtilsTest` (13 tests), and the full `gravitee-apim-rest-api-service` module suite — all green except one pre-existing, unrelated failure (`JsonSchemaServiceTest`, confirmed failing identically on this branch without any of this PR's changes).
- Explicitly re-verified `UserServiceRegistrationApprovalTest` and `UserServiceResetPasswordTargetTest` (gamma reset target) still pass — these don't go through `register()`/`resetPassword()` and must stay unaffected by this change.

**Additional context**

Addresses the second review round:
- Fixed the two bugs in the whitelist fallback (`DEFAULT_PORTAL_URL` sentinel not filtered; singular `getPortalUrl` dropping non-overriding multi-tenant access points).
- Added the requested warn logging on every path where the redirect URL is not used.
- Switched from rejecting the request to dropping the untrusted URL and falling back to the installation's own link, per review discussion — this removes the breaking-change risk, so the `gravitee.yml` comment was reworded instead of adding a `BREAKING CHANGE` footer.
