### PR TITLE
feat(rest-api): add portal category management API v2 endpoints

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalCategoryMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalCategoryMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import io.gravitee.apim.core.portal_category.model.CreatePortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import io.gravitee.apim.core.portal_category.model.UpdatePortalCategory;
+import java.util.List;
+import java.util.UUID;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Mapper
+public interface PortalCategoryMapper {
+    PortalCategoryMapper INSTANCE = Mappers.getMapper(PortalCategoryMapper.class);
+
+    io.gravitee.rest.api.management.v2.rest.model.PortalCategory map(PortalCategory portalCategory);
+
+    List<io.gravitee.rest.api.management.v2.rest.model.PortalCategory> mapList(List<PortalCategory> portalCategories);
+
+    CreatePortalCategory map(io.gravitee.rest.api.management.v2.rest.model.CreatePortalCategory createPortalCategory);
+
+    UpdatePortalCategory map(io.gravitee.rest.api.management.v2.rest.model.UpdatePortalCategory updatePortalCategory);
+
+    default UUID map(PortalCategoryId id) {
+        return id == null ? null : id.id();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalCategoriesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalCategoriesResource.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import io.gravitee.apim.core.portal_category.use_case.CreatePortalCategoryUseCase;
+import io.gravitee.apim.core.portal_category.use_case.ListPortalCategoriesUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.PortalCategoryMapper;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePortalCategory;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import lombok.CustomLog;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+public class PortalCategoriesResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private CreatePortalCategoryUseCase createPortalCategoryUseCase;
+
+    @Inject
+    private ListPortalCategoriesUseCase listPortalCategoriesUseCase;
+
+    private static final PortalCategoryMapper mapper = PortalCategoryMapper.INSTANCE;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.READ) })
+    public Response getPortalCategories() {
+        var output = listPortalCategoriesUseCase.execute(new ListPortalCategoriesUseCase.Input(GraviteeContext.getCurrentEnvironment()));
+
+        return Response.ok(mapper.mapList(output.portalCategories())).build();
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = { RolePermissionAction.CREATE }) })
+    public Response createPortalCategory(@Valid @NotNull final CreatePortalCategory createPortalCategory) {
+        var output = createPortalCategoryUseCase.execute(
+            new CreatePortalCategoryUseCase.Input(GraviteeContext.getCurrentEnvironment(), mapper.map(createPortalCategory))
+        );
+
+        return Response.created(this.getLocationHeader(output.portalCategory().getId().toString()))
+            .entity(mapper.map(output.portalCategory()))
+            .build();
+    }
+
+    @Path("{categoryId}")
+    public PortalCategoryResource getPortalCategoryResource() {
+        return resourceContext.getResource(PortalCategoryResource.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalCategoryResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalCategoryResource.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import io.gravitee.apim.core.portal_category.use_case.DeletePortalCategoryUseCase;
+import io.gravitee.apim.core.portal_category.use_case.UpdatePortalCategoryUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.PortalCategoryMapper;
+import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalCategory;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import lombok.CustomLog;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+public class PortalCategoryResource extends AbstractResource {
+
+    @Inject
+    private UpdatePortalCategoryUseCase updatePortalCategoryUseCase;
+
+    @Inject
+    private DeletePortalCategoryUseCase deletePortalCategoryUseCase;
+
+    private static final PortalCategoryMapper mapper = PortalCategoryMapper.INSTANCE;
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.UPDATE) })
+    public Response updatePortalCategory(
+        @PathParam("categoryId") String categoryId,
+        @Valid @NotNull final UpdatePortalCategory updatePortalCategory
+    ) {
+        var output = updatePortalCategoryUseCase.execute(
+            new UpdatePortalCategoryUseCase.Input(
+                GraviteeContext.getCurrentEnvironment(),
+                PortalCategoryId.of(categoryId),
+                mapper.map(updatePortalCategory)
+            )
+        );
+
+        return Response.ok(mapper.map(output.portalCategory())).build();
+    }
+
+    @DELETE
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.DELETE) })
+    public Response deletePortalCategory(@PathParam("categoryId") String categoryId) {
+        deletePortalCategoryUseCase.execute(
+            new DeletePortalCategoryUseCase.Input(GraviteeContext.getCurrentEnvironment(), PortalCategoryId.of(categoryId))
+        );
+
+        return Response.noContent().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/EnvironmentResource.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.management.v2.rest.resource.environment.EnvironmentA
 import io.gravitee.rest.api.management.v2.rest.resource.environment.EnvironmentLogsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.environment.EnvironmentNewtAIResource;
 import io.gravitee.rest.api.management.v2.rest.resource.environment.EnvironmentScoringResource;
+import io.gravitee.rest.api.management.v2.rest.resource.environment.PortalCategoriesResource;
 import io.gravitee.rest.api.management.v2.rest.resource.environment.PortalNavigationItemsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.environment.PortalPageContentsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.environment.SharedPolicyGroupsResource;
@@ -123,6 +124,11 @@ public class EnvironmentResource extends AbstractResource {
     @Path("/portal-navigation-items")
     public PortalNavigationItemsResource getPortalNavigationItemsResource() {
         return resourceContext.getResource(PortalNavigationItemsResource.class);
+    }
+
+    @Path("/portal-categories")
+    public PortalCategoriesResource getPortalCategoriesResource() {
+        return resourceContext.getResource(PortalCategoriesResource.class);
     }
 
     @Path("/portal-page-contents")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1231,6 +1231,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PortalCategory"
+        "409":
+          description: A portal category with the same title already exists in this environment
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           $ref: "#/components/responses/Error"
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -42,6 +42,8 @@ tags:
     description: Everything about Newt Ai
   - name: Subscription Forms
     description: Everything about subscription forms for API consumers
+  - name: Portal Categories
+    description: Everything about Portal Next categories used to group APIs on the New Developer Portal
 
 paths:
   # Environment Analytics
@@ -1188,6 +1190,97 @@ paths:
       responses:
         "204":
           description: Portal navigation item deleted
+        default:
+          $ref: "#/components/responses/Error"
+
+  # Portal Categories
+  /portal-categories:
+    get:
+      tags:
+        - Portal Categories
+      summary: Get portal categories
+      description: User must have the ENVIRONMENT_DOCUMENTATION[read] permission.
+      operationId: getPortalCategories
+      responses:
+        "200":
+          description: List of portal categories, sorted alphabetically by title
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PortalCategory"
+        default:
+          $ref: "#/components/responses/Error"
+    post:
+      tags:
+        - Portal Categories
+      summary: Create a portal category
+      description: User must have the ENVIRONMENT_DOCUMENTATION[create] permission.
+      operationId: createPortalCategory
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePortalCategory"
+        required: true
+      responses:
+        "201":
+          description: Portal category created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PortalCategory"
+        default:
+          $ref: "#/components/responses/Error"
+
+  /portal-categories/{categoryId}:
+    put:
+      tags:
+        - Portal Categories
+      summary: Update a portal category
+      description: User must have the ENVIRONMENT_DOCUMENTATION[update] permission.
+      operationId: updatePortalCategory
+      parameters:
+        - name: categoryId
+          in: path
+          description: The unique ID of the portal category
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdatePortalCategory"
+      responses:
+        "200":
+          description: Updated portal category
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PortalCategory"
+        default:
+          $ref: "#/components/responses/Error"
+    delete:
+      tags:
+        - Portal Categories
+      summary: Delete a portal category
+      description: User must have the ENVIRONMENT_DOCUMENTATION[delete] permission.
+      operationId: deletePortalCategory
+      parameters:
+        - name: categoryId
+          in: path
+          description: The unique ID of the portal category
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          description: Portal category deleted
         default:
           $ref: "#/components/responses/Error"
 
@@ -2572,6 +2665,65 @@ components:
           LINK: "#/components/schemas/UpdatePortalNavigationLink"
           API: "#/components/schemas/UpdatePortalNavigationApi"
           API_PRODUCT: "#/components/schemas/UpdatePortalNavigationApiProduct"
+
+    PortalCategory:
+      type: object
+      description: A Portal Next category, used to group APIs on the New Developer Portal
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The unique ID of the portal category
+          example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+        title:
+          type: string
+          description: The title of the portal category
+          example: Weather
+        description:
+          type: string
+          description: The description of the portal category
+          example: APIs related to weather forecasts
+        visible:
+          type: boolean
+          description: Whether the portal category is visible on the portal
+          example: true
+      required: [ id, title ]
+    CreatePortalCategory:
+      type: object
+      description: Portal category to create
+      properties:
+        title:
+          type: string
+          description: The title of the portal category
+          example: Weather
+        description:
+          type: string
+          description: The description of the portal category
+          example: APIs related to weather forecasts
+        visible:
+          type: boolean
+          description: Whether the portal category is visible on the portal
+          default: true
+          example: true
+      required: [ title ]
+    UpdatePortalCategory:
+      type: object
+      description: Portal category to update
+      properties:
+        title:
+          type: string
+          description: The title of the portal category
+          example: Weather
+        description:
+          type: string
+          description: The description of the portal category
+          example: APIs related to weather forecasts
+        visible:
+          type: boolean
+          description: Whether the portal category is visible on the portal
+          default: true
+          example: true
+      required: [ title ]
 
     PortalPageContentType:
       type: string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalCategoryMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalCategoryMapperTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+class PortalCategoryMapperTest {
+
+    private final PortalCategoryMapper mapper = Mappers.getMapper(PortalCategoryMapper.class);
+
+    @Test
+    void should_map_domain_portal_category_to_rest_model() {
+        var domain = PortalCategory.of(
+            PortalCategoryId.of("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+            "env-1",
+            "Weather",
+            "Weather APIs",
+            true
+        );
+
+        var result = mapper.map(domain);
+
+        assertThat(result.getId()).isEqualTo(UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d479"));
+        assertThat(result.getTitle()).isEqualTo("Weather");
+        assertThat(result.getDescription()).isEqualTo("Weather APIs");
+        assertThat(result.getVisible()).isTrue();
+    }
+
+    @Test
+    void should_map_list_of_domain_portal_categories() {
+        var domain = PortalCategory.of(PortalCategoryId.of("f47ac10b-58cc-4372-a567-0e02b2c3d479"), "env-1", "Weather", null, true);
+
+        var result = mapper.mapList(List.of(domain));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getTitle()).isEqualTo("Weather");
+    }
+
+    @Test
+    void should_map_create_rest_model_to_domain() {
+        var createPortalCategory = new io.gravitee.rest.api.management.v2.rest.model.CreatePortalCategory()
+            .title("Weather")
+            .description("Weather APIs")
+            .visible(false);
+
+        var result = mapper.map(createPortalCategory);
+
+        assertThat(result.getTitle()).isEqualTo("Weather");
+        assertThat(result.getDescription()).isEqualTo("Weather APIs");
+        assertThat(result.isVisible()).isFalse();
+    }
+
+    @Test
+    void should_map_update_rest_model_to_domain() {
+        var updatePortalCategory = new io.gravitee.rest.api.management.v2.rest.model.UpdatePortalCategory()
+            .title("Weather")
+            .description("Weather APIs")
+            .visible(false);
+
+        var result = mapper.map(updatePortalCategory);
+
+        assertThat(result.getTitle()).isEqualTo("Weather");
+        assertThat(result.getDescription()).isEqualTo("Weather APIs");
+        assertThat(result.isVisible()).isFalse();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalCategoriesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalCategoriesResourceTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static jakarta.ws.rs.client.Entity.json;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import inmemory.PortalCategoryCrudServiceInMemory;
+import inmemory.PortalCategoryQueryServiceInMemory;
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePortalCategory;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalCategoriesResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "my-env";
+
+    @Inject
+    private PortalCategoryCrudServiceInMemory portalCategoryCrudServiceInMemory;
+
+    @Inject
+    private PortalCategoryQueryServiceInMemory portalCategoryQueryServiceInMemory;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/portal-categories";
+    }
+
+    @BeforeEach
+    void init() {
+        super.setUp();
+        GraviteeContext.cleanContext();
+
+        EnvironmentEntity environmentEntity = EnvironmentEntity.builder().id(ENVIRONMENT).organizationId(ORGANIZATION).build();
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT)).thenReturn(environmentEntity);
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        super.tearDown();
+        GraviteeContext.cleanContext();
+        portalCategoryCrudServiceInMemory.reset();
+        portalCategoryQueryServiceInMemory.reset();
+    }
+
+    @Nested
+    class ListPortalCategories {
+
+        @Test
+        void should_return_portal_categories_sorted_alphabetically() {
+            portalCategoryQueryServiceInMemory.initWith(
+                List.of(
+                    PortalCategory.of(PortalCategoryId.of("f47ac10b-58cc-4372-a567-0e02b2c3d479"), ENVIRONMENT, "Weather", null, true),
+                    PortalCategory.of(PortalCategoryId.of("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), ENVIRONMENT, "Analytics", null, false)
+                )
+            );
+
+            var response = rootTarget().request().get();
+
+            assertThat(response.getStatus()).isEqualTo(OK_200);
+            var body = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.PortalCategory[].class);
+            assertThat(body)
+                .extracting(io.gravitee.rest.api.management.v2.rest.model.PortalCategory::getTitle)
+                .containsExactly("Analytics", "Weather");
+        }
+
+        @Test
+        void should_return_empty_array_when_no_categories() {
+            var response = rootTarget().request().get();
+
+            assertThat(response.getStatus()).isEqualTo(OK_200);
+            var body = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.PortalCategory[].class);
+            assertThat(body).isEmpty();
+        }
+
+        @Test
+        void should_return_403_if_incorrect_permissions() {
+            shouldReturn403(RolePermission.ENVIRONMENT_DOCUMENTATION, ENVIRONMENT, RolePermissionAction.READ, () ->
+                rootTarget().request().get()
+            );
+        }
+    }
+
+    @Nested
+    class CreatePortalCategoryTests {
+
+        @Test
+        void should_create_portal_category() {
+            var createPortalCategory = new CreatePortalCategory().title("Weather").description("Weather APIs").visible(true);
+
+            var response = rootTarget().request().post(json(createPortalCategory));
+
+            assertThat(response.getStatus()).isEqualTo(CREATED_201);
+            var created = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.PortalCategory.class);
+            assertThat(created.getId()).isNotNull();
+            assertThat(created.getTitle()).isEqualTo("Weather");
+            assertThat(created.getDescription()).isEqualTo("Weather APIs");
+            assertThat(created.getVisible()).isTrue();
+
+            assertThat(portalCategoryCrudServiceInMemory.storage()).hasSize(1);
+            assertThat(portalCategoryCrudServiceInMemory.storage().getFirst().getEnvironmentId()).isEqualTo(ENVIRONMENT);
+        }
+
+        @Test
+        void should_return_400_when_title_is_missing() {
+            var createPortalCategory = new CreatePortalCategory().description("Weather APIs");
+
+            var response = rootTarget().request().post(json(createPortalCategory));
+
+            assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_400_when_title_is_blank() {
+            var createPortalCategory = new CreatePortalCategory().title("   ");
+
+            var response = rootTarget().request().post(json(createPortalCategory));
+
+            assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_403_if_incorrect_permissions() {
+            shouldReturn403(RolePermission.ENVIRONMENT_DOCUMENTATION, ENVIRONMENT, RolePermissionAction.CREATE, () ->
+                rootTarget().request().post(json(new CreatePortalCategory().title("Weather")))
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalCategoriesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalCategoriesResourceTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.v2.rest.resource.environment;
 
 import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.CONFLICT_409;
 import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static jakarta.ws.rs.client.Entity.json;
@@ -151,6 +152,19 @@ class PortalCategoriesResourceTest extends AbstractResourceTest {
             var response = rootTarget().request().post(json(createPortalCategory));
 
             assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_409_when_title_already_exists() {
+            portalCategoryQueryServiceInMemory.initWith(
+                List.of(PortalCategory.of(PortalCategoryId.of("f47ac10b-58cc-4372-a567-0e02b2c3d479"), ENVIRONMENT, "Weather", null, true))
+            );
+            var createPortalCategory = new CreatePortalCategory().title("Weather");
+
+            var response = rootTarget().request().post(json(createPortalCategory));
+
+            assertThat(response.getStatus()).isEqualTo(CONFLICT_409);
+            assertThat(portalCategoryCrudServiceInMemory.storage()).isEmpty();
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalCategoryResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalCategoryResourceTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.NO_CONTENT_204;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static jakarta.ws.rs.client.Entity.json;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import inmemory.PortalCategoryCrudServiceInMemory;
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalCategory;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalCategoryResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "my-env";
+    private static final String CATEGORY_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
+
+    @Inject
+    private PortalCategoryCrudServiceInMemory portalCategoryCrudServiceInMemory;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/portal-categories/" + CATEGORY_ID;
+    }
+
+    @BeforeEach
+    void init() {
+        super.setUp();
+        GraviteeContext.cleanContext();
+
+        EnvironmentEntity environmentEntity = EnvironmentEntity.builder().id(ENVIRONMENT).organizationId(ORGANIZATION).build();
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT)).thenReturn(environmentEntity);
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+
+        portalCategoryCrudServiceInMemory.initWith(
+            List.of(PortalCategory.of(PortalCategoryId.of(CATEGORY_ID), ENVIRONMENT, "Weather", "Weather APIs", true))
+        );
+    }
+
+    @AfterEach
+    public void tearDown() {
+        super.tearDown();
+        GraviteeContext.cleanContext();
+        portalCategoryCrudServiceInMemory.reset();
+    }
+
+    @Nested
+    class UpdatePortalCategoryTests {
+
+        @Test
+        void should_update_portal_category() {
+            var updatePortalCategory = new UpdatePortalCategory()
+                .title("Updated Weather")
+                .description("Updated description")
+                .visible(false);
+
+            var response = rootTarget().request().put(json(updatePortalCategory));
+
+            assertThat(response.getStatus()).isEqualTo(OK_200);
+            var updated = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.PortalCategory.class);
+            assertThat(updated.getTitle()).isEqualTo("Updated Weather");
+            assertThat(updated.getDescription()).isEqualTo("Updated description");
+            assertThat(updated.getVisible()).isFalse();
+
+            assertThat(portalCategoryCrudServiceInMemory.storage().getFirst().getTitle()).isEqualTo("Updated Weather");
+        }
+
+        @Test
+        void should_return_400_when_title_is_blank() {
+            var updatePortalCategory = new UpdatePortalCategory().title(" ");
+
+            var response = rootTarget().request().put(json(updatePortalCategory));
+
+            assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_404_when_category_does_not_exist() {
+            portalCategoryCrudServiceInMemory.reset();
+
+            var response = rootTarget().request().put(json(new UpdatePortalCategory().title("Weather")));
+
+            assertThat(response.getStatus()).isEqualTo(NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_if_incorrect_permissions() {
+            shouldReturn403(RolePermission.ENVIRONMENT_DOCUMENTATION, ENVIRONMENT, RolePermissionAction.UPDATE, () ->
+                rootTarget().request().put(json(new UpdatePortalCategory().title("Weather")))
+            );
+        }
+    }
+
+    @Nested
+    class DeletePortalCategoryTests {
+
+        @Test
+        void should_delete_portal_category() {
+            var response = rootTarget().request().delete();
+
+            assertThat(response.getStatus()).isEqualTo(NO_CONTENT_204);
+            assertThat(portalCategoryCrudServiceInMemory.storage()).isEmpty();
+        }
+
+        @Test
+        void should_return_404_when_category_does_not_exist() {
+            portalCategoryCrudServiceInMemory.reset();
+
+            var response = rootTarget().request().delete();
+
+            assertThat(response.getStatus()).isEqualTo(NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_if_incorrect_permissions() {
+            shouldReturn403(RolePermission.ENVIRONMENT_DOCUMENTATION, ENVIRONMENT, RolePermissionAction.DELETE, () ->
+                rootTarget().request().delete()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-16

## Description

Adds the OpenAPI-first `/portal-categories` endpoints (list, create, update, delete) to `openapi-environments.yaml`, the generated-DTO mapper, and the JAX-RS resources, wired into `EnvironmentResource`. Endpoints are gated on the `ENVIRONMENT_DOCUMENTATION` permission, matching the sibling Portal Navigation Items endpoints. Documents and tests the `409` response returned when creating a category with a title that already exists in the environment.

## Additional context

Part 4/7 of a stacked chain for PORTAL-16, stacked on #18537 (domain service and use cases). Compatibility-sensitive: new public REST endpoints/OpenAPI schema.