### PR TITLE
chore(master): bump gravitee-plugin from 5.1.4 to 5.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <gravitee-node.version>9.2.1</gravitee-node.version>
     <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
     <gravitee-platform-repository-api.version>2.0.0</gravitee-platform-repository-api.version>
-    <gravitee-plugin.version>5.1.4</gravitee-plugin.version>
+    <gravitee-plugin.version>5.1.5</gravitee-plugin.version>
     <gravitee-plugin-common-configurations.version>1.4.0</gravitee-plugin-common-configurations.version>
     <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
     <gravitee-reporter-api.version>2.6.0</gravitee-reporter-api.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-plugin](https://github.com/gravitee-io/gravitee-plugin)** from `5.1.4` to `5.1.5` on branch `master`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-plugin/releases) page.

## Backport

- `apply-on-4-12-x`
- `apply-on-4-11-x`
