### PR TITLE
chore(deps): bump gravitee-policy-data-logging-masking from 3.1.2 to 3.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <gravitee-policy-custom-query-parameters.version>2.0.0</gravitee-policy-custom-query-parameters.version>
         <gravitee-policy-cloud-events.version>1.1.0</gravitee-policy-cloud-events.version>
         <gravitee-policy-data-cache.version>1.0.6</gravitee-policy-data-cache.version>
-        <gravitee-policy-data-logging-masking.version>3.1.2</gravitee-policy-data-logging-masking.version>
+        <gravitee-policy-data-logging-masking.version>3.1.3</gravitee-policy-data-logging-masking.version>
         <gravitee-policy-dynamic-routing.version>1.13.0</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.3.0</gravitee-policy-generate-http-signature.version>
         <gravitee-policy-generate-jwt.version>1.8.0</gravitee-policy-generate-jwt.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14724

## Description

Bump `gravitee-policy-data-logging-masking` from `3.1.2` to `3.1.3` on `4.9.x`.

`3.1.3` fixes a silent masking failure where body masking rules using a `regex`/`type` left values in clear text in `metrics.log` when the value contained regex special characters (`+`, `/`, `(`, `[`, `\`) or ended on a non-word character (base64 `==`). See the policy PR gravitee-io/gravitee-policy-data-logging-masking#91.

## Additional context

This unblocks a customer whose SOAP credentials were leaking into logs. The other maintained branches (4.10.x, 4.11.x, 4.12.x) will be updated via cherry-pick.
