### PR TITLE
fix(rest-api): normalize legacy SSL none values on read and for all shared-SSL-schema plugins

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/LegacySslConfigurationNormalizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/LegacySslConfigurationNormalizer.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Set;
 import lombok.experimental.UtilityClass;
 
 /**
@@ -38,7 +39,23 @@ public class LegacySslConfigurationNormalizer {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String NONE = "NONE";
 
-    public static String normalizeLegacySslNoneValues(String sharedConfiguration) {
+    /**
+     * Endpoint connectors whose shared configuration embeds the shared SSL options schema, and whose
+     * definitions may therefore carry the legacy empty-string discriminator. Connectors declaring their
+     * own SSL schema (kafka, native-kafka) never used that representation and must be left untouched,
+     * since normalization drops the sibling fields of the store it rewrites.
+     */
+    private static final Set<String> SHARED_SSL_SCHEMA_TYPES = Set.of("http-proxy", "tcp-proxy", "mcp-proxy", "llm-proxy", "a2a-proxy");
+
+    /**
+     * Normalizes the given shared configuration when the connector is known to embed the shared SSL
+     * options schema, and returns it untouched otherwise.
+     */
+    public static String normalizeLegacySslNoneValues(String connectorType, String sharedConfiguration) {
+        return SHARED_SSL_SCHEMA_TYPES.contains(connectorType) ? normalizeLegacySslNoneValues(sharedConfiguration) : sharedConfiguration;
+    }
+
+    private static String normalizeLegacySslNoneValues(String sharedConfiguration) {
         try {
             JsonNode root = OBJECT_MAPPER.readTree(sharedConfiguration);
             if (!(root.path("ssl") instanceof ObjectNode sslObject)) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/LegacySslConfigurationNormalizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/LegacySslConfigurationNormalizer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.service.v4.impl.validation;
+package io.gravitee.rest.api.service.common;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -21,13 +21,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.experimental.UtilityClass;
 
+/**
+ * Normalizes the legacy representation of the SSL "None" keyStore/trustStore discriminator.
+ * <p>
+ * Configurations written before gravitee-plugin-common-configurations 1.2.3 persist that
+ * discriminator as an empty string, while the shared SSL form schema now pins the "None"
+ * branch on {@code const: "NONE"}. The empty string therefore matches no {@code oneOf}
+ * branch, which makes both the generated form and the JSON schema validation reject it.
+ * <p>
+ * Both representations are equivalent for the gateway, which maps {@code ""} to
+ * {@code NONE} when deserializing.
+ */
 @UtilityClass
-class HttpProxySharedConfigurationNormalizer {
+public class LegacySslConfigurationNormalizer {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String NONE = "NONE";
 
-    static String normalizeLegacySslNoneValues(String sharedConfiguration) {
+    public static String normalizeLegacySslNoneValues(String sharedConfiguration) {
         try {
             JsonNode root = OBJECT_MAPPER.readTree(sharedConfiguration);
             if (!(root.path("ssl") instanceof ObjectNode sslObject)) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/LegacySslConfigurationNormalizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/LegacySslConfigurationNormalizer.java
@@ -40,19 +40,26 @@ public class LegacySslConfigurationNormalizer {
     private static final String NONE = "NONE";
 
     /**
-     * Endpoint connectors whose shared configuration embeds the shared SSL options schema, and whose
-     * definitions may therefore carry the legacy empty-string discriminator. Connectors declaring their
-     * own SSL schema (kafka, native-kafka) never used that representation and must be left untouched,
-     * since normalization drops the sibling fields of the store it rewrites.
+     * Plugins whose configuration embeds the shared SSL options schema, and whose definitions may
+     * therefore carry the legacy empty-string discriminator. Plugins declaring their own SSL schema
+     * (kafka, native-kafka) never used that representation and must be left untouched, since
+     * normalization drops the sibling fields of the store it rewrites.
      */
-    private static final Set<String> SHARED_SSL_SCHEMA_TYPES = Set.of("http-proxy", "tcp-proxy", "mcp-proxy", "llm-proxy", "a2a-proxy");
+    private static final Set<String> SHARED_SSL_SCHEMA_TYPES = Set.of(
+        "http-proxy",
+        "tcp-proxy",
+        "mcp-proxy",
+        "llm-proxy",
+        "a2a-proxy",
+        "http-dynamic-properties"
+    );
 
     /**
-     * Normalizes the given shared configuration when the connector is known to embed the shared SSL
-     * options schema, and returns it untouched otherwise.
+     * Normalizes the given configuration when the plugin is known to embed the shared SSL options
+     * schema, and returns it untouched otherwise.
      */
-    public static String normalizeLegacySslNoneValues(String connectorType, String sharedConfiguration) {
-        return SHARED_SSL_SCHEMA_TYPES.contains(connectorType) ? normalizeLegacySslNoneValues(sharedConfiguration) : sharedConfiguration;
+    public static String normalizeLegacySslNoneValues(String pluginType, String configuration) {
+        return SHARED_SSL_SCHEMA_TYPES.contains(pluginType) ? normalizeLegacySslNoneValues(configuration) : configuration;
     }
 
     private static String normalizeLegacySslNoneValues(String sharedConfiguration) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -37,6 +37,7 @@ import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.sanitizer.HtmlSanitizer;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.LegacySslConfigurationNormalizer;
 import io.gravitee.rest.api.service.exceptions.DefinitionVersionException;
 import io.gravitee.rest.api.service.exceptions.DynamicPropertiesInvalidException;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
@@ -327,7 +328,10 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
             dynamicProperties.setConfiguration(
                 this.apiServicePluginService.validateApiServiceConfiguration(
                     dynamicProperties.getType(),
-                    dynamicProperties.getConfiguration()
+                    LegacySslConfigurationNormalizer.normalizeLegacySslNoneValues(
+                        dynamicProperties.getType(),
+                        dynamicProperties.getConfiguration()
+                    )
                 )
             );
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
@@ -69,7 +69,23 @@ import org.springframework.stereotype.Component;
 public class EndpointGroupsValidationServiceImpl extends TransactionalService implements EndpointGroupsValidationService {
 
     private static final String HTTP_PROXY_TYPE = "http-proxy";
+    private static final String TCP_PROXY_TYPE = "tcp-proxy";
+    private static final String MCP_PROXY_TYPE = "mcp-proxy";
     private static final String LLM_PROXY_TYPE = "llm-proxy";
+    private static final String A2A_PROXY_TYPE = "a2a-proxy";
+
+    /**
+     * Endpoint connectors whose shared configuration embeds the shared SSL options schema, and whose
+     * definitions may therefore carry the legacy empty-string "None" keyStore/trustStore discriminator.
+     * Connectors declaring their own SSL schema (kafka, native-kafka) never used that representation.
+     */
+    private static final Set<String> SHARED_SSL_SCHEMA_TYPES = Set.of(
+        HTTP_PROXY_TYPE,
+        TCP_PROXY_TYPE,
+        MCP_PROXY_TYPE,
+        LLM_PROXY_TYPE,
+        A2A_PROXY_TYPE
+    );
 
     private final EndpointConnectorPluginService endpointService;
     private final ApiServicePluginService apiServicePluginService;
@@ -168,7 +184,7 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
     }
 
     private String normalizeSharedConfiguration(ConnectorPluginEntity endpointConnector, String sharedConfiguration) {
-        return HTTP_PROXY_TYPE.equals(endpointConnector.getId())
+        return SHARED_SSL_SCHEMA_TYPES.contains(endpointConnector.getId())
             ? LegacySslConfigurationNormalizer.normalizeLegacySslNoneValues(sharedConfiguration)
             : sharedConfiguration;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
@@ -33,6 +33,7 @@ import io.gravitee.definition.model.v4.endpointgroup.service.EndpointServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
+import io.gravitee.rest.api.service.common.LegacySslConfigurationNormalizer;
 import io.gravitee.rest.api.service.exceptions.EndpointConfigurationValidationException;
 import io.gravitee.rest.api.service.exceptions.EndpointGroupNameAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.EndpointMissingException;
@@ -168,7 +169,7 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
 
     private String normalizeSharedConfiguration(ConnectorPluginEntity endpointConnector, String sharedConfiguration) {
         return HTTP_PROXY_TYPE.equals(endpointConnector.getId())
-            ? HttpProxySharedConfigurationNormalizer.normalizeLegacySslNoneValues(sharedConfiguration)
+            ? LegacySslConfigurationNormalizer.normalizeLegacySslNoneValues(sharedConfiguration)
             : sharedConfiguration;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
@@ -68,24 +68,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class EndpointGroupsValidationServiceImpl extends TransactionalService implements EndpointGroupsValidationService {
 
-    private static final String HTTP_PROXY_TYPE = "http-proxy";
-    private static final String TCP_PROXY_TYPE = "tcp-proxy";
-    private static final String MCP_PROXY_TYPE = "mcp-proxy";
     private static final String LLM_PROXY_TYPE = "llm-proxy";
-    private static final String A2A_PROXY_TYPE = "a2a-proxy";
-
-    /**
-     * Endpoint connectors whose shared configuration embeds the shared SSL options schema, and whose
-     * definitions may therefore carry the legacy empty-string "None" keyStore/trustStore discriminator.
-     * Connectors declaring their own SSL schema (kafka, native-kafka) never used that representation.
-     */
-    private static final Set<String> SHARED_SSL_SCHEMA_TYPES = Set.of(
-        HTTP_PROXY_TYPE,
-        TCP_PROXY_TYPE,
-        MCP_PROXY_TYPE,
-        LLM_PROXY_TYPE,
-        A2A_PROXY_TYPE
-    );
 
     private final EndpointConnectorPluginService endpointService;
     private final ApiServicePluginService apiServicePluginService;
@@ -184,9 +167,7 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
     }
 
     private String normalizeSharedConfiguration(ConnectorPluginEntity endpointConnector, String sharedConfiguration) {
-        return SHARED_SSL_SCHEMA_TYPES.contains(endpointConnector.getId())
-            ? LegacySslConfigurationNormalizer.normalizeLegacySslNoneValues(sharedConfiguration)
-            : sharedConfiguration;
+        return LegacySslConfigurationNormalizer.normalizeLegacySslNoneValues(endpointConnector.getId(), sharedConfiguration);
     }
 
     private void validateSharedConfigurationInheritance(AbstractEndpointGroup<?> endpointGroup, AbstractEndpoint endpoint) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -31,6 +31,8 @@ import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.property.Property;
+import io.gravitee.definition.model.v4.service.ApiServices;
+import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
 import io.gravitee.repository.management.model.LifecycleState;
@@ -142,6 +144,23 @@ public class ApiMapper {
         return endpointGroups;
     }
 
+    /**
+     * Same legacy SSL concern as {@link #normalizeLegacySslConfiguration(List)}, for the API services
+     * whose configuration embeds the shared SSL options schema.
+     */
+    private ApiServices normalizeLegacySslConfiguration(final ApiServices services) {
+        if (services == null) {
+            return null;
+        }
+        final Service dynamicProperty = services.getDynamicProperty();
+        if (dynamicProperty != null && dynamicProperty.getConfiguration() != null) {
+            dynamicProperty.setConfiguration(
+                LegacySslConfigurationNormalizer.normalizeLegacySslNoneValues(dynamicProperty.getType(), dynamicProperty.getConfiguration())
+            );
+        }
+        return services;
+    }
+
     public ApiEntity toEntity(final Api api, final PrimaryOwnerEntity primaryOwner) {
         ApiEntity apiEntity = new ApiEntity();
 
@@ -163,7 +182,7 @@ public class ApiMapper {
                 apiEntity.setFailover(apiDefinition.getFailover());
                 apiEntity.setListeners(apiDefinition.getListeners());
                 apiEntity.setEndpointGroups(normalizeLegacySslConfiguration(apiDefinition.getEndpointGroups()));
-                apiEntity.setServices(apiDefinition.getServices());
+                apiEntity.setServices(normalizeLegacySslConfiguration(apiDefinition.getServices()));
                 apiEntity.setResources(apiDefinition.getResources());
                 apiEntity.setProperties(apiDefinition.getProperties());
                 apiEntity.setTags(apiDefinition.getTags());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -27,6 +27,7 @@ import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.federation.FederatedAgent;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.property.Property;
@@ -52,6 +53,7 @@ import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.LegacySslConfigurationNormalizer;
 import io.gravitee.rest.api.service.common.ReferenceContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
@@ -100,6 +102,46 @@ public class ApiMapper {
         this.categoryMapper = categoryMapper;
     }
 
+    /**
+     * Rewrites the legacy empty-string SSL "None" discriminator carried by definitions written before
+     * gravitee-plugin-common-configurations 1.2.3, so that the forms generated from the current shared
+     * SSL schema accept them. Without it the Console form is invalid, no update can be submitted, and
+     * the symmetric normalization applied on write is never reached.
+     * <p>
+     * This is applied here, at the single point where a stored definition is deserialized for the
+     * Management API, because {@code ApiStateServiceImpl} also builds the deployed definition through
+     * this mapper: normalizing here keeps both sides of the synchronization check consistent, whereas
+     * normalizing further up would flag every legacy API as out of sync.
+     */
+    private List<EndpointGroup> normalizeLegacySslConfiguration(final List<EndpointGroup> endpointGroups) {
+        if (endpointGroups == null) {
+            return null;
+        }
+        endpointGroups.forEach(endpointGroup -> {
+            final String connectorType = endpointGroup.getType();
+            if (endpointGroup.getSharedConfiguration() != null) {
+                endpointGroup.setSharedConfiguration(
+                    LegacySslConfigurationNormalizer.normalizeLegacySslNoneValues(connectorType, endpointGroup.getSharedConfiguration())
+                );
+            }
+            if (endpointGroup.getEndpoints() != null) {
+                endpointGroup
+                    .getEndpoints()
+                    .forEach(endpoint -> {
+                        if (endpoint.getSharedConfigurationOverride() != null) {
+                            endpoint.setSharedConfigurationOverride(
+                                LegacySslConfigurationNormalizer.normalizeLegacySslNoneValues(
+                                    connectorType,
+                                    endpoint.getSharedConfigurationOverride()
+                                )
+                            );
+                        }
+                    });
+            }
+        });
+        return endpointGroups;
+    }
+
     public ApiEntity toEntity(final Api api, final PrimaryOwnerEntity primaryOwner) {
         ApiEntity apiEntity = new ApiEntity();
 
@@ -120,7 +162,7 @@ public class ApiMapper {
                 apiEntity.setAnalytics(apiDefinition.getAnalytics());
                 apiEntity.setFailover(apiDefinition.getFailover());
                 apiEntity.setListeners(apiDefinition.getListeners());
-                apiEntity.setEndpointGroups(apiDefinition.getEndpointGroups());
+                apiEntity.setEndpointGroups(normalizeLegacySslConfiguration(apiDefinition.getEndpointGroups()));
                 apiEntity.setServices(apiDefinition.getServices());
                 apiEntity.setResources(apiDefinition.getResources());
                 apiEntity.setProperties(apiDefinition.getProperties());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -21,6 +21,7 @@ import static io.gravitee.rest.api.model.api.ApiLifecycleState.CREATED;
 import static io.gravitee.rest.api.model.api.ApiLifecycleState.DEPRECATED;
 import static io.gravitee.rest.api.model.api.ApiLifecycleState.PUBLISHED;
 import static io.gravitee.rest.api.model.api.ApiLifecycleState.UNPUBLISHED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -639,6 +640,25 @@ public class ApiValidationServiceImplTest {
         apiValidationService.validateDynamicProperties(dynamicProperties);
 
         verify(apiServicePluginService, times(1)).validateApiServiceConfiguration("http-dynamic-properties", "{}");
+    }
+
+    @Test
+    public void should_normalize_legacy_ssl_none_values_before_validating_dynamic_properties() {
+        String legacyConfiguration = "{\"ssl\":{\"trustStore\":{\"type\":\"\"}}}";
+        String normalizedConfiguration = "{\"ssl\":{\"trustStore\":{\"type\":\"NONE\"}}}";
+        Service dynamicProperties = Service.builder()
+            .enabled(true)
+            .type("http-dynamic-properties")
+            .configuration(legacyConfiguration)
+            .build();
+        when(apiServicePluginService.validateApiServiceConfiguration("http-dynamic-properties", normalizedConfiguration)).thenReturn(
+            normalizedConfiguration
+        );
+
+        apiValidationService.validateDynamicProperties(dynamicProperties);
+
+        verify(apiServicePluginService, times(1)).validateApiServiceConfiguration("http-dynamic-properties", normalizedConfiguration);
+        assertThat(dynamicProperties.getConfiguration()).isEqualTo(normalizedConfiguration);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
@@ -69,6 +69,7 @@ public class EndpointGroupsValidationServiceImplTest {
     public static final String FIXED_HC_CONFIG = "{fixed}";
     public static final String HEALTH_CHECK_TYPE = "http-health-check";
     public static final String HTTP_PROXY_ENDPOINT_TYPE = "http-proxy";
+    public static final String TCP_PROXY_ENDPOINT_TYPE = "tcp-proxy";
     public static final String NATIVE_ENDPOINT_TYPE = "native-friendly";
 
     @Mock
@@ -97,6 +98,11 @@ public class EndpointGroupsValidationServiceImplTest {
         httpProxyEndpoint.setId(HTTP_PROXY_ENDPOINT_TYPE);
         httpProxyEndpoint.setSupportedApiType(ApiType.PROXY);
         lenient().when(endpointService.findById(HTTP_PROXY_ENDPOINT_TYPE)).thenReturn(httpProxyEndpoint);
+
+        var tcpProxyEndpoint = new ConnectorPluginEntity();
+        tcpProxyEndpoint.setId(TCP_PROXY_ENDPOINT_TYPE);
+        tcpProxyEndpoint.setSupportedApiType(ApiType.PROXY);
+        lenient().when(endpointService.findById(TCP_PROXY_ENDPOINT_TYPE)).thenReturn(tcpProxyEndpoint);
 
         var nativeFriendlyEndpoint = new ConnectorPluginEntity();
         nativeFriendlyEndpoint.setId(NATIVE_ENDPOINT_TYPE);
@@ -593,7 +599,7 @@ public class EndpointGroupsValidationServiceImplTest {
     }
 
     @Test
-    public void should_not_normalize_legacy_ssl_store_types_for_non_http_proxy_shared_configuration() {
+    public void should_not_normalize_legacy_ssl_store_types_for_connectors_without_the_shared_ssl_schema() {
         String sharedConfiguration = "{\"ssl\":{\"trustStore\":{\"type\":\"\"},\"keyStore\":{\"type\":\"\"}}}";
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("my name");
@@ -680,6 +686,47 @@ public class EndpointGroupsValidationServiceImplTest {
             normalizedSharedConfigurationOverride
         );
         verify(endpointService).validateSharedConfiguration(any(), eq(normalizedSharedConfigurationOverride));
+    }
+
+    @Test
+    public void should_normalize_legacy_ssl_store_types_for_non_http_proxy_connectors() {
+        String legacySharedConfiguration = "{\"ssl\":{\"trustStore\":{\"type\":\"\"}}}";
+        String normalizedSharedConfiguration = "{\"ssl\":{\"trustStore\":{\"type\":\"NONE\"}}}";
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setName("my name");
+        endpointGroup.setType(TCP_PROXY_ENDPOINT_TYPE);
+        endpointGroup.setSharedConfiguration(legacySharedConfiguration);
+
+        Endpoint endpoint = new Endpoint();
+        endpoint.setName("endpoint");
+        endpoint.setType(TCP_PROXY_ENDPOINT_TYPE);
+        endpoint.setInheritConfiguration(true);
+        endpointGroup.setEndpoints(List.of(endpoint));
+
+        var endpointGroups = endpointGroupsValidationService.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(endpointGroup));
+
+        assertThat(endpointGroups.getFirst().getSharedConfiguration()).isEqualTo(normalizedSharedConfiguration);
+        verify(endpointService).validateSharedConfiguration(any(), eq(normalizedSharedConfiguration));
+    }
+
+    @Test
+    public void should_leave_shared_configuration_without_ssl_block_untouched() {
+        String sharedConfigurationWithoutSsl = "{\"security\":{\"protocol\":\"PLAINTEXT\"}}";
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setName("my name");
+        endpointGroup.setType(TCP_PROXY_ENDPOINT_TYPE);
+        endpointGroup.setSharedConfiguration(sharedConfigurationWithoutSsl);
+
+        Endpoint endpoint = new Endpoint();
+        endpoint.setName("endpoint");
+        endpoint.setType(TCP_PROXY_ENDPOINT_TYPE);
+        endpoint.setInheritConfiguration(true);
+        endpointGroup.setEndpoints(List.of(endpoint));
+
+        var endpointGroups = endpointGroupsValidationService.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(endpointGroup));
+
+        assertThat(endpointGroups.getFirst().getSharedConfiguration()).isEqualTo(sharedConfigurationWithoutSsl);
+        verify(endpointService).validateSharedConfiguration(any(), eq(sharedConfigurationWithoutSsl));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
@@ -28,6 +28,7 @@ import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.flow.Flow;
@@ -108,6 +109,74 @@ public class ApiMapperTest {
     public void setUp() throws Exception {
         objectMapper = new ObjectMapper();
         apiMapper = new ApiMapper(objectMapper, planService, flowService, parameterService, workflowService, categoryMapper);
+    }
+
+    @Test
+    public void should_normalize_legacy_ssl_none_values_when_reading_the_definition() throws Exception {
+        // Given
+        var api = apiWithSharedConfiguration("http-proxy", "{\"ssl\":{\"trustStore\":{\"type\":\"\"},\"keyStore\":{\"type\":\"\"}}}");
+
+        // When
+        var entity = apiMapper.toEntity(api, new PrimaryOwnerEntity());
+
+        // Then
+        assertThat(entity.getEndpointGroups().getFirst().getSharedConfiguration()).isEqualTo(
+            "{\"ssl\":{\"trustStore\":{\"type\":\"NONE\"},\"keyStore\":{\"type\":\"NONE\"}}}"
+        );
+    }
+
+    @Test
+    public void should_normalize_legacy_ssl_none_values_of_endpoint_shared_configuration_override() throws Exception {
+        // Given
+        var api = apiWithSharedConfiguration("tcp-proxy", "{\"ssl\":{\"trustStore\":{\"type\":\"\"}}}");
+
+        // When
+        var entity = apiMapper.toEntity(api, new PrimaryOwnerEntity());
+
+        // Then
+        assertThat(entity.getEndpointGroups().getFirst().getEndpoints().getFirst().getSharedConfigurationOverride()).isEqualTo(
+            "{\"ssl\":{\"trustStore\":{\"type\":\"NONE\"}}}"
+        );
+    }
+
+    @Test
+    public void should_not_normalize_when_the_connector_does_not_use_the_shared_ssl_schema() throws Exception {
+        // Given
+        var legacySsl = "{\"ssl\":{\"trustStore\":{\"type\":\"\"}}}";
+        var api = apiWithSharedConfiguration("kafka", legacySsl);
+
+        // When
+        var entity = apiMapper.toEntity(api, new PrimaryOwnerEntity());
+
+        // Then
+        assertThat(entity.getEndpointGroups().getFirst().getSharedConfiguration()).isEqualTo(legacySsl);
+    }
+
+    private Api apiWithSharedConfiguration(String connectorType, String sharedConfiguration) throws Exception {
+        var endpoint = new Endpoint();
+        endpoint.setName("endpoint");
+        endpoint.setType(connectorType);
+        endpoint.setInheritConfiguration(false);
+        endpoint.setSharedConfigurationOverride(sharedConfiguration);
+
+        var endpointGroup = new EndpointGroup();
+        endpointGroup.setName("group");
+        endpointGroup.setType(connectorType);
+        endpointGroup.setSharedConfiguration(sharedConfiguration);
+        endpointGroup.setEndpoints(List.of(endpoint));
+
+        var definition = new io.gravitee.definition.model.v4.Api();
+        definition.setDefinitionVersion(DefinitionVersion.V4);
+        definition.setType(ApiType.PROXY);
+        definition.setName("name");
+        definition.setApiVersion("1");
+        definition.setEndpointGroups(List.of(endpointGroup));
+
+        var api = new Api();
+        api.setId("api-id");
+        api.setType(ApiType.PROXY);
+        api.setDefinition(objectMapper.writeValueAsString(definition));
+        return api;
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
@@ -42,6 +42,7 @@ import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
+import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
 import io.gravitee.repository.management.model.LifecycleState;
@@ -150,6 +151,37 @@ public class ApiMapperTest {
 
         // Then
         assertThat(entity.getEndpointGroups().getFirst().getSharedConfiguration()).isEqualTo(legacySsl);
+    }
+
+    @Test
+    public void should_normalize_legacy_ssl_none_values_of_dynamic_properties_configuration() throws Exception {
+        // Given
+        var dynamicProperty = new Service();
+        dynamicProperty.setType("http-dynamic-properties");
+        dynamicProperty.setEnabled(true);
+        dynamicProperty.setConfiguration("{\"ssl\":{\"trustStore\":{\"type\":\"\"}}}");
+        var services = new ApiServices();
+        services.setDynamicProperty(dynamicProperty);
+
+        var definition = new io.gravitee.definition.model.v4.Api();
+        definition.setDefinitionVersion(DefinitionVersion.V4);
+        definition.setType(ApiType.PROXY);
+        definition.setName("name");
+        definition.setApiVersion("1");
+        definition.setServices(services);
+
+        var api = new Api();
+        api.setId("api-id");
+        api.setType(ApiType.PROXY);
+        api.setDefinition(objectMapper.writeValueAsString(definition));
+
+        // When
+        var entity = apiMapper.toEntity(api, new PrimaryOwnerEntity());
+
+        // Then
+        assertThat(entity.getServices().getDynamicProperty().getConfiguration()).isEqualTo(
+            "{\"ssl\":{\"trustStore\":{\"type\":\"NONE\"}}}"
+        );
     }
 
     private Api apiWithSharedConfiguration(String connectorType, String sharedConfiguration) throws Exception {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14701

## Description

V4 APIs created before 2026-05-04 persist the SSL keyStore/trustStore "None" discriminator as an
empty string (`{"type": ""}`). The shared SSL form schema pinned that branch on `const: ""` until
[450a347](https://github.com/gravitee-io/gravitee-plugin-common-configurations/commit/450a347) aligned
it on `const: "NONE"` (released in `1.2.3`, shipped in APIM 4.12.x via `1.4.0`). No migration came with
it, so existing definitions still carry `""`, which matches no `oneOf` branch.

The consequence is a deadlock in the Console: the generated form is invalid, so no update can be
submitted, so the normalization applied on write is never reached. Gateway traffic is unaffected —
`TrustStoreType` / `KeyStoreType` map `""` to `NONE` at runtime.

APIM-14599 (#18361) already introduced this normalization, but wired it on the **write path only** and
behind an `http-proxy` guard. This PR completes it:

- *(refactor)* extract the normalizer to a shared package, no behaviour change
- *(fix)* extend the guard from `http-proxy` to every plugin embedding the shared SSL schema
- *(refactor)* move the plugin-type gate into the normalizer, which now owns both the *what* and the *for whom*
- *(fix)* **normalize on read** — this is what unblocks the Console
- *(fix)* cover `http-dynamic-properties`, on both paths

### Why the read hook lives in `ApiMapper.toEntity`

`ApiStateServiceImpl` builds the *deployed* definition through the very same mapper before handing it
to `checkSynchronization`. Normalizing there keeps **both sides** of the comparison consistent.
Hooking any higher — `ApiSearchService`, for instance — would normalize the current definition but not
the deployed one, and every legacy API would report "needs redeploy" forever.

It is also the single point where a stored definition is deserialized for the Management API, so one
hook covers the Console GET, the API list and `_export/crd`. The gateway is structurally out of reach:
`gravitee-apim-gateway-services-sync` has no dependency on any `rest-api` module and deserializes with
its own mapper.

The MapStruct `EndpointMapper` in `management-v2-rest` was considered and rejected: normalization is a
business rule, not a structural transformation, and the connector type isn't available there.

## Additional context

**Scope.** Affected plugins are those embedding the shared SSL schema: `http-proxy`, `tcp-proxy`,
`mcp-proxy`, `llm-proxy`, `a2a-proxy` and `http-dynamic-properties`. Plugin ids were checked against
each `plugin.properties`.

Deliberately excluded:
- `kafka` / `native-kafka` endpoints — they declare their own inline SSL schema and never used `const: ""`.
  The guard matters here: normalization drops the sibling fields of the store it rewrites.
- Kafka clusters — 450a347's own message shows their payloads came back as `"NONE"` from the typed Java
  models, so they never wrote `""`.
- `_export/definition` — it goes through `ImportExportApiMapper`, outside `toEntity`. An export of a
  legacy API still carries `""`, which the write-path normalization repairs on re-import.

**Test plan.**
- Force `{"type": ""}` into an existing V4 API definition in the database
- Open *Endpoint group > Configuration* in the Console: the form is valid and Save submits
- Confirm the value is persisted as `"NONE"` and that the API is not flagged out of sync
- Unit tests cover both paths for endpoints and dynamic properties, incl. the no-op on plugins outside
  the list

The existing `should_not_normalize_...` test from #18361 still passes unmodified; only its name was
updated, since "non-http-proxy" no longer describes the rule.
