### PR TITLE
fix(repository): base64-encode DCR claimMappings keys for MongoDB (APIM-13949)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoClientRegistrationProviderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoClientRegistrationProviderRepository.java
@@ -21,9 +21,13 @@ import io.gravitee.repository.management.model.ClientRegistrationProvider;
 import io.gravitee.repository.mongodb.management.internal.application.ClientRegistrationProviderMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.ClientRegistrationProviderMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -96,7 +100,7 @@ public class MongoClientRegistrationProviderRepository implements ClientRegistra
             clientRegistrationProviderMongo.setRenewClientSecretMethod(clientRegistrationProvider.getRenewClientSecretMethod());
             clientRegistrationProviderMongo.setRenewClientSecretEndpoint(clientRegistrationProvider.getRenewClientSecretEndpoint());
             clientRegistrationProviderMongo.setSoftwareId(clientRegistrationProvider.getSoftwareId());
-            clientRegistrationProviderMongo.setClaimMappings(clientRegistrationProvider.getClaimMappings());
+            clientRegistrationProviderMongo.setClaimMappings(encodeClaimKeys(clientRegistrationProvider.getClaimMappings()));
             clientRegistrationProviderMongo.setTrustStoreType(clientRegistrationProvider.getTrustStoreType());
             clientRegistrationProviderMongo.setTrustStorePath(clientRegistrationProvider.getTrustStorePath());
             clientRegistrationProviderMongo.setTrustStorePassword(clientRegistrationProvider.getTrustStorePassword());
@@ -133,7 +137,7 @@ public class MongoClientRegistrationProviderRepository implements ClientRegistra
         log.debug("Find all client registration providers");
 
         List<ClientRegistrationProviderMongo> clientRegistrationProviders = internalClientRegistrationProviderRepository.findAll();
-        Set<ClientRegistrationProvider> res = mapper.mapClientRegistrationProviders(clientRegistrationProviders);
+        Set<ClientRegistrationProvider> res = clientRegistrationProviders.stream().map(this::map).collect(Collectors.toSet());
 
         log.debug("Find all client registration providers - Done");
         return res;
@@ -145,7 +149,7 @@ public class MongoClientRegistrationProviderRepository implements ClientRegistra
         final List<ClientRegistrationProviderMongo> clientRegistrationProviders =
             internalClientRegistrationProviderRepository.findByEnvironmentId(environmentId);
 
-        Set<ClientRegistrationProvider> res = mapper.mapClientRegistrationProviders(clientRegistrationProviders);
+        Set<ClientRegistrationProvider> res = clientRegistrationProviders.stream().map(this::map).collect(Collectors.toSet());
 
         log.debug("Find all client registration providers by environment - Done");
         return res;
@@ -169,10 +173,43 @@ public class MongoClientRegistrationProviderRepository implements ClientRegistra
     }
 
     private ClientRegistrationProvider map(ClientRegistrationProviderMongo provider) {
-        return (provider == null) ? null : mapper.map(provider);
+        if (provider == null) {
+            return null;
+        }
+        ClientRegistrationProvider mapped = mapper.map(provider);
+        mapped.setClaimMappings(decodeClaimKeys(provider.getClaimMappings()));
+        return mapped;
     }
 
     private ClientRegistrationProviderMongo map(ClientRegistrationProvider provider) {
-        return (provider == null) ? null : mapper.map(provider);
+        if (provider == null) {
+            return null;
+        }
+        ClientRegistrationProviderMongo mapped = mapper.map(provider);
+        mapped.setClaimMappings(encodeClaimKeys(provider.getClaimMappings()));
+        return mapped;
+    }
+
+    /**
+     * IdP claim names are used as {@code claimMappings} keys and OIDC namespaced claims contain dots, which MongoDB
+     * rejects as map keys; Base64-encode the keys on write and decode on read, mirroring how identity provider
+     * group/role mapping keys and {@code User.idpClaims} are stored.
+     */
+    private static Map<String, String> encodeClaimKeys(Map<String, String> claimMappings) {
+        if (claimMappings == null) {
+            return null;
+        }
+        Map<String, String> encoded = new HashMap<>(claimMappings.size());
+        claimMappings.forEach((key, value) -> encoded.put(new String(Base64.getEncoder().encode(key.getBytes())), value));
+        return encoded;
+    }
+
+    private static Map<String, String> decodeClaimKeys(Map<String, String> claimMappings) {
+        if (claimMappings == null) {
+            return null;
+        }
+        Map<String, String> decoded = new HashMap<>(claimMappings.size());
+        claimMappings.forEach((key, value) -> decoded.put(new String(Base64.getDecoder().decode(key)), value));
+        return decoded;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClientRegistrationProviderRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClientRegistrationProviderRepositoryTest.java
@@ -159,26 +159,28 @@ public class ClientRegistrationProviderRepositoryTest extends AbstractManagement
         clientRegistrationProvider.setScopes(Arrays.asList("openid"));
         clientRegistrationProvider.setCreatedAt(new Date(1000000000000L));
         clientRegistrationProvider.setUpdatedAt(new Date(1486771200000L));
-        clientRegistrationProvider.setClaimMappings(Map.of("org_id", "metadata.organization"));
+        // include an OIDC-namespaced claim name (dots) as a map KEY — MongoDB rejects dots in map keys unless handled
+        Map<String, String> mappings = Map.of("org_id", "metadata.organization", "https://acme.example/tenant", "metadata.tenant");
+        clientRegistrationProvider.setClaimMappings(mappings);
 
         clientRegistrationProviderRepository.create(clientRegistrationProvider);
 
         Optional<ClientRegistrationProvider> optional = clientRegistrationProviderRepository.findById("dcr-claim-mappings");
         Assertions.assertTrue(optional.isPresent(), "Client registration provider saved not found");
-        Assertions.assertEquals(
-            Map.of("org_id", "metadata.organization"),
-            optional.get().getClaimMappings(),
-            "Invalid saved claim mappings."
-        );
+        Assertions.assertEquals(mappings, optional.get().getClaimMappings(), "Invalid saved claim mappings.");
 
-        // The claim mappings must also survive an update (refreshed, not dropped)
+        // The claim mappings must also survive an update (refreshed, not dropped), including a dotted key
         final ClientRegistrationProvider toUpdate = optional.get();
-        toUpdate.setClaimMappings(Map.of("tenant", "metadata.tenant"));
+        toUpdate.setClaimMappings(Map.of("https://acme.example/department", "metadata.department"));
         clientRegistrationProviderRepository.update(toUpdate);
 
         Optional<ClientRegistrationProvider> updated = clientRegistrationProviderRepository.findById("dcr-claim-mappings");
         Assertions.assertTrue(updated.isPresent(), "Client registration provider updated not found");
-        Assertions.assertEquals(Map.of("tenant", "metadata.tenant"), updated.get().getClaimMappings(), "Invalid updated claim mappings.");
+        Assertions.assertEquals(
+            Map.of("https://acme.example/department", "metadata.department"),
+            updated.get().getClaimMappings(),
+            "Invalid updated claim mappings."
+        );
     }
 
     @Test


### PR DESCRIPTION
## What

Follow-up bug fix for epic **APIM-13949**. `ClientRegistrationProvider.claimMappings` is a `Map` **keyed by IdP claim name**. OIDC/Auth0 commonly use namespaced claim names (e.g. `https://acme.example/tenant`), and MongoDB rejects map keys containing dots — so saving such a mapping throws `MappingException` and the client-registration-provider config save fails.

This is the same dotted-key class of bug already fixed for `User.idpClaims` (#18383) and how identity-provider group/role mappings are stored; `claimMappings` was missed because its repo test used a plain `org_id` key. JDBC is unaffected (stored as serialized JSON); only MongoDB's native map storage is impacted.

## How

`MongoClientRegistrationProviderRepository` now Base64-encodes `claimMappings` keys on write and decodes on read, centralised in the `map(...)` conversion methods (plus the manual `update` setter), and `findAll`/`findAllByEnvironment` route through the decoding mapper.

## Tests

`ClientRegistrationProviderRepositoryTest.should_persist_and_read_claim_mappings` now uses a namespaced (dotted) claim-name key across create, update and read — this reproduced the failure before the fix.

> Note: found via local end-to-end verification of the merged feature against a mock OIDC provider. I could not run the Mongo Testcontainers test locally in this session (Docker Desktop was unresponsive in my environment); the change compiles cleanly and mirrors the proven `User.idpClaims` fix — relying on CI to exercise the Mongo path.

Ref: **APIM-13949**.
