### PR TITLE
feat(rest-api): enforce Kafka virtual cluster lifecycle guards

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -496,6 +496,15 @@ paths:
             responses:
                 "202":
                     description: API deployment request received
+                "400":
+                    description: |-
+                        The API cannot be deployed. This includes a Kafka Native API bound (via a
+                        `native-kafka-virtual-cluster` endpoint) to a Kafka virtual cluster that is
+                        not currently deployed.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
                 default:
                     $ref: "#/components/responses/Error"
     /environments/{envId}/apis/{apiId}/deployments/current:
@@ -808,12 +817,22 @@ paths:
                  - when user tries to start an ARCHIVED API
                  - when the API is already STARTED
                  - when the API needs to be reviewed (only if Review feature is activated).
+                 - when the API is a Kafka Native API bound to a Kafka virtual cluster that is not deployed.
 
                 User must have the API_DEFINITION[UPDATE] permission.
             operationId: startApi
             responses:
                 "204":
                     description: API successfully started
+                "400":
+                    description: |-
+                        The API cannot be started. In addition to the cases above, this includes a
+                        Kafka Native API bound (via a `native-kafka-virtual-cluster` endpoint) to a
+                        Kafka virtual cluster that is not currently deployed.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
                 default:
                     $ref: "#/components/responses/Error"
     /environments/{envId}/apis/{apiId}/_migrate:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -547,6 +547,11 @@ paths:
       summary: Update a cluster
       description: |-
         User must have the CLUSTER_DEFINITION[UPDATE] permission.
+
+        Kafka virtual cluster lifecycle: removing all backends from a deployed (or pending) virtual
+        cluster undeploys it — the response is 200 with `lifecycleState` set to `UNDEPLOYED` — but
+        only when no started Kafka Native API is bound to it. If a started API is bound, the update
+        is rejected with 400 so the started API is never left pointing at a backend-less cluster.
       operationId: updateCluster
       requestBody:
         content:
@@ -561,6 +566,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Cluster"
+        "400":
+          description: |-
+            All backends were removed from the virtual cluster while one or more started Kafka Native
+            APIs are bound to it. Stop those APIs first.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           $ref: "#/components/responses/Error"
     delete:
@@ -593,6 +606,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Cluster"
+        "400":
+          description: A Kafka virtual cluster cannot be deployed without at least one backend.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           $ref: "#/components/responses/Error"
   /clusters/{clusterId}/_undeploy:
@@ -602,7 +621,12 @@ paths:
       tags:
         - Clusters
       summary: Undeploy a cluster
-      description: Undeploy the cluster from the gateway. Sets lifecycle state to UNDEPLOYED.
+      description: |-
+        Undeploy the cluster from the gateway. Sets lifecycle state to UNDEPLOYED.
+
+        A Kafka virtual cluster cannot be undeployed while a started Kafka Native API is bound to it
+        (via a `native-kafka-virtual-cluster` endpoint): the request is rejected with 400 so the
+        started API is never left pointing at an undeployed cluster.
       operationId: undeployCluster
       responses:
         "200":
@@ -611,6 +635,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Cluster"
+        "400":
+          description: |-
+            The Kafka virtual cluster cannot be undeployed because one or more started Kafka Native
+            APIs are bound to it. Stop those APIs first.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           $ref: "#/components/responses/Error"
   /clusters/{clusterId}/groups:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/UndeployClusterDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/UndeployClusterDomainService.java
@@ -25,6 +25,7 @@ import io.gravitee.apim.core.audit.model.EnvironmentAuditLogEntity;
 import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterAuditEvent;
+import io.gravitee.apim.core.cluster.model.ClusterLifecycleState;
 import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.event.model.Event;
@@ -51,9 +52,18 @@ public class UndeployClusterDomainService {
     private final AuditDomainService auditService;
 
     public Cluster undeploy(Cluster cluster, AuditInfo auditInfo) {
+        return undeploy(cluster, cluster.getLifecycleState(), auditInfo);
+    }
+
+    /**
+     * Variant for callers that mutated the cluster before undeploying it (e.g. an update that
+     * empties the backends): {@code previousLifecycleState} is the state to record as the audit
+     * log's "before" value instead of the cluster's current (already mutated) one.
+     */
+    public Cluster undeploy(Cluster cluster, ClusterLifecycleState previousLifecycleState, AuditInfo auditInfo) {
         Cluster beforeUndeploy = Cluster.builder()
             .id(cluster.getId())
-            .lifecycleState(cluster.getLifecycleState())
+            .lifecycleState(previousLifecycleState)
             .version(cluster.getVersion())
             .build();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/UndeployClusterDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/UndeployClusterDomainService.java
@@ -13,13 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.cluster.use_case;
+package io.gravitee.apim.core.cluster.domain_service;
 
 import static java.util.Map.entry;
-import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
@@ -31,54 +29,43 @@ import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.event.model.Event;
 import io.gravitee.common.utils.TimeProvider;
-import io.gravitee.definition.model.cluster.ClusterType;
 import io.gravitee.rest.api.model.EventType;
-import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.util.Map;
 import java.util.Set;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
-@UseCase
-@AllArgsConstructor
-public class DeployClusterUseCase {
+/**
+ * Undeploys a cluster: flips its lifecycle state to UNDEPLOYED, publishes the UNDEPLOY_CLUSTER
+ * event and writes the CLUSTER_UNDEPLOYED audit log, then persists and returns the updated cluster.
+ *
+ * <p>Shared by {@code UndeployClusterUseCase} (explicit undeploy) and {@code UpdateClusterUseCase}
+ * (a deployed virtual cluster whose backends are all removed is auto-undeployed).
+ */
+@DomainService
+@RequiredArgsConstructor
+public class UndeployClusterDomainService {
 
     private final ClusterCrudService clusterCrudService;
     private final EventCrudService eventCrudService;
     private final EventLatestCrudService eventLatestCrudService;
     private final AuditDomainService auditService;
-    private final ObjectMapper objectMapper;
 
-    public record Input(String clusterId, AuditInfo auditInfo) {}
-
-    public record Output(Cluster cluster) {}
-
-    public Output execute(Input input) {
-        Cluster cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.auditInfo().environmentId());
-
-        if (cluster.getType() == ClusterType.KAFKA_VIRTUAL_CLUSTER) {
-            var configuration = cluster.getKafkaVirtualClusterConfiguration(objectMapper);
-            if (configuration.backends() == null || configuration.backends().isEmpty()) {
-                throw new InvalidDataException("A virtual cluster cannot be deployed without at least one backend.");
-            }
-        }
-
-        Cluster beforeDeploy = Cluster.builder()
+    public Cluster undeploy(Cluster cluster, AuditInfo auditInfo) {
+        Cluster beforeUndeploy = Cluster.builder()
             .id(cluster.getId())
             .lifecycleState(cluster.getLifecycleState())
             .version(cluster.getVersion())
             .build();
 
-        requireNonNull(cluster.getCrossId(), "Cluster crossId must not be null to deploy");
+        cluster.undeploy();
 
-        cluster.deploy();
-
-        publishEvent(input.auditInfo(), cluster);
+        publishEvent(auditInfo, cluster);
 
         Cluster updatedCluster = clusterCrudService.update(cluster);
 
-        createAuditLog(beforeDeploy, updatedCluster, input.auditInfo());
+        createAuditLog(beforeUndeploy, updatedCluster, auditInfo);
 
-        return new Output(updatedCluster);
+        return updatedCluster;
     }
 
     private void publishEvent(AuditInfo auditInfo, Cluster cluster) {
@@ -86,7 +73,7 @@ public class DeployClusterUseCase {
             auditInfo.organizationId(),
             auditInfo.environmentId(),
             Set.of(auditInfo.environmentId()),
-            EventType.DEPLOY_CLUSTER,
+            EventType.UNDEPLOY_CLUSTER,
             cluster,
             Map.ofEntries(
                 entry(Event.EventProperties.USER, auditInfo.actor().userId()),
@@ -102,7 +89,7 @@ public class DeployClusterUseCase {
             EnvironmentAuditLogEntity.builder()
                 .organizationId(auditInfo.organizationId())
                 .environmentId(auditInfo.environmentId())
-                .event(ClusterAuditEvent.CLUSTER_DEPLOYED)
+                .event(ClusterAuditEvent.CLUSTER_UNDEPLOYED)
                 .actor(auditInfo.actor())
                 .oldValue(oldCluster)
                 .newValue(newCluster)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateApiClusterBindingService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateApiClusterBindingService.java
@@ -69,7 +69,7 @@ public class ValidateApiClusterBindingService {
             .orElse(false);
         if (!deployed) {
             throw new ApiNotDeployableException(
-                "The API {" + apiId + "} cannot be started because its virtual cluster {" + crossId + "} is not deployed"
+                "The API {" + apiId + "} cannot be deployed or started because its virtual cluster {" + crossId + "} is not deployed"
             );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateApiClusterBindingService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateApiClusterBindingService.java
@@ -24,6 +24,7 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.rest.api.service.exceptions.ApiNotDeployableException;
 import java.util.Optional;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -32,6 +33,7 @@ import lombok.RequiredArgsConstructor;
  * only be started or deployed while that virtual cluster is itself deployed. Otherwise the API would
  * sit at the gateway pointing at a cluster with no backends.
  */
+@CustomLog
 @DomainService
 @RequiredArgsConstructor
 public class ValidateApiClusterBindingService {
@@ -52,7 +54,9 @@ public class ValidateApiClusterBindingService {
         try {
             nativeDefinition = objectMapper.readValue(apiDefinition, NativeApi.class);
         } catch (JsonProcessingException e) {
-            // Unparseable definition: leave existing start/deploy behaviour unchanged.
+            // Unparseable definition: leave existing start/deploy behaviour unchanged, but trace it —
+            // a corrupted definition silently bypasses the virtual-cluster binding guard.
+            log.warn("Unable to parse native API definition of API {}; skipping virtual cluster binding validation", apiId, e);
             return;
         }
         Optional<String> virtualClusterCrossId = VirtualClusterBoundApisQueryService.extractVirtualClusterCrossId(
@@ -63,9 +67,15 @@ public class ValidateApiClusterBindingService {
             return;
         }
         String crossId = virtualClusterCrossId.get();
+        // PENDING means the cluster is deployed at the gateway with not-yet-redeployed edits
+        // (a cluster only reaches PENDING from DEPLOYED), so it is a valid target.
         boolean deployed = clusterQueryService
             .findByCrossIdAndEnvironmentId(crossId, environmentId)
-            .map(cluster -> cluster.getLifecycleState() == ClusterLifecycleState.DEPLOYED)
+            .map(
+                cluster ->
+                    cluster.getLifecycleState() == ClusterLifecycleState.DEPLOYED ||
+                    cluster.getLifecycleState() == ClusterLifecycleState.PENDING
+            )
             .orElse(false);
         if (!deployed) {
             throw new ApiNotDeployableException(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateApiClusterBindingService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateApiClusterBindingService.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.cluster.domain_service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.cluster.model.ClusterLifecycleState;
+import io.gravitee.apim.core.cluster.query_service.ClusterQueryService;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
+import io.gravitee.rest.api.service.exceptions.ApiNotDeployableException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Guards start/deploy of a Kafka Native API: an API bound to a virtual cluster via a
+ * {@code native-kafka-virtual-cluster} endpoint ({@code configuration.virtualClusterCrossId}) can
+ * only be started or deployed while that virtual cluster is itself deployed. Otherwise the API would
+ * sit at the gateway pointing at a cluster with no backends.
+ */
+@DomainService
+@RequiredArgsConstructor
+public class ValidateApiClusterBindingService {
+
+    private final ClusterQueryService clusterQueryService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Throws {@link ApiNotDeployableException} when {@code apiDefinition} is a native API bound to a
+     * virtual cluster that is not currently deployed. No-op for non-native APIs, APIs not bound to a
+     * virtual cluster, or definitions that cannot be parsed.
+     */
+    public void validateDeployable(String apiId, String environmentId, ApiType apiType, String apiDefinition) {
+        if (apiType != ApiType.NATIVE || apiDefinition == null) {
+            return;
+        }
+        NativeApi nativeDefinition;
+        try {
+            nativeDefinition = objectMapper.readValue(apiDefinition, NativeApi.class);
+        } catch (JsonProcessingException e) {
+            // Unparseable definition: leave existing start/deploy behaviour unchanged.
+            return;
+        }
+        Optional<String> virtualClusterCrossId = VirtualClusterBoundApisQueryService.extractVirtualClusterCrossId(
+            nativeDefinition,
+            objectMapper
+        );
+        if (virtualClusterCrossId.isEmpty()) {
+            return;
+        }
+        String crossId = virtualClusterCrossId.get();
+        boolean deployed = clusterQueryService
+            .findByCrossIdAndEnvironmentId(crossId, environmentId)
+            .map(cluster -> cluster.getLifecycleState() == ClusterLifecycleState.DEPLOYED)
+            .orElse(false);
+        if (!deployed) {
+            throw new ApiNotDeployableException(
+                "The API {" + apiId + "} cannot be started because its virtual cluster {" + crossId + "} is not deployed"
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/VirtualClusterBoundApisQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/VirtualClusterBoundApisQueryService.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.cluster.domain_service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiFieldFilter;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Resolves which Kafka Native APIs are bound to a Kafka Virtual Cluster through their
+ * {@code native-kafka-virtual-cluster} endpoint ({@code configuration.virtualClusterCrossId}).
+ *
+ * <p>Backing service for the virtual-cluster lifecycle guards: a started API bound to a virtual
+ * cluster must never be left pointing at a cluster that gets undeployed or emptied of its backends.
+ */
+@DomainService
+@RequiredArgsConstructor
+public class VirtualClusterBoundApisQueryService {
+
+    /** Endpoint plugin id a Kafka Native API uses to target a virtual cluster. */
+    public static final String NATIVE_KAFKA_VIRTUAL_CLUSTER_ENDPOINT_TYPE = "native-kafka-virtual-cluster";
+    private static final String VIRTUAL_CLUSTER_CROSS_ID_FIELD = "virtualClusterCrossId";
+
+    private final ApiQueryService apiQueryService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Native APIs in the given environment that are STARTED and whose endpoint binds the given
+     * virtual cluster crossId.
+     *
+     * <p>The STARTED filter is applied here rather than pushed into the search criteria on purpose:
+     * it keeps the guard correct regardless of the underlying store's support for running-state
+     * filtering. The set of native APIs per environment is small.
+     */
+    // ponytail: in-memory STARTED filter; push into ApiSearchCriteria.state if native-API counts per env ever grow large.
+    public List<Api> findStartedBoundApis(String environmentId, String virtualClusterCrossId) {
+        if (virtualClusterCrossId == null) {
+            return List.of();
+        }
+        var criteria = ApiSearchCriteria.builder().environmentId(environmentId).definitionVersion(List.of(DefinitionVersion.V4)).build();
+        return apiQueryService
+            .search(criteria, null, ApiFieldFilter.builder().build())
+            .filter(Api::isNative)
+            .filter(api -> api.getLifecycleState() == Api.LifecycleState.STARTED)
+            .filter(api ->
+                extractVirtualClusterCrossId(api.getApiDefinitionNativeV4(), objectMapper).filter(virtualClusterCrossId::equals).isPresent()
+            )
+            .toList();
+    }
+
+    /**
+     * The virtual cluster crossId a native API definition binds to, if any: read from the first
+     * {@code native-kafka-virtual-cluster} endpoint's {@code virtualClusterCrossId} field. Never
+     * throws — a null definition or malformed endpoint configuration yields {@link Optional#empty()}.
+     */
+    public static Optional<String> extractVirtualClusterCrossId(NativeApi definition, ObjectMapper objectMapper) {
+        if (definition == null || definition.getEndpointGroups() == null) {
+            return Optional.empty();
+        }
+        for (NativeEndpointGroup group : definition.getEndpointGroups()) {
+            if (group == null || group.getEndpoints() == null) {
+                continue;
+            }
+            for (NativeEndpoint endpoint : group.getEndpoints()) {
+                if (endpoint == null || !NATIVE_KAFKA_VIRTUAL_CLUSTER_ENDPOINT_TYPE.equals(endpoint.getType())) {
+                    continue;
+                }
+                Optional<String> crossId = readVirtualClusterCrossId(endpoint.getConfiguration(), objectMapper);
+                if (crossId.isPresent()) {
+                    return crossId;
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> readVirtualClusterCrossId(String configuration, ObjectMapper objectMapper) {
+        if (configuration == null || configuration.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            JsonNode node = objectMapper.readTree(configuration);
+            JsonNode value = node.get(VIRTUAL_CLUSTER_CROSS_ID_FIELD);
+            if (value != null && !value.isNull() && !value.asText().isBlank()) {
+                return Optional.of(value.asText());
+            }
+        } catch (JsonProcessingException e) {
+            // Malformed endpoint configuration: treat as "not bound" rather than failing the caller.
+        }
+        return Optional.empty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/VirtualClusterBoundApisQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/VirtualClusterBoundApisQueryService.java
@@ -29,6 +29,7 @@ import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import java.util.List;
 import java.util.Optional;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -38,6 +39,7 @@ import lombok.RequiredArgsConstructor;
  * <p>Backing service for the virtual-cluster lifecycle guards: a started API bound to a virtual
  * cluster must never be left pointing at a cluster that gets undeployed or emptied of its backends.
  */
+@CustomLog
 @DomainService
 @RequiredArgsConstructor
 public class VirtualClusterBoundApisQueryService {
@@ -53,18 +55,21 @@ public class VirtualClusterBoundApisQueryService {
      * Native APIs in the given environment that are STARTED and whose endpoint binds the given
      * virtual cluster crossId.
      *
-     * <p>The STARTED filter is applied here rather than pushed into the search criteria on purpose:
-     * it keeps the guard correct regardless of the underlying store's support for running-state
-     * filtering. The set of native APIs per environment is small.
+     * <p>The STARTED filter is pushed into the search criteria to shrink the result set at the
+     * store level, and re-applied in memory so the guard stays correct even if an underlying store
+     * ignores running-state filtering.
      */
-    // ponytail: in-memory STARTED filter; push into ApiSearchCriteria.state if native-API counts per env ever grow large.
     public List<Api> findStartedBoundApis(String environmentId, String virtualClusterCrossId) {
         if (virtualClusterCrossId == null) {
             return List.of();
         }
-        var criteria = ApiSearchCriteria.builder().environmentId(environmentId).definitionVersion(List.of(DefinitionVersion.V4)).build();
+        var criteria = ApiSearchCriteria.builder()
+            .environmentId(environmentId)
+            .definitionVersion(List.of(DefinitionVersion.V4))
+            .state(Api.LifecycleState.STARTED)
+            .build();
         return apiQueryService
-            .search(criteria, null, ApiFieldFilter.builder().build())
+            .search(criteria, null, ApiFieldFilter.builder().pictureExcluded(true).build())
             .filter(Api::isNative)
             .filter(api -> api.getLifecycleState() == Api.LifecycleState.STARTED)
             .filter(api ->
@@ -110,7 +115,9 @@ public class VirtualClusterBoundApisQueryService {
                 return Optional.of(value.asText());
             }
         } catch (JsonProcessingException e) {
-            // Malformed endpoint configuration: treat as "not bound" rather than failing the caller.
+            // Malformed endpoint configuration: treat as "not bound" rather than failing the caller,
+            // but trace it — such an API becomes invisible to the lifecycle guards.
+            log.warn("Unable to parse native-kafka-virtual-cluster endpoint configuration; treating API as not bound", e);
         }
         return Optional.empty();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/DeployClusterUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/DeployClusterUseCase.java
@@ -57,7 +57,7 @@ public class DeployClusterUseCase {
 
         if (cluster.getType() == ClusterType.KAFKA_VIRTUAL_CLUSTER) {
             var configuration = cluster.getKafkaVirtualClusterConfiguration(objectMapper);
-            if (configuration.backends() == null || configuration.backends().isEmpty()) {
+            if (configuration == null || configuration.backends() == null || configuration.backends().isEmpty()) {
                 throw new InvalidDataException("A virtual cluster cannot be deployed without at least one backend.");
             }
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/UndeployClusterUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/UndeployClusterUseCase.java
@@ -15,24 +15,19 @@
  */
 package io.gravitee.apim.core.cluster.use_case;
 
-import static java.util.Map.entry;
 import static java.util.Objects.requireNonNull;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditInfo;
-import io.gravitee.apim.core.audit.model.AuditProperties;
-import io.gravitee.apim.core.audit.model.EnvironmentAuditLogEntity;
 import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
+import io.gravitee.apim.core.cluster.domain_service.UndeployClusterDomainService;
+import io.gravitee.apim.core.cluster.domain_service.VirtualClusterBoundApisQueryService;
 import io.gravitee.apim.core.cluster.model.Cluster;
-import io.gravitee.apim.core.cluster.model.ClusterAuditEvent;
-import io.gravitee.apim.core.event.crud_service.EventCrudService;
-import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
-import io.gravitee.apim.core.event.model.Event;
-import io.gravitee.common.utils.TimeProvider;
-import io.gravitee.rest.api.model.EventType;
-import java.util.Map;
-import java.util.Set;
+import io.gravitee.definition.model.cluster.ClusterType;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 
 @UseCase
@@ -40,9 +35,8 @@ import lombok.AllArgsConstructor;
 public class UndeployClusterUseCase {
 
     private final ClusterCrudService clusterCrudService;
-    private final EventCrudService eventCrudService;
-    private final EventLatestCrudService eventLatestCrudService;
-    private final AuditDomainService auditService;
+    private final UndeployClusterDomainService undeployClusterDomainService;
+    private final VirtualClusterBoundApisQueryService virtualClusterBoundApisQueryService;
 
     public record Input(String clusterId, AuditInfo auditInfo) {}
 
@@ -51,53 +45,30 @@ public class UndeployClusterUseCase {
     public Output execute(Input input) {
         Cluster cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.auditInfo().environmentId());
 
-        Cluster beforeUndeploy = Cluster.builder()
-            .id(cluster.getId())
-            .lifecycleState(cluster.getLifecycleState())
-            .version(cluster.getVersion())
-            .build();
-
         requireNonNull(cluster.getCrossId(), "Cluster crossId must not be null to undeploy");
 
-        cluster.undeploy();
+        // A started native API bound to this virtual cluster must never be left pointing at an
+        // undeployed cluster. Block the undeploy and ask the operator to stop those APIs first.
+        if (cluster.getType() == ClusterType.KAFKA_VIRTUAL_CLUSTER) {
+            List<Api> startedApis = virtualClusterBoundApisQueryService.findStartedBoundApis(
+                input.auditInfo().environmentId(),
+                cluster.getCrossId()
+            );
+            if (!startedApis.isEmpty()) {
+                throw new InvalidDataException(
+                    "Cannot undeploy virtual cluster '" +
+                        cluster.getName() +
+                        "': " +
+                        startedApis.size() +
+                        " started API(s) are bound to it. Stop them first: " +
+                        startedApis.stream().map(Api::getName).collect(Collectors.joining(", ")) +
+                        "."
+                );
+            }
+        }
 
-        publishEvent(input.auditInfo(), cluster);
-
-        Cluster updatedCluster = clusterCrudService.update(cluster);
-
-        createAuditLog(beforeUndeploy, updatedCluster, input.auditInfo());
+        Cluster updatedCluster = undeployClusterDomainService.undeploy(cluster, input.auditInfo());
 
         return new Output(updatedCluster);
-    }
-
-    private void publishEvent(AuditInfo auditInfo, Cluster cluster) {
-        Event event = eventCrudService.createEvent(
-            auditInfo.organizationId(),
-            auditInfo.environmentId(),
-            Set.of(auditInfo.environmentId()),
-            EventType.UNDEPLOY_CLUSTER,
-            cluster,
-            Map.ofEntries(
-                entry(Event.EventProperties.USER, auditInfo.actor().userId()),
-                entry(Event.EventProperties.CLUSTER_ID, cluster.getCrossId())
-            )
-        );
-
-        eventLatestCrudService.createOrPatchLatestEvent(auditInfo.organizationId(), cluster.getId(), event);
-    }
-
-    private void createAuditLog(Cluster oldCluster, Cluster newCluster, AuditInfo auditInfo) {
-        auditService.createEnvironmentAuditLog(
-            EnvironmentAuditLogEntity.builder()
-                .organizationId(auditInfo.organizationId())
-                .environmentId(auditInfo.environmentId())
-                .event(ClusterAuditEvent.CLUSTER_UNDEPLOYED)
-                .actor(auditInfo.actor())
-                .oldValue(oldCluster)
-                .newValue(newCluster)
-                .createdAt(newCluster.getUpdatedAt().atZone(TimeProvider.clock().getZone()))
-                .properties(Map.of(AuditProperties.CLUSTER, newCluster.getId()))
-                .build()
-        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCase.java
@@ -17,16 +17,21 @@ package io.gravitee.apim.core.cluster.use_case;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.EnvironmentAuditLogEntity;
 import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
+import io.gravitee.apim.core.cluster.domain_service.UndeployClusterDomainService;
 import io.gravitee.apim.core.cluster.domain_service.ValidateClusterService;
+import io.gravitee.apim.core.cluster.domain_service.VirtualClusterBoundApisQueryService;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterAuditEvent;
+import io.gravitee.apim.core.cluster.model.ClusterLifecycleState;
 import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
 import io.gravitee.apim.core.cluster.model.KafkaClusterConnection;
+import io.gravitee.apim.core.cluster.model.KafkaVirtualClusterConfiguration;
 import io.gravitee.apim.core.cluster.model.UpdateCluster;
 import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
 import io.gravitee.apim.core.utils.StringUtils;
@@ -35,8 +40,10 @@ import io.gravitee.definition.model.cluster.ClusterType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
@@ -48,6 +55,8 @@ public class UpdateClusterUseCase {
     private final AuditDomainService auditService;
     private final PermissionDomainService permissionDomainService;
     private final ObjectMapper objectMapper;
+    private final UndeployClusterDomainService undeployClusterDomainService;
+    private final VirtualClusterBoundApisQueryService virtualClusterBoundApisQueryService;
 
     public record Input(String clusterId, UpdateCluster updateCluster, AuditInfo auditInfo) {}
 
@@ -72,6 +81,34 @@ public class UpdateClusterUseCase {
             input.updateCluster().setConfiguration(generateConnectionCrossIds(input.updateCluster().getConfiguration()));
         }
 
+        // Removing all backends from a deployed virtual cluster undeploys it. A started native API
+        // bound to that cluster must never be left pointing at it, so block the change while any
+        // such API exists.
+        boolean undeployEmptiedVirtualCluster =
+            clusterToUpdate.getType() == ClusterType.KAFKA_VIRTUAL_CLUSTER &&
+            input.updateCluster().getConfiguration() != null &&
+            hasNoBackends(input.updateCluster().getConfiguration()) &&
+            (clusterToUpdate.getLifecycleState() == ClusterLifecycleState.DEPLOYED ||
+                clusterToUpdate.getLifecycleState() == ClusterLifecycleState.PENDING);
+
+        if (undeployEmptiedVirtualCluster) {
+            List<Api> startedApis = virtualClusterBoundApisQueryService.findStartedBoundApis(
+                input.auditInfo().environmentId(),
+                clusterToUpdate.getCrossId()
+            );
+            if (!startedApis.isEmpty()) {
+                throw new InvalidDataException(
+                    "Cannot remove all backends from virtual cluster '" +
+                        clusterToUpdate.getName() +
+                        "': " +
+                        startedApis.size() +
+                        " started API(s) are bound to it. Stop them first: " +
+                        startedApis.stream().map(Api::getName).collect(Collectors.joining(", ")) +
+                        "."
+                );
+            }
+        }
+
         Cluster existingClusterSnapshot = Cluster.builder()
             .id(clusterToUpdate.getId())
             .crossId(clusterToUpdate.getCrossId())
@@ -85,11 +122,22 @@ public class UpdateClusterUseCase {
 
         validateClusterService.validateForUpdate(existingClusterSnapshot, clusterToUpdate);
 
+        if (undeployEmptiedVirtualCluster) {
+            // Persist the emptied configuration and transition the cluster to UNDEPLOYED in one step.
+            Cluster undeployedCluster = undeployClusterDomainService.undeploy(clusterToUpdate, input.auditInfo());
+            return new Output(undeployedCluster);
+        }
+
         Cluster updatedCluster = clusterCrudService.update(clusterToUpdate);
 
         createAuditLog(clusterToUpdate, updatedCluster, input.auditInfo());
 
         return new Output(updatedCluster);
+    }
+
+    private boolean hasNoBackends(Object configuration) {
+        KafkaVirtualClusterConfiguration config = objectMapper.convertValue(configuration, KafkaVirtualClusterConfiguration.class);
+        return config.backends() == null || config.backends().isEmpty();
     }
 
     private Object generateConnectionCrossIds(Object configuration) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCase.java
@@ -109,6 +109,10 @@ public class UpdateClusterUseCase {
             }
         }
 
+        // Captured before update(): applying an edit to a DEPLOYED cluster flips it to PENDING,
+        // and the undeploy audit log must record the true pre-update lifecycle state.
+        ClusterLifecycleState lifecycleStateBeforeUpdate = clusterToUpdate.getLifecycleState();
+
         Cluster existingClusterSnapshot = Cluster.builder()
             .id(clusterToUpdate.getId())
             .crossId(clusterToUpdate.getCrossId())
@@ -124,7 +128,11 @@ public class UpdateClusterUseCase {
 
         if (undeployEmptiedVirtualCluster) {
             // Persist the emptied configuration and transition the cluster to UNDEPLOYED in one step.
-            Cluster undeployedCluster = undeployClusterDomainService.undeploy(clusterToUpdate, input.auditInfo());
+            Cluster undeployedCluster = undeployClusterDomainService.undeploy(
+                clusterToUpdate,
+                lifecycleStateBeforeUpdate,
+                input.auditInfo()
+            );
             return new Output(undeployedCluster);
         }
 
@@ -136,8 +144,13 @@ public class UpdateClusterUseCase {
     }
 
     private boolean hasNoBackends(Object configuration) {
-        KafkaVirtualClusterConfiguration config = objectMapper.convertValue(configuration, KafkaVirtualClusterConfiguration.class);
-        return config.backends() == null || config.backends().isEmpty();
+        try {
+            KafkaVirtualClusterConfiguration config = objectMapper.convertValue(configuration, KafkaVirtualClusterConfiguration.class);
+            return config.backends() == null || config.backends().isEmpty();
+        } catch (IllegalArgumentException e) {
+            // Unconvertible configuration: let schema validation reject it with a proper 400.
+            return false;
+        }
     }
 
     private Object generateConnectionCrossIds(Object configuration) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
@@ -22,6 +22,7 @@ import static java.util.Comparator.comparing;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.cluster.domain_service.ValidateApiClusterBindingService;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.definition.model.DefinitionVersion;
@@ -100,6 +101,7 @@ public class ApiStateServiceImpl implements ApiStateService {
     private final SynchronizationService synchronizationService;
     private final EventManager eventManager;
     private final SearchEngineService searchEngineService;
+    private final ValidateApiClusterBindingService validateApiClusterBindingService;
 
     public ApiStateServiceImpl(
         @Lazy final ApiSearchService apiSearchService,
@@ -118,7 +120,8 @@ public class ApiStateServiceImpl implements ApiStateService {
         final ApiConverter apiConverter,
         final SynchronizationService synchronizationService,
         final EventManager eventManager,
-        final SearchEngineService searchEngineService
+        final SearchEngineService searchEngineService,
+        @Lazy final ValidateApiClusterBindingService validateApiClusterBindingService
     ) {
         this.apiSearchService = apiSearchService;
         this.apiRepository = apiRepository;
@@ -137,6 +140,7 @@ public class ApiStateServiceImpl implements ApiStateService {
         this.synchronizationService = synchronizationService;
         this.eventManager = eventManager;
         this.searchEngineService = searchEngineService;
+        this.validateApiClusterBindingService = validateApiClusterBindingService;
     }
 
     @Override
@@ -180,6 +184,13 @@ public class ApiStateServiceImpl implements ApiStateService {
                 "The api {" + apiToDeploy.getId() + "} can not be deployed without at least one published plan"
             );
         }
+
+        validateApiClusterBindingService.validateDeployable(
+            apiToDeploy.getId(),
+            apiToDeploy.getEnvironmentId(),
+            apiToDeploy.getType(),
+            apiToDeploy.getDefinition()
+        );
 
         // FIXME: improvement: what about updating deployedAt only when the user trigger it manually ?
         this.updateDeploymentDate(apiFromDb);
@@ -369,6 +380,15 @@ public class ApiStateServiceImpl implements ApiStateService {
         Optional<Api> optApi = apiRepository.findById(apiId);
         if (optApi.isPresent()) {
             Api api = optApi.get();
+
+            if (lifecycleState == LifecycleState.STARTED) {
+                validateApiClusterBindingService.validateDeployable(
+                    api.getId(),
+                    api.getEnvironmentId(),
+                    api.getType(),
+                    api.getDefinition()
+                );
+            }
 
             Api previousApi = new Api(api);
             api.setUpdatedAt(new Date());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApiFixtures.java
@@ -480,4 +480,47 @@ public class ApiFixtures {
             )
             .build();
     }
+
+    /**
+     * A V4 native (Kafka) API whose single endpoint binds a virtual cluster through a
+     * {@code native-kafka-virtual-cluster} endpoint ({@code configuration.virtualClusterCrossId}).
+     */
+    public static Api aNativeApiBoundToVirtualCluster(
+        String id,
+        String environmentId,
+        Api.LifecycleState lifecycleState,
+        String virtualClusterCrossId
+    ) {
+        return aNativeApi()
+            .toBuilder()
+            .id(id)
+            .name(id)
+            .environmentId(environmentId)
+            .lifecycleState(lifecycleState)
+            .apiDefinitionValue(
+                NativeApi.builder()
+                    .id(id)
+                    .name(id)
+                    .type(ApiType.NATIVE)
+                    .endpointGroups(
+                        List.of(
+                            NativeEndpointGroup.builder()
+                                .name("default-group")
+                                .type("native-kafka")
+                                .endpoints(
+                                    List.of(
+                                        NativeEndpoint.builder()
+                                            .name("default-endpoint")
+                                            .type("native-kafka-virtual-cluster")
+                                            .configuration("{\"virtualClusterCrossId\":\"" + virtualClusterCrossId + "\"}")
+                                            .build()
+                                    )
+                                )
+                                .build()
+                        )
+                    )
+                    .build()
+            )
+            .build();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -608,4 +608,9 @@ public class InMemoryConfiguration {
     public ClusterQueryServiceInMemory clusterQueryService() {
         return new ClusterQueryServiceInMemory();
     }
+
+    @Bean
+    public ClusterCrudServiceInMemory clusterCrudService() {
+        return new ClusterCrudServiceInMemory();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/ValidateApiClusterBindingServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/ValidateApiClusterBindingServiceTest.java
@@ -75,6 +75,16 @@ class ValidateApiClusterBindingServiceTest {
     }
 
     @Test
+    void should_pass_when_bound_virtual_cluster_is_pending() {
+        // PENDING = deployed at the gateway with not-yet-redeployed edits, so still a valid target.
+        clusterQueryService.initWith(List.of(virtualCluster(ClusterLifecycleState.PENDING)));
+
+        assertThatCode(() ->
+            service.validateDeployable("api-1", ENV_ID, ApiType.NATIVE, boundDefinition(VC_CROSS_ID))
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
     void should_be_noop_for_non_native_api() {
         assertThatCode(() ->
             service.validateDeployable("api-1", ENV_ID, ApiType.PROXY, boundDefinition(VC_CROSS_ID))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/ValidateApiClusterBindingServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/ValidateApiClusterBindingServiceTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.cluster.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inmemory.ClusterQueryServiceInMemory;
+import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.apim.core.cluster.model.ClusterLifecycleState;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.cluster.ClusterType;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
+import io.gravitee.rest.api.service.exceptions.ApiNotDeployableException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ValidateApiClusterBindingServiceTest {
+
+    private static final String ENV_ID = "env-id";
+    private static final String VC_CROSS_ID = "mesh";
+
+    private final ClusterQueryServiceInMemory clusterQueryService = new ClusterQueryServiceInMemory();
+    private final ObjectMapper objectMapper = new GraviteeMapper();
+
+    private ValidateApiClusterBindingService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ValidateApiClusterBindingService(clusterQueryService, objectMapper);
+        clusterQueryService.reset();
+    }
+
+    @Test
+    void should_throw_when_bound_virtual_cluster_is_missing() {
+        assertThatThrownBy(() -> service.validateDeployable("api-1", ENV_ID, ApiType.NATIVE, boundDefinition(VC_CROSS_ID)))
+            .isInstanceOf(ApiNotDeployableException.class)
+            .hasMessageContaining(VC_CROSS_ID);
+    }
+
+    @Test
+    void should_throw_when_bound_virtual_cluster_is_not_deployed() {
+        clusterQueryService.initWith(List.of(virtualCluster(ClusterLifecycleState.UNDEPLOYED)));
+
+        assertThatThrownBy(() -> service.validateDeployable("api-1", ENV_ID, ApiType.NATIVE, boundDefinition(VC_CROSS_ID))).isInstanceOf(
+            ApiNotDeployableException.class
+        );
+    }
+
+    @Test
+    void should_pass_when_bound_virtual_cluster_is_deployed() {
+        clusterQueryService.initWith(List.of(virtualCluster(ClusterLifecycleState.DEPLOYED)));
+
+        assertThatCode(() ->
+            service.validateDeployable("api-1", ENV_ID, ApiType.NATIVE, boundDefinition(VC_CROSS_ID))
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_be_noop_for_non_native_api() {
+        assertThatCode(() ->
+            service.validateDeployable("api-1", ENV_ID, ApiType.PROXY, boundDefinition(VC_CROSS_ID))
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_be_noop_when_api_is_not_bound_to_a_virtual_cluster() throws Exception {
+        String definition = objectMapper.writeValueAsString(
+            NativeApi.builder()
+                .endpointGroups(
+                    List.of(
+                        NativeEndpointGroup.builder()
+                            .endpoints(List.of(NativeEndpoint.builder().type("mock").configuration("{}").build()))
+                            .build()
+                    )
+                )
+                .build()
+        );
+
+        assertThatCode(() -> service.validateDeployable("api-1", ENV_ID, ApiType.NATIVE, definition)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_be_noop_for_null_and_malformed_definition() {
+        assertThatCode(() -> service.validateDeployable("api-1", ENV_ID, ApiType.NATIVE, null)).doesNotThrowAnyException();
+        assertThatCode(() -> service.validateDeployable("api-1", ENV_ID, ApiType.NATIVE, "{ not-json")).doesNotThrowAnyException();
+    }
+
+    private Cluster virtualCluster(ClusterLifecycleState lifecycleState) {
+        return Cluster.builder()
+            .id("cluster-id")
+            .crossId(VC_CROSS_ID)
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("Mesh")
+            .environmentId(ENV_ID)
+            .lifecycleState(lifecycleState)
+            .build();
+    }
+
+    private String boundDefinition(String vcCrossId) {
+        try {
+            return objectMapper.writeValueAsString(
+                NativeApi.builder()
+                    .endpointGroups(
+                        List.of(
+                            NativeEndpointGroup.builder()
+                                .endpoints(
+                                    List.of(
+                                        NativeEndpoint.builder()
+                                            .type("native-kafka-virtual-cluster")
+                                            .configuration("{\"virtualClusterCrossId\":\"" + vcCrossId + "\"}")
+                                            .build()
+                                    )
+                                )
+                                .build()
+                        )
+                    )
+                    .build()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/VirtualClusterBoundApisQueryServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/VirtualClusterBoundApisQueryServiceTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.cluster.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.core.model.ApiFixtures;
+import inmemory.ApiQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class VirtualClusterBoundApisQueryServiceTest {
+
+    private static final String ENV_ID = "env-id";
+    private static final String OTHER_ENV_ID = "other-env-id";
+    private static final String VC_CROSS_ID = "mesh";
+    private static final String VC_ENDPOINT_TYPE = "native-kafka-virtual-cluster";
+
+    private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private VirtualClusterBoundApisQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new VirtualClusterBoundApisQueryService(apiQueryService, objectMapper);
+    }
+
+    @Test
+    void should_return_started_native_apis_bound_to_the_virtual_cluster() {
+        apiQueryService.initWith(
+            List.of(
+                boundNativeApi("started-bound", ENV_ID, Api.LifecycleState.STARTED, VC_ENDPOINT_TYPE, vcConfig(VC_CROSS_ID)),
+                boundNativeApi("stopped-bound", ENV_ID, Api.LifecycleState.STOPPED, VC_ENDPOINT_TYPE, vcConfig(VC_CROSS_ID)),
+                boundNativeApi("started-other-vc", ENV_ID, Api.LifecycleState.STARTED, VC_ENDPOINT_TYPE, vcConfig("other-vc")),
+                // managed-cluster binding must be ignored: endpoint type is not the virtual-cluster one
+                boundNativeApi(
+                    "started-managed-cluster",
+                    ENV_ID,
+                    Api.LifecycleState.STARTED,
+                    "native-kafka-cluster",
+                    "{\"clusterCrossId\":\"mesh\"}"
+                ),
+                boundNativeApi("started-other-env", OTHER_ENV_ID, Api.LifecycleState.STARTED, VC_ENDPOINT_TYPE, vcConfig(VC_CROSS_ID)),
+                startedProxyApi("started-non-native")
+            )
+        );
+
+        var result = service.findStartedBoundApis(ENV_ID, VC_CROSS_ID);
+
+        assertThat(result).extracting(Api::getId).containsExactly("started-bound");
+    }
+
+    @Test
+    void should_return_empty_when_no_started_api_is_bound() {
+        apiQueryService.initWith(
+            List.of(boundNativeApi("stopped-bound", ENV_ID, Api.LifecycleState.STOPPED, VC_ENDPOINT_TYPE, vcConfig(VC_CROSS_ID)))
+        );
+
+        assertThat(service.findStartedBoundApis(ENV_ID, VC_CROSS_ID)).isEmpty();
+    }
+
+    @Test
+    void should_tolerate_malformed_endpoint_configuration_without_throwing() {
+        apiQueryService.initWith(
+            List.of(boundNativeApi("started-malformed", ENV_ID, Api.LifecycleState.STARTED, VC_ENDPOINT_TYPE, "{ not-json"))
+        );
+
+        assertThatCode(() -> assertThat(service.findStartedBoundApis(ENV_ID, VC_CROSS_ID)).isEmpty()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_return_empty_for_null_cross_id() {
+        apiQueryService.initWith(
+            List.of(boundNativeApi("started-bound", ENV_ID, Api.LifecycleState.STARTED, VC_ENDPOINT_TYPE, vcConfig(VC_CROSS_ID)))
+        );
+
+        assertThat(service.findStartedBoundApis(ENV_ID, null)).isEmpty();
+    }
+
+    private static String vcConfig(String crossId) {
+        return "{\"virtualClusterCrossId\":\"" + crossId + "\"}";
+    }
+
+    private static Api boundNativeApi(
+        String id,
+        String environmentId,
+        Api.LifecycleState state,
+        String endpointType,
+        String endpointConfiguration
+    ) {
+        return ApiFixtures.aNativeApi()
+            .toBuilder()
+            .id(id)
+            .environmentId(environmentId)
+            .lifecycleState(state)
+            .apiDefinitionValue(
+                NativeApi.builder()
+                    .id(id)
+                    .name(id)
+                    .type(ApiType.NATIVE)
+                    .endpointGroups(
+                        List.of(
+                            NativeEndpointGroup.builder()
+                                .name("default-group")
+                                .type("native-kafka")
+                                .endpoints(
+                                    List.of(
+                                        NativeEndpoint.builder()
+                                            .name("default-endpoint")
+                                            .type(endpointType)
+                                            .configuration(endpointConfiguration)
+                                            .build()
+                                    )
+                                )
+                                .build()
+                        )
+                    )
+                    .build()
+            )
+            .build();
+    }
+
+    private static Api startedProxyApi(String id) {
+        return ApiFixtures.aProxyApiV4().toBuilder().id(id).environmentId(ENV_ID).lifecycleState(Api.LifecycleState.STARTED).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/DeployClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/DeployClusterUseCaseTest.java
@@ -174,6 +174,24 @@ class DeployClusterUseCaseTest {
     }
 
     @Test
+    void should_throw_when_deploying_virtual_cluster_with_null_configuration() {
+        Cluster existing = Cluster.builder()
+            .id(CLUSTER_ID)
+            .crossId(CLUSTER_CROSS_ID)
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("My Virtual Cluster")
+            .environmentId(ENV_ID)
+            .organizationId(ORG_ID)
+            .lifecycleState(ClusterLifecycleState.UNDEPLOYED)
+            .build();
+        clusterCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() -> useCase.execute(new DeployClusterUseCase.Input(CLUSTER_ID, AUDIT_INFO)))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("without at least one backend");
+    }
+
+    @Test
     void should_publish_deploy_event() {
         Cluster existing = Cluster.builder()
             .id(CLUSTER_ID)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/DeployClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/DeployClusterUseCaseTest.java
@@ -17,7 +17,9 @@ package io.gravitee.apim.core.cluster.use_case;
 
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.ClusterCrudServiceInMemory;
 import inmemory.EventCrudInMemory;
@@ -34,6 +36,7 @@ import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.cluster.ClusterType;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -81,7 +84,13 @@ class DeployClusterUseCaseTest {
     @BeforeEach
     void setUp() {
         var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
-        useCase = new DeployClusterUseCase(clusterCrudService, eventCrudInMemory, eventLatestCrudInMemory, auditService);
+        useCase = new DeployClusterUseCase(
+            clusterCrudService,
+            eventCrudInMemory,
+            eventLatestCrudInMemory,
+            auditService,
+            new ObjectMapper()
+        );
     }
 
     @Test
@@ -123,6 +132,45 @@ class DeployClusterUseCaseTest {
         var output = useCase.execute(new DeployClusterUseCase.Input(CLUSTER_ID, AUDIT_INFO));
 
         assertThat(output.cluster().getVersion()).isEqualTo(3);
+    }
+
+    @Test
+    void should_deploy_virtual_cluster_with_backends() {
+        Cluster existing = Cluster.builder()
+            .id(CLUSTER_ID)
+            .crossId(CLUSTER_CROSS_ID)
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("My Virtual Cluster")
+            .environmentId(ENV_ID)
+            .organizationId(ORG_ID)
+            .lifecycleState(ClusterLifecycleState.UNDEPLOYED)
+            .configuration(Map.of("backends", List.of(Map.of("clusterCrossId", "kafka-1", "connectionCrossId", "conn-1"))))
+            .build();
+        clusterCrudService.initWith(List.of(existing));
+
+        var output = useCase.execute(new DeployClusterUseCase.Input(CLUSTER_ID, AUDIT_INFO));
+
+        assertThat(output.cluster().getLifecycleState()).isEqualTo(ClusterLifecycleState.DEPLOYED);
+        assertThat(output.cluster().getVersion()).isEqualTo(1);
+    }
+
+    @Test
+    void should_throw_when_deploying_virtual_cluster_without_backends() {
+        Cluster existing = Cluster.builder()
+            .id(CLUSTER_ID)
+            .crossId(CLUSTER_CROSS_ID)
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("My Virtual Cluster")
+            .environmentId(ENV_ID)
+            .organizationId(ORG_ID)
+            .lifecycleState(ClusterLifecycleState.UNDEPLOYED)
+            .configuration(Map.of("backends", List.of()))
+            .build();
+        clusterCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() -> useCase.execute(new DeployClusterUseCase.Input(CLUSTER_ID, AUDIT_INFO)))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("without at least one backend");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/UndeployClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/UndeployClusterUseCaseTest.java
@@ -17,15 +17,22 @@ package io.gravitee.apim.core.cluster.use_case;
 
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.core.model.ApiFixtures;
+import inmemory.ApiQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.ClusterCrudServiceInMemory;
 import inmemory.EventCrudInMemory;
 import inmemory.EventLatestCrudInMemory;
 import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.cluster.domain_service.UndeployClusterDomainService;
+import io.gravitee.apim.core.cluster.domain_service.VirtualClusterBoundApisQueryService;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterLifecycleState;
 import io.gravitee.apim.core.event.model.Event;
@@ -34,6 +41,7 @@ import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.cluster.ClusterType;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -63,6 +71,8 @@ class UndeployClusterUseCaseTest {
     private final EventLatestCrudInMemory eventLatestCrudInMemory = new EventLatestCrudInMemory();
     private final AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
     private final UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+    private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private UndeployClusterUseCase useCase;
 
@@ -81,7 +91,15 @@ class UndeployClusterUseCaseTest {
     @BeforeEach
     void setUp() {
         var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
-        useCase = new UndeployClusterUseCase(clusterCrudService, eventCrudInMemory, eventLatestCrudInMemory, auditService);
+        var undeployClusterDomainService = new UndeployClusterDomainService(
+            clusterCrudService,
+            eventCrudInMemory,
+            eventLatestCrudInMemory,
+            auditService
+        );
+        var virtualClusterBoundApisQueryService = new VirtualClusterBoundApisQueryService(apiQueryService, objectMapper);
+        apiQueryService.reset();
+        useCase = new UndeployClusterUseCase(clusterCrudService, undeployClusterDomainService, virtualClusterBoundApisQueryService);
     }
 
     @Test
@@ -149,5 +167,57 @@ class UndeployClusterUseCaseTest {
 
         assertThat(auditCrudService.storage()).hasSize(1);
         assertThat(auditCrudService.storage().get(0).getEvent()).isEqualTo("CLUSTER_UNDEPLOYED");
+    }
+
+    @Test
+    void should_undeploy_virtual_cluster_when_no_started_bound_api() {
+        Cluster existing = Cluster.builder()
+            .id(CLUSTER_ID)
+            .crossId(CLUSTER_CROSS_ID)
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("My Virtual Cluster")
+            .environmentId(ENV_ID)
+            .organizationId(ORG_ID)
+            .lifecycleState(ClusterLifecycleState.DEPLOYED)
+            .version(1)
+            .configuration(Map.of("backends", List.of()))
+            .build();
+        clusterCrudService.initWith(List.of(existing));
+        // A stopped API bound to the same virtual cluster must not block the undeploy.
+        apiQueryService.initWith(
+            List.of(ApiFixtures.aNativeApiBoundToVirtualCluster("stopped-api", ENV_ID, Api.LifecycleState.STOPPED, CLUSTER_CROSS_ID))
+        );
+
+        var output = useCase.execute(new UndeployClusterUseCase.Input(CLUSTER_ID, AUDIT_INFO));
+
+        assertThat(output.cluster().getLifecycleState()).isEqualTo(ClusterLifecycleState.UNDEPLOYED);
+    }
+
+    @Test
+    void should_throw_when_undeploying_virtual_cluster_with_started_bound_apis() {
+        Cluster existing = Cluster.builder()
+            .id(CLUSTER_ID)
+            .crossId(CLUSTER_CROSS_ID)
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("My Virtual Cluster")
+            .environmentId(ENV_ID)
+            .organizationId(ORG_ID)
+            .lifecycleState(ClusterLifecycleState.DEPLOYED)
+            .version(1)
+            .configuration(Map.of("backends", List.of()))
+            .build();
+        clusterCrudService.initWith(List.of(existing));
+        apiQueryService.initWith(
+            List.of(ApiFixtures.aNativeApiBoundToVirtualCluster("started-api", ENV_ID, Api.LifecycleState.STARTED, CLUSTER_CROSS_ID))
+        );
+
+        assertThatThrownBy(() -> useCase.execute(new UndeployClusterUseCase.Input(CLUSTER_ID, AUDIT_INFO)))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("Cannot undeploy virtual cluster")
+            .hasMessageContaining("started-api");
+
+        // The block must have no side effect: the cluster stays deployed and no undeploy event is emitted.
+        assertThat(clusterCrudService.storage().get(0).getLifecycleState()).isEqualTo(ClusterLifecycleState.DEPLOYED);
+        assertThat(eventCrudInMemory.storage()).isEmpty();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCaseTest.java
@@ -272,6 +272,17 @@ class UpdateClusterUseCaseTest extends AbstractUseCaseTest {
     }
 
     @Test
+    void should_undeploy_pending_virtual_cluster_when_removing_all_backends() {
+        seedVirtualCluster(ClusterLifecycleState.PENDING, backends("kafka-1", "conn-1"));
+
+        var toUpdate = UpdateCluster.builder().configuration(Map.of("backends", List.of())).build();
+
+        var output = updateClusterUseCase.execute(new UpdateClusterUseCase.Input(GENERATED_UUID, toUpdate, AUDIT_INFO));
+
+        assertThat(output.cluster().getLifecycleState()).isEqualTo(ClusterLifecycleState.UNDEPLOYED);
+    }
+
+    @Test
     void should_keep_pending_flow_when_backends_are_kept() {
         seedVirtualCluster(ClusterLifecycleState.DEPLOYED, backends("kafka-1", "conn-1"));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCaseTest.java
@@ -16,30 +16,44 @@
 package io.gravitee.apim.core.cluster.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.core.model.ApiFixtures;
 import inmemory.AbstractUseCaseTest;
+import inmemory.ApiQueryServiceInMemory;
 import inmemory.ClusterCrudServiceInMemory;
 import inmemory.ClusterQueryServiceInMemory;
+import inmemory.EventCrudInMemory;
+import inmemory.EventLatestCrudInMemory;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
 import io.gravitee.apim.core.cluster.domain_service.ClusterConfigurationSchemaService;
+import io.gravitee.apim.core.cluster.domain_service.UndeployClusterDomainService;
 import io.gravitee.apim.core.cluster.domain_service.ValidateClusterService;
+import io.gravitee.apim.core.cluster.domain_service.VirtualClusterBoundApisQueryService;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterAuditEvent;
+import io.gravitee.apim.core.cluster.model.ClusterLifecycleState;
 import io.gravitee.apim.core.cluster.model.UpdateCluster;
 import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
 import io.gravitee.apim.infra.json.JsonSchemaCheckerImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.definition.model.cluster.ClusterType;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.json.validation.JsonSchemaValidatorImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.impl.JsonSchemaServiceImpl;
 import java.time.ZoneId;
 import java.util.List;
@@ -54,6 +68,9 @@ class UpdateClusterUseCaseTest extends AbstractUseCaseTest {
     private final ClusterQueryServiceInMemory clusterQueryService = new ClusterQueryServiceInMemory();
     private final PermissionDomainService permissionDomainService = mock(PermissionDomainService.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory();
+    private final EventCrudInMemory eventCrudInMemory = new EventCrudInMemory();
+    private final EventLatestCrudInMemory eventLatestCrudInMemory = new EventLatestCrudInMemory();
     private Cluster existingCluster;
 
     @BeforeEach
@@ -67,14 +84,24 @@ class UpdateClusterUseCaseTest extends AbstractUseCaseTest {
             clusterQueryService
         );
         var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
+        var undeployClusterDomainService = new UndeployClusterDomainService(
+            clusterCrudService,
+            eventCrudInMemory,
+            eventLatestCrudInMemory,
+            auditService
+        );
+        var virtualClusterBoundApisQueryService = new VirtualClusterBoundApisQueryService(apiQueryService, objectMapper);
         updateClusterUseCase = new UpdateClusterUseCase(
             clusterCrudService,
             validateClusterService,
             auditService,
             permissionDomainService,
-            objectMapper
+            objectMapper,
+            undeployClusterDomainService,
+            virtualClusterBoundApisQueryService
         );
         clusterQueryService.reset();
+        apiQueryService.reset();
 
         existingCluster = Cluster.builder()
             .id(GENERATED_UUID)
@@ -211,5 +238,79 @@ class UpdateClusterUseCaseTest extends AbstractUseCaseTest {
 
         // Then
         assertThat(updatedCluster.cluster().getConfiguration()).isEqualTo(existingCluster.getConfiguration());
+    }
+
+    @Test
+    void should_undeploy_virtual_cluster_when_removing_all_backends_and_no_started_api() {
+        seedVirtualCluster(ClusterLifecycleState.DEPLOYED, backends("kafka-1", "conn-1"));
+
+        var toUpdate = UpdateCluster.builder().configuration(Map.of("backends", List.of())).build();
+
+        var output = updateClusterUseCase.execute(new UpdateClusterUseCase.Input(GENERATED_UUID, toUpdate, AUDIT_INFO));
+
+        assertThat(output.cluster().getLifecycleState()).isEqualTo(ClusterLifecycleState.UNDEPLOYED);
+    }
+
+    @Test
+    void should_throw_when_removing_all_backends_of_virtual_cluster_with_started_bound_apis() {
+        seedVirtualCluster(ClusterLifecycleState.DEPLOYED, backends("kafka-1", "conn-1"));
+        apiQueryService.initWith(
+            List.of(ApiFixtures.aNativeApiBoundToVirtualCluster("started-api", ENV_ID, Api.LifecycleState.STARTED, "mesh"))
+        );
+
+        var toUpdate = UpdateCluster.builder().configuration(Map.of("backends", List.of())).build();
+
+        assertThatThrownBy(() -> updateClusterUseCase.execute(new UpdateClusterUseCase.Input(GENERATED_UUID, toUpdate, AUDIT_INFO)))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("Cannot remove all backends")
+            .hasMessageContaining("started-api");
+
+        // No undeploy side effect: the cluster remains deployed.
+        assertThat(((ClusterCrudServiceInMemory) clusterCrudService).storage().get(0).getLifecycleState()).isEqualTo(
+            ClusterLifecycleState.DEPLOYED
+        );
+    }
+
+    @Test
+    void should_keep_pending_flow_when_backends_are_kept() {
+        seedVirtualCluster(ClusterLifecycleState.DEPLOYED, backends("kafka-1", "conn-1"));
+
+        var toUpdate = UpdateCluster.builder().configuration(backends("kafka-2", "conn-2")).build();
+
+        var output = updateClusterUseCase.execute(new UpdateClusterUseCase.Input(GENERATED_UUID, toUpdate, AUDIT_INFO));
+
+        assertThat(output.cluster().getLifecycleState()).isEqualTo(ClusterLifecycleState.PENDING);
+    }
+
+    @Test
+    void should_not_undeploy_already_undeployed_virtual_cluster_when_emptying_backends() {
+        seedVirtualCluster(ClusterLifecycleState.UNDEPLOYED, backends("kafka-1", "conn-1"));
+
+        var toUpdate = UpdateCluster.builder().configuration(Map.of("backends", List.of())).build();
+
+        var output = updateClusterUseCase.execute(new UpdateClusterUseCase.Input(GENERATED_UUID, toUpdate, AUDIT_INFO));
+
+        assertThat(output.cluster().getLifecycleState()).isEqualTo(ClusterLifecycleState.UNDEPLOYED);
+        // The plain update path ran: no UNDEPLOY_CLUSTER event was emitted.
+        assertThat(eventCrudInMemory.storage()).isEmpty();
+    }
+
+    private void seedVirtualCluster(ClusterLifecycleState lifecycleState, Object configuration) {
+        Cluster virtualCluster = Cluster.builder()
+            .id(GENERATED_UUID)
+            .crossId("mesh")
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("My Virtual Cluster")
+            .environmentId(ENV_ID)
+            .organizationId(ORG_ID)
+            .lifecycleState(lifecycleState)
+            .version(1)
+            .configuration(configuration)
+            .build();
+        ((ClusterCrudServiceInMemory) clusterCrudService).initWith(List.of(virtualCluster));
+    }
+
+    private static Map<String, Object> backends(String clusterCrossId, String connectionCrossId) {
+        return Map.of("backends", List.of(Map.of("clusterCrossId", clusterCrossId, "connectionCrossId", connectionCrossId)));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -409,7 +409,8 @@ public class ApiServiceImplTest {
             apiConverter,
             synchronizationService,
             eventManager,
-            searchEngineService
+            searchEngineService,
+            mock(io.gravitee.apim.core.cluster.domain_service.ValidateApiClusterBindingService.class)
         );
         //        when(virtualHostService.sanitizeAndValidate(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
         reset(searchEngineService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.cluster.domain_service.ValidateApiClusterBindingService;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.DefinitionVersion;
@@ -145,6 +147,9 @@ public class ApiStateServiceImplTest {
     private ApiValidationService apiValidationService;
 
     @Mock
+    private ValidateApiClusterBindingService validateApiClusterBindingService;
+
+    @Mock
     private ApiConverter apiConverter;
 
     @Mock
@@ -206,7 +211,8 @@ public class ApiStateServiceImplTest {
             apiConverter,
             synchronizationService,
             eventManager,
-            searchEngineService
+            searchEngineService,
+            validateApiClusterBindingService
         );
         reset(searchEngineService);
         UserEntity admin = new UserEntity();
@@ -233,6 +239,23 @@ public class ApiStateServiceImplTest {
         assertThatExceptionOfType(ApiNotDeployableException.class).isThrownBy(() ->
             apiStateService.start(executionContext, API_ID, USER_NAME)
         );
+    }
+
+    @Test
+    public void shouldThrowWhenBoundVirtualClusterIsNotDeployedOnStart() throws TechnicalException {
+        api = new Api();
+        when(apiValidationService.canDeploy(executionContext, API_ID)).thenReturn(true);
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
+        doThrow(new ApiNotDeployableException("virtual cluster not deployed"))
+            .when(validateApiClusterBindingService)
+            .validateDeployable(any(), any(), any(), any());
+
+        assertThatExceptionOfType(ApiNotDeployableException.class).isThrownBy(() ->
+            apiStateService.start(executionContext, API_ID, USER_NAME)
+        );
+
+        // The guard runs before the lifecycle is persisted.
+        verify(apiRepository, never()).update(any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_DeployTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_DeployTest.java
@@ -195,7 +195,8 @@ public class ApiStateServiceImpl_DeployTest {
             apiConverter,
             synchronizationService,
             eventManager,
-            searchEngineService
+            searchEngineService,
+            mock(io.gravitee.apim.core.cluster.domain_service.ValidateApiClusterBindingService.class)
         );
         reset(searchEngineService);
         UserEntity admin = new UserEntity();
@@ -335,6 +336,7 @@ public class ApiStateServiceImpl_DeployTest {
             null,
             null,
             eventLatestRepository,
+            null,
             null,
             null,
             null,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_DeployTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_DeployTest.java
@@ -147,6 +147,10 @@ public class ApiStateServiceImpl_DeployTest {
     @InjectMocks
     private SynchronizationService synchronizationService = Mockito.spy(new SynchronizationService(this.objectMapper));
 
+    private final io.gravitee.apim.core.cluster.domain_service.ValidateApiClusterBindingService validateApiClusterBindingService = mock(
+        io.gravitee.apim.core.cluster.domain_service.ValidateApiClusterBindingService.class
+    );
+
     private Api api;
     private Api updatedApi;
     private ApiStateService apiStateService;
@@ -196,9 +200,9 @@ public class ApiStateServiceImpl_DeployTest {
             synchronizationService,
             eventManager,
             searchEngineService,
-            mock(io.gravitee.apim.core.cluster.domain_service.ValidateApiClusterBindingService.class)
+            validateApiClusterBindingService
         );
-        reset(searchEngineService);
+        reset(searchEngineService, validateApiClusterBindingService);
         UserEntity admin = new UserEntity();
         admin.setId(USER_NAME);
 
@@ -258,6 +262,21 @@ public class ApiStateServiceImpl_DeployTest {
         when(apiValidationService.canDeploy(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(false);
         when(apiSearchService.findRepositoryApiById(any(), eq(API_ID))).thenReturn(api);
         apiStateService.deploy(GraviteeContext.getExecutionContext(), API_ID, "some-user", new ApiDeploymentEntity());
+    }
+
+    @Test(expected = ApiNotDeployableException.class)
+    public void should_not_deploy_when_bound_virtual_cluster_is_not_deployed() throws TechnicalException {
+        when(apiValidationService.canDeploy(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(true);
+        when(apiSearchService.findRepositoryApiById(any(), eq(API_ID))).thenReturn(api);
+        doThrow(new ApiNotDeployableException("bound virtual cluster is not deployed"))
+            .when(validateApiClusterBindingService)
+            .validateDeployable(eq(API_ID), any(), any(), any());
+
+        try {
+            apiStateService.deploy(GraviteeContext.getExecutionContext(), API_ID, USER_NAME, new ApiDeploymentEntity());
+        } finally {
+            verify(apiRepository, never()).update(any());
+        }
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
@@ -203,7 +203,8 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
             apiConverter,
             synchronizationService,
             eventManager,
-            searchEngineService
+            searchEngineService,
+            mock(io.gravitee.apim.core.cluster.domain_service.ValidateApiClusterBindingService.class)
         );
         reset(searchEngineService);
     }


### PR DESCRIPTION
## Context

A Kafka Virtual Cluster (VC) could be deployed with an empty `backends` list, and its backends
could be emptied or the VC undeployed while Kafka Native APIs were still bound to it and running.
The client then connects successfully but gets an empty topic list, with nothing surfaced to the
operator.

## Approach — guards, not cascades

A started native API must never be left pointing at a backend-less / undeployed virtual cluster.
Rather than auto-stopping APIs, dangerous VC operations are **blocked** with a clear `400`.

| Rule | REST behaviour |
|------|----------------|
| A VC cannot be deployed with no backends | `POST /clusters/{id}/_deploy` → **400** |
| Undeploy, or emptying backends, is blocked while a **started** bound API exists | `POST /clusters/{id}/_undeploy` and `PUT /clusters/{id}` → **400** (message lists the APIs) |
| Emptying backends on a deployed VC with **no** started bound API auto-undeploys it | `PUT /clusters/{id}` → **200**, `lifecycleState = UNDEPLOYED` |
| Starting/deploying a native API bound to a not-deployed VC is blocked | `POST /apis/{id}/_start` and `/deployments` → **400** |

## Changes

- New `@DomainService`s (auto-wired via component scan, no Spring config changes):
  - `VirtualClusterBoundApisQueryService` — resolves started native APIs bound to a VC.
  - `UndeployClusterDomainService` — shared undeploy + event + audit, reused by the explicit
    undeploy and the auto-undeploy-on-empty path.
  - `ValidateApiClusterBindingService` — the start/deploy guard, called from `ApiStateServiceImpl`.
- Guards added to `DeployClusterUseCase`, `UndeployClusterUseCase`, `UpdateClusterUseCase`.
- API↔VC binding = native endpoint type `native-kafka-virtual-cluster`,
  `configuration.virtualClusterCrossId`.

## For the UI (Console / Gamma ESM) — separate repo

Backend-only PR. The lifecycle rules and expected UI behaviour are captured in the table above so a
UI-repo agent can implement matching guards/banners. UI checks are UX sugar; the backend 400s are
the source of truth.

## Testing

`mvn -pl gravitee-apim-rest-api/gravitee-apim-rest-api-service test` — the affected classes run
green (`Tests run: 120, Failures: 0, Errors: 0`), covering every rule above plus the unchanged
start/deploy paths. New unit tests: `VirtualClusterBoundApisQueryServiceTest`,
`ValidateApiClusterBindingServiceTest`, and additions to the three cluster use-case tests and
`ApiStateServiceImplTest`.

