### PR TITLE
perf(gateway): shrink subscription cache memory footprint at scale

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheService.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.handlers.api.services;
 
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.ApiKeyService;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -52,12 +51,13 @@ public class ApiKeyCacheService implements ApiKeyService {
               Based on that, we could cache only what is required
              */
             cacheMd5ApiKeys.put(buildMd5CacheKey(apiKey), apiKey);
-            Set<String> keysByApi = cacheApiKeysByApi.get(apiKey.getApi());
-            if (keysByApi == null) {
-                keysByApi = new HashSet<>();
-            }
-            keysByApi.add(cacheKey);
-            cacheApiKeysByApi.put(apiKey.getApi(), keysByApi);
+            // compute() so concurrent register/unregister calls for the same API (sync appenders
+            // run in parallel) cannot lose updates or mutate a plain HashSet across threads.
+            cacheApiKeysByApi.compute(apiKey.getApi(), (api, keysByApi) -> {
+                Set<String> keys = keysByApi != null ? keysByApi : ConcurrentHashMap.newKeySet();
+                keys.add(cacheKey);
+                return keys;
+            });
         } else {
             unregister(apiKey);
         }
@@ -75,14 +75,10 @@ public class ApiKeyCacheService implements ApiKeyService {
         );
         if (cacheApiKeys.remove(cacheKey) != null) {
             cacheMd5ApiKeys.remove(buildMd5CacheKey(apiKey));
-            Set<String> keysByApi = cacheApiKeysByApi.get(apiKey.getApi());
-            if (keysByApi != null && keysByApi.remove(cacheKey)) {
-                if (keysByApi.isEmpty()) {
-                    cacheApiKeysByApi.remove(apiKey.getApi());
-                } else {
-                    cacheApiKeysByApi.put(apiKey.getApi(), keysByApi);
-                }
-            }
+            cacheApiKeysByApi.computeIfPresent(apiKey.getApi(), (api, keysByApi) -> {
+                keysByApi.remove(cacheKey);
+                return keysByApi.isEmpty() ? null : keysByApi;
+            });
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheService.java
@@ -17,19 +17,22 @@ package io.gravitee.gateway.handlers.api.services;
 
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.ApiKeyService;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import lombok.CustomLog;
 import org.springframework.util.DigestUtils;
 
 @CustomLog
 public class ApiKeyCacheService implements ApiKeyService {
 
-    private final Map<String, ApiKey> cacheApiKeys = new ConcurrentHashMap<>();
-    private final Map<String, ApiKey> cacheMd5ApiKeys = new ConcurrentHashMap<>();
-    private final Map<String, Set<String>> cacheApiKeysByApi = new ConcurrentHashMap<>();
+    // ConcurrentMap on purpose (not plain Map): register()/unregister() rely on thread-safe
+    // compute()/computeIfPresent() for the per-API index. Unlike SubscriptionCacheService, the
+    // lambdas here are idempotent, so any honest ConcurrentMap implementation is acceptable.
+    private final ConcurrentMap<String, ApiKey> cacheApiKeys = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ApiKey> cacheMd5ApiKeys = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Set<String>> cacheApiKeysByApi = new ConcurrentHashMap<>();
 
     @Override
     public void register(final ApiKey apiKey) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -178,7 +178,10 @@ public class SubscriptionCacheService implements SubscriptionService {
     @Override
     public void unregisterByApiId(final String apiId) {
         log.debug("Unregistering all subscriptions for API [{}]", apiId);
-        cacheKeysByApiId.computeIfPresent(apiId, (k, subscriptionsByApi) -> {
+        // Remove the whole entry first so no cacheKeysByApiId lock is held while updating the
+        // other caches (unregister() acquires the same locks in the opposite order).
+        Set<String> subscriptionsByApi = cacheKeysByApiId.remove(apiId);
+        if (subscriptionsByApi != null) {
             subscriptionsByApi.forEach(cacheKey -> {
                 cacheBySubscriptionIdAll.computeIfPresent(cacheKey, (id, all) -> {
                     Set<Subscription> remaining = all
@@ -191,8 +194,7 @@ public class SubscriptionCacheService implements SubscriptionService {
                 cacheByApiClientId.remove(cacheKey);
                 cacheByClientCertificate.remove(cacheKey);
             });
-            return null;
-        });
+        }
     }
 
     private void registerFromId(final Subscription subscription) {
@@ -265,12 +267,13 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private void updateCacheKeyByApiId(final String apiId, final String cacheKey) {
-        Set<String> subscriptionsByApi = cacheKeysByApiId.get(apiId);
-        if (subscriptionsByApi == null) {
-            subscriptionsByApi = new HashSet<>();
-        }
-        subscriptionsByApi.add(cacheKey);
-        cacheKeysByApiId.put(apiId, subscriptionsByApi);
+        // compute() so concurrent register/unregister calls for the same API (sync appenders run
+        // in parallel) cannot lose updates or mutate a plain HashSet across threads.
+        cacheKeysByApiId.compute(apiId, (id, subscriptionsByApi) -> {
+            Set<String> keys = subscriptionsByApi != null ? subscriptionsByApi : ConcurrentHashMap.newKeySet();
+            keys.add(cacheKey);
+            return keys;
+        });
     }
 
     private void updateSubscriptionIdById(Subscription subscription) {
@@ -315,14 +318,10 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private void evictKeyForApi(final String apiId, final String cacheKey) {
-        Set<String> keysByApi = cacheKeysByApiId.get(apiId);
-        if (keysByApi != null && keysByApi.remove(cacheKey)) {
-            if (keysByApi.isEmpty()) {
-                cacheKeysByApiId.remove(apiId);
-            } else {
-                cacheKeysByApiId.put(apiId, keysByApi);
-            }
-        }
+        cacheKeysByApiId.computeIfPresent(apiId, (id, keysByApi) -> {
+            keysByApi.remove(cacheKey);
+            return keysByApi.isEmpty() ? null : keysByApi;
+        });
     }
 
     // visible for testing

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -31,11 +31,11 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.CustomLog;
@@ -50,15 +50,19 @@ public class SubscriptionCacheService implements SubscriptionService {
     private final SubscriptionTrustStoreLoaderManager subscriptionTrustStoreLoaderManager;
     private final ApiManager apiManager;
 
-    // Caches only contains active subscriptions
-    private final Map<IdentityKey, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
-    private final Map<IdentityKey, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
+    // Caches only contains active subscriptions.
+    // Must stay backed by ConcurrentHashMap: the compute() lambdas below have side effects and
+    // rely on CHM running the remapping function at most once, under the bin lock. The
+    // ConcurrentMap contract alone allows implementations that retry the lambda (e.g.
+    // ConcurrentSkipListMap), which would double those side effects under contention.
+    private final ConcurrentMap<IdentityKey, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<IdentityKey, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
     // Single by-id index, including exploded API-Product subscriptions. Values are immutable sets
     // (almost always a singleton), replaced atomically via compute(): keeps the per-entry footprint
     // minimal at multi-million-subscription scale and lets readers use them without defensive copies.
-    private final Map<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
     // Holds subscription ids (String) and identity keys (IdentityKey) for per-API eviction
-    private final Map<String, Set<Object>> cacheKeysByApiId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Set<Object>> cacheKeysByApiId = new ConcurrentHashMap<>();
 
     /**
      * Identity-cache key referencing the subscription's own field strings instead of a formatted
@@ -281,7 +285,7 @@ public class SubscriptionCacheService implements SubscriptionService {
         }
     }
 
-    private void updateIdentityCache(Subscription subscription, Map<IdentityKey, Subscription> cache) {
+    private void updateIdentityCache(Subscription subscription, ConcurrentMap<IdentityKey, Subscription> cache) {
         updateCacheKeyByApiId(subscription.getApi(), subscription.getId());
         IdentityKey cacheKey = identityCacheKey(subscription);
         updateCacheKeyByApiId(subscription.getApi(), cacheKey);
@@ -341,7 +345,7 @@ public class SubscriptionCacheService implements SubscriptionService {
         }
     }
 
-    private void evictIdentityCache(Subscription subscription, Map<IdentityKey, Subscription> cacheByApiClientId) {
+    private void evictIdentityCache(Subscription subscription, ConcurrentMap<IdentityKey, Subscription> cacheByApiClientId) {
         final IdentityKey identityCacheKey = identityCacheKey(subscription);
         if (cacheByApiClientId.remove(identityCacheKey) != null) {
             evictKeyForApi(subscription.getApi(), identityCacheKey);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -54,7 +54,10 @@ public class SubscriptionCacheService implements SubscriptionService {
     private final Map<String, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
     private final Map<String, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
     private final Map<String, Subscription> cacheBySubscriptionId = new ConcurrentHashMap<>();
-    private final Map<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>(); // exploded subscriptions
+    // Exploded subscriptions. Values are immutable sets (almost always a singleton), replaced
+    // atomically via compute(): keeps the per-entry footprint minimal at multi-million-subscription
+    // scale and lets readers use them without defensive copies.
+    private final Map<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
     private final Map<String, Set<String>> cacheKeysByApiId = new ConcurrentHashMap<>();
 
     @Override
@@ -84,10 +87,11 @@ public class SubscriptionCacheService implements SubscriptionService {
 
     /**
      * Returns all subscriptions for the given ID (multiple for exploded API Product subscriptions).
+     * The returned collection is immutable.
      */
     public Collection<Subscription> getAllById(String subscriptionId) {
         Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        return subscriptions != null ? Set.copyOf(subscriptions) : Collections.emptySet();
+        return subscriptions != null ? subscriptions : Collections.emptySet();
     }
 
     @Override
@@ -135,25 +139,30 @@ public class SubscriptionCacheService implements SubscriptionService {
                 .filter(s -> Objects.equals(candidate.getApi(), s.getApi()))
                 .toList();
 
+            if (toEvict.isEmpty()) {
+                return allSubscriptions;
+            }
+
             toEvict.forEach(existing -> {
-                allSubscriptions.remove(existing);
                 unregisterFromClientId(existing);
                 unregisterFromClientCertificate(existing);
             });
 
-            if (!toEvict.isEmpty()) {
-                evictKeyForApi(candidate.getApi(), candidate.getId());
-                // Handle the case where the candidate carries a different clientId/cert than
-                // what was cached (e.g. a status-change event arriving after a credential update).
-                if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientId(), candidate.getClientId()))) {
-                    unregisterFromClientId(candidate);
-                }
-                if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientCertificate(), candidate.getClientCertificate()))) {
-                    unregisterFromClientCertificate(candidate);
-                }
+            evictKeyForApi(candidate.getApi(), candidate.getId());
+            // Handle the case where the candidate carries a different clientId/cert than
+            // what was cached (e.g. a status-change event arriving after a credential update).
+            if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientId(), candidate.getClientId()))) {
+                unregisterFromClientId(candidate);
+            }
+            if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientCertificate(), candidate.getClientCertificate()))) {
+                unregisterFromClientCertificate(candidate);
             }
 
-            return allSubscriptions.isEmpty() ? null : allSubscriptions;
+            Set<Subscription> remaining = allSubscriptions
+                .stream()
+                .filter(s -> !Objects.equals(candidate.getApi(), s.getApi()))
+                .collect(Collectors.toUnmodifiableSet());
+            return remaining.isEmpty() ? null : remaining;
         });
 
         // Only evict cacheBySubscriptionId when it points to this specific API. If sibling legs
@@ -171,11 +180,13 @@ public class SubscriptionCacheService implements SubscriptionService {
         log.debug("Unregistering all subscriptions for API [{}]", apiId);
         cacheKeysByApiId.computeIfPresent(apiId, (k, subscriptionsByApi) -> {
             subscriptionsByApi.forEach(cacheKey -> {
-                Set<Subscription> all = cacheBySubscriptionIdAll.get(cacheKey);
-                if (all != null) {
-                    all.removeIf(s -> Objects.equals(apiId, s.getApi()));
-                    if (all.isEmpty()) cacheBySubscriptionIdAll.remove(cacheKey);
-                }
+                cacheBySubscriptionIdAll.computeIfPresent(cacheKey, (id, all) -> {
+                    Set<Subscription> remaining = all
+                        .stream()
+                        .filter(s -> !Objects.equals(apiId, s.getApi()))
+                        .collect(Collectors.toUnmodifiableSet());
+                    return remaining.isEmpty() ? null : remaining;
+                });
                 cacheBySubscriptionId.remove(cacheKey);
                 cacheByApiClientId.remove(cacheKey);
                 cacheByClientCertificate.remove(cacheKey);
@@ -220,9 +231,9 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private void registerFromClientId(final Subscription subscription) {
-        // Snapshot old entries before registering
+        // Snapshot old entries before registering (cached sets are immutable)
         Set<Subscription> cachedAll = cacheBySubscriptionIdAll.get(subscription.getId());
-        Set<Subscription> oldEntries = cachedAll != null ? Set.copyOf(cachedAll) : Set.of();
+        Set<Subscription> oldEntries = cachedAll != null ? cachedAll : Set.of();
 
         updateSubscriptionIdById(subscription);
 
@@ -265,14 +276,17 @@ public class SubscriptionCacheService implements SubscriptionService {
     private void updateSubscriptionIdById(Subscription subscription) {
         cacheBySubscriptionId.put(subscription.getId(), subscription);
         cacheBySubscriptionIdAll.compute(subscription.getId(), (id, existing) -> {
-            Set<Subscription> set = existing != null ? existing : ConcurrentHashMap.newKeySet();
-            set.removeIf(
+            if (existing == null || existing.isEmpty()) {
+                return Set.of(subscription);
+            }
+            Set<Subscription> updated = new HashSet<>(existing);
+            updated.removeIf(
                 s ->
                     Objects.equals(s.getApi(), subscription.getApi()) &&
                     Objects.equals(s.getEnvironmentId(), subscription.getEnvironmentId())
             );
-            set.add(subscription);
-            return set;
+            updated.add(subscription);
+            return updated.size() == 1 ? Set.of(subscription) : Set.copyOf(updated);
         });
     }
 
@@ -336,10 +350,14 @@ public class SubscriptionCacheService implements SubscriptionService {
             // Fallback to old cache for backward compatibility
             return getById(subscriptionId);
         }
-        return subscriptions
-            .stream()
-            .filter(sub -> Objects.equals(api, sub.getApi()))
-            .findFirst();
+        // Plain loop: this runs on the request hot path for every API-key call and the set is
+        // almost always a singleton, so avoid allocating a Stream pipeline per request.
+        for (Subscription subscription : subscriptions) {
+            if (Objects.equals(api, subscription.getApi())) {
+                return Optional.of(subscription);
+            }
+        }
+        return Optional.empty();
     }
 
     private String identityCacheKey(Subscription subscription) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -53,10 +53,9 @@ public class SubscriptionCacheService implements SubscriptionService {
     // Caches only contains active subscriptions
     private final Map<String, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
     private final Map<String, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
-    private final Map<String, Subscription> cacheBySubscriptionId = new ConcurrentHashMap<>();
-    // Exploded subscriptions. Values are immutable sets (almost always a singleton), replaced
-    // atomically via compute(): keeps the per-entry footprint minimal at multi-million-subscription
-    // scale and lets readers use them without defensive copies.
+    // Single by-id index, including exploded API-Product subscriptions. Values are immutable sets
+    // (almost always a singleton), replaced atomically via compute(): keeps the per-entry footprint
+    // minimal at multi-million-subscription scale and lets readers use them without defensive copies.
     private final Map<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
     private final Map<String, Set<String>> cacheKeysByApiId = new ConcurrentHashMap<>();
 
@@ -82,7 +81,13 @@ public class SubscriptionCacheService implements SubscriptionService {
 
     @Override
     public Optional<Subscription> getById(String subscriptionId) {
-        return Optional.ofNullable(cacheBySubscriptionId.get(subscriptionId));
+        // For exploded API-Product subscriptions this returns an arbitrary leg, which matches the
+        // historical behavior of the dedicated by-id map (last-registered/rehydrated leg).
+        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
+        if (subscriptions == null || subscriptions.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(subscriptions.iterator().next());
     }
 
     /**
@@ -164,15 +169,6 @@ public class SubscriptionCacheService implements SubscriptionService {
                 .collect(Collectors.toUnmodifiableSet());
             return remaining.isEmpty() ? null : remaining;
         });
-
-        // Only evict cacheBySubscriptionId when it points to this specific API. If sibling legs
-        // remain (exploded API-Product subscriptions), rehydrate from the authoritative set so
-        // getById() stays consistent with getAllById() regardless of unregistration order.
-        cacheBySubscriptionId.computeIfPresent(candidate.getId(), (k, existing) -> {
-            if (!Objects.equals(existing.getApi(), candidate.getApi())) return existing;
-            Set<Subscription> remaining = cacheBySubscriptionIdAll.get(candidate.getId());
-            return (remaining == null || remaining.isEmpty()) ? null : remaining.iterator().next();
-        });
     }
 
     @Override
@@ -190,7 +186,6 @@ public class SubscriptionCacheService implements SubscriptionService {
                         .collect(Collectors.toUnmodifiableSet());
                     return remaining.isEmpty() ? null : remaining;
                 });
-                cacheBySubscriptionId.remove(cacheKey);
                 cacheByApiClientId.remove(cacheKey);
                 cacheByClientCertificate.remove(cacheKey);
             });
@@ -209,8 +204,18 @@ public class SubscriptionCacheService implements SubscriptionService {
         // Ensure trust store is updated before cache to maintain certificate validation consistency
         subscriptionTrustStoreLoaderManager.registerSubscription(subscription, servers);
 
-        // keep the old one
-        Subscription cached = cacheBySubscriptionId.get(subscription.getId());
+        // keep the old same-API leg before the cache is updated (exploded API-Product
+        // subscriptions may carry sibling legs for other APIs, which must not be evicted here)
+        Subscription cached = null;
+        Set<Subscription> existingLegs = cacheBySubscriptionIdAll.get(subscription.getId());
+        if (existingLegs != null) {
+            for (Subscription existing : existingLegs) {
+                if (Objects.equals(subscription.getApi(), existing.getApi())) {
+                    cached = existing;
+                    break;
+                }
+            }
+        }
 
         // Update cache
         updateSubscriptionIdById(subscription);
@@ -277,7 +282,6 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private void updateSubscriptionIdById(Subscription subscription) {
-        cacheBySubscriptionId.put(subscription.getId(), subscription);
         cacheBySubscriptionIdAll.compute(subscription.getId(), (id, existing) -> {
             if (existing == null || existing.isEmpty()) {
                 return Set.of(subscription);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -51,13 +51,21 @@ public class SubscriptionCacheService implements SubscriptionService {
     private final ApiManager apiManager;
 
     // Caches only contains active subscriptions
-    private final Map<String, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
-    private final Map<String, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
+    private final Map<IdentityKey, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
+    private final Map<IdentityKey, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
     // Single by-id index, including exploded API-Product subscriptions. Values are immutable sets
     // (almost always a singleton), replaced atomically via compute(): keeps the per-entry footprint
     // minimal at multi-million-subscription scale and lets readers use them without defensive copies.
     private final Map<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
-    private final Map<String, Set<String>> cacheKeysByApiId = new ConcurrentHashMap<>();
+    // Holds subscription ids (String) and identity keys (IdentityKey) for per-API eviction
+    private final Map<String, Set<Object>> cacheKeysByApiId = new ConcurrentHashMap<>();
+
+    /**
+     * Identity-cache key referencing the subscription's own field strings instead of a formatted
+     * composite String: no per-key byte[] allocation (hundreds of MB at multi-million-subscription
+     * scale) and no String.format on the request hot path. A null plan is the plan-less variant.
+     */
+    private record IdentityKey(String api, String plan, String clientIdentity) {}
 
     @Override
     public Optional<Subscription> getByApiAndSecurityToken(String api, SecurityToken securityToken, String plan) {
@@ -176,16 +184,18 @@ public class SubscriptionCacheService implements SubscriptionService {
         log.debug("Unregistering all subscriptions for API [{}]", apiId);
         // Remove the whole entry first so no cacheKeysByApiId lock is held while updating the
         // other caches (unregister() acquires the same locks in the opposite order).
-        Set<String> subscriptionsByApi = cacheKeysByApiId.remove(apiId);
+        Set<Object> subscriptionsByApi = cacheKeysByApiId.remove(apiId);
         if (subscriptionsByApi != null) {
             subscriptionsByApi.forEach(cacheKey -> {
-                cacheBySubscriptionIdAll.computeIfPresent(cacheKey, (id, all) -> {
-                    Set<Subscription> remaining = all
-                        .stream()
-                        .filter(s -> !Objects.equals(apiId, s.getApi()))
-                        .collect(Collectors.toUnmodifiableSet());
-                    return remaining.isEmpty() ? null : remaining;
-                });
+                if (cacheKey instanceof String subscriptionId) {
+                    cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, all) -> {
+                        Set<Subscription> remaining = all
+                            .stream()
+                            .filter(s -> !Objects.equals(apiId, s.getApi()))
+                            .collect(Collectors.toUnmodifiableSet());
+                        return remaining.isEmpty() ? null : remaining;
+                    });
+                }
                 cacheByApiClientId.remove(cacheKey);
                 cacheByClientCertificate.remove(cacheKey);
             });
@@ -228,8 +238,8 @@ public class SubscriptionCacheService implements SubscriptionService {
             (!Objects.equals(subscription.getClientCertificate(), cached.getClientCertificate()) ||
                 !Objects.equals(subscription.getPlan(), cached.getPlan()))
         ) {
-            String cacheKey = identityCacheKey(cached);
-            String cacheKeyWithoutPlan = identityCacheKeyWithoutPlan(cached);
+            IdentityKey cacheKey = identityCacheKey(cached);
+            IdentityKey cacheKeyWithoutPlan = identityCacheKeyWithoutPlan(cached);
             evictKeyForApi(cached.getApi(), cacheKey);
             evictKeyForApi(cached.getApi(), cacheKeyWithoutPlan);
             cacheByClientCertificate.remove(cacheKey);
@@ -260,22 +270,22 @@ public class SubscriptionCacheService implements SubscriptionService {
         }
     }
 
-    private void updateIdentityCache(Subscription subscription, Map<String, Subscription> cache) {
+    private void updateIdentityCache(Subscription subscription, Map<IdentityKey, Subscription> cache) {
         updateCacheKeyByApiId(subscription.getApi(), subscription.getId());
-        String cacheKey = identityCacheKey(subscription);
+        IdentityKey cacheKey = identityCacheKey(subscription);
         updateCacheKeyByApiId(subscription.getApi(), cacheKey);
         cache.put(cacheKey, subscription);
         // Index the subscription without plan id to allow search without plan criteria.
-        String cacheKeyWithoutPlan = identityCacheKeyWithoutPlan(subscription);
+        IdentityKey cacheKeyWithoutPlan = identityCacheKeyWithoutPlan(subscription);
         cache.put(cacheKeyWithoutPlan, subscription);
         updateCacheKeyByApiId(subscription.getApi(), cacheKeyWithoutPlan);
     }
 
-    private void updateCacheKeyByApiId(final String apiId, final String cacheKey) {
+    private void updateCacheKeyByApiId(final String apiId, final Object cacheKey) {
         // compute() so concurrent register/unregister calls for the same API (sync appenders run
         // in parallel) cannot lose updates or mutate a plain HashSet across threads.
         cacheKeysByApiId.compute(apiId, (id, subscriptionsByApi) -> {
-            Set<String> keys = subscriptionsByApi != null ? subscriptionsByApi : ConcurrentHashMap.newKeySet();
+            Set<Object> keys = subscriptionsByApi != null ? subscriptionsByApi : ConcurrentHashMap.newKeySet();
             keys.add(cacheKey);
             return keys;
         });
@@ -310,18 +320,18 @@ public class SubscriptionCacheService implements SubscriptionService {
         }
     }
 
-    private void evictIdentityCache(Subscription subscription, Map<String, Subscription> cacheByApiClientId) {
-        final String identityCacheKey = identityCacheKey(subscription);
+    private void evictIdentityCache(Subscription subscription, Map<IdentityKey, Subscription> cacheByApiClientId) {
+        final IdentityKey identityCacheKey = identityCacheKey(subscription);
         if (cacheByApiClientId.remove(identityCacheKey) != null) {
             evictKeyForApi(subscription.getApi(), identityCacheKey);
         }
-        final String identityCacheKeyWithoutPlan = identityCacheKeyWithoutPlan(subscription);
+        final IdentityKey identityCacheKeyWithoutPlan = identityCacheKeyWithoutPlan(subscription);
         if (cacheByApiClientId.remove(identityCacheKeyWithoutPlan) != null) {
             evictKeyForApi(subscription.getApi(), identityCacheKeyWithoutPlan);
         }
     }
 
-    private void evictKeyForApi(final String apiId, final String cacheKey) {
+    private void evictKeyForApi(final String apiId, final Object cacheKey) {
         cacheKeysByApiId.computeIfPresent(apiId, (id, keysByApi) -> {
             keysByApi.remove(cacheKey);
             return keysByApi.isEmpty() ? null : keysByApi;
@@ -343,7 +353,7 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     // Visible for testing
-    Set<String> getByApiId(String apiId) {
+    Set<Object> getByApiId(String apiId) {
         return cacheKeysByApiId.getOrDefault(apiId, Collections.emptySet());
     }
 
@@ -363,7 +373,7 @@ public class SubscriptionCacheService implements SubscriptionService {
         return Optional.empty();
     }
 
-    private String identityCacheKey(Subscription subscription) {
+    private IdentityKey identityCacheKey(Subscription subscription) {
         if (subscription.getClientId() != null) {
             Objects.requireNonNull(subscription.getClientId(), "Client ID must not be null");
             return cacheKey(subscription.getApi(), subscription.getPlan(), subscription.getClientId());
@@ -373,7 +383,7 @@ public class SubscriptionCacheService implements SubscriptionService {
         }
     }
 
-    private String identityCacheKeyWithoutPlan(Subscription subscription) {
+    private IdentityKey identityCacheKeyWithoutPlan(Subscription subscription) {
         if (subscription.getClientId() != null) {
             Objects.requireNonNull(subscription.getClientId(), "Client ID must not be null");
             return cacheKey(subscription.getApi(), subscription.getClientId());
@@ -390,13 +400,13 @@ public class SubscriptionCacheService implements SubscriptionService {
         return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
     }
 
-    private String cacheKey(String api, String plan, String clientIdentity) {
+    private IdentityKey cacheKey(String api, String plan, String clientIdentity) {
         Objects.requireNonNull(plan, "Plan must not be null");
-        return String.format("%s.%s.%s", api, plan, clientIdentity);
+        return new IdentityKey(api, plan, clientIdentity);
     }
 
-    private String cacheKey(String api, String clientIdentity) {
-        return String.format("%s.%s", api, clientIdentity);
+    private IdentityKey cacheKey(String api, String clientIdentity) {
+        return new IdentityKey(api, null, clientIdentity);
     }
 
     private Set<String> extractApiServersId(Subscription subscription) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -171,6 +171,11 @@ public class SubscriptionCacheService implements SubscriptionService {
                 unregisterFromClientCertificate(candidate);
             }
 
+            // Singleton fast path: toEvict is non-empty, so the only element is being evicted
+            if (allSubscriptions.size() == 1) {
+                return null;
+            }
+
             Set<Subscription> remaining = allSubscriptions
                 .stream()
                 .filter(s -> !Objects.equals(candidate.getApi(), s.getApi()))
@@ -189,15 +194,21 @@ public class SubscriptionCacheService implements SubscriptionService {
             subscriptionsByApi.forEach(cacheKey -> {
                 if (cacheKey instanceof String subscriptionId) {
                     cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, all) -> {
+                        // Singleton fast path: most entries hold exactly one leg
+                        if (all.size() == 1) {
+                            return Objects.equals(apiId, all.iterator().next().getApi()) ? null : all;
+                        }
                         Set<Subscription> remaining = all
                             .stream()
                             .filter(s -> !Objects.equals(apiId, s.getApi()))
                             .collect(Collectors.toUnmodifiableSet());
                         return remaining.isEmpty() ? null : remaining;
                     });
+                } else {
+                    // Identity maps are keyed by IdentityKey only: removing a String key is a no-op
+                    cacheByApiClientId.remove(cacheKey);
+                    cacheByClientCertificate.remove(cacheKey);
                 }
-                cacheByApiClientId.remove(cacheKey);
-                cacheByClientCertificate.remove(cacheKey);
             });
         }
     }
@@ -295,6 +306,16 @@ public class SubscriptionCacheService implements SubscriptionService {
         cacheBySubscriptionIdAll.compute(subscription.getId(), (id, existing) -> {
             if (existing == null || existing.isEmpty()) {
                 return Set.of(subscription);
+            }
+            // Singleton fast path: replacing the same api/environment leg needs no temporary set
+            if (existing.size() == 1) {
+                Subscription single = existing.iterator().next();
+                if (
+                    Objects.equals(single.getApi(), subscription.getApi()) &&
+                    Objects.equals(single.getEnvironmentId(), subscription.getEnvironmentId())
+                ) {
+                    return Set.of(subscription);
+                }
             }
             Set<Subscription> updated = new HashSet<>(existing);
             updated.removeIf(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheServiceTest.java
@@ -18,9 +18,16 @@ package io.gravitee.gateway.handlers.api.services;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import io.gravitee.gateway.api.service.ApiKey;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -228,6 +235,44 @@ public class ApiKeyCacheServiceTest {
 
             Optional<ApiKey> md5KeyFoundOpt = apiKeyService.getByApiAndMd5Key("my-api", DigestUtils.md5DigestAsHex("my-key".getBytes()));
             assertThat(md5KeyFoundOpt).isEmpty();
+        }
+    }
+
+    @Nested
+    class ConcurrentUpdateTest {
+
+        @Test
+        void should_unregister_every_api_key_registered_concurrently_for_the_same_api() throws Exception {
+            // Sync appenders register api keys of the same API from several threads
+            // (services.sync.appender.parallelism). Every cache key must survive the concurrent
+            // maintenance of cacheApiKeysByApi so unregisterByApiId() can evict them all.
+            int writerCount = 8;
+            int keysPerWriter = 200;
+            CyclicBarrier barrier = new CyclicBarrier(writerCount);
+            List<Future<?>> futures = new ArrayList<>();
+            try (ExecutorService writers = Executors.newFixedThreadPool(writerCount)) {
+                for (int w = 0; w < writerCount; w++) {
+                    int writerId = w;
+                    futures.add(
+                        writers.submit(() -> {
+                            barrier.await();
+                            for (int i = 0; i < keysPerWriter; i++) {
+                                apiKeyService.register(buildApiKey("my-api", "key-" + writerId + "-" + i, true));
+                            }
+                            return null;
+                        })
+                    );
+                }
+                for (Future<?> future : futures) {
+                    future.get(10, TimeUnit.SECONDS);
+                }
+            }
+
+            apiKeyService.unregisterByApiId("my-api");
+
+            assertThat(cacheApiKeys.isEmpty()).isTrue();
+            assertThat(cacheMd5ApiKeys.isEmpty()).isTrue();
+            assertThat(cacheApiKeysByApi.isEmpty()).isTrue();
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -769,6 +769,16 @@ class SubscriptionCacheServiceTest {
         }
 
         @Test
+        void should_get_one_leg_by_id_for_exploded_subscription() {
+            Subscription subApi1 = buildAcceptedSubscription(SUB_ID, API_ID);
+            Subscription subApi2 = buildAcceptedSubscription(SUB_ID, API_ID_2);
+            subscriptionService.register(subApi1);
+            subscriptionService.register(subApi2);
+
+            assertThat(subscriptionService.getById(SUB_ID)).get().isIn(subApi1, subApi2);
+        }
+
+        @Test
         void should_get_exploded_subscription_by_api_key_for_each_api_leg() {
             Subscription subApi1 = buildAcceptedSubscription(SUB_ID, API_ID);
             Subscription subApi2 = buildAcceptedSubscription(SUB_ID, API_ID_2);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -29,6 +29,7 @@ import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.security.core.SubscriptionTrustStoreLoaderManager;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,6 +37,7 @@ import java.util.Set;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -765,6 +767,26 @@ class SubscriptionCacheServiceTest {
             );
             assertThat(subscriptionService.getByApiAndSecurityToken(API_ID_2, SecurityToken.forClientId("unknown"), PLAN_ID_2)).isEmpty();
         }
+
+        @Test
+        void should_get_exploded_subscription_by_api_key_for_each_api_leg() {
+            Subscription subApi1 = buildAcceptedSubscription(SUB_ID, API_ID);
+            Subscription subApi2 = buildAcceptedSubscription(SUB_ID, API_ID_2);
+            subscriptionService.register(subApi1);
+            subscriptionService.register(subApi2);
+
+            ApiKey apiKey = new ApiKey();
+            apiKey.setSubscription(SUB_ID);
+            when(apiKeyService.getByApiAndKey(API_ID, "apiKeyValue")).thenReturn(Optional.of(apiKey));
+            when(apiKeyService.getByApiAndKey(API_ID_2, "apiKeyValue")).thenReturn(Optional.of(apiKey));
+
+            assertThat(subscriptionService.getByApiAndSecurityToken(API_ID, SecurityToken.forApiKey("apiKeyValue"), PLAN_ID)).contains(
+                subApi1
+            );
+            assertThat(subscriptionService.getByApiAndSecurityToken(API_ID_2, SecurityToken.forApiKey("apiKeyValue"), PLAN_ID)).contains(
+                subApi2
+            );
+        }
     }
 
     @Nested
@@ -873,6 +895,48 @@ class SubscriptionCacheServiceTest {
             assertThat(foundEmpty)
                 .describedAs("Subscription must always be reachable by at least one client certificate during update")
                 .isFalse();
+        }
+
+        @Test
+        void should_unregister_every_subscription_registered_concurrently_for_the_same_api() throws Exception {
+            // Sync appenders register subscriptions of the same API from several threads
+            // (services.sync.appender.parallelism). Every registered cache key must survive the
+            // concurrent maintenance of cacheKeysByApiId so unregisterByApiId() can evict them all.
+            int writerCount = 8;
+            int subscriptionsPerWriter = 200;
+            CyclicBarrier barrier = new CyclicBarrier(writerCount);
+            List<Future<?>> futures = new ArrayList<>();
+            try (ExecutorService writers = Executors.newFixedThreadPool(writerCount)) {
+                for (int w = 0; w < writerCount; w++) {
+                    int writerId = w;
+                    futures.add(
+                        writers.submit(() -> {
+                            barrier.await();
+                            for (int i = 0; i < subscriptionsPerWriter; i++) {
+                                String suffix = writerId + "-" + i;
+                                subscriptionService.register(
+                                    buildAcceptedSubscriptionWithClientId("sub-" + suffix, API_ID, "client-" + suffix, PLAN_ID)
+                                );
+                            }
+                            return null;
+                        })
+                    );
+                }
+                for (Future<?> future : futures) {
+                    future.get(10, TimeUnit.SECONDS);
+                }
+            }
+
+            subscriptionService.unregisterByApiId(API_ID);
+
+            for (int w = 0; w < writerCount; w++) {
+                for (int i = 0; i < subscriptionsPerWriter; i++) {
+                    String suffix = w + "-" + i;
+                    assertThat(subscriptionService.getById("sub-" + suffix)).isEmpty();
+                    assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, "client-" + suffix, PLAN_ID)).isEmpty();
+                }
+            }
+            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
@@ -31,6 +31,12 @@
     <name>Gravitee.io APIM - Gateway - Services - Sync</name>
 
     <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Gravitee.io dependencies -->
         <dependency>
             <groupId>io.gravitee.node</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -16,6 +16,8 @@
 package io.gravitee.gateway.services.sync.process.common.mapper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionConfiguration;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
@@ -31,6 +33,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @CustomLog
 public class SubscriptionMapper {
+
+    /**
+     * Deduplicates the low-cardinality fields shared by many subscriptions (a few thousand
+     * distinct apis/plans/applications for millions of cached subscriptions, ~90 bytes wasted per
+     * private copy). Weak interner: entries are reclaimed by the GC as soon as no cached
+     * subscription references them, so the pool cleans itself up and never outlives its values.
+     */
+    private static final Interner<String> STRING_INTERNER = Interners.newWeakInterner();
 
     private final ObjectMapper objectMapper;
     private final ApiProductRegistry apiProductRegistry;
@@ -89,15 +99,15 @@ public class SubscriptionMapper {
 
     private Subscription toSubscription(io.gravitee.repository.management.model.Subscription subscriptionModel) {
         Subscription subscription = new Subscription();
-        subscription.setApi(resolveApiId(subscriptionModel));
-        subscription.setApplication(subscriptionModel.getApplication());
-        subscription.setApplicationName(subscriptionModel.getApplicationName());
+        subscription.setApi(intern(resolveApiId(subscriptionModel)));
+        subscription.setApplication(intern(subscriptionModel.getApplication()));
+        subscription.setApplicationName(intern(subscriptionModel.getApplicationName()));
         subscription.setClientId(subscriptionModel.getClientId());
         subscription.setClientCertificate(subscriptionModel.getClientCertificate());
         subscription.setStartingAt(subscriptionModel.getStartingAt());
         subscription.setEndingAt(subscriptionModel.getEndingAt());
         subscription.setId(subscriptionModel.getId());
-        subscription.setPlan(subscriptionModel.getPlan());
+        subscription.setPlan(intern(subscriptionModel.getPlan()));
         if (subscriptionModel.getStatus() != null) {
             subscription.setStatus(subscriptionModel.getStatus().name());
         }
@@ -122,7 +132,7 @@ public class SubscriptionMapper {
         // non-empty case keeps HashMap on purpose: unlike Map.copyOf it tolerates null values.
         Map<String, String> sourceMetadata = subscriptionModel.getMetadata();
         subscription.setMetadata(sourceMetadata == null || sourceMetadata.isEmpty() ? Map.of() : new HashMap<>(sourceMetadata));
-        subscription.setEnvironmentId(subscriptionModel.getEnvironmentId());
+        subscription.setEnvironmentId(intern(subscriptionModel.getEnvironmentId()));
         return subscription;
     }
 
@@ -137,6 +147,11 @@ public class SubscriptionMapper {
             sub.setApiProductId(subscriptionModel.getReferenceId());
         }
         return sub;
+    }
+
+    /** Never intern id/clientId/clientCertificate: unique per subscription, they would only pollute the pool. */
+    private static String intern(String value) {
+        return value == null ? null : STRING_INTERNER.intern(value);
     }
 
     /** Resolve API id: API ref uses referenceId or legacy api; API Product uses api. */

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -116,10 +116,12 @@ public class SubscriptionMapper {
                 log.warn("Unable to parse subscription configuration for [{}]", subscriptionModel.getId(), e);
             }
         }
-        Map<String, String> metadata = subscriptionModel.getMetadata() != null
-            ? new HashMap<>(subscriptionModel.getMetadata())
-            : new HashMap<>();
-        subscription.setMetadata(metadata);
+        // Share the JVM's empty-map singleton instead of allocating one HashMap per subscription:
+        // on large deployments most subscriptions carry no metadata and the per-instance maps
+        // account for hundreds of MB. Consumers are read-only (template engine variable). The
+        // non-empty case keeps HashMap on purpose: unlike Map.copyOf it tolerates null values.
+        Map<String, String> sourceMetadata = subscriptionModel.getMetadata();
+        subscription.setMetadata(sourceMetadata == null || sourceMetadata.isEmpty() ? Map.of() : new HashMap<>(sourceMetadata));
         subscription.setEnvironmentId(subscriptionModel.getEnvironmentId());
         return subscription;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
@@ -142,6 +142,33 @@ class SubscriptionMapperTest {
     }
 
     @Test
+    void should_intern_repeated_field_values_across_subscriptions() {
+        // new String(...) guarantees distinct input instances (literals are JVM-interned)
+        Subscription other = new Subscription();
+        other.setId("other-id");
+        other.setReferenceType(SubscriptionReferenceType.API);
+        other.setReferenceId(new String("api"));
+        other.setApplication(new String("application"));
+        other.setApplicationName(new String("application-name"));
+        other.setPlan(new String("plan"));
+        other.setEnvironmentId(new String("env"));
+        other.setStatus(Subscription.Status.ACCEPTED);
+        subscription.setApplicationName("application-name");
+        subscription.setEnvironmentId("env");
+
+        io.gravitee.gateway.api.service.Subscription first = cut.to(subscription).getFirst();
+        io.gravitee.gateway.api.service.Subscription second = cut.to(other).getFirst();
+
+        assertThat(second.getApi()).isSameAs(first.getApi());
+        assertThat(second.getApplication()).isSameAs(first.getApplication());
+        assertThat(second.getApplicationName()).isSameAs(first.getApplicationName());
+        assertThat(second.getPlan()).isSameAs(first.getPlan());
+        assertThat(second.getEnvironmentId()).isSameAs(first.getEnvironmentId());
+        // unique-per-subscription fields are not interned
+        assertThat(second.getId()).isEqualTo("other-id");
+    }
+
+    @Test
     void should_return_empty_list_when_api_product_not_in_registry() {
         subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
         subscription.setReferenceId("product-1");

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
@@ -29,6 +29,7 @@ import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMappe
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -115,6 +116,29 @@ class SubscriptionMapperTest {
         assertThat(subscriptionMapped.getType()).isEqualTo(io.gravitee.gateway.api.service.Subscription.Type.STANDARD);
         assertThat(subscriptionMapped.getConfiguration()).isNull();
         assertThat(subscriptionMapped.getMetadata()).isEmpty();
+    }
+
+    @Test
+    void should_share_the_empty_metadata_singleton_across_subscriptions() {
+        subscription.setMetadata(null);
+        io.gravitee.gateway.api.service.Subscription first = cut.to(subscription).getFirst();
+
+        subscription.setMetadata(Map.of());
+        io.gravitee.gateway.api.service.Subscription second = cut.to(subscription).getFirst();
+
+        assertThat(first.getMetadata()).isEmpty();
+        assertThat(first.getMetadata()).isSameAs(second.getMetadata());
+    }
+
+    @Test
+    void should_keep_metadata_entries_with_null_values() {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("key", null);
+        subscription.setMetadata(metadata);
+
+        io.gravitee.gateway.api.service.Subscription mapped = cut.to(subscription).getFirst();
+
+        assertThat(mapped.getMetadata()).containsEntry("key", null);
     }
 
     @Test

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnector.java
@@ -79,6 +79,12 @@ public class HttpProxyEndpointConnector extends HttpEndpointSyncConnector {
     }
 
     @Override
+    protected void doStart() throws Exception {
+        // Override to avoid excessive logging when the service starts.
+        log.debug("Initializing service {}", name());
+    }
+
+    @Override
     public String id() {
         return ENDPOINT_ID;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
         <gravitee-resource-auth-provider-http.version>1.4.0</gravitee-resource-auth-provider-http.version>
         <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>
         <gravitee-resource-auth-provider-ldap.version>2.0.1</gravitee-resource-auth-provider-ldap.version>
-        <gravitee-resource-cache-redis.version>4.0.4</gravitee-resource-cache-redis.version>
+        <gravitee-resource-cache-redis.version>4.2.1</gravitee-resource-cache-redis.version>
         <gravitee-resource-oauth2-provider-keycloak.version>3.0.1</gravitee-resource-oauth2-provider-keycloak.version>
         <gravitee-resource-ai-model-text-classification.version>2.2.1</gravitee-resource-ai-model-text-classification.version>
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>


### PR DESCRIPTION
## Issue

Gateway-side RCA of a customer performance incident on 4.11.x (CPU spikes, Vert.x blocked threads, TLS handshakes > 10 s under load, degraded at ~3.3M active subscriptions and ~5.5k deployed APIs).

**Evidence backing this PR:**
- A full packet capture of a degraded run shows the slow TLS handshakes are **one ~30 s process-wide JVM stall** (egress collapses from ~7,000 to ~100 packets/s, everything stops together — clients, upstream, Redis, reporter — while the network stays clean: no retransmissions, no resets). Signature of a GC death spiral, not a TLS/network problem.
- MAT analysis of a 10 GB heap dump from a gateway pod: a single `SubscriptionCacheService` instance retains **7.8 GB — 72.6% of a 10.75 GB heap** — for 4,101,787 cached `Subscription` objects, leaving no GC headroom. Breakdown: 4.08M `ConcurrentHashMap`-backed keySets (~1.4 GB), composite String cache keys (bulk of a 1.65 GB identity map), a fully redundant by-id map (~0.5 GB), 4.1M **empty** metadata `HashMap`s + cached `EntrySet` views (360 MB), and exactly 6 exclusive strings per subscription (~2 GB, no value sharing at all).

This PR supersedes #18509 and #18511 (closed), carrying the whole stack. Expected total reduction on the analyzed dump: **−3.4 to −4.4 GB** of live heap.

## Description

### Footprint reductions (`SubscriptionCacheService`, `SubscriptionMapper`)

1. **Immutable singleton sets in the exploded-subscription cache** (−0.7 to −1.0 GB). One `ConcurrentHashMap.newKeySet()` per subscription id becomes an immutable, usually singleton, set replaced atomically via `compute()` (~5× smaller per entry); reads need no defensive copies (`getAllById`), and the API-key hot path (`getByApiAndId`) iterates instead of allocating a Stream pipeline per request.
2. **Merge the by-id cache into the exploded-subscription index** (−~0.5 GB). `cacheBySubscriptionId` duplicated every entry. `getById()` reads the single index; for exploded API-Product subscriptions it returns an arbitrary leg, matching the historical behavior. The `unregister()` rehydration block (which only existed to keep both maps consistent) is removed.
3. **Share the empty-metadata singleton** (−~0.36 GB). The mapper allocated one `HashMap` per subscription even when metadata was empty (all 4.1M on the dump). Empty metadata now maps to `Map.of()`; non-empty keeps `HashMap` on purpose (`Map.copyOf` rejects null values coming from the repository). Runtime consumption is read-only (template-engine `SubscriptionVariable`) — verified no `getMetadata()` mutation in the gateway runtime.
4. **Record identity-cache keys** (−0.9 to −1.2 GB). Identity caches were keyed by `String.format("%s.%s.%s", api, plan, clientIdentity)` — two fresh ~176-byte strings per client-id subscription, plus a `String.format` per JWT/OAuth2 request on the hot path. Keys are now a small record reusing the subscription's own field references; lookups allocate one short-lived 32-byte record.
5. **Intern repeated field values at sync-mapping time** (−0.9 to −1.3 GB). Every subscription owned private copies of `api`/`plan`/`application`/`applicationName`/`environmentId` although those fields take a few thousand distinct values. A **Guava weak interner** deduplicates them: entries are reclaimed by the GC as soon as no cached subscription references them — the pool cleans itself up, no eviction logic to maintain. `id`/`clientId`/`clientCertificate` are intentionally not interned. Guava was already on the gateway runtime classpath (used by `gateway-flow` on the request path); it is now declared explicitly (`provided`, version managed by the BOM, matching the sync module's conventions).

### Correctness fixes surfaced by the analysis

- **`cacheKeysByApiId` thread safety**: `updateCacheKeyByApiId()`/`evictKeyForApi()` used get/mutate/put on a plain `HashSet`. Sync appenders register subscriptions of the same API from several threads (`services.sync.appender.parallelism` defaults to 4 since 4.11.9), so concurrent calls could lose updates or corrupt the set. Maintenance is now atomic (`compute()` + concurrent set), with lock ordering arranged so no two map locks are held in opposite orders. Covered by a concurrency regression test that fails on the previous code.
- **Singleton fast paths** in register/unregister/undeploy maintenance (review feedback): skip stream pipelines and temporary sets for the dominant single-leg case.
- **Startup log noise**: the http-proxy endpoint connector logged one INFO line per start — hundreds of thousands of lines at startup on large deployments; lowered to debug.

### Also in this PR

- **`gravitee-resource-cache-redis` bumped to 4.2.1**: the plugin now shares the Lettuce client resources instead of creating one per API resource — on this deployment it cuts Redis client threads from **~5,000 to ~50**, drastically reducing CPU/context-switching pressure.

### Runtime behavior

No public API change (`SubscriptionService` interface untouched); behavior-preserving. The request hot path gets strictly faster (no Stream/`String.format` allocation per call; interned fields enable the `==` fast path in `Subscription.equals()` used by sync change detection every cycle).

## Validation

- `gravitee-apim-gateway-handlers-api`: **919/919** tests — cache test class run ×5 after each commit for concurrency-test stability; includes new tests: exploded api-key lookup per leg, `getById` on exploded subscriptions, and the concurrent same-api registration regression test (verified to fail on the pre-fix code).
- `gravitee-apim-gateway-services-sync`: **388/388** tests — new tests: empty-metadata singleton sharing, null-value metadata tolerance, same-instance interning across mappings (with `new String(...)` inputs).
- Integration tests re-run after each risky step: `SubscriptionElIntegrationTest` (EL access to `subscription.metadata`), `ApiProductV4IntegrationTest`, `ApiProductV4SecurityIntegrationTest` (mTLS/JWT on exploded subscriptions).

## Additional context

- Remaining follow-ups (out of scope): model slimming (`Date` → epoch long, lazy `SubscriptionConfiguration` parse, derived `cacheKeysByApiId`), interning in the distributed-sync mapper, and the per-API reactor footprint work-stream (Redis cache resource sharing — plugin 4.2.1 already bumped here —, inline content dedup, lazy endpoint-group machinery).


