### PR TITLE
fix(console): remove applies-to-both-portals badge from classic categories settings

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/categories/categories.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/categories/categories.component.html
@@ -17,9 +17,6 @@
 -->
 <div class="title">
   <h1>Categories</h1>
-  @if (hasPortalNextEnabled) {
-    <span class="gio-badge-warning"> <mat-icon svgIcon="gio:chat-lines"> </mat-icon>&nbsp;Applies to both portals </span>
-  }
 </div>
 
 <mat-card>

--- a/gravitee-apim-console-webui/src/management/settings/categories/categories.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/categories/categories.component.spec.ts
@@ -24,7 +24,6 @@ import { MatRowHarness, MatTableHarness } from '@angular/material/table/testing'
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
-import { By } from '@angular/platform-browser';
 
 import { CategoriesModule } from './categories.module';
 import { CategoriesComponent } from './categories.component';
@@ -260,32 +259,6 @@ describe('CategoriesComponent', () => {
 
       expectDeleteCategory(CATEGORIES()[0].id);
       expectGetCategoriesList();
-    });
-  });
-
-  describe('Applies to both portals badge', () => {
-    it('should show badge when portal next is enabled', async () => {
-      await init({ ...DEFAULT_PORTAL_SETTINGS, portalNext: { ...DEFAULT_PORTAL_SETTINGS.portalNext, access: { enabled: true } } });
-      expectGetCategoriesList([
-        { id: 'cat-1', name: 'cat-1', key: 'cat-1', order: 1, hidden: false, description: 'nice cat', totalApis: 1 },
-      ]);
-      fixture.detectChanges();
-
-      const title = fixture.debugElement.query(By.css('.title'));
-      const element: HTMLDivElement = title.nativeElement;
-      expect(element.innerHTML).toContain('Applies to both portals');
-    });
-    it('should not show badge when portal next is disabled', async () => {
-      await init({ ...DEFAULT_PORTAL_SETTINGS, portalNext: { ...DEFAULT_PORTAL_SETTINGS.portalNext, access: { enabled: false } } });
-      expectGetCategoriesList([
-        { id: 'cat-1', name: 'cat-1', key: 'cat-1', order: 1, hidden: false, description: 'nice cat', totalApis: 1 },
-      ]);
-      fixture.detectChanges();
-
-      const title = fixture.debugElement.query(By.css('.title'));
-      const element: HTMLDivElement = title.nativeElement;
-      const innerHTML = element.innerHTML;
-      expect(innerHTML.includes('Applies to both portals')).toEqual(false);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/settings/categories/categories.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/categories/categories.component.ts
@@ -39,7 +39,6 @@ export class CategoriesComponent implements OnInit {
   displayedColumns: string[] = ['picture', 'name', 'description', 'count', 'actions'];
   portalSettingsForm: FormGroup<{ enabled: FormControl<boolean> }>;
   portalSettingsInitialValue: unknown;
-  hasPortalNextEnabled: boolean = false;
 
   private categoryList = new BehaviorSubject(1);
   private destroyRef = inject(DestroyRef);
@@ -60,8 +59,6 @@ export class CategoriesComponent implements OnInit {
     }
 
     this.initializeSettings(this.environmentSettingsService.getSnapshot().portal.apis.categoryMode.enabled);
-
-    this.hasPortalNextEnabled = this.environmentSettingsService.getSnapshot().portalNext?.access?.enabled === true;
 
     this.categoriesDS$ = this.categoryList.pipe(
       switchMap(_ => this.categoryService.list(true)),

--- a/gravitee-apim-console-webui/src/portal/api/api-list/portal-api-list.component.html
+++ b/gravitee-apim-console-webui/src/portal/api/api-list/portal-api-list.component.html
@@ -65,7 +65,6 @@
             <div class="api-style__content__header">
               <div class="api-style__content__header__title">
                 <h3>API Details</h3>
-                <both-portals-badge data-testid="both-portals-badge-for-api-details" />
               </div>
               <div class="menu-api__content__header__description">Customize the information displayed on the API details page</div>
             </div>

--- a/gravitee-apim-console-webui/src/portal/api/api-list/portal-api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/api/api-list/portal-api-list.component.spec.ts
@@ -132,7 +132,6 @@ describe('PortalApiListComponent', () => {
     expect(await componentHarness.getApiKeyHeader()).toEqual(portalSettingsOld.portal.apikeyHeader);
     expect(await componentHarness.getAddButton()).toBeTruthy();
     expect(await componentHarness.getBothPortalsForApiSubscription()).toBeTruthy();
-    expect(await componentHarness.getBothPortalsForApiDetails()).toBeTruthy();
     expect(await componentHarness.getTableRows()).toBeTruthy();
   });
 

--- a/gravitee-apim-console-webui/src/portal/api/api-list/portal-api-list.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/api/api-list/portal-api-list.harness.ts
@@ -34,7 +34,6 @@ export class PortalApiListHarness extends ComponentHarness {
   private editButtonLocator = this.locatorFor(MatButtonHarness.with({ selector: 'button[data-testid="edit-button"]' }));
   private deleteButtonLocator = this.locatorFor(MatButtonHarness.with({ selector: 'button[data-testid="delete-button"]' }));
   private bothPortalsBadgeForApiSubscriptionLocator = this.locatorFor('[data-testid="both-portals-badge-for-api-subscription"]');
-  private bothPortalsBadgeForApiDetailsLocator = this.locatorFor('[data-testid="both-portals-badge-for-api-details"]');
   private noDataRowLocator = this.locatorFor('tr[data-testid="no-data-row"]');
   private rows = this.locatorForAll(MatRowHarness);
 
@@ -45,10 +44,6 @@ export class PortalApiListHarness extends ComponentHarness {
 
   async getBothPortalsForApiSubscription(): Promise<TestElement> {
     return await this.bothPortalsBadgeForApiSubscriptionLocator();
-  }
-
-  async getBothPortalsForApiDetails(): Promise<TestElement> {
-    return await this.bothPortalsBadgeForApiDetailsLocator();
   }
 
   public async getAddButton() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-16

## Description

Portal Next now has its own independent categories (managed at `Portal Settings > Catalog`, rewired to `/portal-categories` in #18540), so screens claiming a classic category "applies to both portals" are now misleading. Removes that badge, and the fields/state driving it, from:

- The classic `Settings > Categories` screen (`hasPortalNextEnabled` field removed as dead code).
- The API Details section on the API configuration page. The unrelated API Subscription section's badge is kept.

## Additional context

Part 7/7 of a stacked chain for PORTAL-16, stacked on #18540 (Catalog screen rewiring). Completes PORTAL-16.