### PR TITLE
fix(console): wire URI (HTTP Path) filter into observability logs search

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
@@ -639,6 +639,16 @@ describe('EnvLogsComponent', () => {
       req.flush(EMPTY_RESPONSE);
     }));
 
+    it('should pass URI (HTTP Path) filter from store to search request', fakeAsync(() => {
+      setupWithFilter('URI', 'HTTP Path', ['/v1/test/test2']);
+
+      const req = httpTestingController.expectOne({ method: 'POST', url: SEARCH_URL });
+      expect(req.request.body.filters).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'URI', operator: 'EQ', value: '/v1/test/test2' })]),
+      );
+      req.flush(EMPTY_RESPONSE);
+    }));
+
     it('should trigger a new search when a filter is removed from the store', fakeAsync(() => {
       setupWithFilter('API', 'API', ['api-1']);
       httpTestingController.expectOne({ method: 'POST', url: SEARCH_URL }).flush(EMPTY_RESPONSE);

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
@@ -242,6 +242,7 @@ export class EnvLogsComponent {
       entrypoints: filterMap.get('ENTRYPOINT'),
       errorKeys: filterMap.get('ERROR_KEY'),
       apiProductIds: filterMap.get('API_PRODUCT'),
+      uri: filterMap.get('URI')?.[0],
       bodyText: filterMap.get('PAYLOAD')?.[0],
     };
   }


### PR DESCRIPTION
## Problem

On the **Observability → Logs** page, adding the **HTTP Path** filter (`URI`) has no effect — results stay unfiltered. Reported on 4.12.8 (APIM-14697); the classic Analytics → Logs path filter still works, so this is a regression specific to the new Observability logs page.

## Root cause

`EnvLogsComponent.buildSearchParam()` builds the search request from the active filters but never reads the `URI` filter, so the value is dropped before the request body is built. The service layer (`EnvironmentLogsService`) already maps `param.uri` to a `URI`/`EQ` filter and `SearchLogsParam.uri` already exists — only the component wiring was missing.

## Fix

- Add `uri: filterMap.get('URI')?.[0]` to the object returned by `buildSearchParam()`, mirroring the adjacent scalar `PAYLOAD` handling.
- Add a unit test asserting an applied URI filter is sent as `{ name: 'URI', operator: 'EQ', value: ... }`.

## Notes

Customer environment is **4.12.8** — this will need backporting to the `4.12.x` line.

Closes APIM-14697