### PR TITLE
feat: persist API product navigation items

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PortalNavigationItemCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PortalNavigationItemCriteria.java
@@ -34,5 +34,6 @@ public class PortalNavigationItemCriteria {
     private Boolean root;
     private String visibility;
     private Set<String> apiIds;
+    private Set<String> apiProductIds;
     private String type;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalNavigationItem.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalNavigationItem.java
@@ -38,6 +38,7 @@ public class PortalNavigationItem {
         FOLDER,
         LINK,
         API,
+        API_PRODUCT,
     }
 
     public enum Area {
@@ -79,4 +80,6 @@ public class PortalNavigationItem {
     private Visibility visibility;
 
     private String apiId;
+
+    private String apiProductId;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
@@ -61,6 +61,7 @@ public class JdbcPortalNavigationItemRepository
             .addColumn("configuration", Types.NVARCHAR, String.class)
             .addColumn("published", Types.BOOLEAN, boolean.class)
             .addColumn("apiId", Types.NVARCHAR, String.class)
+            .addColumn("apiProductId", Types.NVARCHAR, String.class)
             .addColumn("visibility", Types.NVARCHAR, PortalNavigationItem.Visibility.class)
             .build();
     }
@@ -217,6 +218,10 @@ public class JdbcPortalNavigationItemRepository
             if (criteria.getApiIds() != null && !criteria.getApiIds().isEmpty()) {
                 clauses.add("api_id IN (" + String.join(",", Collections.nCopies(criteria.getApiIds().size(), "?")) + ")");
                 params.addAll(criteria.getApiIds());
+            }
+            if (criteria.getApiProductIds() != null && !criteria.getApiProductIds().isEmpty()) {
+                clauses.add("api_product_id IN (" + String.join(",", Collections.nCopies(criteria.getApiProductIds().size(), "?")) + ")");
+                params.addAll(criteria.getApiProductIds());
             }
             if (hasText(criteria.getType())) {
                 try {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/07_add_api_product_id_to_portal_navigation_items.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/07_add_api_product_id_to_portal_navigation_items.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_07_add_api_product_id_to_portal_navigation_items
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}portal_navigation_items
+            columns:
+              - column:
+                  name: api_product_id
+                  type: nvarchar(64)
+                  constraints:
+                    nullable: true

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -399,3 +399,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_13_0/05_add_portal_categories_table.yml
     - include:
         - file: liquibase/changelogs/v4_13_0/06_add_idp_claims_to_users.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/07_add_api_product_id_to_portal_navigation_items.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNavigationItemRepository.java
@@ -128,6 +128,9 @@ public class MongoPortalNavigationItemRepository implements PortalNavigationItem
             if (criteria.getApiIds() != null && !criteria.getApiIds().isEmpty()) {
                 query.addCriteria(where("apiId").in(criteria.getApiIds()));
             }
+            if (criteria.getApiProductIds() != null && !criteria.getApiProductIds().isEmpty()) {
+                query.addCriteria(where("apiProductId").in(criteria.getApiProductIds()));
+            }
             if (hasText(criteria.getType())) {
                 try {
                     PortalNavigationItem.Type type = PortalNavigationItem.Type.valueOf(criteria.getType());

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalNavigationItemMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalNavigationItemMongo.java
@@ -41,4 +41,5 @@ public class PortalNavigationItemMongo {
     private boolean published;
     private PortalNavigationItem.Visibility visibility;
     private String apiId;
+    private String apiProductId;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
@@ -147,6 +147,43 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
     }
 
     @Test
+    public void should_create_update_and_delete_api_product_navigation_item() throws Exception {
+        PortalNavigationItem item = PortalNavigationItem.builder()
+            .id("new-api-product-nav-item")
+            .organizationId("org-1")
+            .environmentId("env-1")
+            .title("API Product")
+            .segment("api-product")
+            .type(PortalNavigationItem.Type.API_PRODUCT)
+            .apiProductId("00000000-0000-0000-0000-000000000020")
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(4)
+            .published(false)
+            .configuration("{}")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("new-api-product-nav-item")
+            .build();
+
+        try {
+            PortalNavigationItem created = portalNavigationItemRepository.create(item);
+            assertThat(created.getType()).isEqualTo(PortalNavigationItem.Type.API_PRODUCT);
+            assertThat(created.getApiProductId()).isEqualTo(item.getApiProductId());
+            assertThat(created.isPublished()).isFalse();
+
+            created.setTitle("Updated API Product");
+            PortalNavigationItem updated = portalNavigationItemRepository.update(created);
+            assertThat(updated.getTitle()).isEqualTo("Updated API Product");
+            assertThat(updated.getApiProductId()).isEqualTo(item.getApiProductId());
+
+            var found = portalNavigationItemRepository.findById(item.getId());
+            assertThat(found).isPresent();
+            assertThat(found.orElseThrow().getApiProductId()).isEqualTo(item.getApiProductId());
+        } finally {
+            portalNavigationItemRepository.delete(item.getId());
+        }
+    }
+
+    @Test
     public void should_find_all_navigation_items_for_parent_id_and_environment() throws Exception {
         List<PortalNavigationItem> items = portalNavigationItemRepository.findAllByParentIdAndEnvironmentId(
             "5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c",
@@ -609,6 +646,62 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
 
         assertThat(items).isEmpty();
+    }
+
+    @Test
+    public void should_search_by_type_and_api_product_ids() throws Exception {
+        PortalNavigationItem first = PortalNavigationItem.builder()
+            .id("api-product-search-1")
+            .organizationId("org-1")
+            .environmentId("env-api-product-search")
+            .title("First API Product")
+            .segment("first-api-product")
+            .type(PortalNavigationItem.Type.API_PRODUCT)
+            .apiProductId("00000000-0000-0000-0000-000000000021")
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(0)
+            .published(true)
+            .configuration("{}")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("api-product-search-1")
+            .build();
+        PortalNavigationItem second = PortalNavigationItem.builder()
+            .id("api-product-search-2")
+            .organizationId("org-1")
+            .environmentId("env-api-product-search")
+            .title("Second API Product")
+            .segment("second-api-product")
+            .type(PortalNavigationItem.Type.API_PRODUCT)
+            .apiProductId("00000000-0000-0000-0000-000000000022")
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(1)
+            .published(true)
+            .configuration("{}")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("api-product-search-2")
+            .build();
+
+        portalNavigationItemRepository.create(first);
+        portalNavigationItemRepository.create(second);
+        try {
+            PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+                .environmentId("env-api-product-search")
+                .type(PortalNavigationItem.Type.API_PRODUCT.name())
+                .apiProductIds(Set.of(first.getApiProductId()))
+                .build();
+
+            List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+            assertThat(items)
+                .singleElement()
+                .satisfies(item -> {
+                    assertThat(item.getType()).isEqualTo(PortalNavigationItem.Type.API_PRODUCT);
+                    assertThat(item.getApiProductId()).isEqualTo(first.getApiProductId());
+                });
+        } finally {
+            portalNavigationItemRepository.delete(first.getId());
+            portalNavigationItemRepository.delete(second.getId());
+        }
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
@@ -41,6 +41,7 @@ public interface PortalNavigationItemAdapter {
             case PAGE -> portalNavigationPageFromRepository(portalNavigationItem);
             case LINK -> portalNavigationLinkFromRepository(portalNavigationItem);
             case API -> portalNavigationApiFromRepository(portalNavigationItem);
+            case API_PRODUCT -> throw new IllegalStateException("API product navigation items are not supported by the REST domain");
         };
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
@@ -444,6 +444,7 @@ public class DeleteEnvironmentCommandHandlerTest {
                     "{\"portalPageContentId\":\"" + PAGE_CONTENT_ID + "\"}",
                     true,
                     PortalNavigationItem.Visibility.PUBLIC,
+                    null,
                     null
                 )
             )
@@ -675,6 +676,7 @@ public class DeleteEnvironmentCommandHandlerTest {
                     "{}",
                     true,
                     PortalNavigationItem.Visibility.PUBLIC,
+                    null,
                     null
                 )
             )


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-56

## Changes

- Add the `API_PRODUCT` repository navigation item type.
- Persist `apiProductId` in the repository model.
- Add filtering by API Product IDs to repository search criteria.
- Add JDBC mapping and a nullable `api_product_id` column through Liquibase.
- Add MongoDB document mapping and filtering.
- Add shared repository contract coverage for create, update, find, delete, and search operations.

No unique database index is introduced. Uniqueness will be enforced by the service layer in the follow-up REST/domain PR.

## Validation

- Repository formatting checks passed.
- Repository API, Test, JDBC, and MongoDB modules built successfully.
- Shared repository contract tests passed for JDBC and MongoDB.

## Follow-up

The REST and domain integration is provided in a stacked PR based on this branch.
