### PR TITLE
feat(console): add branded-senders inherited badge and reset-to-org action

### DIFF
--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -228,6 +228,10 @@ export interface PortalSettingsEmail {
   subject: string;
   from: string;
   brandedSenders?: BrandedSender[];
+  // True (Environment scope only) when the branded senders shown are inherited from the Organization, i.e. no
+  // Environment-level override is set and no valid system value is in effect. Does not imply the Organization has a
+  // non-empty configuration.
+  brandedSendersInherited?: boolean;
   properties: {
     auth: boolean;
     startTlsEnable: boolean;

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -740,6 +740,9 @@
           formControlName="brandedSenders"
           [defaultFrom]="portalForm.get('email.from')?.value ?? ''"
           [defaultSubject]="portalForm.get('email.subject')?.value ?? ''"
+          [inheritedFromOrg]="settings.email?.brandedSendersInherited ?? false"
+          [canReset]="canResetBrandedSenders"
+          (reset)="resetBrandedSenders()"
         ></branded-senders>
       </mat-card-content>
     </mat-card>

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -24,6 +24,7 @@ import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import {
+  GioConfirmDialogHarness,
   GioFormTagsInputHarness,
   GioLicenseService,
   GioLicenseTestingModule,
@@ -32,12 +33,14 @@ import {
 } from '@gravitee/ui-particles-angular';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { SpanHarness } from '@gravitee/ui-particles-angular/testing';
 import { of } from 'rxjs';
 
 import { PortalSettingsComponent } from './portal-settings.component';
 import { PortalSettingsModule } from './portal-settings.module';
 import { PortalSettingsHarness } from './portal-settings.harness';
 
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { GioTestingPermission, GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 import { fakePortalSettings } from '../../../entities/portal/portalSettings.fixture';
@@ -708,6 +711,157 @@ describe('PortalSettingsComponent', () => {
 
       const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
       expect(await addConfigurationButton.isDisabled()).toBe(true);
+    });
+  });
+
+  describe('branded senders reset', () => {
+    const resetButton = () => loader.getHarnessOrNull(MatButtonHarness.with({ selector: '[data-testid="reset-branded-senders"]' }));
+
+    const overriddenSettings = () => {
+      const settings = fakePortalSettings();
+      settings.email.enabled = true;
+      settings.email.brandedSenders = [{ domains: ['example.com'], from: 'noreply@example.com', subject: '' }];
+      settings.email.brandedSendersInherited = false;
+      return settings;
+    };
+
+    it('should show the reset button when there is an environment-level override', async () => {
+      await init();
+      expectPortalSettingsGetRequest(overriddenSettings());
+
+      expect(await resetButton()).not.toBeNull();
+    });
+
+    it('should hide the reset button when the value is inherited from the organization', async () => {
+      await init();
+      const settings = fakePortalSettings();
+      settings.email.enabled = true;
+      settings.email.brandedSendersInherited = true;
+      expectPortalSettingsGetRequest(settings);
+
+      expect(await resetButton()).toBeNull();
+    });
+
+    it('should hide the reset button when email.branded_senders is read-only', async () => {
+      await init();
+      const settings = overriddenSettings();
+      settings.metadata.readonly.push('email.branded_senders');
+      expectPortalSettingsGetRequest(settings);
+
+      expect(await resetButton()).toBeNull();
+    });
+
+    it('should hide the reset button when the user lacks environment-settings update permission', async () => {
+      await init([]);
+      expectPortalSettingsGetRequest(overriddenSettings());
+
+      expect(await resetButton()).toBeNull();
+    });
+
+    it('should hide the reset button when the inheritance flag is absent from the response', async () => {
+      await init();
+      const settings = overriddenSettings();
+      delete settings.email.brandedSendersInherited;
+      expectPortalSettingsGetRequest(settings);
+
+      expect(await resetButton()).toBeNull();
+    });
+
+    it('should reset via the dedicated endpoint, not through save', async () => {
+      await init();
+      expectPortalSettingsGetRequest(overriddenSettings());
+
+      await (await resetButton())!.click();
+
+      // The reset endpoint is called; verify() (afterEach) fails if a /settings POST were issued instead.
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings/email/branded-senders/reset`);
+      expect(req.request.method).toEqual('POST');
+    });
+
+    it('should show a success snackbar, re-fetch, and re-display the inherited configuration with the badge on success', async () => {
+      await init();
+      expectPortalSettingsGetRequest(overriddenSettings());
+      const snackBarSuccess = jest.spyOn(TestBed.inject(SnackBarService), 'success');
+
+      await (await resetButton())!.click();
+
+      const inheritedSettings = fakePortalSettings();
+      inheritedSettings.email.enabled = true;
+      inheritedSettings.email.brandedSenders = [{ domains: ['org.com'], from: 'noreply@org.com', subject: '[Org] %s' }];
+      inheritedSettings.email.brandedSendersInherited = true;
+
+      httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings/email/branded-senders/reset`).flush(inheritedSettings);
+      // The service reloads the environment settings cache, then ngOnInit re-fetches the settings.
+      httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/portal`).flush({});
+      expectPortalSettingsGetRequest(inheritedSettings);
+
+      expect(snackBarSuccess).toHaveBeenCalled();
+      // Falls back to the org-inherited configuration: badge shown, reset button gone (now inherited).
+      const badge = await loader.getHarnessOrNull(SpanHarness.with({ selector: '[data-testid="branded-senders-inherited-badge"]' }));
+      expect(badge).not.toBeNull();
+      expect(await resetButton()).toBeNull();
+    });
+
+    it('should show an error snackbar and not re-fetch when the reset fails', async () => {
+      await init();
+      expectPortalSettingsGetRequest(overriddenSettings());
+      const snackBarError = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+
+      await (await resetButton())!.click();
+
+      httpTestingController
+        .expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings/email/branded-senders/reset`)
+        .flush({ message: 'Boom' }, { status: 500, statusText: 'Server Error' });
+
+      expect(snackBarError).toHaveBeenCalledWith('Boom');
+      // No re-fetch on error — verify() in afterEach fails if a GET /settings or /portal were issued.
+    });
+
+    it('should confirm before resetting when the form has unsaved changes, then reset on confirm', async () => {
+      await init();
+      expectPortalSettingsGetRequest(overriddenSettings());
+
+      // Unrelated unsaved edit makes the form dirty.
+      const companyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=apikeyHeader' }));
+      await companyInput.setValue('Unsaved edit');
+
+      await (await resetButton())!.click();
+
+      const confirmDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(GioConfirmDialogHarness);
+      await confirmDialog.confirm();
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings/email/branded-senders/reset`);
+      expect(req.request.method).toEqual('POST');
+    });
+
+    it('should not reset when the unsaved-changes confirmation is cancelled', async () => {
+      await init();
+      expectPortalSettingsGetRequest(overriddenSettings());
+
+      const companyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=apikeyHeader' }));
+      await companyInput.setValue('Unsaved edit');
+
+      await (await resetButton())!.click();
+
+      const confirmDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(GioConfirmDialogHarness);
+      await confirmDialog.cancel();
+
+      httpTestingController.expectNone(`${CONSTANTS_TESTING.env.baseURL}/settings/email/branded-senders/reset`);
+    });
+
+    it('should still persist an empty override through save (not reset) when all configurations are removed and saved', async () => {
+      await init();
+      expectPortalSettingsGetRequest(overriddenSettings());
+
+      const deleteButton = await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Delete configuration"]' }));
+      await deleteButton.click();
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body.email.brandedSenders).toEqual([]);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -15,10 +15,11 @@
  */
 import { Component, DestroyRef, OnInit, inject, Inject } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
 import { combineLatest, EMPTY, Observable, of, Subject } from 'rxjs';
-import { catchError, map, tap } from 'rxjs/operators';
+import { catchError, filter, map, tap } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { GioLicenseService } from '@gravitee/ui-particles-angular';
+import { GioConfirmDialogComponent, GioConfirmDialogData, GioLicenseService } from '@gravitee/ui-particles-angular';
 import { isEmpty } from 'lodash';
 
 import { PortalSettingsService } from '../../../services-ngx/portal-settings.service';
@@ -225,6 +226,7 @@ export class PortalSettingsComponent implements OnInit {
     private readonly snackBarService: SnackBarService,
     private readonly permissionService: GioPermissionService,
     private readonly licenseService: GioLicenseService,
+    private readonly matDialog: MatDialog,
     @Inject(Constants) public readonly constants: Constants,
   ) {}
 
@@ -817,6 +819,65 @@ export class PortalSettingsComponent implements OnInit {
 
   isReadonly(property: string): boolean {
     return PortalSettingsService.isReadonly(this.settings, property);
+  }
+
+  // Reset is only offered when there is an Environment-level override to drop (not inherited), the field is editable
+  // (not system-locked, email enabled) and the user may update settings — mirroring the branded-senders control's own
+  // enablement. Deleting all cards and saving would persist an empty override; this is the explicit "fall back to Org".
+  // The inherited check is strict (=== false): an absent flag means "unknown", so the reset action is hidden rather
+  // than offered against an endpoint that may not resolve.
+  get canResetBrandedSenders(): boolean {
+    const email = this.settings?.email;
+    // Strict === false: an absent flag means "unknown", so the reset action is hidden rather than offered.
+    const hasEnvironmentOverride = email?.brandedSendersInherited === false;
+    const isEditable = !!email?.enabled && !this.isReadonly('email.branded_senders');
+    return this.hasEnvironmentSettingsUpdatePermission && isEditable && hasEnvironmentOverride;
+  }
+
+  resetBrandedSenders(): void {
+    // Reset re-fetches and rebuilds the whole form (via ngOnInit), so confirm first when there are unsaved edits
+    // elsewhere on the page that would otherwise be discarded silently.
+    if (!this.portalForm.dirty) {
+      this.performBrandedSendersReset();
+      return;
+    }
+    this.confirmDiscardUnsavedChanges()
+      .pipe(
+        filter(confirmed => confirmed),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => this.performBrandedSendersReset());
+  }
+
+  private confirmDiscardUnsavedChanges(): Observable<boolean> {
+    return this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        width: '500px',
+        data: {
+          title: 'Reset branded senders',
+          content:
+            'You have unsaved changes on this page that will be discarded. Do you want to reset the branded senders to the organization configuration?',
+          confirmButton: 'Reset',
+        },
+        role: 'alertdialog',
+        id: 'resetBrandedSendersConfirmDialog',
+      })
+      .afterClosed()
+      .pipe(map(confirmed => confirmed === true));
+  }
+
+  private performBrandedSendersReset(): void {
+    this.portalSettingsService
+      .resetBrandedSenders()
+      .pipe(
+        tap(() => this.snackBarService.success('Branded senders reset to the organization configuration.')),
+        catchError(({ error }) => {
+          this.snackBarService.error(error?.message ?? 'An error occurred while resetting the branded senders.');
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => this.ngOnInit());
   }
 
   get isPortalNextAccessEnabled(): boolean {

--- a/gravitee-apim-console-webui/src/services-ngx/portal-settings.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-settings.service.spec.ts
@@ -63,6 +63,26 @@ describe('PortalSettingsService', () => {
     });
   });
 
+  describe('resetBrandedSenders', () => {
+    it('should POST to the reset endpoint with an empty body and return the refreshed settings', done => {
+      const refreshed = fakePortalSettings();
+
+      portalSettingsService.resetBrandedSenders().subscribe(settings => {
+        expect(settings).toMatchObject(refreshed);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.baseURL}/settings/email/branded-senders/reset`,
+      });
+      expect(req.request.body).toBeNull();
+
+      req.flush(refreshed);
+      httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/portal` }).flush({});
+    });
+  });
+
   afterEach(() => {
     httpTestingController.verify();
   });

--- a/gravitee-apim-console-webui/src/services-ngx/portal-settings.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-settings.service.ts
@@ -68,4 +68,17 @@ export class PortalSettingsService {
       }),
     );
   }
+
+  /**
+   * Resets the environment-scoped branded senders so they fall back to the organization (or system) value, and
+   * returns the refreshed settings. The backend deletes the environment-level override; sending an empty list via
+   * {@link save} would instead persist an empty override that shadows the organization value.
+   */
+  resetBrandedSenders(): Observable<PortalSettings> {
+    return this.http.post<PortalSettings>(`${this.constants.env.baseURL}/settings/email/branded-senders/reset`, null).pipe(
+      tap(() => {
+        this.environmentSettingsService.load().subscribe();
+      }),
+    );
+  }
 }

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.html
@@ -55,7 +55,12 @@
   @for (group of configurations.controls; track $index) {
     <mat-card [formGroup]="group" class="branded-senders__card">
       <div class="branded-senders__card__header">
-        <span class="branded-senders__card__header__title">Configuration {{ $index + 1 }}</span>
+        <div class="branded-senders__card__header__label">
+          <span class="branded-senders__card__header__title">Configuration {{ $index + 1 }}</span>
+          @if (inheritedFromOrg() && !hasUserEdited()) {
+            <span class="gio-badge" data-testid="branded-senders-inherited-badge">Inherited from Org</span>
+          }
+        </div>
         <button
           mat-icon-button
           type="button"
@@ -69,7 +74,11 @@
 
       <mat-form-field class="branded-senders__field">
         <mat-label>Recipient domains</mat-label>
-        <gio-form-tags-input formControlName="domains" [addOnBlur]="true" placeholder="example.com, eu.example.com"></gio-form-tags-input>
+        <gio-form-tags-input
+          formControlName="domains"
+          [addOnBlur]="true"
+          [placeholder]="group.controls.domains.value.length === 0 ? 'example.com, eu.example.com' : ''"
+        ></gio-form-tags-input>
         <mat-hint>Match is case-insensitive on the part after &#64; in the recipient address.</mat-hint>
         @if (group.controls.domains.hasError('required')) {
           <mat-error>At least one domain is required.</mat-error>
@@ -110,15 +119,21 @@
     <p class="branded-senders__error">These configurations are too large to save. Remove some domains or configurations and try again.</p>
   }
 
-  <button
-    mat-raised-button
-    color="primary"
-    type="button"
-    class="branded-senders__add"
-    [disabled]="isDisabled()"
-    (click)="addConfiguration()"
-  >
-    <mat-icon>add</mat-icon>
-    Add configuration
-  </button>
+  <div class="branded-senders__actions">
+    <button
+      mat-raised-button
+      color="primary"
+      type="button"
+      class="branded-senders__add"
+      [disabled]="isDisabled()"
+      (click)="addConfiguration()"
+    >
+      <mat-icon>add</mat-icon>
+      Add configuration
+    </button>
+
+    @if (canReset()) {
+      <button mat-stroked-button type="button" data-testid="reset-branded-senders" (click)="reset.emit()">Reset to Org settings</button>
+    }
+  </div>
 </div>

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.scss
@@ -53,6 +53,12 @@ $warn: map.get(gio.$mat-theme, warn);
       justify-content: space-between;
       margin-bottom: 8px;
 
+      &__label {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
       &__title {
         @include mat.m2-typography-level($typography, subtitle-2);
       }
@@ -65,7 +71,10 @@ $warn: map.get(gio.$mat-theme, warn);
     color: mat.m2-get-color-from-palette($warn);
   }
 
-  &__add {
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     margin-top: 8px;
   }
 }

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.spec.ts
@@ -23,6 +23,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatFormFieldHarness } from '@angular/material/form-field/testing';
 import { MatTooltipHarness } from '@angular/material/tooltip/testing';
 import { GioFormTagsInputHarness } from '@gravitee/ui-particles-angular';
+import { SpanHarness } from '@gravitee/ui-particles-angular/testing';
 
 import { BrandedSendersComponent } from './branded-senders.component';
 
@@ -34,13 +35,23 @@ import { GioTestingModule } from '../../testing';
   imports: [ReactiveFormsModule, BrandedSendersComponent],
   template: `
     <form [formGroup]="form">
-      <branded-senders formControlName="brandedSenders" [defaultFrom]="defaultFrom" [defaultSubject]="defaultSubject" />
+      <branded-senders
+        formControlName="brandedSenders"
+        [defaultFrom]="defaultFrom"
+        [defaultSubject]="defaultSubject"
+        [inheritedFromOrg]="inheritedFromOrg"
+        [canReset]="canReset"
+        (reset)="resetEmitted = resetEmitted + 1"
+      />
     </form>
   `,
 })
 class TestHostComponent {
   defaultFrom = '';
   defaultSubject = '';
+  inheritedFromOrg = false;
+  canReset = false;
+  resetEmitted = 0;
   form = new FormGroup({
     brandedSenders: new FormControl<BrandedSender[]>([], { nonNullable: true }),
   });
@@ -349,6 +360,92 @@ describe('BrandedSendersComponent', () => {
       await fromInput.blur();
 
       expect(await fromField.getTextErrors()).toEqual(['Enter a valid email address, optionally with a display name.']);
+    });
+  });
+
+  describe('inherited from org badge', () => {
+    const badges = () => loader.getAllHarnesses(SpanHarness.with({ selector: '[data-testid="branded-senders-inherited-badge"]' }));
+
+    it('should show an "Inherited from Org" badge on each displayed configuration when inherited', async () => {
+      component.inheritedFromOrg = true;
+      control().setValue([
+        { domains: ['a.com'], from: 'a@a.com', subject: 'A' },
+        { domains: ['b.com'], from: 'b@b.com', subject: 'B' },
+      ]);
+      fixture.detectChanges();
+
+      const shown = await badges();
+      expect(shown.length).toBe(2);
+      expect(await shown[0].getText()).toBe('Inherited from Org');
+    });
+
+    it('should show no badge when inherited but there are no configurations to display', async () => {
+      component.inheritedFromOrg = true;
+      control().setValue([]);
+      fixture.detectChanges();
+
+      expect((await badges()).length).toBe(0);
+    });
+
+    it('should show no badge when not inherited, even with configurations present', async () => {
+      component.inheritedFromOrg = false;
+      control().setValue([{ domains: ['a.com'], from: 'a@a.com', subject: 'A' }]);
+      fixture.detectChanges();
+
+      expect((await badges()).length).toBe(0);
+    });
+
+    it('should hide the badge once the user edits the list (creating an override)', async () => {
+      component.inheritedFromOrg = true;
+      control().setValue([{ domains: ['a.com'], from: 'a@a.com', subject: 'A' }]);
+      fixture.detectChanges();
+      expect((await badges()).length).toBe(1);
+
+      // Adding a configuration diverges from the inherited value -> badge should disappear.
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      await addButton.click();
+
+      expect((await badges()).length).toBe(0);
+    });
+
+    it('should show the badge again after a fresh value is written (e.g. a save or reset reload)', async () => {
+      component.inheritedFromOrg = true;
+      control().setValue([{ domains: ['a.com'], from: 'a@a.com', subject: 'A' }]);
+      fixture.detectChanges();
+
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      await addButton.click();
+      expect((await badges()).length).toBe(0);
+
+      // A reload writes a fresh (server) value, which resets the edited state.
+      control().setValue([{ domains: ['org.com'], from: 'org@org.com', subject: 'O' }]);
+      fixture.detectChanges();
+
+      expect((await badges()).length).toBe(1);
+    });
+  });
+
+  describe('reset action', () => {
+    const resetButton = () => loader.getHarnessOrNull(MatButtonHarness.with({ selector: '[data-testid="reset-branded-senders"]' }));
+
+    it('should not show the reset button by default', async () => {
+      expect(await resetButton()).toBeNull();
+    });
+
+    it('should show the reset button when canReset is set', async () => {
+      component.canReset = true;
+      fixture.detectChanges();
+
+      expect(await resetButton()).not.toBeNull();
+    });
+
+    it('should emit reset when the reset button is clicked', async () => {
+      component.canReset = true;
+      fixture.detectChanges();
+
+      await (await resetButton())!.click();
+
+      expect(component.resetEmitted).toBe(1);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.stories.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.stories.ts
@@ -69,3 +69,15 @@ export const Disabled: StoryObj = {
     },
   }),
 };
+
+export const InheritedFromOrg: StoryObj = {
+  render: () => ({
+    template: `<branded-senders [formControl]="control" [defaultFrom]="defaultFrom" [defaultSubject]="defaultSubject" [inheritedFromOrg]="true" />`,
+    props: {
+      control: new FormControl<BrandedSender[]>([
+        { domains: ['example.com', 'eu.example.com'], from: 'noreply@example.com', subject: '[Example] %s' },
+      ]),
+      ...defaults,
+    },
+  }),
+};

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.ts
@@ -22,6 +22,7 @@ import {
   forwardRef,
   inject,
   input,
+  output,
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -150,9 +151,27 @@ export class BrandedSendersComponent implements ControlValueAccessor, Validator 
   readonly defaultFrom = input('');
   readonly defaultSubject = input('');
 
+  /**
+   * Whether the shown configurations are inherited from the Organization scope (no Environment-level override).
+   * Drives the per-configuration "Inherited from Org" badge; only meaningful at Environment scope. A true value does
+   * not imply the Organization has a non-empty configuration, so the badge only renders for configurations actually
+   * displayed (none when the list is empty).
+   */
+  readonly inheritedFromOrg = input(false);
+
+  /** Whether to offer the reset-to-inherited action; the parent decides based on scope, permissions and override state. */
+  readonly canReset = input(false);
+
+  /** Emitted when the user triggers the reset action; the parent performs the actual reset. */
+  readonly reset = output<void>();
+
   protected readonly subjectMaxLength = SUBJECT_MAX_LENGTH;
   protected readonly configurations = new FormArray<BrandedSenderForm>([], [serializedSizeValidator, duplicateDomainsValidator]);
   protected readonly isDisabled = signal(false);
+  // Flipped true on the first user edit and reset on each (programmatic) writeValue. While true, the configurations are
+  // diverging into an Environment override, so the "Inherited from Org" badge is hidden until the edit is saved or
+  // discarded (both of which trigger a fresh writeValue).
+  protected readonly hasUserEdited = signal(false);
 
   private _onChange: (value: BrandedSender[]) => void = () => undefined;
   private _onTouched: () => void = () => undefined;
@@ -161,6 +180,9 @@ export class BrandedSendersComponent implements ControlValueAccessor, Validator 
   // callback is caught so it can't terminate this long-lived stream (which would silently stop propagating edits to
   // the parent control); it is reported via Angular's ErrorHandler instead.
   private readonly _propagateValue = this.configurations.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+    // valueChanges only fires on user edits — writeValue rebuilds the array with emitEvent: false — so any emission
+    // means the user has diverged from the inherited value.
+    this.hasUserEdited.set(true);
     try {
       this._onChange(this.snapshot());
     } catch (error) {
@@ -171,6 +193,8 @@ export class BrandedSendersComponent implements ControlValueAccessor, Validator 
   // --- ControlValueAccessor ---
 
   writeValue(value: BrandedSender[] | null): void {
+    // A fresh (server-driven) value: the list once again reflects the saved/inherited state, so clear the edited flag.
+    this.hasUserEdited.set(false);
     this.configurations.clear({ emitEvent: false });
     (value ?? []).forEach(brandedSender => this.configurations.push(this.newConfiguration(brandedSender), { emitEvent: false }));
     // Freshly-built controls are always enabled; Angular only calls setDisabledState() once at setup, so a later


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14612
## Description

Frontend half of APIM-14612 — completes the Env-scope branded-senders UX that S4 (APIM-14191) couldn't ship without backend support. Adds an "Inherited from Org" indicator and an explicit "Reset to Org settings" action, built against the contract locked with the backend PR.

Changes

- BrandedSendersComponent (shared): new inheritedFromOrg signal input → per-configuration "Inherited from Org" gio-badge. Rendered per-card, so it naturally shows nothing when the list is empty (a true flag doesn't imply the Org has a non-empty config).
- Model/service: brandedSendersInherited?: boolean on PortalSettingsEmail; PortalSettingsService.resetBrandedSenders() → POST {env}/settings/email/branded-senders/reset + env-settings reload.
- Portal (Env) settings page: threads the flag into the embed; adds "Reset to Org settings" — shown only when there's an editable Env override and the user has ENVIRONMENT_SETTINGS[U]. It calls the dedicated reset endpoint (not save) and reloads, so the form falls back to the Org values instead of persisting an empty override.

Tests

Shared component (badge: shown/empty/not-inherited) + Storybook InheritedFromOrg variant; service (resetBrandedSenders); portal component (reset button visibility × 4, reset-routes-to-reset-not-save, empty-save-still-writes-override). Prettier + ESLint clean.
## Additional context

https://github.com/user-attachments/assets/6da0064d-066c-46f8-b460-c417c9a20e48



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

