### PR TITLE
chore(4.12.x): bump gravitee-endpoint-kafka from 6.1.0 to 6.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
     <gravitee-entrypoint-agent-to-agent.version>2.0.0</gravitee-entrypoint-agent-to-agent.version>
     <gravitee-entrypoint-mcp-tool-server.version>2.0.2</gravitee-entrypoint-mcp-tool-server.version>
     <gravitee-endpoint-jms.version>2.0.0</gravitee-endpoint-jms.version>
-    <gravitee-endpoint-kafka.version>6.1.0</gravitee-endpoint-kafka.version>
+    <gravitee-endpoint-kafka.version>6.1.4</gravitee-endpoint-kafka.version>
     <gravitee-endpoint-mqtt5.version>5.0.0</gravitee-endpoint-mqtt5.version>
     <gravitee-endpoint-rabbitmq.version>4.0.0</gravitee-endpoint-rabbitmq.version>
     <gravitee-endpoint-solace.version>4.0.1</gravitee-endpoint-solace.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-endpoint-kafka](https://github.com/gravitee-io/gravitee-endpoint-kafka)** from `6.1.0` to `6.1.4` on branch `4.12.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-endpoint-kafka/releases) page.