### PR TITLE
feat(gamma-platform): add view plan security type catalog

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -57,6 +57,10 @@ jest.mock('../pages/RegisterApplicationPage', () => ({
     RegisterApplicationPage: () => <div data-testid="register-application-page" />,
 }));
 
+jest.mock('../features/plan-security-catalog/PlanSecurityCatalogPage', () => ({
+    PlanSecurityCatalogPage: () => <div data-testid="plan-security-catalog-page" />,
+}));
+
 jest.mock('../features/applications/components/detail', () => ({
     ApplicationDetailLayout: () => <div data-testid="application-detail-layout" />,
     ApplicationDetailIndexRedirect: () => null,
@@ -76,5 +80,15 @@ describe('AppRoutes', () => {
 
         expect(screen.getByTestId('platform-toaster')).not.toBeNull();
         expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('renders the plan security catalog route without a permission guard', () => {
+        render(
+            <MemoryRouter initialEntries={['/plan-security-catalog']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('plan-security-catalog-page')).not.toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -25,6 +25,7 @@ import { applicationDetailTabElement } from '../config/applicationDetailPages';
 import { NAV_GROUPS } from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
+import { PlanSecurityCatalogPage } from '../features/plan-security-catalog/PlanSecurityCatalogPage';
 import { AccessManagementPage } from '../pages/AccessManagementPage';
 import { ApplicationDetailSubscriptionPage } from '../pages/ApplicationDetailSubscriptionPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
@@ -109,6 +110,7 @@ export function AppRoutes() {
                         </Route>
                         <Route path="access-management" element={<AccessManagementPage />} />
                         <Route path="metadata" element={<MetadataGuard />} />
+                        <Route path="plan-security-catalog" element={<PlanSecurityCatalogPage />} />
                     </Route>
                 </Routes>
             </ConsoleSettingsProvider>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import type { NavGroup } from '@gravitee/graphene-core';
-import { AppWindowIcon, DatabaseIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
+import { AppWindowIcon, DatabaseIcon, KeyIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
 
 import { ROUTES } from './routes';
 
@@ -29,6 +29,9 @@ export const NAV_GROUPS: NavGroup[] = [
     },
     {
         label: 'System & Security',
-        items: [{ key: 'access-management', title: ROUTES['access-management'].label, icon: ShieldIcon }],
+        items: [
+            { key: 'access-management', title: ROUTES['access-management'].label, icon: ShieldIcon },
+            { key: 'plan-security-catalog', title: ROUTES['plan-security-catalog'].label, icon: KeyIcon },
+        ],
     },
 ];

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -15,7 +15,7 @@
  */
 import type { ModuleRouteConfig } from '@gravitee/gamma-modules-sdk/routing';
 
-export const ROUTE_KEYS: readonly string[] = ['applications', 'access-management', 'metadata'];
+export const ROUTE_KEYS: readonly string[] = ['applications', 'access-management', 'metadata', 'plan-security-catalog'];
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
 const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
@@ -24,6 +24,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     applications: { path: 'applications', label: 'Applications' },
     'access-management': { path: 'access-management', label: 'Access Management' },
     metadata: { path: 'metadata', label: 'Metadata' },
+    'plan-security-catalog': { path: 'plan-security-catalog', label: 'Plan Security Catalog' },
 };
 
 export const PLATFORM_ROUTE_CONFIG: ModuleRouteConfig<RouteKey> = {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/plan-security-catalog/PlanSecurityCatalogPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/plan-security-catalog/PlanSecurityCatalogPage.spec.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, within } from '@testing-library/react';
+
+import { PLAN_SECURITY_CATALOG } from './planSecurityCatalog';
+import { PlanSecurityCatalogPage } from './PlanSecurityCatalogPage';
+
+describe('PlanSecurityCatalogPage', () => {
+    beforeEach(() => {
+        render(<PlanSecurityCatalogPage />);
+    });
+
+    it('renders the page title and description', () => {
+        expect(screen.queryByText('Plan Security Type Catalog')).not.toBeNull();
+        expect(screen.queryByText('Reference catalog of available plan security types supported by the platform.')).not.toBeNull();
+    });
+
+    it('renders the section heading', () => {
+        expect(screen.queryByText('Security Types')).not.toBeNull();
+    });
+
+    it('renders column headers', () => {
+        expect(screen.queryByText('Security Type ID')).not.toBeNull();
+        expect(screen.queryByText('Name')).not.toBeNull();
+        expect(screen.queryByText('Policy Name')).not.toBeNull();
+    });
+
+    it('renders each catalog row with matching id, name, and policy name', () => {
+        const dataRows = screen.getAllByRole('row').slice(1);
+
+        expect(dataRows.length).toBe(PLAN_SECURITY_CATALOG.length);
+
+        PLAN_SECURITY_CATALOG.forEach((entry, index) => {
+            const cells = within(dataRows[index]).getAllByRole('cell');
+            expect(cells[0].textContent).toContain(entry.id);
+            expect(cells[1].textContent).toContain(entry.name);
+            expect(cells[2].textContent).toContain(entry.policyName);
+        });
+    });
+
+    it('includes the required catalog types from the specification', () => {
+        const ids = PLAN_SECURITY_CATALOG.map(entry => entry.id);
+        expect(ids).toContain('OAUTH2');
+        expect(ids).toContain('JWT');
+        expect(ids).toContain('API_KEY');
+        expect(ids).toContain('KEY_LESS');
+        expect(ids.length).toBe(4);
+    });
+
+    it('does not render any edit controls', () => {
+        expect(screen.queryByRole('button')).toBeNull();
+        expect(screen.queryByRole('switch')).toBeNull();
+        expect(screen.queryByText('Save changes')).toBeNull();
+        expect(screen.queryByText('Discard')).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/plan-security-catalog/PlanSecurityCatalogPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/plan-security-catalog/PlanSecurityCatalogPage.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DataTable } from '@gravitee/graphene-core';
+import { ShieldCheckIcon } from '@gravitee/graphene-core/icons';
+import type { ColumnDef } from '@tanstack/react-table';
+import { useMemo } from 'react';
+
+import { PLAN_SECURITY_CATALOG, type PlanSecurityType } from './planSecurityCatalog';
+
+export function PlanSecurityCatalogPage() {
+    const columns: ColumnDef<PlanSecurityType>[] = useMemo(
+        () => [
+            {
+                id: 'id',
+                accessorKey: 'id',
+                enableSorting: false,
+                header: () => <span className="text-sm font-medium text-muted-foreground">Security Type ID</span>,
+                cell: ({ row }) => <span className="font-mono text-xs">{row.original.id}</span>,
+            },
+            {
+                id: 'name',
+                accessorKey: 'name',
+                enableSorting: false,
+                header: () => <span className="text-sm font-medium text-muted-foreground">Name</span>,
+                cell: ({ row }) => <span className="text-sm font-medium">{row.original.name}</span>,
+            },
+            {
+                id: 'policyName',
+                accessorKey: 'policyName',
+                enableSorting: false,
+                header: () => <span className="text-sm font-medium text-muted-foreground">Policy Name</span>,
+                cell: ({ row }) => <span className="font-mono text-xs rounded bg-muted px-1.5 py-0.5">{row.original.policyName}</span>,
+            },
+        ],
+        [],
+    );
+
+    return (
+        <div className="space-y-6">
+            <div className="space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">Plan Security Type Catalog</h1>
+                <p className="text-sm text-muted-foreground">
+                    Reference catalog of available plan security types supported by the platform.
+                </p>
+            </div>
+
+            <div className="rounded-lg border">
+                <div className="flex items-center gap-2 border-b px-4 py-3">
+                    <ShieldCheckIcon className="size-5 text-muted-foreground" aria-hidden />
+                    <h2 className="text-base font-semibold">Security Types</h2>
+                </div>
+
+                <DataTable
+                    columns={columns}
+                    data={PLAN_SECURITY_CATALOG}
+                    emptyMessage="No security types available."
+                    className="**:data-[slot=table-cell]:py-3"
+                />
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/plan-security-catalog/planSecurityCatalog.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/plan-security-catalog/planSecurityCatalog.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface PlanSecurityType {
+    id: string;
+    name: string;
+    policyName: string;
+}
+
+export const PLAN_SECURITY_CATALOG: PlanSecurityType[] = [
+    { id: 'API_KEY', name: 'API Key', policyName: 'api-key' },
+    { id: 'OAUTH2', name: 'OAuth2', policyName: 'oauth2' },
+    { id: 'JWT', name: 'JWT', policyName: 'jwt' },
+    { id: 'KEY_LESS', name: 'Keyless', policyName: 'key-less' },
+];


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-49

## Description
This adds a read-only reference page where users can see which plan security types the platform supports, including their security type ID, display name, and policy name.

**What's included**
New Plan Security Catalog page under Platform → System & Security
Read-only table with columns:
Security Type ID
Name
Policy Name
Hardcoded catalog entries:
API Key (API_KEY / api-key)
OAuth2 (OAUTH2 / oauth2)
JWT (JWT / jwt)
Keyless (KEY_LESS / key-less)

<img width="1512" height="608" alt="image" src="https://github.com/user-attachments/assets/6f4070ce-b806-46e6-bf2f-d5f81038dcda" />