### PR TITLE
chore: bump gravitee-policy-groovy from 4.3.6 to 5.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <gravitee-policy-generate-jwt.version>1.8.0</gravitee-policy-generate-jwt.version>
     <gravitee-policy-generate-wssecurity.version>1.0.0</gravitee-policy-generate-wssecurity.version>
     <gravitee-policy-geoip-filtering.version>2.2.2</gravitee-policy-geoip-filtering.version>
-    <gravitee-policy-groovy.version>4.3.6</gravitee-policy-groovy.version>
+    <gravitee-policy-groovy.version>5.0.4</gravitee-policy-groovy.version>
     <gravitee-policy-html-json.version>1.6.3</gravitee-policy-html-json.version>
     <gravitee-policy-http-signature.version>1.7.0</gravitee-policy-http-signature.version>
     <gravitee-policy-interrupt.version>2.2.0</gravitee-policy-interrupt.version>


### PR DESCRIPTION
## Issue

N/A

## Description

Bump `gravitee-policy-groovy` from 4.3.6 to 5.0.4.

## Additional context

Release: https://github.com/gravitee-io/gravitee-policy-groovy/releases/tag/5.0.4