### PR TITLE
feat: add configurable connection pool max wait queue size to v4 http proxy

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/HttpProxyMaxWaitQueueEdgeCasesV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/HttpProxyMaxWaitQueueEdgeCasesV4IntegrationTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Edge-case smoke coverage for the v4 HTTP proxy {@code maxWaitQueueSize} across its meaningful values, all with a
+ * single-connection pool ({@code maxConcurrentConnections = 1}) and a slow backend so requests contend for the pool.
+ */
+@GatewayTest
+@DeployApi(
+    {
+        "/apis/v4/http/api-mwq-unbounded.json",
+        "/apis/v4/http/api-mwq-absent.json",
+        "/apis/v4/http/api-mwq-null.json",
+        "/apis/v4/http/api-mwq-bounded.json",
+    }
+)
+class HttpProxyMaxWaitQueueEdgeCasesV4IntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    private List<Integer> fireConcurrent(HttpClient httpClient, String path, int count) {
+        return Flowable.range(0, count)
+            .flatMap(i -> httpClient.rxRequest(HttpMethod.GET, path).flatMap(HttpClientRequest::rxSend).toFlowable(), false, count)
+            .map(response -> response.statusCode())
+            .toList()
+            .blockingGet();
+    }
+
+    @Test
+    @DisplayName("Unbounded (-1): all contending requests are queued and served, none shed")
+    void unbounded_queue_serves_all(HttpClient httpClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("ok").withFixedDelay(300)));
+        assertThat(fireConcurrent(httpClient, "/mwq-unbounded", 4)).containsOnly(200);
+    }
+
+    @Test
+    @DisplayName("Absent field: defaults to unbounded, all requests served")
+    void absent_defaults_to_unbounded(HttpClient httpClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("ok").withFixedDelay(300)));
+        assertThat(fireConcurrent(httpClient, "/mwq-absent", 4)).containsOnly(200);
+    }
+
+    @Test
+    @DisplayName("Explicit null: treated as absent (unbounded), all requests served")
+    void explicit_null_defaults_to_unbounded(HttpClient httpClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("ok").withFixedDelay(300)));
+        assertThat(fireConcurrent(httpClient, "/mwq-null", 4)).containsOnly(200);
+    }
+
+    @Test
+    @DisplayName("Bounded (1): the pool + one queued request are served, the rest are shed with 503")
+    void bounded_queue_sheds_overflow(HttpClient httpClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("ok").withFixedDelay(1500)));
+        List<Integer> statuses = fireConcurrent(httpClient, "/mwq-bounded", 6);
+        assertThat(statuses).contains(200);
+        assertThat(statuses).contains(503);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/HttpProxyMaxWaitQueueV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/HttpProxyMaxWaitQueueV4IntegrationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@code maxWaitQueueSize} shared configuration of the v4 HTTP proxy endpoint: when the connection
+ * pool is full and the wait queue is disabled, a pending request is rejected immediately instead of being queued.
+ *
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi("/apis/v4/http/api-max-wait-queue.json")
+class HttpProxyMaxWaitQueueV4IntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    private static final int CONCURRENT_REQUESTS = 5;
+
+    @Test
+    @DisplayName("Should reject overflowing requests with 503 load-shedding when the pool is full and the wait queue is disabled")
+    void should_reject_requests_when_wait_queue_is_full(HttpClient httpClient) {
+        // The backend keeps its single pooled connection (maxConcurrentConnections = 1) busy for a while, so the
+        // concurrent requests pile up: with the wait queue disabled (maxWaitQueueSize = 0) they must be rejected
+        // immediately instead of being queued.
+        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend").withFixedDelay(2000)));
+
+        final List<Integer> statuses = Flowable.range(0, CONCURRENT_REQUESTS)
+            .flatMap(
+                i -> httpClient.rxRequest(HttpMethod.GET, "/test").flatMap(HttpClientRequest::rxSend).toFlowable(),
+                false,
+                CONCURRENT_REQUESTS
+            )
+            .map(response -> response.statusCode())
+            .toList()
+            .blockingGet();
+
+        // The single request that grabs the connection succeeds; every request that overflows the disabled queue
+        // is shed with a retryable 503 (distinct from the 502 used for other backend connection errors).
+        assertThat(statuses).contains(503);
+        assertThat(statuses).doesNotContain(502);
+        assertThat(statuses)
+            .filteredOn(status -> status == 200)
+            .hasSize(1);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-max-wait-queue.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-max-wait-queue.json
@@ -1,0 +1,65 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000,
+              "maxConcurrentConnections": 1,
+              "maxWaitQueueSize": 0
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "GET"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-absent.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-absent.json
@@ -1,0 +1,27 @@
+{
+  "id": "mwq-absent",
+  "name": "mwq-absent",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    { "type": "http", "paths": [ { "path": "/mwq-absent" } ], "entrypoints": [ { "type": "http-proxy" } ] }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": { "target": "http://localhost:8080/endpoint" },
+          "sharedConfigurationOverride": { "http": { "connectTimeout": 3000, "readTimeout": 60000, "maxConcurrentConnections": 1 } }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": { "enabled": false }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-bounded.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-bounded.json
@@ -1,0 +1,27 @@
+{
+  "id": "mwq-bounded",
+  "name": "mwq-bounded",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    { "type": "http", "paths": [ { "path": "/mwq-bounded" } ], "entrypoints": [ { "type": "http-proxy" } ] }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": { "target": "http://localhost:8080/endpoint" },
+          "sharedConfigurationOverride": { "http": { "connectTimeout": 3000, "readTimeout": 60000, "maxConcurrentConnections": 1, "maxWaitQueueSize": 1 } }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": { "enabled": false }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-null.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-null.json
@@ -1,0 +1,27 @@
+{
+  "id": "mwq-null",
+  "name": "mwq-null",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    { "type": "http", "paths": [ { "path": "/mwq-null" } ], "entrypoints": [ { "type": "http-proxy" } ] }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": { "target": "http://localhost:8080/endpoint" },
+          "sharedConfigurationOverride": { "http": { "connectTimeout": 3000, "readTimeout": 60000, "maxConcurrentConnections": 1, "maxWaitQueueSize": null } }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": { "enabled": false }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-unbounded.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-unbounded.json
@@ -1,0 +1,27 @@
+{
+  "id": "mwq-unbounded",
+  "name": "mwq-unbounded",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    { "type": "http", "paths": [ { "path": "/mwq-unbounded" } ], "entrypoints": [ { "type": "http-proxy" } ] }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": { "target": "http://localhost:8080/endpoint" },
+          "sharedConfigurationOverride": { "http": { "connectTimeout": 3000, "readTimeout": 60000, "maxConcurrentConnections": 1, "maxWaitQueueSize": -1 } }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": { "enabled": false }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnector.java
@@ -36,6 +36,7 @@ import io.netty.channel.ConnectTimeoutException;
 import io.netty.handler.timeout.ReadTimeoutException;
 import io.reactivex.rxjava3.core.Completable;
 import io.vertx.circuitbreaker.TimeoutException;
+import io.vertx.core.http.ConnectionPoolTooBusyException;
 import io.vertx.core.impl.NoStackTraceTimeoutException;
 import java.io.IOException;
 import java.util.Map;
@@ -53,6 +54,8 @@ public class HttpProxyEndpointConnector extends HttpEndpointSyncConnector {
     private static final String ENDPOINT_ID = "http-proxy";
     private final Set<ConnectorMode> SUPPORTED_MODES = Set.of(ConnectorMode.REQUEST_RESPONSE);
     static final String GATEWAY_CLIENT_CONNECTION_ERROR = "GATEWAY_CLIENT_CONNECTION_ERROR";
+    static final String GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED = "GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED";
+    static final String CONNECTION_POOL_EXHAUSTED_MESSAGE = "Connection pool exhausted, please retry later.";
     static final String REQUEST_TIMEOUT = "REQUEST_TIMEOUT";
     private static final String SERVER_NULL_PATTERN = " for server null";
     static final String CLIENT_ABORTED_DURING_RESPONSE_ERROR = "CLIENT_ABORTED_DURING_RESPONSE_ERROR";
@@ -164,6 +167,12 @@ public class HttpProxyEndpointConnector extends HttpEndpointSyncConnector {
             );
             case ConnectTimeoutException e -> ctx.interruptWith(
                 new ExecutionFailure(HttpStatusCode.GATEWAY_TIMEOUT_504).key(REQUEST_TIMEOUT).cause(throwable)
+            );
+            case ConnectionPoolTooBusyException e -> ctx.interruptWith(
+                new ExecutionFailure(HttpStatusCode.SERVICE_UNAVAILABLE_503)
+                    .key(GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED)
+                    .message(CONNECTION_POOL_EXHAUSTED_MESSAGE)
+                    .cause(throwable)
             );
             default -> ctx.interruptWith(
                 new ExecutionFailure(HttpStatusCode.BAD_GATEWAY_502).key(GATEWAY_CLIENT_CONNECTION_ERROR).cause(throwable)

--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-7.26.5.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.26.5.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-7.26.5.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.26.5.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-7.27.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.27.0.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-7.27.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.27.0.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -473,8 +473,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.26.5.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.26.5.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.27.0.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.27.0.zip
 
 api:
   enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,11 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.7.1</gravitee-kubernetes.version>
-        <gravitee-node.version>7.26.5</gravitee-node.version>
+        <gravitee-node.version>7.27.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>4.11.1</gravitee-plugin.version>
-        <gravitee-plugin-common-configurations.version>1.0.0</gravitee-plugin-common-configurations.version>
+        <gravitee-plugin-common-configurations.version>1.0.2</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>2.1.0</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>


### PR DESCRIPTION
Backport of the v4 HTTP proxy `maxWaitQueueSize` change to 4.10.x (Vert.x 4 line, same as 4.9.x #18571).

- definition-model v4 `HttpClientOptions.maxWaitQueueSize` (default `-1`) + MapStruct mapping + gateway integration test.
- **No schema-form change here**: 4.10.x resolves `httpClientOptions` from the shared `@gravitee/ui-particles-angular` external definition (+ Gamma serializer); the field is added there separately.
- `gravitee-node.version` → **7.27.0** (gravitee-io/gravitee-node#589).

Depends on gravitee-node 7.27.0. Refs: https://gravitee.atlassian.net/browse/APIM-14715