### PR TITLE
feat: execute plan flows for ai product subscriptions

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/ApiProductPlanPolicyManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/ApiProductPlanPolicyManager.java
@@ -16,7 +16,10 @@
 package io.gravitee.gateway.reactive.handlers.api.v4;
 
 import io.gravitee.definition.model.Policy;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.definition.model.v4.plan.AbstractPlan;
+import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.gateway.core.classloader.DefaultClassLoader;
 import io.gravitee.gateway.core.component.ComponentProvider;
@@ -27,6 +30,7 @@ import io.gravitee.gateway.reactive.policy.PolicyFactoryManager;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.policy.PolicyClassLoaderFactory;
 import io.gravitee.plugin.policy.PolicyPlugin;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
@@ -76,29 +80,60 @@ public class ApiProductPlanPolicyManager extends AbstractPolicyManager {
 
         List<ApiProductRegistry.ApiProductPlanEntry> entries = apiProductRegistry.getApiProductPlanEntriesForApi(apiId, environmentId);
 
-        // Deduplicate by policy name (multiple plans can share same security type)
-        LinkedHashMap<String, Policy> byName = new LinkedHashMap<>();
+        // Deduplicate security policies by name (multiple plans can share same security type)
+        LinkedHashMap<String, Policy> securityByName = new LinkedHashMap<>();
+        // Flow-step policies (budget, rate-limit, ...) carried by each product plan's flows
+        Set<Policy> flowPolicies = new HashSet<>();
 
         for (ApiProductRegistry.ApiProductPlanEntry entry : entries) {
             AbstractPlan plan = entry.plan();
-            if (!plan.useStandardMode() || plan.getSecurity() == null) {
-                continue;
+
+            if (plan.useStandardMode() && plan.getSecurity() != null && plan.getSecurity().getType() != null) {
+                PlanSecurity planSecurity = plan.getSecurity();
+                String policyName = planSecurity.getType().toLowerCase().replaceAll("_", "-");
+                if (!securityByName.containsKey(policyName)) {
+                    Policy policy = new Policy();
+                    policy.setName(policyName);
+                    policy.setConfiguration(planSecurity.getConfiguration());
+                    securityByName.put(policyName, policy);
+                }
             }
 
-            PlanSecurity planSecurity = plan.getSecurity();
-            if (planSecurity.getType() == null) {
-                continue;
-            }
-
-            String policyName = planSecurity.getType().toLowerCase().replaceAll("_", "-");
-            if (!byName.containsKey(policyName)) {
-                Policy policy = new Policy();
-                policy.setName(policyName);
-                policy.setConfiguration(planSecurity.getConfiguration());
-                byName.put(policyName, policy);
+            if (plan instanceof Plan v4Plan && v4Plan.getFlows() != null) {
+                addFlowsPolicies(flowPolicies, v4Plan.getFlows());
             }
         }
 
-        return Set.copyOf(byName.values());
+        Set<Policy> result = new HashSet<>(securityByName.values());
+        result.addAll(flowPolicies);
+        return Set.copyOf(result);
+    }
+
+    private void addFlowsPolicies(final Set<Policy> policies, final List<Flow> flows) {
+        flows
+            .stream()
+            .filter(Flow::isEnabled)
+            .forEach(flow -> {
+                policies.addAll(getPolicies(flow.getRequest()));
+                policies.addAll(getPolicies(flow.getResponse()));
+                policies.addAll(getPolicies(flow.getSubscribe()));
+                policies.addAll(getPolicies(flow.getPublish()));
+            });
+    }
+
+    private List<Policy> getPolicies(final List<Step> flowStep) {
+        if (flowStep == null || flowStep.isEmpty()) {
+            return List.of();
+        }
+        return flowStep
+            .stream()
+            .filter(Step::isEnabled)
+            .map(step -> {
+                Policy policy = new Policy();
+                policy.setName(step.getPolicy());
+                policy.setConfiguration(step.getConfiguration());
+                return policy;
+            })
+            .toList();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -152,6 +152,7 @@ public class DefaultApiReactor extends AbstractApiReactor {
     protected final io.gravitee.gateway.reactive.handlers.api.flow.FlowChain organizationFlowChain;
     protected final FlowChain apiPlanFlowChain;
     protected final FlowChain apiFlowChain;
+    protected volatile FlowChain apiProductPlanFlowChain;
     private final Node node;
     protected final String loggingExcludedResponseType;
     protected final String loggingMaxSize;
@@ -165,6 +166,7 @@ public class DefaultApiReactor extends AbstractApiReactor {
     protected final LogGuardService logGuardService;
     private final ApiProductRegistry apiProductRegistry;
     private final ApiProductPlanPolicyManagerFactory apiProductPlanPolicyManagerFactory;
+    private final FlowChainFactory v4FlowChainFactory;
     private PolicyManager apiProductPlanPolicyManager;
     private EventListener<ApiProductEventType, ApiProductChangedEvent> apiProductEventListener;
 
@@ -279,6 +281,7 @@ public class DefaultApiReactor extends AbstractApiReactor {
         this.afterApiExecutionProcessors = apiProcessorChainFactory.afterApiExecution(api);
         this.onErrorProcessors = apiProcessorChainFactory.onError(api);
 
+        this.v4FlowChainFactory = v4FlowChainFactory;
         this.organizationFlowChain = flowChainFactory.createOrganizationFlow(api, tracingContext);
         this.apiPlanFlowChain = v4FlowChainFactory.createPlanFlow(api, tracingContext);
         this.apiFlowChain = v4FlowChainFactory.createApiFlow(api, tracingContext);
@@ -362,7 +365,8 @@ public class DefaultApiReactor extends AbstractApiReactor {
             .chainWith(executeProcessorChain(ctx, beforeApiExecutionProcessors, REQUEST))
             // Resolve entrypoint and prepare request to be handled.
             .chainWith(handleEntrypointRequest(ctx))
-            // Execute all flows for request phases.
+            // Execute all flows for request phases (product plan flows first, then API plan and API flows).
+            .chainWith(executeProductPlanFlowChain(ctx, REQUEST))
             .chainWith(apiPlanFlowChain.execute(ctx, REQUEST))
             .chainWith(apiFlowChain.execute(ctx, REQUEST))
             .chainWith(upstream -> endRequestPhaseTracing(upstream, ctx))
@@ -370,7 +374,8 @@ public class DefaultApiReactor extends AbstractApiReactor {
             .chainWith(invokeBackend(ctx))
             // Start RESPONSE traces
             .chainWith(startPhaseTracing(ctx, RESPONSE))
-            // Execute all flows for response phases.
+            // Execute all flows for response phases (product plan flows first, then API plan and API flows).
+            .chainWith(executeProductPlanFlowChain(ctx, RESPONSE))
             .chainWith(apiPlanFlowChain.execute(ctx, RESPONSE))
             .chainWith(apiFlowChain.execute(ctx, RESPONSE))
             // After flows processors.
@@ -635,6 +640,7 @@ public class DefaultApiReactor extends AbstractApiReactor {
 
         // Create httpSecurityChain once policy manager has been started.
         refreshSecurityChain();
+        refreshApiProductPlanFlowChain();
 
         tracingContext.start();
         analyticsContext = createAnalyticsContext();
@@ -699,6 +705,7 @@ public class DefaultApiReactor extends AbstractApiReactor {
                 }
             }
             refreshSecurityChain();
+            refreshApiProductPlanFlowChain();
             log.debug("API [{}] security chain refreshed after API Product change", api.getId());
         } catch (Exception e) {
             log.warn("Failed to refresh security chain for API [{}] on API Product change", api.getId(), e);
@@ -735,6 +742,31 @@ public class DefaultApiReactor extends AbstractApiReactor {
             chain.addHooks(List.of(new TracingHook("Security")));
         }
         this.httpSecurityChain = chain;
+    }
+
+    private void refreshApiProductPlanFlowChain() {
+        if (apiProductRegistry != null && apiProductPlanPolicyManager != null) {
+            io.gravitee.gateway.reactive.v4.policy.HttpPolicyChainFactory productPlanPolicyChainFactory =
+                new io.gravitee.gateway.reactive.v4.policy.HttpPolicyChainFactory(
+                    api.getId(),
+                    apiProductPlanPolicyManager,
+                    tracingContext != null && tracingContext.isEnabled()
+                );
+            this.apiProductPlanFlowChain = v4FlowChainFactory.createProductPlanFlow(
+                api,
+                api.getEnvironmentId(),
+                apiProductRegistry,
+                productPlanPolicyChainFactory,
+                tracingContext
+            );
+        } else {
+            this.apiProductPlanFlowChain = null;
+        }
+    }
+
+    private Completable executeProductPlanFlowChain(final MutableExecutionContext ctx, final ExecutionPhase phase) {
+        final FlowChain chain = apiProductPlanFlowChain;
+        return chain != null ? chain.execute(ctx, phase) : Completable.complete();
     }
 
     protected void addInvokerHooks(List<InvokerHook> invokerHooks) {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChainFactory.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.handlers.api.v4.flow;
 
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.reactive.api.hook.ChainHook;
 import io.gravitee.gateway.reactive.core.tracing.TracingHook;
@@ -45,6 +46,24 @@ public class FlowChainFactory {
         FlowChain flowPlanChain = new FlowChain("plan", flowResolverFactory.forApiPlan(api), policyChainFactory, true, false);
         flowPlanChain.addHooks(flowHooks(tracingContext));
         return flowPlanChain;
+    }
+
+    public FlowChain createProductPlanFlow(
+        final Api api,
+        final String environmentId,
+        final ApiProductRegistry apiProductRegistry,
+        final PolicyChainFactory productPlanPolicyChainFactory,
+        final TracingContext tracingContext
+    ) {
+        FlowChain flowProductPlanChain = new FlowChain(
+            "product-plan",
+            flowResolverFactory.forApiProductPlan(api, environmentId, apiProductRegistry),
+            productPlanPolicyChainFactory,
+            true,
+            false
+        );
+        flowProductPlanChain.addHooks(flowHooks(tracingContext));
+        return flowProductPlanChain;
     }
 
     public FlowChain createApiFlow(final Api api, final TracingContext tracingContext) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/ApiProductPlanFlowResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/ApiProductPlanFlowResolver.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4.flow.resolver;
+
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry.ApiProductPlanEntry;
+import io.gravitee.gateway.reactive.api.context.ContextAttributes;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
+import io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor;
+import io.gravitee.gateway.reactive.v4.flow.AbstractFlowResolver;
+import io.reactivex.rxjava3.core.Flowable;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Resolves {@link Flow}s defined on the product plan selected for the current request. Product plans
+ * are not part of the {@link Api} definition; they are held in the {@link ApiProductRegistry} and may
+ * change on a product redeploy, so flows are read fresh from the registry rather than memoized.
+ *
+ * @author GraviteeSource Team
+ */
+@SuppressWarnings("common-java:DuplicatedBlocks")
+class ApiProductPlanFlowResolver extends AbstractFlowResolver {
+
+    private final Api api;
+    private final String environmentId;
+    private final ApiProductRegistry apiProductRegistry;
+
+    ApiProductPlanFlowResolver(
+        Api api,
+        String environmentId,
+        ApiProductRegistry apiProductRegistry,
+        ConditionFilter<BaseExecutionContext, Flow> filter
+    ) {
+        super(filter);
+        this.api = api;
+        this.environmentId = environmentId;
+        this.apiProductRegistry = apiProductRegistry;
+    }
+
+    @Override
+    public Flowable<Flow> provideFlows(BaseExecutionContext ctx) {
+        if (apiProductRegistry == null || environmentId == null) {
+            return Flowable.empty();
+        }
+
+        final String apiProductId = ctx.getAttribute(SubscriptionProcessor.ATTR_API_PRODUCT);
+        if (apiProductId == null) {
+            return Flowable.empty();
+        }
+
+        final String planId = ctx.getAttribute(ContextAttributes.ATTR_PLAN);
+        if (planId == null) {
+            return Flowable.empty();
+        }
+
+        return Flowable.fromIterable(resolveFlows(planId));
+    }
+
+    private List<Flow> resolveFlows(String planId) {
+        return apiProductRegistry
+            .getApiProductPlanEntriesForApi(api.getId(), environmentId)
+            .stream()
+            .map(ApiProductPlanEntry::plan)
+            .filter(plan -> Objects.equals(plan.getId(), planId))
+            .filter(Plan.class::isInstance)
+            .map(Plan.class::cast)
+            .filter(plan -> Objects.nonNull(plan.getFlows()))
+            .flatMap(plan -> plan.getFlows().stream())
+            .filter(Flow::isEnabled)
+            .collect(Collectors.toList());
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/FlowResolverFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/FlowResolverFactory.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.reactive.handlers.api.v4.flow.resolver;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.flow.execution.FlowMode;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
@@ -59,6 +60,19 @@ public class FlowResolverFactory {
             return new BestMatchFlowResolver(apiPlanFlowResolver, bestMatchFlowSelector);
         }
         return apiPlanFlowResolver;
+    }
+
+    public FlowResolver forApiProductPlan(Api api, String environmentId, ApiProductRegistry apiProductRegistry) {
+        ApiProductPlanFlowResolver apiProductPlanFlowResolver = new ApiProductPlanFlowResolver(
+            api.getDefinition(),
+            environmentId,
+            apiProductRegistry,
+            apiFlowFilter
+        );
+        if (isBestMatchFlowMode(api.getDefinition().getFlowExecution())) {
+            return new BestMatchFlowResolver(apiProductPlanFlowResolver, bestMatchFlowSelector);
+        }
+        return apiProductPlanFlowResolver;
     }
 
     private static boolean isBestMatchFlowMode(final FlowExecution flowExecution) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/ApiProductPlanPolicyManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/ApiProductPlanPolicyManagerTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.Policy;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
@@ -176,6 +178,43 @@ class ApiProductPlanPolicyManagerTest {
 
         assertThat(dependencies).hasSize(1);
         assertThat(dependencies).extracting(Policy::getName).containsExactly("api-key");
+    }
+
+    @Test
+    void should_return_flow_step_policies_from_product_plan_flows() {
+        Step tokenRateLimitStep = new Step();
+        tokenRateLimitStep.setPolicy("token-ratelimit");
+        tokenRateLimitStep.setConfiguration("{\"limit\":1000}");
+        tokenRateLimitStep.setEnabled(true);
+
+        Flow flow = new Flow();
+        flow.setEnabled(true);
+        flow.setRequest(List.of(tokenRateLimitStep));
+
+        Plan plan = new Plan();
+        plan.setMode(PlanMode.STANDARD);
+        plan.setSecurity(new PlanSecurity("API_KEY", "{}"));
+        plan.setFlows(List.of(flow));
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(API_ID, ENV_ID)).thenReturn(
+            List.of(new ApiProductRegistry.ApiProductPlanEntry("product-1", plan))
+        );
+
+        ApiProductPlanPolicyManager manager = new ApiProductPlanPolicyManager(
+            classLoader,
+            policyFactoryManager,
+            policyConfigurationFactory,
+            policyPluginManager,
+            policyClassLoaderFactory,
+            componentProvider,
+            API_ID,
+            ENV_ID,
+            apiProductRegistry
+        );
+
+        Set<Policy> dependencies = invokeDependencies(manager);
+
+        assertThat(dependencies).extracting(Policy::getName).containsExactlyInAnyOrder("api-key", "token-ratelimit");
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/ApiProductPlanFlowResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/ApiProductPlanFlowResolverTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4.flow.resolver;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry.ApiProductPlanEntry;
+import io.gravitee.gateway.reactive.api.context.ContextAttributes;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
+import io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class ApiProductPlanFlowResolverTest {
+
+    private static final String API_ID = "api-1";
+    private static final String ENV_ID = "env-1";
+    private static final String PRODUCT_ID = "product-1";
+    private static final String PLAN_1 = "plan1";
+    private static final String PLAN_2 = "plan2";
+
+    @Mock
+    private Api api;
+
+    @Mock
+    private ApiProductRegistry apiProductRegistry;
+
+    @Mock
+    private ConditionFilter<BaseExecutionContext, Flow> filter;
+
+    @Mock
+    private HttpPlainExecutionContext ctx;
+
+    @Test
+    void shouldProvideProductPlanFlowsForSelectedPlan() {
+        final Plan plan1 = mock(Plan.class);
+        when(plan1.getId()).thenReturn(PLAN_1);
+        final Flow flow1 = mock(Flow.class);
+        final Flow flow2 = mock(Flow.class);
+        when(plan1.getFlows()).thenReturn(asList(flow1, flow2));
+        when(flow1.isEnabled()).thenReturn(true);
+        when(flow2.isEnabled()).thenReturn(true);
+
+        final Plan plan2 = mock(Plan.class);
+        when(plan2.getId()).thenReturn(PLAN_2);
+
+        when(api.getId()).thenReturn(API_ID);
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(API_ID, ENV_ID)).thenReturn(
+            List.of(new ApiProductPlanEntry(PRODUCT_ID, plan1), new ApiProductPlanEntry(PRODUCT_ID, plan2))
+        );
+        when(ctx.getAttribute(SubscriptionProcessor.ATTR_API_PRODUCT)).thenReturn(PRODUCT_ID);
+        when(ctx.getAttribute(ContextAttributes.ATTR_PLAN)).thenReturn(PLAN_1);
+
+        final ApiProductPlanFlowResolver cut = new ApiProductPlanFlowResolver(api, ENV_ID, apiProductRegistry, filter);
+        final TestSubscriber<Flow> obs = cut.provideFlows(ctx).test();
+
+        obs.assertResult(flow1, flow2);
+    }
+
+    @Test
+    void shouldProvideEnabledProductPlanFlowsOnly() {
+        final Plan plan = mock(Plan.class);
+        when(plan.getId()).thenReturn(PLAN_1);
+        final Flow enabledFlow = mock(Flow.class);
+        final Flow disabledFlow = mock(Flow.class);
+        when(plan.getFlows()).thenReturn(asList(enabledFlow, disabledFlow));
+        when(enabledFlow.isEnabled()).thenReturn(true);
+        when(disabledFlow.isEnabled()).thenReturn(false);
+
+        when(api.getId()).thenReturn(API_ID);
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(API_ID, ENV_ID)).thenReturn(
+            List.of(new ApiProductPlanEntry(PRODUCT_ID, plan))
+        );
+        when(ctx.getAttribute(SubscriptionProcessor.ATTR_API_PRODUCT)).thenReturn(PRODUCT_ID);
+        when(ctx.getAttribute(ContextAttributes.ATTR_PLAN)).thenReturn(PLAN_1);
+
+        final ApiProductPlanFlowResolver cut = new ApiProductPlanFlowResolver(api, ENV_ID, apiProductRegistry, filter);
+        final TestSubscriber<Flow> obs = cut.provideFlows(ctx).test();
+
+        obs.assertResult(enabledFlow);
+    }
+
+    @Test
+    void shouldProvideEmptyFlowsWhenRegistryIsNull() {
+        final ApiProductPlanFlowResolver cut = new ApiProductPlanFlowResolver(api, ENV_ID, null, filter);
+        final TestSubscriber<Flow> obs = cut.provideFlows(ctx).test();
+
+        obs.assertResult();
+    }
+
+    @Test
+    void shouldProvideEmptyFlowsWhenEnvironmentIdIsNull() {
+        final ApiProductPlanFlowResolver cut = new ApiProductPlanFlowResolver(api, null, apiProductRegistry, filter);
+        final TestSubscriber<Flow> obs = cut.provideFlows(ctx).test();
+
+        obs.assertResult();
+    }
+
+    @Test
+    void shouldProvideEmptyFlowsWhenApiProductIsMissingFromContext() {
+        when(ctx.getAttribute(SubscriptionProcessor.ATTR_API_PRODUCT)).thenReturn(null);
+
+        final ApiProductPlanFlowResolver cut = new ApiProductPlanFlowResolver(api, ENV_ID, apiProductRegistry, filter);
+        final TestSubscriber<Flow> obs = cut.provideFlows(ctx).test();
+
+        obs.assertResult();
+    }
+
+    @Test
+    void shouldProvideEmptyFlowsWhenPlanIsMissingFromContext() {
+        when(ctx.getAttribute(SubscriptionProcessor.ATTR_API_PRODUCT)).thenReturn(PRODUCT_ID);
+        when(ctx.getAttribute(ContextAttributes.ATTR_PLAN)).thenReturn(null);
+
+        final ApiProductPlanFlowResolver cut = new ApiProductPlanFlowResolver(api, ENV_ID, apiProductRegistry, filter);
+        final TestSubscriber<Flow> obs = cut.provideFlows(ctx).test();
+
+        obs.assertResult();
+    }
+
+    @Test
+    void shouldProvideEmptyFlowsWhenNoMatchingPlanInRegistry() {
+        final Plan plan = new Plan();
+        plan.setId(PLAN_2);
+        plan.setFlows(new ArrayList<>());
+
+        when(api.getId()).thenReturn(API_ID);
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(API_ID, ENV_ID)).thenReturn(
+            List.of(new ApiProductPlanEntry(PRODUCT_ID, plan))
+        );
+        when(ctx.getAttribute(SubscriptionProcessor.ATTR_API_PRODUCT)).thenReturn(PRODUCT_ID);
+        when(ctx.getAttribute(ContextAttributes.ATTR_PLAN)).thenReturn(PLAN_1);
+
+        final ApiProductPlanFlowResolver cut = new ApiProductPlanFlowResolver(api, ENV_ID, apiProductRegistry, filter);
+        final TestSubscriber<Flow> obs = cut.provideFlows(ctx).test();
+
+        obs.assertResult();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/FlowResolverFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/FlowResolverFactoryTest.java
@@ -22,8 +22,8 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.flow.execution.FlowMode;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
-import io.gravitee.gateway.reactive.api.context.http.HttpBaseExecutionContext;
 import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
 import io.gravitee.gateway.reactive.v4.flow.AbstractBestMatchFlowSelector;
@@ -46,6 +46,9 @@ class FlowResolverFactoryTest {
 
     @Mock
     private AbstractBestMatchFlowSelector<Flow> bestMatchFlowSelector;
+
+    @Mock
+    private ApiProductRegistry apiProductRegistry;
 
     private FlowResolverFactory cut;
     private Api api;
@@ -73,5 +76,13 @@ class FlowResolverFactoryTest {
 
         assertNotNull(flowResolver);
         assertTrue(flowResolver instanceof ApiPlanFlowResolver);
+    }
+
+    @Test
+    void shouldCreateApiProductPlanFlowResolver() {
+        final FlowResolver flowResolver = cut.forApiProductPlan(api, "env-1", apiProductRegistry);
+
+        assertNotNull(flowResolver);
+        assertTrue(flowResolver instanceof ApiProductPlanFlowResolver);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-99

## Description

**What we did**
Added gateway support to execute API Product plan flows on each request/response. Introduced ApiProductPlanFlowResolver, wired a product-plan flow chain in DefaultApiReactor, and extended ApiProductPlanPolicyManager to load flow-step policies (e.g. token-ratelimit) from the registry. Added unit tests for resolver, factory, and policy manager.

**Why required**
AI Product Budget Router policies live on the product plan flow, not the LLM proxy API. Without this, budget/RPM limits never run and per-user isolation via subscription counters cannot work. This is the gateway backbone needed before create-product / add-user flows can enforce limits.

**Additive / breaking change**
Additive only — no breaking change. The product-plan chain runs only when a product subscription is active and product plans have flows; otherwise it is a no-op. Classic APIs and API Products without product-plan flows behave exactly as before; existing API plan and API flows still run unchanged after the new chain.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

