### PR TITLE
Perf/gateway subscription cache footprint

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -53,10 +53,9 @@ public class SubscriptionCacheService implements SubscriptionService {
     // Caches only contains active subscriptions
     private final Map<String, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
     private final Map<String, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
-    private final Map<String, Subscription> cacheBySubscriptionId = new ConcurrentHashMap<>();
-    // Exploded subscriptions. Values are immutable sets (almost always a singleton), replaced
-    // atomically via compute(): keeps the per-entry footprint minimal at multi-million-subscription
-    // scale and lets readers use them without defensive copies.
+    // Single by-id index, including exploded API-Product subscriptions. Values are immutable sets
+    // (almost always a singleton), replaced atomically via compute(): keeps the per-entry footprint
+    // minimal at multi-million-subscription scale and lets readers use them without defensive copies.
     private final Map<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
     private final Map<String, Set<String>> cacheKeysByApiId = new ConcurrentHashMap<>();
 
@@ -82,7 +81,13 @@ public class SubscriptionCacheService implements SubscriptionService {
 
     @Override
     public Optional<Subscription> getById(String subscriptionId) {
-        return Optional.ofNullable(cacheBySubscriptionId.get(subscriptionId));
+        // For exploded API-Product subscriptions this returns an arbitrary leg, which matches the
+        // historical behavior of the dedicated by-id map (last-registered/rehydrated leg).
+        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
+        if (subscriptions == null || subscriptions.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(subscriptions.iterator().next());
     }
 
     /**
@@ -164,15 +169,6 @@ public class SubscriptionCacheService implements SubscriptionService {
                 .collect(Collectors.toUnmodifiableSet());
             return remaining.isEmpty() ? null : remaining;
         });
-
-        // Only evict cacheBySubscriptionId when it points to this specific API. If sibling legs
-        // remain (exploded API-Product subscriptions), rehydrate from the authoritative set so
-        // getById() stays consistent with getAllById() regardless of unregistration order.
-        cacheBySubscriptionId.computeIfPresent(candidate.getId(), (k, existing) -> {
-            if (!Objects.equals(existing.getApi(), candidate.getApi())) return existing;
-            Set<Subscription> remaining = cacheBySubscriptionIdAll.get(candidate.getId());
-            return (remaining == null || remaining.isEmpty()) ? null : remaining.iterator().next();
-        });
     }
 
     @Override
@@ -190,7 +186,6 @@ public class SubscriptionCacheService implements SubscriptionService {
                         .collect(Collectors.toUnmodifiableSet());
                     return remaining.isEmpty() ? null : remaining;
                 });
-                cacheBySubscriptionId.remove(cacheKey);
                 cacheByApiClientId.remove(cacheKey);
                 cacheByClientCertificate.remove(cacheKey);
             });
@@ -209,8 +204,18 @@ public class SubscriptionCacheService implements SubscriptionService {
         // Ensure trust store is updated before cache to maintain certificate validation consistency
         subscriptionTrustStoreLoaderManager.registerSubscription(subscription, servers);
 
-        // keep the old one
-        Subscription cached = cacheBySubscriptionId.get(subscription.getId());
+        // keep the old same-API leg before the cache is updated (exploded API-Product
+        // subscriptions may carry sibling legs for other APIs, which must not be evicted here)
+        Subscription cached = null;
+        Set<Subscription> existingLegs = cacheBySubscriptionIdAll.get(subscription.getId());
+        if (existingLegs != null) {
+            for (Subscription existing : existingLegs) {
+                if (Objects.equals(subscription.getApi(), existing.getApi())) {
+                    cached = existing;
+                    break;
+                }
+            }
+        }
 
         // Update cache
         updateSubscriptionIdById(subscription);
@@ -277,7 +282,6 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private void updateSubscriptionIdById(Subscription subscription) {
-        cacheBySubscriptionId.put(subscription.getId(), subscription);
         cacheBySubscriptionIdAll.compute(subscription.getId(), (id, existing) -> {
             if (existing == null || existing.isEmpty()) {
                 return Set.of(subscription);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -51,13 +51,21 @@ public class SubscriptionCacheService implements SubscriptionService {
     private final ApiManager apiManager;
 
     // Caches only contains active subscriptions
-    private final Map<String, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
-    private final Map<String, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
+    private final Map<IdentityKey, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
+    private final Map<IdentityKey, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
     // Single by-id index, including exploded API-Product subscriptions. Values are immutable sets
     // (almost always a singleton), replaced atomically via compute(): keeps the per-entry footprint
     // minimal at multi-million-subscription scale and lets readers use them without defensive copies.
     private final Map<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
-    private final Map<String, Set<String>> cacheKeysByApiId = new ConcurrentHashMap<>();
+    // Holds subscription ids (String) and identity keys (IdentityKey) for per-API eviction
+    private final Map<String, Set<Object>> cacheKeysByApiId = new ConcurrentHashMap<>();
+
+    /**
+     * Identity-cache key referencing the subscription's own field strings instead of a formatted
+     * composite String: no per-key byte[] allocation (hundreds of MB at multi-million-subscription
+     * scale) and no String.format on the request hot path. A null plan is the plan-less variant.
+     */
+    private record IdentityKey(String api, String plan, String clientIdentity) {}
 
     @Override
     public Optional<Subscription> getByApiAndSecurityToken(String api, SecurityToken securityToken, String plan) {
@@ -176,16 +184,18 @@ public class SubscriptionCacheService implements SubscriptionService {
         log.debug("Unregistering all subscriptions for API [{}]", apiId);
         // Remove the whole entry first so no cacheKeysByApiId lock is held while updating the
         // other caches (unregister() acquires the same locks in the opposite order).
-        Set<String> subscriptionsByApi = cacheKeysByApiId.remove(apiId);
+        Set<Object> subscriptionsByApi = cacheKeysByApiId.remove(apiId);
         if (subscriptionsByApi != null) {
             subscriptionsByApi.forEach(cacheKey -> {
-                cacheBySubscriptionIdAll.computeIfPresent(cacheKey, (id, all) -> {
-                    Set<Subscription> remaining = all
-                        .stream()
-                        .filter(s -> !Objects.equals(apiId, s.getApi()))
-                        .collect(Collectors.toUnmodifiableSet());
-                    return remaining.isEmpty() ? null : remaining;
-                });
+                if (cacheKey instanceof String subscriptionId) {
+                    cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, all) -> {
+                        Set<Subscription> remaining = all
+                            .stream()
+                            .filter(s -> !Objects.equals(apiId, s.getApi()))
+                            .collect(Collectors.toUnmodifiableSet());
+                        return remaining.isEmpty() ? null : remaining;
+                    });
+                }
                 cacheByApiClientId.remove(cacheKey);
                 cacheByClientCertificate.remove(cacheKey);
             });
@@ -228,8 +238,8 @@ public class SubscriptionCacheService implements SubscriptionService {
             (!Objects.equals(subscription.getClientCertificate(), cached.getClientCertificate()) ||
                 !Objects.equals(subscription.getPlan(), cached.getPlan()))
         ) {
-            String cacheKey = identityCacheKey(cached);
-            String cacheKeyWithoutPlan = identityCacheKeyWithoutPlan(cached);
+            IdentityKey cacheKey = identityCacheKey(cached);
+            IdentityKey cacheKeyWithoutPlan = identityCacheKeyWithoutPlan(cached);
             evictKeyForApi(cached.getApi(), cacheKey);
             evictKeyForApi(cached.getApi(), cacheKeyWithoutPlan);
             cacheByClientCertificate.remove(cacheKey);
@@ -260,22 +270,22 @@ public class SubscriptionCacheService implements SubscriptionService {
         }
     }
 
-    private void updateIdentityCache(Subscription subscription, Map<String, Subscription> cache) {
+    private void updateIdentityCache(Subscription subscription, Map<IdentityKey, Subscription> cache) {
         updateCacheKeyByApiId(subscription.getApi(), subscription.getId());
-        String cacheKey = identityCacheKey(subscription);
+        IdentityKey cacheKey = identityCacheKey(subscription);
         updateCacheKeyByApiId(subscription.getApi(), cacheKey);
         cache.put(cacheKey, subscription);
         // Index the subscription without plan id to allow search without plan criteria.
-        String cacheKeyWithoutPlan = identityCacheKeyWithoutPlan(subscription);
+        IdentityKey cacheKeyWithoutPlan = identityCacheKeyWithoutPlan(subscription);
         cache.put(cacheKeyWithoutPlan, subscription);
         updateCacheKeyByApiId(subscription.getApi(), cacheKeyWithoutPlan);
     }
 
-    private void updateCacheKeyByApiId(final String apiId, final String cacheKey) {
+    private void updateCacheKeyByApiId(final String apiId, final Object cacheKey) {
         // compute() so concurrent register/unregister calls for the same API (sync appenders run
         // in parallel) cannot lose updates or mutate a plain HashSet across threads.
         cacheKeysByApiId.compute(apiId, (id, subscriptionsByApi) -> {
-            Set<String> keys = subscriptionsByApi != null ? subscriptionsByApi : ConcurrentHashMap.newKeySet();
+            Set<Object> keys = subscriptionsByApi != null ? subscriptionsByApi : ConcurrentHashMap.newKeySet();
             keys.add(cacheKey);
             return keys;
         });
@@ -310,18 +320,18 @@ public class SubscriptionCacheService implements SubscriptionService {
         }
     }
 
-    private void evictIdentityCache(Subscription subscription, Map<String, Subscription> cacheByApiClientId) {
-        final String identityCacheKey = identityCacheKey(subscription);
+    private void evictIdentityCache(Subscription subscription, Map<IdentityKey, Subscription> cacheByApiClientId) {
+        final IdentityKey identityCacheKey = identityCacheKey(subscription);
         if (cacheByApiClientId.remove(identityCacheKey) != null) {
             evictKeyForApi(subscription.getApi(), identityCacheKey);
         }
-        final String identityCacheKeyWithoutPlan = identityCacheKeyWithoutPlan(subscription);
+        final IdentityKey identityCacheKeyWithoutPlan = identityCacheKeyWithoutPlan(subscription);
         if (cacheByApiClientId.remove(identityCacheKeyWithoutPlan) != null) {
             evictKeyForApi(subscription.getApi(), identityCacheKeyWithoutPlan);
         }
     }
 
-    private void evictKeyForApi(final String apiId, final String cacheKey) {
+    private void evictKeyForApi(final String apiId, final Object cacheKey) {
         cacheKeysByApiId.computeIfPresent(apiId, (id, keysByApi) -> {
             keysByApi.remove(cacheKey);
             return keysByApi.isEmpty() ? null : keysByApi;
@@ -343,7 +353,7 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     // Visible for testing
-    Set<String> getByApiId(String apiId) {
+    Set<Object> getByApiId(String apiId) {
         return cacheKeysByApiId.getOrDefault(apiId, Collections.emptySet());
     }
 
@@ -363,7 +373,7 @@ public class SubscriptionCacheService implements SubscriptionService {
         return Optional.empty();
     }
 
-    private String identityCacheKey(Subscription subscription) {
+    private IdentityKey identityCacheKey(Subscription subscription) {
         if (subscription.getClientId() != null) {
             Objects.requireNonNull(subscription.getClientId(), "Client ID must not be null");
             return cacheKey(subscription.getApi(), subscription.getPlan(), subscription.getClientId());
@@ -373,7 +383,7 @@ public class SubscriptionCacheService implements SubscriptionService {
         }
     }
 
-    private String identityCacheKeyWithoutPlan(Subscription subscription) {
+    private IdentityKey identityCacheKeyWithoutPlan(Subscription subscription) {
         if (subscription.getClientId() != null) {
             Objects.requireNonNull(subscription.getClientId(), "Client ID must not be null");
             return cacheKey(subscription.getApi(), subscription.getClientId());
@@ -390,13 +400,13 @@ public class SubscriptionCacheService implements SubscriptionService {
         return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
     }
 
-    private String cacheKey(String api, String plan, String clientIdentity) {
+    private IdentityKey cacheKey(String api, String plan, String clientIdentity) {
         Objects.requireNonNull(plan, "Plan must not be null");
-        return String.format("%s.%s.%s", api, plan, clientIdentity);
+        return new IdentityKey(api, plan, clientIdentity);
     }
 
-    private String cacheKey(String api, String clientIdentity) {
-        return String.format("%s.%s", api, clientIdentity);
+    private IdentityKey cacheKey(String api, String clientIdentity) {
+        return new IdentityKey(api, null, clientIdentity);
     }
 
     private Set<String> extractApiServersId(Subscription subscription) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -171,6 +171,11 @@ public class SubscriptionCacheService implements SubscriptionService {
                 unregisterFromClientCertificate(candidate);
             }
 
+            // Singleton fast path: toEvict is non-empty, so the only element is being evicted
+            if (allSubscriptions.size() == 1) {
+                return null;
+            }
+
             Set<Subscription> remaining = allSubscriptions
                 .stream()
                 .filter(s -> !Objects.equals(candidate.getApi(), s.getApi()))
@@ -189,15 +194,21 @@ public class SubscriptionCacheService implements SubscriptionService {
             subscriptionsByApi.forEach(cacheKey -> {
                 if (cacheKey instanceof String subscriptionId) {
                     cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, all) -> {
+                        // Singleton fast path: most entries hold exactly one leg
+                        if (all.size() == 1) {
+                            return Objects.equals(apiId, all.iterator().next().getApi()) ? null : all;
+                        }
                         Set<Subscription> remaining = all
                             .stream()
                             .filter(s -> !Objects.equals(apiId, s.getApi()))
                             .collect(Collectors.toUnmodifiableSet());
                         return remaining.isEmpty() ? null : remaining;
                     });
+                } else {
+                    // Identity maps are keyed by IdentityKey only: removing a String key is a no-op
+                    cacheByApiClientId.remove(cacheKey);
+                    cacheByClientCertificate.remove(cacheKey);
                 }
-                cacheByApiClientId.remove(cacheKey);
-                cacheByClientCertificate.remove(cacheKey);
             });
         }
     }
@@ -295,6 +306,16 @@ public class SubscriptionCacheService implements SubscriptionService {
         cacheBySubscriptionIdAll.compute(subscription.getId(), (id, existing) -> {
             if (existing == null || existing.isEmpty()) {
                 return Set.of(subscription);
+            }
+            // Singleton fast path: replacing the same api/environment leg needs no temporary set
+            if (existing.size() == 1) {
+                Subscription single = existing.iterator().next();
+                if (
+                    Objects.equals(single.getApi(), subscription.getApi()) &&
+                    Objects.equals(single.getEnvironmentId(), subscription.getEnvironmentId())
+                ) {
+                    return Set.of(subscription);
+                }
             }
             Set<Subscription> updated = new HashSet<>(existing);
             updated.removeIf(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -769,6 +769,16 @@ class SubscriptionCacheServiceTest {
         }
 
         @Test
+        void should_get_one_leg_by_id_for_exploded_subscription() {
+            Subscription subApi1 = buildAcceptedSubscription(SUB_ID, API_ID);
+            Subscription subApi2 = buildAcceptedSubscription(SUB_ID, API_ID_2);
+            subscriptionService.register(subApi1);
+            subscriptionService.register(subApi2);
+
+            assertThat(subscriptionService.getById(SUB_ID)).get().isIn(subApi1, subApi2);
+        }
+
+        @Test
         void should_get_exploded_subscription_by_api_key_for_each_api_leg() {
             Subscription subApi1 = buildAcceptedSubscription(SUB_ID, API_ID);
             Subscription subApi2 = buildAcceptedSubscription(SUB_ID, API_ID_2);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -116,10 +116,12 @@ public class SubscriptionMapper {
                 log.warn("Unable to parse subscription configuration for [{}]", subscriptionModel.getId(), e);
             }
         }
-        Map<String, String> metadata = subscriptionModel.getMetadata() != null
-            ? new HashMap<>(subscriptionModel.getMetadata())
-            : new HashMap<>();
-        subscription.setMetadata(metadata);
+        // Share the JVM's empty-map singleton instead of allocating one HashMap per subscription:
+        // on large deployments most subscriptions carry no metadata and the per-instance maps
+        // account for hundreds of MB. Consumers are read-only (template engine variable). The
+        // non-empty case keeps HashMap on purpose: unlike Map.copyOf it tolerates null values.
+        Map<String, String> sourceMetadata = subscriptionModel.getMetadata();
+        subscription.setMetadata(sourceMetadata == null || sourceMetadata.isEmpty() ? Map.of() : new HashMap<>(sourceMetadata));
         subscription.setEnvironmentId(subscriptionModel.getEnvironmentId());
         return subscription;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
@@ -29,6 +29,7 @@ import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMappe
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -115,6 +116,29 @@ class SubscriptionMapperTest {
         assertThat(subscriptionMapped.getType()).isEqualTo(io.gravitee.gateway.api.service.Subscription.Type.STANDARD);
         assertThat(subscriptionMapped.getConfiguration()).isNull();
         assertThat(subscriptionMapped.getMetadata()).isEmpty();
+    }
+
+    @Test
+    void should_share_the_empty_metadata_singleton_across_subscriptions() {
+        subscription.setMetadata(null);
+        io.gravitee.gateway.api.service.Subscription first = cut.to(subscription).getFirst();
+
+        subscription.setMetadata(Map.of());
+        io.gravitee.gateway.api.service.Subscription second = cut.to(subscription).getFirst();
+
+        assertThat(first.getMetadata()).isEmpty();
+        assertThat(first.getMetadata()).isSameAs(second.getMetadata());
+    }
+
+    @Test
+    void should_keep_metadata_entries_with_null_values() {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("key", null);
+        subscription.setMetadata(metadata);
+
+        io.gravitee.gateway.api.service.Subscription mapped = cut.to(subscription).getFirst();
+
+        assertThat(mapped.getMetadata()).containsEntry("key", null);
     }
 
     @Test

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnector.java
@@ -79,6 +79,12 @@ public class HttpProxyEndpointConnector extends HttpEndpointSyncConnector {
     }
 
     @Override
+    protected void doStart() throws Exception {
+        // Override to avoid excessive logging when the service starts.
+        log.debug("Initializing service {}", name());
+    }
+
+    @Override
     public String id() {
         return ENDPOINT_ID;
     }


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-14675

Follow-up of #18509 — gateway-side RCA of a customer performance incident on 4.11.x. Heap analysis of a customer dump (10.75 GB heap) showed a single `SubscriptionCacheService` instance retaining **7.8 GB (72.6%)** for 4.1M cached subscriptions, leaving no GC headroom under load (GC death spiral → TLS handshakes > 10 s).

## Description

Second wave of subscription-cache footprint reductions (expected **−1.7 to −2.0 GB** on the analyzed dump, on top of #18509):

- **Merge the by-id cache into the exploded-subscription index** (−~0.5 GB). `cacheBySubscriptionId` duplicated every entry of `cacheBySubscriptionIdAll`. `getById()` now reads the single index; for exploded API-Product subscriptions it returns an arbitrary leg, matching the historical last-registered/rehydrated behavior. The `unregister()` rehydration block (which only existed to keep the two maps consistent) is removed.
- **Share the empty-metadata singleton** (−~0.36 GB). `SubscriptionMapper` allocated one `HashMap` (plus its lazily cached `EntrySet` view) per subscription even when metadata was empty — which is the case for all 4.1M subscriptions on the customer dump. Empty metadata now maps to `Map.of()`. Non-empty metadata keeps `HashMap` on purpose (`Map.copyOf` rejects null values coming from the repository). Verified read-only consumption at runtime (template-engine `SubscriptionVariable`; no `getMetadata()` mutation in the gateway runtime).
- **Replace composite String identity-cache keys with record keys** (−0.9 to −1.2 GB). Identity caches were keyed by `String.format("%s.%s.%s", api, plan, clientIdentity)` — two fresh ~176-byte strings per client-id subscription, and a `String.format` **per JWT/OAuth2 request** on the hot path. Keys are now a small record reusing the subscription's own field references; lookups allocate one short-lived 32-byte record instead of formatting a string.
- **Singleton fast paths in cache maintenance** (review feedback): register/unregister/undeploy paths skip stream pipelines and temporary sets for the dominant single-leg case.
- Also lowers the per-connector "Initializing service" startup log of the http-proxy endpoint to debug (one INFO line per endpoint connector — hundreds of thousands of lines at startup on large deployments).

No public API change (`SubscriptionService` interface untouched); all changes are behavior-preserving.

**Validation**

- `gravitee-apim-gateway-handlers-api`: 919/919 tests (cache test class run ×5 for the concurrency tests' stability, after each commit)
- `gravitee-apim-gateway-services-sync`: 387/387 tests (2 new: empty-metadata sharing, null-value metadata tolerance)
- Integration tests re-run after each risky step: `SubscriptionElIntegrationTest` (EL access to `subscription.metadata`), `ApiProductV4IntegrationTest` and `ApiProductV4SecurityIntegrationTest` (mTLS/JWT on exploded subscriptions)

## Additional context

- Stacked on #18509 (`perf/gateway-subscription-cache-scale`) — the first commits belong to that PR; review from "merge subscription by-id cache…" onwards.
- Sync-time string interning of repeated subscription fields (api/plan/application/environmentId, −0.9 to −1.3 GB) was pulled out of this PR and will be proposed separately.
- Remaining planned steps (not in this PR): model slimming (`Date` → epoch long, lazy `SubscriptionConfiguration` parse, derived `cacheKeysByApiId`).
