### PR TITLE
feat(gateway): expose error cause in response templates

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/EvaluableExecutionFailure.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/EvaluableExecutionFailure.java
@@ -25,9 +25,20 @@ import java.util.Map;
 public class EvaluableExecutionFailure {
 
     private final ExecutionFailure executionFailure;
+    private final String cause;
 
     public EvaluableExecutionFailure(final ExecutionFailure executionFailure) {
+        this(executionFailure, null);
+    }
+
+    /**
+     * @param cause the cleaned-up failure detail (the {@code Diagnostic} message stored on the metrics and indexed in
+     *   analytics), exposed to templates as {@code {#error.cause}}. May be {@code null}, in which case
+     *   {@link #getCause()} falls back to the {@link ExecutionFailure#message()}.
+     */
+    public EvaluableExecutionFailure(final ExecutionFailure executionFailure, final String cause) {
         this.executionFailure = executionFailure;
+        this.cause = cause;
     }
 
     public int getStatusCode() {
@@ -40,6 +51,10 @@ public class EvaluableExecutionFailure {
 
     public String getMessage() {
         return executionFailure.message();
+    }
+
+    public String getCause() {
+        return cause != null ? cause : executionFailure.message();
     }
 
     public Map<String, Object> getParameters() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessor.java
@@ -24,6 +24,7 @@ import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.handlers.api.processor.error.AbstractFailureProcessor;
+import io.gravitee.reporter.api.v4.metric.Diagnostic;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
@@ -183,7 +184,12 @@ public class ResponseTemplateBasedFailureProcessor extends AbstractFailureProces
         if (template.getBody() != null && !template.getBody().isEmpty()) {
             // Prepare templating context
             final TemplateEngine templateEngine = context.getTemplateEngine();
-            templateEngine.getTemplateContext().setVariable("error", new EvaluableExecutionFailure(executionFailure));
+            // Expose the cleaned-up failure detail (the Diagnostic message indexed in analytics) as {#error.cause}, so a
+            // template can surface it even when ExecutionFailure has only a key + cause and no message (e.g. connection
+            // failures towards the backend). Kept out of the default failure body to avoid leaking detail by default.
+            final Diagnostic diagnostic = context.metrics().getFailure();
+            final String cause = diagnostic != null ? diagnostic.getMessage() : null;
+            templateEngine.getTemplateContext().setVariable("error", new EvaluableExecutionFailure(executionFailure, cause));
 
             if (executionFailure.parameters() != null && !executionFailure.parameters().isEmpty()) {
                 templateEngine.getTemplateContext().setVariable("parameters", executionFailure.parameters());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/EvaluableExecutionFailureTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/EvaluableExecutionFailureTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.processor.error.template;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+class EvaluableExecutionFailureTest {
+
+    @Test
+    void should_expose_cause_from_diagnostic_message() {
+        ExecutionFailure failure = new ExecutionFailure(HttpStatusCode.BAD_GATEWAY_502).key("GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR");
+
+        EvaluableExecutionFailure evaluable = new EvaluableExecutionFailure(failure, "Received fatal alert: handshake_failure");
+
+        assertThat(evaluable.getCause()).isEqualTo("Received fatal alert: handshake_failure");
+    }
+
+    @Test
+    void should_fallback_cause_to_message_when_diagnostic_message_is_null() {
+        ExecutionFailure failure = new ExecutionFailure(HttpStatusCode.BAD_REQUEST_400).key("POLICY_ERROR_KEY").message("Policy failed");
+
+        EvaluableExecutionFailure evaluable = new EvaluableExecutionFailure(failure, null);
+
+        assertThat(evaluable.getCause()).isEqualTo("Policy failed");
+    }
+
+    @Test
+    void should_return_null_cause_when_no_diagnostic_and_no_message() {
+        ExecutionFailure failure = new ExecutionFailure(HttpStatusCode.BAD_GATEWAY_502).key("GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR");
+
+        EvaluableExecutionFailure evaluable = new EvaluableExecutionFailure(failure, null);
+
+        assertThat(evaluable.getCause()).isNull();
+    }
+
+    @Test
+    void should_leave_message_unchanged() {
+        ExecutionFailure failure = new ExecutionFailure(HttpStatusCode.BAD_REQUEST_400).key("POLICY_ERROR_KEY").message("Policy failed");
+
+        // Even with a diagnostic cause, getMessage() keeps returning the raw ExecutionFailure message (no breaking change).
+        EvaluableExecutionFailure evaluable = new EvaluableExecutionFailure(failure, "Policy failed (some cause)");
+
+        assertThat(evaluable.getMessage()).isEqualTo("Policy failed");
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessorTest.java
@@ -16,15 +16,18 @@
 package io.gravitee.gateway.reactive.handlers.api.processor.error.template;
 
 import static io.gravitee.gateway.api.http.HttpHeaderNames.ACCEPT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.ResponseTemplate;
+import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.handlers.api.processor.AbstractProcessorTest;
+import io.gravitee.reporter.api.v4.metric.Diagnostic;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -32,6 +35,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -265,6 +269,65 @@ public class ResponseTemplateBasedFailureProcessorTest extends AbstractProcessor
 
         verify(mockResponse, times(1)).status(HttpStatusCode.BAD_REQUEST_400);
         verify(mockResponse, times(1)).reason("Bad Request");
+    }
+
+    @Test
+    public void shouldRenderErrorCauseFromDiagnosticMessage() {
+        ResponseTemplate template = new ResponseTemplate();
+        template.setStatusCode(HttpStatusCode.BAD_GATEWAY_502);
+        template.setBody("{\"detail\": \"{#error.cause}\"}");
+
+        Map<String, ResponseTemplate> mapTemplates = new HashMap<>();
+        mapTemplates.put(ResponseTemplateBasedFailureProcessor.WILDCARD_CONTENT_TYPE, template);
+
+        Map<String, Map<String, ResponseTemplate>> templates = new HashMap<>();
+        templates.put("GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR", mapTemplates);
+        api.setResponseTemplates(templates);
+
+        // The gateway already stored the cleaned-up detail on the metrics (the value indexed in analytics).
+        spyCtx
+            .metrics()
+            .setFailure(
+                new Diagnostic("GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR", "Received fatal alert: handshake_failure", "ENDPOINT", "default")
+            );
+
+        // Connection failures carry only a key + cause, no message.
+        ExecutionFailure executionFailure = new ExecutionFailure(HttpStatusCode.BAD_GATEWAY_502).key("GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR");
+        spyRequestHeaders.add(ACCEPT, MediaType.APPLICATION_JSON);
+        spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
+
+        templateBasedFailureProcessor.execute(spyCtx).test().assertResult();
+
+        ArgumentCaptor<Buffer> bodyCaptor = ArgumentCaptor.forClass(Buffer.class);
+        verify(mockResponse).body(bodyCaptor.capture());
+        assertThat(bodyCaptor.getValue().toString()).isEqualTo("{\"detail\": \"Received fatal alert: handshake_failure\"}");
+    }
+
+    @Test
+    public void shouldFallbackErrorCauseToMessageWhenNoDiagnostic() {
+        ResponseTemplate template = new ResponseTemplate();
+        template.setStatusCode(HttpStatusCode.BAD_REQUEST_400);
+        template.setBody("{\"detail\": \"{#error.cause}\"}");
+
+        Map<String, ResponseTemplate> mapTemplates = new HashMap<>();
+        mapTemplates.put(ResponseTemplateBasedFailureProcessor.WILDCARD_CONTENT_TYPE, template);
+
+        Map<String, Map<String, ResponseTemplate>> templates = new HashMap<>();
+        templates.put("POLICY_ERROR_KEY", mapTemplates);
+        api.setResponseTemplates(templates);
+
+        // No diagnostic message on the metrics: {#error.cause} must fall back to the ExecutionFailure message.
+        ExecutionFailure executionFailure = new ExecutionFailure(HttpStatusCode.BAD_REQUEST_400)
+            .key("POLICY_ERROR_KEY")
+            .message("Policy failed");
+        spyRequestHeaders.add(ACCEPT, MediaType.APPLICATION_JSON);
+        spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
+
+        templateBasedFailureProcessor.execute(spyCtx).test().assertResult();
+
+        ArgumentCaptor<Buffer> bodyCaptor = ArgumentCaptor.forClass(Buffer.class);
+        verify(mockResponse).body(bodyCaptor.capture());
+        assertThat(bodyCaptor.getValue().toString()).isEqualTo("{\"detail\": \"Policy failed\"}");
     }
 
     @Test

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ConnectionFailureV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ConnectionFailureV4IntegrationTest.java
@@ -127,6 +127,47 @@ class ConnectionFailureV4IntegrationTest extends AbstractGatewayTest {
     }
 
     @Test
+    @DeployApi("/apis/v4/http/connectionfailure/api-tls-handshake-with-template.json")
+    void should_render_tls_handshake_detail_in_response_template_via_error_cause(HttpClient httpClient) {
+        // The endpoint targets the WireMock HTTPS port (self-signed cert) while the endpoint does not trust it, so the
+        // gateway→backend TLS handshake fails → GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR (502). The response template renders
+        // {#error.cause}, which must expose the cleaned-up failure detail (the same value indexed in analytics) instead
+        // of the empty string {#error.message} would have produced.
+        // Capture the Metrics that get reported (this is exactly what is indexed in Elasticsearch analytics).
+        var reportedMetrics = metricsSubject
+            .filter(metrics -> metrics.getFailure() != null)
+            .take(1)
+            .test();
+
+        String json = httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(request -> request.putHeader("Accept", "application/json").rxSend())
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(502);
+                return response.rxBody();
+            })
+            .blockingGet()
+            .toString();
+
+        assertThat(json).contains("\"code\": \"GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR\"");
+        assertThat(json).contains("\"status\": 502");
+        // {#error.cause} is populated (non-empty)...
+        assertThat(json).doesNotContain("\"detail\": \"\"");
+        assertThat(json).containsPattern("\"detail\": \"[^\"]+\"");
+        // ...while {#error.message} stays empty (unchanged behaviour, so no breaking change).
+        assertThat(json).contains("\"message\": \"\"");
+
+        // {#error.cause} equals the Diagnostic message reported to analytics (Elasticsearch).
+        reportedMetrics
+            .awaitDone(30, TimeUnit.SECONDS)
+            .assertValue(metrics -> {
+                String esDetail = metrics.getFailure().getMessage();
+                assertThat(json).contains("\"detail\": \"" + esDetail + "\"");
+                return true;
+            });
+    }
+
+    @Test
     @DeployApi("/apis/v4/http/api.json")
     void should_report_connection_reset_when_backend_resets_the_connection(HttpClient httpClient) {
         wiremock.stubFor(get("/endpoint").willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/connectionfailure/api-tls-handshake-with-template.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/connectionfailure/api-tls-handshake-with-template.json
@@ -1,0 +1,72 @@
+{
+  "id": "my-api-v4-tls-handshake-with-template",
+  "name": "my-api-v4-tls-handshake-with-template",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "https://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 10000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": ["GET"]
+        }
+      ]
+    }
+  ],
+  "responseTemplates": {
+    "GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR": {
+      "*/*": {
+        "status": 502,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": "{\n  \"error\": {\n    \"code\": \"{#error.key}\",\n    \"status\": {#error.statusCode},\n    \"detail\": \"{#error.cause}\",\n    \"message\": \"{#error.message}\"\n  }\n}"
+      }
+    }
+  },
+  "analytics": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
## Description

Response templates could not surface the underlying error detail for failures that carry only a key + a causing `Throwable` and no `message` — most visibly gateway → backend connection failures (TLS handshake, connection refused, DNS, reset/closed, timeouts). A template using `{#error.message}` rendered an empty `detail`:

```json
{ "error": { "code": "GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR", "status": 502, "detail": "" } }
```

### Change

Introduce a new **template-only** variable `{#error.cause}` that returns the gateway's already-computed, cleaned-up failure detail — the `Diagnostic` message stored on `Metrics.failure`, i.e. the exact value indexed in the Elasticsearch v4 analytics record. It falls back to `{#error.message}` when no diagnostic is available.

- `{#error.message}` semantics are left **unchanged** (no breaking change).
- Default (no-template) error responses are **unchanged** — nothing new leaked by default; the detail is opt-in per template.
- The rendered `detail` is **identical** to what appears in analytics.

Example (`detail` now populated):

```json
{ "error": { "code": "GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR", "status": 502, "detail": "unable to find valid certification path to requested target" } }
```

### Files

- `EvaluableExecutionFailure` — new `getCause()` (diagnostic message, fallback to message).
- `ResponseTemplateBasedFailureProcessor` — feeds `metrics().getFailure()` message as the cause.

## Tests

- `EvaluableExecutionFailureTest` — unit coverage of `getCause()` (diagnostic, fallback, null, message unchanged).
- `ResponseTemplateBasedFailureProcessorTest` — 2 new rendering tests (`{#error.cause}` from diagnostic; fallback to message).
- `ConnectionFailureV4IntegrationTest` — new end-to-end test on a **real embedded gateway** doing an actual failing TLS handshake against an untrusted HTTPS backend; asserts `{#error.cause}` is populated, `{#error.message}` stays empty, and `{#error.cause}` equals the reported analytics `Metrics.failure.message`.

## Jira

APIM-14688
