### PR TITLE
fix(console): increase broadcast message character limit to 4000

### DIFF
--- a/gravitee-apim-console-webui/src/management/messages/messages.component.html
+++ b/gravitee-apim-console-webui/src/management/messages/messages.component.html
@@ -60,9 +60,9 @@
       </div>
       <mat-form-field>
         <mat-label>Text</mat-label>
-        <textarea matInput formControlName="text" required maxlength="250" #textarea></textarea>
+        <textarea matInput formControlName="text" required maxlength="4000" #textarea></textarea>
         <mat-error *ngIf="form.controls['text'].hasError('required')">Text is required</mat-error>
-        <mat-hint align="end">{{ 250 - textarea.value.length }} / 250</mat-hint>
+        <mat-hint align="end">{{ 4000 - textarea.value.length }} / 4000</mat-hint>
       </mat-form-field>
     </mat-card-content>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14336

## Description

Increase broadcast message character limit (250 → 4000)                                                                                                                                                                                                                                                                                                                                                                        

Raises the maxlength on the broadcast message Text field from 250 to 4000 characters (and updates the character counter to match), so users can send longer, more detailed broadcast messages to subscribers and environment members.                                                                                                                                                                                          

**Why 4000:** the limit was hardcoded frontend-only, but the PORTAL delivery channel persists the message into portal_notifications.message (nvarchar(4000)). 4000 is the true safe ceiling — it clears the customer's 1500-char need and avoids DB truncation/errors on SQL backends without needing a schema migration.                                                                                                          

**Scope:** frontend-only, one file (messages.component.html). No backend/API change (MessageEntity.text has no length constraint; other channels don't persist).   

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

