### PR TITLE
fix: preserve colons in relative endpoint paths (forward-port of #17173)

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/invoker/HttpEndpointInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/invoker/HttpEndpointInvoker.java
@@ -46,7 +46,7 @@ public class HttpEndpointInvoker implements HttpInvoker, Invoker {
     private static final String MATCH_GROUP_ENDPOINT = "endpoint";
     private static final String MATCH_GROUP_PATH = "path";
     private static final Pattern ENDPOINT_PATTERN = Pattern.compile(
-        "^(?<" + MATCH_GROUP_ENDPOINT + ">[^:]+):(?<" + MATCH_GROUP_PATH + ">.*)$"
+        "^(?<" + MATCH_GROUP_ENDPOINT + ">[^/:][^:]*):(?<" + MATCH_GROUP_PATH + ">.*)$"
     );
 
     static final Set<String> KNOWN_URL_SCHEMES = Set.of("http", "https", "ws", "wss");
@@ -121,7 +121,6 @@ public class HttpEndpointInvoker implements HttpInvoker, Invoker {
                     ctx.setAttribute(ATTR_REQUEST_ENDPOINT, matcher.group(MATCH_GROUP_PATH));
                 }
             }
-            // No else needed: any string with a colon matches ENDPOINT_PATTERN, including all absolute URIs.
         }
 
         final ManagedEndpoint managedEndpoint = endpointManager.next(endpointCriteria);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/invoker/HttpEndpointInvokerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/invoker/HttpEndpointInvokerTest.java
@@ -146,6 +146,26 @@ class HttpEndpointInvokerTest {
         verify(ctx).setAttribute(ATTR_REQUEST_ENDPOINT, "with:colon:");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = { "/bar:analyze", "/document:translate", "/openai/deployments/gpt-4o/chat/completions:stream" })
+    void should_treat_relative_path_with_colon_as_literal_request_endpoint(String endpointTarget) {
+        final HttpEntrypointAsyncConnector httpEntrypointAsyncConnector = mock(HttpEntrypointAsyncConnector.class);
+        when(ctx.getInternalAttribute(ATTR_INTERNAL_ENTRYPOINT_CONNECTOR)).thenReturn(httpEntrypointAsyncConnector);
+        when(ctx.getAttribute(ATTR_REQUEST_ENDPOINT)).thenReturn(endpointTarget);
+        when(ctx.getTemplateEngine()).thenReturn(templateEngine);
+        when(templateEngine.getValue(anyString(), eq(String.class))).thenAnswer(i -> i.getArgument(0));
+        when(endpointManager.next(any(EndpointCriteria.class))).thenReturn(managedEndpoint);
+        when(managedEndpoint.getConnector()).thenReturn(endpointConnector);
+        when(endpointConnector.connect(ctx)).thenReturn(Completable.complete());
+
+        final TestObserver<Void> obs = cut.invoke(ctx).test();
+
+        obs.assertNoValues();
+
+        verify(endpointManager).next(argThat(criteria -> criteria.getName() == null));
+        verify(ctx, never()).setAttribute(eq(ATTR_REQUEST_ENDPOINT), anyString());
+    }
+
     @Test
     void shouldConnectToNextEndpointConnectorWhenUrlEndpointAttributeIsDefined() {
         final HttpEntrypointAsyncConnector httpEntrypointAsyncConnector = mock(HttpEntrypointAsyncConnector.class);


### PR DESCRIPTION
## Problem

On 4.12.x, a V4 endpoint whose relative path contains a colon (e.g. `/foo:analyze`) returns **503 NO_ENDPOINT_FOUND**. The invoker parses `/foo:analyze` as endpoint `foo` + path `analyze` and fails to resolve. Changing the colon to a slash works. Reported on 4.12.0–4.12.3 (APIM-14652).

## Root cause

This is a regression of APIM-14220. The fix (PR #17173) landed on `4.11.x` only and was never forward-ported. `HttpEndpointInvoker.ENDPOINT_PATTERN` still used the pre-fix regex `[^:]+` on `master` and `4.12.x`, so colon-containing relative paths were split at the colon.

## Fix

Cherry-pick of the original fix (`2feddfbc3f`, PR #17173): change the endpoint match group from `[^:]+` to `[^/:][^:]*` so a leading `/` (relative path) no longer matches the endpoint group, preserving colon-containing relative paths as literal paths. Includes the original parameterized tests in `HttpEndpointInvokerTest`.

## Backport

Fix is absent from both `master` and `4.12.x`. This PR targets `master`; `apply-on-4-12-x` label added so Mergify backports to `4.12.x` (the customer's line) after merge.

Closes APIM-14652