### PR TITLE
feat(rest-api): expose branded-senders inherited flag and add env-scope reset endpoint

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalSettingsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalSettingsResource.java
@@ -37,6 +37,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
@@ -92,6 +93,27 @@ public class PortalSettingsResource {
         environmentService.findById(GraviteeContext.getCurrentEnvironment());
 
         configService.save(GraviteeContext.getExecutionContext(), portalSettingsEntity);
+        return Response.ok().entity(portalSettingsEntity).build();
+    }
+
+    @POST
+    @Path("email/branded-senders/reset")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+        summary = "Reset the environment branded senders, deleting the environment override so the value falls back through the cascade (organization, or system configuration if set)"
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Updated portal settings",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PortalSettingsEntity.class))
+    )
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_SETTINGS, acls = UPDATE) })
+    public Response resetPortalBrandedSenders() {
+        // Fail fast with 404 (findById throws) when the current environment does not exist, before resetting anything.
+        environmentService.findById(GraviteeContext.getCurrentEnvironment());
+
+        PortalSettingsEntity portalSettingsEntity = configService.resetPortalBrandedSenders(GraviteeContext.getExecutionContext());
         return Response.ok().entity(portalSettingsEntity).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PortalSettingsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PortalSettingsResourceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.rest.api.model.settings.PortalSettingsEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.EnvironmentNotFoundException;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalSettingsResourceTest extends AbstractResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "settings";
+    }
+
+    @BeforeEach
+    public void init() {
+        reset(configService, environmentService);
+    }
+
+    @Test
+    public void shouldResetBrandedSendersAndReturnRefreshedInheritedSettings() {
+        PortalSettingsEntity refreshed = new PortalSettingsEntity();
+        refreshed.getEmail().setBrandedSendersInherited(true);
+        when(configService.resetPortalBrandedSenders(any(ExecutionContext.class))).thenReturn(refreshed);
+
+        final Response response = envTarget("/email/branded-senders/reset").request().post(Entity.json(""));
+        response.bufferEntity();
+
+        assertEquals(OK_200, response.getStatus(), response.readEntity(String.class));
+        assertTrue(response.readEntity(PortalSettingsEntity.class).getEmail().isBrandedSendersInherited());
+        verify(configService).resetPortalBrandedSenders(any(ExecutionContext.class));
+    }
+
+    @Test
+    public void shouldReturn404WhenEnvironmentDoesNotExist() {
+        when(environmentService.findById(any())).thenThrow(new EnvironmentNotFoundException("unknown-env"));
+
+        final Response response = envTarget("/email/branded-senders/reset").request().post(Entity.json(""));
+
+        assertEquals(NOT_FOUND_404, response.getStatus(), response.readEntity(String.class));
+        verify(configService, never()).resetPortalBrandedSenders(any(ExecutionContext.class));
+    }
+
+    @Test
+    public void shouldReturn403WhenMissingUpdatePermission() {
+        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
+
+        final Response response = envTarget("/email/branded-senders/reset").request().post(Entity.json(""));
+
+        assertEquals(FORBIDDEN_403, response.getStatus(), response.readEntity(String.class));
+        verify(configService, never()).resetPortalBrandedSenders(any(ExecutionContext.class));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Email.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Email.java
@@ -64,6 +64,18 @@ public class Email {
     @JsonIgnore
     private String brandedSendersRaw = "[]";
 
+    /**
+     * Whether the effective branded-sender configurations are inherited from the Organization scope,
+     * i.e. no Environment-level override is set and no valid system value is in effect. Derived at read
+     * time for the Environment settings response; always {@code false} at Organization scope.
+     * <p>
+     * A {@code true} value means only that no Environment override exists (so the effective value comes
+     * from the Organization or the built-in default) — it does <em>not</em> imply the Organization has a
+     * non-empty configuration; it may be inheriting an empty/default list. UI showing an "Inherited from
+     * Org" badge should therefore also gate on there being at least one configuration to display.
+     */
+    private boolean brandedSendersInherited = false;
+
     private EmailProperties properties;
 
     public Email() {
@@ -163,6 +175,16 @@ public class Email {
     @JsonProperty("brandedSenders")
     public void setBrandedSenders(List<BrandedSenderConfig> brandedSenders) {
         this.brandedSendersRaw = BrandedSenders.write(brandedSenders);
+    }
+
+    @JsonProperty("brandedSendersInherited")
+    public boolean isBrandedSendersInherited() {
+        return brandedSendersInherited;
+    }
+
+    @JsonProperty("brandedSendersInherited")
+    public void setBrandedSendersInherited(boolean brandedSendersInherited) {
+        this.brandedSendersInherited = brandedSendersInherited;
     }
 
     public EmailProperties getProperties() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ConfigService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ConfigService.java
@@ -33,6 +33,12 @@ public interface ConfigService {
 
     void save(ExecutionContext executionContext, PortalSettingsEntity portalSettingsEntity);
 
+    /**
+     * Resets the environment-scoped branded senders so the value falls back to the organization
+     * (or system) scope, and returns the refreshed portal settings.
+     */
+    PortalSettingsEntity resetPortalBrandedSenders(ExecutionContext executionContext);
+
     ConsoleSettingsEntity getConsoleSettings(ExecutionContext executionContext);
 
     void save(ExecutionContext executionContext, ConsoleSettingsEntity consoleSettingsEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ParameterService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ParameterService.java
@@ -202,6 +202,27 @@ public interface ParameterService {
     );
 
     /**
+     * Returns whether a parameter is set at the exact given scope, without cascading to the
+     * organization or system scope. Used to distinguish an environment-level override from a value
+     * inherited from a broader scope.
+     * <p>
+     * Unlike {@code find}/{@code save}/{@code findAll}, this method takes no {@link ExecutionContext}
+     * and therefore does not resolve a {@code null} {@code referenceId} from the current context:
+     * {@code referenceId} must be a concrete, non-null reference id.
+     */
+    boolean existsOnScope(Key key, String referenceId, ParameterReferenceType referenceType);
+
+    /**
+     * Deletes the parameter set at the exact given scope, so the value falls back to a broader scope
+     * of the cascade. No-op when no parameter is set at that scope. Invalidates the parameter cache.
+     * <p>
+     * Like the {@code save(..., null)} delete path, this writes no audit entry and publishes no
+     * {@link Key} change event. It must therefore not be used to reset keys whose runtime state is
+     * driven by such events (e.g. SMTP/CORS) without adding that propagation separately.
+     */
+    void delete(ExecutionContext executionContext, Key key, String referenceId, ParameterReferenceType referenceType);
+
+    /**
      * Invalidate cache for a specific parameter
      */
     void invalidateCache(String key, String referenceId, String referenceType);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -36,6 +36,7 @@ import io.gravitee.rest.api.model.settings.CommonAuthentication;
 import io.gravitee.rest.api.model.settings.ConsoleConfigEntity;
 import io.gravitee.rest.api.model.settings.ConsoleReCaptcha;
 import io.gravitee.rest.api.model.settings.ConsoleSettingsEntity;
+import io.gravitee.rest.api.model.settings.Email;
 import io.gravitee.rest.api.model.settings.Enabled;
 import io.gravitee.rest.api.model.settings.Newsletter;
 import io.gravitee.rest.api.model.settings.PortalAuthentication;
@@ -137,6 +138,17 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
     }
 
     @Override
+    public PortalSettingsEntity resetPortalBrandedSenders(ExecutionContext executionContext) {
+        parameterService.delete(
+            executionContext,
+            Key.EMAIL_BRANDED_SENDERS,
+            executionContext.getEnvironmentId(),
+            ParameterReferenceType.ENVIRONMENT
+        );
+        return getPortalSettings(executionContext);
+    }
+
+    @Override
     public ConsoleConfigEntity getConsoleConfig(ExecutionContext executionContext) {
         return MAPPER.convertValue(getConsoleSettings(executionContext), ConsoleConfigEntity.class);
     }
@@ -159,6 +171,32 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
         hideForTrialInstance(consoleConfigEntity);
 
         return consoleConfigEntity;
+    }
+
+    /**
+     * Flags whether the Environment inherits the Organization branded-senders value — true only at ENVIRONMENT scope
+     * when no environment-level override exists and no valid system value is in effect. No-op for other keys/scopes
+     * (the Organization response has nothing above it to inherit from).
+     */
+    private void applyBrandedSendersInheritance(
+        Object object,
+        Key parameterKey,
+        ParameterReferenceType referenceType,
+        String referenceId,
+        boolean systemConfigured
+    ) {
+        if (
+            parameterKey == Key.EMAIL_BRANDED_SENDERS &&
+            referenceType == ParameterReferenceType.ENVIRONMENT &&
+            object instanceof Email email
+        ) {
+            boolean environmentOverride = parameterService.existsOnScope(
+                Key.EMAIL_BRANDED_SENDERS,
+                referenceId,
+                ParameterReferenceType.ENVIRONMENT
+            );
+            email.setBrandedSendersInherited(!systemConfigured && !environmentOverride);
+        }
     }
 
     private void loadConfigByReference(
@@ -205,6 +243,7 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
                         if (systemConfigured) {
                             configEntity.getMetadata().add(PortalSettingsEntity.METADATA_READONLY, parameterKey.value().key());
                         }
+                        applyBrandedSendersInheritance(o, parameterKey.value(), referenceType, referenceId, systemConfigured);
                         final String defaultValue = parameterKey.value().defaultValue();
                         if (Enabled.class.isAssignableFrom(f.getType())) {
                             f.set(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ParameterServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ParameterServiceImpl.java
@@ -469,9 +469,7 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
 
             if (updateMode) {
                 if (value == null) {
-                    parameterRepository.delete(key.key(), refIdToUse, ParameterReferenceType.valueOf(referenceType.name()));
-                    cache.invalidate(computeCacheKey(key.key(), refIdToUse, ParameterReferenceType.valueOf(referenceType.name())));
-                    sendInvalidateParameterCacheCommand(
+                    deleteParameterAndInvalidateCache(
                         key.key(),
                         refIdToUse,
                         ParameterReferenceType.valueOf(referenceType.name()),
@@ -718,6 +716,61 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
 
     private String getDefaultParameterValue(Key key) {
         return key.defaultValue();
+    }
+
+    @Override
+    public boolean existsOnScope(Key key, String referenceId, io.gravitee.rest.api.model.parameters.ParameterReferenceType referenceType) {
+        try {
+            return parameterRepository.findById(key.key(), referenceId, ParameterReferenceType.valueOf(referenceType.name())).isPresent();
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException(
+                "An error occurs while checking parameter existence with key: " + key.key() + " on scope: " + referenceType,
+                e
+            );
+        }
+    }
+
+    @Override
+    public void delete(
+        ExecutionContext executionContext,
+        Key key,
+        String referenceId,
+        io.gravitee.rest.api.model.parameters.ParameterReferenceType referenceType
+    ) {
+        String refIdToUse = getEffectiveReferenceId(executionContext, referenceId, referenceType);
+        ParameterReferenceType repositoryReferenceType = ParameterReferenceType.valueOf(referenceType.name());
+        try {
+            if (parameterRepository.findById(key.key(), refIdToUse, repositoryReferenceType).isEmpty()) {
+                return;
+            }
+            deleteParameterAndInvalidateCache(key.key(), refIdToUse, repositoryReferenceType, executionContext);
+        } catch (TechnicalException ex) {
+            throw new TechnicalManagementException(
+                "An error occurs while trying to delete parameter with key: " +
+                    key.key() +
+                    " on scope: " +
+                    referenceType +
+                    " for reference: " +
+                    refIdToUse,
+                ex
+            );
+        }
+    }
+
+    /**
+     * Deletes a parameter and invalidates its cache locally and across the cluster. Shared by the value-less
+     * {@code save(...)} path and {@link #delete(ExecutionContext, Key, String, io.gravitee.rest.api.model.parameters.ParameterReferenceType)}
+     * so the delete + invalidation sequence stays in one place.
+     */
+    private void deleteParameterAndInvalidateCache(
+        String key,
+        String referenceId,
+        ParameterReferenceType referenceType,
+        ExecutionContext executionContext
+    ) throws TechnicalException {
+        parameterRepository.delete(key, referenceId, referenceType);
+        cache.invalidate(computeCacheKey(key, referenceId, referenceType));
+        sendInvalidateParameterCacheCommand(key, referenceId, referenceType, executionContext);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
@@ -92,6 +92,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -313,6 +314,86 @@ class ConfigServiceTest {
 
         List<String> readonly = portalSettings.getMetadata().get(PortalSettingsEntity.METADATA_READONLY);
         assertThat(readonly == null ? List.<String>of() : readonly).doesNotContain(Key.EMAIL_BRANDED_SENDERS.key());
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        {
+            // systemConfigured, envOverride, expectedInherited
+            "false, false, true", // no valid system value and no environment override -> inherited from the organization
+            "false, true, false", // an environment-level override exists -> the environment's own value, not inherited
+            "true, false, false", // a valid system value is in effect -> comes from system, not inherited
+        }
+    )
+    void shouldFlagBrandedSendersInheritedFromSystemAndEnvOverride(
+        boolean systemConfigured,
+        boolean envOverride,
+        boolean expectedInherited
+    ) {
+        when(
+            mockParameterService.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                any(List.class),
+                any(Function.class),
+                eq("DEFAULT"),
+                eq(ParameterReferenceType.ENVIRONMENT)
+            )
+        ).thenReturn(new HashMap<>());
+        when(brandedSendersEnvironmentReader.isConfigured()).thenReturn(systemConfigured);
+        when(mockParameterService.existsOnScope(Key.EMAIL_BRANDED_SENDERS, "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(
+            envOverride
+        );
+
+        PortalSettingsEntity portalSettings = configService.getPortalSettings(GraviteeContext.getExecutionContext());
+
+        assertThat(portalSettings.getEmail().isBrandedSendersInherited()).isEqualTo(expectedInherited);
+    }
+
+    @Test
+    void shouldNotMarkBrandedSendersInheritedForConsoleSettings() {
+        // Organization scope has nothing above it to inherit branded senders from; the flag stays false.
+        when(
+            mockParameterService.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                any(List.class),
+                any(Function.class),
+                eq("DEFAULT"),
+                eq(ParameterReferenceType.ORGANIZATION)
+            )
+        ).thenReturn(new HashMap<>());
+
+        ConsoleSettingsEntity consoleSettings = configService.getConsoleSettings(GraviteeContext.getExecutionContext());
+
+        assertThat(consoleSettings.getEmail().isBrandedSendersInherited()).isFalse();
+    }
+
+    @Test
+    void shouldResetPortalBrandedSendersByDeletingEnvParameterAndReturningInheritedSettings() {
+        when(
+            mockParameterService.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                any(List.class),
+                any(Function.class),
+                eq("DEFAULT"),
+                eq(ParameterReferenceType.ENVIRONMENT)
+            )
+        ).thenReturn(new HashMap<>());
+        // After the delete there is no environment override and no valid system value in effect.
+        when(brandedSendersEnvironmentReader.isConfigured()).thenReturn(false);
+        when(mockParameterService.existsOnScope(Key.EMAIL_BRANDED_SENDERS, "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(
+            false
+        );
+
+        PortalSettingsEntity portalSettings = configService.resetPortalBrandedSenders(GraviteeContext.getExecutionContext());
+
+        verify(mockParameterService).delete(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(Key.EMAIL_BRANDED_SENDERS),
+            eq("DEFAULT"),
+            eq(ParameterReferenceType.ENVIRONMENT)
+        );
+        // The refreshed settings resolve through delete -> getPortalSettings -> applyBrandedSendersInheritance to inherited.
+        assertThat(portalSettings.getEmail().isBrandedSendersInherited()).isTrue();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ParameterServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ParameterServiceTest.java
@@ -24,8 +24,10 @@ import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -45,10 +47,13 @@ import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -1092,5 +1097,110 @@ public class ParameterServiceTest {
         Command command = commandCaptor.getValue();
         assertEquals(List.of(CommandTags.PARAMETER_CACHE_UPDATE.name()), command.getTags());
         assertTrue(command.getContent().contains(PORTAL_TOP_APIS.key()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void shouldReportParameterExistenceOnScope(boolean present) throws TechnicalException {
+        final Parameter parameter = new Parameter();
+        parameter.setKey(EMAIL_BRANDED_SENDERS.key());
+        when(parameterRepository.findById(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(
+            present ? of(parameter) : empty()
+        );
+
+        boolean exists = parameterService.existsOnScope(
+            EMAIL_BRANDED_SENDERS,
+            "DEFAULT",
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        assertEquals(present, exists);
+    }
+
+    @Test
+    public void shouldWrapTechnicalExceptionWhenCheckingExistenceOnScope() throws TechnicalException {
+        when(parameterRepository.findById(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenThrow(
+            new TechnicalException("boom")
+        );
+
+        assertThrows(TechnicalManagementException.class, () ->
+            parameterService.existsOnScope(
+                EMAIL_BRANDED_SENDERS,
+                "DEFAULT",
+                io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+            )
+        );
+    }
+
+    @Test
+    public void shouldDeleteParameterOnScopeAndInvalidateCacheWhenPresent() throws TechnicalException {
+        final Parameter parameter = new Parameter();
+        parameter.setKey(EMAIL_BRANDED_SENDERS.key());
+        when(parameterRepository.findById(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(
+            of(parameter)
+        );
+
+        parameterService.delete(
+            GraviteeContext.getExecutionContext(),
+            EMAIL_BRANDED_SENDERS,
+            "DEFAULT",
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        verify(parameterRepository).delete(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT);
+
+        ArgumentCaptor<Command> commandCaptor = ArgumentCaptor.forClass(Command.class);
+        verify(commandRepository).create(commandCaptor.capture());
+        assertEquals(List.of(CommandTags.PARAMETER_CACHE_UPDATE.name()), commandCaptor.getValue().getTags());
+    }
+
+    @Test
+    public void shouldNotDeleteParameterOnScopeWhenAbsent() throws TechnicalException {
+        when(parameterRepository.findById(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(empty());
+
+        parameterService.delete(
+            GraviteeContext.getExecutionContext(),
+            EMAIL_BRANDED_SENDERS,
+            "DEFAULT",
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        verify(parameterRepository, never()).delete(anyString(), anyString(), any());
+        verifyNoInteractions(commandRepository);
+    }
+
+    @Test
+    public void shouldWrapTechnicalExceptionWhenDeletingOnScope() throws TechnicalException {
+        when(parameterRepository.findById(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenThrow(
+            new TechnicalException("boom")
+        );
+
+        assertThrows(TechnicalManagementException.class, () ->
+            parameterService.delete(
+                GraviteeContext.getExecutionContext(),
+                EMAIL_BRANDED_SENDERS,
+                "DEFAULT",
+                io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+            )
+        );
+    }
+
+    @Test
+    public void shouldResolveNullReferenceIdFromContextWhenDeleting() throws TechnicalException {
+        final Parameter parameter = new Parameter();
+        parameter.setKey(EMAIL_BRANDED_SENDERS.key());
+        when(parameterRepository.findById(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(
+            of(parameter)
+        );
+
+        // A null referenceId resolves to the execution context's environment id ("DEFAULT"), unlike existsOnScope.
+        parameterService.delete(
+            GraviteeContext.getExecutionContext(),
+            EMAIL_BRANDED_SENDERS,
+            null,
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        verify(parameterRepository).delete(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14612
## Description

Backend half of APIM-14612. Adds the two pieces the S4 Portal branded-senders UI (APIM-14191) couldn't ship without backend support: (1) an inherited flag so the Env settings response can tell an Org-inherited value from an Env override, and (2) a reset-to-inherited endpoint that deletes the Env-scoped email.branded_senders param so the cascade falls back to Org/System.

▎ Reviewer note — the ticket's "mirror notification-templates" framing is inaccurate. That backend pattern doesn't exist: notification-templates "overridden" is computed client-side from enabled/id, is org-scoped only, and has no reset endpoint. This work is built on the ParameterService/ParameterRepository cascade layer instead (SYSTEM → ENV → ORG → default), so existsOnScope / delete / the reset endpoint are net-new surface, not a copy.

Changes

- Email — new derived brandedSendersInherited boolean (not a @ParameterKey; set at read time).
- ParameterService.existsOnScope — scope-exact presence check (no cascade), to distinguish an Env override from inheritance.
- ParameterService.delete — scope-exact, idempotent delete (no-op when absent), reusing the save-path cache-invalidate + cluster command logic.
- ConfigServiceImpl.loadConfigByReference — sets brandedSendersInherited at ENVIRONMENT scope only (!systemConfigured && !envOverride); left false at Org scope.
- ConfigService.resetPortalBrandedSenders — deletes the Env param and returns the refreshed PortalSettings.
- PortalSettingsResource — POST .../settings/email/branded-senders/reset, gated by ENVIRONMENT_SETTINGS[U], returns the refreshed settings — mirroring ThemeResource.resetTheme() (POST+/reset, not DELETE).

Tests

ConfigServiceTest (+5), ParameterServiceTest (+4), and a net-new PortalSettingsResourceTest (+2). All green.
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

