### PR TITLE
chore: bump gravitee-policy-json-validation to 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <gravitee-policy-javascript.version>1.4.0</gravitee-policy-javascript.version>
         <gravitee-policy-json-threat-protection.version>2.1.0</gravitee-policy-json-threat-protection.version>
         <gravitee-policy-json-to-json.version>3.0.1</gravitee-policy-json-to-json.version>
-        <gravitee-policy-json-validation.version>2.1.4</gravitee-policy-json-validation.version>
+        <gravitee-policy-json-validation.version>2.2.0</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.3</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>2.0.0</gravitee-policy-jws.version>
         <gravitee-policy-jwt.version>7.0.4</gravitee-policy-jwt.version>


### PR DESCRIPTION
## Purpose

Bump the bundled `gravitee-policy-json-validation` policy from 2.1.4 to 2.2.0 so APIM distributions ship the latest version. 2.2.0 adds an opt-in `returnDetailedErrorReport` flag that, when enabled, returns a per-violation detail string (JSON pointer + reason) instead of the configured error message.

## Summary of changes

- Update the `gravitee-policy-json-validation.version` property in the root aggregator `pom.xml` from `2.1.4` to `2.2.0`. The property is consumed by `gravitee-apim-integration-tests` and `gravitee-apim-distribution`, so both the integration-test classpath and the packaged distributions pick up the new plugin version.

### Behaviour changes

- No behaviour change for existing configurations. The new policy capability (`returnDetailedErrorReport`) is opt-in and defaults to `false`; APIs that do not set it keep their current validation-error behaviour.

## Testing

Verified locally by building the distributions (gateway logs `json-validation [2.2.0] has been loaded`), deploying a V4 proxy API with a `json-validation` request policy using `returnDetailedErrorReport: true`, and posting an invalid payload:

- With `Accept: text/plain`, the gateway returns the raw per-violation detail string (`Content-Type: text/plain`).
- With the default `Accept`, the gateway wraps the same message in its JSON error template — expected content negotiation, not a policy change.
