### PR TITLE
feat: add configurable connection pool max wait queue size and max connection lifetime to v4 http proxy

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/HttpProxyMaxWaitQueueEdgeCasesV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/HttpProxyMaxWaitQueueEdgeCasesV4IntegrationTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Edge-case smoke coverage for the v4 HTTP proxy {@code maxWaitQueueSize} across its meaningful values, all with a
+ * single-connection pool ({@code maxConcurrentConnections = 1}) and a slow backend so requests contend for the pool.
+ */
+@GatewayTest
+@DeployApi(
+    {
+        "/apis/v4/http/api-mwq-unbounded.json",
+        "/apis/v4/http/api-mwq-absent.json",
+        "/apis/v4/http/api-mwq-null.json",
+        "/apis/v4/http/api-mwq-bounded.json",
+    }
+)
+class HttpProxyMaxWaitQueueEdgeCasesV4IntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    private List<Integer> fireConcurrent(HttpClient httpClient, String path, int count) {
+        return Flowable.range(0, count)
+            .flatMap(i -> httpClient.rxRequest(HttpMethod.GET, path).flatMap(HttpClientRequest::rxSend).toFlowable(), false, count)
+            .map(response -> response.statusCode())
+            .toList()
+            .blockingGet();
+    }
+
+    @Test
+    @DisplayName("Unbounded (-1): all contending requests are queued and served, none shed")
+    void unbounded_queue_serves_all(HttpClient httpClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("ok").withFixedDelay(300)));
+        assertThat(fireConcurrent(httpClient, "/mwq-unbounded", 4)).containsOnly(200);
+    }
+
+    @Test
+    @DisplayName("Absent field: defaults to unbounded, all requests served")
+    void absent_defaults_to_unbounded(HttpClient httpClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("ok").withFixedDelay(300)));
+        assertThat(fireConcurrent(httpClient, "/mwq-absent", 4)).containsOnly(200);
+    }
+
+    @Test
+    @DisplayName("Explicit null: treated as absent (unbounded), all requests served")
+    void explicit_null_defaults_to_unbounded(HttpClient httpClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("ok").withFixedDelay(300)));
+        assertThat(fireConcurrent(httpClient, "/mwq-null", 4)).containsOnly(200);
+    }
+
+    @Test
+    @DisplayName("Bounded (1): the pool + one queued request are served, the rest are shed with 503")
+    void bounded_queue_sheds_overflow(HttpClient httpClient) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("ok").withFixedDelay(1500)));
+        List<Integer> statuses = fireConcurrent(httpClient, "/mwq-bounded", 6);
+        assertThat(statuses).contains(200);
+        assertThat(statuses).contains(503);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/HttpProxyMaxWaitQueueV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/HttpProxyMaxWaitQueueV4IntegrationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@code maxWaitQueueSize} shared configuration of the v4 HTTP proxy endpoint: when the connection
+ * pool is full and the wait queue is disabled, a pending request is rejected immediately instead of being queued.
+ *
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi("/apis/v4/http/api-max-wait-queue.json")
+class HttpProxyMaxWaitQueueV4IntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    private static final int CONCURRENT_REQUESTS = 5;
+
+    @Test
+    @DisplayName("Should reject overflowing requests with 503 load-shedding when the pool is full and the wait queue is disabled")
+    void should_reject_requests_when_wait_queue_is_full(HttpClient httpClient) {
+        // The backend keeps its single pooled connection (maxConcurrentConnections = 1) busy for a while, so the
+        // concurrent requests pile up: with the wait queue disabled (maxWaitQueueSize = 0) they must be rejected
+        // immediately instead of being queued.
+        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend").withFixedDelay(2000)));
+
+        final List<Integer> statuses = Flowable.range(0, CONCURRENT_REQUESTS)
+            .flatMap(
+                i -> httpClient.rxRequest(HttpMethod.GET, "/test").flatMap(HttpClientRequest::rxSend).toFlowable(),
+                false,
+                CONCURRENT_REQUESTS
+            )
+            .map(response -> response.statusCode())
+            .toList()
+            .blockingGet();
+
+        // The single request that grabs the connection succeeds; every request that overflows the disabled queue
+        // is shed with a retryable 503 (distinct from the 502 used for other backend connection errors).
+        assertThat(statuses).contains(503);
+        assertThat(statuses).doesNotContain(502);
+        assertThat(statuses)
+            .filteredOn(status -> status == 200)
+            .hasSize(1);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-max-wait-queue.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-max-wait-queue.json
@@ -1,0 +1,65 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000,
+              "maxConcurrentConnections": 1,
+              "maxWaitQueueSize": 0
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "GET"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-absent.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-absent.json
@@ -1,0 +1,27 @@
+{
+  "id": "mwq-absent",
+  "name": "mwq-absent",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    { "type": "http", "paths": [ { "path": "/mwq-absent" } ], "entrypoints": [ { "type": "http-proxy" } ] }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": { "target": "http://localhost:8080/endpoint" },
+          "sharedConfigurationOverride": { "http": { "connectTimeout": 3000, "readTimeout": 60000, "maxConcurrentConnections": 1 } }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": { "enabled": false }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-bounded.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-bounded.json
@@ -1,0 +1,27 @@
+{
+  "id": "mwq-bounded",
+  "name": "mwq-bounded",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    { "type": "http", "paths": [ { "path": "/mwq-bounded" } ], "entrypoints": [ { "type": "http-proxy" } ] }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": { "target": "http://localhost:8080/endpoint" },
+          "sharedConfigurationOverride": { "http": { "connectTimeout": 3000, "readTimeout": 60000, "maxConcurrentConnections": 1, "maxWaitQueueSize": 1 } }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": { "enabled": false }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-null.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-null.json
@@ -1,0 +1,27 @@
+{
+  "id": "mwq-null",
+  "name": "mwq-null",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    { "type": "http", "paths": [ { "path": "/mwq-null" } ], "entrypoints": [ { "type": "http-proxy" } ] }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": { "target": "http://localhost:8080/endpoint" },
+          "sharedConfigurationOverride": { "http": { "connectTimeout": 3000, "readTimeout": 60000, "maxConcurrentConnections": 1, "maxWaitQueueSize": null } }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": { "enabled": false }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-unbounded.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-mwq-unbounded.json
@@ -1,0 +1,27 @@
+{
+  "id": "mwq-unbounded",
+  "name": "mwq-unbounded",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    { "type": "http", "paths": [ { "path": "/mwq-unbounded" } ], "entrypoints": [ { "type": "http-proxy" } ] }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": { "target": "http://localhost:8080/endpoint" },
+          "sharedConfigurationOverride": { "http": { "connectTimeout": 3000, "readTimeout": 60000, "maxConcurrentConnections": 1, "maxWaitQueueSize": -1 } }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": { "enabled": false }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/failure/ConnectionFailureClassifier.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/failure/ConnectionFailureClassifier.java
@@ -18,6 +18,7 @@ package io.gravitee.plugin.endpoint.http.proxy.failure;
 import io.gravitee.common.http.HttpStatusCode;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.handler.timeout.ReadTimeoutException;
+import io.vertx.core.http.ConnectionPoolTooBusyException;
 import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.StreamResetException;
 import java.net.ConnectException;
@@ -54,6 +55,7 @@ public final class ConnectionFailureClassifier {
     public static final String CONNECTION_CLOSED = "GATEWAY_CLIENT_CONNECTION_CLOSED";
     public static final String CONNECT_TIMEOUT = "GATEWAY_CLIENT_CONNECT_TIMEOUT";
     public static final String READ_TIMEOUT = "GATEWAY_CLIENT_READ_TIMEOUT";
+    public static final String CONNECTION_POOL_EXHAUSTED = "GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED";
 
     /**
      * Name of the {@link io.gravitee.gateway.reactive.api.ExecutionFailure} parameter carrying the umbrella/parent
@@ -116,6 +118,11 @@ public final class ConnectionFailureClassifier {
                 return new Classification(HttpStatusCode.GATEWAY_TIMEOUT_504, CONNECT_TIMEOUT, REQUEST_TIMEOUT);
             }
             return new Classification(HttpStatusCode.GATEWAY_TIMEOUT_504, READ_TIMEOUT, REQUEST_TIMEOUT);
+        }
+        // Pool wait-queue saturation is deliberate load-shedding, not a backend fault: expose it as a retryable 503
+        // with its own key so it is distinguishable from genuine backend connection errors (502) in analytics.
+        if (t instanceof ConnectionPoolTooBusyException) {
+            return new Classification(HttpStatusCode.SERVICE_UNAVAILABLE_503, CONNECTION_POOL_EXHAUSTED, GATEWAY_CLIENT_CONNECTION_ERROR);
         }
         // Connection-level (502). TLS before the generic IOException family it extends.
         if (t instanceof SSLException) {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/failure/ConnectionFailureClassifierTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/failure/ConnectionFailureClassifierTest.java
@@ -21,6 +21,7 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.plugin.endpoint.http.proxy.failure.ConnectionFailureClassifier.Classification;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.handler.timeout.ReadTimeoutException;
+import io.vertx.core.http.ConnectionPoolTooBusyException;
 import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.StreamResetException;
 import java.io.IOException;
@@ -33,6 +34,17 @@ import javax.net.ssl.SSLHandshakeException;
 import org.junit.jupiter.api.Test;
 
 class ConnectionFailureClassifierTest {
+
+    @Test
+    void should_classify_pool_wait_queue_saturation_as_retryable_service_unavailable() {
+        Classification classification = ConnectionFailureClassifier.classify(
+            new ConnectionPoolTooBusyException("Connection pool reached max wait queue size of 0")
+        );
+        // Load-shedding is a retryable 503 with its own key, distinct from the 502 backend-connection umbrella.
+        assertThat(classification.statusCode()).isEqualTo(HttpStatusCode.SERVICE_UNAVAILABLE_503);
+        assertThat(classification.key()).isEqualTo("GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED");
+        assertThat(classification.parentKey()).isEqualTo("GATEWAY_CLIENT_CONNECTION_ERROR");
+    }
 
     @Test
     void should_classify_connection_refused_as_bad_gateway() {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/group-form/ConfigurationStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/group-form/ConfigurationStep.tsx
@@ -126,6 +126,22 @@ function HttpSection({ http, onChange }: { http: HttpFormState; onChange: (p: Pa
                     onChange={v => onChange({ maxConcurrentConnections: v })}
                     hint="Maximum pool size for connections. For HTTP/2, this is the maximum number of multiplexed connections to the upstream server."
                 />
+                <NumInput
+                    id="http-max-wait-queue-size"
+                    label="Max wait queue size"
+                    value={http.maxWaitQueueSize}
+                    min={-1}
+                    onChange={v => onChange({ maxWaitQueueSize: v })}
+                    hint="Maximum number of requests allowed to wait when the connection pool is full. -1 means an unbounded queue (default); 0 rejects a request as soon as the pool is full; a positive value bounds the queue so the gateway fails fast under overload."
+                />
+                <NumInput
+                    id="http-max-connection-lifetime"
+                    label="Max connection lifetime (ms)"
+                    value={http.maxConnectionLifetime}
+                    min={0}
+                    onChange={v => onChange({ maxConnectionLifetime: v })}
+                    hint="Maximum lifetime of a pooled connection in milliseconds, after which it is recycled. 0 means no maximum lifetime (default). A positive value periodically recycles long-lived connections so traffic rebalances when upstream instances change."
+                />
                 <div className="space-y-2">
                     <Label htmlFor="http-version" className="text-sm">
                         HTTP version

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/types.ts
@@ -59,6 +59,8 @@ export interface HttpFormState {
     idleTimeout: number;
     connectTimeout: number;
     maxConcurrentConnections: number;
+    maxWaitQueueSize: number;
+    maxConnectionLifetime: number;
     useCompression: boolean;
     propagateClientAcceptEncoding: boolean;
     /** V4 schema field name (`propagateClientHost`, not `propagateClientHostHeader`). */
@@ -109,6 +111,8 @@ export const DEFAULT_HTTP: HttpFormState = {
     idleTimeout: 60000,
     connectTimeout: 5000,
     maxConcurrentConnections: 20,
+    maxWaitQueueSize: -1,
+    maxConnectionLifetime: 0,
     useCompression: true,
     propagateClientAcceptEncoding: false,
     propagateClientHost: false,
@@ -166,6 +170,8 @@ export function parseSharedConfigDto(sc: EndpointGroupSharedConfiguration): Shar
             idleTimeout: http.idleTimeout ?? 60000,
             connectTimeout: http.connectTimeout ?? 5000,
             maxConcurrentConnections: http.maxConcurrentConnections ?? 20,
+            maxWaitQueueSize: http.maxWaitQueueSize ?? -1,
+            maxConnectionLifetime: http.maxConnectionLifetime ?? 0,
             useCompression: http.useCompression ?? true,
             propagateClientAcceptEncoding: http.propagateClientAcceptEncoding ?? false,
             propagateClientHost:

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
@@ -207,6 +207,8 @@ export interface EndpointGroupHttp {
     idleTimeout?: number;
     connectTimeout?: number;
     maxConcurrentConnections?: number;
+    maxWaitQueueSize?: number;
+    maxConnectionLifetime?: number;
     useCompression?: boolean;
     propagateClientAcceptEncoding?: boolean;
     propagateClientHost?: boolean;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/endpointSharedConfiguration.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/endpointSharedConfiguration.spec.ts
@@ -38,6 +38,24 @@ describe('endpointSharedConfiguration', () => {
         expect(http).not.toHaveProperty('maxHeaderSize');
     });
 
+    it('serializes the connection pool wait queue size and connection lifetime for both protocols', () => {
+        const http1 = serializeHttpClientOptions({
+            ...DEFAULT_HTTP,
+            version: 'HTTP_1_1',
+            maxWaitQueueSize: 50,
+            maxConnectionLifetime: 120000,
+        });
+        expect(http1).toMatchObject({ maxWaitQueueSize: 50, maxConnectionLifetime: 120000 });
+
+        const http2 = serializeHttpClientOptions({
+            ...DEFAULT_HTTP,
+            version: 'HTTP_2',
+            maxWaitQueueSize: 50,
+            maxConnectionLifetime: 120000,
+        });
+        expect(http2).toMatchObject({ maxWaitQueueSize: 50, maxConnectionLifetime: 120000 });
+    });
+
     it('serializes disabled proxy without extraneous keys', () => {
         expect(serializeHttpProxyOptions({ ...DEFAULT_PROXY, enabled: false })).toEqual({
             enabled: false,

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/endpointSharedConfiguration.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/endpointSharedConfiguration.ts
@@ -37,6 +37,8 @@ export function serializeHttpClientOptions(http: HttpFormState): EndpointGroupHt
         idleTimeout: http.idleTimeout,
         followRedirects: http.followRedirects,
         maxConcurrentConnections: http.maxConcurrentConnections,
+        maxWaitQueueSize: http.maxWaitQueueSize,
+        maxConnectionLifetime: http.maxConnectionLifetime,
     };
 
     if (http.version === 'HTTP_2') {

--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-9.2.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.2.1.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-9.2.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.2.1.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-9.4.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.4.0.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-9.4.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.4.0.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -510,8 +510,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.2.1.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.2.1.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.4.0.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.4.0.zip
 
 api:
   enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -66,11 +66,11 @@
     <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
     <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
     <gravitee-kubernetes.version>4.0.0</gravitee-kubernetes.version>
-    <gravitee-node.version>9.2.1</gravitee-node.version>
+    <gravitee-node.version>9.4.0</gravitee-node.version>
     <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
     <gravitee-platform-repository-api.version>2.0.0</gravitee-platform-repository-api.version>
     <gravitee-plugin.version>5.1.5</gravitee-plugin.version>
-    <gravitee-plugin-common-configurations.version>1.4.0</gravitee-plugin-common-configurations.version>
+    <gravitee-plugin-common-configurations.version>1.4.2</gravitee-plugin-common-configurations.version>
     <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
     <gravitee-reporter-api.version>2.5.0</gravitee-reporter-api.version>
     <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>


### PR DESCRIPTION
Exposes `maxWaitQueueSize` and `maxConnectionLifetime` (ms) on the v4 HTTP proxy endpoint HTTP config for 4.12.x.

- Fields/mapper/schema-form from **gravitee-plugin-common-configurations 1.4.1** (gravitee-io/gravitee-plugin-common-configurations#30).
- Bumps `gravitee-node` → **9.4.0** (gravitee-io/gravitee-node#590) for Vert.x 5 `PoolOptions.maxWaitQueueSize` + `maxLifetime`.
- Adds `HttpProxyMaxWaitQueueV4IntegrationTest` (fast 502 rejection when pool full + queue disabled).

Refs: https://gravitee.atlassian.net/browse/APIM-14715