### PR TITLE
fix: show content download URL in Swagger documentation preview

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/edit-page.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-page.component.ajs.ts
@@ -54,6 +54,7 @@ class EditPageComponentController implements IController {
 
   apiId: string;
   pageId: string;
+  contentUrl: string;
   tabs: { id: number; name: string; isUnavailable: () => boolean }[];
   error: any;
   page: any;
@@ -130,6 +131,7 @@ class EditPageComponentController implements IController {
   $onInit() {
     this.apiId = this.activatedRoute.snapshot.params.apiId;
     this.pageId = this.activatedRoute.snapshot.params.pageId;
+    this.contentUrl = this.DocumentationService.contentUrl(this.pageId, this.apiId);
     this.page = deepClone(this.resolvedPage);
     this.fetchers = deepClone(this.resolvedFetchers);
     this.tabs = this.tabs.filter((tab) => !tab.isUnavailable());

--- a/gravitee-apim-console-webui/src/components/documentation/edit-page.html
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-page.html
@@ -97,6 +97,7 @@
                 can-update="!$ctrl.readOnly && $ctrl.canUpdate"
                 page="$ctrl.page"
                 pages-to-link="$ctrl.pagesToLink"
+                content-url="$ctrl.contentUrl"
               ></gv-edit-page-content>
               <gv-edit-link-content
                 ng-if="$ctrl.isLink()"

--- a/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-content.components.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-content.components.ts
@@ -28,6 +28,7 @@ class EditPageContentComponentController implements IController {
   page: any;
   pagesToLink: any[];
   pageType: string;
+  contentUrl: string;
 
   // for asciidoc & swagger
   codeMirrorOptions: any;
@@ -77,6 +78,7 @@ export const EditPageContentComponent: ng.IComponentOptions = {
     page: '<',
     pagesToLink: '<',
     pageType: '<',
+    contentUrl: '<',
   },
   template: require('html-loader!./edit-page-content.html').default, // eslint-disable-line @typescript-eslint/no-var-requires
   controller: EditPageContentComponentController,

--- a/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-content.html
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-content.html
@@ -37,6 +37,7 @@
       page="$ctrl.page"
       page-content="$ctrl.page.content"
       page-configuration="$ctrl.page.configuration"
+      content-url="$ctrl.contentUrl"
       edit="$ctrl.canUpdate"
     ></gv-page-swagger>
   </div>

--- a/gravitee-apim-console-webui/src/components/documentation/gio-swagger-ui/gio-swagger-ui.component.scss
+++ b/gravitee-apim-console-webui/src/components/documentation/gio-swagger-ui/gio-swagger-ui.component.scss
@@ -4,6 +4,11 @@
       line-height: 12px;
     }
 
+    // content download URL (showURL option) on its own line under the title, as in the portal
+    .swagger-ui .info hgroup.main > a {
+      display: block;
+    }
+
     // reset models expand control paddings so that the whole zone is clickable
     .swagger-ui section.models h4 {
       padding: 0;

--- a/gravitee-apim-console-webui/src/components/documentation/gio-swagger-ui/gio-swagger-ui.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/gio-swagger-ui/gio-swagger-ui.component.ts
@@ -16,7 +16,7 @@
 import angular from 'angular';
 
 import { AfterViewInit, Component, ElementRef, Input, OnChanges, ViewChild } from '@angular/core';
-import SwaggerUI from 'swagger-ui';
+import SwaggerUI, { SwaggerUIPlugin } from 'swagger-ui';
 import * as yaml from 'js-yaml';
 
 const yamlSchema = yaml.DEFAULT_SCHEMA.extend([]);
@@ -60,6 +60,23 @@ const loadContent = (spec: string) => {
   return contentAsJson;
 };
 
+/**
+ * Makes Swagger UI display the download URL under the page title (as the Developer Portal does
+ * when `showURL` is enabled) while still rendering the inline spec, so the preview keeps
+ * reflecting unsaved editor content.
+ */
+const showContentUrlPlugin =
+  (contentUrl: string): SwaggerUIPlugin =>
+  () => ({
+    statePlugins: {
+      spec: {
+        wrapSelectors: {
+          url: () => () => contentUrl,
+        },
+      },
+    },
+  });
+
 const loadOauth2RedirectUrl = () => {
   return (
     window.location.origin +
@@ -97,6 +114,9 @@ export class GioSwaggerUiComponent implements AfterViewInit, OnChanges {
   @Input()
   maxDisplayedTags: number;
 
+  @Input()
+  contentUrl: string;
+
   @ViewChild('swagger')
   swaggerNode: ElementRef;
 
@@ -114,6 +134,7 @@ export class GioSwaggerUiComponent implements AfterViewInit, OnChanges {
     SwaggerUI({
       domNode: this.swaggerNode.nativeElement,
       spec: loadContent(this.spec),
+      plugins: this.contentUrl ? [showContentUrlPlugin(this.contentUrl)] : [],
       docExpansion: this.docExpansion,
       displayOperationId: this.displayOperationId,
       filter: this.filter,

--- a/gravitee-apim-console-webui/src/components/documentation/page/_page.scss
+++ b/gravitee-apim-console-webui/src/components/documentation/page/_page.scss
@@ -158,6 +158,11 @@
     border: initial;
   }
 
+  // content download URL (showURL option) on its own line under the title, as in the portal
+  .info hgroup.main > a {
+    display: block;
+  }
+
   //@use 'swagger-ui-dist/swagger-ui.css';
 
   a.tablelinks {

--- a/gravitee-apim-console-webui/src/components/documentation/page/page-swagger.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/page/page-swagger.component.spec.ts
@@ -146,6 +146,44 @@ describe('PageSwaggerComponent', () => {
       expect(config.plugins).toHaveLength(0);
     });
 
+    it('should display the content URL while keeping the inline spec when showURL is enabled (APIM-14714)', () => {
+      controller.pageConfiguration = { showURL: 'true' };
+      controller.contentUrl = 'http://host/management/apis/api-id/pages/page-id/content';
+
+      controller.$onChanges();
+
+      const config = SwaggerUIMock.mock.calls[0][0];
+      // spec stays inline (no crash / 401 from Swagger UI fetching the URL, see APIM-14243);
+      // the plugin only makes Swagger UI display the download link
+      expect(config.spec).toBeDefined();
+      expect(config.url).toBeUndefined();
+      const showContentUrlPlugin = config.plugins.at(-1);
+      expect(showContentUrlPlugin().statePlugins.spec.wrapSelectors.url()()).toBe(
+        'http://host/management/apis/api-id/pages/page-id/content',
+      );
+    });
+
+    it('should not add the ShowContentUrl plugin when showURL is disabled', () => {
+      mockUserService.isAuthenticated.mockReturnValue(true);
+      controller.pageConfiguration = { showURL: 'false', tryIt: 'true' };
+      controller.contentUrl = 'http://host/management/apis/api-id/pages/page-id/content';
+
+      controller.$onChanges();
+
+      const config = SwaggerUIMock.mock.calls[0][0];
+      expect(config.plugins).toHaveLength(0);
+    });
+
+    it('should not add the ShowContentUrl plugin when contentUrl is not provided', () => {
+      mockUserService.isAuthenticated.mockReturnValue(true);
+      controller.pageConfiguration = { showURL: 'true', tryIt: 'true' };
+
+      controller.$onChanges();
+
+      const config = SwaggerUIMock.mock.calls[0][0];
+      expect(config.plugins).toHaveLength(0);
+    });
+
     it('should mount to dom_id #swagger-container', () => {
       controller.$onChanges();
 

--- a/gravitee-apim-console-webui/src/components/documentation/page/page-swagger.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/page/page-swagger.component.ts
@@ -59,10 +59,26 @@ const DisableTryItOutPlugin = function () {
     },
   };
 };
+
+/**
+ * Makes Swagger UI display the download URL under the page title (as the Developer Portal does
+ * when `showURL` is enabled) while still rendering the inline spec, so the preview keeps
+ * reflecting unsaved editor content and Swagger UI never fetches the URL itself (APIM-14243).
+ */
+const ShowContentUrlPlugin = (contentUrl: string) => () => ({
+  statePlugins: {
+    spec: {
+      wrapSelectors: {
+        url: () => () => contentUrl,
+      },
+    },
+  },
+});
 class PageSwaggerComponentController implements IController {
   pageConfiguration: any;
   pageContent: string;
   edit: boolean;
+  contentUrl: string;
 
   constructor(
     private readonly UserService: UserService,
@@ -99,6 +115,9 @@ class PageSwaggerComponentController implements IController {
     if (!this.tryItEnabled()) {
       plugins.push(DisableTryItOutPlugin);
     }
+    if (this.pageConfiguration?.showURL === 'true' && this.contentUrl) {
+      plugins.push(ShowContentUrlPlugin(this.contentUrl));
+    }
     return plugins;
   }
 
@@ -132,6 +151,7 @@ export const PageSwaggerComponent: ng.IComponentOptions = {
     pageConfiguration: '<',
     pageContent: '<',
     edit: '<',
+    contentUrl: '<',
   },
   controller: PageSwaggerComponentController,
 };

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-content-editor/api-documentation-v4-content-editor.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-content-editor/api-documentation-v4-content-editor.component.html
@@ -40,7 +40,7 @@
         <markdown class="markdown-content" [data]="_value"></markdown>
       }
       @case ('SWAGGER') {
-        <gio-swagger-ui [spec]="_value"></gio-swagger-ui>
+        <gio-swagger-ui [spec]="_value" [contentUrl]="contentUrl"></gio-swagger-ui>
       }
       @case ('ASYNCAPI') {
         <gio-async-api [schema]="_value"></gio-async-api>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-content-editor/api-documentation-v4-content-editor.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-content-editor/api-documentation-v4-content-editor.component.ts
@@ -53,6 +53,9 @@ export class ApiDocumentationV4ContentEditorComponent implements ControlValueAcc
   @Input()
   pageType: PageType;
 
+  @Input()
+  contentUrl: string;
+
   preview = true;
   _value: string;
   private _disabled = false;

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.html
@@ -214,7 +214,12 @@
                   </gio-banner-info>
                 }
               }
-              <api-documentation-content formControlName="content" [published]="page?.published || isReadOnly" [pageType]="page.type" />
+              <api-documentation-content
+                formControlName="content"
+                [published]="page?.published || isReadOnly"
+                [pageType]="page.type"
+                [contentUrl]="swaggerContentUrl$ | async"
+              />
 
               @if (form.controls.content.errors?.required) {
                 <mat-error>Page content cannot be empty</mat-error>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.spec.ts
@@ -28,6 +28,7 @@ import { CommonModule } from '@angular/common';
 import { MatTabHarness } from '@angular/material/tabs/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { By } from '@angular/platform-browser';
+import SwaggerUI from 'swagger-ui';
 
 import { DocumentationEditPageHarness } from './documentation-edit-page.harness';
 import { DocumentationEditPageComponent } from './documentation-edit-page.component';
@@ -510,6 +511,23 @@ describe('DocumentationEditPageComponent', () => {
             expect(await saveBtn.isDisabled()).toEqual(true);
           });
 
+          it('should not show content URL in Swagger UI preview', () => {
+            const swaggerUiConfig = (SwaggerUI as unknown as jest.Mock).mock.calls.at(-1)[0];
+            expect(swaggerUiConfig.plugins).toEqual([]);
+          });
+
+          it('should show content URL in Swagger UI preview after enabling Show URL', async () => {
+            const showUrlToggle = await harness.getShowUrlToggle();
+            await showUrlToggle.toggle();
+
+            const swaggerUiConfig = (SwaggerUI as unknown as jest.Mock).mock.calls.at(-1)[0];
+            expect(swaggerUiConfig.plugins).toHaveLength(1);
+            const statePlugins = swaggerUiConfig.plugins[0]().statePlugins;
+            expect(statePlugins.spec.wrapSelectors.url()()).toEqual(
+              `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/pages/${PAGE.id}/content`,
+            );
+          });
+
           it('should disable Base URL input when user enables entrypoints as server URLs', async () => {
             const baseUrlInput = await harness.getBaseUrlInput();
             expect(await baseUrlInput.isDisabled()).toEqual(false);
@@ -637,6 +655,15 @@ describe('DocumentationEditPageComponent', () => {
 
             const saveBtn = await harness.getPublishChangesButton();
             expect(await saveBtn.isDisabled()).toEqual(true);
+          });
+
+          it('should show content URL in Swagger UI preview when Show URL is enabled', () => {
+            const swaggerUiConfig = (SwaggerUI as unknown as jest.Mock).mock.calls.at(-1)[0];
+            expect(swaggerUiConfig.plugins).toHaveLength(1);
+            const statePlugins = swaggerUiConfig.plugins[0]().statePlugins;
+            expect(statePlugins.spec.wrapSelectors.url()()).toEqual(
+              `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/pages/${PAGE.id}/content`,
+            );
           });
 
           it('should save configuration changes', async () => {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Input, Component, OnInit, signal, inject, DestroyRef } from '@angular/core';
+import { Input, Component, Inject, OnInit, signal, inject, DestroyRef } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import {
   GioBannerModule,
@@ -34,7 +34,7 @@ import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { combineLatest, EMPTY, Observable, of } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
-import { catchError, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, distinctUntilChanged, filter, map, startWith, switchMap, tap } from 'rxjs/operators';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -57,6 +57,7 @@ import {
 import { ApiDocumentationV4PageHeaderComponent } from '../api-documentation-v4-page-header/api-documentation-v4-page-header.component';
 import { FetcherService } from '../../../../../services-ngx/fetcher.service';
 import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
+import { Constants } from '../../../../../entities/Constants';
 
 interface OpenApiConfiguration {
   entrypointAsBasePath: FormControl<boolean>;
@@ -141,6 +142,7 @@ export class DocumentationEditPageComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   private initialFormValue: unknown;
   sourceConfigurationChanged$: Observable<boolean> = of(false);
+  swaggerContentUrl$: Observable<string | null> = of(null);
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -152,6 +154,7 @@ export class DocumentationEditPageComponent implements OnInit {
     private readonly matDialog: MatDialog,
     private readonly fetcherService: FetcherService,
     private readonly environmentSettingsService: EnvironmentSettingsService,
+    @Inject(Constants) private readonly constants: Constants,
   ) {}
 
   ngOnInit(): void {
@@ -251,6 +254,21 @@ export class DocumentationEditPageComponent implements OnInit {
 
     this.sourceConfigurationChanged$ = this.form.controls.sourceConfiguration.valueChanges.pipe(
       map((_) => !isEqual(this.initialFormValue['sourceConfiguration'], this.form.getRawValue().sourceConfiguration)),
+    );
+
+    const showURLControl = this.form.controls.openApiConfiguration.controls.showURL;
+    this.swaggerContentUrl$ = showURLControl.valueChanges.pipe(
+      startWith(showURLControl.value),
+      map((showURL: boolean) => (showURL ? this.buildContentUrl() : null)),
+    );
+  }
+
+  // Used as an anchor href, outside HttpClient — the {:envId} placeholder cannot be
+  // resolved by ReplaceEnvInterceptor and is replaced here.
+  private buildContentUrl(): string {
+    return `${this.constants.env.baseURL}/apis/${this.api.id}/pages/${this.page.id}/content`.replace(
+      '{:envId}',
+      this.constants.org?.currentEnv?.id ?? 'DEFAULT',
     );
   }
 

--- a/gravitee-apim-console-webui/src/services/documentation.service.ts
+++ b/gravitee-apim-console-webui/src/services/documentation.service.ts
@@ -117,6 +117,12 @@ export class DocumentationService {
     return `${this.Constants.env.baseURL}/portal/pages/` + (importFiles ? '_import' : '') + (pageId ? pageId : '');
   }
 
+  // Unlike url(), the result is used outside HttpClient (e.g. as an anchor href),
+  // so the {:envId} placeholder cannot be resolved by ReplaceEnvInterceptor and is replaced here.
+  contentUrl(pageId: string, apiId?: string): string {
+    return `${this.url(apiId, pageId)}/content`.replace('{:envId}', this.Constants.org?.currentEnv?.id ?? 'DEFAULT');
+  }
+
   supportedTypes(folderSituation: FolderSituation): PageType[] {
     switch (folderSituation) {
       case FolderSituation.ROOT:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14714

## Description

## Description
The "Show the URL to download the content" option had no effect in the Console
documentation preview (legacy v2 editor and v4 documentation editor). The link
display was removed together with the URL mode in APIM-14243.

This PR restores the download link without reintroducing APIM-14243:
- the preview keeps rendering the inline spec from the editor (live preview,
  Swagger UI never fetches the URL itself.
- A Swagger UI plugin wrapping the `spec.url` selector makes the link render
  natively under the page title, exactly as in the Developer Portal,
- the link points to the management content endpoint (works for the console
  user via cookie auth, also for unpublished pages), with the `{:envId}`
  placeholder resolved manually since anchors bypass ReplaceEnvInterceptor.

## Additional context

Video presenting the working fix 🎬

https://github.com/user-attachments/assets/085f192c-4e14-42cd-bc8f-b52c9e9c60f3


