### PR TITLE
feat(rest-api): add portal category core crud/query services

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/crud_service/PortalCategoryCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/crud_service/PortalCategoryCrudService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_category.crud_service;
+
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import java.util.Optional;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface PortalCategoryCrudService {
+    PortalCategory create(PortalCategory portalCategory);
+
+    PortalCategory update(PortalCategory portalCategory);
+
+    void delete(String id);
+
+    Optional<PortalCategory> get(String id);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/exception/PortalCategoryNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/exception/PortalCategoryNotFoundException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_category.exception;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalCategoryNotFoundException extends NotFoundDomainException {
+
+    public PortalCategoryNotFoundException(String id) {
+        super("Portal category not found.", id);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/model/CreatePortalCategory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/model/CreatePortalCategory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_category.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class CreatePortalCategory {
+
+    private String title;
+    private String description;
+    private boolean visible;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/model/PortalCategory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/model/PortalCategory.java
@@ -43,7 +43,6 @@ public class PortalCategory {
         this.visible = visible;
     }
 
-    /** New portal category with a random id. */
     public static PortalCategory create(String environmentId, String title, String description, boolean visible) {
         return new PortalCategory(PortalCategoryId.random(), environmentId, title, description, visible);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/model/PortalCategory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/model/PortalCategory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_category.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class PortalCategory {
+
+    private String id;
+    private String environmentId;
+    private String title;
+    private String description;
+    private boolean visible;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/model/PortalCategory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/model/PortalCategory.java
@@ -15,23 +15,60 @@
  */
 package io.gravitee.apim.core.portal_category.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import jakarta.annotation.Nonnull;
+import lombok.Getter;
 
 /**
  * @author GraviteeSource Team
  */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder(toBuilder = true)
+@Getter
 public class PortalCategory {
 
-    private String id;
-    private String environmentId;
+    @Nonnull
+    private final PortalCategoryId id;
+
+    @Nonnull
+    private final String environmentId;
+
     private String title;
     private String description;
     private boolean visible;
+
+    /** Raw constructor - only used for database mapping, use {@link #create} or {@link #of} instead. */
+    private PortalCategory(PortalCategoryId id, String environmentId, String title, String description, boolean visible) {
+        this.id = id;
+        this.environmentId = environmentId;
+        this.title = title;
+        this.description = description;
+        this.visible = visible;
+    }
+
+    /** New portal category with a random id. */
+    public static PortalCategory create(String environmentId, String title, String description, boolean visible) {
+        return new PortalCategory(PortalCategoryId.random(), environmentId, title, description, visible);
+    }
+
+    /** Reconstitute a portal category from a known id (database mapping). */
+    public static PortalCategory of(PortalCategoryId id, String environmentId, String title, String description, boolean visible) {
+        return new PortalCategory(id, environmentId, title, description, visible);
+    }
+
+    public void update(UpdatePortalCategory update) {
+        this.title = update.getTitle();
+        this.description = update.getDescription();
+        this.visible = update.isVisible();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PortalCategory that = (PortalCategory) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/model/PortalCategoryId.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/model/PortalCategoryId.java
@@ -13,21 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal_category.crud_service;
+package io.gravitee.apim.core.portal_category.model;
 
-import io.gravitee.apim.core.portal_category.model.PortalCategory;
-import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
-import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonValue;
+import jakarta.annotation.Nonnull;
+import java.util.UUID;
 
-/**
- * @author GraviteeSource Team
- */
-public interface PortalCategoryCrudService {
-    PortalCategory create(PortalCategory portalCategory);
+public record PortalCategoryId(@Nonnull UUID id) {
+    public static PortalCategoryId random() {
+        return new PortalCategoryId(UUID.randomUUID());
+    }
 
-    PortalCategory update(PortalCategory portalCategory);
+    public static PortalCategoryId of(String value) {
+        return new PortalCategoryId(UUID.fromString(value));
+    }
 
-    void delete(PortalCategoryId id);
-
-    Optional<PortalCategory> get(PortalCategoryId id);
+    @JsonValue
+    @Override
+    public String toString() {
+        return id.toString();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/model/UpdatePortalCategory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/model/UpdatePortalCategory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_category.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class UpdatePortalCategory {
+
+    private String title;
+    private String description;
+    private boolean visible;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/query_service/PortalCategoryQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/query_service/PortalCategoryQueryService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_category.query_service;
+
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface PortalCategoryQueryService {
+    List<PortalCategory> findByEnvironmentId(String environmentId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalCategoryAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalCategoryAdapter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Mapper
+public interface PortalCategoryAdapter {
+    PortalCategoryAdapter INSTANCE = Mappers.getMapper(PortalCategoryAdapter.class);
+
+    PortalCategory toModel(io.gravitee.repository.management.model.PortalCategory repository);
+
+    io.gravitee.repository.management.model.PortalCategory toRepository(PortalCategory domain);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalCategoryAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalCategoryAdapter.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.infra.adapter;
 
 import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
@@ -26,7 +27,29 @@ import org.mapstruct.factory.Mappers;
 public interface PortalCategoryAdapter {
     PortalCategoryAdapter INSTANCE = Mappers.getMapper(PortalCategoryAdapter.class);
 
-    PortalCategory toModel(io.gravitee.repository.management.model.PortalCategory repository);
+    default PortalCategory toModel(io.gravitee.repository.management.model.PortalCategory repository) {
+        if (repository == null) {
+            return null;
+        }
+        return PortalCategory.of(
+            PortalCategoryId.of(repository.getId()),
+            repository.getEnvironmentId(),
+            repository.getTitle(),
+            repository.getDescription(),
+            repository.isVisible()
+        );
+    }
 
-    io.gravitee.repository.management.model.PortalCategory toRepository(PortalCategory domain);
+    default io.gravitee.repository.management.model.PortalCategory toRepository(PortalCategory domain) {
+        if (domain == null) {
+            return null;
+        }
+        return io.gravitee.repository.management.model.PortalCategory.builder()
+            .id(domain.getId().toString())
+            .environmentId(domain.getEnvironmentId())
+            .title(domain.getTitle())
+            .description(domain.getDescription())
+            .visible(domain.isVisible())
+            .build();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalCategoryAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalCategoryAdapter.java
@@ -27,6 +27,9 @@ import org.mapstruct.factory.Mappers;
 public interface PortalCategoryAdapter {
     PortalCategoryAdapter INSTANCE = Mappers.getMapper(PortalCategoryAdapter.class);
 
+    // Hand-written, not MapStruct-generated: PortalCategory's constructor is deliberately
+    // private (to prevent constructing it as a plain POJO), so MapStruct has no public
+    // constructor, setters, or builder on this type to target.
     default PortalCategory toModel(io.gravitee.repository.management.model.PortalCategory repository) {
         if (repository == null) {
             return null;
@@ -40,16 +43,9 @@ public interface PortalCategoryAdapter {
         );
     }
 
-    default io.gravitee.repository.management.model.PortalCategory toRepository(PortalCategory domain) {
-        if (domain == null) {
-            return null;
-        }
-        return io.gravitee.repository.management.model.PortalCategory.builder()
-            .id(domain.getId().toString())
-            .environmentId(domain.getEnvironmentId())
-            .title(domain.getTitle())
-            .description(domain.getDescription())
-            .visible(domain.isVisible())
-            .build();
+    io.gravitee.repository.management.model.PortalCategory toRepository(PortalCategory domain);
+
+    default String map(PortalCategoryId id) {
+        return id == null ? null : id.toString();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_category/PortalCategoryCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_category/PortalCategoryCrudServiceImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.portal_category;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal_category.crud_service.PortalCategoryCrudService;
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.infra.adapter.PortalCategoryAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalCategoryRepository;
+import java.util.Optional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Service
+public class PortalCategoryCrudServiceImpl implements PortalCategoryCrudService {
+
+    private final PortalCategoryRepository portalCategoryRepository;
+
+    public PortalCategoryCrudServiceImpl(@Lazy PortalCategoryRepository portalCategoryRepository) {
+        this.portalCategoryRepository = portalCategoryRepository;
+    }
+
+    @Override
+    public PortalCategory create(PortalCategory portalCategory) {
+        try {
+            var repositoryModel = PortalCategoryAdapter.INSTANCE.toRepository(portalCategory);
+            var created = portalCategoryRepository.create(repositoryModel);
+            return PortalCategoryAdapter.INSTANCE.toModel(created);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurred while trying to create a portal category", e);
+        }
+    }
+
+    @Override
+    public PortalCategory update(PortalCategory portalCategory) {
+        try {
+            var repositoryModel = PortalCategoryAdapter.INSTANCE.toRepository(portalCategory);
+            var updated = portalCategoryRepository.update(repositoryModel);
+            return PortalCategoryAdapter.INSTANCE.toModel(updated);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurred while trying to update portal category: " + portalCategory.getId(), e);
+        }
+    }
+
+    @Override
+    public void delete(String id) {
+        try {
+            portalCategoryRepository.delete(id);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurred while trying to delete portal category: " + id, e);
+        }
+    }
+
+    @Override
+    public Optional<PortalCategory> get(String id) {
+        try {
+            return portalCategoryRepository.findById(id).map(PortalCategoryAdapter.INSTANCE::toModel);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurred while trying to find portal category: " + id, e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_category/PortalCategoryCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_category/PortalCategoryCrudServiceImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.infra.crud_service.portal_category;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal_category.crud_service.PortalCategoryCrudService;
 import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.infra.adapter.PortalCategoryAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalCategoryRepository;
@@ -60,18 +61,18 @@ public class PortalCategoryCrudServiceImpl implements PortalCategoryCrudService 
     }
 
     @Override
-    public void delete(String id) {
+    public void delete(PortalCategoryId id) {
         try {
-            portalCategoryRepository.delete(id);
+            portalCategoryRepository.delete(id.toString());
         } catch (TechnicalException e) {
             throw new TechnicalDomainException("An error occurred while trying to delete portal category: " + id, e);
         }
     }
 
     @Override
-    public Optional<PortalCategory> get(String id) {
+    public Optional<PortalCategory> get(PortalCategoryId id) {
         try {
-            return portalCategoryRepository.findById(id).map(PortalCategoryAdapter.INSTANCE::toModel);
+            return portalCategoryRepository.findById(id.toString()).map(PortalCategoryAdapter.INSTANCE::toModel);
         } catch (TechnicalException e) {
             throw new TechnicalDomainException("An error occurred while trying to find portal category: " + id, e);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/portal_category/PortalCategoryQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/portal_category/PortalCategoryQueryServiceImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.portal_category;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.query_service.PortalCategoryQueryService;
+import io.gravitee.apim.infra.adapter.PortalCategoryAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalCategoryRepository;
+import java.util.List;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Service
+public class PortalCategoryQueryServiceImpl implements PortalCategoryQueryService {
+
+    private final PortalCategoryRepository portalCategoryRepository;
+
+    public PortalCategoryQueryServiceImpl(@Lazy PortalCategoryRepository portalCategoryRepository) {
+        this.portalCategoryRepository = portalCategoryRepository;
+    }
+
+    @Override
+    public List<PortalCategory> findByEnvironmentId(String environmentId) {
+        try {
+            return portalCategoryRepository
+                .findAllByEnvironmentId(environmentId)
+                .stream()
+                .map(PortalCategoryAdapter.INSTANCE::toModel)
+                .toList();
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                "An error occurred while trying to find portal categories for environment: " + environmentId,
+                e
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalCategoryFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalCategoryFixtures.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.core.model;
+
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import io.gravitee.apim.core.portal_category.model.UpdatePortalCategory;
+
+public class PortalCategoryFixtures {
+
+    private PortalCategoryFixtures() {}
+
+    public static final PortalCategoryId PORTAL_CATEGORY_ID = PortalCategoryId.of("00000000-0000-0000-0000-0000000000b1");
+
+    public static PortalCategory aPortalCategory() {
+        return PortalCategory.of(PORTAL_CATEGORY_ID, "environment-id", "News", "News category", true);
+    }
+
+    public static UpdatePortalCategory anUpdatePortalCategory() {
+        return UpdatePortalCategory.builder().title("Updated title").description("Updated description").visible(false).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCategoryCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCategoryCrudServiceInMemory.java
@@ -17,6 +17,7 @@ package inmemory;
 
 import io.gravitee.apim.core.portal_category.crud_service.PortalCategoryCrudService;
 import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -43,12 +44,12 @@ public class PortalCategoryCrudServiceInMemory implements PortalCategoryCrudServ
     }
 
     @Override
-    public void delete(String id) {
+    public void delete(PortalCategoryId id) {
         storage.removeIf(pc -> id.equals(pc.getId()));
     }
 
     @Override
-    public Optional<PortalCategory> get(String id) {
+    public Optional<PortalCategory> get(PortalCategoryId id) {
         return storage
             .stream()
             .filter(pc -> id.equals(pc.getId()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCategoryCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCategoryCrudServiceInMemory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.portal_category.crud_service.PortalCategoryCrudService;
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class PortalCategoryCrudServiceInMemory implements PortalCategoryCrudService, InMemoryAlternative<PortalCategory> {
+
+    final ArrayList<PortalCategory> storage = new ArrayList<>();
+
+    @Override
+    public PortalCategory create(PortalCategory portalCategory) {
+        storage.add(portalCategory);
+        return portalCategory;
+    }
+
+    @Override
+    public PortalCategory update(PortalCategory portalCategory) {
+        var index = findIndex(storage, pc -> pc.getId().equals(portalCategory.getId()));
+        if (index.isPresent()) {
+            storage.set(index.getAsInt(), portalCategory);
+            return portalCategory;
+        }
+        throw new IllegalStateException("Portal category not found");
+    }
+
+    @Override
+    public void delete(String id) {
+        storage.removeIf(pc -> id.equals(pc.getId()));
+    }
+
+    @Override
+    public Optional<PortalCategory> get(String id) {
+        return storage
+            .stream()
+            .filter(pc -> id.equals(pc.getId()))
+            .findFirst();
+    }
+
+    @Override
+    public void initWith(List<PortalCategory> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<PortalCategory> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCategoryQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCategoryQueryServiceInMemory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.query_service.PortalCategoryQueryService;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+public class PortalCategoryQueryServiceInMemory implements PortalCategoryQueryService, InMemoryAlternative<PortalCategory> {
+
+    final ArrayList<PortalCategory> storage = new ArrayList<>();
+
+    @Override
+    public List<PortalCategory> findByEnvironmentId(String environmentId) {
+        return storage
+            .stream()
+            .filter(pc -> environmentId.equals(pc.getEnvironmentId()))
+            .sorted(Comparator.comparing(PortalCategory::getTitle))
+            .toList();
+    }
+
+    @Override
+    public void initWith(List<PortalCategory> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<PortalCategory> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCategoryQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCategoryQueryServiceInMemory.java
@@ -28,6 +28,8 @@ public class PortalCategoryQueryServiceInMemory implements PortalCategoryQuerySe
 
     @Override
     public List<PortalCategory> findByEnvironmentId(String environmentId) {
+        // Mirrors the ORDER BY title done at the repository layer (JDBC/Mongo), which this
+        // in-memory fake has no real query engine to perform.
         return storage
             .stream()
             .filter(pc -> environmentId.equals(pc.getEnvironmentId()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_category/model/PortalCategoryIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_category/model/PortalCategoryIdTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_category.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalCategoryIdTest {
+
+    @Test
+    void random_generates_distinct_ids() {
+        assertThat(PortalCategoryId.random()).isNotEqualTo(PortalCategoryId.random());
+    }
+
+    @Test
+    void of_parses_a_valid_uuid_string() {
+        var id = PortalCategoryId.of("00000000-0000-0000-0000-0000000000b1");
+
+        assertThat(id.toString()).isEqualTo("00000000-0000-0000-0000-0000000000b1");
+    }
+
+    @Test
+    void of_rejects_a_non_uuid_string() {
+        assertThatThrownBy(() -> PortalCategoryId.of("not-a-uuid")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void two_ids_built_from_the_same_uuid_string_are_equal() {
+        var id = "00000000-0000-0000-0000-0000000000b1";
+
+        assertThat(PortalCategoryId.of(id)).isEqualTo(PortalCategoryId.of(id));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_category/model/PortalCategoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_category/model/PortalCategoryTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_category.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalCategoryTest {
+
+    @Nested
+    class Create {
+
+        @Test
+        void generates_a_random_id() {
+            var first = PortalCategory.create("env", "News", "News category", true);
+            var second = PortalCategory.create("env", "News", "News category", true);
+
+            assertThat(first.getId()).isNotNull().isNotEqualTo(second.getId());
+        }
+
+        @Test
+        void sets_all_fields() {
+            var category = PortalCategory.create("env", "News", "News category", true);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(category.getEnvironmentId()).isEqualTo("env");
+                soft.assertThat(category.getTitle()).isEqualTo("News");
+                soft.assertThat(category.getDescription()).isEqualTo("News category");
+                soft.assertThat(category.isVisible()).isTrue();
+            });
+        }
+    }
+
+    @Nested
+    class Of {
+
+        @Test
+        void reconstitutes_with_the_given_id() {
+            var id = PortalCategoryId.random();
+
+            var category = PortalCategory.of(id, "env", "News", "News category", false);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(category.getId()).isEqualTo(id);
+                soft.assertThat(category.getEnvironmentId()).isEqualTo("env");
+                soft.assertThat(category.getTitle()).isEqualTo("News");
+                soft.assertThat(category.getDescription()).isEqualTo("News category");
+                soft.assertThat(category.isVisible()).isFalse();
+            });
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        void mutates_title_description_and_visible_in_place() {
+            var id = PortalCategoryId.random();
+            var category = PortalCategory.of(id, "env", "News", "News category", true);
+
+            category.update(UpdatePortalCategory.builder().title("Updated").description("Updated description").visible(false).build());
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(category.getId()).isEqualTo(id);
+                soft.assertThat(category.getEnvironmentId()).isEqualTo("env");
+                soft.assertThat(category.getTitle()).isEqualTo("Updated");
+                soft.assertThat(category.getDescription()).isEqualTo("Updated description");
+                soft.assertThat(category.isVisible()).isFalse();
+            });
+        }
+    }
+
+    @Nested
+    class EqualsAndHashCode {
+
+        @Test
+        void same_instance_is_equal_to_itself() {
+            var category = PortalCategory.create("env", "News", "News category", true);
+
+            assertThat(category).isEqualTo(category);
+        }
+
+        @Test
+        void is_not_equal_to_null() {
+            var category = PortalCategory.create("env", "News", "News category", true);
+
+            assertThat(category).isNotEqualTo(null);
+        }
+
+        @Test
+        void is_not_equal_to_a_different_type() {
+            var category = PortalCategory.create("env", "News", "News category", true);
+
+            assertThat(category).isNotEqualTo("not a portal category");
+        }
+
+        @Test
+        void two_categories_with_the_same_id_are_equal_even_if_other_fields_differ() {
+            var id = PortalCategoryId.random();
+            var first = PortalCategory.of(id, "env", "News", "News category", true);
+            var second = PortalCategory.of(id, "other-env", "Other", "Other description", false);
+
+            assertThat(first).isEqualTo(second);
+            assertThat(first.hashCode()).isEqualTo(second.hashCode());
+        }
+
+        @Test
+        void two_categories_with_different_ids_are_not_equal() {
+            var first = PortalCategory.create("env", "News", "News category", true);
+            var second = PortalCategory.create("env", "News", "News category", true);
+
+            assertThat(first).isNotEqualTo(second);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalCategoryAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalCategoryAdapterTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalCategoryAdapterTest {
+
+    private final PortalCategoryAdapter adapter = PortalCategoryAdapter.INSTANCE;
+
+    @Nested
+    class ToModel {
+
+        @Test
+        void maps_all_fields() {
+            var repository = io.gravitee.repository.management.model.PortalCategory.builder()
+                .id("00000000-0000-0000-0000-0000000000b1")
+                .environmentId("env")
+                .title("News")
+                .description("News category")
+                .visible(true)
+                .build();
+
+            var domain = adapter.toModel(repository);
+
+            assertThat(domain.getId()).isEqualTo(PortalCategoryId.of("00000000-0000-0000-0000-0000000000b1"));
+            assertThat(domain.getEnvironmentId()).isEqualTo("env");
+            assertThat(domain.getTitle()).isEqualTo("News");
+            assertThat(domain.getDescription()).isEqualTo("News category");
+            assertThat(domain.isVisible()).isTrue();
+        }
+
+        @Test
+        void returns_null_for_null_input() {
+            assertThat(adapter.toModel(null)).isNull();
+        }
+    }
+
+    @Nested
+    class ToRepository {
+
+        @Test
+        void maps_all_fields() {
+            var domain = PortalCategory.of(
+                PortalCategoryId.of("00000000-0000-0000-0000-0000000000b1"),
+                "env",
+                "News",
+                "News category",
+                true
+            );
+
+            var repository = adapter.toRepository(domain);
+
+            assertThat(repository.getId()).isEqualTo("00000000-0000-0000-0000-0000000000b1");
+            assertThat(repository.getEnvironmentId()).isEqualTo("env");
+            assertThat(repository.getTitle()).isEqualTo("News");
+            assertThat(repository.getDescription()).isEqualTo("News category");
+            assertThat(repository.isVisible()).isTrue();
+        }
+
+        @Test
+        void returns_null_for_null_input() {
+            assertThat(adapter.toRepository(null)).isNull();
+        }
+    }
+
+    @Test
+    void round_trip_through_repository_and_back() {
+        var domain = PortalCategory.of(PortalCategoryId.of("00000000-0000-0000-0000-0000000000b1"), "env", "News", "News category", true);
+
+        var roundTripped = adapter.toModel(adapter.toRepository(domain));
+
+        assertThat(roundTripped).isEqualTo(domain);
+        assertThat(roundTripped.getTitle()).isEqualTo(domain.getTitle());
+        assertThat(roundTripped.getDescription()).isEqualTo(domain.getDescription());
+        assertThat(roundTripped.isVisible()).isEqualTo(domain.isVisible());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_category/PortalCategoryCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_category/PortalCategoryCrudServiceImplTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.portal_category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.PortalCategoryFixtures;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.infra.adapter.PortalCategoryAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalCategoryRepository;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PortalCategoryCrudServiceImplTest {
+
+    PortalCategoryRepository repository;
+    PortalCategoryCrudServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(PortalCategoryRepository.class);
+        service = new PortalCategoryCrudServiceImpl(repository);
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        @SneakyThrows
+        void should_create_a_portal_category() {
+            var category = PortalCategoryFixtures.aPortalCategory();
+            when(repository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            var result = service.create(category);
+
+            assertThat(result).isEqualTo(category);
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            var category = PortalCategoryFixtures.aPortalCategory();
+            when(repository.create(any())).thenThrow(TechnicalException.class);
+
+            var throwable = catchThrowable(() -> service.create(category));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to create a portal category");
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        @SneakyThrows
+        void should_update_and_return_the_updated_portal_category() {
+            var category = PortalCategoryFixtures.aPortalCategory();
+            when(repository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            var result = service.update(category);
+
+            assertThat(result).isEqualTo(category);
+            verify(repository).update(PortalCategoryAdapter.INSTANCE.toRepository(category));
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            var category = PortalCategoryFixtures.aPortalCategory();
+            when(repository.update(any())).thenThrow(TechnicalException.class);
+
+            var throwable = catchThrowable(() -> service.update(category));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to update portal category: " + category.getId());
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_portal_category() throws TechnicalException {
+            var id = PortalCategoryFixtures.PORTAL_CATEGORY_ID;
+
+            service.delete(id);
+
+            verify(repository).delete(id.toString());
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            var id = PortalCategoryFixtures.PORTAL_CATEGORY_ID;
+            doThrow(new TechnicalException("boom")).when(repository).delete(id.toString());
+
+            assertThatThrownBy(() -> service.delete(id))
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to delete portal category: " + id);
+        }
+    }
+
+    @Nested
+    class Get {
+
+        @Test
+        @SneakyThrows
+        void should_return_portal_category_and_adapt_it() {
+            var id = PortalCategoryFixtures.PORTAL_CATEGORY_ID;
+            var category = PortalCategoryFixtures.aPortalCategory();
+            when(repository.findById(id.toString())).thenReturn(Optional.of(PortalCategoryAdapter.INSTANCE.toRepository(category)));
+
+            var result = service.get(id);
+
+            assertThat(result).contains(category);
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_empty_when_not_found() {
+            when(repository.findById(any())).thenReturn(Optional.empty());
+
+            assertThat(service.get(PortalCategoryFixtures.PORTAL_CATEGORY_ID)).isEmpty();
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            var id = PortalCategoryFixtures.PORTAL_CATEGORY_ID;
+            when(repository.findById(any())).thenThrow(TechnicalException.class);
+
+            var throwable = catchThrowable(() -> service.get(id));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to find portal category: " + id);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_category/PortalCategoryCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_category/PortalCategoryCrudServiceImplTest.java
@@ -57,7 +57,7 @@ class PortalCategoryCrudServiceImplTest {
 
             var result = service.create(category);
 
-            assertThat(result).isEqualTo(category);
+            assertThat(result).usingRecursiveComparison().isEqualTo(category);
         }
 
         @Test
@@ -85,7 +85,7 @@ class PortalCategoryCrudServiceImplTest {
 
             var result = service.update(category);
 
-            assertThat(result).isEqualTo(category);
+            assertThat(result).usingRecursiveComparison().isEqualTo(category);
             verify(repository).update(PortalCategoryAdapter.INSTANCE.toRepository(category));
         }
 
@@ -138,7 +138,7 @@ class PortalCategoryCrudServiceImplTest {
 
             var result = service.get(id);
 
-            assertThat(result).contains(category);
+            assertThat(result).get().usingRecursiveComparison().isEqualTo(category);
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_category/PortalCategoryQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_category/PortalCategoryQueryServiceImplTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.portal_category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.PortalCategoryFixtures;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.infra.adapter.PortalCategoryAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalCategoryRepository;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PortalCategoryQueryServiceImplTest {
+
+    PortalCategoryRepository repository;
+    PortalCategoryQueryServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(PortalCategoryRepository.class);
+        service = new PortalCategoryQueryServiceImpl(repository);
+    }
+
+    @Nested
+    class FindByEnvironmentId {
+
+        @Test
+        @SneakyThrows
+        void should_return_categories_adapted_from_the_repository() {
+            var category = PortalCategoryFixtures.aPortalCategory();
+            when(repository.findAllByEnvironmentId("env")).thenReturn(List.of(PortalCategoryAdapter.INSTANCE.toRepository(category)));
+
+            var result = service.findByEnvironmentId("env");
+
+            assertThat(result).containsExactly(category);
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_empty_list_when_none_found() {
+            when(repository.findAllByEnvironmentId("env")).thenReturn(List.of());
+
+            assertThat(service.findByEnvironmentId("env")).isEmpty();
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            when(repository.findAllByEnvironmentId(any())).thenThrow(TechnicalException.class);
+
+            var throwable = catchThrowable(() -> service.findByEnvironmentId("env"));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to find portal categories for environment: env");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_category/PortalCategoryQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_category/PortalCategoryQueryServiceImplTest.java
@@ -54,7 +54,7 @@ class PortalCategoryQueryServiceImplTest {
 
             var result = service.findByEnvironmentId("env");
 
-            assertThat(result).containsExactly(category);
+            assertThat(result).usingRecursiveFieldByFieldElementComparator().containsExactly(category);
         }
 
         @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-16

## Description

Adds the core domain model (`PortalCategory`, `CreatePortalCategory`, `UpdatePortalCategory`), `crud_service`/`query_service` interfaces, their infra implementations, and the repository adapter — following the hexagonal layering established by the sibling `portal_page` (navigation items) feature.

## Additional context

Part 2/7 of a stacked chain for PORTAL-16, stacked on #18535 (repository layer).