### PR TITLE
feat(console): rewire Portal Settings Catalog category screens to portal category endpoints

### DIFF
--- a/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.html
+++ b/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.html
@@ -36,7 +36,6 @@
         <div class="categories__header__information">
           <div class="categories__header__information__title">
             <h3>Categories</h3>
-            <both-portals-badge data-testid="both-portals-badge" />
           </div>
           <div class="mat-body-2">Organize your API into categories</div>
         </div>
@@ -52,29 +51,14 @@
         </button>
       </div>
 
-      <table
-        mat-table
-        class="gio-table-light"
-        [dataSource]="categoriesDS$ | async"
-        cdkDropList
-        (cdkDropListDropped)="drop($event)"
-        cdkDropListData="dataSource"
-      >
-        <!-- Position Column -->
-        <ng-container matColumnDef="order" sticky>
-          <th mat-header-cell *matHeaderCellDef></th>
-          <td mat-cell *matCellDef="let element">
-            <mat-icon class="drag-cursor">drag_indicator</mat-icon>
-          </td>
-        </ng-container>
-
-        <!-- Display Name Column -->
+      <table mat-table class="gio-table-light" [dataSource]="categoriesDS$ | async">
+        <!-- Display Title Column -->
         <ng-container matColumnDef="name">
           <th mat-header-cell *matHeaderCellDef id="name">Name</th>
-          <td mat-cell *matCellDef="let element" title="{{ element.name }}">
+          <td mat-cell *matCellDef="let element" title="{{ element.title }}">
             <div>
-              {{ element.name }}
-              @if (element.hidden) {
+              {{ element.title }}
+              @if (!element.visible) {
                 <span class="gio-badge-neutral" matTooltip="Hidden"><mat-icon svgIcon="gio:eye-off" /></span>
               }
             </div>
@@ -87,20 +71,12 @@
           <td mat-cell *matCellDef="let element">{{ element.description }}</td>
         </ng-container>
 
-        <!-- Display API Count Column -->
-        <ng-container matColumnDef="count">
-          <th mat-header-cell *matHeaderCellDef id="api-count">API Count</th>
-          <td mat-cell *matCellDef="let element">
-            {{ element.totalApis }}
-          </td>
-        </ng-container>
-
         <!-- Display Actions Column -->
         <ng-container matColumnDef="actions">
           <th mat-header-cell *matHeaderCellDef id="actions"></th>
           <td mat-cell *matCellDef="let element">
             <div class="categories__list__actions">
-              @if (element.hidden) {
+              @if (!element.visible) {
                 <button
                   mat-button
                   (click)="showCategory(element)"
@@ -141,14 +117,7 @@
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr
-          mat-row
-          *matRowDef="let row; columns: displayedColumns"
-          data-testid="link_table_row"
-          cdkDrag
-          [cdkDragData]="row"
-          cdkDragLockAxis="y"
-        ></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns" data-testid="link_table_row"></tr>
         <!-- Row shown when there is no data -->
         <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
           <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">

--- a/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.html
+++ b/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.html
@@ -15,21 +15,7 @@
     limitations under the License.
 
 -->
-<form [formGroup]="form" class="categories">
-  <mat-card *gioPermission="{ anyOf: ['environment-settings-r', 'environment-settings-u'] }">
-    <mat-card-content>
-      <h3>Settings</h3>
-      <mat-form-field class="categories__settings__form-field" id="category-view-mode">
-        <mat-select formControlName="catalogViewMode">
-          @for (viewMode of viewModes; track $index) {
-            <mat-option [value]="viewMode.value">{{ viewMode.label }}</mat-option>
-          }
-        </mat-select>
-        <mat-label>Category View Mode</mat-label>
-        <mat-hint>Choose how categories are displayed in the Developer Portal</mat-hint>
-      </mat-form-field>
-    </mat-card-content>
-  </mat-card>
+<div class="categories">
   <mat-card class="menu-catalog">
     <mat-card-content class="categories__content">
       <div class="categories__header">
@@ -127,5 +113,4 @@
       </table>
     </mat-card-content>
   </mat-card>
-  <gio-save-bar [form]="form" [formInitialValues]="initialValues" (resetClicked)="reset()" (submitted)="submit()"></gio-save-bar>
-</form>
+</div>

--- a/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.scss
+++ b/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.scss
@@ -42,21 +42,10 @@
     }
   }
 
-  &__settings {
-    &__form-field {
-      width: 50%;
-    }
-  }
-
   &__content {
     display: flex;
     flex-flow: column;
     gap: 24px;
-  }
-  &__actions {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
   }
   &__list {
     &__actions {

--- a/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.spec.ts
@@ -23,18 +23,22 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { GioConfirmDialogHarness, GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTableHarness } from '@angular/material/table/testing';
+import { of } from 'rxjs';
 
 import { CategoryListComponent } from './category-list.component';
 import { CategoryListHarness } from './category-list.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
-import { Category } from '../../../entities/category/Category';
 import { EnvSettings } from '../../../entities/Constants';
 import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 import { EnvironmentSettingsService } from '../../../services-ngx/environment-settings.service';
-import { CategoriesModule } from '../../../management/settings/categories/categories.module';
-import { UpdateCategory } from '../../../entities/category/UpdateCategory';
 import { PortalSettings } from '../../../entities/portal/portalSettings';
+import { fakePortalCategory, PortalCategory } from '../../../entities/management-api-v2';
+import {
+  expectDeletePortalCategoryRequest,
+  expectListPortalCategoriesRequest,
+  expectUpdatePortalCategoryRequest,
+} from '../../../services-ngx/portal-category.service.spec';
 
 describe('CategoryListComponent', () => {
   let fixture: ComponentFixture<CategoryListComponent>;
@@ -107,16 +111,9 @@ describe('CategoryListComponent', () => {
             'environment-settings-u',
           ],
         },
-        { provide: EnvironmentSettingsService, useValue: { getSnapshot: () => snapshot } },
+        { provide: EnvironmentSettingsService, useValue: { getSnapshot: () => snapshot, load: () => of(snapshot) } },
       ],
-      imports: [
-        NoopAnimationsModule,
-        GioTestingModule,
-        CategoriesModule,
-        MatIconTestingModule,
-        MatSlideToggleModule,
-        CategoryListComponent,
-      ],
+      imports: [NoopAnimationsModule, GioTestingModule, MatIconTestingModule, MatSlideToggleModule, CategoryListComponent],
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {
@@ -143,7 +140,7 @@ describe('CategoryListComponent', () => {
   describe('No categories', () => {
     beforeEach(async () => {
       await init();
-      expectGetCategoriesList();
+      expectListPortalCategoriesRequest(httpTestingController, []);
     });
     it('should display empty message', async () => {
       const table = await harnessLoader.getHarness(MatTableHarness);
@@ -153,63 +150,56 @@ describe('CategoryListComponent', () => {
   });
 
   describe('Category list', () => {
+    const CATEGORIES = [
+      fakePortalCategory({ id: 'cat-1', title: 'cat-1', description: 'nice cat', visible: true }),
+      fakePortalCategory({ id: 'cat-2', title: 'cat-2', description: 'nice cat - second', visible: true }),
+      fakePortalCategory({ id: 'cat-3', title: 'cat-3', description: 'nice cat - hidden', visible: false }),
+    ];
     beforeEach(async () => {
       await init();
-      expectGetCategoriesList([
-        { id: 'cat-1', name: 'cat-1', key: 'cat-1', order: 1, hidden: false, description: 'nice cat', totalApis: 1 },
-        { id: 'cat-2', name: 'cat-2', key: 'cat-2', order: 3, hidden: false, description: 'nice cat - out of order', totalApis: 10 },
-        { id: 'cat-3', name: 'cat-3', key: 'cat-3', order: 2, hidden: true, description: 'nice cat - hidden', totalApis: 0 },
-      ]);
+      expectListPortalCategoriesRequest(httpTestingController, CATEGORIES);
     });
     it('should show multiple categories', async () => {
       expect(await componentHarness.getTableRows(harnessLoader).then(rows => rows.length)).toEqual(3);
     });
-    it('should sort categories by order', async () => {
-      expect(await componentHarness.getNameByRowIndex(harnessLoader, 0)).toEqual('cat-1');
-      expect(await componentHarness.getNameByRowIndex(harnessLoader, 1)).toEqual('cat-3');
-      expect(await componentHarness.getNameByRowIndex(harnessLoader, 2)).toEqual('cat-2');
-    });
     it('should show which categories are hidden', async () => {
       const rows = await componentHarness.getTableRows(harnessLoader);
-      const hiddenIcon = await rows[1].getCells({ columnName: 'name' }).then(cells => cells[0].getHarnessOrNull(MatIconHarness));
+      const hiddenIcon = await rows[2].getCells({ columnName: 'name' }).then(cells => cells[0].getHarnessOrNull(MatIconHarness));
       expect(hiddenIcon).toBeTruthy();
-    });
-    it('should show api count', async () => {
-      expect(await componentHarness.getApiCountByRowIndex(harnessLoader, 0)).toEqual('1');
-      expect(await componentHarness.getApiCountByRowIndex(harnessLoader, 1)).toEqual('0');
-      expect(await componentHarness.getApiCountByRowIndex(harnessLoader, 2)).toEqual('10');
     });
     it('should show category description', async () => {
       expect(await componentHarness.getDescriptionByRowIndex(harnessLoader, 0)).toEqual('nice cat');
-      expect(await componentHarness.getDescriptionByRowIndex(harnessLoader, 1)).toEqual('nice cat - hidden');
-      expect(await componentHarness.getDescriptionByRowIndex(harnessLoader, 2)).toEqual('nice cat - out of order');
+      expect(await componentHarness.getDescriptionByRowIndex(harnessLoader, 1)).toEqual('nice cat - second');
+      expect(await componentHarness.getDescriptionByRowIndex(harnessLoader, 2)).toEqual('nice cat - hidden');
     });
   });
 
   describe('Actions', () => {
-    const CATEGORIES = () => [
-      { id: 'cat-1', name: 'cat-1', key: 'cat-1', order: 1, hidden: false, description: 'nice cat', totalApis: 1 },
-      { id: 'cat-2', name: 'cat-2', key: 'cat-2', order: 3, hidden: false, description: 'nice cat - out of order', totalApis: 10 },
-      { id: 'cat-3', name: 'cat-3', key: 'cat-3', order: 2, hidden: true, description: 'nice cat - hidden', totalApis: 0 },
+    const CATEGORIES: () => PortalCategory[] = () => [
+      fakePortalCategory({ id: 'cat-1', title: 'cat-1', description: 'nice cat', visible: true }),
+      fakePortalCategory({ id: 'cat-2', title: 'cat-2', description: 'nice cat - second', visible: true }),
+      fakePortalCategory({ id: 'cat-3', title: 'cat-3', description: 'nice cat - hidden', visible: false }),
     ];
     beforeEach(async () => {
       await init();
-      expectGetCategoriesList(CATEGORIES());
+      expectListPortalCategoriesRequest(httpTestingController, CATEGORIES());
     });
 
     it('should show category', async () => {
-      const showCategoryButton = await componentHarness.getActionButtonByRowIndexAndTooltip(harnessLoader, 1, 'Show Category');
+      const showCategoryButton = await componentHarness.getActionButtonByRowIndexAndTooltip(harnessLoader, 2, 'Show Category');
       expect(showCategoryButton).toBeTruthy();
       expect(await showCategoryButton.isDisabled()).toEqual(false);
 
       await showCategoryButton.click();
-      const updatedCategory = { ...CATEGORIES()[2], hidden: false };
-      expectPutCategory(updatedCategory);
-      expectGetCategoriesList();
+      expectUpdatePortalCategoryRequest(httpTestingController, 'cat-3', {
+        title: 'cat-3',
+        description: 'nice cat - hidden',
+        visible: true,
+      });
+      expectListPortalCategoriesRequest(httpTestingController, []);
     });
 
     it('should delete category', async () => {
-      expect(await componentHarness.getBothPortalsBadge()).toBeTruthy();
       const deleteButton = await componentHarness.getActionButtonByRowIndexAndTooltip(harnessLoader, 0, 'Delete');
       expect(deleteButton).toBeTruthy();
       expect(await deleteButton.isDisabled()).toEqual(false);
@@ -220,8 +210,8 @@ describe('CategoryListComponent', () => {
       expect(confirmDialog).toBeTruthy();
       await confirmDialog.confirm();
 
-      expectDeleteCategory(CATEGORIES()[0].id);
-      expectGetCategoriesList();
+      expectDeletePortalCategoryRequest(httpTestingController, CATEGORIES()[0].id);
+      expectListPortalCategoriesRequest(httpTestingController, []);
     });
   });
 
@@ -233,14 +223,14 @@ describe('CategoryListComponent', () => {
       };
 
       await init({}, settings);
-      expectGetCategoriesList();
+      expectListPortalCategoriesRequest(httpTestingController, []);
 
       const viewModeSelect = await componentHarness.getCategoryViewMode(harnessLoader);
       expect(await viewModeSelect.getValueText()).toEqual('Tiles');
     });
     it('should select Tabs catalog view mode', async () => {
       await init({}, {});
-      expectGetCategoriesList();
+      expectListPortalCategoriesRequest(httpTestingController, []);
 
       const viewModeSelect = await componentHarness.getCategoryViewMode(harnessLoader);
       expect(await viewModeSelect.getValueText()).toEqual('Tabs (Default)');
@@ -262,7 +252,7 @@ describe('CategoryListComponent', () => {
     });
     it('should reset settings', async () => {
       await init({}, {});
-      expectGetCategoriesList();
+      expectListPortalCategoriesRequest(httpTestingController, []);
 
       const viewModeSelect = await componentHarness.getCategoryViewMode(harnessLoader);
       await viewModeSelect.clickOptions({ text: 'Tiles' });
@@ -272,24 +262,6 @@ describe('CategoryListComponent', () => {
       expect(await viewModeSelect.getValueText()).toEqual('Tabs (Default)');
     });
   });
-
-  function expectGetCategoriesList(list: Category[] = []) {
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/configuration/categories?include=total-apis`).flush(list);
-  }
-  function expectPutCategory(category: UpdateCategory) {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/configuration/categories/${category.id}`);
-    expect(req.request.body).toEqual(category);
-    req.flush(category);
-  }
-
-  function expectDeleteCategory(categoryId: string) {
-    httpTestingController
-      .expectOne({
-        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/categories/${categoryId}`,
-        method: 'DELETE',
-      })
-      .flush({});
-  }
 
   function expectGetPortalSettings(portalSettings: PortalSettings) {
     httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`).flush(portalSettings);

--- a/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.spec.ts
@@ -20,19 +20,14 @@ import { MatIconHarness, MatIconTestingModule } from '@angular/material/icon/tes
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { GioConfirmDialogHarness, GioSaveBarHarness } from '@gravitee/ui-particles-angular';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
 import { MatTableHarness } from '@angular/material/table/testing';
-import { of } from 'rxjs';
 
 import { CategoryListComponent } from './category-list.component';
 import { CategoryListHarness } from './category-list.harness';
 
-import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
-import { EnvSettings } from '../../../entities/Constants';
+import { GioTestingModule } from '../../../shared/testing';
 import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
-import { EnvironmentSettingsService } from '../../../services-ngx/environment-settings.service';
-import { PortalSettings } from '../../../entities/portal/portalSettings';
 import { fakePortalCategory, PortalCategory } from '../../../entities/management-api-v2';
 import {
   expectDeletePortalCategoryRequest,
@@ -46,74 +41,16 @@ describe('CategoryListComponent', () => {
   let rootLoader: HarnessLoader;
   let httpTestingController: HttpTestingController;
   let componentHarness: CategoryListHarness;
-  const DEFAULT_ENV_SETTINGS = {
-    portal: {
-      url: 'url',
-      entrypoint: 'entrypoint',
-      apikeyHeader: 'apiKeyHeader',
-      support: {
-        enabled: true,
-      },
-      apis: {
-        categoryMode: {
-          enabled: true,
-        },
-        tilesMode: {
-          enabled: true,
-        },
-        apiHeaderShowTags: {
-          enabled: true,
-        },
-        apiHeaderShowCategories: {
-          enabled: true,
-        },
-      },
-      analytics: {
-        enabled: true,
-      },
-      rating: {
-        enabled: true,
-        comment: { mandatory: true },
-      },
-      userCreation: {
-        enabled: true,
-        automaticValidation: { enabled: true },
-      },
-      uploadMedia: { enabled: true, maxSizeInOctet: 10 },
-    },
-  };
 
-  const DEFAULT_PORTAL_SETTINGS: PortalSettings = {
-    portalNext: {
-      access: {
-        enabled: true,
-      },
-      banner: {},
-      catalog: {
-        viewMode: 'TABS',
-      },
-    },
-  };
-
-  const init = async (
-    snapshot: Partial<EnvSettings> = DEFAULT_ENV_SETTINGS,
-    portalSettings: Partial<PortalSettings> = DEFAULT_PORTAL_SETTINGS,
-  ) => {
+  const init = async (permissions: string[] = ['environment-category-u', 'environment-category-d', 'environment-category-c']) => {
     await TestBed.configureTestingModule({
       providers: [
         {
           provide: GioTestingPermissionProvider,
-          useValue: [
-            'environment-category-u',
-            'environment-category-d',
-            'environment-category-c',
-            'environment-settings-r',
-            'environment-settings-u',
-          ],
+          useValue: permissions,
         },
-        { provide: EnvironmentSettingsService, useValue: { getSnapshot: () => snapshot, load: () => of(snapshot) } },
       ],
-      imports: [NoopAnimationsModule, GioTestingModule, MatIconTestingModule, MatSlideToggleModule, CategoryListComponent],
+      imports: [NoopAnimationsModule, GioTestingModule, MatIconTestingModule, CategoryListComponent],
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {
@@ -129,8 +66,6 @@ describe('CategoryListComponent', () => {
     componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, CategoryListHarness);
     rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
     fixture.detectChanges();
-
-    expectGetPortalSettings({ ...DEFAULT_PORTAL_SETTINGS, ...portalSettings });
   };
 
   afterEach(() => {
@@ -214,64 +149,4 @@ describe('CategoryListComponent', () => {
       expectListPortalCategoriesRequest(httpTestingController, []);
     });
   });
-
-  describe('Settings', () => {
-    it('should load current settings', async () => {
-      const settings = {
-        ...DEFAULT_PORTAL_SETTINGS,
-        portalNext: { ...DEFAULT_PORTAL_SETTINGS.portalNext, catalog: { viewMode: 'CATEGORIES' } },
-      };
-
-      await init({}, settings);
-      expectListPortalCategoriesRequest(httpTestingController, []);
-
-      const viewModeSelect = await componentHarness.getCategoryViewMode(harnessLoader);
-      expect(await viewModeSelect.getValueText()).toEqual('Tiles');
-    });
-    it('should select Tabs catalog view mode', async () => {
-      await init({}, {});
-      expectListPortalCategoriesRequest(httpTestingController, []);
-
-      const viewModeSelect = await componentHarness.getCategoryViewMode(harnessLoader);
-      expect(await viewModeSelect.getValueText()).toEqual('Tabs (Default)');
-
-      await viewModeSelect.clickOptions({ text: 'Tiles' });
-
-      const saveBar = await harnessLoader.getHarness(GioSaveBarHarness);
-      expect(await saveBar.isVisible()).toEqual(true);
-
-      await saveBar.clickSubmit();
-      expectGetPortalSettings(DEFAULT_PORTAL_SETTINGS);
-
-      const newSettings = {
-        ...DEFAULT_PORTAL_SETTINGS,
-        portalNext: { ...DEFAULT_PORTAL_SETTINGS.portalNext, catalog: { viewMode: 'CATEGORIES' } },
-      };
-
-      expectSavePortalSettings(newSettings);
-    });
-    it('should reset settings', async () => {
-      await init({}, {});
-      expectListPortalCategoriesRequest(httpTestingController, []);
-
-      const viewModeSelect = await componentHarness.getCategoryViewMode(harnessLoader);
-      await viewModeSelect.clickOptions({ text: 'Tiles' });
-
-      const saveBar = await harnessLoader.getHarness(GioSaveBarHarness);
-      await saveBar.clickReset();
-      expect(await viewModeSelect.getValueText()).toEqual('Tabs (Default)');
-    });
-  });
-
-  function expectGetPortalSettings(portalSettings: PortalSettings) {
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`).flush(portalSettings);
-  }
-
-  function expectSavePortalSettings(portalSettings: PortalSettings) {
-    const request = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
-
-    expect(request.request.body).toEqual(portalSettings);
-
-    request.flush(portalSettings);
-  }
 });

--- a/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.ts
@@ -16,10 +16,9 @@
 import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { MatTableModule } from '@angular/material/table';
 import { BehaviorSubject, Observable, of } from 'rxjs';
-import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { catchError, filter, switchMap } from 'rxjs/operators';
-import { GioAvatarModule, GioConfirmDialogComponent, GioConfirmDialogData, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { GioAvatarModule, GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AsyncPipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
@@ -27,34 +26,23 @@ import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
-import { MatSelectModule } from '@angular/material/select';
 
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { PortalCategoryService } from '../../../services-ngx/portal-category.service';
 import { PortalCategory } from '../../../entities/management-api-v2';
-import { PortalSettingsService } from '../../../services-ngx/portal-settings.service';
-import { PortalSettings } from '../../../entities/portal/portalSettings';
-
-interface CatalogViewModeVM {
-  value: string;
-  label: string;
-}
 
 @Component({
   selector: 'category-list',
   imports: [
     // Angular Common & Forms
     AsyncPipe,
-    FormsModule,
-    ReactiveFormsModule,
     RouterLink,
 
     // Gravitee UI Particles & Custom Components
     GioAvatarModule,
     GioPermissionModule,
-    GioSaveBarModule,
 
     // Angular Material
     MatButtonModule,
@@ -62,7 +50,6 @@ interface CatalogViewModeVM {
     MatIconModule,
     MatTableModule,
     MatTooltipModule,
-    MatSelectModule,
     MatDialogModule,
   ],
   templateUrl: './category-list.component.html',
@@ -72,23 +59,6 @@ export class CategoryListComponent implements OnInit {
   categoriesDS$: Observable<PortalCategory[]> = of([]);
   private categoryList = new BehaviorSubject(1);
   displayedColumns: string[] = ['name', 'description', 'actions'];
-  portalCatalogViewMode: FormControl<string> = new FormControl();
-
-  form: FormGroup<{ catalogViewMode: FormControl<string> }> = new FormGroup({
-    catalogViewMode: this.portalCatalogViewMode,
-  });
-  initialValues: { catalogViewMode?: string };
-
-  viewModes: CatalogViewModeVM[] = [
-    {
-      value: 'TABS',
-      label: 'Tabs (Default)',
-    },
-    {
-      value: 'CATEGORIES',
-      label: 'Tiles',
-    },
-  ];
 
   private destroyRef = inject(DestroyRef);
 
@@ -97,7 +67,6 @@ export class CategoryListComponent implements OnInit {
     private readonly snackBarService: SnackBarService,
     private matDialog: MatDialog,
     private readonly permissionService: GioPermissionService,
-    private readonly portalSettingsService: PortalSettingsService,
   ) {}
 
   ngOnInit(): void {
@@ -105,23 +74,11 @@ export class CategoryListComponent implements OnInit {
     if (!this.permissionService.hasAnyMatching(['environment-category-u', 'environment-category-d'])) {
       this.displayedColumns.pop();
     }
-    // If cannot update settings, disable form
-    if (!this.permissionService.hasAnyMatching(['environment-settings-u'])) {
-      this.form.disable();
-    }
 
     this.categoriesDS$ = this.categoryList.pipe(
       switchMap(_ => this.portalCategoryService.list()),
       catchError(_ => of([])),
     );
-    this.portalSettingsService
-      .get()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: settings => {
-          this.initializeForm(settings);
-        },
-      });
   }
 
   deleteCategory(category: PortalCategory) {
@@ -169,40 +126,5 @@ export class CategoryListComponent implements OnInit {
         },
         error: ({ error }) => this.snackBarService.error(error.message),
       });
-  }
-
-  reset() {
-    this.form.reset(this.initialValues);
-  }
-
-  submit() {
-    this.portalSettingsService
-      .get()
-      .pipe(
-        switchMap(settings =>
-          this.portalSettingsService.save({
-            ...settings,
-            portalNext: {
-              ...settings.portalNext,
-              catalog: {
-                viewMode: this.form.getRawValue().catalogViewMode,
-              },
-            },
-          }),
-        ),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe({
-        next: settings => {
-          this.initializeForm(settings);
-        },
-      });
-  }
-
-  private initializeForm(settings: PortalSettings): void {
-    this.portalCatalogViewMode.setValue(settings.portalNext.catalog?.viewMode ?? 'TABS');
-    this.initialValues = this.form.getRawValue();
-    this.form.markAsPristine();
-    this.form.markAsUntouched();
   }
 }

--- a/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.component.ts
@@ -18,16 +18,9 @@ import { MatTableModule } from '@angular/material/table';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { catchError, filter, map, switchMap, take, tap } from 'rxjs/operators';
-import {
-  GioAvatarModule,
-  GioConfirmDialogComponent,
-  GioConfirmDialogData,
-  GioFormSlideToggleModule,
-  GioSaveBarModule,
-} from '@gravitee/ui-particles-angular';
+import { catchError, filter, switchMap } from 'rxjs/operators';
+import { GioAvatarModule, GioConfirmDialogComponent, GioConfirmDialogData, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CdkDrag, CdkDragDrop, CdkDropList } from '@angular/cdk/drag-drop';
 import { AsyncPipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -39,9 +32,8 @@ import { MatSelectModule } from '@angular/material/select';
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
-import { CategoryService } from '../../../services-ngx/category.service';
-import { Category } from '../../../entities/category/Category';
-import { BothPortalsBadgeComponent } from '../../components/portal-badge/both-portals-badge/both-portals-badge.component';
+import { PortalCategoryService } from '../../../services-ngx/portal-category.service';
+import { PortalCategory } from '../../../entities/management-api-v2';
 import { PortalSettingsService } from '../../../services-ngx/portal-settings.service';
 import { PortalSettings } from '../../../entities/portal/portalSettings';
 
@@ -61,10 +53,8 @@ interface CatalogViewModeVM {
 
     // Gravitee UI Particles & Custom Components
     GioAvatarModule,
-    GioFormSlideToggleModule,
     GioPermissionModule,
     GioSaveBarModule,
-    BothPortalsBadgeComponent,
 
     // Angular Material
     MatButtonModule,
@@ -74,18 +64,14 @@ interface CatalogViewModeVM {
     MatTooltipModule,
     MatSelectModule,
     MatDialogModule,
-
-    // Angular CDK
-    CdkDropList,
-    CdkDrag,
   ],
   templateUrl: './category-list.component.html',
   styleUrl: './category-list.component.scss',
 })
 export class CategoryListComponent implements OnInit {
-  categoriesDS$: Observable<Category[]> = of([]);
+  categoriesDS$: Observable<PortalCategory[]> = of([]);
   private categoryList = new BehaviorSubject(1);
-  displayedColumns: string[] = ['order', 'name', 'description', 'count', 'actions'];
+  displayedColumns: string[] = ['name', 'description', 'actions'];
   portalCatalogViewMode: FormControl<string> = new FormControl();
 
   form: FormGroup<{ catalogViewMode: FormControl<string> }> = new FormGroup({
@@ -107,7 +93,7 @@ export class CategoryListComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
 
   constructor(
-    private categoryService: CategoryService,
+    private portalCategoryService: PortalCategoryService,
     private readonly snackBarService: SnackBarService,
     private matDialog: MatDialog,
     private readonly permissionService: GioPermissionService,
@@ -125,14 +111,8 @@ export class CategoryListComponent implements OnInit {
     }
 
     this.categoriesDS$ = this.categoryList.pipe(
-      switchMap(_ => this.categoryService.list(true)),
-      map(categories => categories.sort((a, b) => a.order - b.order)),
+      switchMap(_ => this.portalCategoryService.list()),
       catchError(_ => of([])),
-      tap(categories => {
-        if (categories.length < 2) {
-          this.displayedColumns.shift();
-        }
-      }),
     );
     this.portalSettingsService
       .get()
@@ -144,12 +124,12 @@ export class CategoryListComponent implements OnInit {
       });
   }
 
-  deleteCategory(category: Category) {
+  deleteCategory(category: PortalCategory) {
     this.matDialog
       .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
         data: {
           title: 'Delete Category',
-          content: `Are you sure you want to delete the category '${category.name}'?`,
+          content: `Are you sure you want to delete the category '${category.title}'?`,
           confirmButton: 'Delete',
         },
         role: 'alertdialog',
@@ -158,65 +138,37 @@ export class CategoryListComponent implements OnInit {
       .afterClosed()
       .pipe(
         filter(confirmed => confirmed),
-        switchMap(_ => this.categoryService.delete(category.id)),
+        switchMap(_ => this.portalCategoryService.delete(category.id)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe({
         next: _ => {
-          this.snackBarService.success(`'${category.name}' deleted successfully`);
+          this.snackBarService.success(`'${category.title}' deleted successfully`);
           this.categoryList.next(1);
         },
         error: ({ error }) => this.snackBarService.error(error?.message ?? 'Error during deletion'),
       });
   }
 
-  showCategory(category: Category) {
-    this.updateCategoryVisibility(false, category);
-  }
-
-  hideCategory(category: Category) {
+  showCategory(category: PortalCategory) {
     this.updateCategoryVisibility(true, category);
   }
 
-  private updateCategoryVisibility(isHidden: boolean, category: Category): void {
-    const categoryToUpdate: Category = { ...category, hidden: isHidden };
-    this.categoryService
-      .update(categoryToUpdate)
+  hideCategory(category: PortalCategory) {
+    this.updateCategoryVisibility(false, category);
+  }
+
+  private updateCategoryVisibility(visible: boolean, category: PortalCategory): void {
+    this.portalCategoryService
+      .update(category.id, { title: category.title, description: category.description, visible })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: _ => {
-          this.snackBarService.success(`Category [${category.name}] is now ${isHidden ? 'hidden' : 'shown'}`);
+          this.snackBarService.success(`Category [${category.title}] is now ${visible ? 'shown' : 'hidden'}`);
           this.categoryList.next(1);
         },
         error: ({ error }) => this.snackBarService.error(error.message),
       });
-  }
-
-  drop(event: CdkDragDrop<string>) {
-    if (event.previousIndex !== event.currentIndex) {
-      this.categoriesDS$
-        .pipe(
-          take(1),
-          switchMap(categories => {
-            const { previousIndex, currentIndex } = event;
-            const categoryToMove = categories.splice(previousIndex, 1)[0];
-            categories.splice(currentIndex, 0, categoryToMove);
-
-            categories.forEach((category, index) => (category.order = index + 1));
-
-            return this.categoryService.updateList(categories).pipe(
-              tap(() => {
-                this.categoryList.next(1);
-                this.snackBarService.success(`Category order has been changed`);
-              }),
-            );
-          }),
-          takeUntilDestroyed(this.destroyRef),
-        )
-        .subscribe({
-          error: ({ error }) => this.snackBarService.error(error.message),
-        });
-    }
   }
 
   reset() {

--- a/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.harness.ts
@@ -16,16 +16,11 @@
 
 import { MatRowHarness, MatTableHarness } from '@angular/material/table/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { ComponentHarness, HarnessLoader, TestElement } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessLoader } from '@angular/cdk/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
 
 export class CategoryListHarness extends ComponentHarness {
   static hostSelector = 'category-list';
-  private bothPortalsBadgeLocator = this.locatorFor('[data-testid="both-portals-badge"]');
-
-  async getBothPortalsBadge(): Promise<TestElement> {
-    return await this.bothPortalsBadgeLocator();
-  }
 
   async getTableRows(harnessLoader: HarnessLoader): Promise<MatRowHarness[]> {
     return await harnessLoader.getHarness(MatTableHarness).then(table => table.getRows());
@@ -33,10 +28,6 @@ export class CategoryListHarness extends ComponentHarness {
 
   async getNameByRowIndex(harnessLoader: HarnessLoader, index: number): Promise<string> {
     return await this.getTextByColumnNameAndRowIndex(harnessLoader, 'name', index);
-  }
-
-  async getApiCountByRowIndex(harnessLoader: HarnessLoader, index: number): Promise<string> {
-    return await this.getTextByColumnNameAndRowIndex(harnessLoader, 'count', index);
   }
 
   async getDescriptionByRowIndex(harnessLoader: HarnessLoader, index: number): Promise<string> {

--- a/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category-list/category-list.harness.ts
@@ -17,7 +17,6 @@
 import { MatRowHarness, MatTableHarness } from '@angular/material/table/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { ComponentHarness, HarnessLoader } from '@angular/cdk/testing';
-import { MatSelectHarness } from '@angular/material/select/testing';
 
 export class CategoryListHarness extends ComponentHarness {
   static hostSelector = 'category-list';
@@ -49,9 +48,5 @@ export class CategoryListHarness extends ComponentHarness {
       .then(rows => rows[rowIndex].getCells({ columnName: 'actions' }))
       .then(cells => cells[0])
       .then(actionCell => actionCell.getHarnessOrNull(MatButtonHarness.with({ selector: `[mattooltip="${tooltipText}"]` })));
-  }
-
-  async getCategoryViewMode(harnessLoader: HarnessLoader): Promise<MatSelectHarness> {
-    return harnessLoader.getHarness(MatSelectHarness.with({ ancestor: '#category-view-mode' }));
   }
 }

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.html
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.html
@@ -25,17 +25,21 @@
       <mat-card-content class="category__content">
         <div class="category__content__header">
           <h3>General</h3>
-          <both-portals-badge data-testid="both-portals-badge-for-category-list" />
         </div>
         <mat-form-field appearance="outline">
-          <input matInput formControlName="name" />
-          <mat-label>Name</mat-label>
+          <input matInput formControlName="title" />
+          <mat-label>Title</mat-label>
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <input matInput formControlName="description" />
           <mat-label>Description</mat-label>
         </mat-form-field>
+
+        <gio-form-slide-toggle>
+          <gio-form-label>Visible</gio-form-label>
+          <mat-slide-toggle formControlName="visible" gioFormSlideToggle aria-label="Visible"></mat-slide-toggle>
+        </gio-form-slide-toggle>
       </mat-card-content>
     </mat-card>
     @if (mode === 'edit') {
@@ -44,13 +48,13 @@
           <div class="category__apis__title">
             <div class="category__content__header">
               <h3>APIs</h3>
-              <both-portals-badge data-testid="both-portals-badge-for-adding-category" />
             </div>
             <button
               class="add-button"
-              (click)="addApiToCategory(category)"
               mat-raised-button
               color="primary"
+              [disabled]="!apiAssociationEnabled"
+              matTooltip="Assigning APIs to Portal Next categories is not yet available"
               *gioPermission="{ anyOf: ['environment-api-u'] }"
             >
               <mat-icon>add</mat-icon>
@@ -58,24 +62,7 @@
             </button>
           </div>
           @if (apis$ | async; as apis) {
-            <table
-              mat-table
-              class="gio-table-light"
-              [dataSource]="apis"
-              id="categoriesTable"
-              aria-label="Categories table"
-              cdkDropList
-              (cdkDropListDropped)="drop($event)"
-              cdkDropListData="dataSource"
-            >
-              <!-- Position Column -->
-              <ng-container matColumnDef="order" sticky>
-                <th mat-header-cell *matHeaderCellDef></th>
-                <td mat-cell *matCellDef="let element">
-                  <mat-icon class="drag-cursor">drag_indicator</mat-icon>
-                </td>
-              </ng-container>
-
+            <table mat-table class="gio-table-light" [dataSource]="apis" id="categoriesTable" aria-label="Categories table">
               <!-- Display Name Column -->
               <ng-container matColumnDef="name">
                 <th mat-header-cell *matHeaderCellDef id="name">Name</th>
@@ -101,32 +88,8 @@
                 </td>
               </ng-container>
 
-              <!-- Display Context Path Column -->
-              <ng-container matColumnDef="actions">
-                <th mat-header-cell *matHeaderCellDef id="api-list-actions">Actions</th>
-                <td mat-cell *matCellDef="let element">
-                  <div class="category__table__actions">
-                    <button
-                      mat-button
-                      (click)="removeApiFromCategory(element, category)"
-                      matTooltip="Remove API"
-                      *gioPermission="{ anyOf: ['environment-api-u'] }"
-                    >
-                      <mat-icon svgIcon="gio:trash"></mat-icon>
-                    </button>
-                  </div>
-                </td>
-              </ng-container>
-
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-              <tr
-                mat-row
-                *matRowDef="let row; columns: displayedColumns"
-                data-testid="link_table_row"
-                cdkDrag
-                [cdkDragData]="row"
-                cdkDragLockAxis="y"
-              ></tr>
+              <tr mat-row *matRowDef="let row; columns: displayedColumns" data-testid="link_table_row"></tr>
 
               <!-- Row shown when there is no data -->
               <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.spec.ts
@@ -20,40 +20,31 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Router } from '@angular/router';
 import { of } from 'rxjs';
-import { GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
 import { InteractivityChecker } from '@angular/cdk/a11y';
-import { MatSnackBarHarness } from '@angular/material/snack-bar/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
 
 import { CategoryCatalogComponent } from './category.component';
 import { CategoryHarness } from './category.harness';
 
-import { NewCategory } from '../../../entities/category/NewCategory';
-import { UpdateCategory } from '../../../entities/category/UpdateCategory';
-import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
-import { Category } from '../../../entities/category/Category';
-import { UpdateApi, Api as MAPIv2Api, fakeApiV2 as fakeMAPIv2Api } from '../../../entities/management-api-v2';
+import { GioTestingModule } from '../../../shared/testing';
+import { fakePortalCategory, PortalCategory } from '../../../entities/management-api-v2';
 import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
-import { CategoryApi } from '../../../entities/management-api-v2/category/categoryApi';
-import { fakeCategoryApi } from '../../../entities/management-api-v2/category/categoryApi.fixture';
-import { GioApiSelectDialogHarness } from '../../../shared/components/gio-api-select-dialog/gio-api-select-dialog.harness';
 import { PortalCatalogComponent } from '../portal-catalog.component';
+import {
+  expectCreatePortalCategoryRequest,
+  expectListPortalCategoriesRequest,
+  expectUpdatePortalCategoryRequest,
+} from '../../../services-ngx/portal-category.service.spec';
 
 describe('CategoryCatalogComponent', () => {
   let component: CategoryCatalogComponent;
   let fixture: ComponentFixture<CategoryCatalogComponent>;
   let httpTestingController: HttpTestingController;
   let harnessLoader: HarnessLoader;
-  let rootLoader: HarnessLoader;
   let router: Router;
   let componentHarness: CategoryHarness;
 
-  const CATEGORY: Category = {
-    id: 'cat',
-    name: 'cat name',
-    description: 'cat desc',
-    key: '',
-  };
+  const CATEGORY: PortalCategory = fakePortalCategory({ id: 'cat', title: 'cat title', description: 'cat desc', visible: true });
 
   const init = async (categoryId: string) => {
     await TestBed.configureTestingModule({
@@ -61,7 +52,7 @@ describe('CategoryCatalogComponent', () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useValue: { params: of({ categoryId }) },
+          useValue: { params: of({ categoryId }), snapshot: { params: { categoryId } } },
         },
         {
           provide: GioTestingPermissionProvider,
@@ -88,7 +79,6 @@ describe('CategoryCatalogComponent', () => {
     router = TestBed.inject(Router);
     harnessLoader = TestbedHarnessEnvironment.loader(fixture);
     componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, CategoryHarness);
-    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
     component = fixture.componentInstance;
     fixture.detectChanges();
   };
@@ -105,21 +95,22 @@ describe('CategoryCatalogComponent', () => {
 
     it('should initialize with all input as blank', () => {
       expect(component.categoryDetails.getRawValue()).toEqual({
-        name: null,
+        title: null,
         description: null,
+        visible: true,
       });
     });
 
     it('should be able to create', async () => {
       const spy = jest.spyOn(router, 'navigate');
-      await componentHarness.getNameInput(harnessLoader).then(input => input.setValue('Cat'));
+      await componentHarness.getTitleInput(harnessLoader).then(input => input.setValue('Cat'));
       await componentHarness.getDescriptionInput(harnessLoader).then(input => input.setValue('Cat desc'));
 
       const saveBar = await componentHarness.getSaveBar(harnessLoader);
       expect(await saveBar.isVisible()).toEqual(true);
       expect(await saveBar.isSubmitButtonVisible()).toEqual(true);
       await saveBar.clickSubmit();
-      expectPostCategory({ name: 'Cat', description: 'Cat desc' }, CATEGORY);
+      expectCreatePortalCategoryRequest(httpTestingController, { title: 'Cat', description: 'Cat desc', visible: true }, CATEGORY);
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(['..', CATEGORY.id], expect.anything());
     });
@@ -128,174 +119,76 @@ describe('CategoryCatalogComponent', () => {
   describe('Update', () => {
     beforeEach(async () => {
       await init(CATEGORY.id);
-      expectGetCategory(CATEGORY);
+      expectListPortalCategoriesRequest(httpTestingController, [CATEGORY]);
       fixture.detectChanges();
 
       expect(component.mode).toEqual('edit');
-      expectGetCategoryApis(CATEGORY.id);
     });
 
     it('should initialize with category input', () => {
       expect(component.categoryDetails.getRawValue()).toEqual({
-        name: CATEGORY.name,
+        title: CATEGORY.title,
         description: CATEGORY.description,
+        visible: CATEGORY.visible,
       });
     });
 
     it('should be able to update', async () => {
-      await componentHarness.getNameInput(harnessLoader).then(input => input.setValue('Cat'));
+      await componentHarness.getTitleInput(harnessLoader).then(input => input.setValue('Cat'));
       await componentHarness.getDescriptionInput(harnessLoader).then(input => input.setValue('Cat desc'));
 
       const saveBar = await componentHarness.getSaveBar(harnessLoader);
       expect(await saveBar.isVisible()).toEqual(true);
       expect(await saveBar.isSubmitButtonVisible()).toEqual(true);
       await saveBar.clickSubmit();
-      expectGetCategory(CATEGORY);
-      expectPutCategory({ ...CATEGORY, name: 'Cat', description: 'Cat desc' });
-      expectGetCategory(CATEGORY);
-      expectGetCategoryApis(CATEGORY.id);
+      expectUpdatePortalCategoryRequest(httpTestingController, CATEGORY.id, { title: 'Cat', description: 'Cat desc', visible: true });
+      expectListPortalCategoriesRequest(httpTestingController, [CATEGORY]);
     });
   });
 
   describe('Form', () => {
     beforeEach(async () => {
       await init(CATEGORY.id);
-      expectGetCategory(CATEGORY);
+      expectListPortalCategoriesRequest(httpTestingController, [CATEGORY]);
       fixture.detectChanges();
-      expectGetCategoryApis(CATEGORY.id);
     });
 
-    it('should require name', async () => {
-      const nameInput = await componentHarness.getNameInput(harnessLoader);
-      expect(await nameInput.getValue()).toEqual(CATEGORY.name);
+    it('should require title', async () => {
+      const titleInput = await componentHarness.getTitleInput(harnessLoader);
+      expect(await titleInput.getValue()).toEqual(CATEGORY.title);
       expect(await componentHarness.getSaveBar(harnessLoader).then(saveBar => saveBar.isVisible())).toBeFalsy();
-      await nameInput.setValue('New name');
+      await titleInput.setValue('New title');
       expect(await componentHarness.getSaveBar(harnessLoader).then(saveBar => saveBar.isVisible())).toBeTruthy();
       expect(await componentHarness.getSaveBar(harnessLoader).then(saveBar => saveBar.isSubmitButtonInvalid())).toBeFalsy();
-      await nameInput.setValue('');
+      await titleInput.setValue('');
       expect(await componentHarness.getSaveBar(harnessLoader).then(saveBar => saveBar.isSubmitButtonInvalid())).toBeTruthy();
+    });
+
+    it('should toggle visible', async () => {
+      const visibleToggle = await componentHarness.getVisibleToggle(harnessLoader);
+      expect(await visibleToggle.isChecked()).toEqual(true);
+      await visibleToggle.toggle();
+      expect(await visibleToggle.isChecked()).toEqual(false);
     });
   });
 
   describe('API List', () => {
-    const APIS: CategoryApi[] = [
-      fakeCategoryApi({ id: 'lowlight', name: 'Lowlight', order: 0 }),
-      fakeCategoryApi({ id: 'highlight', name: 'Highlight', order: 1 }),
-    ];
-    const CAT_API_LIST: Category = { ...CATEGORY, highlightApi: 'highlight' };
-
     beforeEach(async () => {
-      await init(CAT_API_LIST.id);
-      expectGetCategory(CAT_API_LIST);
+      await init(CATEGORY.id);
+      expectListPortalCategoriesRequest(httpTestingController, [CATEGORY]);
       fixture.detectChanges();
     });
 
-    it('should show empty APIs', async () => {
-      expectGetCategoryApis(CAT_API_LIST.id);
+    it('should show empty APIs, API association not yet supported', async () => {
       const table = await harnessLoader.getHarness(MatTableHarness);
       const tableHost = await table.host();
       expect(await tableHost.text()).toContain('There are no APIs for this category.');
     });
 
-    it('should show API list', async () => {
-      expectGetCategoryApis(CAT_API_LIST.id, APIS);
-      expect(await componentHarness.getNameByRowIndex(harnessLoader, 0)).toEqual('Lowlight');
-      expect(await componentHarness.getNameByRowIndex(harnessLoader, 1)).toEqual('Highlight');
-    });
-
-    it('should remove API from category', async () => {
-      expectGetCategoryApis(CAT_API_LIST.id, APIS);
-      const removeApiBtn = await componentHarness.getActionButtonByRowIndexAndTooltip(harnessLoader, 0, 'Remove API');
-      expect(removeApiBtn).toBeTruthy();
-      await removeApiBtn.click();
-      const removeApiDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
-      await removeApiDialog.confirm();
-      const api = fakeMAPIv2Api({ id: 'lowlight', categories: [CAT_API_LIST.key, 'other-category'] });
-      expectGetApi(api);
-      expectUpdateApi({ ...api, categories: ['other-category'] }, { ...api, categories: ['other-category'] });
-      expectGetCategory(CATEGORY);
-      expectGetCategoryApis(CATEGORY.id);
+    it('should have the add API button disabled', async () => {
+      const addApiButton = await componentHarness.getAddApiButton(harnessLoader);
+      expect(addApiButton).toBeTruthy();
+      expect(await addApiButton.isDisabled()).toEqual(true);
     });
   });
-
-  describe('Add API to Category', () => {
-    const CAT_API_LIST: Category = { ...CATEGORY, highlightApi: 'highlight' };
-
-    beforeEach(async () => {
-      await init(CAT_API_LIST.id);
-      expectGetCategory(CAT_API_LIST);
-      fixture.detectChanges();
-
-      expectGetCategoryApis(CAT_API_LIST.id);
-      fixture.detectChanges();
-      await componentHarness.addApiToCategory(harnessLoader);
-    });
-
-    it('should not allow user to choose API already in category', async () => {
-      const apiToAdd = fakeMAPIv2Api({ id: CAT_API_LIST.id, name: CAT_API_LIST.name, categories: ['other-category', CATEGORY.key] });
-      const dialog = await rootLoader.getHarness(GioApiSelectDialogHarness);
-      await dialog.fillFormAndSubmit(CAT_API_LIST.name, () => {
-        expectSearchApi(CAT_API_LIST.name, [apiToAdd]);
-      });
-      expectGetApi(apiToAdd);
-      const snackbar = await rootLoader.getHarness(MatSnackBarHarness);
-      expect(await snackbar.getMessage()).toEqual('API "cat name" is already defined in the category.');
-    });
-
-    it('should add API to category', async () => {
-      const apiToAdd = fakeMAPIv2Api({ id: 'api-1', name: 'API 1', categories: [] });
-      const dialog = await rootLoader.getHarness(GioApiSelectDialogHarness);
-      await dialog.fillFormAndSubmit(CAT_API_LIST.name, () => {
-        expectSearchApi(CAT_API_LIST.name, [apiToAdd]);
-      });
-      expectGetApi(apiToAdd);
-      expectUpdateApi({ ...apiToAdd, categories: [CAT_API_LIST.key] }, { ...apiToAdd, categories: [CAT_API_LIST.key] });
-      expectGetCategoryApis(CAT_API_LIST.id);
-    });
-
-    it('portal badges should be present', async () => {
-      expect(await componentHarness.getBothPortalsForCategoryList()).toBeTruthy();
-      expect(await componentHarness.getBothPortalsForNewCategory()).toBeTruthy();
-    });
-  });
-
-  function expectGetCategory(category: Category) {
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/configuration/categories/${category.id}`).flush(category);
-  }
-
-  function expectPutCategory(category: UpdateCategory) {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/configuration/categories/${category.id}`);
-    expect(req.request.body).toEqual(category);
-    req.flush(category);
-  }
-
-  function expectPostCategory(newCategory: NewCategory, category: Category) {
-    const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/configuration/categories`, method: 'POST' });
-    expect(req.request.body).toEqual(newCategory);
-    req.flush(category);
-  }
-
-  function expectGetCategoryApis(categoryId: string, apis: CategoryApi[] = []) {
-    httpTestingController
-      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/categories/${categoryId}/apis?perPage=9999`)
-      .flush({ data: apis, pagination: { totalCount: apis.length } });
-  }
-
-  function expectGetApi(api: MAPIv2Api) {
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`).flush(api);
-  }
-
-  function expectSearchApi(query: string, apis: MAPIv2Api[]) {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=10`);
-
-    expect(req.request.body).toEqual({ query });
-
-    req.flush({ data: apis, pagination: { totalCount: apis.length } });
-  }
-
-  function expectUpdateApi(request: UpdateApi, response: MAPIv2Api) {
-    const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${response.id}`, method: 'PUT' });
-    expect(req.request.body).toEqual(request);
-    req.flush(response);
-  }
 });

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.spec.ts
@@ -30,6 +30,7 @@ import { GioTestingModule } from '../../../shared/testing';
 import { fakePortalCategory, PortalCategory } from '../../../entities/management-api-v2';
 import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 import { PortalCatalogComponent } from '../portal-catalog.component';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import {
   expectCreatePortalCategoryRequest,
   expectListPortalCategoriesRequest,
@@ -169,6 +170,19 @@ describe('CategoryCatalogComponent', () => {
       expect(await visibleToggle.isChecked()).toEqual(true);
       await visibleToggle.toggle();
       expect(await visibleToggle.isChecked()).toEqual(false);
+    });
+  });
+
+  describe('Not found', () => {
+    it('should redirect to the category list and show an error when the category does not exist', async () => {
+      await init('unknown-id');
+      const navigateSpy = jest.spyOn(router, 'navigate');
+      const snackBarErrorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+
+      expectListPortalCategoriesRequest(httpTestingController, [CATEGORY]);
+
+      expect(snackBarErrorSpy).toHaveBeenCalledWith('Category not found');
+      expect(navigateSpy).toHaveBeenCalledWith(['..', '..'], expect.anything());
     });
   });
 

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.ts
@@ -15,21 +15,11 @@
  */
 import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
-import { BehaviorSubject, EMPTY, Observable, of, switchMap } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { MatDialog } from '@angular/material/dialog';
-import { catchError, filter, map, tap } from 'rxjs/operators';
-import { isEmpty } from 'lodash';
+import { map, switchMap, tap } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import {
-  GIO_DIALOG_WIDTH,
-  GioAvatarModule,
-  GioConfirmDialogComponent,
-  GioConfirmDialogData,
-  GioFormFilePickerModule,
-  GioFormSlideToggleModule,
-  GioSaveBarModule,
-} from '@gravitee/ui-particles-angular';
+import { GioAvatarModule, GioFormFilePickerModule, GioFormSlideToggleModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { AsyncPipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -37,32 +27,21 @@ import { MatTableModule } from '@angular/material/table';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { CdkDrag, CdkDragDrop, CdkDropList } from '@angular/cdk/drag-drop';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
 import { GioGoBackButtonModule } from '../../../shared/components/gio-go-back-button/gio-go-back-button.module';
-import {
-  GioApiSelectDialogComponent,
-  GioApiSelectDialogData,
-  GioApiSelectDialogResult,
-} from '../../../shared/components/gio-api-select-dialog/gio-api-select-dialog.component';
-import { NewCategory } from '../../../entities/category/NewCategory';
-import { UpdateCategory } from '../../../entities/category/UpdateCategory';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
-import { ApiV2Service } from '../../../services-ngx/api-v2.service';
-import { CategoryV2Service } from '../../../services-ngx/category-v2.service';
-import { CategoryService } from '../../../services-ngx/category.service';
-import { Category } from '../../../entities/category/Category';
-import { BothPortalsBadgeComponent } from '../../components/portal-badge/both-portals-badge/both-portals-badge.component';
+import { PortalCategoryService } from '../../../services-ngx/portal-category.service';
+import { CreatePortalCategory, PortalCategory, UpdatePortalCategory } from '../../../entities/management-api-v2';
 
 interface ApiVM {
   id: string;
   name: string;
   version: string;
   contextPath: string;
-  order: number;
 }
 
 @Component({
@@ -81,7 +60,6 @@ interface ApiVM {
     GioGoBackButtonModule,
     GioPermissionModule,
     GioSaveBarModule,
-    BothPortalsBadgeComponent,
 
     // Angular Material Modules
     MatButtonModule,
@@ -89,12 +67,9 @@ interface ApiVM {
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
+    MatSlideToggleModule,
     MatTableModule,
     MatTooltipModule,
-
-    // Angular CDK Modules & Directives
-    CdkDrag,
-    CdkDropList,
   ],
   templateUrl: './category.component.html',
   styleUrl: './category.component.scss',
@@ -102,30 +77,31 @@ interface ApiVM {
 export class CategoryCatalogComponent implements OnInit {
   mode: 'new' | 'edit' = 'new';
 
+  // API-to-category association is not yet supported by the Portal Next category API.
+  // It will be reintroduced in a future story - for now the "APIs" table is always empty and read-only.
+  readonly apiAssociationEnabled = false;
+
   categoryDetails: FormGroup<{
-    name: FormControl<string>;
+    title: FormControl<string>;
     description: FormControl<string>;
+    visible: FormControl<boolean>;
   }>;
   categoryDetailsInitialValue: unknown;
 
-  category$: Observable<Category>;
-  apis$: Observable<ApiVM[]>;
+  category$: Observable<PortalCategory>;
+  apis$: Observable<ApiVM[]> = of([]);
 
-  displayedColumns = ['order', 'name', 'version', 'contextPath', 'actions'];
+  displayedColumns = ['name', 'version', 'contextPath'];
 
   private refreshData = new BehaviorSubject(1);
-  private category = new BehaviorSubject<Category>(null);
   private destroyRef = inject(DestroyRef);
 
   constructor(
     private activatedRoute: ActivatedRoute,
     private router: Router,
-    private categoryService: CategoryService,
-    private categoryV2Service: CategoryV2Service,
-    private apiV2Service: ApiV2Service,
+    private portalCategoryService: PortalCategoryService,
     private readonly snackBarService: SnackBarService,
     private readonly permissionService: GioPermissionService,
-    private matDialog: MatDialog,
   ) {}
 
   ngOnInit() {
@@ -134,39 +110,18 @@ export class CategoryCatalogComponent implements OnInit {
       switchMap(({ categoryId }) => {
         if (!!categoryId && categoryId !== 'new') {
           this.mode = 'edit';
-          return this.categoryService.get(categoryId);
+          return this.portalCategoryService.list().pipe(map(categories => categories.find(category => category.id === categoryId)));
         }
-        return of({} as Category);
+        return of({} as PortalCategory);
       }),
       tap(category => {
-        this.category.next(category);
-
         this.categoryDetails = new FormGroup({
-          name: new FormControl<string>(category.name, { validators: Validators.required }),
+          title: new FormControl<string>(category.title, { validators: Validators.required }),
           description: new FormControl<string>(category.description),
+          visible: new FormControl<boolean>(category.visible ?? true),
         });
         this.categoryDetailsInitialValue = this.categoryDetails.getRawValue();
         this.handleReadOnly();
-      }),
-    );
-
-    this.apis$ = this.category.pipe(
-      filter(category => !isEmpty(category)),
-      switchMap(category => this.categoryV2Service.getApis(category.id)),
-      map(pagedResult => {
-        return pagedResult.data.map(api => ({
-          id: api.id,
-          name: api.name,
-          version: api.apiVersion,
-          contextPath: api.accessPaths?.join(','),
-          order: api.order,
-        }));
-      }),
-      catchError(_ => of([])),
-      tap(apis => {
-        if (apis.length < 2) {
-          this.displayedColumns.shift();
-        }
       }),
     );
   }
@@ -179,7 +134,7 @@ export class CategoryCatalogComponent implements OnInit {
       )
       .subscribe({
         next: category => {
-          this.snackBarService.success(`Category [${category.name}] successfully ${this.mode === 'new' ? 'created' : 'updated'}.`);
+          this.snackBarService.success(`Category [${category.title}] successfully ${this.mode === 'new' ? 'created' : 'updated'}.`);
           if (this.mode === 'new') {
             this.router.navigate(['..', category.id], { relativeTo: this.activatedRoute });
           } else {
@@ -190,116 +145,32 @@ export class CategoryCatalogComponent implements OnInit {
       });
   }
 
-  private updateCategory$(): Observable<Category> {
-    return this.categoryService.get(this.category.getValue().id).pipe(
-      switchMap(category => {
-        const newValues = this.categoryDetails.getRawValue();
-        const categoryToUpdate: UpdateCategory = {
-          ...category,
-          name: newValues.name,
-          description: newValues.description,
-        };
-        return this.categoryService.update(categoryToUpdate);
-      }),
-    );
+  private updateCategory$(): Observable<PortalCategory> {
+    const categoryId = this.activatedRoute.snapshot.params.categoryId;
+    const newValues = this.categoryDetails.getRawValue();
+    const categoryToUpdate: UpdatePortalCategory = {
+      title: newValues.title,
+      description: newValues.description,
+      visible: newValues.visible,
+    };
+    return this.portalCategoryService.update(categoryId, categoryToUpdate);
   }
 
-  private createCategory$(): Observable<Category> {
+  private createCategory$(): Observable<PortalCategory> {
     const newValues = this.categoryDetails.getRawValue();
-    const newCategory: NewCategory = {
-      name: newValues.name,
+    const newCategory: CreatePortalCategory = {
+      title: newValues.title,
       description: newValues.description,
+      visible: newValues.visible,
     };
 
-    return this.categoryService.create(newCategory);
-  }
-
-  addApiToCategory(category: Category) {
-    this.matDialog
-      .open<GioApiSelectDialogComponent, GioApiSelectDialogData, GioApiSelectDialogResult>(GioApiSelectDialogComponent, {
-        data: {
-          title: 'Add API',
-        },
-        width: GIO_DIALOG_WIDTH.SMALL,
-      })
-      .afterClosed()
-      .pipe(
-        filter(result => !!result?.id),
-        switchMap(({ id }) => this.apiV2Service.get(id)),
-        switchMap(api => {
-          if (api.categories?.includes(category.key)) {
-            this.snackBarService.error(`API "${api.name}" is already defined in the category.`);
-            return EMPTY;
-          }
-          const updatedCategories = api.categories ? [...api.categories, category.key] : [category.key];
-          return this.apiV2Service.update(api.id, { ...api, categories: updatedCategories });
-        }),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe({
-        next: api => {
-          this.snackBarService.success(`API [${api.name}] has been added to the category.`);
-          this.category.next(category);
-        },
-        error: ({ error }) => this.snackBarService.error(error.message),
-      });
-  }
-
-  removeApiFromCategory(api: ApiVM, category: Category) {
-    this.matDialog
-      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
-        data: {
-          title: 'Remove API',
-          content: `Are you sure you want to remove API '${api.name}' from the category '${category.name}'?`,
-          confirmButton: 'Remove',
-        },
-        role: 'alertdialog',
-        id: 'confirmDialog',
-      })
-      .afterClosed()
-      .pipe(
-        filter(confirmed => confirmed),
-        switchMap(_ => this.apiV2Service.get(api.id)),
-        switchMap(api => {
-          const categories = api.categories.filter(c => c !== category.key);
-          return this.apiV2Service.update(api.id, { ...api, categories });
-        }),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe({
-        next: _ => {
-          this.snackBarService.success(`'${api.name}' removed successfully`);
-          this.refreshData.next(1);
-        },
-        error: ({ error }) => this.snackBarService.error(error?.message ?? 'Error during API removal'),
-      });
+    return this.portalCategoryService.create(newCategory);
   }
 
   private handleReadOnly(): void {
     // User cannot change category details
     if (!this.permissionService.hasAnyMatching(['environment-category-u'])) {
       this.categoryDetails.disable();
-
-      // User cannot edit an API either
-      if (!this.permissionService.hasAnyMatching(['environment-api-u'])) {
-        this.displayedColumns.pop();
-      }
-    }
-  }
-
-  drop(event: CdkDragDrop<string>) {
-    if (event.previousIndex !== event.currentIndex) {
-      const category = this.category.getValue();
-      this.categoryV2Service
-        .updateCategoryApi(category.id, event.item.data.id, { order: event.currentIndex })
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe({
-          next: () => {
-            this.snackBarService.success('API order updated successfully.');
-            this.category.next(category);
-          },
-          error: ({ error }) => this.snackBarService.error(error?.message ? error.message : 'Error during API order update!'),
-        });
     }
   }
 }

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.ts
@@ -17,7 +17,7 @@ import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { map, switchMap, tap } from 'rxjs/operators';
+import { filter, map, switchMap, tap } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GioAvatarModule, GioFormFilePickerModule, GioFormSlideToggleModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { AsyncPipe } from '@angular/common';
@@ -110,7 +110,16 @@ export class CategoryCatalogComponent implements OnInit {
       switchMap(({ categoryId }) => {
         if (!!categoryId && categoryId !== 'new') {
           this.mode = 'edit';
-          return this.portalCategoryService.list().pipe(map(categories => categories.find(category => category.id === categoryId)));
+          return this.portalCategoryService.list().pipe(
+            map(categories => categories.find(category => category.id === categoryId)),
+            tap(category => {
+              if (!category) {
+                this.snackBarService.error('Category not found');
+                this.router.navigate(['..', '..'], { relativeTo: this.activatedRoute });
+              }
+            }),
+            filter(category => !!category),
+          );
         }
         return of({} as PortalCategory);
       }),

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.harness.ts
@@ -17,27 +17,26 @@ import { MatInputHarness } from '@angular/material/input/testing';
 import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 import { MatRowHarness, MatTableHarness } from '@angular/material/table/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { ComponentHarness, HarnessLoader, TestElement } from '@angular/cdk/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { ComponentHarness, HarnessLoader } from '@angular/cdk/testing';
 
 export class CategoryHarness extends ComponentHarness {
   static hostSelector = 'category';
-  private bothPortalsBadgeForCategoryListLocator = this.locatorFor('[data-testid="both-portals-badge-for-category-list"]');
-  private bothPortalsBadgeForNewCategoryLocator = this.locatorFor('[data-testid="both-portals-badge-for-adding-category"]');
 
-  async getBothPortalsForCategoryList(): Promise<TestElement> {
-    return await this.bothPortalsBadgeForCategoryListLocator();
-  }
-
-  async getBothPortalsForNewCategory(): Promise<TestElement> {
-    return await this.bothPortalsBadgeForNewCategoryLocator();
-  }
-
-  async getNameInput(harnessLoader: HarnessLoader): Promise<MatInputHarness> {
-    return await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+  async getTitleInput(harnessLoader: HarnessLoader): Promise<MatInputHarness> {
+    return await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="title"]' }));
   }
 
   async getDescriptionInput(harnessLoader: HarnessLoader): Promise<MatInputHarness> {
     return await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="description"]' }));
+  }
+
+  async getVisibleToggle(harnessLoader: HarnessLoader): Promise<MatSlideToggleHarness> {
+    return await harnessLoader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="visible"]' }));
+  }
+
+  async getAddApiButton(harnessLoader: HarnessLoader): Promise<MatButtonHarness | null> {
+    return await harnessLoader.getHarnessOrNull(MatButtonHarness.with({ selector: '.add-button' }));
   }
 
   async getSaveBar(rootLoader: HarnessLoader): Promise<GioSaveBarHarness> {
@@ -58,20 +57,5 @@ export class CategoryHarness extends ComponentHarness {
       .then(table => table.getRows())
       .then(rows => rows[index])
       .then(row => row.getCellTextByIndex({ columnName }).then(cell => cell[0]));
-  }
-
-  async getActionButtonByRowIndexAndTooltip(
-    harnessLoader: HarnessLoader,
-    rowIndex: number,
-    tooltipText: string,
-  ): Promise<MatButtonHarness | null> {
-    return await this.getTableRows(harnessLoader)
-      .then(rows => rows[rowIndex].getCells({ columnName: 'actions' }))
-      .then(cells => cells[0])
-      .then(actionCell => actionCell.getHarnessOrNull(MatButtonHarness.with({ selector: `[mattooltip="${tooltipText}"]` })));
-  }
-
-  async addApiToCategory(harnessLoader: HarnessLoader): Promise<void> {
-    return await harnessLoader.getHarness(MatButtonHarness.with({ selector: '.add-button' })).then(btn => btn.click());
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-16

## Description

- `CategoryListComponent` / `CategoryCatalogComponent` (`src/portal/catalog/`) are rewired from the classic `/configuration/categories` API to the new `/portal-categories` API (`PortalCategoryService`).
- Field mapping: `name` → `title`, `hidden` → `!visible`.
- Manual drag-and-drop reordering removed — Portal Next categories are sorted alphabetically server-side, no `order` field exists.
- API-to-category association (add/remove/reorder APIs within a category) is not yet supported by the new backend. The "Add API" button is disabled and the APIs table is always empty until a follow-up story reintroduces it against the new model.
- Added a required "visible" toggle to the create/edit form (previously missing from this screen).
- Removed the `both-portals-badge` from both screens, since Portal Next categories are now independent from Classic categories.

## Additional context

Part 6/7 of a stacked chain for PORTAL-16, stacked on #18539 (console entities and service).