### PR TITLE
fix: show out of sync status for all apis in api list page

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -233,7 +233,13 @@ describe('ApisListComponent', () => {
 
         await loader.getHarness(GioTableWrapperHarness).then(tableWrapper => tableWrapper.setSearchValue('bad-search'));
         await tick(400);
-        const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=25`);
+        const req = httpTestingController.expectOne(
+          request =>
+            request.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search` &&
+            request.params.get('page') === '1' &&
+            request.params.get('perPage') === '25' &&
+            request.params.get('expands') === 'deploymentState',
+        );
         expect(req.request.body).toEqual({ query: 'bad-search' });
 
         req.flush('Internal error', { status: 500, statusText: 'Internal error' });
@@ -261,12 +267,10 @@ describe('ApisListComponent', () => {
 
         const nameSort = await loader.getHarness(MatSortHeaderHarness.with({ selector: '#name' })).then(sortHarness => sortHarness.host());
         await nameSort.click();
-        apis.map(api => expectSyncedApi(api.id, true));
         expectApisListRequest(apis, 'name');
 
         fixture.detectChanges();
         await nameSort.click();
-        apis.map(api => expectSyncedApi(api.id, true));
         expectApisListRequest(apis, '-name');
       }));
 
@@ -280,21 +284,56 @@ describe('ApisListComponent', () => {
           .getHarness(MatSortHeaderHarness.with({ selector: '#access' }))
           .then(sortHarness => sortHarness.host());
         await accessSort.click();
-        apis.map(api => expectSyncedApi(api.id, true));
         expectApisListRequest(apis, 'paths');
 
         fixture.detectChanges();
         await accessSort.click();
-        apis.map(api => expectSyncedApi(api.id, true));
         expectApisListRequest(apis, '-paths');
       }));
 
-      it('should display out of sync api icon', fakeAsync(async () => {
-        const api = fakeApiV2();
-        const apis = [api];
-        await initComponent(apis);
+      it('should display out of sync api icon for v2 api', fakeAsync(async () => {
+        const api = fakeApiV2({ deploymentState: 'NEED_REDEPLOY' });
+        await initComponent([api]);
+
+        expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-is-not-synced' }))).toBeTruthy();
+      }));
+
+      it('should display out of sync icon for v4 http proxy api', fakeAsync(async () => {
+        const api = fakeProxyApiV4({
+          deploymentState: 'NEED_REDEPLOY',
+          listeners: [
+            {
+              type: 'HTTP',
+              entrypoints: [{ type: 'http-proxy' }],
+              paths: [{ path: '/test' }],
+            },
+          ],
+        });
+        await initComponent([api]);
+
+        expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-is-not-synced' }))).toBeTruthy();
+      }));
+
+      it('should not display out of sync icon for synced v4 http proxy api', fakeAsync(async () => {
+        const api = fakeProxyApiV4({
+          deploymentState: 'DEPLOYED',
+          listeners: [
+            {
+              type: 'HTTP',
+              entrypoints: [{ type: 'http-proxy' }],
+              paths: [{ path: '/test' }],
+            },
+          ],
+        });
+        await initComponent([api]);
+
         expect(await loader.getAllHarnesses(MatIconHarness.with({ selector: '.states__api-is-not-synced' }))).toHaveLength(0);
-        expectSyncedApi(api.id, false);
+      }));
+
+      it('should display out of sync icon for other v4 api types', fakeAsync(async () => {
+        const api = fakeApiV4({ type: 'LLM_PROXY', listeners: [], deploymentState: 'NEED_REDEPLOY' });
+        await initComponent([api]);
+
         expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-is-not-synced' }))).toBeTruthy();
       }));
 
@@ -346,7 +385,6 @@ describe('ApisListComponent', () => {
       async function initComponent(api: Api, score = 1) {
         expectApisListRequest([api], 'name');
         loader = TestbedHarnessEnvironment.loader(fixture);
-        expectSyncedApi(api.id, true);
         expectTagsRequest();
         expectQualityRequest(api.id, score);
         httpTestingController.verify();
@@ -589,7 +627,12 @@ describe('ApisListComponent', () => {
     tick(400);
 
     const req = httpTestingController.expectOne(
-      `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=${page}&perPage=25${sortBy ? `&sortBy=${sortBy}` : ''}`,
+      request =>
+        request.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search` &&
+        request.params.get('page') === `${page}` &&
+        request.params.get('perPage') === '25' &&
+        request.params.get('expands') === 'deploymentState' &&
+        (sortBy ? request.params.get('sortBy') === sortBy : request.params.get('sortBy') === null),
     );
     expect(req.request.method).toEqual('POST');
 
@@ -598,15 +641,5 @@ describe('ApisListComponent', () => {
     }
 
     req.flush(fakePagedResult(apis));
-  }
-
-  function expectSyncedApi(apiId: string, isSynced: boolean) {
-    // wait debounceTime
-    fixture.detectChanges();
-    tick();
-
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/state`);
-    expect(req.request.method).toEqual('GET');
-    req.flush({ api_id: apiId, is_synchronized: isSynced });
   }
 });

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -42,7 +42,7 @@ import {
   PagedResult,
 } from '../../../entities/management-api-v2';
 import { CategoryService } from '../../../services-ngx/category.service';
-import { getApiAccess } from '../../../shared/utils';
+import { getApiAccess, isApiOutOfSync } from '../../../shared/utils';
 
 export enum FilterType {
   API_TYPE,
@@ -252,7 +252,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
             visibilities: this.filters.portalVisibilities,
           };
           return this.apiServiceV2
-            .search(body, apiSortByParamFromString(order), filters.pagination.index, filters.pagination.size)
+            .search(body, apiSortByParamFromString(order), filters.pagination.index, filters.pagination.size, true, ['deploymentState'])
             .pipe(catchError(() => of(new PagedResult<Api>())));
         }),
         tap(apisPage => {
@@ -372,18 +372,20 @@ export class ApiListComponent implements OnInit, OnDestroy {
             picture: api._links.pictureUrl,
             categories: (api.categories ?? []).map(cat => this.categoriesNames.get(cat)),
           };
+          const isNotSynced$ = of(isApiOutOfSync(api));
+
           if (api.definitionVersion === 'V4') {
             return {
               ...tableDS,
               access: getApiAccess(api),
-              isNotSynced$: undefined,
+              isNotSynced$,
               qualityScore$: null,
             };
           } else if (api.definitionVersion === 'FEDERATED' || api.definitionVersion === 'FEDERATED_AGENT') {
             return {
               ...tableDS,
               access: [],
-              isNotSynced$: undefined,
+              isNotSynced$,
               qualityScore$: null,
               provider: api.originContext.provider,
             };
@@ -392,7 +394,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
             return {
               ...tableDS,
               access: getApiAccess(apiv2),
-              isNotSynced$: this.apiService.isAPISynchronized(apiv2.id).pipe(map(a => !a.is_synchronized)),
+              isNotSynced$,
               qualityScore$: this.isQualityDisplayed
                 ? this.apiService.getQualityMetrics(apiv2.id).pipe(map(a => this.getQualityScore(Math.floor(a.score * 100))))
                 : null,

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -340,6 +340,23 @@ describe('ApiV2Service', () => {
       });
     });
 
+    it('should pass expands query param', done => {
+      const fakeApi = fakeApiV4();
+
+      apiV2Service.search({ ids: [fakeApi.id] }, undefined, 1, 10, true, ['deploymentState']).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=10&expands=deploymentState`,
+        method: 'POST',
+      });
+
+      req.flush({
+        data: [fakeApi],
+      });
+    });
+
     it('should not get manage only APIs', done => {
       const fakeApi = fakeApiV4();
 

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -236,13 +236,21 @@ export class ApiV2Service {
     });
   }
 
-  search(searchQuery: ApiSearchQuery = {}, sortBy?: ApiSortByParam, page = 1, perPage = 10, manageOnly = true): Observable<ApisResponse> {
+  search(
+    searchQuery: ApiSearchQuery = {},
+    sortBy?: ApiSortByParam,
+    page = 1,
+    perPage = 10,
+    manageOnly = true,
+    expands?: string[],
+  ): Observable<ApisResponse> {
     return this.http.post<ApisResponse>(`${this.constants.env.v2BaseURL}/apis/_search`, searchQuery, {
       params: {
         page,
         perPage,
         ...(sortBy ? { sortBy } : {}),
         ...(manageOnly ? {} : { manageOnly: false }),
+        ...(expands?.length ? { expands: expands.join(',') } : {}),
       },
     });
   }

--- a/gravitee-apim-console-webui/src/shared/utils/api-access.util.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/api-access.util.spec.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { getApiAccess, getApiContextPath } from './api-access.util';
+import { getApiAccess, getApiContextPath, isApiOutOfSync } from './api-access.util';
 
-import { fakeApiV2, fakeApiV4, fakeNativeKafkaApiV4 } from '../../entities/management-api-v2';
+import { fakeApiV2, fakeApiV4, fakeNativeKafkaApiV4, fakeProxyApiV4 } from '../../entities/management-api-v2';
 
 describe('getApiAccess', () => {
   it('should return v2 virtualHosts when present', () => {
@@ -138,5 +138,22 @@ describe('getApiContextPath', () => {
   it('should return null for unsupported definition version', () => {
     const api = { definitionVersion: 'FEDERATED' } as Parameters<typeof getApiContextPath>[0];
     expect(getApiContextPath(api)).toBe(null);
+  });
+});
+
+describe('isApiOutOfSync', () => {
+  it('should return true when deployment state is NEED_REDEPLOY', () => {
+    expect(isApiOutOfSync(fakeApiV2({ deploymentState: 'NEED_REDEPLOY' }))).toBe(true);
+    expect(isApiOutOfSync(fakeProxyApiV4({ deploymentState: 'NEED_REDEPLOY' }))).toBe(true);
+  });
+
+  it('should return false when deployment state is DEPLOYED', () => {
+    expect(isApiOutOfSync(fakeApiV2({ deploymentState: 'DEPLOYED' }))).toBe(false);
+    expect(isApiOutOfSync(fakeApiV4({ deploymentState: 'DEPLOYED' }))).toBe(false);
+  });
+
+  it('should return false when deployment state is missing', () => {
+    expect(isApiOutOfSync(fakeApiV2())).toBe(false);
+    expect(isApiOutOfSync(fakeApiV4())).toBe(false);
   });
 });

--- a/gravitee-apim-console-webui/src/shared/utils/api-access.util.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/api-access.util.ts
@@ -52,3 +52,5 @@ export function getApiContextPath(api: Api | null | undefined): string | null {
   const access = getApiAccess(api as ApiV4 | ApiV2);
   return access?.[0] ?? null;
 }
+
+export const isApiOutOfSync = (api: Api): boolean => api.deploymentState === 'NEED_REDEPLOY';


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14633

## Description

On the APIs list page in APIM Console, APIs that need redeployment did not show the out-of-sync refresh icon for V4 (and Federated) APIs, even though the API detail page correctly showed the “This API is out of sync” banner.

## Root Cause

The APIs list page and the API detail page used different ways to decide if an API was out of sync.

On the detail page, it looked at a field on the API called deploymentState. If that said the API needed redeploy, it showed the warning.
On the list page, for V4 and Federated APIs, that check was never done. The code always treated them as “in sync,” so the refresh icon never appeared.
For V2 APIs, the list page did check sync status, but by making a separate request per API, not by using the same deploymentState field.
So the backend already knew when V4 APIs were out of sync, and the detail page showed it correctly. The list page simply ignored that information for V4 (and Federated) APIs.



https://github.com/user-attachments/assets/e3b5618d-79b5-40ea-bc6e-4630bf7844f2


## Fix


https://github.com/user-attachments/assets/eb06cedf-b3fc-4c26-a1ae-d71d1817a423



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

