### PR TITLE
feat: add API product navigation item contract

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -35,7 +35,9 @@ import java.util.List;
 import java.util.UUID;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
 import org.mapstruct.Named;
+import org.mapstruct.ValueMapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -154,6 +156,12 @@ public interface PortalNavigationItemsMapper {
         if (type == null) return null;
         return io.gravitee.apim.core.portal_page.model.PortalPageContentType.valueOf(type.name());
     }
+
+    // API_PRODUCT domain support is added by the follow-up backend task.
+    @ValueMapping(source = "API_PRODUCT", target = MappingConstants.THROW_EXCEPTION)
+    io.gravitee.apim.core.portal_page.model.PortalNavigationItemType map(
+        io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType type
+    );
 
     default io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem map(
         BaseUpdatePortalNavigationItem updatePortalNavigationItem

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -975,11 +975,29 @@ paths:
         required: true
       responses:
         "201":
-          description: Portal navigation item created
+          description: Portal navigation item created. Newly created items are unpublished by default.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/PortalNavigationItem"
+        "400":
+          description: Missing API Product reference, invalid parent, invalid TOP_NAVBAR root placement, or malformed request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Referenced API Product does not exist in the current environment
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: The API Product is already represented in the environment navigation tree
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           $ref: "#/components/responses/Error"
 
@@ -999,6 +1017,24 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/PortalNavigationItemsResponse"
+        "400":
+          description: Invalid navigation item payload or hierarchy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: A referenced API Product or parent does not exist in the current environment
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: An API Product is already represented in the environment navigation tree
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           $ref: "#/components/responses/Error"
 
@@ -1032,7 +1068,7 @@ paths:
         * Optional parent ID. If provided, the item is set to that parent.
         * If omitted, the item is moved to the root level.
 
-        Publication propagation applies only when the `published` value changes on a container navigation item (`FOLDER` or `API`).
+        Publication propagation applies only when the `published` value changes on a container navigation item (`FOLDER`, `API`, or `API_PRODUCT`).
         When publishing a container, descendants are published only if `propagatePublishToChildren=true`.
         If `propagatePublishToChildren` is omitted or false, only the selected item is published.
         When unpublishing a container, descendants are always unpublished according to the business rule; `propagatePublishToChildren` is ignored and may be omitted.
@@ -1047,7 +1083,7 @@ paths:
         - name: propagatePublishToChildren
           in: query
           description: >
-            Controls whether publishing a container navigation item (`FOLDER` or `API`) is propagated to descendants.
+            Controls whether publishing a container navigation item (`FOLDER`, `API`, or `API_PRODUCT`) is propagated to descendants.
             Only evaluated when `published` changes to true on a container item.
             If omitted or false, publishing affects only the selected item.
             If true, publishing also affects descendants.
@@ -1069,6 +1105,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PortalNavigationItem"
+        "400":
+          description: Invalid navigation item move, parent, visibility, or malformed request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Navigation item or target parent does not exist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: The update would violate navigation hierarchy or API Product uniqueness constraints
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           $ref: "#/components/responses/Error"
     delete:
@@ -2097,7 +2151,7 @@ components:
       type: string
       description: The type of the navigation item
       example: FOLDER
-      enum: [ PAGE, FOLDER, LINK, API ]
+      enum: [ PAGE, FOLDER, LINK, API, API_PRODUCT ]
     BasePortalNavigationItem:
       type: object
       description: Base portal navigation item
@@ -2150,6 +2204,7 @@ components:
           FOLDER: "#/components/schemas/PortalNavigationFolder"
           LINK: "#/components/schemas/PortalNavigationLink"
           API: "#/components/schemas/PortalNavigationApi"
+          API_PRODUCT: "#/components/schemas/PortalNavigationApiProduct"
     PortalNavigationPage:
       description: Portal navigation item of type PAGE
       allOf:
@@ -2185,12 +2240,24 @@ components:
               description: ApiId referenced from the navItem
               example: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
           required: [ apiId ]
+    PortalNavigationApiProduct:
+      description: Portal navigation item of type API_PRODUCT
+      allOf:
+        - $ref: "#/components/schemas/BasePortalNavigationItem"
+        - properties:
+            apiProductId:
+              type: string
+              format: uuid
+              description: API Product referenced by the navigation item
+              example: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
+          required: [ apiProductId ]
     PortalNavigationItem:
       oneOf:
         - $ref: "#/components/schemas/PortalNavigationPage"
         - $ref: "#/components/schemas/PortalNavigationFolder"
         - $ref: "#/components/schemas/PortalNavigationLink"
         - $ref: "#/components/schemas/PortalNavigationApi"
+        - $ref: "#/components/schemas/PortalNavigationApiProduct"
       discriminator:
         propertyName: type
         mapping:
@@ -2198,9 +2265,10 @@ components:
           FOLDER: "#/components/schemas/PortalNavigationFolder"
           LINK: "#/components/schemas/PortalNavigationLink"
           API: "#/components/schemas/PortalNavigationApi"
+          API_PRODUCT: "#/components/schemas/PortalNavigationApiProduct"
     BaseCreatePortalNavigationItem:
       type: object
-      description: Base portal navigation item
+      description: Base portal navigation item. Newly created items are unpublished by default.
       properties:
         id:
           type: string
@@ -2233,6 +2301,7 @@ components:
           PAGE: "#/components/schemas/CreatePortalNavigationPage"
           LINK: "#/components/schemas/CreatePortalNavigationLink"
           API:  "#/components/schemas/CreatePortalNavigationApi"
+          API_PRODUCT: "#/components/schemas/CreatePortalNavigationApiProduct"
       required: [ title, type, area, visibility ]
     CreatePortalNavigationFolder:
       type: object
@@ -2279,12 +2348,26 @@ components:
               description: The apiId for the navigationItem
               example: "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
           required: [ apiId ]
+    CreatePortalNavigationApiProduct:
+      type: object
+      title: "CreatePortalNavigationApiProduct"
+      description: Portal navigation API Product item to create. Newly created items are unpublished by default.
+      allOf:
+        - $ref: "#/components/schemas/BaseCreatePortalNavigationItem"
+        - properties:
+            apiProductId:
+              type: string
+              format: uuid
+              description: API Product referenced by the navigation item
+              example: "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+          required: [ apiProductId ]
     CreatePortalNavigationItem:
       oneOf:
         - $ref: "#/components/schemas/CreatePortalNavigationPage"
         - $ref: "#/components/schemas/CreatePortalNavigationFolder"
         - $ref: "#/components/schemas/CreatePortalNavigationLink"
         - $ref: "#/components/schemas/CreatePortalNavigationApi"
+        - $ref: "#/components/schemas/CreatePortalNavigationApiProduct"
 
       discriminator:
         propertyName: type
@@ -2293,6 +2376,7 @@ components:
           FOLDER: "#/components/schemas/CreatePortalNavigationFolder"
           LINK: "#/components/schemas/CreatePortalNavigationLink"
           API: "#/components/schemas/CreatePortalNavigationApi"
+          API_PRODUCT: "#/components/schemas/CreatePortalNavigationApiProduct"
 
     CreatePortalNavigationItems:
       type: object
@@ -2359,6 +2443,7 @@ components:
           PAGE: "#/components/schemas/UpdatePortalNavigationPage"
           LINK: "#/components/schemas/UpdatePortalNavigationLink"
           API: "#/components/schemas/UpdatePortalNavigationApi"
+          API_PRODUCT: "#/components/schemas/UpdatePortalNavigationApiProduct"
 
       required: [ type, title, order, published, visibility ]
     UpdatePortalNavigationFolder:
@@ -2397,11 +2482,19 @@ components:
               description: The apiId for the navigationItem
               example: "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
           required: [ apiId ]
+    UpdatePortalNavigationApiProduct:
+      type: object
+      title: "UpdatePortalNavigationApiProduct"
+      description: Portal navigation API Product item to update. The linked API Product is immutable; an apiProductId property supplied in an update payload is ignored.
+      allOf:
+        - $ref: "#/components/schemas/BaseUpdatePortalNavigationItem"
     UpdatePortalNavigationItem:
       oneOf:
         - $ref: "#/components/schemas/UpdatePortalNavigationPage"
         - $ref: "#/components/schemas/UpdatePortalNavigationFolder"
         - $ref: "#/components/schemas/UpdatePortalNavigationLink"
+        - $ref: "#/components/schemas/UpdatePortalNavigationApi"
+        - $ref: "#/components/schemas/UpdatePortalNavigationApiProduct"
       discriminator:
         propertyName: type
         mapping:
@@ -2409,6 +2502,7 @@ components:
           FOLDER: "#/components/schemas/UpdatePortalNavigationFolder"
           LINK: "#/components/schemas/UpdatePortalNavigationLink"
           API: "#/components/schemas/UpdatePortalNavigationApi"
+          API_PRODUCT: "#/components/schemas/UpdatePortalNavigationApiProduct"
 
     PortalPageContentType:
       type: string


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14684

## Description

Add Management API v2 contract support for `API_PRODUCT` portal navigation items.

- add read, create, update and bulk-create schemas
- add `apiProductId` and discriminator mappings
- document validation responses and publication propagation
- fix the missing `API` type in the update union
- keep generated models compilable before backend domain support lands

## Validation

- Management v2 REST module compile
- `PortalNavigationItemsMapperTest` — 10 tests passed