### PR TITLE
fix(portal): prevent subscription metadata leak to users without applications

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
@@ -232,6 +232,14 @@ public class ApplicationsResource extends AbstractResource<Application, String> 
 
         subscriptionApplicationIds.retainAll(pageContent);
 
+        // Security (APIM-14585): an empty authorized-application set must not fall through to an
+        // unfiltered subscription search. Downstream, an empty "applications" filter means "no filter",
+        // which would leak every ACCEPTED subscription (including request comments) across the environment
+        // to a user who owns no application.
+        if (subscriptionApplicationIds.isEmpty()) {
+            return metadata;
+        }
+
         SubscriptionQuery query = new SubscriptionQuery();
         query.setApplications(subscriptionApplicationIds);
         query.setStatuses(Arrays.asList(SubscriptionStatus.ACCEPTED));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
@@ -232,7 +232,7 @@ public class ApplicationsResource extends AbstractResource<Application, String> 
 
         subscriptionApplicationIds.retainAll(pageContent);
 
-        // Security (APIM-14585): an empty authorized-application set must not fall through to an
+        // Security: an empty authorized-application set must not fall through to an
         // unfiltered subscription search. Downstream, an empty "applications" filter means "no filter",
         // which would leak every ACCEPTED subscription (including request comments) across the environment
         // to a user who owns no application.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResourceTest.java
@@ -291,6 +291,15 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
         doReturn(true)
             .when(permissionService)
             .hasPermission(any(), eq(RolePermission.APPLICATION_SUBSCRIPTION), any(), eq(RolePermissionAction.READ));
+        doReturn(new HashSet<>(Arrays.asList("A", "B")))
+            .when(applicationService)
+            .findIdsByUserAndPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                any(),
+                any(),
+                eq(RolePermission.APPLICATION_SUBSCRIPTION),
+                eq(RolePermissionAction.READ)
+            );
         SubscriptionEntity sub1 = createSubscriptionEntity("sub-1", "A");
         SubscriptionEntity sub2 = createSubscriptionEntity("sub-2", "A");
         SubscriptionEntity sub3 = createSubscriptionEntity("sub-3", "B");
@@ -317,6 +326,32 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
         assertEquals(2, metadataSubscriptions.size());
         assertEquals(2, ((List) metadataSubscriptions.get("A")).size());
         assertEquals(1, ((List) metadataSubscriptions.get("B")).size());
+    }
+
+    @Test
+    public void shouldNotLeakSubscriptionsMetadataWhenUserHasNoAuthorizedApplication() {
+        // APIM-14585: a user who owns no application must not receive other users' subscription metadata.
+        doReturn(true)
+            .when(permissionService)
+            .hasPermission(any(), eq(RolePermission.APPLICATION_SUBSCRIPTION), any(), eq(RolePermissionAction.READ));
+        // Caller is authorized to READ subscriptions for NO application (owns none).
+        doReturn(new HashSet<String>())
+            .when(applicationService)
+            .findIdsByUserAndPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                any(),
+                any(),
+                eq(RolePermission.APPLICATION_SUBSCRIPTION),
+                eq(RolePermissionAction.READ)
+            );
+
+        final Response response = target().request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        ApplicationsResponse applicationsResponse = response.readEntity(ApplicationsResponse.class);
+
+        // The unfiltered subscription search must never run, so no metadata can leak.
+        verify(subscriptionService, never()).search(eq(GraviteeContext.getExecutionContext()), any());
+        assertNull(applicationsResponse.getMetadata().get(METADATA_SUBSCRIPTIONS_KEY));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResourceTest.java
@@ -330,7 +330,7 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldNotLeakSubscriptionsMetadataWhenUserHasNoAuthorizedApplication() {
-        // APIM-14585: a user who owns no application must not receive other users' subscription metadata.
+        // A user who owns no application must not receive other users' subscription metadata.
         doReturn(true)
             .when(permissionService)
             .hasPermission(any(), eq(RolePermission.APPLICATION_SUBSCRIPTION), any(), eq(RolePermissionAction.READ));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
@@ -105,7 +105,7 @@ public class FilteringServiceImpl extends AbstractService implements FilteringSe
 
     @Override
     public Collection<String> getApplicationsOrderByNumberOfSubscriptions(Collection<String> ids, Order order) {
-        // Security (APIM-14585): an empty application set must not run an unfiltered ranking query.
+        // Security: an empty application set must not run an unfiltered ranking query.
         // Downstream, empty "applications" means "no filter", which would rank subscriptions across the
         // whole environment for a user who owns no application.
         if (ids == null || ids.isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
@@ -105,6 +105,12 @@ public class FilteringServiceImpl extends AbstractService implements FilteringSe
 
     @Override
     public Collection<String> getApplicationsOrderByNumberOfSubscriptions(Collection<String> ids, Order order) {
+        // Security (APIM-14585): an empty application set must not run an unfiltered ranking query.
+        // Downstream, empty "applications" means "no filter", which would rank subscriptions across the
+        // whole environment for a user who owns no application.
+        if (ids == null || ids.isEmpty()) {
+            return ids == null ? Collections.emptyList() : ids;
+        }
         SubscriptionQuery subscriptionQuery = new SubscriptionQuery();
         subscriptionQuery.setStatuses(Arrays.asList(SubscriptionStatus.ACCEPTED, SubscriptionStatus.PAUSED));
         subscriptionQuery.setApplications(ids);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImplTest.java
@@ -46,7 +46,7 @@ class FilteringServiceImplTest {
 
     @Test
     void getApplicationsOrderByNumberOfSubscriptions_emptyIds_doesNotRunUnfilteredQuery() {
-        // APIM-14585: an empty application set must not trigger an unfiltered ranking query.
+        // An empty application set must not trigger an unfiltered ranking query.
         Collection<String> result = filteringService.getApplicationsOrderByNumberOfSubscriptions(new HashSet<>(), Order.DESC);
 
         assertThat(result).isEmpty();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.filtering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.rest.api.service.SubscriptionService;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FilteringServiceImplTest {
+
+    @Mock
+    SubscriptionService subscriptionService;
+
+    @InjectMocks
+    FilteringServiceImpl filteringService;
+
+    @Test
+    void getApplicationsOrderByNumberOfSubscriptions_emptyIds_doesNotRunUnfilteredQuery() {
+        // APIM-14585: an empty application set must not trigger an unfiltered ranking query.
+        Collection<String> result = filteringService.getApplicationsOrderByNumberOfSubscriptions(new HashSet<>(), Order.DESC);
+
+        assertThat(result).isEmpty();
+        verifyNoInteractions(subscriptionService);
+    }
+
+    @Test
+    void getApplicationsOrderByNumberOfSubscriptions_nullIds_doesNotRunUnfilteredQuery() {
+        Collection<String> result = filteringService.getApplicationsOrderByNumberOfSubscriptions(null, Order.DESC);
+
+        assertThat(result).isEmpty();
+        verifyNoInteractions(subscriptionService);
+    }
+
+    @Test
+    void getApplicationsOrderByNumberOfSubscriptions_withIds_delegatesToRanking() {
+        Set<String> ranking = new LinkedHashSet<>(List.of("app-2"));
+        when(subscriptionService.findReferenceIdsOrderByNumberOfSubscriptions(any(), eq(Order.DESC))).thenReturn(ranking);
+
+        Collection<String> result = filteringService.getApplicationsOrderByNumberOfSubscriptions(
+            new HashSet<>(List.of("app-1", "app-2")),
+            Order.DESC
+        );
+
+        assertThat(result).contains("app-1", "app-2");
+        verify(subscriptionService).findReferenceIdsOrderByNumberOfSubscriptions(any(), eq(Order.DESC));
+    }
+}


### PR DESCRIPTION
## Problem

`GET /portal/environments/{envId}/applications` (notably with `order=-nbSubscriptions`) leaked subscription metadata to a portal user who owns **no application**. The response `data` was `[]`, but `metadata.subscriptions` contained ACCEPTED subscriptions from across the environment — including other users' subscription `request` comments.

Root cause: an empty (non-null) authorized-application set was passed to the subscription query. Downstream, an empty `applications` filter is treated as "no filter" (JDBC `addStringsWhereClause` skips empty collections), so the query returned every ACCEPTED subscription in the environment.

## Fix

Guard the two source call-sites that pass a user-authorization-scoped application set, so an empty set means "authorized to see nothing" rather than "no filter":

- `ApplicationsResource.fillMetadata` — returns the metadata unchanged when the scoped set is empty.
- `FilteringServiceImpl.getApplicationsOrderByNumberOfSubscriptions` — short-circuits on an empty/null id set (also avoids a full-table subscription scan).

The shared JDBC criteria builder is intentionally left unchanged: empty-means-all is a deliberate convention used by many admin/management queries. Fixing at the authorization boundary is the correct and narrowest change, and the empty set never reaches the repository.

## Tests

- `ApplicationsResourceTest` (18/18) — adds `shouldNotLeakSubscriptionsMetadataWhenUserHasNoAuthorizedApplication`, which asserts the unfiltered subscription search never runs and no subscription metadata is returned. The existing `shouldGetApplicationsWithSubscriptions` was passing because of the bug; it now authorizes the user explicitly.
- `FilteringServiceImplTest` (3/3, new) — covers the empty, null, and populated id-set paths.

Ref: https://gravitee.atlassian.net/browse/APIM-14585
