### PR TITLE
feat(gamma-platform): add security plan types toggle

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -25,6 +25,7 @@ import { applicationDetailTabElement } from '../config/applicationDetailPages';
 import { NAV_GROUPS } from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
+import { SecurityPlanTypesPage } from '../features/security-plan-types/SecurityPlanTypesPage';
 import { AccessManagementPage } from '../pages/AccessManagementPage';
 import { ApplicationDetailSubscriptionPage } from '../pages/ApplicationDetailSubscriptionPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
@@ -109,6 +110,7 @@ export function AppRoutes() {
                         </Route>
                         <Route path="access-management" element={<AccessManagementPage />} />
                         <Route path="metadata" element={<MetadataGuard />} />
+                        <Route path="security-plan-types" element={<SecurityPlanTypesPage />} />
                     </Route>
                 </Routes>
             </ConsoleSettingsProvider>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import type { NavGroup } from '@gravitee/graphene-core';
-import { AppWindowIcon, DatabaseIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
+import { AppWindowIcon, DatabaseIcon, KeyIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
 
 import { ROUTES } from './routes';
 
@@ -29,6 +29,9 @@ export const NAV_GROUPS: NavGroup[] = [
     },
     {
         label: 'System & Security',
-        items: [{ key: 'access-management', title: ROUTES['access-management'].label, icon: ShieldIcon }],
+        items: [
+            { key: 'access-management', title: ROUTES['access-management'].label, icon: ShieldIcon },
+            { key: 'security-plan-types', title: ROUTES['security-plan-types'].label, icon: KeyIcon },
+        ],
     },
 ];

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -15,7 +15,7 @@
  */
 import type { ModuleRouteConfig } from '@gravitee/gamma-modules-sdk/routing';
 
-export const ROUTE_KEYS: readonly string[] = ['applications', 'access-management', 'metadata'];
+export const ROUTE_KEYS: readonly string[] = ['applications', 'access-management', 'metadata', 'security-plan-types'];
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
 const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
@@ -23,6 +23,7 @@ const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
 export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: string }> = {
     applications: { path: 'applications', label: 'Applications' },
     'access-management': { path: 'access-management', label: 'Access Management' },
+    'security-plan-types': { path: 'security-plan-types', label: 'Security Plan Types' },
     metadata: { path: 'metadata', label: 'Metadata' },
 };
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/SecurityPlanTypesPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/SecurityPlanTypesPage.spec.tsx
@@ -1,0 +1,477 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { usePortalSettings } from './hooks/usePortalSettings';
+import { useSavePortalSettings } from './hooks/useSavePortalSettings';
+import { SecurityPlanTypesPage } from './SecurityPlanTypesPage';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+    useEnvironment: jest.fn(),
+}));
+
+jest.mock('./hooks/usePortalSettings', () => ({
+    usePortalSettings: jest.fn(),
+}));
+
+jest.mock('./hooks/useSavePortalSettings', () => ({
+    useSavePortalSettings: jest.fn(),
+}));
+
+const mockNotifySuccess = jest.fn();
+const mockNotifyError = jest.fn();
+jest.mock('../../shared/notify', () => ({
+    notify: {
+        success: (msg: string) => mockNotifySuccess(msg),
+        error: (err: unknown, fallback?: string) => mockNotifyError(err, fallback),
+    },
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseEnvironment = jest.mocked(useEnvironment);
+const mockUsePortalSettings = jest.mocked(usePortalSettings);
+const mockUseSavePortalSettings = jest.mocked(useSavePortalSettings);
+
+beforeAll(() => {
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as typeof ResizeObserver;
+});
+
+const SETTINGS_ALL_ENABLED = {
+    company: { name: 'Acme Corp' },
+    cors: { allowOrigin: ['https://portal.example.com'] },
+    plan: {
+        security: {
+            keyless: { enabled: true },
+            apikey: { enabled: true },
+            customApiKey: { enabled: true },
+            customApiKeyReuse: { enabled: true },
+            sharedApiKey: { enabled: true },
+            oauth2: { enabled: true },
+            jwt: { enabled: true },
+            push: { enabled: true },
+            mtls: { enabled: true },
+        },
+        validation: { enabled: true },
+    },
+};
+
+const SETTINGS_PARTIAL = {
+    plan: {
+        security: {
+            keyless: { enabled: true },
+            apikey: { enabled: true },
+            customApiKey: { enabled: false },
+            customApiKeyReuse: { enabled: false },
+            sharedApiKey: { enabled: true },
+            oauth2: { enabled: true },
+            jwt: { enabled: false },
+            push: { enabled: false },
+            mtls: { enabled: true },
+        },
+    },
+};
+
+function createTestContext() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    function Wrapper({ children }: { children: ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    }
+    return { Wrapper };
+}
+
+function getToggle(label: string) {
+    return screen.getByLabelText(label);
+}
+
+function expectChecked(label: string, checked: boolean) {
+    expect(getToggle(label).getAttribute('aria-checked')).toBe(checked ? 'true' : 'false');
+}
+
+function expectDisabled(label: string) {
+    expect(getToggle(label).hasAttribute('disabled')).toBe(true);
+}
+
+let mockMutate: jest.Mock;
+
+function renderPage() {
+    const { Wrapper } = createTestContext();
+    return render(
+        <Wrapper>
+            <SecurityPlanTypesPage />
+        </Wrapper>,
+    );
+}
+
+describe('SecurityPlanTypesPage', () => {
+    beforeEach(() => {
+        mockMutate = jest.fn();
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseEnvironment.mockReturnValue({ id: 'env-1', organizationId: 'org-1' });
+        mockUsePortalSettings.mockReturnValue({ data: SETTINGS_ALL_ENABLED, isLoading: false, isError: false } as unknown as ReturnType<
+            typeof usePortalSettings
+        >);
+        mockUseSavePortalSettings.mockReturnValue({
+            mutate: mockMutate.mockImplementation((_payload: unknown, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.()),
+            isPending: false,
+        } as unknown as ReturnType<typeof useSavePortalSettings>);
+        mockNotifySuccess.mockClear();
+        mockNotifyError.mockClear();
+    });
+
+    afterEach(() => jest.clearAllMocks());
+
+    it('renders the page title and description', () => {
+        renderPage();
+        expect(screen.queryByText('Security Plan Types')).not.toBeNull();
+        expect(screen.queryByText('Configure which security plan types are available for APIs across the environment.')).not.toBeNull();
+    });
+
+    it('renders all security plan type toggles', () => {
+        renderPage();
+        expect(screen.queryByText('Keyless plans')).not.toBeNull();
+        expect(screen.queryByText('API Key plans')).not.toBeNull();
+        expect(screen.queryByText('Allow custom API Key')).not.toBeNull();
+        expect(screen.queryByText('Allow custom API Key reuse')).not.toBeNull();
+        expect(screen.queryByText('Allow to share API Key on an application')).not.toBeNull();
+        expect(screen.queryByText('OAuth2 plans')).not.toBeNull();
+        expect(screen.queryByText('JWT plans')).not.toBeNull();
+        expect(screen.queryByText('Push plans')).not.toBeNull();
+        expect(screen.queryByText('mTLS plans')).not.toBeNull();
+    });
+
+    it('shows V4-only descriptions for Push and mTLS', () => {
+        renderPage();
+        const descriptions = screen.getAllByText('Only available for API V4');
+        expect(descriptions.length).toBe(2);
+    });
+
+    it('reflects loaded settings state', () => {
+        mockUsePortalSettings.mockReturnValue({ data: SETTINGS_PARTIAL, isLoading: false } as unknown as ReturnType<
+            typeof usePortalSettings
+        >);
+        renderPage();
+
+        expectChecked('Keyless plans', true);
+        expectChecked('API Key plans', true);
+        expectChecked('Allow custom API Key', false);
+        expectChecked('Allow custom API Key reuse', false);
+        expectChecked('Allow to share API Key on an application', true);
+        expectChecked('OAuth2 plans', true);
+        expectChecked('JWT plans', false);
+        expectChecked('Push plans', false);
+        expectChecked('mTLS plans', true);
+    });
+
+    it('does not show Save/Discard buttons when no changes are made', () => {
+        renderPage();
+        expect(screen.queryByRole('button', { name: /Save changes/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /Discard/i })).toBeNull();
+    });
+
+    it('shows Save/Discard after toggling', () => {
+        renderPage();
+        fireEvent.click(getToggle('JWT plans'));
+        expect(screen.queryByText('Save changes')).not.toBeNull();
+        expect(screen.queryByText('Discard')).not.toBeNull();
+    });
+
+    it('reverts changes when Discard is clicked', () => {
+        renderPage();
+        expectChecked('JWT plans', true);
+        fireEvent.click(getToggle('JWT plans'));
+        expectChecked('JWT plans', false);
+        fireEvent.click(screen.getByText('Discard'));
+        expectChecked('JWT plans', true);
+        expect(screen.queryByText('Save changes')).toBeNull();
+    });
+
+    it('calls save mutation with merged full settings payload', () => {
+        renderPage();
+        fireEvent.click(getToggle('Push plans'));
+        fireEvent.click(screen.getByText('Save changes'));
+
+        expect(mockMutate).toHaveBeenCalledWith(
+            {
+                company: { name: 'Acme Corp' },
+                cors: { allowOrigin: ['https://portal.example.com'] },
+                plan: {
+                    security: {
+                        keyless: { enabled: true },
+                        apikey: { enabled: true },
+                        customApiKey: { enabled: true },
+                        customApiKeyReuse: { enabled: true },
+                        sharedApiKey: { enabled: true },
+                        oauth2: { enabled: true },
+                        jwt: { enabled: true },
+                        push: { enabled: false },
+                        mtls: { enabled: true },
+                    },
+                    validation: { enabled: true },
+                },
+            },
+            expect.objectContaining({ onSuccess: expect.any(Function) }),
+        );
+    });
+
+    describe('API Key cascade logic', () => {
+        it('disables sub-toggles when API Key is turned off', () => {
+            renderPage();
+            fireEvent.click(getToggle('API Key plans'));
+
+            expectChecked('API Key plans', false);
+            expectChecked('Allow custom API Key', false);
+            expectChecked('Allow custom API Key reuse', false);
+            expectChecked('Allow to share API Key on an application', false);
+        });
+
+        it('disables custom API Key reuse when custom API Key is turned off', () => {
+            renderPage();
+            fireEvent.click(getToggle('Allow custom API Key'));
+
+            expectChecked('Allow custom API Key', false);
+            expectChecked('Allow custom API Key reuse', false);
+        });
+
+        it('sub-toggles are disabled (non-interactive) when API Key is off', () => {
+            renderPage();
+            fireEvent.click(getToggle('API Key plans'));
+
+            expectDisabled('Allow custom API Key');
+            expectDisabled('Allow custom API Key reuse');
+            expectDisabled('Allow to share API Key on an application');
+        });
+
+        it('custom API Key reuse is disabled when custom API Key is off', () => {
+            mockUsePortalSettings.mockReturnValue({ data: SETTINGS_PARTIAL, isLoading: false } as unknown as ReturnType<
+                typeof usePortalSettings
+            >);
+            renderPage();
+
+            expectDisabled('Allow custom API Key reuse');
+        });
+    });
+
+    describe('permission gating', () => {
+        beforeEach(() => {
+            mockUseHasPermission.mockReturnValue(false);
+        });
+
+        it('disables all toggles when user lacks edit permission', () => {
+            renderPage();
+            expectDisabled('Keyless plans');
+            expectDisabled('API Key plans');
+            expectDisabled('Allow custom API Key');
+            expectDisabled('Allow custom API Key reuse');
+            expectDisabled('Allow to share API Key on an application');
+            expectDisabled('OAuth2 plans');
+            expectDisabled('JWT plans');
+            expectDisabled('Push plans');
+            expectDisabled('mTLS plans');
+        });
+
+        it('does not show Save/Discard when user lacks permission', () => {
+            renderPage();
+            expect(screen.queryByText('Save changes')).toBeNull();
+            expect(screen.queryByText('Discard')).toBeNull();
+        });
+
+        it('shows read-only alert banner', () => {
+            renderPage();
+            expect(
+                screen.queryByText('You do not have permission to modify these settings. Contact your administrator for access.'),
+            ).not.toBeNull();
+        });
+    });
+
+    it('shows loading skeleton while settings are fetched', () => {
+        mockUsePortalSettings.mockReturnValue({ data: undefined, isLoading: true, isError: false } as unknown as ReturnType<
+            typeof usePortalSettings
+        >);
+        renderPage();
+        expect(screen.queryByText('Security Plan Types')).toBeNull();
+        expect(screen.queryByText('Keyless plans')).toBeNull();
+    });
+
+    it('shows an error message and blocks editing when settings fail to load', () => {
+        mockUsePortalSettings.mockReturnValue({ data: undefined, isLoading: false, isError: true } as unknown as ReturnType<
+            typeof usePortalSettings
+        >);
+        renderPage();
+        expect(screen.queryByText('Security Plan Types')).not.toBeNull();
+        expect(screen.queryByText('Failed to load settings. Please refresh and try again.')).not.toBeNull();
+        expect(screen.queryByText('Keyless plans')).toBeNull();
+        expect(screen.queryByRole('button', { name: /Save changes/i })).toBeNull();
+    });
+
+    it('shows Enabled/Disabled labels next to toggles', () => {
+        mockUsePortalSettings.mockReturnValue({ data: SETTINGS_PARTIAL, isLoading: false } as unknown as ReturnType<
+            typeof usePortalSettings
+        >);
+        renderPage();
+        const enabledLabels = screen.getAllByText('Enabled');
+        const disabledLabels = screen.getAllByText('Disabled');
+        expect(enabledLabels.length).toBe(5);
+        expect(disabledLabels.length).toBe(4);
+    });
+
+    it('re-initializes toggles when the environment changes', () => {
+        const { Wrapper } = createTestContext();
+        const { rerender } = render(
+            <Wrapper>
+                <SecurityPlanTypesPage />
+            </Wrapper>,
+        );
+
+        expectChecked('JWT plans', true);
+
+        mockUseEnvironment.mockReturnValue({ id: 'env-2', organizationId: 'org-1' });
+        mockUsePortalSettings.mockReturnValue({ data: SETTINGS_PARTIAL, isLoading: false } as unknown as ReturnType<
+            typeof usePortalSettings
+        >);
+
+        rerender(
+            <Wrapper>
+                <SecurityPlanTypesPage />
+            </Wrapper>,
+        );
+
+        expectChecked('JWT plans', false);
+        expectChecked('Push plans', false);
+    });
+
+    describe('system readonly settings', () => {
+        const SETTINGS_WITH_READONLY = {
+            ...SETTINGS_ALL_ENABLED,
+            metadata: {
+                readonly: ['plan.security.jwt.enabled', 'plan.security.push.enabled'],
+            },
+        };
+
+        beforeEach(() => {
+            mockUsePortalSettings.mockReturnValue({
+                data: SETTINGS_WITH_READONLY,
+                isLoading: false,
+                isError: false,
+            } as unknown as ReturnType<typeof usePortalSettings>);
+        });
+
+        it('disables toggles locked by metadata.readonly', () => {
+            renderPage();
+
+            expectDisabled('JWT plans');
+            expectDisabled('Push plans');
+            expect(getToggle('Keyless plans').hasAttribute('disabled')).toBe(false);
+        });
+
+        it('shows Save when an editable key changes even if cascade updates a readonly key', () => {
+            mockUsePortalSettings.mockReturnValue({
+                data: {
+                    ...SETTINGS_ALL_ENABLED,
+                    metadata: {
+                        readonly: ['plan.security.apikey.allowCustom.enabled'],
+                    },
+                },
+                isLoading: false,
+                isError: false,
+            } as unknown as ReturnType<typeof usePortalSettings>);
+
+            renderPage();
+            fireEvent.click(getToggle('API Key plans'));
+
+            expectChecked('Allow custom API Key', false);
+            expect(screen.queryByText('Save changes')).not.toBeNull();
+        });
+
+        it('preserves readonly values in the save payload', () => {
+            renderPage();
+
+            fireEvent.click(getToggle('Keyless plans'));
+            fireEvent.click(screen.getByText('Save changes'));
+
+            expect(mockMutate).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    plan: expect.objectContaining({
+                        security: expect.objectContaining({
+                            keyless: { enabled: false },
+                            jwt: { enabled: true },
+                            push: { enabled: true },
+                        }),
+                    }),
+                }),
+                expect.objectContaining({ onSuccess: expect.any(Function) }),
+            );
+        });
+
+        it('disables shared API Key when metadata uses the backend readonly key', () => {
+            mockUsePortalSettings.mockReturnValue({
+                data: {
+                    ...SETTINGS_ALL_ENABLED,
+                    metadata: {
+                        readonly: ['plan.security.apikey.allowShared.enabled'],
+                    },
+                },
+                isLoading: false,
+                isError: false,
+            } as unknown as ReturnType<typeof usePortalSettings>);
+
+            renderPage();
+
+            expectDisabled('Allow to share API Key on an application');
+            expect(getToggle('API Key plans').hasAttribute('disabled')).toBe(false);
+        });
+
+        it('wraps gravitee-locked toggles with the system readonly tooltip trigger', () => {
+            mockUsePortalSettings.mockReturnValue({
+                data: {
+                    ...SETTINGS_ALL_ENABLED,
+                    plan: {
+                        ...SETTINGS_ALL_ENABLED.plan,
+                        security: {
+                            ...SETTINGS_ALL_ENABLED.plan.security,
+                            customApiKeyReuse: { enabled: false },
+                        },
+                    },
+                    metadata: {
+                        readonly: ['plan.security.apikey.allowShared.enabled', 'plan.security.apikey.allowCustomReuse.enabled'],
+                    },
+                },
+                isLoading: false,
+                isError: false,
+            } as unknown as ReturnType<typeof usePortalSettings>);
+
+            renderPage();
+
+            expect(getToggle('Allow to share API Key on an application').closest('[data-system-readonly="true"]')).not.toBeNull();
+            expect(getToggle('Allow custom API Key reuse').closest('[data-system-readonly="true"]')).not.toBeNull();
+            expect(getToggle('Keyless plans').closest('[data-system-readonly="true"]')).toBeNull();
+        });
+
+        it('does not wrap cascade-disabled toggles with the system readonly tooltip trigger', () => {
+            renderPage();
+            fireEvent.click(getToggle('API Key plans'));
+
+            expect(getToggle('Allow custom API Key').closest('[data-system-readonly="true"]')).toBeNull();
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/SecurityPlanTypesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/SecurityPlanTypesPage.tsx
@@ -1,0 +1,309 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Skeleton,
+    Switch,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@gravitee/graphene-core';
+import { CheckIcon, InfoIcon, ShieldCheckIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { usePortalSettings } from './hooks/usePortalSettings';
+import { useSavePortalSettings } from './hooks/useSavePortalSettings';
+import type { PortalSettings } from './services/portalSettings';
+import type { SecurityState } from './utils/buildPortalSettingsSavePayload';
+import { buildPortalSettingsSavePayload } from './utils/buildPortalSettingsSavePayload';
+import { applyReadonlySecurityState, getSecurityReadonlyState, type SecurityKey } from './utils/securityPlanReadonly';
+
+const SYSTEM_READONLY_TOOLTIP = 'Configuration provided by the system';
+
+function buildState(settings: PortalSettings | undefined): SecurityState {
+    const security = settings?.plan?.security;
+    return {
+        keyless: security?.keyless?.enabled ?? true,
+        apikey: security?.apikey?.enabled ?? true,
+        customApiKey: security?.customApiKey?.enabled ?? true,
+        customApiKeyReuse: security?.customApiKeyReuse?.enabled ?? true,
+        sharedApiKey: security?.sharedApiKey?.enabled ?? true,
+        oauth2: security?.oauth2?.enabled ?? true,
+        jwt: security?.jwt?.enabled ?? true,
+        push: security?.push?.enabled ?? true,
+        mtls: security?.mtls?.enabled ?? true,
+    };
+}
+
+interface ToggleRowProps {
+    id: string;
+    label: string;
+    description?: string;
+    checked: boolean;
+    disabled: boolean;
+    systemReadonly?: boolean;
+    indented?: boolean;
+    onToggle: (checked: boolean) => void;
+}
+
+function ToggleRow({ id, label, description, checked, disabled, systemReadonly = false, indented, onToggle }: ToggleRowProps) {
+    const switchControl = <Switch id={id} checked={checked} onCheckedChange={onToggle} disabled={disabled} aria-label={label} />;
+
+    return (
+        <div className={`flex items-center justify-between border-b py-4 ${indented ? 'pl-8' : ''}`}>
+            <div className="space-y-0.5">
+                <label htmlFor={id} className={`text-sm font-medium ${disabled ? 'cursor-default' : 'cursor-pointer'}`}>
+                    {label}
+                </label>
+                {description && <p className="text-xs text-muted-foreground">{description}</p>}
+            </div>
+            <div className="flex items-center gap-2">
+                {systemReadonly ? (
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span className="inline-flex" data-system-readonly="true">
+                                {switchControl}
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent>{SYSTEM_READONLY_TOOLTIP}</TooltipContent>
+                    </Tooltip>
+                ) : (
+                    switchControl
+                )}
+                <span className="w-16 text-xs text-muted-foreground">{checked ? 'Enabled' : 'Disabled'}</span>
+            </div>
+        </div>
+    );
+}
+
+export function SecurityPlanTypesPage() {
+    const canEdit = useHasPermission({ anyOf: ['environment-settings-u'] });
+    const env = useEnvironment();
+
+    const { data: settings, isLoading, isError } = usePortalSettings();
+
+    const readonlyState = useMemo(() => getSecurityReadonlyState(settings), [settings]);
+
+    const [localState, setLocalState] = useState<SecurityState>(() => buildState(settings));
+    const [savedState, setSavedState] = useState<SecurityState>(() => buildState(settings));
+    const initializedForEnvId = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (settings && env?.id && initializedForEnvId.current !== env.id) {
+            const state = buildState(settings);
+            setLocalState(state);
+            setSavedState(state);
+            initializedForEnvId.current = env.id;
+        }
+    }, [settings, env?.id]);
+
+    const isDirty = useMemo(
+        () =>
+            (Object.keys(savedState) as SecurityKey[]).filter(key => !readonlyState[key]).some(key => localState[key] !== savedState[key]),
+        [localState, savedState, readonlyState],
+    );
+
+    const handleToggle = useCallback(
+        (key: SecurityKey, checked: boolean) => {
+            if (!canEdit || readonlyState[key]) return;
+            setLocalState(prev => {
+                const next = { ...prev, [key]: checked };
+
+                if (key === 'apikey' && !checked) {
+                    next.customApiKey = false;
+                    next.customApiKeyReuse = false;
+                    next.sharedApiKey = false;
+                }
+                if (key === 'customApiKey' && !checked) {
+                    next.customApiKeyReuse = false;
+                }
+
+                return next;
+            });
+        },
+        [canEdit, readonlyState],
+    );
+
+    const saveMutation = useSavePortalSettings();
+
+    const handleSave = () => {
+        if (!isDirty || saveMutation.isPending || !settings) return;
+        const stateAtSaveTime = applyReadonlySecurityState(localState, savedState, readonlyState);
+        saveMutation.mutate(buildPortalSettingsSavePayload(settings, stateAtSaveTime), {
+            onSuccess: () => setSavedState(stateAtSaveTime),
+        });
+    };
+
+    const handleDiscard = () => {
+        setLocalState(savedState);
+    };
+
+    if (isLoading) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-10 w-64" />
+                <Skeleton className="h-96 w-full rounded-lg" />
+            </div>
+        );
+    }
+
+    if (isError) {
+        return (
+            <div className="space-y-6">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Security Plan Types</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Configure which security plan types are available for APIs across the environment.
+                    </p>
+                </div>
+                <div className="flex items-center justify-center rounded-lg border p-8">
+                    <p className="text-sm text-muted-foreground">Failed to load settings. Please refresh and try again.</p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-start justify-between">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Security Plan Types</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Configure which security plan types are available for APIs across the environment.
+                    </p>
+                </div>
+                {isDirty && canEdit && (
+                    <div className="flex shrink-0 items-center gap-2">
+                        <Button variant="outline" size="sm" onClick={handleDiscard} disabled={saveMutation.isPending}>
+                            Discard
+                        </Button>
+                        <Button size="sm" onClick={handleSave} disabled={saveMutation.isPending}>
+                            <CheckIcon className="size-4" aria-hidden />
+                            {saveMutation.isPending ? 'Saving…' : 'Save changes'}
+                        </Button>
+                    </div>
+                )}
+            </div>
+
+            {!canEdit && (
+                <Alert>
+                    <InfoIcon className="size-4" />
+                    <AlertDescription>
+                        You do not have permission to modify these settings. Contact your administrator for access.
+                    </AlertDescription>
+                </Alert>
+            )}
+
+            <div className="rounded-lg border">
+                <div className="flex items-center gap-2 border-b px-4 py-3">
+                    <ShieldCheckIcon className="size-5 text-muted-foreground" aria-hidden />
+                    <h2 className="text-base font-semibold">Security plan types available</h2>
+                </div>
+
+                <div className="px-4">
+                    <TooltipProvider delayDuration={200}>
+                        <ToggleRow
+                            id="plan-keyless"
+                            label="Keyless plans"
+                            checked={localState.keyless}
+                            disabled={!canEdit || readonlyState.keyless}
+                            systemReadonly={readonlyState.keyless}
+                            onToggle={checked => handleToggle('keyless', checked)}
+                        />
+
+                        <ToggleRow
+                            id="plan-apikey"
+                            label="API Key plans"
+                            checked={localState.apikey}
+                            disabled={!canEdit || readonlyState.apikey}
+                            systemReadonly={readonlyState.apikey}
+                            onToggle={checked => handleToggle('apikey', checked)}
+                        />
+                        <ToggleRow
+                            id="plan-custom-apikey"
+                            label="Allow custom API Key"
+                            checked={localState.customApiKey}
+                            disabled={!canEdit || readonlyState.customApiKey || !localState.apikey}
+                            systemReadonly={readonlyState.customApiKey}
+                            indented
+                            onToggle={checked => handleToggle('customApiKey', checked)}
+                        />
+                        <ToggleRow
+                            id="plan-custom-apikey-reuse"
+                            label="Allow custom API Key reuse"
+                            checked={localState.customApiKeyReuse}
+                            disabled={!canEdit || readonlyState.customApiKeyReuse || !localState.apikey || !localState.customApiKey}
+                            systemReadonly={readonlyState.customApiKeyReuse}
+                            indented
+                            onToggle={checked => handleToggle('customApiKeyReuse', checked)}
+                        />
+                        <ToggleRow
+                            id="plan-shared-apikey"
+                            label="Allow to share API Key on an application"
+                            checked={localState.sharedApiKey}
+                            disabled={!canEdit || readonlyState.sharedApiKey || !localState.apikey}
+                            systemReadonly={readonlyState.sharedApiKey}
+                            indented
+                            onToggle={checked => handleToggle('sharedApiKey', checked)}
+                        />
+
+                        <ToggleRow
+                            id="plan-oauth2"
+                            label="OAuth2 plans"
+                            checked={localState.oauth2}
+                            disabled={!canEdit || readonlyState.oauth2}
+                            systemReadonly={readonlyState.oauth2}
+                            onToggle={checked => handleToggle('oauth2', checked)}
+                        />
+
+                        <ToggleRow
+                            id="plan-jwt"
+                            label="JWT plans"
+                            checked={localState.jwt}
+                            disabled={!canEdit || readonlyState.jwt}
+                            systemReadonly={readonlyState.jwt}
+                            onToggle={checked => handleToggle('jwt', checked)}
+                        />
+
+                        <ToggleRow
+                            id="plan-push"
+                            label="Push plans"
+                            description="Only available for API V4"
+                            checked={localState.push}
+                            disabled={!canEdit || readonlyState.push}
+                            systemReadonly={readonlyState.push}
+                            onToggle={checked => handleToggle('push', checked)}
+                        />
+
+                        <ToggleRow
+                            id="plan-mtls"
+                            label="mTLS plans"
+                            description="Only available for API V4"
+                            checked={localState.mtls}
+                            disabled={!canEdit || readonlyState.mtls}
+                            systemReadonly={readonlyState.mtls}
+                            onToggle={checked => handleToggle('mtls', checked)}
+                        />
+                    </TooltipProvider>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/hooks/usePortalSettings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/hooks/usePortalSettings.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { getPortalSettings } from '../services/portalSettings';
+import { portalSettingsKeys } from '../utils/queryKeys';
+
+export function usePortalSettings() {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: portalSettingsKeys.env(env?.id ?? ''),
+        queryFn: () => getPortalSettings(env!.id),
+        enabled: Boolean(env),
+        staleTime: 60_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/hooks/useSavePortalSettings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/hooks/useSavePortalSettings.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { notify } from '../../../shared/notify';
+import type { PortalSettings } from '../services/portalSettings';
+import { savePortalSettings } from '../services/portalSettings';
+import { portalSettingsKeys } from '../utils/queryKeys';
+
+export function useSavePortalSettings() {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (payload: PortalSettings) => savePortalSettings(env!.id, payload),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: portalSettingsKeys.env(env?.id ?? '') });
+            notify.success('Security plan types saved successfully.');
+        },
+        onError: error => notify.error(error, 'Failed to save security plan types.'),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/services/portalSettings.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/services/portalSettings.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getPortalSettings, savePortalSettings } from './portalSettings';
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({ apimFetchJsonV1Env: jest.fn() }));
+
+const mockApimFetchJsonV1Env = jest.mocked(apimFetchJsonV1Env);
+
+describe('portalSettings service', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    describe('getPortalSettings', () => {
+        it('calls the settings endpoint for the given environment', async () => {
+            const mockResponse = { plan: { security: { apikey: { enabled: true } } } };
+            mockApimFetchJsonV1Env.mockResolvedValue(mockResponse);
+
+            const result = await getPortalSettings('env-1');
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/settings');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('savePortalSettings', () => {
+        it('posts the settings payload to the environment settings endpoint', async () => {
+            const payload = { plan: { security: { jwt: { enabled: false } } } };
+            const mockResponse = { plan: { security: { jwt: { enabled: false } } } };
+            mockApimFetchJsonV1Env.mockResolvedValue(mockResponse);
+
+            const result = await savePortalSettings('env-2', payload);
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-2', '/settings', {
+                method: 'POST',
+                body: JSON.stringify(payload),
+            });
+            expect(result).toEqual(mockResponse);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/services/portalSettings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/services/portalSettings.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+
+export interface PlanSecurityEnabled {
+    enabled?: boolean;
+}
+
+export interface PlanSecuritySettings {
+    apikey?: PlanSecurityEnabled;
+    customApiKey?: PlanSecurityEnabled;
+    customApiKeyReuse?: PlanSecurityEnabled;
+    sharedApiKey?: PlanSecurityEnabled;
+    oauth2?: PlanSecurityEnabled;
+    keyless?: PlanSecurityEnabled;
+    jwt?: PlanSecurityEnabled;
+    push?: PlanSecurityEnabled;
+    mtls?: PlanSecurityEnabled;
+}
+
+export interface PortalSettingsMetadata {
+    readonly?: string[];
+}
+
+export interface PortalSettings {
+    metadata?: PortalSettingsMetadata;
+    plan?: {
+        security?: PlanSecuritySettings;
+        [key: string]: unknown;
+    };
+    [key: string]: unknown;
+}
+
+export async function getPortalSettings(environmentId: string): Promise<PortalSettings> {
+    return apimFetchJsonV1Env<PortalSettings>(environmentId, '/settings');
+}
+
+export async function savePortalSettings(environmentId: string, settings: PortalSettings): Promise<PortalSettings> {
+    return apimFetchJsonV1Env<PortalSettings>(environmentId, '/settings', {
+        method: 'POST',
+        body: JSON.stringify(settings),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/utils/buildPortalSettingsSavePayload.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/utils/buildPortalSettingsSavePayload.spec.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { buildPortalSettingsSavePayload } from './buildPortalSettingsSavePayload';
+import type { PortalSettings } from '../services/portalSettings';
+
+const CURRENT_SETTINGS: PortalSettings = {
+    company: { name: 'Acme Corp' },
+    cors: { allowOrigin: ['https://portal.example.com'] },
+    plan: {
+        security: {
+            keyless: { enabled: true },
+            apikey: { enabled: true },
+            customApiKey: { enabled: true },
+            customApiKeyReuse: { enabled: true },
+            sharedApiKey: { enabled: true },
+            oauth2: { enabled: true },
+            jwt: { enabled: true },
+            push: { enabled: true },
+            mtls: { enabled: true },
+        },
+        validation: { enabled: true },
+    },
+};
+
+const UPDATED_STATE = {
+    keyless: true,
+    apikey: true,
+    customApiKey: true,
+    customApiKeyReuse: true,
+    sharedApiKey: true,
+    oauth2: true,
+    jwt: true,
+    push: false,
+    mtls: true,
+};
+
+describe('buildPortalSettingsSavePayload', () => {
+    it('merges updated plan security into the full settings document', () => {
+        const payload = buildPortalSettingsSavePayload(CURRENT_SETTINGS, UPDATED_STATE);
+
+        expect(payload.company).toEqual({ name: 'Acme Corp' });
+        expect(payload.cors).toEqual({ allowOrigin: ['https://portal.example.com'] });
+        expect(payload.plan?.validation).toEqual({ enabled: true });
+        expect(payload.plan?.security).toEqual({
+            keyless: { enabled: true },
+            apikey: { enabled: true },
+            customApiKey: { enabled: true },
+            customApiKeyReuse: { enabled: true },
+            sharedApiKey: { enabled: true },
+            oauth2: { enabled: true },
+            jwt: { enabled: true },
+            push: { enabled: false },
+            mtls: { enabled: true },
+        });
+    });
+
+    it('does not send a partial document with only plan.security', () => {
+        const payload = buildPortalSettingsSavePayload(CURRENT_SETTINGS, UPDATED_STATE);
+
+        expect(Object.keys(payload).sort()).toEqual(['company', 'cors', 'plan']);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/utils/buildPortalSettingsSavePayload.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/utils/buildPortalSettingsSavePayload.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { PlanSecuritySettings, PortalSettings } from '../services/portalSettings';
+
+export interface SecurityState {
+    keyless: boolean;
+    apikey: boolean;
+    customApiKey: boolean;
+    customApiKeyReuse: boolean;
+    sharedApiKey: boolean;
+    oauth2: boolean;
+    jwt: boolean;
+    push: boolean;
+    mtls: boolean;
+}
+
+export function buildPortalSettingsSavePayload(current: PortalSettings, state: SecurityState): PortalSettings {
+    const security: PlanSecuritySettings = {
+        ...current.plan?.security,
+        keyless: { enabled: state.keyless },
+        apikey: { enabled: state.apikey },
+        customApiKey: { enabled: state.customApiKey },
+        customApiKeyReuse: { enabled: state.customApiKeyReuse },
+        sharedApiKey: { enabled: state.sharedApiKey },
+        oauth2: { enabled: state.oauth2 },
+        jwt: { enabled: state.jwt },
+        push: { enabled: state.push },
+        mtls: { enabled: state.mtls },
+    };
+
+    return {
+        ...current,
+        plan: {
+            ...current.plan,
+            security,
+        },
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/utils/isPortalSettingReadonly.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/utils/isPortalSettingReadonly.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { PortalSettings } from '../services/portalSettings';
+
+export function isPortalSettingReadonly(settings: PortalSettings | undefined, property: string): boolean {
+    return settings?.metadata?.readonly?.some(key => key === property) ?? false;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/utils/queryKeys.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const portalSettingsKeys = {
+    all: ['portal-settings'] as const,
+    env: (envId: string) => [...portalSettingsKeys.all, envId] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/utils/securityPlanReadonly.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/utils/securityPlanReadonly.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SecurityState } from './buildPortalSettingsSavePayload';
+import { applyReadonlySecurityState, getSecurityReadonlyState } from './securityPlanReadonly';
+
+const BASE_STATE: SecurityState = {
+    keyless: true,
+    apikey: true,
+    customApiKey: true,
+    customApiKeyReuse: true,
+    sharedApiKey: true,
+    oauth2: true,
+    jwt: true,
+    push: true,
+    mtls: true,
+};
+
+describe('securityPlanReadonly', () => {
+    it('marks only keys listed in metadata.readonly as readonly', () => {
+        const readonlyState = getSecurityReadonlyState({
+            metadata: {
+                readonly: ['plan.security.jwt.enabled', 'plan.security.apikey.allowCustom.enabled'],
+            },
+        });
+
+        expect(readonlyState.jwt).toBe(true);
+        expect(readonlyState.customApiKey).toBe(true);
+        expect(readonlyState.keyless).toBe(false);
+    });
+
+    it('marks shared API Key readonly using the backend metadata key', () => {
+        const readonlyState = getSecurityReadonlyState({
+            metadata: {
+                readonly: ['plan.security.apikey.allowShared.enabled'],
+            },
+        });
+
+        expect(readonlyState.sharedApiKey).toBe(true);
+        expect(readonlyState.apikey).toBe(false);
+    });
+
+    it('marks shared API Key readonly using the legacy Classic metadata key', () => {
+        const readonlyState = getSecurityReadonlyState({
+            metadata: {
+                readonly: ['plan.security.apikey.sharedApiKey.enabled'],
+            },
+        });
+
+        expect(readonlyState.sharedApiKey).toBe(true);
+    });
+
+    it('preserves saved values for readonly keys when building save state', () => {
+        const readonlyState = getSecurityReadonlyState({
+            metadata: {
+                readonly: ['plan.security.jwt.enabled'],
+            },
+        });
+
+        const localState: SecurityState = { ...BASE_STATE, jwt: false };
+        const savedState: SecurityState = { ...BASE_STATE, jwt: true };
+
+        expect(applyReadonlySecurityState(localState, savedState, readonlyState).jwt).toBe(true);
+        expect(applyReadonlySecurityState(localState, savedState, readonlyState).push).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/utils/securityPlanReadonly.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/security-plan-types/utils/securityPlanReadonly.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SecurityState } from './buildPortalSettingsSavePayload';
+import { isPortalSettingReadonly } from './isPortalSettingReadonly';
+import type { PortalSettings } from '../services/portalSettings';
+
+export type SecurityKey = keyof SecurityState;
+
+export const SECURITY_PLAN_READONLY_PROPERTY: Record<SecurityKey, string> = {
+    keyless: 'plan.security.keyless.enabled',
+    apikey: 'plan.security.apikey.enabled',
+    customApiKey: 'plan.security.apikey.allowCustom.enabled',
+    customApiKeyReuse: 'plan.security.apikey.allowCustomReuse.enabled',
+    sharedApiKey: 'plan.security.apikey.allowShared.enabled',
+    oauth2: 'plan.security.oauth2.enabled',
+    jwt: 'plan.security.jwt.enabled',
+    push: 'plan.security.push.enabled',
+    mtls: 'plan.security.mtls.enabled',
+};
+
+const SHARED_API_KEY_LEGACY_READONLY_PROPERTY = 'plan.security.apikey.sharedApiKey.enabled';
+
+function isSecurityKeyReadonly(settings: PortalSettings | undefined, key: SecurityKey): boolean {
+    if (key === 'sharedApiKey') {
+        return (
+            isPortalSettingReadonly(settings, SECURITY_PLAN_READONLY_PROPERTY.sharedApiKey) ||
+            isPortalSettingReadonly(settings, SHARED_API_KEY_LEGACY_READONLY_PROPERTY)
+        );
+    }
+
+    return isPortalSettingReadonly(settings, SECURITY_PLAN_READONLY_PROPERTY[key]);
+}
+
+export function getSecurityReadonlyState(settings: PortalSettings | undefined): Record<SecurityKey, boolean> {
+    return (Object.keys(SECURITY_PLAN_READONLY_PROPERTY) as SecurityKey[]).reduce(
+        (readonlyState, key) => {
+            readonlyState[key] = isSecurityKeyReadonly(settings, key);
+            return readonlyState;
+        },
+        {} as Record<SecurityKey, boolean>,
+    );
+}
+
+export function applyReadonlySecurityState(
+    state: SecurityState,
+    savedState: SecurityState,
+    readonlyState: Record<SecurityKey, boolean>,
+): SecurityState {
+    const next = { ...state };
+
+    for (const key of Object.keys(readonlyState) as SecurityKey[]) {
+        if (readonlyState[key]) {
+            next[key] = savedState[key];
+        }
+    }
+
+    return next;
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-50

**Description**
This adds a new Security Plan Types page where platform administrators can enable or disable security plan types for the selected environment. The page reuses the existing Management API settings endpoint and matches the classic APIM Portal Settings behaviour for plan.security.*.enabled.

**Additional Context:**

What's included?
New page under Platform → System & Security → Security Plan Types
Environment-scoped toggles for:
Keyless plans
API Key plans
Allow custom API Key
Allow custom API Key reuse
Allow to share API Key on an application
OAuth2 plans
JWT plans
Push plans (only available for API V4)
mTLS plans (only available for API V4)
API Key cascade behavior:
Turning off API Key disables and clears custom API Key, custom API Key reuse, and shared API Key
Turning off custom API Key disables and clears custom API Key reuse
Save / Discard flow with dirty-state detection
Success and error notifications on save
Read-only mode for users without environment-settings-u
Read-only alert banner when the user cannot edit settings


https://github.com/user-attachments/assets/dcbfbe44-030c-4807-8877-050f579e1f37

