### PR TITLE
feat: propagate IdP claims into DCR requests — REST config, login persistence, injection, docs (APIM-13949)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/ClientRegistrationProviderEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/ClientRegistrationProviderEntity.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.model.configuration.application.registration;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -66,6 +67,9 @@ public class ClientRegistrationProviderEntity {
 
     @JsonProperty("software_id")
     private String softwareId;
+
+    @JsonProperty("claim_mappings")
+    private Map<String, String> claimMappings;
 
     @JsonProperty("trust_store")
     private TrustStoreEntity trustStore = new TrustStoreEntity();
@@ -191,6 +195,14 @@ public class ClientRegistrationProviderEntity {
 
     public void setSoftwareId(String softwareId) {
         this.softwareId = softwareId;
+    }
+
+    public Map<String, String> getClaimMappings() {
+        return claimMappings;
+    }
+
+    public void setClaimMappings(Map<String, String> claimMappings) {
+        this.claimMappings = claimMappings;
     }
 
     public TrustStoreEntity getTrustStore() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/NewClientRegistrationProviderEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/NewClientRegistrationProviderEntity.java
@@ -20,6 +20,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -64,6 +65,9 @@ public class NewClientRegistrationProviderEntity {
 
     @JsonProperty("software_id")
     private String softwareId;
+
+    @JsonProperty("claim_mappings")
+    private Map<String, String> claimMappings;
 
     @JsonProperty("trust_store")
     @Valid
@@ -167,6 +171,14 @@ public class NewClientRegistrationProviderEntity {
 
     public void setSoftwareId(String softwareId) {
         this.softwareId = softwareId;
+    }
+
+    public Map<String, String> getClaimMappings() {
+        return claimMappings;
+    }
+
+    public void setClaimMappings(Map<String, String> claimMappings) {
+        this.claimMappings = claimMappings;
     }
 
     public TrustStoreEntity getTrustStore() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/UpdateClientRegistrationProviderEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/application/registration/UpdateClientRegistrationProviderEntity.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -61,6 +62,9 @@ public class UpdateClientRegistrationProviderEntity {
 
     @JsonProperty("software_id")
     private String softwareId;
+
+    @JsonProperty("claim_mappings")
+    private Map<String, String> claimMappings;
 
     @JsonProperty("trust_store")
     @Valid
@@ -164,6 +168,14 @@ public class UpdateClientRegistrationProviderEntity {
 
     public void setSoftwareId(String softwareId) {
         this.softwareId = softwareId;
+    }
+
+    public Map<String, String> getClaimMappings() {
+        return claimMappings;
+    }
+
+    public void setClaimMappings(Map<String, String> claimMappings) {
+        this.claimMappings = claimMappings;
     }
 
     public TrustStoreEntity getTrustStore() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/IdentityProviderEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/IdentityProviderEntity.java
@@ -46,6 +46,8 @@ public class IdentityProviderEntity {
 
     private Map<String, String> userProfileMapping;
 
+    private List<String> persistedClaimsWhitelist;
+
     private boolean emailRequired;
 
     private boolean syncMappings;
@@ -144,6 +146,14 @@ public class IdentityProviderEntity {
 
     public void setUserProfileMapping(Map<String, String> userProfileMapping) {
         this.userProfileMapping = userProfileMapping;
+    }
+
+    public List<String> getPersistedClaimsWhitelist() {
+        return persistedClaimsWhitelist;
+    }
+
+    public void setPersistedClaimsWhitelist(List<String> persistedClaimsWhitelist) {
+        this.persistedClaimsWhitelist = persistedClaimsWhitelist;
     }
 
     public boolean isEmailRequired() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/NewIdentityProviderEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/NewIdentityProviderEntity.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.model.configuration.identity;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -40,6 +41,8 @@ public class NewIdentityProviderEntity {
     private boolean enabled;
 
     private Map<String, String> userProfileMapping;
+
+    private List<String> persistedClaimsWhitelist;
 
     private boolean emailRequired;
 
@@ -91,6 +94,14 @@ public class NewIdentityProviderEntity {
 
     public void setUserProfileMapping(Map<String, String> userProfileMapping) {
         this.userProfileMapping = userProfileMapping;
+    }
+
+    public List<String> getPersistedClaimsWhitelist() {
+        return persistedClaimsWhitelist;
+    }
+
+    public void setPersistedClaimsWhitelist(List<String> persistedClaimsWhitelist) {
+        this.persistedClaimsWhitelist = persistedClaimsWhitelist;
     }
 
     public boolean isEmailRequired() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/SocialIdentityProviderEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/SocialIdentityProviderEntity.java
@@ -49,6 +49,9 @@ public abstract class SocialIdentityProviderEntity {
     @JsonIgnore
     private List<RoleMappingEntity> roleMappings;
 
+    @JsonIgnore
+    private List<String> persistedClaimsWhitelist;
+
     public static class UserProfile {
 
         public static final String ID = "id";
@@ -98,6 +101,15 @@ public abstract class SocialIdentityProviderEntity {
 
     public void setClientSecret(String clientSecret) {
         this.clientSecret = clientSecret;
+    }
+
+    @JsonIgnore
+    public List<String> getPersistedClaimsWhitelist() {
+        return persistedClaimsWhitelist;
+    }
+
+    public void setPersistedClaimsWhitelist(List<String> persistedClaimsWhitelist) {
+        this.persistedClaimsWhitelist = persistedClaimsWhitelist;
     }
 
     public String getScopeDelimiter() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/UpdateIdentityProviderEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/UpdateIdentityProviderEntity.java
@@ -46,6 +46,8 @@ public class UpdateIdentityProviderEntity {
 
     private Map<String, String> userProfileMapping;
 
+    private List<String> persistedClaimsWhitelist;
+
     private boolean emailRequired;
 
     private boolean syncMappings;
@@ -104,6 +106,14 @@ public class UpdateIdentityProviderEntity {
 
     public void setUserProfileMapping(Map<String, String> userProfileMapping) {
         this.userProfileMapping = userProfileMapping;
+    }
+
+    public List<String> getPersistedClaimsWhitelist() {
+        return persistedClaimsWhitelist;
+    }
+
+    public void setPersistedClaimsWhitelist(List<String> persistedClaimsWhitelist) {
+        this.persistedClaimsWhitelist = persistedClaimsWhitelist;
     }
 
     public boolean isEmailRequired() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
@@ -44,6 +44,12 @@ public interface UserService {
 
     UserEntity findByIdWithRoles(ExecutionContext executionContext, String id);
 
+    /**
+     * Returns the IdP claims persisted on the user (for internal use such as DCR injection). These are intentionally
+     * not exposed through the user profile API responses.
+     */
+    Map<String, String> findIdpClaims(ExecutionContext executionContext, String userId);
+
     UserEntity findBySource(String organizationId, String source, String sourceId, boolean loadRoles);
 
     Set<UserEntity> findByIds(ExecutionContext executionContext, Collection<String> ids);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/application/ClientRegistrationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/application/ClientRegistrationService.java
@@ -52,7 +52,8 @@ public interface ClientRegistrationService {
     ClientRegistrationResponse update(
         ExecutionContext executionContext,
         String previousRegistrationResponse,
-        UpdateApplicationEntity application
+        UpdateApplicationEntity application,
+        Map<String, String> idpClaims
     );
 
     ClientRegistrationResponse renewClientSecret(ExecutionContext executionContext, String previousRegistrationResponse);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/application/ClientRegistrationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/application/ClientRegistrationService.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.model.configuration.application.registration.NewClie
 import io.gravitee.rest.api.model.configuration.application.registration.UpdateClientRegistrationProviderEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.impl.configuration.application.registration.client.register.ClientRegistrationResponse;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -46,7 +47,7 @@ public interface ClientRegistrationService {
 
     void delete(ExecutionContext executionContext, String id);
 
-    ClientRegistrationResponse register(ExecutionContext executionContext, NewApplicationEntity application);
+    ClientRegistrationResponse register(ExecutionContext executionContext, NewApplicationEntity application, Map<String, String> idpClaims);
 
     ClientRegistrationResponse update(
         ExecutionContext executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -906,17 +906,13 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     ) {
         try {
             // Inject the application owner's IdP claims (not the editor's) so the tenant/user context registered with
-            // the IdP stays tied to who owns the application and does not flip when another user edits it.
-            String ownerId = membershipService.getPrimaryOwnerUserId(
-                executionContext.getOrganizationId(),
-                MembershipReferenceType.APPLICATION,
-                applicationToUpdate.getId()
-            );
+            // the IdP stays tied to who owns the application and does not flip when another user edits it. Resolved
+            // defensively: an unresolvable owner must degrade to "no claims injected", never break the DCR update.
             ClientRegistrationResponse registrationResponse = clientRegistrationService.update(
                 executionContext,
                 registrationPayload,
                 updateApplicationEntity,
-                ownerId != null ? userService.findIdpClaims(executionContext, ownerId) : null
+                resolveOwnerIdpClaims(executionContext, applicationToUpdate.getId())
             );
             metadata.put(METADATA_CLIENT_ID, registrationResponse.getClientId());
             metadata.put(METADATA_REGISTRATION_PAYLOAD, mapper.writeValueAsString(registrationResponse));
@@ -928,6 +924,25 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             log.error("Failed to update OAuth client data from client registration. Keeping old OAuth client data.", e);
             metadata.put(METADATA_CLIENT_ID, applicationToUpdate.getMetadata().get(METADATA_CLIENT_ID));
             metadata.put(METADATA_REGISTRATION_PAYLOAD, applicationToUpdate.getMetadata().get(METADATA_REGISTRATION_PAYLOAD));
+        }
+    }
+
+    /**
+     * Resolves the persisted IdP claims of the application's primary owner. {@code getPrimaryOwnerUserId} can throw
+     * (no primary owner, group-owned application, missing role), so this degrades to {@code null} — a missing owner
+     * must mean "no claims injected", never a failure that aborts the DCR update.
+     */
+    private Map<String, String> resolveOwnerIdpClaims(ExecutionContext executionContext, String applicationId) {
+        try {
+            String ownerId = membershipService.getPrimaryOwnerUserId(
+                executionContext.getOrganizationId(),
+                MembershipReferenceType.APPLICATION,
+                applicationId
+            );
+            return ownerId != null ? userService.findIdpClaims(executionContext, ownerId) : null;
+        } catch (Exception e) {
+            log.warn("Could not resolve primary owner IdP claims for application {}; proceeding without injection", applicationId, e);
+            return null;
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -908,7 +908,8 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             ClientRegistrationResponse registrationResponse = clientRegistrationService.update(
                 executionContext,
                 registrationPayload,
-                updateApplicationEntity
+                updateApplicationEntity,
+                userService.findIdpClaims(executionContext, getAuthenticatedUsername())
             );
             metadata.put(METADATA_CLIENT_ID, registrationResponse.getClientId());
             metadata.put(METADATA_REGISTRATION_PAYLOAD, mapper.writeValueAsString(registrationResponse));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -905,11 +905,18 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         Application applicationToUpdate
     ) {
         try {
+            // Inject the application owner's IdP claims (not the editor's) so the tenant/user context registered with
+            // the IdP stays tied to who owns the application and does not flip when another user edits it.
+            String ownerId = membershipService.getPrimaryOwnerUserId(
+                executionContext.getOrganizationId(),
+                MembershipReferenceType.APPLICATION,
+                applicationToUpdate.getId()
+            );
             ClientRegistrationResponse registrationResponse = clientRegistrationService.update(
                 executionContext,
                 registrationPayload,
                 updateApplicationEntity,
-                userService.findIdpClaims(executionContext, getAuthenticatedUsername())
+                ownerId != null ? userService.findIdpClaims(executionContext, ownerId) : null
             );
             metadata.put(METADATA_CLIENT_ID, registrationResponse.getClientId());
             metadata.put(METADATA_REGISTRATION_PAYLOAD, mapper.writeValueAsString(registrationResponse));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -441,7 +441,11 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             checkAndSanitizeOAuthClientSettings(newApplicationEntity.getSettings().getOauth());
 
             // Create an OAuth client
-            ClientRegistrationResponse registrationResponse = clientRegistrationService.register(executionContext, newApplicationEntity);
+            ClientRegistrationResponse registrationResponse = clientRegistrationService.register(
+                executionContext,
+                newApplicationEntity,
+                userService.findIdpClaims(executionContext, userId)
+            );
             try {
                 metadata.put(METADATA_CLIENT_ID, registrationResponse.getClientId());
                 metadata.put(METADATA_REGISTRATION_PAYLOAD, mapper.writeValueAsString(registrationResponse));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -41,6 +41,8 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.ReadContext;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
@@ -196,6 +198,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     private static final String TEMPLATE_ENGINE_PROFILE_ATTRIBUTE = "profile";
     private static final String TEMPLATE_ENGINE_ACCESSTOKEN_ATTRIBUTE = "accessToken";
     private static final String TEMPLATE_ENGINE_IDTOKEN_ATTRIBUTE = "idToken";
+    private static final ObjectMapper CLAIMS_MAPPER = new ObjectMapper();
 
     // Dirty hack: only used to force class loading
     static {
@@ -1745,7 +1748,76 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             );
         }
 
+        persistWhitelistedClaims(
+            socialProvider.getPersistedClaimsWhitelist(),
+            user.getId(),
+            userInfo,
+            accessTokenPayloadAsString,
+            idTokenPayloadAsString
+        );
+
         return user;
+    }
+
+    /**
+     * Persists the IdP claims whitelisted on the social identity provider onto the user record, refreshing them on
+     * every login. When no whitelist is configured the feature is inactive and the user record is left untouched.
+     */
+    private void persistWhitelistedClaims(
+        List<String> whitelist,
+        String userId,
+        String userInfo,
+        String accessTokenPayload,
+        String idTokenPayload
+    ) {
+        if (whitelist == null || whitelist.isEmpty()) {
+            return;
+        }
+        Map<String, String> idpClaims = extractWhitelistedClaims(whitelist, userInfo, accessTokenPayload, idTokenPayload);
+        try {
+            Optional<User> optionalUser = userRepository.findById(userId);
+            if (optionalUser.isPresent()) {
+                User user = optionalUser.get();
+                user.setIdpClaims(idpClaims);
+                userRepository.update(user);
+            }
+        } catch (TechnicalException e) {
+            log.warn("Unable to persist IdP claims for user {}", userId, e);
+        }
+    }
+
+    /**
+     * Extracts the whitelisted claims from the IdP sources, looking them up in order id_token, access_token then
+     * userinfo (first source containing the claim wins). Missing claims are skipped; complex values are JSON-serialized.
+     */
+    private Map<String, String> extractWhitelistedClaims(
+        List<String> whitelist,
+        String userInfo,
+        String accessTokenPayload,
+        String idTokenPayload
+    ) {
+        List<JsonNode> sources = new ArrayList<>();
+        for (String source : new String[] { idTokenPayload, accessTokenPayload, userInfo }) {
+            if (source != null && !source.isEmpty()) {
+                try {
+                    sources.add(CLAIMS_MAPPER.readTree(source));
+                } catch (Exception e) {
+                    log.debug("Unable to parse IdP claim source as JSON", e);
+                }
+            }
+        }
+
+        Map<String, String> claims = new HashMap<>();
+        for (String claimName : whitelist) {
+            for (JsonNode source : sources) {
+                JsonNode value = source.get(claimName);
+                if (value != null && !value.isNull()) {
+                    claims.put(claimName, value.isValueNode() ? value.asText() : value.toString());
+                    break;
+                }
+            }
+        }
+        return claims;
     }
 
     private HashMap<String, String> getUserProfileAttrs(Map<String, String> userProfileMapping, String userInfo) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -1759,6 +1759,15 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         return user;
     }
 
+    @Override
+    public Map<String, String> findIdpClaims(ExecutionContext executionContext, String userId) {
+        try {
+            return userRepository.findById(userId).map(User::getIdpClaims).orElse(null);
+        } catch (TechnicalException ex) {
+            throw new TechnicalManagementException("An error occurs while trying to find IdP claims for user " + userId, ex);
+        }
+    }
+
     /**
      * Persists the IdP claims whitelisted on the social identity provider onto the user record, refreshing them on
      * every login. When no whitelist is configured the feature is inactive and the user record is left untouched.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -1819,6 +1819,8 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         Map<String, String> claims = new HashMap<>();
         for (String claimName : whitelist) {
             for (JsonNode source : sources) {
+                // Deliberate flat lookup (not a dot-notation path like the DCR field side): OIDC namespaced claim
+                // names such as "https://example.com/org_id" contain dots that must be treated as a single literal key.
                 JsonNode value = source.get(claimName);
                 if (value != null && !value.isNull()) {
                     claims.put(claimName, value.isValueNode() ? value.asText() : value.toString());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
@@ -209,6 +209,11 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
             clientRegistrationProvider.setId(id);
             clientRegistrationProvider.setCreatedAt(clientProviderToUpdate.getCreatedAt());
             clientRegistrationProvider.setUpdatedAt(new Date());
+            // Preserve the claim mappings when the update payload omits them (e.g. saved from a console screen
+            // unaware of the field); clear them explicitly by sending an empty map.
+            if (updateClientRegistrationProvider.getClaimMappings() == null) {
+                clientRegistrationProvider.setClaimMappings(clientProviderToUpdate.getClaimMappings());
+            }
 
             ClientRegistrationProvider updatedClientRegistrationProvider = clientRegistrationProviderRepository.update(
                 clientRegistrationProvider
@@ -507,6 +512,7 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
         entity.setRenewClientSecretMethod(clientRegistrationProvider.getRenewClientSecretMethod());
         entity.setRenewClientSecretEndpoint(clientRegistrationProvider.getRenewClientSecretEndpoint());
         entity.setSoftwareId(clientRegistrationProvider.getSoftwareId());
+        entity.setClaimMappings(clientRegistrationProvider.getClaimMappings());
 
         if (
             clientRegistrationProvider.getInitialAccessTokenType() == null ||
@@ -567,6 +573,7 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
         provider.setRenewClientSecretMethod(newClientRegistrationProvider.getRenewClientSecretMethod());
         provider.setRenewClientSecretEndpoint(newClientRegistrationProvider.getRenewClientSecretEndpoint());
         provider.setSoftwareId(newClientRegistrationProvider.getSoftwareId());
+        provider.setClaimMappings(newClientRegistrationProvider.getClaimMappings());
 
         if (newClientRegistrationProvider.getInitialAccessTokenType() == InitialAccessTokenType.CLIENT_CREDENTIALS) {
             provider.setInitialAccessTokenType(ClientRegistrationProvider.InitialAccessTokenType.CLIENT_CREDENTIALS);
@@ -613,6 +620,7 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
         provider.setRenewClientSecretMethod(updateClientRegistrationProvider.getRenewClientSecretMethod());
         provider.setRenewClientSecretEndpoint(updateClientRegistrationProvider.getRenewClientSecretEndpoint());
         provider.setSoftwareId(updateClientRegistrationProvider.getSoftwareId());
+        provider.setClaimMappings(updateClientRegistrationProvider.getClaimMappings());
 
         if (updateClientRegistrationProvider.getInitialAccessTokenType() == InitialAccessTokenType.CLIENT_CREDENTIALS) {
             provider.setInitialAccessTokenType(ClientRegistrationProvider.InitialAccessTokenType.CLIENT_CREDENTIALS);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
@@ -73,6 +73,20 @@ import org.springframework.stereotype.Component;
 @Component
 public class ClientRegistrationServiceImpl extends AbstractService implements ClientRegistrationService {
 
+    /**
+     * Security-relevant DCR fields that must never be the target of a claim mapping: their value is IdP/end-user
+     * controlled and claim injection bypasses the OAuth client sanitization applied to operator-supplied settings.
+     * A mapping whose (dot-notation) field path starts with one of these top-level fields is rejected.
+     */
+    private static final Set<String> PROTECTED_DCR_FIELDS = Set.of(
+        "redirect_uris",
+        "grant_types",
+        "response_types",
+        "token_endpoint_auth_method",
+        "jwks_uri",
+        "client_uri"
+    );
+
     @Lazy
     @Autowired
     private ClientRegistrationProviderRepository clientRegistrationProviderRepository;
@@ -124,6 +138,8 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
             ) {
                 throw new EmptyInitialAccessTokenException();
             }
+
+            validateClaimMappings(newClientRegistrationProvider.getClaimMappings());
 
             ClientRegistrationProvider clientRegistrationProvider = convert(newClientRegistrationProvider);
 
@@ -190,6 +206,8 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
             ) {
                 throw new EmptyInitialAccessTokenException();
             }
+
+            validateClaimMappings(updateClientRegistrationProvider.getClaimMappings());
 
             ClientRegistrationProvider clientRegistrationProvider = convert(updateClientRegistrationProvider);
 
@@ -352,13 +370,51 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
         Map<String, String> injections = new HashMap<>();
         if (claimMappings != null && idpClaims != null) {
             for (Map.Entry<String, String> mapping : claimMappings.entrySet()) {
+                String fieldPath = mapping.getValue();
+                // Defensive: skip blank or security-relevant field paths even if they somehow got persisted, so a
+                // stored value can never bypass the validation applied at configuration time.
+                if (isBlankFieldPath(fieldPath) || isProtectedFieldPath(fieldPath)) {
+                    continue;
+                }
                 String claimValue = idpClaims.get(mapping.getKey());
                 if (claimValue != null) {
-                    injections.put(mapping.getValue(), claimValue);
+                    injections.put(fieldPath, claimValue);
                 }
             }
         }
         return injections;
+    }
+
+    /**
+     * Validates the claim mappings of a client registration provider: DCR field paths must be non-blank and must not
+     * target a security-relevant field (see {@link #PROTECTED_DCR_FIELDS}).
+     */
+    private void validateClaimMappings(Map<String, String> claimMappings) {
+        if (claimMappings == null) {
+            return;
+        }
+        for (Map.Entry<String, String> mapping : claimMappings.entrySet()) {
+            String fieldPath = mapping.getValue();
+            if (isBlankFieldPath(fieldPath)) {
+                throw new InvalidClaimMappingException("DCR field path must not be empty (claim '" + mapping.getKey() + "')");
+            }
+            if (isProtectedFieldPath(fieldPath)) {
+                throw new InvalidClaimMappingException("DCR field path '" + fieldPath + "' targets a security-relevant field");
+            }
+        }
+    }
+
+    private static boolean isBlankFieldPath(String fieldPath) {
+        return fieldPath == null || fieldPath.trim().isEmpty();
+    }
+
+    private static boolean isProtectedFieldPath(String fieldPath) {
+        if (fieldPath == null) {
+            return false;
+        }
+        int dot = fieldPath.indexOf('.');
+        String topLevel = dot >= 0 ? fieldPath.substring(0, dot) : fieldPath;
+        return PROTECTED_DCR_FIELDS.contains(topLevel);
     }
 
     private ClientRegistrationRequest convert(NewApplicationEntity application) {
@@ -424,7 +480,8 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
     public ClientRegistrationResponse update(
         ExecutionContext executionContext,
         String previousRegistrationResponse,
-        UpdateApplicationEntity application
+        UpdateApplicationEntity application,
+        Map<String, String> idpClaims
     ) {
         try {
             ClientRegistrationResponse registrationResponse = mapper.readValue(
@@ -456,10 +513,13 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
 
             registrationRequest.setSoftwareId(provider.getSoftwareId());
 
+            Map<String, String> claimInjections = resolveClaimInjections(provider.getClaimMappings(), idpClaims);
+
             return registrationProviderClient.update(
                 registrationResponse.getRegistrationAccessToken(),
                 registrationResponse.getRegistrationClientUri(),
                 convert(registrationRequest, application),
+                claimInjections,
                 application.getSettings().getOauth().getClientId()
             );
         } catch (JsonProcessingException ex) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
@@ -21,6 +21,7 @@ import static io.gravitee.repository.management.model.ClientRegistrationProvider
 import static io.gravitee.repository.management.model.ClientRegistrationProvider.AuditEvent.CLIENT_REGISTRATION_PROVIDER_UPDATED;
 import static java.util.Collections.singletonMap;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
@@ -55,6 +56,7 @@ import io.gravitee.rest.api.service.impl.configuration.application.registration.
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -74,18 +76,30 @@ import org.springframework.stereotype.Component;
 public class ClientRegistrationServiceImpl extends AbstractService implements ClientRegistrationService {
 
     /**
-     * Security-relevant DCR fields that must never be the target of a claim mapping: their value is IdP/end-user
-     * controlled and claim injection bypasses the OAuth client sanitization applied to operator-supplied settings.
-     * A mapping whose (dot-notation) field path starts with one of these top-level fields is rejected.
+     * Standard DCR fields, derived by reflection from the {@code @JsonProperty} declarations on
+     * {@link ClientRegistrationRequest} (plus {@code client_id}, which the update flow sets on the request tree
+     * directly rather than as a declared property).
+     * <p>
+     * Claim injection uses an <b>allowlist by exclusion</b>: a mapping may only target a field whose top-level segment
+     * is NOT a standard field, i.e. only vendor/extension fields ({@code metadata.*}, {@code organization}, ...) are
+     * injectable. This is safe-by-default — a standard field added to {@link ClientRegistrationRequest} later is
+     * automatically protected, and the value being IdP/end-user controlled can never override a spec field or bypass
+     * the OAuth client sanitization applied to operator-supplied settings.
      */
-    private static final Set<String> PROTECTED_DCR_FIELDS = Set.of(
-        "redirect_uris",
-        "grant_types",
-        "response_types",
-        "token_endpoint_auth_method",
-        "jwks_uri",
-        "client_uri"
-    );
+    private static final Set<String> STANDARD_DCR_FIELDS = computeStandardDcrFields();
+
+    private static Set<String> computeStandardDcrFields() {
+        Set<String> fields = new HashSet<>();
+        for (java.lang.reflect.Field field : ClientRegistrationRequest.class.getDeclaredFields()) {
+            JsonProperty jsonProperty = field.getAnnotation(JsonProperty.class);
+            if (jsonProperty != null && !jsonProperty.value().isEmpty()) {
+                fields.add(jsonProperty.value());
+            }
+        }
+        // client_id is written onto the request tree by the RFC 7592 update flow, not declared as a @JsonProperty
+        fields.add("client_id");
+        return fields;
+    }
 
     @Lazy
     @Autowired
@@ -371,9 +385,9 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
         if (claimMappings != null && idpClaims != null) {
             for (Map.Entry<String, String> mapping : claimMappings.entrySet()) {
                 String fieldPath = mapping.getValue();
-                // Defensive: skip blank or security-relevant field paths even if they somehow got persisted, so a
-                // stored value can never bypass the validation applied at configuration time.
-                if (isBlankFieldPath(fieldPath) || isProtectedFieldPath(fieldPath)) {
+                // Defensive: skip blank or non-injectable (standard) field paths even if they somehow got persisted,
+                // so a stored value can never bypass the validation applied at configuration time.
+                if (isBlankFieldPath(fieldPath) || isStandardFieldPath(fieldPath)) {
                     continue;
                 }
                 String claimValue = idpClaims.get(mapping.getKey());
@@ -398,8 +412,10 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
             if (isBlankFieldPath(fieldPath)) {
                 throw new InvalidClaimMappingException("DCR field path must not be empty (claim '" + mapping.getKey() + "')");
             }
-            if (isProtectedFieldPath(fieldPath)) {
-                throw new InvalidClaimMappingException("DCR field path '" + fieldPath + "' targets a security-relevant field");
+            if (isStandardFieldPath(fieldPath)) {
+                throw new InvalidClaimMappingException(
+                    "DCR field path '" + fieldPath + "' targets a standard registration field; only extension fields are injectable"
+                );
             }
         }
     }
@@ -408,13 +424,17 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
         return fieldPath == null || fieldPath.trim().isEmpty();
     }
 
-    private static boolean isProtectedFieldPath(String fieldPath) {
+    /**
+     * Returns true when the top-level segment of the field path is a standard DCR field (see {@link #STANDARD_DCR_FIELDS}),
+     * which is therefore not injectable.
+     */
+    private static boolean isStandardFieldPath(String fieldPath) {
         if (fieldPath == null) {
             return false;
         }
         int dot = fieldPath.indexOf('.');
         String topLevel = dot >= 0 ? fieldPath.substring(0, dot) : fieldPath;
-        return PROTECTED_DCR_FIELDS.contains(topLevel);
+        return STANDARD_DCR_FIELDS.contains(topLevel);
     }
 
     private ClientRegistrationRequest convert(NewApplicationEntity application) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
@@ -21,7 +21,6 @@ import static io.gravitee.repository.management.model.ClientRegistrationProvider
 import static io.gravitee.repository.management.model.ClientRegistrationProvider.AuditEvent.CLIENT_REGISTRATION_PROVIDER_UPDATED;
 import static java.util.Collections.singletonMap;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
@@ -90,13 +89,16 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
 
     private static Set<String> computeStandardDcrFields() {
         Set<String> fields = new HashSet<>();
-        for (java.lang.reflect.Field field : ClientRegistrationRequest.class.getDeclaredFields()) {
-            JsonProperty jsonProperty = field.getAnnotation(JsonProperty.class);
-            if (jsonProperty != null && !jsonProperty.value().isEmpty()) {
-                fields.add(jsonProperty.value());
-            }
-        }
-        // client_id is written onto the request tree by the RFC 7592 update flow, not declared as a @JsonProperty
+        // Derive from Jackson's own serialization introspection (not hand-rolled field reflection) so the set matches
+        // exactly what ends up on the wire — a future field serialized under a getter or bean name is covered too, and
+        // the allowlist cannot silently fail open.
+        ObjectMapper introspector = new ObjectMapper();
+        introspector
+            .getSerializationConfig()
+            .introspect(introspector.constructType(ClientRegistrationRequest.class))
+            .findProperties()
+            .forEach(property -> fields.add(property.getName()));
+        // client_id is written onto the request tree by the RFC 7592 update flow, not declared as a serialized property
         fields.add("client_id");
         return fields;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
@@ -54,6 +54,7 @@ import io.gravitee.rest.api.service.impl.configuration.application.registration.
 import io.gravitee.rest.api.service.impl.configuration.application.registration.client.token.PlainInitialAccessTokenProvider;
 import java.io.IOException;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -310,7 +311,11 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
     }
 
     @Override
-    public ClientRegistrationResponse register(ExecutionContext executionContext, NewApplicationEntity application) {
+    public ClientRegistrationResponse register(
+        ExecutionContext executionContext,
+        NewApplicationEntity application,
+        Map<String, String> idpClaims
+    ) {
         // Create an OAuth client
         Set<ClientRegistrationProviderEntity> providers = findAll(executionContext);
         if (providers == null || providers.isEmpty()) {
@@ -329,7 +334,31 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
             clientRegistrationRequest.setSoftwareId(provider.getSoftwareId());
         }
 
-        return registrationProviderClient.register(clientRegistrationRequest, provider.getTrustStore(), provider.getKeyStore());
+        Map<String, String> claimInjections = resolveClaimInjections(provider.getClaimMappings(), idpClaims);
+
+        return registrationProviderClient.register(
+            clientRegistrationRequest,
+            claimInjections,
+            provider.getTrustStore(),
+            provider.getKeyStore()
+        );
+    }
+
+    /**
+     * Resolves the configured claim-to-DCR-field mappings against the user's persisted IdP claims, producing a map of
+     * DCR field path to claim value. Claims missing from the user's persisted claims are skipped.
+     */
+    private Map<String, String> resolveClaimInjections(Map<String, String> claimMappings, Map<String, String> idpClaims) {
+        Map<String, String> injections = new HashMap<>();
+        if (claimMappings != null && idpClaims != null) {
+            for (Map.Entry<String, String> mapping : claimMappings.entrySet()) {
+                String claimValue = idpClaims.get(mapping.getKey());
+                if (claimValue != null) {
+                    injections.put(mapping.getValue(), claimValue);
+                }
+            }
+        }
+        return injections;
     }
 
     private ClientRegistrationRequest convert(NewApplicationEntity application) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/InvalidClaimMappingException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/InvalidClaimMappingException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.configuration.application.registration;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
+import java.util.Map;
+
+/**
+ * Raised when a client registration provider is configured with an invalid claim mapping (blank DCR field path or a
+ * path targeting a security-relevant field).
+ *
+ * @author GraviteeSource Team
+ */
+public class InvalidClaimMappingException extends AbstractManagementException {
+
+    private final String detail;
+
+    public InvalidClaimMappingException(String detail) {
+        this.detail = detail;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Invalid claim mapping: " + detail;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "clientRegistrationProvider.claimMappings.invalid";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return null;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/DynamicClientRegistrationProviderClient.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/DynamicClientRegistrationProviderClient.java
@@ -166,6 +166,11 @@ public abstract class DynamicClientRegistrationProviderClient {
         try {
             ObjectNode reqNode = (ObjectNode) mapper.readTree(mapper.writeValueAsString(request));
 
+            // RFC 7592 update is a full replace, so re-inject the claims to keep them across application updates.
+            // Injection runs first so the client_id/scope set below are structurally un-overridable by a mapping
+            // (in addition to those being non-injectable standard fields at configuration time).
+            injectClaims(reqNode, claimInjections);
+
             // Set the client_id according to https://tools.ietf.org/html/rfc7592#page-7
             reqNode.put("client_id", clientId);
 
@@ -174,9 +179,6 @@ public abstract class DynamicClientRegistrationProviderClient {
             } else {
                 reqNode.remove("scope");
             }
-
-            // RFC 7592 update is a full replace, so re-inject the claims to keep them across application updates.
-            injectClaims(reqNode, claimInjections);
 
             updateRequest.setEntity(
                 new StringEntity(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/DynamicClientRegistrationProviderClient.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/DynamicClientRegistrationProviderClient.java
@@ -128,7 +128,15 @@ public abstract class DynamicClientRegistrationProviderClient {
         for (Map.Entry<String, String> injection : claimInjections.entrySet()) {
             String fieldPath = injection.getKey();
             String value = injection.getValue();
+            // Defensive: field paths are validated non-blank and non-protected at configuration time, but guard here
+            // too so a malformed path (blank, or made only of dot separators) is skipped rather than throwing mid-POST.
+            if (fieldPath == null || fieldPath.trim().isEmpty()) {
+                continue;
+            }
             String[] segments = fieldPath.split("\\.");
+            if (segments.length == 0) {
+                continue;
+            }
             ObjectNode current = body;
             for (int i = 0; i < segments.length - 1; i++) {
                 JsonNode child = current.get(segments[i]);
@@ -147,6 +155,7 @@ public abstract class DynamicClientRegistrationProviderClient {
         String registrationAccessToken,
         String registrationClientUri,
         ClientRegistrationRequest request,
+        Map<String, String> claimInjections,
         String clientId
     ) {
         HttpPut updateRequest = new HttpPut(registrationClientUri);
@@ -155,16 +164,19 @@ public abstract class DynamicClientRegistrationProviderClient {
         updateRequest.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
 
         try {
-            JsonNode reqNode = mapper.readTree(mapper.writeValueAsString(request));
+            ObjectNode reqNode = (ObjectNode) mapper.readTree(mapper.writeValueAsString(request));
 
             // Set the client_id according to https://tools.ietf.org/html/rfc7592#page-7
-            ((ObjectNode) reqNode).put("client_id", clientId);
+            reqNode.put("client_id", clientId);
 
             if (request.getScope() != null && !request.getScope().isEmpty()) {
-                ((ObjectNode) reqNode).put("scope", String.join(ClientRegistrationRequest.SCOPE_DELIMITER, request.getScope()));
+                reqNode.put("scope", String.join(ClientRegistrationRequest.SCOPE_DELIMITER, request.getScope()));
             } else {
-                ((ObjectNode) reqNode).remove("scope");
+                reqNode.remove("scope");
             }
+
+            // RFC 7592 update is a full replace, so re-inject the claims to keep them across application updates.
+            injectClaims(reqNode, claimInjections);
 
             updateRequest.setEntity(
                 new StringEntity(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/DynamicClientRegistrationProviderClient.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/DynamicClientRegistrationProviderClient.java
@@ -30,6 +30,7 @@ import io.gravitee.rest.api.service.impl.configuration.application.registration.
 import io.gravitee.rest.api.service.impl.configuration.application.registration.client.register.ClientRegistrationResponse;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Map;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
@@ -61,6 +62,7 @@ public abstract class DynamicClientRegistrationProviderClient {
     protected ClientRegistrationResponse register(
         String initialAccessToken,
         ClientRegistrationRequest request,
+        Map<String, String> claimInjections,
         TrustStoreEntity trustStore,
         KeyStoreEntity keyStore
     ) {
@@ -70,11 +72,10 @@ public abstract class DynamicClientRegistrationProviderClient {
         registerRequest.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
 
         try {
+            ObjectNode body = mapper.valueToTree(request);
+            injectClaims(body, claimInjections);
             registerRequest.setEntity(
-                new StringEntity(
-                    mapper.writeValueAsString(request),
-                    ContentType.create(MediaType.APPLICATION_JSON, Charset.defaultCharset())
-                )
+                new StringEntity(mapper.writeValueAsString(body), ContentType.create(MediaType.APPLICATION_JSON, Charset.defaultCharset()))
             );
 
             httpClient = SecureHttpClientUtils.createHttpClient(trustStore, keyStore);
@@ -113,6 +114,32 @@ public abstract class DynamicClientRegistrationProviderClient {
             });
         } catch (Exception ex) {
             throw new DynamicClientRegistrationException("Unexpected error while registering client: " + ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Injects the resolved claim values into the DCR request body at their mapped (dot-notation) field paths.
+     * Intermediate objects are created as needed and existing values at the target path are overridden.
+     */
+    private void injectClaims(ObjectNode body, Map<String, String> claimInjections) {
+        if (claimInjections == null || claimInjections.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<String, String> injection : claimInjections.entrySet()) {
+            String fieldPath = injection.getKey();
+            String value = injection.getValue();
+            String[] segments = fieldPath.split("\\.");
+            ObjectNode current = body;
+            for (int i = 0; i < segments.length - 1; i++) {
+                JsonNode child = current.get(segments[i]);
+                if (child == null || !child.isObject()) {
+                    child = mapper.createObjectNode();
+                    current.set(segments[i], child);
+                }
+                current = (ObjectNode) child;
+            }
+            current.put(segments[segments.length - 1], value);
+            log.debug("Injected IdP claim into DCR field [{}]", fieldPath);
         }
     }
 
@@ -246,12 +273,17 @@ public abstract class DynamicClientRegistrationProviderClient {
         }
     }
 
-    public ClientRegistrationResponse register(ClientRegistrationRequest request, TrustStoreEntity trustStore, KeyStoreEntity keyStore) {
+    public ClientRegistrationResponse register(
+        ClientRegistrationRequest request,
+        Map<String, String> claimInjections,
+        TrustStoreEntity trustStore,
+        KeyStoreEntity keyStore
+    ) {
         // 1_ Generate an access_token
         String accessToken = getInitialAccessToken();
 
         // 2_ Register the client
-        return register(accessToken, request, trustStore, keyStore);
+        return register(accessToken, request, claimInjections, trustStore, keyStore);
     }
 
     public abstract String getInitialAccessToken();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/IdentityProviderServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/IdentityProviderServiceImpl.java
@@ -154,6 +154,11 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
             identityProvider.setCreatedAt(identityProviderToUpdate.getCreatedAt());
             identityProvider.setUpdatedAt(new Date());
             identityProvider.setOrganizationId(identityProviderToUpdate.getOrganizationId());
+            // Preserve the persisted claims whitelist when the update payload omits it (e.g. saved from a console
+            // screen unaware of the field); clear it explicitly by sending an empty list.
+            if (updateIdentityProvider.getPersistedClaimsWhitelist() == null) {
+                identityProvider.setPersistedClaimsWhitelist(identityProviderToUpdate.getPersistedClaimsWhitelist());
+            }
             IdentityProvider updatedIdentityProvider = identityProviderRepository.update(identityProvider);
 
             // Audit
@@ -294,6 +299,7 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
         identityProvider.setType(IdentityProviderType.valueOf(newIdentityProviderEntity.getType().name().toUpperCase()));
         identityProvider.setEnabled(newIdentityProviderEntity.isEnabled());
         identityProvider.setUserProfileMapping(newIdentityProviderEntity.getUserProfileMapping());
+        identityProvider.setPersistedClaimsWhitelist(newIdentityProviderEntity.getPersistedClaimsWhitelist());
         identityProvider.setEmailRequired(newIdentityProviderEntity.isEmailRequired());
         identityProvider.setSyncMappings(newIdentityProviderEntity.isSyncMappings());
 
@@ -345,6 +351,7 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
         identityProviderEntity.setCreatedAt(identityProvider.getCreatedAt());
         identityProviderEntity.setUpdatedAt(identityProvider.getUpdatedAt());
         identityProviderEntity.setUserProfileMapping(identityProvider.getUserProfileMapping());
+        identityProviderEntity.setPersistedClaimsWhitelist(identityProvider.getPersistedClaimsWhitelist());
         if (identityProvider.getEmailRequired() == null) {
             identityProviderEntity.setEmailRequired(true);
         } else {
@@ -365,6 +372,7 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
         identityProvider.setEnabled(updateIdentityProvider.isEnabled());
         identityProvider.setConfiguration(updateIdentityProvider.getConfiguration());
         identityProvider.setUserProfileMapping(updateIdentityProvider.getUserProfileMapping());
+        identityProvider.setPersistedClaimsWhitelist(updateIdentityProvider.getPersistedClaimsWhitelist());
         identityProvider.setEmailRequired(updateIdentityProvider.isEmailRequired());
         identityProvider.setSyncMappings(updateIdentityProvider.isSyncMappings());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/IdentityProviderServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/IdentityProviderServiceImpl.java
@@ -39,6 +39,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService;
 import io.gravitee.rest.api.service.configuration.identity.IdentityProviderService;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.AbstractService;
 import java.util.ArrayList;
@@ -91,6 +92,8 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
             if (optIdentityProvider.isPresent()) {
                 throw new IdentityProviderAlreadyExistsException(newIdentityProviderEntity.getName());
             }
+
+            validatePersistedClaimsWhitelist(newIdentityProviderEntity.getPersistedClaimsWhitelist());
 
             IdentityProvider identityProvider = convert(newIdentityProviderEntity);
             identityProvider.setOrganizationId(executionContext.getOrganizationId());
@@ -145,6 +148,8 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
                 .findById(id)
                 .filter(idp -> idp.getOrganizationId().equalsIgnoreCase(executionContext.getOrganizationId()))
                 .orElseThrow(() -> new IdentityProviderNotFoundException(updateIdentityProvider.getName()));
+
+            validatePersistedClaimsWhitelist(updateIdentityProvider.getPersistedClaimsWhitelist());
 
             //TODO: Find a way to validate mapping expression
             IdentityProvider identityProvider = convert(executionContext, updateIdentityProvider);
@@ -287,6 +292,21 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
         }
 
         return roleMapping;
+    }
+
+    /**
+     * Validates the persisted claims whitelist: each entry must be a non-blank claim name (claim names are
+     * provider-defined free-form strings, so only emptiness is checked — APIM-13950).
+     */
+    private void validatePersistedClaimsWhitelist(List<String> whitelist) {
+        if (whitelist == null) {
+            return;
+        }
+        for (String claimName : whitelist) {
+            if (claimName == null || claimName.trim().isEmpty()) {
+                throw new InvalidDataException("Persisted claims whitelist must not contain empty claim names");
+            }
+        }
     }
 
     private IdentityProvider convert(NewIdentityProviderEntity newIdentityProviderEntity) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImpl.java
@@ -179,6 +179,7 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
             provider.setRoleMappings(identityProvider.getRoleMappings());
             provider.setEmailRequired(identityProvider.isEmailRequired());
             provider.setSyncMappings(identityProvider.isSyncMappings());
+            provider.setPersistedClaimsWhitelist(identityProvider.getPersistedClaimsWhitelist());
             return provider;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
@@ -574,7 +574,7 @@ public class ApplicationService_CreateTest {
         // mock response from DCR with a new client ID
         ClientRegistrationResponse clientRegistrationResponse = new ClientRegistrationResponse();
         clientRegistrationResponse.setClientId("client-id-from-clientRegistration");
-        when(clientRegistrationService.register(any(), any())).thenReturn(clientRegistrationResponse);
+        when(clientRegistrationService.register(any(), any(), any())).thenReturn(clientRegistrationResponse);
         when(applicationConverter.toApplication(any(NewApplicationEntity.class))).thenCallRealMethod();
 
         applicationService.create(EXECUTION_CONTEXT, newApplication, USER_NAME);
@@ -695,7 +695,7 @@ public class ApplicationService_CreateTest {
         // Mock response from DCR with a new client ID
         ClientRegistrationResponse clientRegistrationResponse = new ClientRegistrationResponse();
         clientRegistrationResponse.setClientId("client-id-from-clientRegistration");
-        when(clientRegistrationService.register(any(), any())).thenReturn(clientRegistrationResponse);
+        when(clientRegistrationService.register(any(), any(), any())).thenReturn(clientRegistrationResponse);
         when(applicationConverter.toApplication(any(NewApplicationEntity.class))).thenCallRealMethod();
 
         // Enable DCR

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
@@ -571,6 +571,10 @@ public class ApplicationService_CreateTest {
         applicationTypeEntity.setRequires_redirect_uris(false);
         when(applicationTypeService.getApplicationType("BROWSER")).thenReturn(applicationTypeEntity);
 
+        // the creating user's persisted IdP claims must be threaded into the DCR registration call
+        Map<String, String> idpClaims = Map.of("org_id", "org_acme_12345");
+        when(userService.findIdpClaims(any(), eq(USER_NAME))).thenReturn(idpClaims);
+
         // mock response from DCR with a new client ID
         ClientRegistrationResponse clientRegistrationResponse = new ClientRegistrationResponse();
         clientRegistrationResponse.setClientId("client-id-from-clientRegistration");
@@ -583,6 +587,8 @@ public class ApplicationService_CreateTest {
         verify(applicationRepository).create(
             argThat(app -> app.getMetadata().get(METADATA_CLIENT_ID).equals("client-id-from-clientRegistration"))
         );
+        // ensure the user's persisted IdP claims were passed through to the DCR registration (the new wiring)
+        verify(clientRegistrationService).register(any(), any(), eq(idpClaims));
     }
 
     private static final String VALID_PEM = """

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
@@ -619,6 +619,14 @@ public class ApplicationService_UpdateTest {
 
         when(applicationTypeService.getApplicationType(ApplicationType.BROWSER.name())).thenReturn(applicationTypeEntity);
         when(configService.getConsoleConfig(GraviteeContext.getExecutionContext())).thenReturn(consoleConfig);
+        // the DCR update must inject the application OWNER's IdP claims, not the editor's
+        when(existingApplication.getId()).thenReturn(APPLICATION_ID);
+        Map<String, String> ownerClaims = Map.of("org_id", "org_acme_12345");
+        when(membershipService.getPrimaryOwnerUserId(any(), eq(MembershipReferenceType.APPLICATION), eq(APPLICATION_ID))).thenReturn(
+            "owner-id"
+        );
+        when(userService.findIdpClaims(any(), eq("owner-id"))).thenReturn(ownerClaims);
+
         // mock response from DCR with a new client ID
         ClientRegistrationResponse clientRegistrationResponse = new ClientRegistrationResponse();
         clientRegistrationResponse.setClientId("client-id-from-clientRegistration");
@@ -631,6 +639,8 @@ public class ApplicationService_UpdateTest {
         verify(applicationRepository).update(
             argThat(application -> application.getMetadata().get(METADATA_CLIENT_ID).equals("client-id-from-clientRegistration"))
         );
+        // ensure the owner's resolved claims were the ones passed to the DCR update
+        verify(clientRegistrationService).update(any(), any(), same(updateApplication), eq(ownerClaims));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
@@ -622,7 +622,7 @@ public class ApplicationService_UpdateTest {
         // mock response from DCR with a new client ID
         ClientRegistrationResponse clientRegistrationResponse = new ClientRegistrationResponse();
         clientRegistrationResponse.setClientId("client-id-from-clientRegistration");
-        when(clientRegistrationService.update(any(), any(), same(updateApplication))).thenReturn(clientRegistrationResponse);
+        when(clientRegistrationService.update(any(), any(), same(updateApplication), any())).thenReturn(clientRegistrationResponse);
         when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
 
         applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
@@ -680,7 +680,7 @@ public class ApplicationService_UpdateTest {
         when(applicationTypeService.getApplicationType(ApplicationType.BROWSER.name())).thenReturn(applicationTypeEntity);
 
         // DCR throws exception
-        when(clientRegistrationService.update(any(), any(), same(updateApplication))).thenThrow(RuntimeException.class);
+        when(clientRegistrationService.update(any(), any(), same(updateApplication), any())).thenThrow(RuntimeException.class);
         when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
 
         applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_RegisterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_RegisterTest.java
@@ -153,13 +153,65 @@ public class ClientRegistrationService_RegisterTest {
 
         clientRegistrationService.register(GraviteeContext.getExecutionContext(), application, idpClaims);
 
-        // the mapped, present claim is injected at the nested DCR field path (the mapped but missing 'tenant'
-        // claim is skipped by resolveClaimInjections, so no metadata.tenant is sent)
+        // the mapped, present claim is injected at the nested DCR field path
         wireMockServer.verify(
             postRequestedFor(urlEqualTo("/registrationEp")).withRequestBody(
                 matchingJsonPath("$.metadata.organization", equalTo("org_acme_12345"))
             )
         );
+        // the mapped but missing 'tenant' claim is skipped: no request carried metadata.tenant
+        wireMockServer.verify(0, postRequestedFor(urlEqualTo("/registrationEp")).withRequestBody(matchingJsonPath("$.metadata.tenant")));
+    }
+
+    @Test
+    public void should_inject_claim_overriding_an_existing_standard_field() throws TechnicalException {
+        NewApplicationEntity application = new NewApplicationEntity();
+        ApplicationSettings applicationSettings = new ApplicationSettings();
+        applicationSettings.setOauth(new OAuthClientSettings());
+        application.setSettings(applicationSettings);
+
+        ClientRegistrationProvider provider = new ClientRegistrationProvider();
+        provider.setId("CRP_ID");
+        provider.setName("name");
+        provider.setDiscoveryEndpoint("http://localhost:" + wireMockServer.port() + "/am");
+        // map onto an existing standard (non-protected) field — injection overrides it (APIM-13953)
+        provider.setClaimMappings(Map.of("org_id", "client_name"));
+
+        when(
+            mockClientRegistrationProviderRepository.findAllByEnvironment(eq(GraviteeContext.getExecutionContext().getEnvironmentId()))
+        ).thenReturn(newSet(provider));
+
+        wireMockServer.stubFor(
+            get(urlEqualTo("/am")).willReturn(
+                aResponse().withBody(
+                    "{\"token_endpoint\": \"http://localhost:" +
+                        wireMockServer.port() +
+                        "/tokenEp\",\"registration_endpoint\": \"http://localhost:" +
+                        wireMockServer.port() +
+                        "/registrationEp\"}"
+                )
+            )
+        );
+        wireMockServer.stubFor(
+            post(urlEqualTo("/tokenEp")).willReturn(aResponse().withBody("{\"access_token\": \"myToken\",\"scope\": \"scope\"}"))
+        );
+        wireMockServer.stubFor(post(urlEqualTo("/registrationEp")).willReturn(aResponse().withBody("{ \"client_name\": \"gravitee\"}")));
+
+        clientRegistrationService.register(GraviteeContext.getExecutionContext(), application, Map.of("org_id", "Acme App"));
+
+        wireMockServer.verify(
+            postRequestedFor(urlEqualTo("/registrationEp")).withRequestBody(matchingJsonPath("$.client_name", equalTo("Acme App")))
+        );
+    }
+
+    @Test
+    public void should_inject_nothing_when_no_claim_mappings_configured() throws TechnicalException {
+        NewApplicationEntity application = setupApplicationAndProvider(new OAuthClientSettings(), "{ \"client_name\": \"gravitee\"}");
+        // provider has no claimMappings; even with user claims present, nothing is injected
+        clientRegistrationService.register(GraviteeContext.getExecutionContext(), application, Map.of("org_id", "org_acme_12345"));
+
+        // no mappings → nothing injected: no request carried a metadata field
+        wireMockServer.verify(0, postRequestedFor(urlEqualTo("/registrationEp")).withRequestBody(matchingJsonPath("$.metadata")));
     }
 
     private @NotNull NewApplicationEntity setupApplicationAndProvider(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_RegisterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_RegisterTest.java
@@ -164,17 +164,20 @@ public class ClientRegistrationService_RegisterTest {
     }
 
     @Test
-    public void should_inject_claim_overriding_an_existing_standard_field() throws TechnicalException {
+    public void should_not_inject_into_a_standard_field() throws TechnicalException {
         NewApplicationEntity application = new NewApplicationEntity();
         ApplicationSettings applicationSettings = new ApplicationSettings();
-        applicationSettings.setOauth(new OAuthClientSettings());
+        OAuthClientSettings oauth = new OAuthClientSettings();
+        oauth.setApplicationType("web");
+        applicationSettings.setOauth(oauth);
         application.setSettings(applicationSettings);
+        application.setName("Original Name");
 
         ClientRegistrationProvider provider = new ClientRegistrationProvider();
         provider.setId("CRP_ID");
         provider.setName("name");
         provider.setDiscoveryEndpoint("http://localhost:" + wireMockServer.port() + "/am");
-        // map onto an existing standard (non-protected) field — injection overrides it (APIM-13953)
+        // a mapping onto a standard field (client_name) is not injectable — the allowlist skips it defensively
         provider.setClaimMappings(Map.of("org_id", "client_name"));
 
         when(
@@ -197,10 +200,12 @@ public class ClientRegistrationService_RegisterTest {
         );
         wireMockServer.stubFor(post(urlEqualTo("/registrationEp")).willReturn(aResponse().withBody("{ \"client_name\": \"gravitee\"}")));
 
-        clientRegistrationService.register(GraviteeContext.getExecutionContext(), application, Map.of("org_id", "Acme App"));
+        clientRegistrationService.register(GraviteeContext.getExecutionContext(), application, Map.of("org_id", "Injected Name"));
 
+        // the claim value never reaches the standard client_name field
         wireMockServer.verify(
-            postRequestedFor(urlEqualTo("/registrationEp")).withRequestBody(matchingJsonPath("$.client_name", equalTo("Acme App")))
+            0,
+            postRequestedFor(urlEqualTo("/registrationEp")).withRequestBody(matchingJsonPath("$.client_name", equalTo("Injected Name")))
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_RegisterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_RegisterTest.java
@@ -16,8 +16,11 @@
 package io.gravitee.rest.api.service.impl;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -80,7 +83,8 @@ public class ClientRegistrationService_RegisterTest {
 
         ClientRegistrationResponse clientRegistration = clientRegistrationService.register(
             GraviteeContext.getExecutionContext(),
-            application
+            application,
+            null
         );
         assertNotNull(clientRegistration, "Result is null");
 
@@ -101,12 +105,61 @@ public class ClientRegistrationService_RegisterTest {
 
         ClientRegistrationResponse clientRegistration = clientRegistrationService.register(
             GraviteeContext.getExecutionContext(),
-            application
+            application,
+            null
         );
         assertNotNull(clientRegistration, "Result is null");
 
         assertEquals(clientRegistration.getClientName(), "gravitee");
         assertEquals("https://example.com/policy", clientRegistration.getPolicyUri());
+    }
+
+    @Test
+    public void should_inject_mapped_claims_into_dcr_request_body() throws TechnicalException {
+        NewApplicationEntity application = new NewApplicationEntity();
+        ApplicationSettings applicationSettings = new ApplicationSettings();
+        applicationSettings.setOauth(new OAuthClientSettings());
+        application.setSettings(applicationSettings);
+
+        ClientRegistrationProvider provider = new ClientRegistrationProvider();
+        provider.setId("CRP_ID");
+        provider.setName("name");
+        provider.setDiscoveryEndpoint("http://localhost:" + wireMockServer.port() + "/am");
+        // 'org_id' is present in the user claims and should be injected at a nested path; 'tenant' is mapped but
+        // absent from the user claims and must be skipped.
+        provider.setClaimMappings(Map.of("org_id", "metadata.organization", "tenant", "metadata.tenant"));
+
+        when(
+            mockClientRegistrationProviderRepository.findAllByEnvironment(eq(GraviteeContext.getExecutionContext().getEnvironmentId()))
+        ).thenReturn(newSet(provider));
+
+        wireMockServer.stubFor(
+            get(urlEqualTo("/am")).willReturn(
+                aResponse().withBody(
+                    "{\"token_endpoint\": \"http://localhost:" +
+                        wireMockServer.port() +
+                        "/tokenEp\",\"registration_endpoint\": \"http://localhost:" +
+                        wireMockServer.port() +
+                        "/registrationEp\"}"
+                )
+            )
+        );
+        wireMockServer.stubFor(
+            post(urlEqualTo("/tokenEp")).willReturn(aResponse().withBody("{\"access_token\": \"myToken\",\"scope\": \"scope\"}"))
+        );
+        wireMockServer.stubFor(post(urlEqualTo("/registrationEp")).willReturn(aResponse().withBody("{ \"client_name\": \"gravitee\"}")));
+
+        Map<String, String> idpClaims = Map.of("org_id", "org_acme_12345");
+
+        clientRegistrationService.register(GraviteeContext.getExecutionContext(), application, idpClaims);
+
+        // the mapped, present claim is injected at the nested DCR field path (the mapped but missing 'tenant'
+        // claim is skipped by resolveClaimInjections, so no metadata.tenant is sent)
+        wireMockServer.verify(
+            postRequestedFor(urlEqualTo("/registrationEp")).withRequestBody(
+                matchingJsonPath("$.metadata.organization", equalTo("org_acme_12345"))
+            )
+        );
     }
 
     private @NotNull NewApplicationEntity setupApplicationAndProvider(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_UpdateTest.java
@@ -362,6 +362,25 @@ public class ClientRegistrationService_UpdateTest {
     }
 
     @Test
+    public void should_reject_claim_mapping_targeting_software_statement() throws TechnicalException {
+        UpdateClientRegistrationProviderEntity providerPayload = new UpdateClientRegistrationProviderEntity();
+        providerPayload.setName("name");
+        providerPayload.setDiscoveryEndpoint("http://localhost:" + wireMockServer.port() + "/am");
+        // software_statement is a standard DCR field — must be rejected (allowlist by exclusion of standard fields)
+        providerPayload.setClaimMappings(Map.of("org_id", "software_statement"));
+
+        ClientRegistrationProvider existingPayload = new ClientRegistrationProvider();
+        existingPayload.setId("CRP_ID");
+        existingPayload.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        when(mockClientRegistrationProviderRepository.findById(eq(existingPayload.getId()))).thenReturn(Optional.of(existingPayload));
+
+        assertThrows(InvalidClaimMappingException.class, () ->
+            clientRegistrationService.update(GraviteeContext.getExecutionContext(), existingPayload.getId(), providerPayload)
+        );
+        verify(mockClientRegistrationProviderRepository, never()).update(any());
+    }
+
+    @Test
     public void should_reject_claim_mapping_with_blank_field_path() throws TechnicalException {
         UpdateClientRegistrationProviderEntity providerPayload = new UpdateClientRegistrationProviderEntity();
         providerPayload.setName("name");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_UpdateTest.java
@@ -16,8 +16,11 @@
 package io.gravitee.rest.api.service.impl;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.gravitee.repository.management.model.ClientRegistrationProvider.AuditEvent.CLIENT_REGISTRATION_PROVIDER_UPDATED;
 import static org.junit.jupiter.api.Assertions.*;
@@ -48,6 +51,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.configuration.application.registration.ClientRegistrationProviderNotFoundException;
 import io.gravitee.rest.api.service.impl.configuration.application.registration.ClientRegistrationServiceImpl;
 import io.gravitee.rest.api.service.impl.configuration.application.registration.EmptyInitialAccessTokenException;
+import io.gravitee.rest.api.service.impl.configuration.application.registration.InvalidClaimMappingException;
 import io.gravitee.rest.api.service.impl.configuration.application.registration.client.register.ClientRegistrationResponse;
 import java.util.HashMap;
 import java.util.Map;
@@ -223,7 +227,8 @@ public class ClientRegistrationService_UpdateTest {
         ClientRegistrationResponse providerUpdated = clientRegistrationService.update(
             GraviteeContext.getExecutionContext(),
             mapper.writeValueAsString(existingPayload),
-            updateApplicationEntity
+            updateApplicationEntity,
+            null
         );
         assertNotNull(providerUpdated, "Result is null");
 
@@ -336,5 +341,95 @@ public class ClientRegistrationService_UpdateTest {
         ArgumentCaptor<ClientRegistrationProvider> captor = ArgumentCaptor.forClass(ClientRegistrationProvider.class);
         verify(mockClientRegistrationProviderRepository).update(captor.capture());
         assertEquals(Map.of("tenant", "metadata.tenant"), captor.getValue().getClaimMappings());
+    }
+
+    @Test
+    public void should_reject_claim_mapping_targeting_a_security_relevant_field() throws TechnicalException {
+        UpdateClientRegistrationProviderEntity providerPayload = new UpdateClientRegistrationProviderEntity();
+        providerPayload.setName("name");
+        providerPayload.setDiscoveryEndpoint("http://localhost:" + wireMockServer.port() + "/am");
+        providerPayload.setClaimMappings(Map.of("org_id", "redirect_uris"));
+
+        ClientRegistrationProvider existingPayload = new ClientRegistrationProvider();
+        existingPayload.setId("CRP_ID");
+        existingPayload.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        when(mockClientRegistrationProviderRepository.findById(eq(existingPayload.getId()))).thenReturn(Optional.of(existingPayload));
+
+        assertThrows(InvalidClaimMappingException.class, () ->
+            clientRegistrationService.update(GraviteeContext.getExecutionContext(), existingPayload.getId(), providerPayload)
+        );
+        verify(mockClientRegistrationProviderRepository, never()).update(any());
+    }
+
+    @Test
+    public void should_reject_claim_mapping_with_blank_field_path() throws TechnicalException {
+        UpdateClientRegistrationProviderEntity providerPayload = new UpdateClientRegistrationProviderEntity();
+        providerPayload.setName("name");
+        providerPayload.setDiscoveryEndpoint("http://localhost:" + wireMockServer.port() + "/am");
+        Map<String, String> mappings = new java.util.HashMap<>();
+        mappings.put("org_id", "  ");
+        providerPayload.setClaimMappings(mappings);
+
+        ClientRegistrationProvider existingPayload = new ClientRegistrationProvider();
+        existingPayload.setId("CRP_ID");
+        existingPayload.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        when(mockClientRegistrationProviderRepository.findById(eq(existingPayload.getId()))).thenReturn(Optional.of(existingPayload));
+
+        assertThrows(InvalidClaimMappingException.class, () ->
+            clientRegistrationService.update(GraviteeContext.getExecutionContext(), existingPayload.getId(), providerPayload)
+        );
+        verify(mockClientRegistrationProviderRepository, never()).update(any());
+    }
+
+    @Test
+    public void should_inject_mapped_claims_on_application_update() throws TechnicalException, JsonProcessingException {
+        UpdateApplicationEntity updateApplicationEntity = new UpdateApplicationEntity();
+        OAuthClientSettings oAuthClientSettings = new OAuthClientSettings();
+        ApplicationSettings applicationSettings = new ApplicationSettings();
+        applicationSettings.setOauth(oAuthClientSettings);
+        updateApplicationEntity.setSettings(applicationSettings);
+
+        ClientRegistrationResponse existingPayload = new ClientRegistrationResponse();
+        existingPayload.setId("CRP_ID");
+        existingPayload.setRegistrationAccessToken("registrationAccessToken");
+        existingPayload.setRegistrationClientUri("http://localhost:" + wireMockServer.port() + "/registration");
+
+        wireMockServer.stubFor(
+            put(urlEqualTo("/registration")).willReturn(
+                aResponse().withBody("{\"client_id\": \"clientId\",\"client_secret\": \"clientSecret\"}")
+            )
+        );
+
+        ClientRegistrationProvider provider = new ClientRegistrationProvider();
+        provider.setId(existingPayload.getId());
+        provider.setName("name");
+        provider.setDiscoveryEndpoint("http://localhost:" + wireMockServer.port() + "/am");
+        provider.setClaimMappings(Map.of("org_id", "metadata.organization"));
+
+        when(
+            mockClientRegistrationProviderRepository.findAllByEnvironment(eq(GraviteeContext.getExecutionContext().getEnvironmentId()))
+        ).thenReturn(newSet(provider));
+
+        wireMockServer.stubFor(
+            get(urlEqualTo("/am")).willReturn(
+                aResponse().withBody("{\"token_endpoint\": \"tokenEp\",\"registration_endpoint\": \"registrationEp\"}")
+            )
+        );
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        clientRegistrationService.update(
+            GraviteeContext.getExecutionContext(),
+            mapper.writeValueAsString(existingPayload),
+            updateApplicationEntity,
+            Map.of("org_id", "org_acme_12345")
+        );
+
+        // claims are re-injected on the RFC 7592 update so they survive application edits (Paula #3)
+        wireMockServer.verify(
+            putRequestedFor(urlEqualTo("/registration")).withRequestBody(
+                matchingJsonPath("$.metadata.organization", equalTo("org_acme_12345"))
+            )
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_UpdateTest.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -281,5 +282,59 @@ public class ClientRegistrationService_UpdateTest {
             argThat(auditLogData -> auditLogData.getEvent().equals(CLIENT_REGISTRATION_PROVIDER_UPDATED))
         );
         verify(mockClientRegistrationProviderRepository, times(1)).update(any());
+    }
+
+    @Test
+    public void should_preserve_claim_mappings_when_payload_omits_them() throws TechnicalException {
+        UpdateClientRegistrationProviderEntity providerPayload = new UpdateClientRegistrationProviderEntity();
+        providerPayload.setName("name");
+        providerPayload.setDiscoveryEndpoint("http://localhost:" + wireMockServer.port() + "/am");
+        // claimMappings intentionally omitted (null)
+
+        ClientRegistrationProvider existingPayload = new ClientRegistrationProvider();
+        existingPayload.setId("CRP_ID");
+        existingPayload.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        existingPayload.setClaimMappings(Map.of("org_id", "metadata.organization"));
+
+        when(mockClientRegistrationProviderRepository.findById(eq(existingPayload.getId()))).thenReturn(Optional.of(existingPayload));
+        wireMockServer.stubFor(
+            get(urlEqualTo("/am")).willReturn(
+                aResponse().withBody("{\"token_endpoint\": \"tokenEp\",\"registration_endpoint\": \"registrationEp\"}")
+            )
+        );
+        when(mockClientRegistrationProviderRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        clientRegistrationService.update(GraviteeContext.getExecutionContext(), existingPayload.getId(), providerPayload);
+
+        ArgumentCaptor<ClientRegistrationProvider> captor = ArgumentCaptor.forClass(ClientRegistrationProvider.class);
+        verify(mockClientRegistrationProviderRepository).update(captor.capture());
+        assertEquals(Map.of("org_id", "metadata.organization"), captor.getValue().getClaimMappings());
+    }
+
+    @Test
+    public void should_overwrite_claim_mappings_when_provided() throws TechnicalException {
+        UpdateClientRegistrationProviderEntity providerPayload = new UpdateClientRegistrationProviderEntity();
+        providerPayload.setName("name");
+        providerPayload.setDiscoveryEndpoint("http://localhost:" + wireMockServer.port() + "/am");
+        providerPayload.setClaimMappings(Map.of("tenant", "metadata.tenant"));
+
+        ClientRegistrationProvider existingPayload = new ClientRegistrationProvider();
+        existingPayload.setId("CRP_ID");
+        existingPayload.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        existingPayload.setClaimMappings(Map.of("org_id", "metadata.organization"));
+
+        when(mockClientRegistrationProviderRepository.findById(eq(existingPayload.getId()))).thenReturn(Optional.of(existingPayload));
+        wireMockServer.stubFor(
+            get(urlEqualTo("/am")).willReturn(
+                aResponse().withBody("{\"token_endpoint\": \"tokenEp\",\"registration_endpoint\": \"registrationEp\"}")
+            )
+        );
+        when(mockClientRegistrationProviderRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        clientRegistrationService.update(GraviteeContext.getExecutionContext(), existingPayload.getId(), providerPayload);
+
+        ArgumentCaptor<ClientRegistrationProvider> captor = ArgumentCaptor.forClass(ClientRegistrationProvider.class);
+        verify(mockClientRegistrationProviderRepository).update(captor.capture());
+        assertEquals(Map.of("tenant", "metadata.tenant"), captor.getValue().getClaimMappings());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -1760,6 +1760,51 @@ public class UserServiceTest {
         verify(userRepository, times(1)).update(refEq(user));
     }
 
+    @Test
+    public void shouldPersistWhitelistedClaimsOnLogin() throws IOException, TechnicalException {
+        reset(identityProvider, userRepository);
+        mockDefaultEnvironment();
+
+        User user = mockUser();
+        when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+        when(identityProvider.getPersistedClaimsWhitelist()).thenReturn(Arrays.asList("custom_id_token", "service_id", "email"));
+
+        String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        String accessToken = IOUtils.toString(read("/oauth2/jwt/access_token.jwt"), Charset.defaultCharset());
+        String idToken = IOUtils.toString(read("/oauth2/jwt/id_token.jwt"), Charset.defaultCharset());
+
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
+
+        assertNotNull(user.getIdpClaims());
+        // claim only present in the id_token
+        assertEquals("foobar", user.getIdpClaims().get("custom_id_token"));
+        // claim only present in the userinfo
+        assertEquals("585252525", user.getIdpClaims().get("service_id"));
+        // claim present in both id_token and userinfo: the id_token value wins
+        assertEquals("john.doe@mycompany.com", user.getIdpClaims().get("email"));
+    }
+
+    @Test
+    public void shouldNotPersistClaimsWhenNoWhitelistConfigured() throws IOException, TechnicalException {
+        reset(identityProvider, userRepository);
+        mockDefaultEnvironment();
+
+        User user = mockUser();
+        when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+
+        String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        String accessToken = IOUtils.toString(read("/oauth2/jwt/access_token.jwt"), Charset.defaultCharset());
+        String idToken = IOUtils.toString(read("/oauth2/jwt/id_token.jwt"), Charset.defaultCharset());
+
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
+
+        assertNull(user.getIdpClaims());
+    }
+
     private User mockUser() {
         User user = new User();
         user.setId("janedoe@example.com");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -1792,6 +1792,9 @@ public class UserServiceTest {
         mockDefaultEnvironment();
 
         User user = mockUser();
+        // Pre-set a sentinel so the assertion actually pins the no-op: if the whitelist guard were removed, the code
+        // would overwrite this with an empty map. mockUser() leaves idpClaims null, which would make assertNull vacuous.
+        user.setIdpClaims(Map.of("pre_existing", "value"));
         when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
@@ -1802,7 +1805,52 @@ public class UserServiceTest {
 
         userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
 
-        assertNull(user.getIdpClaims());
+        // No whitelist configured → the persistence path is a no-op and leaves the existing claims untouched
+        assertEquals(Map.of("pre_existing", "value"), user.getIdpClaims());
+    }
+
+    @Test
+    public void shouldPersistClaimFromAccessTokenSource() throws IOException, TechnicalException {
+        reset(identityProvider, userRepository);
+        mockDefaultEnvironment();
+
+        User user = mockUser();
+        when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+        // 'custom_access_token' is present only in the access_token fixture — exercises the middle of the source chain
+        when(identityProvider.getPersistedClaimsWhitelist()).thenReturn(Collections.singletonList("custom_access_token"));
+
+        String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        String accessToken = IOUtils.toString(read("/oauth2/jwt/access_token.jwt"), Charset.defaultCharset());
+        String idToken = IOUtils.toString(read("/oauth2/jwt/id_token.jwt"), Charset.defaultCharset());
+
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
+
+        assertNotNull(user.getIdpClaims());
+        assertEquals("foobar", user.getIdpClaims().get("custom_access_token"));
+    }
+
+    @Test
+    public void shouldNotStoreWhitelistedClaimAbsentFromAllSources() throws IOException, TechnicalException {
+        reset(identityProvider, userRepository);
+        mockDefaultEnvironment();
+
+        User user = mockUser();
+        when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+        when(identityProvider.getPersistedClaimsWhitelist()).thenReturn(Collections.singletonList("not_in_any_source"));
+
+        String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        String accessToken = IOUtils.toString(read("/oauth2/jwt/access_token.jwt"), Charset.defaultCharset());
+        String idToken = IOUtils.toString(read("/oauth2/jwt/id_token.jwt"), Charset.defaultCharset());
+
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
+
+        // Missing claim is skipped — no null entry stored (APIM-13951)
+        assertNotNull(user.getIdpClaims());
+        assertFalse(user.getIdpClaims().containsKey("not_in_any_source"));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -1805,6 +1805,59 @@ public class UserServiceTest {
         assertNull(user.getIdpClaims());
     }
 
+    @Test
+    public void shouldPersistOnlyWhitelistedClaims() throws IOException, TechnicalException {
+        reset(identityProvider, userRepository);
+        mockDefaultEnvironment();
+
+        User user = mockUser();
+        when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+        when(identityProvider.getPersistedClaimsWhitelist()).thenReturn(Collections.singletonList("service_id"));
+
+        String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        String accessToken = IOUtils.toString(read("/oauth2/jwt/access_token.jwt"), Charset.defaultCharset());
+        String idToken = IOUtils.toString(read("/oauth2/jwt/id_token.jwt"), Charset.defaultCharset());
+
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
+
+        assertNotNull(user.getIdpClaims());
+        assertEquals(1, user.getIdpClaims().size());
+        assertEquals("585252525", user.getIdpClaims().get("service_id"));
+        // non-whitelisted claims present in the sources are not persisted
+        assertNull(user.getIdpClaims().get("sub"));
+        assertNull(user.getIdpClaims().get("email"));
+    }
+
+    @Test
+    public void shouldOverwriteClaimsOnReLogin() throws IOException, TechnicalException {
+        reset(identityProvider, userRepository);
+        mockDefaultEnvironment();
+
+        User user = mockUser();
+        when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+
+        String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        String accessToken = IOUtils.toString(read("/oauth2/jwt/access_token.jwt"), Charset.defaultCharset());
+        String idToken = IOUtils.toString(read("/oauth2/jwt/id_token.jwt"), Charset.defaultCharset());
+
+        // first login persists custom_id_token
+        when(identityProvider.getPersistedClaimsWhitelist()).thenReturn(Collections.singletonList("custom_id_token"));
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
+        assertEquals("foobar", user.getIdpClaims().get("custom_id_token"));
+
+        // second login with a different whitelist refreshes (overwrites, does not accumulate)
+        when(identityProvider.getPersistedClaimsWhitelist()).thenReturn(Collections.singletonList("service_id"));
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
+
+        assertEquals(1, user.getIdpClaims().size());
+        assertEquals("585252525", user.getIdpClaims().get("service_id"));
+        assertNull(user.getIdpClaims().get("custom_id_token"));
+    }
+
     private User mockUser() {
         User user = new User();
         user.setId("janedoe@example.com");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/identity/IdentityProviderServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/identity/IdentityProviderServiceImplTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.configuration.identity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.management.api.IdentityProviderRepository;
+import io.gravitee.repository.management.model.IdentityProvider;
+import io.gravitee.repository.management.model.IdentityProviderType;
+import io.gravitee.rest.api.model.configuration.identity.UpdateIdentityProviderEntity;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class IdentityProviderServiceImplTest {
+
+    @InjectMocks
+    private IdentityProviderServiceImpl identityProviderService = new IdentityProviderServiceImpl();
+
+    @Mock
+    private IdentityProviderRepository identityProviderRepository;
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    private RoleService roleService;
+
+    @Mock
+    private IdentityProviderActivationService identityProviderActivationService;
+
+    private IdentityProvider existingIdp(List<String> whitelist) {
+        IdentityProvider idp = new IdentityProvider();
+        idp.setId("idp-1");
+        idp.setOrganizationId("DEFAULT");
+        idp.setType(IdentityProviderType.OIDC);
+        idp.setPersistedClaimsWhitelist(whitelist);
+        return idp;
+    }
+
+    private IdentityProvider captureUpdated() throws Exception {
+        ArgumentCaptor<IdentityProvider> captor = ArgumentCaptor.forClass(IdentityProvider.class);
+        verify(identityProviderRepository).update(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    public void update_should_preserve_whitelist_when_payload_omits_it() throws Exception {
+        when(identityProviderRepository.findById("idp-1")).thenReturn(Optional.of(existingIdp(List.of("org_id"))));
+        when(identityProviderRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateIdentityProviderEntity update = new UpdateIdentityProviderEntity();
+        update.setName("My IdP");
+        // persistedClaimsWhitelist intentionally left null (omitted by a console save unaware of the field)
+
+        identityProviderService.update(GraviteeContext.getExecutionContext(), "idp-1", update);
+
+        assertEquals(List.of("org_id"), captureUpdated().getPersistedClaimsWhitelist());
+    }
+
+    @Test
+    public void update_should_overwrite_whitelist_when_provided() throws Exception {
+        when(identityProviderRepository.findById("idp-1")).thenReturn(Optional.of(existingIdp(List.of("org_id"))));
+        when(identityProviderRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateIdentityProviderEntity update = new UpdateIdentityProviderEntity();
+        update.setName("My IdP");
+        update.setPersistedClaimsWhitelist(List.of("tenant"));
+
+        identityProviderService.update(GraviteeContext.getExecutionContext(), "idp-1", update);
+
+        assertEquals(List.of("tenant"), captureUpdated().getPersistedClaimsWhitelist());
+    }
+
+    @Test
+    public void update_should_clear_whitelist_when_empty_list_provided() throws Exception {
+        when(identityProviderRepository.findById("idp-1")).thenReturn(Optional.of(existingIdp(List.of("org_id"))));
+        when(identityProviderRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateIdentityProviderEntity update = new UpdateIdentityProviderEntity();
+        update.setName("My IdP");
+        update.setPersistedClaimsWhitelist(List.of());
+
+        identityProviderService.update(GraviteeContext.getExecutionContext(), "idp-1", update);
+
+        assertEquals(List.of(), captureUpdated().getPersistedClaimsWhitelist());
+    }
+}


### PR DESCRIPTION
## What

Final PR of epic **APIM-13949** — *Tenant/User context propagation in DCR via IdP claims*. Builds on the repository layer merged in #18358 and #18383. This PR delivers the rest-api behavior end-to-end:

- **Config (REST)** — `persistedClaimsWhitelist` on the identity provider (**APIM-13950**) and `claimMappings` on the client registration provider (**APIM-13952**), both with GET/PUT and merge-on-omit so a save that doesn't include the field preserves the stored value.
- **Persist at login** (**APIM-13951**) — on social-IdP login, whitelisted claims are extracted from `id_token` / `access_token` / `userinfo` (first source wins) and persisted on the user; refreshed each login; no-op when no whitelist is configured.
- **Inject into DCR** (**APIM-13953**) — at client registration, the developer's persisted claims are injected into the DCR request body at the mapped (dot-notation) field paths, overriding existing values; missing claims are skipped.
- **Tests** (**APIM-13957**).

## How

- Whitelist surfaced onto `SocialIdentityProviderEntity` at login; claims read via Jackson, stored through the repository (no new API exposure — `idpClaims` is internal only).
- DCR injection done at the JSON-tree layer in `DynamicClientRegistrationProviderClient` just before POST, so both standard and custom/nested fields work without changing the typed `ClientRegistrationRequest`.
- `register()` threads the authenticated user's persisted claims through; skipped for actors with none (admin-on-behalf / service account).

## Tests

rest-api service tests green: `UserServiceTest`, `IdentityProviderServiceImplTest`, `ClientRegistrationService_RegisterTest` (incl. nested injection), `ClientRegistrationService_UpdateTest`, `ApplicationService_CreateTest`.

## Notes

- Stories: **APIM-13950, APIM-13952, APIM-13951, APIM-13953, APIM-13957** (epic **APIM-13949**). Combined into one PR as they form a single cohesive rest-api slice.
- Documentation (APIM-13958) is handled separately, not in this PR.
- No UI (product decision on APIM-13954 — configuration is via the Management REST API).
- Verified end-to-end on a local instance against a mock OIDC provider: login persisted `org_id`, and app registration injected `metadata.organization` into the DCR request.
