### PR TITLE
chore(ci): bump Keeper orb to version 0.7.1 across pipeline configurations

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -103,7 +103,7 @@ const orbs = {
   github: '1.0.5',
   gravitee: 'dev:4.5.0',
   helm: '3.0.0',
-  keeper: '0.7.0',
+  keeper: '0.7.1',
   slack: '4.12.5',
 };
 

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -334,5 +334,5 @@ workflows:
                 - graviteeio@4.8
                 - graviteeio@4.8.0
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
@@ -437,6 +437,6 @@ workflows:
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
@@ -437,6 +437,6 @@ workflows:
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
@@ -437,6 +437,6 @@ workflows:
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
@@ -437,6 +437,6 @@ workflows:
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
@@ -437,6 +437,6 @@ workflows:
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm/build-rpm-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm/build-rpm-release-dry-run.yml
@@ -87,4 +87,4 @@ workflows:
             - cicd-orchestrator
           name: Build and push RPM packages for APIM 4.2.0 - Dry Run
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm/build-rpm-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm/build-rpm-release-no-dry-run.yml
@@ -87,4 +87,4 @@ workflows:
             - cicd-orchestrator
           name: Build and push RPM packages for APIM 4.2.0
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -891,7 +891,7 @@ workflows:
             - Trigger APIM API docs ingestion
             - Build and push RPM packages for APIM 4.2.0-alpha.1
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   aws-cli: circleci/aws-cli@5.1.2

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -925,7 +925,7 @@ workflows:
             - Trigger APIM API docs ingestion
             - Build and push RPM packages for APIM 4.2.0 - Dry Run
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   aws-cli: circleci/aws-cli@5.1.2

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -937,7 +937,7 @@ workflows:
             - Trigger APIM API docs ingestion
             - Build and push RPM packages for APIM 4.2.0
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   aws-cli: circleci/aws-cli@5.1.2

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -937,7 +937,7 @@ workflows:
             - Trigger APIM API docs ingestion
             - Build and push RPM packages for APIM 4.2.0
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   aws-cli: circleci/aws-cli@5.1.2

--- a/.circleci/ci/src/pipelines/tests/resources/helm-tests/helm-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/helm-tests/helm-tests.yml
@@ -90,5 +90,5 @@ workflows:
                 - v3.15.1
 orbs:
   helm: circleci/helm@3.0.0
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/nexus-staging/nexus-staging-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nexus-staging/nexus-staging-no-dry-run.yml
@@ -149,5 +149,5 @@ workflows:
             - Nexus staging
           message: 🎆 APIM - 1.2.3-alpha.1 released!
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-prerelease-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-prerelease-dry-run.yml
@@ -110,6 +110,6 @@ workflows:
           requires:
             - Setup
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-prerelease-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-prerelease-no-dry-run.yml
@@ -110,6 +110,6 @@ workflows:
           requires:
             - Setup
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-release-dry-run.yml
@@ -110,6 +110,6 @@ workflows:
           requires:
             - Setup
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-release-no-dry-run.yml
@@ -110,6 +110,6 @@ workflows:
           requires:
             - Setup
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -481,7 +481,7 @@ workflows:
             - Build APIM Console docker image
             - Build APIM Portal docker image
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -447,7 +447,7 @@ workflows:
             - Build APIM Console docker image
             - Build APIM Portal docker image
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -481,7 +481,7 @@ workflows:
             - Build APIM Console docker image
             - Build APIM Portal docker image
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -1605,7 +1605,7 @@ workflows:
             - Build APIM Console docker image
             - Build APIM Portal docker image
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -197,6 +197,6 @@ workflows:
           requires:
             - Build backend
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -334,6 +334,6 @@ workflows:
             - Test gateway
             - Integration tests
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -251,6 +251,6 @@ workflows:
           requires:
             - Integration tests
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -568,6 +568,6 @@ workflows:
             - Test reporters
             - Test repository
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -335,6 +335,6 @@ workflows:
             - Integration tests
             - Test plugins
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -335,6 +335,6 @@ workflows:
             - Integration tests
             - Test reporters
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -280,6 +280,6 @@ workflows:
           requires:
             - Test rest-api
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -357,7 +357,7 @@ workflows:
             - Lint & test APIM Console
             - Build APIM Console
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-helm-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-helm-only.yml
@@ -128,7 +128,7 @@ workflows:
           requires:
             - Helm Chart - Lint & Test
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-next-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-next-only.yml
@@ -310,6 +310,6 @@ workflows:
             - Lint & test APIM Portal Next
             - Build APIM Portal
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -305,6 +305,6 @@ workflows:
             - Lint & test APIM Portal
             - Build APIM Portal
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -986,7 +986,7 @@ workflows:
             - Lint & test APIM Portal
             - Build APIM Portal
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -1669,7 +1669,7 @@ workflows:
             - Trigger SaaS Docker images creation
             - Publish Helm chart (internal repo)
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -986,7 +986,7 @@ workflows:
             - Lint & test APIM Portal
             - Build APIM Portal
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -1345,7 +1345,7 @@ workflows:
             - Build APIM Console docker image
             - Build APIM Portal docker image
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   aquasec: gravitee-io/aquasec@1.0.5
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/release-helm/release-helm-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release-helm/release-helm-dry-run.yml
@@ -185,6 +185,6 @@ workflows:
             - cicd-orchestrator
 orbs:
   helm: circleci/helm@3.0.0
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/release-helm/release-helm.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release-helm/release-helm.yml
@@ -179,6 +179,6 @@ workflows:
             - cicd-orchestrator
 orbs:
   helm: circleci/helm@3.0.0
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/release-notes-apim/release-notes-apim-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release-notes-apim/release-notes-apim-dry-run.yml
@@ -81,5 +81,5 @@ workflows:
             - cicd-orchestrator
           name: Generate release note and create PR
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/release-notes-apim/release-notes-apim-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release-notes-apim/release-notes-apim-no-dry-run.yml
@@ -99,6 +99,6 @@ workflows:
             - cicd-orchestrator
           name: Generate release note and create PR
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   gh: circleci/github-cli@1.0.5
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -404,7 +404,7 @@ workflows:
             - Build APIM Console
             - Build APIM Portal
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -406,7 +406,7 @@ workflows:
             - Build APIM Console
             - Build APIM Portal
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
@@ -406,7 +406,7 @@ workflows:
             - Build APIM Console
             - Build APIM Portal
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -371,5 +371,5 @@ workflows:
                 - 7.2.0-v7
                 - latest
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -565,6 +565,6 @@ workflows:
             - Build APIM Console docker image
             - Build APIM Portal docker image
 orbs:
-  keeper: gravitee-io/keeper@0.7.0
+  keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   aquasec: gravitee-io/aquasec@1.0.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
     continuation: circleci/continuation@1.1.0
     node: circleci/node@7.2.1
-    keeper: gravitee-io/keeper@0.7.0
+    keeper: gravitee-io/keeper@0.7.1
     slack: circleci/slack@5.1.1
 
 setup: true


### PR DESCRIPTION
Bump the gravitee-io/keeper CircleCI orb from 0.7.0 to 0.7.1 across the APIM CI configuration on the 4.11.x branch.

This keeps the 4.11.x pipeline aligned with the same Keeper orb version used in newer branches.

Changes include:

.circleci/config.yml — update the root pipeline orb reference
.circleci/ci/src/config.ts — update the CI generator source of truth
46 generated pipeline test snapshots under .circleci/ci/src/pipelines/tests/resources/ — update expected keeper orb version in fixture YAML files

Additional context

No functional CI workflow changes; this is an orb version bump only.
Snapshot fixtures were updated to stay consistent with config.ts

