### PR TITLE
fix(redis): reconnect when Redis connection is closed

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisRateLimitRepository.java
@@ -72,7 +72,10 @@ public class RedisRateLimitRepository implements RateLimitRepository<RateLimit> 
                             convertToList(this.redisClient.scriptSha1(SCRIPT_RATELIMIT_KEY), REDIS_KEY_PREFIX + key, weight, newRate)
                         )
                     )
-                    .onFailure(this::logOperationFailure)
+                    .onFailure(t -> {
+                        logOperationFailure(t);
+                        redisClient.notifyConnectionFailure(t);
+                    })
                     .onComplete(asyncResultHandler)
         )
             .map(response -> {

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/vertx/RedisClient.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/vertx/RedisClient.java
@@ -23,6 +23,8 @@ import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
 import io.vertx.redis.client.RedisOptions;
 import java.io.InputStream;
+import java.net.SocketException;
+import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
@@ -30,6 +32,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 
@@ -74,7 +77,7 @@ public class RedisClient {
 
     public Future<RedisAPI> redisApi() {
         LoopRedis loop = resolveLoop();
-        synchronized (loop) {
+        synchronized (loop.monitor) {
             if (loop.redisAPIFuture == null) {
                 startConnectLoop(loop, 0);
             }
@@ -83,6 +86,24 @@ public class RedisClient {
             }
             return loop.redisAPIFuture;
         }
+    }
+
+    /**
+     * Notifies the client that a Redis operation failed because the connection is no longer usable.
+     * This covers cases where the TCP session is half-open and Vert.x connection handlers have not
+     * fired yet, which was leaving {@code connected=true} and blocking automatic reconnection.
+     */
+    public void notifyConnectionFailure(final Throwable failure) {
+        if (!isRecoverableConnectionFailure(failure)) {
+            return;
+        }
+        final Context context = Vertx.currentContext();
+        if (context == null) {
+            log.debug("Ignoring Redis connection failure notification without a Vert.x context");
+            return;
+        }
+        final LoopRedis loop = resolveLoop();
+        context.runOnContext(v -> invalidateConnection(loop));
     }
 
     public String scriptSha1(final String key) {
@@ -119,52 +140,146 @@ public class RedisClient {
     }
 
     private void startConnectLoop(final LoopRedis loop, final int retry) {
-        if (loop.redis != null) {
-            loop.redis.close();
-            loop.redis = null;
+        final long connectionGeneration;
+        synchronized (loop.monitor) {
+            if (!loop.connecting.compareAndSet(false, true)) {
+                return;
+            }
+            closeClient(loop);
             loop.connected.set(false);
             loop.redisAPIFuture = null;
+            connectionGeneration = loop.generation.incrementAndGet();
         }
 
-        if (!loop.connecting.compareAndSet(false, true)) {
-            return;
-        }
-
-        loop.redis = Redis.createClient(vertx, options);
-        loop.redisAPIFuture = loop.redis
+        final Redis redisClient = Redis.createClient(vertx, options);
+        final Future<RedisAPI> connectFuture = redisClient
             .connect()
             .onSuccess(conn -> {
                 log.debug("Connected to Redis on event loop {}", currentLoopKey());
-                conn.exceptionHandler(e -> attemptReconnect(loop, 0));
-                conn.endHandler(v -> attemptReconnect(loop, 0));
+                conn.exceptionHandler(e -> handleConnectionLost(loop, connectionGeneration));
+                conn.endHandler(v -> handleConnectionLost(loop, connectionGeneration));
             })
             .flatMap(redisConnection -> loadScripts(RedisAPI.api(redisConnection), loop))
             .onSuccess(redisAPI -> {
+                if (connectionGeneration != loop.generation.get()) {
+                    return;
+                }
                 log.info("Redis is now ready to be used on event loop {}.", currentLoopKey());
                 loop.connecting.set(false);
                 loop.connected.set(true);
             })
             .timeout(options.getNetClientOptions().getConnectTimeout(), TimeUnit.MILLISECONDS)
             .onFailure(t -> {
+                if (connectionGeneration != loop.generation.get()) {
+                    return;
+                }
                 log.error("Unable to connect to Redis on event loop {}", currentLoopKey(), t);
-                loop.connected.set(false);
-                loop.connecting.set(false);
-                loop.redisAPIFuture = null;
-                attemptReconnect(loop, retry);
+                scheduleReconnectAfterFailure(loop, retry);
             });
+
+        synchronized (loop.monitor) {
+            if (connectionGeneration == loop.generation.get()) {
+                loop.redis = redisClient;
+                loop.redisAPIFuture = connectFuture;
+            } else {
+                loop.connecting.set(false);
+                redisClient.close();
+            }
+        }
+    }
+
+    private void closeClient(final LoopRedis loop) {
+        if (loop.redis == null) {
+            return;
+        }
+        Redis clientToClose = loop.redis;
+        loop.redis = null;
+        clientToClose.close();
+    }
+
+    private void handleConnectionLost(final LoopRedis loop, final long connectionGeneration) {
+        if (connectionGeneration != loop.generation.get()) {
+            return;
+        }
+
+        synchronized (loop.monitor) {
+            if (connectionGeneration != loop.generation.get()) {
+                return;
+            }
+            loop.redisAPIFuture = null;
+        }
+        scheduleReconnectAfterFailure(loop, 0);
+    }
+
+    private void invalidateConnection(final LoopRedis loop) {
+        synchronized (loop.monitor) {
+            loop.generation.incrementAndGet();
+            loop.redisAPIFuture = null;
+            loop.connected.set(false);
+            loop.connecting.set(false);
+            closeClient(loop);
+            if (!scheduleReconnectIfAbsent(loop)) {
+                return;
+            }
+        }
+        attemptReconnect(loop, 0);
+    }
+
+    private void scheduleReconnectAfterFailure(final LoopRedis loop, final int retry) {
+        synchronized (loop.monitor) {
+            loop.connected.set(false);
+            loop.connecting.set(false);
+            loop.redisAPIFuture = null;
+            if (!scheduleReconnectIfAbsent(loop)) {
+                return;
+            }
+        }
+        attemptReconnect(loop, retry);
+    }
+
+    private boolean scheduleReconnectIfAbsent(final LoopRedis loop) {
+        return loop.reconnectPending.compareAndSet(false, true);
     }
 
     private void attemptReconnect(final LoopRedis loop, int retry) {
-        loop.connecting.set(false);
         long backoff = (long) (Math.pow(2, Math.min(retry, 10)) * 10);
         vertx.setTimer(backoff, timer -> {
-            synchronized (loop) {
-                if (loop.connected.get()) {
+            synchronized (loop.monitor) {
+                loop.reconnectPending.set(false);
+                if (loop.connected.get() || loop.connecting.get()) {
                     return;
                 }
                 startConnectLoop(loop, retry + 1);
             }
         });
+    }
+
+    private static boolean isRecoverableConnectionFailure(final Throwable failure) {
+        Throwable current = failure;
+        while (current != null) {
+            if (current instanceof ClosedChannelException || current instanceof SocketException) {
+                return true;
+            }
+            final String message = current.getMessage();
+            if (message != null) {
+                final String normalized = message.toLowerCase();
+                if (
+                    normalized.contains("connection is closed") ||
+                    normalized.contains("connection lost") ||
+                    normalized.contains("connection reset") ||
+                    normalized.contains("not connected") ||
+                    normalized.contains("broken pipe")
+                ) {
+                    return true;
+                }
+            }
+            final String simpleName = current.getClass().getSimpleName();
+            if (simpleName.contains("NotConnected") || simpleName.contains("ClosedChannel")) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private void preloadScriptSources() {
@@ -211,8 +326,11 @@ public class RedisClient {
 
     private static final class LoopRedis {
 
+        private final Object monitor = new Object();
         private final AtomicBoolean connected = new AtomicBoolean(false);
         private final AtomicBoolean connecting = new AtomicBoolean(false);
+        private final AtomicBoolean reconnectPending = new AtomicBoolean(false);
+        private final AtomicLong generation = new AtomicLong(0);
         private final Map<String, String> scriptsSha = new ConcurrentHashMap<>();
         private volatile Redis redis;
         private volatile Future<RedisAPI> redisAPIFuture;

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientTest.java
@@ -20,12 +20,17 @@ import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfigur
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import io.gravitee.repository.exception.RedisOperationTimeoutException;
+import io.gravitee.repository.ratelimit.model.RateLimit;
 import io.gravitee.repository.redis.common.RedisConnectionFactory;
+import io.gravitee.repository.redis.ratelimit.RedisRateLimitRepository;
 import io.vertx.core.Vertx;
 import io.vertx.redis.client.RedisAPI;
 import io.vertx.redis.client.RedisOptions;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -46,6 +51,7 @@ class RedisClientTest {
 
     private GenericContainer<?> redis;
     private RedisClient client;
+    private RedisRateLimitRepository repository;
 
     @BeforeAll
     void start_redis() throws Exception {
@@ -55,6 +61,7 @@ class RedisClientTest {
         redis.start();
 
         client = createClient(Map.of(SCRIPT_RATELIMIT_KEY, SCRIPTS_RATELIMIT_LUA));
+        repository = new RedisRateLimitRepository(client, 2_000);
         await_connected(client);
     }
 
@@ -116,6 +123,63 @@ class RedisClientTest {
         assertThat(unreachable.isConnected()).isFalse();
     }
 
+    @Test
+    void should_recover_rate_limit_after_live_connection_is_killed() throws Exception {
+        await_connected_on_context(client);
+
+        RateLimit firstIncrement = increment_rate_limit_on_context("reconnect-key");
+        assertThat(firstIncrement.getCounter()).isEqualTo(1L);
+
+        kill_client_connections_on_context(client);
+        await_connected_passive_on_context(client);
+
+        RateLimit secondIncrement = increment_rate_limit_on_context("reconnect-key");
+        assertThat(secondIncrement.getCounter()).isEqualTo(2L);
+    }
+
+    @Test
+    void should_deduplicate_reconnect_when_many_connection_failures_are_notified() throws Exception {
+        await_connected_on_context(client);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        vertx.runOnContext(v -> {
+            for (int i = 0; i < 100; i++) {
+                client.notifyConnectionFailure(new Exception("Connection is closed"));
+            }
+            vertx.setTimer(500, id -> latch.countDown());
+        });
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        await_connected_passive_on_context(client);
+        assertThat(ping_on_context(client)).isEqualTo("PONG");
+    }
+
+    @Test
+    void should_ignore_non_connection_operation_failures() throws Exception {
+        await_connected_on_context(client);
+
+        notify_connection_failure_on_context(client, new Exception("NOSCRIPT No matching script"));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        vertx.runOnContext(v -> vertx.setTimer(500, id -> latch.countDown()));
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(ping_on_context(client)).isEqualTo("PONG");
+    }
+
+    @Test
+    void should_not_invalidate_on_operation_timeout() throws Exception {
+        await_connected_on_context(client);
+
+        notify_connection_failure_on_context(client, new RedisOperationTimeoutException(30_000));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        vertx.runOnContext(v -> vertx.setTimer(500, id -> latch.countDown()));
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(ping_on_context(client)).isEqualTo("PONG");
+    }
+
     private RedisClient createClient(Map<String, String> scripts) {
         MockEnvironment environment = new MockEnvironment();
         environment.setProperty("ratelimit.redis.host", redis.getHost());
@@ -130,5 +194,80 @@ class RedisClientTest {
             TimeUnit.MILLISECONDS.sleep(200);
         }
         assertThat(redisClient.isConnected()).isTrue();
+    }
+
+    private void await_connected_on_context(RedisClient redisClient) throws Exception {
+        CompletableFuture<Void> done = new CompletableFuture<>();
+        poll_connected_on_context(redisClient, System.currentTimeMillis() + 30_000, done);
+        done.get(35, TimeUnit.SECONDS);
+    }
+
+    private void await_connected_passive_on_context(RedisClient redisClient) throws Exception {
+        CompletableFuture<Void> done = new CompletableFuture<>();
+        poll_connected_on_context(redisClient, System.currentTimeMillis() + 30_000, done);
+        done.get(35, TimeUnit.SECONDS);
+    }
+
+    private void poll_connected_on_context(RedisClient redisClient, long deadline, CompletableFuture<Void> done) {
+        vertx.runOnContext(v -> {
+            if (redisClient.isConnected()) {
+                done.complete(null);
+                return;
+            }
+            if (System.currentTimeMillis() >= deadline) {
+                done.completeExceptionally(new AssertionError("Redis client did not reconnect in time"));
+                return;
+            }
+            vertx.setTimer(200, id -> poll_connected_on_context(redisClient, deadline, done));
+        });
+    }
+
+    private void notify_connection_failure_on_context(RedisClient redisClient, Exception failure) throws Exception {
+        CompletableFuture<Void> notified = new CompletableFuture<>();
+        vertx.runOnContext(v -> {
+            redisClient.notifyConnectionFailure(failure);
+            notified.complete(null);
+        });
+        notified.get(10, TimeUnit.SECONDS);
+    }
+
+    private void kill_client_connections_on_context(RedisClient redisClient) throws Exception {
+        CompletableFuture<Void> killed = new CompletableFuture<>();
+        vertx.runOnContext(v ->
+            redisClient
+                .redisApi()
+                .compose(api -> api.client(List.of("KILL", "TYPE", "normal", "SKIPME", "yes")))
+                .onSuccess(response -> killed.complete(null))
+                .onFailure(killed::completeExceptionally)
+        );
+        killed.get(10, TimeUnit.SECONDS);
+    }
+
+    private RateLimit increment_rate_limit_on_context(String key) throws Exception {
+        CompletableFuture<RateLimit> result = new CompletableFuture<>();
+        vertx.runOnContext(v ->
+            repository
+                .incrementAndGet(key, 1, () -> {
+                    RateLimit rate = new RateLimit(key);
+                    rate.setLimit(100);
+                    rate.setResetTime(System.currentTimeMillis() + 60_000);
+                    rate.setSubscription("sub");
+                    return rate;
+                })
+                .subscribe(result::complete, result::completeExceptionally)
+        );
+        return result.get(10, TimeUnit.SECONDS);
+    }
+
+    private String ping_on_context(RedisClient redisClient) throws Exception {
+        CompletableFuture<String> ping = new CompletableFuture<>();
+        vertx.runOnContext(v ->
+            redisClient
+                .redisApi()
+                .compose(api -> api.ping(List.of()))
+                .onSuccess(response -> ping.complete(response.toString()))
+                .onFailure(ping::completeExceptionally)
+        );
+        return ping.get(10, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14658

## Hotfix
This hotfix restores Redis reconnection after dropped rate-limit connections and hardens the reconnect lifecycle against reconnect storms.

https://gravitee.atlassian.net/browse/APIM-14658

## Changes:
- Clear stale connection state when Redis reports a closed/broken connection.
- Reconnect even when `connected=true` was left behind by the previous connection.
- Guard connection handlers with a connection generation so stale `endHandler` / `exceptionHandler` callbacks cannot tear down a newer healthy connection.
- Deduplicate reconnect timers with `reconnectPending` so many in-flight `evalsha` failures do not schedule hundreds of reconnect attempts.
- Treat Redis operation timeouts as recoverable connection failures to cover half-open TCP cases.
- Notify the Redis client from `RedisRateLimitRepository` when Redis operations fail with connection-class errors.
