### PR TITLE
fix(APIM-14632): reject multi-address branded sender From at save time via a shared single-address helper

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/email/EmailAddresses.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/email/EmailAddresses.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.email;
+
+import java.util.Optional;
+
+/**
+ * Shared parsing of a single sender/recipient email address, so the save-time {@code SenderAddressValidator}
+ * and the send-time branded-sender matching ({@code BrandedSenders}) agree on what counts as a single,
+ * sendable address. Extracting this in one place keeps validation honest: a value the validator accepts is
+ * one {@code new jakarta.mail.internet.InternetAddress(value)} can also send, rather than a multi-address
+ * list the greedy display-name strip once let through.
+ *
+ * @author GraviteeSource Team
+ */
+public final class EmailAddresses {
+
+    private EmailAddresses() {}
+
+    /**
+     * Extracts the single address from a raw value that may carry a personal-name wrapper
+     * ({@code Name <addr>}). Returns {@link Optional#empty()} when the value is {@code null}/blank, has no
+     * {@code '@'}, or is really a multi-address list — either the bare form ({@code a@x.com, b@y.com}) or the
+     * comma-joined personal-name form ({@code Jane <jane@x.com>, John <john@y.com>}).
+     *
+     * <p>The single-address check counts {@code '@'} on the whole value <em>before</em> any bracket
+     * stripping, so a trailing {@code Name <addr>} pair cannot hide earlier addresses from the check. A
+     * consequence is that a quoted display name which itself contains {@code '@'} (e.g.
+     * {@code "Support @ Acme" <a@x.com>}) is intentionally rejected even though it is technically sendable:
+     * the narrowing errs on the safe side (reject at save rather than accept-then-fail at send) and such
+     * values are vanishingly rare.</p>
+     *
+     * <p>The {@code Name <addr>} wrapper is only unwrapped when the value actually ends with {@code '>'}, so
+     * trailing content after the bracket ({@code Name <a@x.com> more}) is not silently unwrapped. The returned
+     * value always contains a {@code '@'}, but is not guaranteed to be a <em>well-formed</em> address — callers
+     * must still validate it (that a domain is present and the format is legal).</p>
+     */
+    public static Optional<String> singleAddress(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        final String trimmed = value.trim();
+        // A single address carries exactly one '@'. Zero means there is no address; more than one means the
+        // value is really an address list, which delivery cannot send from and branding must not match.
+        final int firstAt = trimmed.indexOf('@');
+        if (firstAt < 0 || firstAt != trimmed.lastIndexOf('@')) {
+            return Optional.empty();
+        }
+        String address = trimmed;
+        if (address.endsWith(">")) {
+            final int lt = address.lastIndexOf('<');
+            if (lt >= 0) {
+                address = address.substring(lt + 1, address.length() - 1).trim();
+            }
+        }
+        // When the single '@' sat outside the brackets (e.g. "jane@work <Jane>"), unwrapping leaves
+        // display-name-only content with no '@'. Honour the "contains a local@domain" contract by returning
+        // empty here rather than a domain-less fragment a trusting caller might use.
+        return address.indexOf('@') < 0 ? Optional.empty() : Optional.of(address);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenders.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/BrandedSenders.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.model.settings;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.rest.api.model.email.EmailAddresses;
 import io.gravitee.rest.api.model.parameters.Key;
 import java.util.ArrayList;
 import java.util.List;
@@ -111,31 +112,18 @@ public final class BrandedSenders {
      * one tenant, so it falls through to the default sender instead.
      */
     private static String extractDomain(String recipientEmail) {
-        if (recipientEmail == null) {
-            return null;
-        }
-        final String trimmed = recipientEmail.trim();
-        // A single recipient carries exactly one '@'. Zero means there is no domain to match; more than one
-        // means the value is really an address list — either the bare form ("a@x.com, b@y.com") or the
-        // personal-name form ("Jane <jane@x.com>, John <john@y.com>"). Matching such a value on a single
-        // domain would brand every address for one tenant, so it falls through to the default sender instead.
-        // This count is taken on the whole value (before any bracket stripping) so a trailing "Name <addr>"
-        // pair cannot hide the earlier addresses from the check.
-        final int firstAt = trimmed.indexOf('@');
-        if (firstAt < 0 || firstAt != trimmed.lastIndexOf('@')) {
-            return null;
-        }
-        String address = trimmed;
-        final int lt = address.lastIndexOf('<');
-        final int gt = address.lastIndexOf('>');
-        if (lt >= 0 && gt > lt) {
-            address = address.substring(lt + 1, gt);
-        }
-        final int at = address.lastIndexOf('@');
-        if (at < 0 || at == address.length() - 1) {
-            return null;
-        }
-        return normalizeDomain(address.substring(at + 1));
+        // Reuse the shared single-address parsing (personal-name unwrapping + multi-address rejection) so
+        // matching stays aligned with what SenderAddressValidator accepts and what delivery can send. A
+        // multi-address value must not brand every address for one tenant, so it falls through to the default.
+        return EmailAddresses.singleAddress(recipientEmail)
+            .map(address -> {
+                final int at = address.lastIndexOf('@');
+                if (at < 0 || at == address.length() - 1) {
+                    return null;
+                }
+                return normalizeDomain(address.substring(at + 1));
+            })
+            .orElse(null);
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/SenderAddressValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/SenderAddressValidator.java
@@ -15,9 +15,9 @@
  */
 package io.gravitee.rest.api.validator;
 
+import io.gravitee.rest.api.model.email.EmailAddresses;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -36,22 +36,16 @@ public class SenderAddressValidator implements ConstraintValidator<ValidSenderAd
         "^[A-Za-z0-9._%+-]+@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)++[A-Za-z]{2,}$"
     );
 
-    /** Optional {@code Display Name <addr>} wrapper; captures the angle-bracketed address. */
-    private static final Pattern PERSONAL_NAME = Pattern.compile("^.*<\\s*([^<>]+?)\\s*>$");
-
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
         if (value == null || value.isBlank()) {
             return true;
         }
-        final String trimmed = value.trim();
-        final Matcher personalName = PERSONAL_NAME.matcher(trimmed);
-        final String address;
-        if (personalName.matches()) {
-            address = personalName.group(1).trim();
-        } else {
-            address = trimmed;
-        }
-        return EMAIL.matcher(address).matches();
+        // Resolve the single address (unwrapping a "Name <addr>" personal name and rejecting multi-address
+        // lists) with the same helper the send-time branded-sender matching uses, so save never accepts a
+        // From that delivery cannot send. The format check then rejects a malformed single address.
+        return EmailAddresses.singleAddress(value)
+            .filter(address -> EMAIL.matcher(address).matches())
+            .isPresent();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/email/EmailAddressesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/email/EmailAddressesTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.email;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Contract of the shared single-address parsing used by both the save-time {@code SenderAddressValidator}
+ * and the send-time branded-sender matching, so the two never disagree on what is a single, sendable address.
+ *
+ * @author GraviteeSource Team
+ */
+class EmailAddressesTest {
+
+    @Test
+    void should_return_a_bare_single_address() {
+        assertThat(EmailAddresses.singleAddress("noreply@example.com")).contains("noreply@example.com");
+    }
+
+    @Test
+    void should_unwrap_a_personal_name_address() {
+        assertThat(EmailAddresses.singleAddress("Jane Developer <jane@example.com>")).contains("jane@example.com");
+    }
+
+    @Test
+    void should_unwrap_a_bare_bracketed_address() {
+        assertThat(EmailAddresses.singleAddress("<jane@example.com>")).contains("jane@example.com");
+    }
+
+    @Test
+    void should_trim_surrounding_whitespace() {
+        assertThat(EmailAddresses.singleAddress("  Jane <jane@example.com>  ")).contains("jane@example.com");
+    }
+
+    @Test
+    void should_be_empty_for_null() {
+        assertThat(EmailAddresses.singleAddress(null)).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = { "   ", "not-an-email", "alice@example.com, bob@example.org", "Jane <jane@example.com>, John <john@example.org>" }
+    )
+    void should_be_empty_for_inputs_without_a_single_resolvable_address(String input) {
+        // Blank, no '@', and both multi-address forms (bare and personal-name) all resolve to no single
+        // sendable address. Cases that pin a specific documented decision are kept as named tests below.
+        assertThat(EmailAddresses.singleAddress(input)).isEmpty();
+    }
+
+    @Test
+    void should_be_empty_when_an_address_precedes_the_personal_name() {
+        // The greedy display-name strip used to keep only the bracketed address and accept this; the '@' count
+        // on the whole value must catch the earlier address first.
+        assertThat(EmailAddresses.singleAddress("alice@example.com, Team <noreply@example.org>")).isEmpty();
+    }
+
+    @Test
+    void should_reject_a_quoted_display_name_containing_an_at_sign() {
+        // "Support @ Acme" <a@x.com> is technically sendable, but the whole-value '@' count rejects it. This is
+        // a deliberate, safe narrowing (reject at save rather than accept-then-fail at send); pin the choice.
+        assertThat(EmailAddresses.singleAddress("\"Support @ Acme\" <a@x.com>")).isEmpty();
+    }
+
+    @Test
+    void should_be_empty_when_the_at_is_outside_the_brackets() {
+        // "jane@work <Jane>" unwraps to display-name-only content with no '@'; the helper must not return a
+        // domain-less fragment.
+        assertThat(EmailAddresses.singleAddress("jane@work <Jane>")).isEmpty();
+    }
+
+    @Test
+    void should_not_unwrap_trailing_content_after_the_bracket() {
+        // A wrapper is only unwrapped when the value actually ends with '>'; trailing junk leaves the value
+        // whole (and a downstream format check then rejects it).
+        assertThat(EmailAddresses.singleAddress("Team <a@x.com> more")).contains("Team <a@x.com> more");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/BrandedSenderValidationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/BrandedSenderValidationTest.java
@@ -105,6 +105,14 @@ class BrandedSenderValidationTest {
     }
 
     @Test
+    void should_reject_from_with_an_address_before_the_display_name() {
+        // A multi-address value whose trailing "Name <addr>" pair is itself a single valid address must still
+        // be rejected: the greedy display-name strip used to accept it, but new InternetAddress(from) rejects
+        // the whole string at send time — save must not accept a From that delivery cannot send.
+        assertThat(validator.validate(validConfig().from("alice@example.com, Team <noreply@graviteecustomer.com>").build())).isNotEmpty();
+    }
+
+    @Test
     void should_reject_subject_exceeding_max_length() {
         assertThat(validator.validate(validConfig().subject("x".repeat(256)).build())).isNotEmpty();
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14632
## Description

What & why

Follow-up M4 from the branded-senders review (APIM-14632). The branded-sender From was validated more leniently than it could actually be sent: an admin could save a config that then failed at send time.

The bug

SenderAddressValidator used a greedy ^.*<...>$ display-name strip. Given a multi-address value like:

alice@example.com, Team <noreply@example.org>

the .* swallowed everything before the last <…>, leaving one valid-looking address, so validation passed. At send time new InternetAddress(from) parses the whole string, rejects the list, and the notification errors out — a failure remote from its cause (save looked fine days earlier). Meanwhile BrandedSenders.extractDomain already rejected multi-address values correctly, so the two code paths disagreed on "what is a single address."

The fix

- New shared helper EmailAddresses.singleAddress(String) — the single source of truth for "extract one sendable address": unwraps a Name <addr> personal name and rejects null/blank/zero-@/multi-@ (counting @ on the whole value before bracket stripping, so a trailing Name <addr> can't mask earlier addresses).
- SenderAddressValidator now routes through it (drops the greedy regex) → save no longer accepts a From delivery can't send.
- BrandedSenders.extractDomain now delegates to the same helper → the two paths can't drift apart again. Behavior unchanged.

Net effect is line-negative: it removes duplicated parsing rather than adding logic.

Tests

- New EmailAddressesTest (9) pins the helper contract.
- New validator regression test for the address-before-display-name case.
- Existing BrandedSenderValidationTest (22) and EmailBrandedSendersTest (27) unchanged and green.
- Full gravitee-apim-rest-api-model suite: 188 passing; prettier clean.
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

