### PR TITLE
ci: build chainguard docker images on master and support branches

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -113,7 +113,7 @@ const orbs = {
   github: '1.0.5',
   gravitee: 'dev:4.5.0',
   helm: '3.0.0',
-  keeper: '0.7.0',
+  keeper: '0.7.1',
   slack: '4.12.5',
 };
 

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -341,5 +341,5 @@ workflows:
                 - 4.9.x-latest
                 - graviteeio@4.9.0
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
@@ -697,6 +697,6 @@ workflows:
           docker-image-name: gamma-ui
           docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
@@ -697,6 +697,6 @@ workflows:
           docker-image-name: gamma-ui
           docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
@@ -697,6 +697,6 @@ workflows:
           docker-image-name: gamma-ui
           docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
@@ -697,6 +697,6 @@ workflows:
           docker-image-name: gamma-ui
           docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
@@ -697,6 +697,6 @@ workflows:
           docker-image-name: gamma-ui
           docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm/build-rpm-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm/build-rpm-release-dry-run.yml
@@ -87,4 +87,4 @@ workflows:
             - cicd-orchestrator
           name: Build and push RPM packages for APIM 4.2.0 - Dry Run
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm/build-rpm-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm/build-rpm-release-no-dry-run.yml
@@ -87,4 +87,4 @@ workflows:
             - cicd-orchestrator
           name: Build and push RPM packages for APIM 4.2.0
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -1229,7 +1229,7 @@ workflows:
             - Trigger APIM API docs ingestion
             - Build and push RPM packages for APIM 4.2.0-alpha.1
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   aws-cli: circleci/aws-cli@5.1.2

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -1263,7 +1263,7 @@ workflows:
             - Trigger APIM API docs ingestion
             - Build and push RPM packages for APIM 4.2.0 - Dry Run
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   aws-cli: circleci/aws-cli@5.1.2

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -1275,7 +1275,7 @@ workflows:
             - Trigger APIM API docs ingestion
             - Build and push RPM packages for APIM 4.2.0
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   aws-cli: circleci/aws-cli@5.1.2

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -1275,7 +1275,7 @@ workflows:
             - Trigger APIM API docs ingestion
             - Build and push RPM packages for APIM 4.2.0
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   aws-cli: circleci/aws-cli@5.1.2

--- a/.circleci/ci/src/pipelines/tests/resources/helm-tests/helm-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/helm-tests/helm-tests.yml
@@ -90,5 +90,5 @@ workflows:
                 - v3.15.1
 orbs:
   helm: circleci/helm@3.0.0
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/maven-release/maven-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/maven-release/maven-release.yml
@@ -183,4 +183,4 @@ workflows:
           requires:
             - Commit and prepare next version
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/pipelines/tests/resources/nexus-staging/nexus-staging-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nexus-staging/nexus-staging-no-dry-run.yml
@@ -149,5 +149,5 @@ workflows:
             - Nexus staging
           message: 🎆 APIM - 1.2.3-alpha.1 released!
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-prerelease-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-prerelease-dry-run.yml
@@ -113,6 +113,6 @@ workflows:
           requires:
             - Setup
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-prerelease-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-prerelease-no-dry-run.yml
@@ -113,6 +113,6 @@ workflows:
           requires:
             - Setup
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-release-dry-run.yml
@@ -113,6 +113,6 @@ workflows:
           requires:
             - Setup
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-release-no-dry-run.yml
@@ -113,6 +113,6 @@ workflows:
           requires:
             - Setup
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -539,7 +539,7 @@ workflows:
             - Build Gamma Console docker image
             - Build APIM Portal docker image
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -505,7 +505,7 @@ workflows:
             - Build Gamma Console docker image
             - Build APIM Portal docker image
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -539,7 +539,7 @@ workflows:
             - Build Gamma Console docker image
             - Build APIM Portal docker image
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -1880,7 +1880,7 @@ workflows:
             - Build APIM Console docker image
             - Build APIM Portal docker image
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -1371,6 +1371,43 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-chainguard -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-784ff35-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
 workflows:
   pull_requests:
     jobs:
@@ -1735,6 +1772,56 @@ workflows:
           docker-context: .
           docker-image-name: gamma-ui
           docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image
+          requires:
+            - Build backend
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image
+          requires:
+            - Build backend
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
       - job-community-build:
           name: Check build as Community user
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -198,6 +198,6 @@ workflows:
           requires:
             - Build backend
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -336,6 +336,6 @@ workflows:
             - Test gateway
             - Integration tests
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -253,6 +253,6 @@ workflows:
             - Build backend
             - Integration tests
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -571,6 +571,6 @@ workflows:
             - Test reporters
             - Test repository
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -337,6 +337,6 @@ workflows:
             - Integration tests
             - Test plugins
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -337,6 +337,6 @@ workflows:
             - Integration tests
             - Test reporters
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -283,6 +283,6 @@ workflows:
             - Build backend
             - Test rest-api
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -357,7 +357,7 @@ workflows:
             - Lint & test APIM Console
             - Build APIM Console
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -314,6 +314,6 @@ workflows:
             - Lint & test Gamma Console
             - Build Gamma Console
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-helm-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-helm-only.yml
@@ -128,7 +128,7 @@ workflows:
           requires:
             - Helm Chart - Lint & Test
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-next-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-next-only.yml
@@ -315,6 +315,6 @@ workflows:
             - Lint & test APIM Portal Next
             - Build APIM Portal
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -316,6 +316,6 @@ workflows:
             - Lint & test APIM Portal
             - Build APIM Portal
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -1037,7 +1037,7 @@ workflows:
             - Lint & test Gamma Console
             - Build Gamma Console
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -1944,7 +1944,7 @@ workflows:
             - Trigger SaaS Docker images creation
             - Publish Helm chart (internal repo)
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -1428,6 +1428,43 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-chainguard -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
 workflows:
   pull_requests:
     jobs:
@@ -1792,6 +1829,56 @@ workflows:
           docker-context: .
           docker-image-name: gamma-ui
           docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image
+          requires:
+            - Build backend
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image
+          requires:
+            - Build backend
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
       - job-community-build:
           name: Check build as Community user
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -1037,7 +1037,7 @@ workflows:
             - Lint & test Gamma Console
             - Build Gamma Console
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -1422,7 +1422,7 @@ workflows:
             - Build APIM Console docker image
             - Build APIM Portal docker image
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/release-helm/release-helm-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release-helm/release-helm-dry-run.yml
@@ -185,6 +185,6 @@ workflows:
             - cicd-orchestrator
 orbs:
   helm: circleci/helm@3.0.0
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/release-helm/release-helm.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release-helm/release-helm.yml
@@ -179,6 +179,6 @@ workflows:
             - cicd-orchestrator
 orbs:
   helm: circleci/helm@3.0.0
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/release-notes-apim/release-notes-apim-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release-notes-apim/release-notes-apim-dry-run.yml
@@ -81,5 +81,5 @@ workflows:
             - cicd-orchestrator
           name: Generate release note and create PR
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/release-notes-apim/release-notes-apim-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release-notes-apim/release-notes-apim-no-dry-run.yml
@@ -99,6 +99,6 @@ workflows:
             - cicd-orchestrator
           name: Generate release note and create PR
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   gh: circleci/github-cli@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -411,7 +411,7 @@ workflows:
             - Build APIM Console
             - Build APIM Portal
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -413,7 +413,7 @@ workflows:
             - Build APIM Console
             - Build APIM Portal
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
@@ -413,7 +413,7 @@ workflows:
             - Build APIM Console
             - Build APIM Portal
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -372,5 +372,5 @@ workflows:
                 - 7.2.0-v7
                 - latest
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -585,6 +585,6 @@ workflows:
             - Build APIM Console docker image
             - Build APIM Portal docker image
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -23,6 +23,7 @@ import {
   BuildBackendJob,
   BuildDockerBackendImageJob,
   BuildDockerChainguardFipsImageJob,
+  BuildDockerChainguardImageJob,
   BuildDockerWebUiImageJob,
   ChromaticConsoleJob,
   CommunityBuildBackendJob,
@@ -740,7 +741,55 @@ export class PullRequestsWorkflow {
     );
     dynamicConfig.addJob(runTriggerSaasDockerImagesJob);
 
+    const buildDockerChainguardImageJob = BuildDockerChainguardImageJob.create(dynamicConfig, environment, false);
+    dynamicConfig.addJob(buildDockerChainguardImageJob);
+
     return [
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Management API chainguard docker image`,
+        requires: ['Build backend'],
+        'apim-project': config.components.managementApi.project,
+        'apim-project-workdir': config.components.managementApi.workdir,
+        'docker-context': 'gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target',
+        'docker-image-name': config.components.managementApi.image,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Gateway chainguard docker image`,
+        requires: ['Build backend'],
+        'apim-project': config.components.gateway.project,
+        'apim-project-workdir': config.components.gateway.workdir,
+        'docker-context': 'gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target',
+        'docker-image-name': config.components.gateway.image,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Console chainguard docker image`,
+        requires: ['Build APIM Console'],
+        'apim-project': config.components.console.project,
+        'apim-project-workdir': config.components.console.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.console.image,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Portal chainguard docker image`,
+        requires: ['Build APIM Portal'],
+        'apim-project': config.components.portal.project,
+        'apim-project-workdir': config.components.portal.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.portal.image,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardImageJob, {
+        context: config.jobContext,
+        name: `Build Gamma Console chainguard docker image`,
+        requires: ['Build Gamma Console'],
+        'apim-project': config.components.gamma.project,
+        'apim-project-workdir': config.components.gamma.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.gamma.image,
+      }),
       new workflow.WorkflowJob(communityBuildJob, {
         name: 'Check build as Community user',
         context: config.jobContext,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
     continuation: circleci/continuation@1.1.0
     node: circleci/node@7.2.1
-    keeper: gravitee-io/keeper@0.7.0
+    keeper: gravitee-io/keeper@0.7.1
     slack: circleci/slack@5.1.1
 
 setup: true


### PR DESCRIPTION
## Issue

N/A

## Description

Build the chainguard variant of the APIM docker images (Gateway, Management API, Console, Portal) on every push to master and support branches, exactly like the existing `-debian` variant.

The `pull_requests` workflow now pushes to Azure Container Registry:

- `graviteeio.azurecr.io/<image>:4.12.x-latest-chainguard`
- `graviteeio.azurecr.io/<image>:4.12.x-<sha1>-chainguard`

in addition to the existing `-latest`/`-debian` tags (multi-arch arm64 + amd64).

## Additional context

- Reuses the existing `BuildDockerChainguardImageJob` (`isProd=false` → single azurecr login used to pull the private chainguard base image and push the result).
- Chainguard images are only built on master/support branches, not on e2e branches.
- Test snapshots `pull-requests-master.yml` and `pull-requests-4-1-x.yml` regenerated accordingly.