### PR TITLE
feat(repository): add portal category persistence (JDBC + MongoDB)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalCategoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalCategoryRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.PortalCategory;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface PortalCategoryRepository extends CrudRepository<PortalCategory, String> {
+    List<PortalCategory> findAllByEnvironmentId(String environmentId) throws TechnicalException;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalCategoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalCategoryRepository.java
@@ -24,4 +24,6 @@ import java.util.List;
  */
 public interface PortalCategoryRepository extends CrudRepository<PortalCategory, String> {
     List<PortalCategory> findAllByEnvironmentId(String environmentId) throws TechnicalException;
+
+    void deleteByEnvironmentId(String environmentId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalCategory.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalCategory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@EqualsAndHashCode(of = "id")
+public class PortalCategory {
+
+    private String id;
+    private String environmentId;
+    private String title;
+    private String description;
+    private boolean visible;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalCategory.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalCategory.java
@@ -35,5 +35,7 @@ public class PortalCategory {
     private String environmentId;
     private String title;
     private String description;
-    private boolean visible;
+
+    @Builder.Default
+    private boolean visible = true;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalCategoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalCategoryRepository.java
@@ -65,4 +65,14 @@ public class JdbcPortalCategoryRepository extends JdbcAbstractCrudRepository<Por
             throw new TechnicalException("Failed to find portal categories by environment id", ex);
         }
     }
+
+    @Override
+    public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("JdbcPortalCategoryRepository.deleteByEnvironmentId({})", environmentId);
+        try {
+            jdbcTemplate.update("delete from " + this.tableName + " where environment_id = ?", environmentId);
+        } catch (final Exception ex) {
+            throw new TechnicalException("Failed to delete portal categories by environment id: " + environmentId, ex);
+        }
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalCategoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalCategoryRepository.java
@@ -62,9 +62,7 @@ public class JdbcPortalCategoryRepository extends JdbcAbstractCrudRepository<Por
                 environmentId
             );
         } catch (final Exception ex) {
-            final String error = "Failed to find portal categories by environment id";
-            log.error(error, ex);
-            throw new TechnicalException(error, ex);
+            throw new TechnicalException("Failed to find portal categories by environment id", ex);
         }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalCategoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalCategoryRepository.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import io.gravitee.repository.management.api.PortalCategoryRepository;
+import io.gravitee.repository.management.model.PortalCategory;
+import java.sql.Types;
+import java.util.List;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Repository
+public class JdbcPortalCategoryRepository extends JdbcAbstractCrudRepository<PortalCategory, String> implements PortalCategoryRepository {
+
+    JdbcPortalCategoryRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
+        super(tablePrefix, "portal_categories");
+    }
+
+    @Override
+    protected JdbcObjectMapper<PortalCategory> buildOrm() {
+        return JdbcObjectMapper.builder(PortalCategory.class, this.tableName, "id")
+            .addColumn("id", Types.NVARCHAR, String.class)
+            .addColumn("environment_id", Types.NVARCHAR, String.class)
+            .addColumn("title", Types.NVARCHAR, String.class)
+            .addColumn("description", Types.NVARCHAR, String.class)
+            .addColumn("visible", Types.BOOLEAN, boolean.class)
+            .build();
+    }
+
+    @Override
+    protected String getId(final PortalCategory item) {
+        return item.getId();
+    }
+
+    @Override
+    public List<PortalCategory> findAllByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("JdbcPortalCategoryRepository.findAllByEnvironmentId({})", environmentId);
+        try {
+            return jdbcTemplate.query(
+                getOrm().getSelectAllSql() + " where environment_id = ? order by title",
+                getOrm().getRowMapper(),
+                environmentId
+            );
+        } catch (final Exception ex) {
+            final String error = "Failed to find portal categories by environment id";
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/05_add_portal_categories_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/05_add_portal_categories_table.yml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_05_add_portal_categories_table
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      changes:
+        - createTable:
+            tableName: ${gravitee_prefix}portal_categories
+            columns:
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}portal_categories" } }
+              - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: title, type: nvarchar(512), constraints: { nullable: false } }
+              - column: { name: description, type: nvarchar(2000) }
+              - column: { name: visible, type: boolean, defaultValueBoolean: true, constraints: { nullable: false } }
+        - createIndex:
+            tableName: ${gravitee_prefix}portal_categories
+            indexName: idx_${gravitee_prefix}portal_categories_environment_id
+            columns:
+              - column:
+                  name: environment_id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -395,3 +395,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_13_0/03_add_kind_to_api_products.yml
     - include:
         - file: liquibase/changelogs/v4_13_0/04_add_ai_workspace_components_table.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/05_add_portal_categories_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -167,7 +167,8 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
         "kafka_port_ranges",
         "am_connections",
         "portals",
-        "portal_listings"
+        "portal_listings",
+        "portal_categories"
     );
     private static final List<String> tablesToDrop = concatenate(tablesToTruncate, List.of("databasechangelog", "databasechangeloglock"));
     private final DataSource dataSource;

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalCategoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalCategoryRepository.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalCategoryRepository;
+import io.gravitee.repository.management.model.PortalCategory;
+import io.gravitee.repository.mongodb.management.internal.PortalCategoryMongoRepository;
+import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Component
+@RequiredArgsConstructor
+public class MongoPortalCategoryRepository implements PortalCategoryRepository {
+
+    private final PortalCategoryMongoRepository internalPortalCategoryRepo;
+    private final GraviteeMapper mapper;
+
+    @Override
+    public Set<PortalCategory> findAll() throws TechnicalException {
+        log.debug("Find all portal categories");
+        var portalCategories = internalPortalCategoryRepo.findAll();
+        var res = mapper.mapPortalCategories(portalCategories);
+        log.debug("Find all portal categories - Done");
+        return res;
+    }
+
+    @Override
+    public Optional<PortalCategory> findById(String id) throws TechnicalException {
+        log.debug("Find portal category by ID [{}]", id);
+        var portalCategory = internalPortalCategoryRepo.findById(id).orElse(null);
+        log.debug("Find portal category by ID [{}] - Done", id);
+        return Optional.ofNullable(mapper.map(portalCategory));
+    }
+
+    @Override
+    public PortalCategory create(PortalCategory portalCategory) throws TechnicalException {
+        log.debug("Create portal category [{}]", portalCategory.getTitle());
+        var portalCategoryMongo = mapper.map(portalCategory);
+        var createdPortalCategoryMongo = internalPortalCategoryRepo.insert(portalCategoryMongo);
+        var res = mapper.map(createdPortalCategoryMongo);
+        log.debug("Create portal category [{}] - Done", portalCategory.getTitle());
+        return res;
+    }
+
+    @Override
+    public PortalCategory update(PortalCategory portalCategory) throws TechnicalException {
+        if (portalCategory == null || portalCategory.getTitle() == null) {
+            throw new IllegalStateException("Portal category to update must have a title");
+        }
+
+        var existing = internalPortalCategoryRepo.findById(portalCategory.getId()).orElse(null);
+
+        if (existing == null) {
+            throw new IllegalStateException(String.format("No portal category found with id [%s]", portalCategory.getId()));
+        }
+
+        try {
+            var portalCategoryMongo = mapper.map(portalCategory);
+            var updatedPortalCategoryMongo = internalPortalCategoryRepo.save(portalCategoryMongo);
+            return mapper.map(updatedPortalCategoryMongo);
+        } catch (Exception e) {
+            var error = "An error occurred when updating portal category";
+            log.error(error, e);
+            throw new TechnicalException(error);
+        }
+    }
+
+    @Override
+    public void delete(String id) throws TechnicalException {
+        try {
+            internalPortalCategoryRepo.deleteById(id);
+        } catch (Exception e) {
+            var error = "An error occurred when deleting portal category " + id;
+            log.error(error, e);
+            throw new TechnicalException(error);
+        }
+    }
+
+    @Override
+    public List<PortalCategory> findAllByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("Find portal categories by environment ID [{}]", environmentId);
+        var portalCategories = internalPortalCategoryRepo.findByEnvironmentId(environmentId, Sort.by("title"));
+        log.debug("Find portal categories by environment ID [{}] - Done", environmentId);
+        return portalCategories.stream().map(mapper::map).toList();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalCategoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalCategoryRepository.java
@@ -103,4 +103,13 @@ public class MongoPortalCategoryRepository implements PortalCategoryRepository {
         log.debug("Find portal categories by environment ID [{}] - Done", environmentId);
         return portalCategories.stream().map(mapper::map).toList();
     }
+
+    @Override
+    public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
+        try {
+            internalPortalCategoryRepo.deleteByEnvironmentId(environmentId);
+        } catch (Exception e) {
+            throw new TechnicalException("An error occurred when deleting portal categories by environment: " + environmentId, e);
+        }
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalCategoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalCategoryRepository.java
@@ -83,9 +83,7 @@ public class MongoPortalCategoryRepository implements PortalCategoryRepository {
             var updatedPortalCategoryMongo = internalPortalCategoryRepo.save(portalCategoryMongo);
             return mapper.map(updatedPortalCategoryMongo);
         } catch (Exception e) {
-            var error = "An error occurred when updating portal category";
-            log.error(error, e);
-            throw new TechnicalException(error);
+            throw new TechnicalException("An error occurred when updating portal category", e);
         }
     }
 
@@ -94,9 +92,7 @@ public class MongoPortalCategoryRepository implements PortalCategoryRepository {
         try {
             internalPortalCategoryRepo.deleteById(id);
         } catch (Exception e) {
-            var error = "An error occurred when deleting portal category " + id;
-            log.error(error, e);
-            throw new TechnicalException(error);
+            throw new TechnicalException("An error occurred when deleting portal category " + id, e);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/PortalCategoryMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/PortalCategoryMongoRepository.java
@@ -27,4 +27,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PortalCategoryMongoRepository extends MongoRepository<PortalCategoryMongo, String> {
     List<PortalCategoryMongo> findByEnvironmentId(String environmentId, Sort sort);
+
+    void deleteByEnvironmentId(String environmentId);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/PortalCategoryMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/PortalCategoryMongoRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal;
+
+import io.gravitee.repository.mongodb.management.internal.model.PortalCategoryMongo;
+import java.util.List;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Repository
+public interface PortalCategoryMongoRepository extends MongoRepository<PortalCategoryMongo, String> {
+    List<PortalCategoryMongo> findByEnvironmentId(String environmentId, Sort sort);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalCategoryMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalCategoryMongo.java
@@ -38,5 +38,5 @@ public class PortalCategoryMongo {
     private String environmentId;
     private String title;
     private String description;
-    private boolean visible;
+    private boolean visible = true;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalCategoryMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalCategoryMongo.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Document(collection = "#{@environment.getProperty('management.mongodb.prefix')}portal_categories")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+public class PortalCategoryMongo {
+
+    @Id
+    private String id;
+
+    private String environmentId;
+    private String title;
+    private String description;
+    private boolean visible;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
@@ -148,6 +148,13 @@ public interface GraviteeMapper {
 
     CustomDashboardWidgetMongo map(CustomDashboardWidget toMap);
 
+    // PortalCategory mapping
+    PortalCategory map(PortalCategoryMongo toMap);
+
+    PortalCategoryMongo map(PortalCategory toMap);
+
+    Set<PortalCategory> mapPortalCategories(Collection<PortalCategoryMongo> toMap);
+
     // Dictionary mapping
     Dictionary map(DictionaryMongo toMap);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portalcategories/EnvironmentIdTitleIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portalcategories/EnvironmentIdTitleIndexUpgrader.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.portalcategories;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+@Component("PortalCategoriesEnvironmentIdTitleIndexUpgrader")
+public class EnvironmentIdTitleIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("portal_categories")
+            .name("e1t1")
+            .key("environmentId", ascending())
+            .key("title", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
@@ -255,6 +255,9 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
     protected CustomDashboardRepository customDashboardRepository;
 
     @Inject
+    protected PortalCategoryRepository portalCategoryRepository;
+
+    @Inject
     protected ApiProductsRepository apiProductsRepository;
 
     @Inject
@@ -309,6 +312,7 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
             case ScoringRuleset scoringRuleset -> scoringRulesetRepository.create(scoringRuleset);
             case ScoringFunction scoringFunction -> scoringFunctionRepository.create(scoringFunction);
             case CustomDashboard customDashboard -> customDashboardRepository.create(customDashboard);
+            case PortalCategory portalCategory -> portalCategoryRepository.create(portalCategory);
             case Dashboard apiQualityRule -> dashboardRepository.create(apiQualityRule);
             case AlertEvent alertEvent -> alertEventRepository.create(alertEvent);
             case Environment environment -> environmentRepository.create(environment);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalCategoryRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalCategoryRepositoryTest.java
@@ -29,14 +29,14 @@ public class PortalCategoryRepositoryTest extends AbstractManagementRepositoryTe
     }
 
     @Test
-    public void shouldFindAllByEnvironmentIdOrderedByTitle() throws Exception {
+    public void should_find_all_by_environment_id_ordered_by_title() throws Exception {
         List<PortalCategory> categories = portalCategoryRepository.findAllByEnvironmentId("DEFAULT");
 
         assertThat(categories).extracting(PortalCategory::getTitle).containsExactly("Analytics", "Banking", "Weather");
     }
 
     @Test
-    public void shouldFindAllByEnvironmentId_otherEnv() throws Exception {
+    public void should_find_all_by_environment_id_other_env() throws Exception {
         List<PortalCategory> categories = portalCategoryRepository.findAllByEnvironmentId("OTHER_ENV");
 
         assertThat(categories).hasSize(1);
@@ -44,12 +44,12 @@ public class PortalCategoryRepositoryTest extends AbstractManagementRepositoryTe
     }
 
     @Test
-    public void shouldReturnEmptyListForUnknownEnvironmentId() throws Exception {
+    public void should_return_empty_list_for_unknown_environment_id() throws Exception {
         assertThat(portalCategoryRepository.findAllByEnvironmentId("UNKNOWN")).isEmpty();
     }
 
     @Test
-    public void shouldFindById() throws Exception {
+    public void should_find_by_id() throws Exception {
         var portalCategory = portalCategoryRepository.findById("pc-2");
 
         assertThat(portalCategory).hasValueSatisfying(result -> {
@@ -61,12 +61,12 @@ public class PortalCategoryRepositoryTest extends AbstractManagementRepositoryTe
     }
 
     @Test
-    public void shouldReturnEmptyForUnknownId() throws Exception {
+    public void should_return_empty_for_unknown_id() throws Exception {
         assertThat(portalCategoryRepository.findById("unknown")).isEmpty();
     }
 
     @Test
-    public void shouldCreate() throws Exception {
+    public void should_create() throws Exception {
         var portalCategory = PortalCategory.builder()
             .id("new-pc")
             .environmentId("DEFAULT")
@@ -87,7 +87,7 @@ public class PortalCategoryRepositoryTest extends AbstractManagementRepositoryTe
     }
 
     @Test
-    public void shouldCreateWithNullDescription() throws Exception {
+    public void should_create_with_null_description() throws Exception {
         var portalCategory = PortalCategory.builder()
             .id("new-pc-null-desc")
             .environmentId("DEFAULT")
@@ -103,7 +103,7 @@ public class PortalCategoryRepositoryTest extends AbstractManagementRepositoryTe
     }
 
     @Test
-    public void shouldUpdate() throws Exception {
+    public void should_update() throws Exception {
         var optional = portalCategoryRepository.findById("pc-3");
         assertThat(optional).as("Portal category to update not found").isPresent();
 
@@ -123,7 +123,7 @@ public class PortalCategoryRepositoryTest extends AbstractManagementRepositoryTe
     }
 
     @Test
-    public void shouldDelete() throws Exception {
+    public void should_delete() throws Exception {
         var nbBefore = portalCategoryRepository.findAllByEnvironmentId("DEFAULT").size();
 
         portalCategoryRepository.delete("pc-1");

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalCategoryRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalCategoryRepositoryTest.java
@@ -19,8 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.repository.management.model.PortalCategory;
 import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class PortalCategoryRepositoryTest extends AbstractManagementRepositoryTest {
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalCategoryRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalCategoryRepositoryTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.management.model.PortalCategory;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class PortalCategoryRepositoryTest extends AbstractManagementRepositoryTest {
+
+    @Override
+    protected String getTestCasesPath() {
+        return "/data/portal-category-tests/";
+    }
+
+    @Test
+    public void shouldFindAllByEnvironmentIdOrderedByTitle() throws Exception {
+        List<PortalCategory> categories = portalCategoryRepository.findAllByEnvironmentId("DEFAULT");
+
+        assertThat(categories).extracting(PortalCategory::getTitle).containsExactly("Analytics", "Banking", "Weather");
+    }
+
+    @Test
+    public void shouldFindAllByEnvironmentId_otherEnv() throws Exception {
+        List<PortalCategory> categories = portalCategoryRepository.findAllByEnvironmentId("OTHER_ENV");
+
+        assertThat(categories).hasSize(1);
+        assertThat(categories.get(0).getTitle()).isEqualTo("Other Env Category");
+    }
+
+    @Test
+    public void shouldReturnEmptyListForUnknownEnvironmentId() throws Exception {
+        assertThat(portalCategoryRepository.findAllByEnvironmentId("UNKNOWN")).isEmpty();
+    }
+
+    @Test
+    public void shouldFindById() throws Exception {
+        var portalCategory = portalCategoryRepository.findById("pc-2");
+
+        assertThat(portalCategory).hasValueSatisfying(result -> {
+            assertThat(result.getEnvironmentId()).isEqualTo("DEFAULT");
+            assertThat(result.getTitle()).isEqualTo("Analytics");
+            assertThat(result.getDescription()).isEqualTo("Analytics related APIs");
+            assertThat(result.isVisible()).isFalse();
+        });
+    }
+
+    @Test
+    public void shouldReturnEmptyForUnknownId() throws Exception {
+        assertThat(portalCategoryRepository.findById("unknown")).isEmpty();
+    }
+
+    @Test
+    public void shouldCreate() throws Exception {
+        var portalCategory = PortalCategory.builder()
+            .id("new-pc")
+            .environmentId("DEFAULT")
+            .title("New Category")
+            .description("A new category")
+            .visible(true)
+            .build();
+
+        portalCategoryRepository.create(portalCategory);
+
+        var saved = portalCategoryRepository.findById("new-pc");
+        assertThat(saved).hasValueSatisfying(result -> {
+            assertThat(result.getEnvironmentId()).isEqualTo("DEFAULT");
+            assertThat(result.getTitle()).isEqualTo("New Category");
+            assertThat(result.getDescription()).isEqualTo("A new category");
+            assertThat(result.isVisible()).isTrue();
+        });
+    }
+
+    @Test
+    public void shouldCreateWithNullDescription() throws Exception {
+        var portalCategory = PortalCategory.builder()
+            .id("new-pc-null-desc")
+            .environmentId("DEFAULT")
+            .title("No Description")
+            .description(null)
+            .visible(true)
+            .build();
+
+        portalCategoryRepository.create(portalCategory);
+
+        var saved = portalCategoryRepository.findById("new-pc-null-desc");
+        assertThat(saved).hasValueSatisfying(result -> assertThat(result.getDescription()).isNull());
+    }
+
+    @Test
+    public void shouldUpdate() throws Exception {
+        var optional = portalCategoryRepository.findById("pc-3");
+        assertThat(optional).as("Portal category to update not found").isPresent();
+
+        var portalCategory = optional.get();
+        portalCategory.setTitle("Updated Banking");
+        portalCategory.setDescription("Updated description");
+        portalCategory.setVisible(false);
+
+        portalCategoryRepository.update(portalCategory);
+
+        var updated = portalCategoryRepository.findById("pc-3");
+        assertThat(updated).hasValueSatisfying(result -> {
+            assertThat(result.getTitle()).isEqualTo("Updated Banking");
+            assertThat(result.getDescription()).isEqualTo("Updated description");
+            assertThat(result.isVisible()).isFalse();
+        });
+    }
+
+    @Test
+    public void shouldDelete() throws Exception {
+        var nbBefore = portalCategoryRepository.findAllByEnvironmentId("DEFAULT").size();
+
+        portalCategoryRepository.delete("pc-1");
+
+        var nbAfter = portalCategoryRepository.findAllByEnvironmentId("DEFAULT").size();
+        assertThat(nbAfter).isEqualTo(nbBefore - 1);
+        assertThat(portalCategoryRepository.findById("pc-1")).isEmpty();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portal-category-tests/portalCategorys.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portal-category-tests/portalCategorys.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "pc-1",
+    "environmentId": "DEFAULT",
+    "title": "Weather",
+    "description": "Weather related APIs",
+    "visible": true
+  },
+  {
+    "id": "pc-2",
+    "environmentId": "DEFAULT",
+    "title": "Analytics",
+    "description": "Analytics related APIs",
+    "visible": false
+  },
+  {
+    "id": "pc-3",
+    "environmentId": "DEFAULT",
+    "title": "Banking",
+    "description": null,
+    "visible": true
+  },
+  {
+    "id": "pc-4",
+    "environmentId": "OTHER_ENV",
+    "title": "Other Env Category",
+    "description": "Category in another environment",
+    "visible": true
+  }
+]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
@@ -58,6 +58,7 @@ import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.api.PageRevisionRepository;
 import io.gravitee.repository.management.api.ParameterRepository;
 import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.api.PortalCategoryRepository;
 import io.gravitee.repository.management.api.PortalListingRepository;
 import io.gravitee.repository.management.api.PortalMenuLinkRepository;
 import io.gravitee.repository.management.api.PortalNavigationItemRepository;
@@ -167,6 +168,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
     private final PageRevisionRepository pageRevisionRepository;
     private final ParameterRepository parameterRepository;
     private final PlanRepository planRepository;
+    private final PortalCategoryRepository portalCategoryRepository;
     private final PortalMenuLinkRepository portalMenuLinkRepository;
     private final PortalNotificationConfigRepository portalNotificationConfigRepository;
     private final PortalPageRepository portalPageRepository;
@@ -228,6 +230,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         @Lazy PageRevisionRepository pageRevisionRepository,
         @Lazy ParameterRepository parameterRepository,
         @Lazy PlanRepository planRepository,
+        @Lazy PortalCategoryRepository portalCategoryRepository,
         @Lazy PortalMenuLinkRepository portalMenuLinkRepository,
         @Lazy PortalNotificationConfigRepository portalNotificationConfigRepository,
         @Lazy PortalPageRepository portalPageRepository,
@@ -302,6 +305,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         this.pageRevisionRepository = pageRevisionRepository;
         this.parameterRepository = parameterRepository;
         this.planRepository = planRepository;
+        this.portalCategoryRepository = portalCategoryRepository;
         this.portalMenuLinkRepository = portalMenuLinkRepository;
         this.portalNotificationConfigRepository = portalNotificationConfigRepository;
         this.portalPageRepository = portalPageRepository;
@@ -413,6 +417,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         accessPointRepository.deleteByReferenceIdAndReferenceType(environment.getId(), AccessPointReferenceType.ENVIRONMENT);
         parameterRepository.deleteByReferenceIdAndReferenceType(environment.getId(), ParameterReferenceType.ENVIRONMENT);
         portalMenuLinkRepository.deleteByEnvironmentId(environment.getId());
+        portalCategoryRepository.deleteByEnvironmentId(environment.getId());
         portalPageRepository.deleteByEnvironmentId(environment.getId());
         deletePortalNavigationItems(environment);
         portalNavigationItemRepository.deleteByEnvironmentId(environment.getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
@@ -62,6 +62,7 @@ import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.api.PageRevisionRepository;
 import io.gravitee.repository.management.api.ParameterRepository;
 import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.api.PortalCategoryRepository;
 import io.gravitee.repository.management.api.PortalListingRepository;
 import io.gravitee.repository.management.api.PortalMenuLinkRepository;
 import io.gravitee.repository.management.api.PortalNavigationItemRepository;
@@ -306,6 +307,9 @@ public class DeleteEnvironmentCommandHandlerTest {
     private MembershipRepository membershipRepository;
 
     @Mock
+    private PortalCategoryRepository portalCategoryRepository;
+
+    @Mock
     private PortalMenuLinkRepository portalMenuLinkRepository;
 
     @Mock
@@ -479,6 +483,7 @@ public class DeleteEnvironmentCommandHandlerTest {
             pageRevisionRepository,
             parameterRepository,
             planRepository,
+            portalCategoryRepository,
             portalMenuLinkRepository,
             portalNotificationConfigRepository,
             portalPageRepository,
@@ -593,6 +598,7 @@ public class DeleteEnvironmentCommandHandlerTest {
         );
         verify(commandRepository).deleteByEnvironmentId(ENV_ID);
         verify(mediaRepository).deleteByEnvironment(ENV_ID);
+        verify(portalCategoryRepository).deleteByEnvironmentId(ENV_ID);
         verify(portalMenuLinkRepository).deleteByEnvironmentId(ENV_ID);
         verify(portalPageRepository).deleteByEnvironmentId(ENV_ID);
         verify(portalPageContextRepository).deleteByEnvironmentId(ENV_ID);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-16

## Description

Adds the persistence layer for Portal Next categories: repository model + interface, JDBC implementation with a new Liquibase changelog (`portal_categories` table), MongoDB implementation with a new `environmentId`+`title` index upgrader, and repository tests run against both backends.

## Additional context

Part 1/7 of a stacked chain for PORTAL-16. **Draft — do not review or merge until the full chain lands.**