### PR TITLE
fix(definition): ignore clearTextUpgrade for HTTP/1.1 endpoints

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/HttpClientOptions.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/HttpClientOptions.java
@@ -162,6 +162,10 @@ public class HttpClientOptions implements Serializable {
     }
 
     public boolean isClearTextUpgrade() {
+        // h2c cleartext upgrade is an HTTP/2-only mechanism; it has no meaning for HTTP/1.1 (APIM-14613)
+        if (version == ProtocolVersion.HTTP_1_1) {
+            return false;
+        }
         return clearTextUpgrade;
     }
 

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/HttpClientOptionsTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/HttpClientOptionsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class HttpClientOptionsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void shouldForceClearTextUpgradeToFalseForHttp11() {
+        // A brand-new endpoint keeps the model defaults (HTTP_1_1 + clearTextUpgrade=true), which is
+        // an invalid combination: h2c is an HTTP/2-only mechanism (APIM-14613).
+        HttpClientOptions options = new HttpClientOptions();
+
+        assertThat(options.getVersion()).isEqualTo(ProtocolVersion.HTTP_1_1);
+        assertThat(options.isClearTextUpgrade()).isFalse();
+    }
+
+    @Test
+    void shouldNotSerializeClearTextUpgradeAsTrueForHttp11() throws Exception {
+        HttpClientOptions options = new HttpClientOptions();
+        options.setClearTextUpgrade(true);
+        options.setVersion(ProtocolVersion.HTTP_1_1);
+
+        // Default (bean) serialization is the path that leaked the invalid combo in the exported definition.
+        boolean clearTextUpgrade = objectMapper.readTree(objectMapper.writeValueAsString(options)).path("clearTextUpgrade").asBoolean();
+
+        assertThat(clearTextUpgrade).isFalse();
+    }
+
+    @Test
+    void shouldPreserveClearTextUpgradeForHttp2() {
+        HttpClientOptions options = new HttpClientOptions();
+        options.setVersion(ProtocolVersion.HTTP_2);
+        options.setClearTextUpgrade(true);
+
+        assertThat(options.isClearTextUpgrade()).isTrue();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/src/test/java/io/gravitee/gateway/services/endpoint/discovery/verticle/EndpointDiscoveryVerticleTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/src/test/java/io/gravitee/gateway/services/endpoint/discovery/verticle/EndpointDiscoveryVerticleTest.java
@@ -233,7 +233,7 @@ public class EndpointDiscoveryVerticleTest {
             "\"useCompression\":true," +
             "\"propagateClientAcceptEncoding\":false," +
             "\"followRedirects\":false," +
-            "\"clearTextUpgrade\":true," +
+            "\"clearTextUpgrade\":false," +
             "\"version\":\"HTTP_1_1\",\"maxHeaderSize\":8192,\"maxChunkSize\":8192" +
             "}," +
             "\"proxy\":{" +


### PR DESCRIPTION
## Problem

When a new endpoint is added to a **V2 API** without touching the protocol settings, the exported definition contains the invalid combination:

```json
"clearTextUpgrade": true, "version": "HTTP_1_1"
```

`clearTextUpgrade` (h2c) is an **HTTP/2-only** upgrade mechanism and has no meaning for HTTP/1.1. (APIM-14613, affects 4.8.x–4.11.x)

## Root cause

- The console leaves `clearTextUpgrade` undefined for a new endpoint (and only disables the control for HTTP/1.1), so it does **not** send `true`.
- The value comes from the backend model default `DEFAULT_CLEAR_TEXT_UPGRADE = true`, combined with the default protocol `HTTP_1_1`.
- The custom `HttpClientOptionsSerializer` already omits `clearTextUpgrade`/`version` for HTTP/1.1, but the export path uses **default Jackson bean serialization** (the model's `@JsonProperty` getters), which writes the field regardless of version.

## Fix

`HttpClientOptions.isClearTextUpgrade()` (V2 definition model) now returns `false` when `version == HTTP_1_1`. Since Jackson bean serialization reads the getter, every serialization path is now consistent with the custom serializer.

**No runtime behaviour change:** the only consumer, `HttpEndpointRuleHandler` (health-check), reads `isClearTextUpgrade()` exclusively inside a `version == HTTP_2` guard.

## Tests

New `HttpClientOptionsTest`:
- default (HTTP_1_1) → `isClearTextUpgrade()` is `false`
- HTTP_1_1 + `clearTextUpgrade=true` → default bean serialization writes `false`
- HTTP_2 + `clearTextUpgrade=true` → preserved as `true`

`mvn test -Dtest=HttpClientOptionsTest` → `Tests run: 3, Failures: 0`.
