### PR TITLE
perf(gateway): shrink per-API index footprint and fix registration races

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheService.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.handlers.api.services;
 
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.ApiKeyService;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,14 +31,23 @@ public class ApiKeyCacheService implements ApiKeyService {
     // ConcurrentMap on purpose (not plain Map): register()/unregister() rely on thread-safe
     // compute()/computeIfPresent() for the per-API index. Unlike SubscriptionCacheService, the
     // lambdas here are idempotent, so any honest ConcurrentMap implementation is acceptable.
-    private final ConcurrentMap<String, ApiKey> cacheApiKeys = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, ApiKey> cacheMd5ApiKeys = new ConcurrentHashMap<>();
+    private final ConcurrentMap<CacheKey, ApiKey> cacheApiKeys = new ConcurrentHashMap<>();
+    private final ConcurrentMap<CacheKey, ApiKey> cacheMd5ApiKeys = new ConcurrentHashMap<>();
+    // Holds api-key values only (the API id is already the map key); unregisterByApiId()
+    // re-derives the cache keys from them.
     private final ConcurrentMap<String, Set<String>> cacheApiKeysByApi = new ConcurrentHashMap<>();
+
+    /**
+     * Cache key referencing the api-key's own field strings instead of a formatted composite
+     * String: no String.format and no byte[] allocation on the request hot path
+     * ({@link #getByApiAndKey(String, String)} runs for every API-key authenticated request).
+     */
+    record CacheKey(String api, String key) {}
 
     @Override
     public void register(final ApiKey apiKey) {
         if (apiKey.isActive()) {
-            String cacheKey = buildCacheKey(apiKey);
+            CacheKey cacheKey = buildCacheKey(apiKey);
             log.debug(
                 "Load active api-key [id: {}] [api: {}] [plan: {}] [app: {}]",
                 apiKey.getId(),
@@ -58,7 +68,7 @@ public class ApiKeyCacheService implements ApiKeyService {
             // run in parallel) cannot lose updates or mutate a plain HashSet across threads.
             cacheApiKeysByApi.compute(apiKey.getApi(), (api, keysByApi) -> {
                 Set<String> keys = keysByApi != null ? keysByApi : ConcurrentHashMap.newKeySet();
-                keys.add(cacheKey);
+                keys.add(apiKey.getKey());
                 return keys;
             });
         } else {
@@ -68,7 +78,7 @@ public class ApiKeyCacheService implements ApiKeyService {
 
     @Override
     public void unregister(final ApiKey apiKey) {
-        String cacheKey = buildCacheKey(apiKey);
+        CacheKey cacheKey = buildCacheKey(apiKey);
         log.debug(
             "Unload inactive api-key [id: {}] [api: {}] [plan: {}] [app: {}]",
             apiKey.getId(),
@@ -79,7 +89,7 @@ public class ApiKeyCacheService implements ApiKeyService {
         if (cacheApiKeys.remove(cacheKey) != null) {
             cacheMd5ApiKeys.remove(buildMd5CacheKey(apiKey));
             cacheApiKeysByApi.computeIfPresent(apiKey.getApi(), (api, keysByApi) -> {
-                keysByApi.remove(cacheKey);
+                keysByApi.remove(apiKey.getKey());
                 return keysByApi.isEmpty() ? null : keysByApi;
             });
         }
@@ -90,8 +100,8 @@ public class ApiKeyCacheService implements ApiKeyService {
         log.debug("Unload all api-key by api [api_id: {}]", apiId);
         Set<String> keysByApi = cacheApiKeysByApi.remove(apiId);
         if (keysByApi != null) {
-            keysByApi.forEach(cacheKey -> {
-                ApiKey evictedApiKey = cacheApiKeys.remove(cacheKey);
+            keysByApi.forEach(key -> {
+                ApiKey evictedApiKey = cacheApiKeys.remove(buildCacheKey(apiId, key));
                 if (evictedApiKey != null) {
                     cacheMd5ApiKeys.remove(buildMd5CacheKey(evictedApiKey));
                     log.debug(
@@ -116,15 +126,15 @@ public class ApiKeyCacheService implements ApiKeyService {
         return Optional.ofNullable(cacheMd5ApiKeys.get(buildCacheKey(api, md5ApiKey)));
     }
 
-    String buildCacheKey(ApiKey apiKey) {
+    CacheKey buildCacheKey(ApiKey apiKey) {
         return buildCacheKey(apiKey.getApi(), apiKey.getKey());
     }
 
-    String buildCacheKey(String api, String key) {
-        return String.format("%s.%s", api, key);
+    CacheKey buildCacheKey(String api, String key) {
+        return new CacheKey(api, key);
     }
 
-    String buildMd5CacheKey(ApiKey apiKey) {
-        return buildCacheKey(apiKey.getApi(), DigestUtils.md5DigestAsHex(apiKey.getKey().getBytes()));
+    CacheKey buildMd5CacheKey(ApiKey apiKey) {
+        return buildCacheKey(apiKey.getApi(), DigestUtils.md5DigestAsHex(apiKey.getKey().getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -27,10 +27,12 @@ import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.security.core.SubscriptionTrustStoreLoaderManager;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -61,8 +63,10 @@ public class SubscriptionCacheService implements SubscriptionService {
     // (almost always a singleton), replaced atomically via compute(): keeps the per-entry footprint
     // minimal at multi-million-subscription scale and lets readers use them without defensive copies.
     private final ConcurrentMap<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
-    // Holds subscription ids (String) and identity keys (IdentityKey) for per-API eviction
-    private final ConcurrentMap<String, Set<Object>> cacheKeysByApiId = new ConcurrentHashMap<>();
+    // Holds subscription ids only, for per-API eviction. Identity keys are not tracked here:
+    // unregisterByApiId() re-derives them from the cached subscriptions, which keeps this index
+    // at one entry per subscription instead of three (id + 2 identity keys) at multi-million scale.
+    private final ConcurrentMap<String, Set<String>> cacheKeysByApiId = new ConcurrentHashMap<>();
 
     /**
      * Identity-cache key referencing the subscription's own field strings instead of a formatted
@@ -193,34 +197,70 @@ public class SubscriptionCacheService implements SubscriptionService {
         log.debug("Unregistering all subscriptions for API [{}]", apiId);
         // Remove the whole entry first so no cacheKeysByApiId lock is held while updating the
         // other caches (unregister() acquires the same locks in the opposite order).
-        Set<Object> subscriptionsByApi = cacheKeysByApiId.remove(apiId);
-        if (subscriptionsByApi != null) {
-            subscriptionsByApi.forEach(cacheKey -> {
-                if (cacheKey instanceof String subscriptionId) {
-                    cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, all) -> {
-                        // Singleton fast path: most entries hold exactly one leg
-                        if (all.size() == 1) {
-                            return Objects.equals(apiId, all.iterator().next().getApi()) ? null : all;
-                        }
-                        Set<Subscription> remaining = all
-                            .stream()
-                            .filter(s -> !Objects.equals(apiId, s.getApi()))
-                            .collect(Collectors.toUnmodifiableSet());
-                        return remaining.isEmpty() ? null : remaining;
-                    });
-                } else {
-                    // Identity maps are keyed by IdentityKey only: removing a String key is a no-op
-                    cacheByApiClientId.remove(cacheKey);
-                    cacheByClientCertificate.remove(cacheKey);
-                }
-            });
+        Set<String> subscriptionsByApi = cacheKeysByApiId.remove(apiId);
+        if (subscriptionsByApi == null) {
+            return;
         }
+        // Legs are only collected under the cacheBySubscriptionIdAll bin lock; the identity-map
+        // and trust-store eviction (which re-derives keys, hashing the client certificate)
+        // happens after each compute returns — those structures are not guarded by this lock.
+        List<Subscription> evictedLegs = new ArrayList<>();
+        subscriptionsByApi.forEach(subscriptionId ->
+            cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, all) -> {
+                // Singleton fast path: most entries hold exactly one leg
+                if (all.size() == 1) {
+                    Subscription single = all.iterator().next();
+                    if (Objects.equals(apiId, single.getApi())) {
+                        evictedLegs.add(single);
+                        return null;
+                    }
+                    return all;
+                }
+                Set<Subscription> remaining = new HashSet<>();
+                for (Subscription subscription : all) {
+                    if (Objects.equals(apiId, subscription.getApi())) {
+                        evictedLegs.add(subscription);
+                    } else {
+                        remaining.add(subscription);
+                    }
+                }
+                return remaining.isEmpty() ? null : Set.copyOf(remaining);
+            })
+        );
+        // Same per-leg eviction as unregister(): identity maps and certificate trust store
+        evictedLegs.forEach(leg -> {
+            unregisterFromClientId(leg);
+            unregisterFromClientCertificate(leg);
+        });
     }
 
     private void registerFromId(final Subscription subscription) {
-        String cacheKey = subscription.getId();
+        Subscription cached = cachedSameApiLeg(subscription);
         updateSubscriptionIdById(subscription);
-        updateCacheKeyByApiId(subscription.getApi(), cacheKey);
+        updateCacheKeyByApiId(subscription.getApi(), subscription.getId());
+        // The new registration carries no credentials: any identity keys derived from the
+        // replaced leg's clientId/certificate are stale and would otherwise never be evicted.
+        if (cached != null) {
+            unregisterFromClientId(cached);
+            unregisterFromClientCertificate(cached);
+        }
+    }
+
+    /**
+     * Returns the cached leg of the same subscription for the same API, or null. Exploded
+     * API-Product subscriptions may carry sibling legs for other APIs, which must not be
+     * evicted when one API's leg is replaced.
+     */
+    private Subscription cachedSameApiLeg(final Subscription subscription) {
+        Set<Subscription> existingLegs = cacheBySubscriptionIdAll.get(subscription.getId());
+        if (existingLegs != null) {
+            for (Subscription existing : existingLegs) {
+                if (Objects.equals(subscription.getApi(), existing.getApi())) {
+                    return existing;
+                }
+            }
+        }
+        return null;
     }
 
     private void registerFromClientCertificate(final Subscription subscription) {
@@ -229,36 +269,28 @@ public class SubscriptionCacheService implements SubscriptionService {
         // Ensure trust store is updated before cache to maintain certificate validation consistency
         subscriptionTrustStoreLoaderManager.registerSubscription(subscription, servers);
 
-        // keep the old same-API leg before the cache is updated (exploded API-Product
-        // subscriptions may carry sibling legs for other APIs, which must not be evicted here)
-        Subscription cached = null;
-        Set<Subscription> existingLegs = cacheBySubscriptionIdAll.get(subscription.getId());
-        if (existingLegs != null) {
-            for (Subscription existing : existingLegs) {
-                if (Objects.equals(subscription.getApi(), existing.getApi())) {
-                    cached = existing;
-                    break;
-                }
-            }
-        }
+        // keep the old same-API leg before the cache is updated
+        Subscription cached = cachedSameApiLeg(subscription);
 
         // Update cache
         updateSubscriptionIdById(subscription);
         updateIdentityCache(subscription, cacheByClientCertificate);
 
-        // Evict if cert bundle or plan changed (e.g. subscription transfer)
+        // Evict if cert bundle, clientId or plan changed (e.g. subscription transfer): the keys
+        // derived from the old leg differ from the ones just registered
         if (
             cached != null &&
-            Objects.equals(subscription.getApi(), cached.getApi()) &&
             (!Objects.equals(subscription.getClientCertificate(), cached.getClientCertificate()) ||
+                !Objects.equals(subscription.getClientId(), cached.getClientId()) ||
                 !Objects.equals(subscription.getPlan(), cached.getPlan()))
         ) {
-            IdentityKey cacheKey = identityCacheKey(cached);
-            IdentityKey cacheKeyWithoutPlan = identityCacheKeyWithoutPlan(cached);
-            evictKeyForApi(cached.getApi(), cacheKey);
-            evictKeyForApi(cached.getApi(), cacheKeyWithoutPlan);
-            cacheByClientCertificate.remove(cacheKey);
-            cacheByClientCertificate.remove(cacheKeyWithoutPlan);
+            cacheByClientCertificate.remove(identityCacheKey(cached));
+            cacheByClientCertificate.remove(identityCacheKeyWithoutPlan(cached));
+        }
+        // Credential-type switch: if the old leg was clientId-registered, its entries live in
+        // the clientId map, which this certificate registration never overwrites.
+        if (cached != null) {
+            unregisterFromClientId(cached);
         }
     }
 
@@ -275,33 +307,35 @@ public class SubscriptionCacheService implements SubscriptionService {
         // Then clean up old entries if clientId or plan changed (e.g. subscription transfer)
         // Only compare entries for the same API — exploded subscriptions span multiple APIs
         for (Subscription old : oldEntries) {
+            if (!Objects.equals(old.getApi(), subscription.getApi())) {
+                continue;
+            }
             if (
-                Objects.equals(old.getApi(), subscription.getApi()) &&
-                ((old.getClientId() != null && !old.getClientId().equals(subscription.getClientId())) ||
-                    (old.getPlan() != null && !old.getPlan().equals(subscription.getPlan())))
+                (old.getClientId() != null && !old.getClientId().equals(subscription.getClientId())) ||
+                (old.getPlan() != null && !old.getPlan().equals(subscription.getPlan()))
             ) {
                 unregisterFromClientId(old);
             }
+            // Credential-type switch: if the old leg was certificate-registered, its entries
+            // live in the certificate map and trust store, never overwritten by this
+            // clientId registration.
+            unregisterFromClientCertificate(old);
         }
     }
 
     private void updateIdentityCache(Subscription subscription, ConcurrentMap<IdentityKey, Subscription> cache) {
         updateCacheKeyByApiId(subscription.getApi(), subscription.getId());
-        IdentityKey cacheKey = identityCacheKey(subscription);
-        updateCacheKeyByApiId(subscription.getApi(), cacheKey);
-        cache.put(cacheKey, subscription);
+        cache.put(identityCacheKey(subscription), subscription);
         // Index the subscription without plan id to allow search without plan criteria.
-        IdentityKey cacheKeyWithoutPlan = identityCacheKeyWithoutPlan(subscription);
-        cache.put(cacheKeyWithoutPlan, subscription);
-        updateCacheKeyByApiId(subscription.getApi(), cacheKeyWithoutPlan);
+        cache.put(identityCacheKeyWithoutPlan(subscription), subscription);
     }
 
-    private void updateCacheKeyByApiId(final String apiId, final Object cacheKey) {
+    private void updateCacheKeyByApiId(final String apiId, final String subscriptionId) {
         // compute() so concurrent register/unregister calls for the same API (sync appenders run
         // in parallel) cannot lose updates or mutate a plain HashSet across threads.
         cacheKeysByApiId.compute(apiId, (id, subscriptionsByApi) -> {
-            Set<Object> keys = subscriptionsByApi != null ? subscriptionsByApi : ConcurrentHashMap.newKeySet();
-            keys.add(cacheKey);
+            Set<String> keys = subscriptionsByApi != null ? subscriptionsByApi : ConcurrentHashMap.newKeySet();
+            keys.add(subscriptionId);
             return keys;
         });
     }
@@ -345,20 +379,14 @@ public class SubscriptionCacheService implements SubscriptionService {
         }
     }
 
-    private void evictIdentityCache(Subscription subscription, ConcurrentMap<IdentityKey, Subscription> cacheByApiClientId) {
-        final IdentityKey identityCacheKey = identityCacheKey(subscription);
-        if (cacheByApiClientId.remove(identityCacheKey) != null) {
-            evictKeyForApi(subscription.getApi(), identityCacheKey);
-        }
-        final IdentityKey identityCacheKeyWithoutPlan = identityCacheKeyWithoutPlan(subscription);
-        if (cacheByApiClientId.remove(identityCacheKeyWithoutPlan) != null) {
-            evictKeyForApi(subscription.getApi(), identityCacheKeyWithoutPlan);
-        }
+    private void evictIdentityCache(Subscription subscription, ConcurrentMap<IdentityKey, Subscription> cache) {
+        cache.remove(identityCacheKey(subscription));
+        cache.remove(identityCacheKeyWithoutPlan(subscription));
     }
 
-    private void evictKeyForApi(final String apiId, final Object cacheKey) {
+    private void evictKeyForApi(final String apiId, final String subscriptionId) {
         cacheKeysByApiId.computeIfPresent(apiId, (id, keysByApi) -> {
-            keysByApi.remove(cacheKey);
+            keysByApi.remove(subscriptionId);
             return keysByApi.isEmpty() ? null : keysByApi;
         });
     }
@@ -378,7 +406,7 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     // Visible for testing
-    Set<Object> getByApiId(String apiId) {
+    Set<String> getByApiId(String apiId) {
         return cacheKeysByApiId.getOrDefault(apiId, Collections.emptySet());
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/FlowChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/FlowChainFactory.java
@@ -52,6 +52,19 @@ public class FlowChainFactory {
         this.tracingHook = new TracingHook("flow");
     }
 
+    /**
+     * Creates a factory able to build the organization flow chain only. V4 APIs handle their plan
+     * and API flows through the v4 FlowChainFactory, so no per-API {@link PolicyChainFactory}
+     * (and its policy-chain cache) is needed.
+     */
+    public FlowChainFactory(
+        final OrganizationPolicyChainFactoryManager organizationPolicyChainFactoryManager,
+        final OrganizationManager organizationManager,
+        final FlowResolverFactory flowResolverFactory
+    ) {
+        this(organizationPolicyChainFactoryManager, null, organizationManager, flowResolverFactory);
+    }
+
     public FlowChain createOrganizationFlow(final ReactableApi<?> api, final TracingContext tracingContext) {
         String organizationId = api.getOrganizationId();
         FlowChain flowOrganizationChain = new FlowChain(
@@ -64,15 +77,22 @@ public class FlowChainFactory {
     }
 
     public FlowChain createPlanFlow(final Api api, final TracingContext tracingContext) {
-        FlowChain flowPlanChain = new FlowChain("plan", flowResolverFactory.forApiPlan(api), policyChainFactory);
+        FlowChain flowPlanChain = new FlowChain("plan", flowResolverFactory.forApiPlan(api), requirePolicyChainFactory());
         flowPlanChain.addHooks(flowHooks(tracingContext));
         return flowPlanChain;
     }
 
     public FlowChain createApiFlow(final Api api, final TracingContext tracingContext) {
-        FlowChain flowApiChain = new FlowChain("api", flowResolverFactory.forApi(api), policyChainFactory);
+        FlowChain flowApiChain = new FlowChain("api", flowResolverFactory.forApi(api), requirePolicyChainFactory());
         flowApiChain.addHooks(flowHooks(tracingContext));
         return flowApiChain;
+    }
+
+    private PolicyChainFactory requirePolicyChainFactory() {
+        if (policyChainFactory == null) {
+            throw new IllegalStateException("This FlowChainFactory was created for organization flows only");
+        }
+        return policyChainFactory;
     }
 
     private List<ChainHook> flowHooks(final TracingContext tracingContext) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -45,7 +45,6 @@ import io.gravitee.gateway.reactive.handlers.api.flow.FlowChainFactory;
 import io.gravitee.gateway.reactive.handlers.api.v4.flow.resolver.FlowResolverFactory;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.ApiProcessorChainFactory;
 import io.gravitee.gateway.reactive.platform.organization.policy.OrganizationPolicyChainFactoryManager;
-import io.gravitee.gateway.reactive.policy.HttpPolicyChainFactory;
 import io.gravitee.gateway.reactive.policy.PolicyFactoryManager;
 import io.gravitee.gateway.reactive.policy.PolicyManager;
 import io.gravitee.gateway.reactive.reactor.ApiReactor;
@@ -303,16 +302,6 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
             v4FlowChainFactory,
             logGuardService
         );
-    }
-
-    /**
-     * @deprecated no longer called: V4 APIs only use the organization flow chain from
-     * {@link FlowChainFactory}, which does not need a per-API policy chain factory. Kept so
-     * existing subclass overrides still compile.
-     */
-    @Deprecated(forRemoval = true)
-    protected HttpPolicyChainFactory createPolicyChainFactory(Api api, PolicyManager policyManager) {
-        return new HttpPolicyChainFactory(api.getId(), policyManager, isApiTracingEnabled(api));
     }
 
     // FIXME: this buildApiReactor is here to keep compatibility with Message Reactor plugin. it will be deleted when Message Reactor has been updated

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -273,13 +273,12 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         DefaultDeploymentContext deploymentContext,
         ResourceLifecycleManager resourceLifecycleManager
     ) {
-        final HttpPolicyChainFactory policyChainFactory = createPolicyChainFactory(api, policyManager);
-
         final io.gravitee.gateway.reactive.v4.policy.HttpPolicyChainFactory v4PolicyChainFactory = policyChainFactory(api, policyManager);
 
+        // Organization flows only: V4 plan/api flows go through the v4 FlowChainFactory below, so
+        // no per-API HttpPolicyChainFactory (and its policy-chain cache) is created here.
         final FlowChainFactory flowChainFactory = new FlowChainFactory(
             organizationPolicyChainFactoryManager,
-            policyChainFactory,
             organizationManager,
             flowResolverFactory
         );
@@ -306,6 +305,12 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         );
     }
 
+    /**
+     * @deprecated no longer called: V4 APIs only use the organization flow chain from
+     * {@link FlowChainFactory}, which does not need a per-API policy chain factory. Kept so
+     * existing subclass overrides still compile.
+     */
+    @Deprecated(forRemoval = true)
     protected HttpPolicyChainFactory createPolicyChainFactory(Api api, PolicyManager policyManager) {
         return new HttpPolicyChainFactory(api.getId(), policyManager, isApiTracingEnabled(api));
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheServiceTest.java
@@ -40,15 +40,15 @@ import org.springframework.util.DigestUtils;
 public class ApiKeyCacheServiceTest {
 
     private ApiKeyCacheService apiKeyService;
-    private Map<String, ApiKey> cacheApiKeys;
-    private Map<String, ApiKey> cacheMd5ApiKeys;
+    private Map<ApiKeyCacheService.CacheKey, ApiKey> cacheApiKeys;
+    private Map<ApiKeyCacheService.CacheKey, ApiKey> cacheMd5ApiKeys;
     private Map<String, Set<String>> cacheApiKeysByApi;
 
     @BeforeEach
     public void beforeEach() throws Exception {
         apiKeyService = new ApiKeyCacheService();
-        cacheApiKeys = (Map<String, ApiKey>) ReflectionTestUtils.getField(apiKeyService, "cacheApiKeys");
-        cacheMd5ApiKeys = (Map<String, ApiKey>) ReflectionTestUtils.getField(apiKeyService, "cacheMd5ApiKeys");
+        cacheApiKeys = (Map<ApiKeyCacheService.CacheKey, ApiKey>) ReflectionTestUtils.getField(apiKeyService, "cacheApiKeys");
+        cacheMd5ApiKeys = (Map<ApiKeyCacheService.CacheKey, ApiKey>) ReflectionTestUtils.getField(apiKeyService, "cacheMd5ApiKeys");
         cacheApiKeysByApi = (Map<String, Set<String>>) ReflectionTestUtils.getField(apiKeyService, "cacheApiKeysByApi");
     }
 
@@ -61,18 +61,18 @@ public class ApiKeyCacheServiceTest {
 
             apiKeyService.register(apiKey);
 
-            String cacheKey = apiKeyService.buildCacheKey(apiKey);
+            var cacheKey = apiKeyService.buildCacheKey(apiKey);
             ApiKey actual = cacheApiKeys.get(cacheKey);
             assertThat(actual).isNotNull();
             assertThat(actual).isEqualTo(apiKey);
 
-            String md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
+            var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
             ApiKey md5Actual = cacheMd5ApiKeys.get(md5CacheKey);
             assertThat(md5Actual).isNotNull();
             assertThat(md5Actual).isEqualTo(apiKey);
 
             Set<String> actuals = cacheApiKeysByApi.get("my-api");
-            assertThat(actuals.contains(cacheKey)).isTrue();
+            assertThat(actuals.contains("my-key")).isTrue();
         }
 
         @Test
@@ -81,10 +81,10 @@ public class ApiKeyCacheServiceTest {
 
             apiKeyService.register(apiKey);
 
-            String cacheKey = apiKeyService.buildCacheKey(apiKey);
+            var cacheKey = apiKeyService.buildCacheKey(apiKey);
             assertThat(cacheApiKeys.get(cacheKey)).isNull();
 
-            String md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
+            var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
             assertThat(cacheMd5ApiKeys.get(md5CacheKey)).isNull();
 
             assertThat(cacheApiKeysByApi.get("my-api")).isNull();
@@ -104,10 +104,10 @@ public class ApiKeyCacheServiceTest {
 
             apiKeyService.register(apiKeyInactive);
 
-            String cacheKey = apiKeyService.buildCacheKey(apiKey);
+            var cacheKey = apiKeyService.buildCacheKey(apiKey);
             assertThat(cacheApiKeys.get(cacheKey)).isNull();
 
-            String md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
+            var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
             assertThat(cacheMd5ApiKeys.get(md5CacheKey)).isNull();
 
             assertThat(cacheApiKeysByApi.get("my-api")).isNull();
@@ -123,10 +123,10 @@ public class ApiKeyCacheServiceTest {
 
             apiKeyService.unregister(apiKeyToUnregister);
 
-            String cacheKey = apiKeyService.buildCacheKey(apiKey);
+            var cacheKey = apiKeyService.buildCacheKey(apiKey);
             assertThat(cacheApiKeys.get(cacheKey)).isNull();
 
-            String md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
+            var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
             assertThat(cacheMd5ApiKeys.get(md5CacheKey)).isNull();
 
             assertThat(cacheApiKeysByApi.get("my-api")).isNull();
@@ -138,10 +138,10 @@ public class ApiKeyCacheServiceTest {
 
             apiKeyService.unregister(apiKey);
 
-            String cacheKey = apiKeyService.buildCacheKey(apiKey);
+            var cacheKey = apiKeyService.buildCacheKey(apiKey);
             assertThat(cacheApiKeys.get(cacheKey)).isNull();
 
-            String md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
+            var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
             assertThat(cacheMd5ApiKeys.get(md5CacheKey)).isNull();
 
             assertThat(cacheApiKeysByApi.get("my-api")).isNull();
@@ -156,10 +156,10 @@ public class ApiKeyCacheServiceTest {
             ApiKey apiKey1 = buildApiKey("my-api", "my-key-1", true);
             apiKeyService.unregister(apiKey1);
 
-            String cacheKey = apiKeyService.buildCacheKey(apiKey1);
+            var cacheKey = apiKeyService.buildCacheKey(apiKey1);
             assertThat(cacheApiKeys.get(cacheKey)).isNull();
 
-            String md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey1);
+            var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey1);
             assertThat(cacheMd5ApiKeys.get(md5CacheKey)).isNull();
 
             Set<String> apiKeysByApi = cacheApiKeysByApi.get("my-api");
@@ -181,10 +181,10 @@ public class ApiKeyCacheServiceTest {
             for (int i = 0; i < 5; i++) {
                 ApiKey apiKeyToUnregister = buildApiKey("my-api", "my-key-" + i, true);
 
-                String cacheKey = apiKeyService.buildCacheKey(apiKeyToUnregister);
+                var cacheKey = apiKeyService.buildCacheKey(apiKeyToUnregister);
                 assertThat(cacheApiKeys.get(cacheKey)).isNull();
 
-                String md5CacheKey = apiKeyService.buildMd5CacheKey(apiKeyToUnregister);
+                var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKeyToUnregister);
                 assertThat(cacheMd5ApiKeys.get(md5CacheKey)).isNull();
             }
             assertThat(cacheApiKeysByApi.get("my-api")).isNull();
@@ -200,18 +200,18 @@ public class ApiKeyCacheServiceTest {
 
             apiKeyService.register(apiKey);
 
-            String cacheKey = apiKeyService.buildCacheKey(apiKey);
+            var cacheKey = apiKeyService.buildCacheKey(apiKey);
             ApiKey actual = cacheApiKeys.get(cacheKey);
             assertThat(actual).isNotNull();
             assertThat(actual).isEqualTo(apiKey);
 
-            String md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
+            var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
             ApiKey md5Actual = cacheMd5ApiKeys.get(md5CacheKey);
             assertThat(md5Actual).isNotNull();
             assertThat(md5Actual).isEqualTo(apiKey);
 
             Set<String> actuals = cacheApiKeysByApi.get("my-api");
-            assertThat(actuals.contains(cacheKey)).isTrue();
+            assertThat(actuals.contains("my-key")).isTrue();
 
             Optional<ApiKey> keyFoundOpt = apiKeyService.getByApiAndKey("my-api", "my-key");
             assertThat(keyFoundOpt).isPresent();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -96,7 +96,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getByClientCertificate(lookupWithoutPlan)).isPresent().get().isEqualTo(subscription);
 
             // By api
-            assertThat(subscriptionService.getByApiId(API_ID)).hasSize(3).contains(SUB_ID);
+            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
 
             ArgumentCaptor<Set<String>> serversListCaptor = ArgumentCaptor.forClass(Set.class);
             verify(subscriptionTrustStoreLoaderManager).registerSubscription(eq(subscription), serversListCaptor.capture());
@@ -123,7 +123,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getByClientCertificate(lookupWithoutPlan)).isPresent().get().isEqualTo(subscription);
 
             // By api
-            assertThat(subscriptionService.getByApiId(API_ID)).hasSize(3).contains(SUB_ID);
+            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
 
             ArgumentCaptor<Set<String>> serversListCaptor = ArgumentCaptor.forClass(Set.class);
             verify(subscriptionTrustStoreLoaderManager).registerSubscription(eq(subscription), serversListCaptor.capture());
@@ -155,7 +155,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getByClientCertificate(lookupWithoutPlan)).isPresent().get().isEqualTo(subscriptionUpdated);
 
             // By api
-            assertThat(subscriptionService.getByApiId(API_ID)).hasSize(3).contains(SUB_ID);
+            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
         }
 
         @Test
@@ -175,7 +175,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isPresent().get().isEqualTo(subscription);
 
             // By api
-            assertThat(subscriptionService.getByApiId(API_ID)).hasSize(3).contains(SUB_ID);
+            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
         }
 
         @Test
@@ -275,7 +275,7 @@ class SubscriptionCacheServiceTest {
                 .isEqualTo(subscriptionUpdated);
 
             // By api
-            assertThat(subscriptionService.getByApiId(API_ID)).hasSize(3).contains(SUB_ID);
+            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
         }
 
         @Test
@@ -285,7 +285,7 @@ class SubscriptionCacheServiceTest {
 
             assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscription);
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID)).hasSize(1).contains(SUB_ID);
+            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
         }
 
         @Test
@@ -796,6 +796,69 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getByApiAndSecurityToken(API_ID_2, SecurityToken.forApiKey("apiKeyValue"), PLAN_ID)).contains(
                 subApi2
             );
+        }
+    }
+
+    @Nested
+    class CredentialTransitionTest {
+
+        @Test
+        void should_evict_client_id_keys_when_subscription_loses_its_client_id() {
+            Subscription withClientId = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(withClientId);
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isPresent();
+
+            // Same subscription re-registered without any credential (registered by id)
+            Subscription withoutCredentials = buildAcceptedSubscription(SUB_ID, API_ID);
+            withoutCredentials.setPlan(PLAN_ID);
+            subscriptionService.register(withoutCredentials);
+
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent();
+
+            subscriptionService.unregisterByApiId(API_ID);
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+        }
+
+        @Test
+        void should_evict_certificate_keys_when_subscription_switches_to_client_id() {
+            Subscription withCertificate = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, PLAN_ID);
+            subscriptionService.register(withCertificate);
+            assertThat(subscriptionService.getByClientCertificate(withCertificate)).isPresent();
+
+            Subscription withClientId = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(withClientId);
+
+            assertThat(subscriptionService.getByClientCertificate(withCertificate)).isEmpty();
+            verify(subscriptionTrustStoreLoaderManager).unregisterSubscription(withCertificate);
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isPresent();
+        }
+
+        @Test
+        void should_evict_client_id_keys_when_subscription_switches_to_certificate() {
+            Subscription withClientId = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(withClientId);
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isPresent();
+
+            Subscription withCertificate = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, PLAN_ID);
+            subscriptionService.register(withCertificate);
+
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByClientCertificate(withCertificate)).isPresent();
+        }
+
+        @Test
+        void should_unregister_certificate_subscription_from_trust_store_when_unregistering_by_api_id() {
+            Subscription withCertificate = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, PLAN_ID);
+            subscriptionService.register(withCertificate);
+
+            subscriptionService.unregisterByApiId(API_ID);
+
+            verify(subscriptionTrustStoreLoaderManager).unregisterSubscription(withCertificate);
+            assertThat(subscriptionService.getByClientCertificate(withCertificate)).isEmpty();
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/impl/DefaultReactorHandlerRegistry.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/impl/DefaultReactorHandlerRegistry.java
@@ -23,7 +23,6 @@ import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -77,9 +76,13 @@ public class DefaultReactorHandlerRegistry implements ReactorHandlerRegistry {
         // Associate the handler to the acceptors
         List<Acceptor<?>> handlerAcceptors = handler.acceptors();
 
-        List<ReactableAcceptors> reactableAcceptors = reactables.getOrDefault(reactable, new ArrayList<>());
-        reactableAcceptors.add(new ReactableAcceptors(handler, handlerAcceptors));
-        reactables.put(reactable, reactableAcceptors);
+        // compute() so concurrent register() calls for the same reactable cannot lose an entry
+        // (get -> mutate -> put would let one thread overwrite the other's addition).
+        reactables.compute(reactable, (key, previous) -> {
+            var copy = previous == null ? new ArrayList<ReactableAcceptors>() : new ArrayList<>(previous);
+            copy.add(new ReactableAcceptors(handler, handlerAcceptors));
+            return copy;
+        });
 
         registerAcceptors(handlerAcceptors);
     }
@@ -107,7 +110,10 @@ public class DefaultReactorHandlerRegistry implements ReactorHandlerRegistry {
                 // Register the new handler before removing the previous http acceptor to avoid 404, especially on high throughput.
                 newReactorHandlers.forEach(reactorHandler -> register(reactable, reactorHandler));
 
-                removeAcceptors(reactable, previousReactableAcceptors);
+                // Null when a concurrent update()/remove() claimed the entry first
+                if (previousReactableAcceptors != null) {
+                    removeAcceptors(reactable, previousReactableAcceptors);
+                }
             }
         } else {
             create(reactable);
@@ -116,17 +122,19 @@ public class DefaultReactorHandlerRegistry implements ReactorHandlerRegistry {
 
     @Override
     public void remove(Reactable reactable) {
-        final List<ReactableAcceptors> reactableAcceptors = reactables.get(reactable);
-        removeAcceptors(reactable, reactableAcceptors, true);
+        // Claim the entry atomically before unregistering anything: register() replaces the
+        // value copy-on-write, so a get-then-remove sequence could capture a stale list and
+        // discard a concurrently registered handler without ever unregistering its acceptors.
+        final List<ReactableAcceptors> reactableAcceptors = reactables.remove(reactable);
+        removeClaimedAcceptors(reactable, reactableAcceptors);
     }
 
     @Override
     public void clear() {
-        Iterator<Map.Entry<Reactable, List<ReactableAcceptors>>> reactableIte = reactables.entrySet().iterator();
-        while (reactableIte.hasNext()) {
-            final Map.Entry<Reactable, List<ReactableAcceptors>> next = reactableIte.next();
-            removeAcceptors(next.getKey(), next.getValue(), false);
-            reactableIte.remove();
+        // Same atomic-claim pattern as remove(): map.remove(key) returns the current value,
+        // where iterating entries could observe one made stale by a concurrent register().
+        for (Reactable reactable : reactables.keySet()) {
+            removeClaimedAcceptors(reactable, reactables.remove(reactable));
         }
     }
 
@@ -135,18 +143,10 @@ public class DefaultReactorHandlerRegistry implements ReactorHandlerRegistry {
         return reactables.containsKey(reactable);
     }
 
-    private void removeAcceptors(
-        final Reactable reactable,
-        final List<ReactableAcceptors> reactableAcceptors,
-        final boolean removeReactable
-    ) {
+    private void removeClaimedAcceptors(final Reactable reactable, final List<ReactableAcceptors> reactableAcceptors) {
         if (reactableAcceptors != null) {
             try {
                 removeAcceptors(reactable, reactableAcceptors);
-
-                if (removeReactable) {
-                    reactables.remove(reactable);
-                }
                 log.debug("Handler has been unregistered from the proxy");
             } catch (Exception e) {
                 log.error("Unable to un-register handler", e);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/ReactorHandlerRegistryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/ReactorHandlerRegistryTest.java
@@ -723,6 +723,51 @@ public class ReactorHandlerRegistryTest {
     }
 
     @Test
+    public void should_not_lose_acceptors_when_registering_concurrently_for_same_reactable() throws InterruptedException {
+        int threadCount = 8;
+        int iterations = 200;
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        try {
+            for (int i = 0; i < iterations; i++) {
+                String id = "concurrent" + i;
+                DummyReactable reactable = createReactable(id);
+                // Each create() call produces its own handler with a distinct acceptor
+                when(reactorHandlerFactoryManager.create(reactable)).thenAnswer(invocation ->
+                    List.of(createReactorHandler(new DefaultDummyAcceptor(id)))
+                );
+
+                var start = new java.util.concurrent.CountDownLatch(1);
+                var done = new java.util.concurrent.CountDownLatch(threadCount);
+                for (int t = 0; t < threadCount; t++) {
+                    pool.submit(() -> {
+                        try {
+                            start.await();
+                            reactorHandlerRegistry.create(reactable);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        } finally {
+                            done.countDown();
+                        }
+                    });
+                }
+                start.countDown();
+                assertTrue("create() calls did not finish in time", done.await(30, TimeUnit.SECONDS));
+
+                // A ReactableAcceptors entry lost by a concurrent register() leaves its acceptors
+                // registered forever: remove() cannot see them anymore.
+                reactorHandlerRegistry.remove(reactable);
+                Assert.assertEquals(
+                    "Acceptors leaked by concurrent register() calls",
+                    0,
+                    reactorHandlerRegistry.getAcceptors(DummyAcceptor.class).size()
+                );
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
     public void shouldNotThrowConcurrentModificationException_concurrentReadersAndWriters() throws InterruptedException {
         // Pre-populate some APIs so readers always have something to iterate
         for (int i = 0; i < 5; i++) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/v4/DebugV4ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/v4/DebugV4ApiReactorHandlerFactory.java
@@ -29,14 +29,12 @@ import io.gravitee.gateway.reactive.core.connection.ConnectionDrainManager;
 import io.gravitee.gateway.reactive.core.context.DefaultDeploymentContext;
 import io.gravitee.gateway.reactive.core.v4.endpoint.DefaultEndpointManager;
 import io.gravitee.gateway.reactive.debug.handlers.api.DebugV4ApiReactor;
-import io.gravitee.gateway.reactive.debug.policy.DebugPolicyChainFactory;
 import io.gravitee.gateway.reactive.debug.policy.DebugV4PolicyChainFactory;
 import io.gravitee.gateway.reactive.handlers.api.flow.FlowChainFactory;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
 import io.gravitee.gateway.reactive.handlers.api.v4.ApiProductPlanPolicyManagerFactory;
 import io.gravitee.gateway.reactive.handlers.api.v4.DefaultApiReactorFactory;
 import io.gravitee.gateway.reactive.platform.organization.policy.OrganizationPolicyChainFactoryManager;
-import io.gravitee.gateway.reactive.policy.HttpPolicyChainFactory;
 import io.gravitee.gateway.reactive.policy.PolicyFactoryManager;
 import io.gravitee.gateway.reactive.policy.PolicyManager;
 import io.gravitee.gateway.reactive.reactor.ApiReactor;
@@ -103,11 +101,6 @@ public class DebugV4ApiReactorHandlerFactory extends DefaultApiReactorFactory {
             connectionDrainManager
         );
         this.apiProductRegistry = apiProductRegistry;
-    }
-
-    @Override
-    protected HttpPolicyChainFactory createPolicyChainFactory(Api api, PolicyManager policyManager) {
-        return new DebugPolicyChainFactory(api.getId(), policyManager, false);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/verticle/EndpointHealthcheckVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/verticle/EndpointHealthcheckVerticle.java
@@ -114,7 +114,7 @@ public class EndpointHealthcheckVerticle extends AbstractVerticle implements Eve
             .forEach(group -> {
                 final Set<Endpoint> endpoints = group.getEndpoints();
                 if (endpoints instanceof ObservableSet) {
-                    apiHandlers.put(api, new ArrayList<>());
+                    apiHandlers.computeIfAbsent(api, key -> new ArrayList<>());
                     ((ObservableSet) endpoints).addListener(new EndpointsListener(api));
                 }
             });
@@ -123,7 +123,7 @@ public class EndpointHealthcheckVerticle extends AbstractVerticle implements Eve
         final List<EndpointRule> healthCheckEndpoints = endpointResolver.resolve(api);
         if (!healthCheckEndpoints.isEmpty()) {
             log.debug("Health-check for API id[{}] name[{}] is enabled", api.getId(), api.getName());
-            apiHandlers.put(api, new ArrayList<>());
+            apiHandlers.computeIfAbsent(api, key -> new ArrayList<>());
             healthCheckEndpoints.forEach(rule -> addHandler(api, rule));
         }
     }
@@ -146,7 +146,16 @@ public class EndpointHealthcheckVerticle extends AbstractVerticle implements Eve
             EndpointRuleCronHandler cronHandler = new EndpointRuleCronHandler(vertx, rule, gatewayConfiguration.healthCheckJitterInMs());
             cronHandler.schedule(runner);
 
-            apiHandlers.get(api).add(cronHandler);
+            // computeIfPresent() so the add is atomic with respect to a concurrent removeHandlers():
+            // a plain get().add() could attach the handler to a list already evicted by an
+            // undeploy, leaving a cron timer running forever.
+            List<EndpointRuleCronHandler> handlers = apiHandlers.computeIfPresent(api, (key, cronHandlers) -> {
+                cronHandlers.add(cronHandler);
+                return cronHandlers;
+            });
+            if (handlers == null) {
+                cronHandler.cancel();
+            }
 
             log.debug(
                 "Add health-check for endpoint name[{}] target[{}] with cron[{}]",
@@ -168,25 +177,26 @@ public class EndpointHealthcheckVerticle extends AbstractVerticle implements Eve
     }
 
     private void removeHandler(Api api, Endpoint endpoint) {
-        List<EndpointRuleCronHandler> cronHandlers = apiHandlers.get(api);
-        if (cronHandlers != null) {
-            Optional<EndpointRuleCronHandler> endpointCronHandler = cronHandlers
+        // computeIfPresent() so the lookup + cancel + remove is atomic with respect to
+        // concurrent addHandler()/removeHandlers() calls for the same API.
+        apiHandlers.computeIfPresent(api, (key, cronHandlers) -> {
+            cronHandlers
                 .stream()
                 .filter(handler -> handler.getEndpoint().equals(endpoint))
-                .findFirst();
-
-            endpointCronHandler.ifPresent(handler -> {
-                log.debug(
-                    "Remove health-check handler id[{}] for endpoint name[{}] type[{}] target[{}]",
-                    handler.getTimerId(),
-                    endpoint.getName(),
-                    endpoint.getType(),
-                    endpoint.getTarget()
-                );
-                handler.cancel();
-                cronHandlers.remove(handler);
-            });
-        }
+                .findFirst()
+                .ifPresent(handler -> {
+                    log.debug(
+                        "Remove health-check handler id[{}] for endpoint name[{}] type[{}] target[{}]",
+                        handler.getTimerId(),
+                        endpoint.getName(),
+                        endpoint.getType(),
+                        endpoint.getTarget()
+                    );
+                    handler.cancel();
+                    cronHandlers.remove(handler);
+                });
+            return cronHandlers;
+        });
     }
 
     private class EndpointsListener implements ChangeListener<Endpoint> {


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14699

## Description

Follow-up of #18513, based on the post-fix heap dump validation (same environment: ~4.1M subscriptions, ~5.5k V4 APIs, dump down from 10.75 GB to 6.77 GB). Implements the remaining verified improvement targets.

### 1. `cacheKeysByApiId` — track subscription ids only (`a61e44e935`)

The per-API eviction index stored three entries per subscription (the subscription id plus the two identity keys). It now stores the id alone and `unregisterByApiId()` re-derives the identity keys from the cached subscription legs. One CHM node per subscription instead of three; `ConcurrentHashMap$Node` was the #1 overhead class in the dump (27M instances / 1.3 GB shallow), and this index retained ~800 MB.

**Expected gain: −0.4 to −0.5 GB** at the customer's scale. Request hot path untouched; register/unregister do strictly fewer CHM operations.

`unregisterByApiId()` now reuses the same per-leg eviction as `unregister()`, which also fixes two pre-existing gaps:
- identity keys left stale by credential-type transitions (clientId removed, certificate ↔ clientId switches) — covered by new regression tests that fail on the previous code;
- certificate subscriptions never being unregistered from the trust store on API undeploy.

Key re-derivation (a SHA-256 for certificate-based subscriptions, µs range) happens on the sync thread at API undeploy only, outside the ConcurrentHashMap bin locks. The environment that motivated this work has zero certificate subscriptions.

### 2. Two `get → mutate → put` races fixed (`4acef051a7`)

Same anti-pattern as the ones fixed in #18513:
- `DefaultReactorHandlerRegistry`: concurrent `register()` calls for the same reactable could overwrite each other's entry, leaving orphan acceptors registered forever. Now `compute()` + copy-on-write; `remove()`/`clear()` claim the entry atomically before unregistering so a concurrently registered handler can no longer be discarded with its acceptors still routing traffic, and a concurrent-`update()` NPE is guarded. Comes with a concurrent regression test **validated both ways**: on the previous code it fails with 7/8 acceptors leaked.
- `EndpointHealthcheckVerticle` (V2 health-check): attaching a cron handler could race with a concurrent undeploy and leak a timer that is never cancelled. The attach is now atomic and cancels the timer when the API was undeployed in between.

### 3. Unused per-API policy-chain factory removed from the V4 path (`ca0bbd9da8`, `c3d42ac0be`)

Every V4 API deployment created a v3-emulation `HttpPolicyChainFactory` + Caffeine cache that was never used: a V4 reactor only builds the organization flow chain, which relies on the shared organization-level factory manager. Verified in the heap dump: zero live instances (transient garbage), only one `InMemoryCache` per API (the legitimate v4 one). `FlowChainFactory` gains an organization-flows-only constructor; the now-dead `createPolicyChainFactory()` hook is removed (checked: neither the debug factory path nor the known external subclasses — message/llm-proxy/mcp-proxy reactors — call or need it; they override `policyChainFactory()`, the v4 variant, which is untouched).

**Gain: deploy/sync allocation churn only (~5.5k transient Caffeine caches per full sync), no retained-heap change.**

### 4. API-key cache: record keys instead of `String.format` composites (`0199f59e9b`)

`getByApiAndKey()` / `getByApiAndMd5Key()` run for every API-key authenticated request and built their lookup key with `String.format("%s.%s", api, key)`. Keys are now a `CacheKey(api, key)` record referencing existing strings — no format parsing, no byte[] allocation per request — the same recipe as the subscription cache's `IdentityKey` from #18513.

## Tests

- `SubscriptionCacheServiceTest` 46/46 (including 4 new credential-transition regression tests that fail on the previous code), `ApiKeyCacheServiceTest` 10/10 — both include concurrent register/unregisterByApiId scenarios
- `ReactorHandlerRegistryTest` 22/22 including the new concurrent-register regression test (fails on the old implementation)
- Full modules green: handlers-api 930, reactor 257, sync 388, healthcheck 58, debug 142
