### PR TITLE
fix(console): gate overview dashboard behind analytics permission

### DIFF
--- a/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.html
+++ b/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<div class="home-overview">
+<div class="home-overview" *gioPermission="{ anyOf: ['environment-platform-r'] }">
   <div class="time-selector">
     <app-dashboard-filters-bar></app-dashboard-filters-bar>
   </div>
@@ -82,7 +82,7 @@
     <response-times />
   </div>
 
-  <div class="row" *gioPermission="{ anyOf: ['environment-platform-r'] }">
+  <div class="row">
     <h2 class="row-title">API Events</h2>
     <ng-container *ngIf="timeRangeParams; else loader">
       <gio-api-events-table [timeRangeParams]="timeRangeParams" />

--- a/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.spec.ts
@@ -35,10 +35,10 @@ describe('HomeOverviewComponent', () => {
   let componentHarness: HomeOverviewHarness;
   let httpTestingController: HttpTestingController;
 
-  const init = async () => {
+  const init = async (permissions: string[] = ['environment-platform-r']) => {
     await TestBed.configureTestingModule({
       imports: [HomeModule, OwlNativeDateTimeModule, NoopAnimationsModule, MatIconTestingModule, GioTestingModule],
-      providers: [{ provide: GioTestingPermissionProvider, useValue: ['environment-platform-r'] }],
+      providers: [{ provide: GioTestingPermissionProvider, useValue: permissions }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomeOverviewComponent);
@@ -154,6 +154,18 @@ describe('HomeOverviewComponent', () => {
 
       expect(clearSelectedApiIdsSpy).toHaveBeenCalled();
       expect(resetTimeRangeSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('without environment-platform-r permission', () => {
+    beforeEach(async () => {
+      await init([]);
+    });
+
+    it('should hide the dashboard and not fetch any analytics (APIM-14486)', () => {
+      // afterEach httpTestingController.verify() fails if any analytics request was issued.
+      expect(fixture.componentInstance.canReadAnalytics).toBe(false);
+      expect(fixture.nativeElement.querySelector('.home-overview')).toBeNull();
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.ts
+++ b/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.ts
@@ -28,6 +28,7 @@ import { TimeRangeParams } from '../../../shared/utils/timeFrameRanges';
 import { v4ApisRequestStats } from '../components/dashboard-api-request-stats/dashboard-api-request-stats.component';
 import { HomeService } from '../../../services-ngx/home.service';
 import { AnalyticsTopApis } from '../../../entities/analytics/analytics';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 
 @Component({
   selector: 'home-overview',
@@ -48,15 +49,25 @@ export class HomeOverviewComponent implements OnInit, OnDestroy {
   public apiNb: number;
   public applicationNb: number;
   public timeRangeParams: TimeRangeParams;
+  public canReadAnalytics = false;
 
   constructor(
     private readonly homeService: HomeService,
     private readonly statsService: AnalyticsService,
     private readonly changeDetectorRef: ChangeDetectorRef,
     private readonly snackBarService: SnackBarService,
+    private readonly permissionService: GioPermissionService,
   ) {}
 
   ngOnInit(): void {
+    // Every widget on this dashboard exposes environment analytics, gated by 'environment-platform-r'
+    // (same permission as the Observability/Analytics tabs). Without it, skip all fetches so no
+    // analytics data reaches the browser (APIM-14486).
+    this.canReadAnalytics = this.permissionService.hasAnyMatching(['environment-platform-r']);
+    if (!this.canReadAnalytics) {
+      return;
+    }
+
     this.homeService.resetTimeRange();
     this.homeService
       .timeRangeParams()


### PR DESCRIPTION
## Problem

The environment **Overview dashboard** ignores role permissions. A user whose environment role has no permissions still sees every analytics widget (API/Application counts, lifecycle/state, response status, top APIs, request stats, …) — the same data an admin sees — even though the **Observability** and **Analytics** tabs are correctly blocked for that user.

Only the *API Events* row was gated (`environment-platform-r`); every other widget rendered, and the component fetched their data into the browser unconditionally.

Reported on 4.8.x–4.11.x. (APIM-14486)

## Fix

Gate the whole dashboard on `environment-platform-r` — the same permission that already guards the Observability/Analytics tabs (`management-routing.module.ts`) and the existing API Events widget:

- **`home-overview.component.ts`** — `ngOnInit` returns early when the permission is missing, so **no analytics request is issued** (the parent fetches widget data directly and passes it via `[data]`, so template-only hiding would still leak the data to the browser).
- **`home-overview.component.html`** — one `*gioPermission` gate on the dashboard root; removed the now-redundant per-row gate on API Events.

## Tests

- `home-overview.component.spec.ts` — `init()` now takes an optional permissions arg; added a `without environment-platform-r permission` case asserting the dashboard is hidden and (via `httpTestingController.verify()`) that no analytics request fires.

> Not run locally (no `node_modules` in this worktree) — relying on CI.

## Notes

Kept the gate binary (one permission for the whole dashboard), matching the ticket's expectation that a no-permission user sees nothing — same as the tabs. Per-widget granularity (e.g. Summary counts behind `environment-api-r`) was intentionally left out; can be added later if product wants finer roles.
