### PR TITLE
feat(console): add portal category entities and API service

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/index.ts
@@ -43,6 +43,7 @@ export * from './modelError';
 export * from './organization';
 export * from './pagedResult';
 export * from './pagination';
+export * from './portalCategory';
 export * from './portalCustomization';
 export * from './portalMenuLink';
 export * from './portalNavigationItem';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/CreatePortalCategory.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/CreatePortalCategory.fixture.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isFunction } from 'lodash';
+
+import { CreatePortalCategory } from './CreatePortalCategory';
+
+export function fakeCreatePortalCategory(
+  modifier?: Partial<CreatePortalCategory> | ((base: CreatePortalCategory) => CreatePortalCategory),
+): CreatePortalCategory {
+  const base: CreatePortalCategory = {
+    title: 'Portal category',
+    description: 'Description of the portal category',
+    visible: true,
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/CreatePortalCategory.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/CreatePortalCategory.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface CreatePortalCategory {
+  title: string;
+  description?: string;
+  visible?: boolean;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/PortalCategory.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/PortalCategory.fixture.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isFunction } from 'lodash';
+
+import { PortalCategory } from './PortalCategory';
+
+export function fakePortalCategory(modifier?: Partial<PortalCategory> | ((base: PortalCategory) => PortalCategory)): PortalCategory {
+  const base: PortalCategory = {
+    id: '1',
+    title: 'Portal category',
+    description: 'Description of the portal category',
+    visible: true,
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/PortalCategory.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/PortalCategory.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface PortalCategory {
+  id: string;
+  title: string;
+  description?: string;
+  visible: boolean;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/UpdatePortalCategory.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/UpdatePortalCategory.fixture.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isFunction } from 'lodash';
+
+import { UpdatePortalCategory } from './UpdatePortalCategory';
+
+export function fakeUpdatePortalCategory(
+  modifier?: Partial<UpdatePortalCategory> | ((base: UpdatePortalCategory) => UpdatePortalCategory),
+): UpdatePortalCategory {
+  const base: UpdatePortalCategory = {
+    title: 'Portal category',
+    description: 'Description of the portal category',
+    visible: true,
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/UpdatePortalCategory.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/UpdatePortalCategory.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface UpdatePortalCategory {
+  title: string;
+  description?: string;
+  visible: boolean;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/UpdatePortalCategory.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/UpdatePortalCategory.ts
@@ -17,5 +17,5 @@
 export interface UpdatePortalCategory {
   title: string;
   description?: string;
-  visible: boolean;
+  visible?: boolean;
 }

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalCategory/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './PortalCategory';
+export * from './PortalCategory.fixture';
+export * from './CreatePortalCategory';
+export * from './CreatePortalCategory.fixture';
+export * from './UpdatePortalCategory';
+export * from './UpdatePortalCategory.fixture';

--- a/gravitee-apim-console-webui/src/services-ngx/portal-category.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-category.service.spec.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { PortalCategoryService } from './portal-category.service';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
+import {
+  CreatePortalCategory,
+  fakeCreatePortalCategory,
+  fakePortalCategory,
+  fakeUpdatePortalCategory,
+  PortalCategory,
+  UpdatePortalCategory,
+} from '../entities/management-api-v2';
+
+describe('PortalCategoryService', () => {
+  let httpTestingController: HttpTestingController;
+  let service: PortalCategoryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject<PortalCategoryService>(PortalCategoryService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('list', () => {
+    it('should call the API', done => {
+      service.list().subscribe(categories => {
+        expect(categories.length).toEqual(1);
+        done();
+      });
+
+      expectListPortalCategoriesRequest(httpTestingController, [fakePortalCategory()]);
+    });
+  });
+
+  describe('create', () => {
+    it('should call the API', done => {
+      const createPortalCategory = fakeCreatePortalCategory();
+      service.create(createPortalCategory).subscribe(category => {
+        expect(category).toBeTruthy();
+        done();
+      });
+
+      expectCreatePortalCategoryRequest(httpTestingController, createPortalCategory);
+    });
+  });
+
+  describe('update', () => {
+    it('should call the API', done => {
+      const updatePortalCategory = fakeUpdatePortalCategory();
+      service.update('categoryId', updatePortalCategory).subscribe(category => {
+        expect(category).toBeTruthy();
+        done();
+      });
+
+      expectUpdatePortalCategoryRequest(httpTestingController, 'categoryId', updatePortalCategory);
+    });
+  });
+
+  describe('delete', () => {
+    it('should call the API', done => {
+      service.delete('categoryId').subscribe(() => {
+        done();
+      });
+      expectDeletePortalCategoryRequest(httpTestingController, 'categoryId');
+    });
+  });
+});
+
+export const expectListPortalCategoriesRequest = (
+  httpTestingController: HttpTestingController,
+  portalCategories: PortalCategory[] = [fakePortalCategory()],
+) => {
+  const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/portal-categories`);
+  expect(req.request.method).toEqual('GET');
+  req.flush(portalCategories);
+};
+
+export const expectCreatePortalCategoryRequest = (
+  httpTestingController: HttpTestingController,
+  expectedCreatePortalCategory: CreatePortalCategory,
+  portalCategoryCreated: PortalCategory = fakePortalCategory(),
+) => {
+  const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/portal-categories`);
+  expect(req.request.method).toEqual('POST');
+  expect(req.request.body).toStrictEqual(expectedCreatePortalCategory);
+  req.flush(portalCategoryCreated);
+};
+
+export const expectUpdatePortalCategoryRequest = (
+  httpTestingController: HttpTestingController,
+  portalCategoryId: string,
+  expectedUpdatePortalCategory: UpdatePortalCategory,
+  portalCategoryUpdated: PortalCategory = fakePortalCategory(),
+) => {
+  const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/portal-categories/${portalCategoryId}`);
+  expect(req.request.method).toEqual('PUT');
+  expect(req.request.body).toStrictEqual(expectedUpdatePortalCategory);
+  req.flush(portalCategoryUpdated);
+};
+
+export const expectDeletePortalCategoryRequest = (httpTestingController: HttpTestingController, portalCategoryId: string) => {
+  const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/portal-categories/${portalCategoryId}`);
+  expect(req.request.method).toEqual('DELETE');
+  req.flush({});
+};

--- a/gravitee-apim-console-webui/src/services-ngx/portal-category.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-category.service.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { CreatePortalCategory, PortalCategory, UpdatePortalCategory } from '../entities/management-api-v2';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PortalCategoryService {
+  constructor(
+    private readonly http: HttpClient,
+    @Inject(Constants) private readonly constants: Constants,
+  ) {}
+
+  list(): Observable<PortalCategory[]> {
+    return this.http.get<PortalCategory[]>(`${this.constants.env.v2BaseURL}/portal-categories`);
+  }
+
+  create(createPortalCategory: CreatePortalCategory): Observable<PortalCategory> {
+    return this.http.post<PortalCategory>(`${this.constants.env.v2BaseURL}/portal-categories`, createPortalCategory);
+  }
+
+  update(id: string, updatePortalCategory: UpdatePortalCategory): Observable<PortalCategory> {
+    return this.http.put<PortalCategory>(`${this.constants.env.v2BaseURL}/portal-categories/${id}`, updatePortalCategory);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.constants.env.v2BaseURL}/portal-categories/${id}`);
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-16

## Description

Adds the TypeScript entity types/fixtures and a hand-written Angular service (`PortalCategoryService`) for the `/portal-categories` management-api-v2 endpoints, following the `shared-policy-groups.service.ts` convention.

## Additional context

Part 5/7 of a stacked chain for PORTAL-16, stacked on #18538 (v2 REST endpoints).