### PR TITLE
feat(api-product): support AI Workspace product kind and per-plan budget flows

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -400,7 +400,7 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         CompositeComponentProvider componentProvider,
         ApiProductRegistry apiProductRegistry
     ) {
-        String[] beanNamesForType = applicationContext.getBeanNamesForType(
+        String[] beanNamesForType = getBeanNamesForType(
             ResolvableType.forClassWithGenerics(ConfigurablePluginManager.class, PolicyPlugin.class)
         );
         ConfigurablePluginManager<PolicyPlugin<?>> configurablePluginManager = (ConfigurablePluginManager<

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
@@ -415,6 +415,34 @@ class DefaultApiReactorFactoryTest {
     }
 
     @Nested
+    class CreateApiProductPlanPolicyManagerFactory {
+
+        @Test
+        void should_resolve_policy_plugin_manager_from_ancestor_context() {
+            var policyPluginManager = mock(ConfigurablePluginManager.class);
+            when(
+                applicationContextListable.getBeanNamesForType(
+                    ResolvableType.forClassWithGenerics(ConfigurablePluginManager.class, PolicyPlugin.class)
+                )
+            ).thenReturn(new String[] { "policyPluginManager" });
+            when(applicationContext.getBean("policyPluginManager")).thenReturn(policyPluginManager);
+            when(applicationContext.getBean(io.gravitee.gateway.core.classloader.DefaultClassLoader.class)).thenReturn(
+                mock(io.gravitee.gateway.core.classloader.DefaultClassLoader.class)
+            );
+            when(applicationContext.getBean(io.gravitee.plugin.policy.PolicyClassLoaderFactory.class)).thenReturn(
+                mock(io.gravitee.plugin.policy.PolicyClassLoaderFactory.class)
+            );
+
+            var factory = cut.createApiProductPlanPolicyManagerFactory(
+                mock(CompositeComponentProvider.class),
+                mock(io.gravitee.gateway.handlers.api.registry.ApiProductRegistry.class)
+            );
+
+            assertThat(factory).isNotNull();
+        }
+    }
+
+    @Nested
     class CreateTracingContext {
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResource.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.v2.rest.resource.api_product;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.ApiProductKindFilter;
 import io.gravitee.apim.core.api_product.model.CreateApiProduct;
 import io.gravitee.apim.core.api_product.use_case.CreateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
@@ -158,7 +159,8 @@ public class ApiProductsResource extends AbstractResource {
             paginationParam.toPageable(),
             apiProductSortByParam.toSortable(),
             getAuthenticatedUser(),
-            isAdmin()
+            isAdmin(),
+            ApiProductKindFilter.classicOnly()
         );
         var output = searchApiProductsUseCase.execute(input);
         var page = output.page();
@@ -195,7 +197,8 @@ public class ApiProductsResource extends AbstractResource {
                 executionContext.getEnvironmentId(),
                 executionContext.getOrganizationId(),
                 getAuthenticatedUser(),
-                isAdmin()
+                isAdmin(),
+                ApiProductKindFilter.classicOnly()
             )
         );
         Set<ApiProduct> allApiProducts = output.apiProducts();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/query_service/ApiKeyQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/query_service/ApiKeyQueryService.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.api_key.query_service;
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
 import io.gravitee.apim.core.api_key.model.ExpiringApiKey;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -27,6 +28,15 @@ public interface ApiKeyQueryService {
     Stream<ApiKeyEntity> findByApplication(String applicationId);
     Optional<ApiKeyEntity> findByKeyAndApiId(String key, String apiId);
     Stream<ApiKeyEntity> findBySubscription(String subscriptionId);
+
+    /**
+     * Bulk variant of {@link #findBySubscription(String)}: returns the API keys attached to any of
+     * {@code subscriptionIds} in a single repository query. Callers group by subscription in memory.
+     * Matches {@link #findBySubscription(String)} semantics: revoked and federated keys are included.
+     * Returns an empty stream without querying when {@code subscriptionIds} is null or empty.
+     */
+    Stream<ApiKeyEntity> findBySubscriptions(Collection<String> subscriptionIds);
+
     Optional<ApiKeyEntity> findByKeyAndReferenceIdAndReferenceType(String key, String referenceId, String referenceType);
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/DeployApiProductDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/DeployApiProductDomainService.java
@@ -24,12 +24,16 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.event.model.Event;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
+import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
@@ -39,12 +43,25 @@ public class DeployApiProductDomainService {
     private final PlanQueryService planQueryService;
     private final EventCrudService eventCrudService;
     private final EventLatestCrudService eventLatestCrudService;
+    private final FlowCrudService flowCrudService;
 
     public void deploy(AuditInfo auditInfo, ApiProduct apiProduct) {
-        var plans = planQueryService
-            .findAllByReferenceIdAndReferenceType(apiProduct.getId(), GenericPlanEntity.ReferenceType.API_PRODUCT)
+        var productPlans = planQueryService.findAllByReferenceIdAndReferenceType(
+            apiProduct.getId(),
+            GenericPlanEntity.ReferenceType.API_PRODUCT
+        );
+        var flowsByPlanId = flowCrudService.getPlanV4Flows(productPlans.stream().map(Plan::getId).collect(Collectors.toSet()));
+
+        var plans = productPlans
             .stream()
-            .map(io.gravitee.apim.core.plan.model.Plan::getPlanDefinitionHttpV4)
+            .map(plan -> {
+                var definition = plan.getPlanDefinitionHttpV4();
+                if (definition == null) {
+                    return null;
+                }
+                definition.setFlows(flowsByPlanId.getOrDefault(plan.getId(), List.of()));
+                return definition;
+            })
             .filter(Objects::nonNull)
             .toList();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductComposition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductComposition.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.model;
+
+import io.gravitee.definition.model.v4.ApiType;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Which API types may be composed into an API Product, and therefore the only ones for which
+ * {@code allowedInApiProducts} carries meaning.
+ */
+public final class ApiProductComposition {
+
+    private static final Set<ApiType> COMPOSABLE_TYPES = EnumSet.of(ApiType.PROXY, ApiType.LLM_PROXY);
+
+    private ApiProductComposition() {}
+
+    public static boolean supports(final ApiType type) {
+        return type != null && COMPOSABLE_TYPES.contains(type);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductKindFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductKindFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.model;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Which kinds of API Product a listing wants. A classic API Product carries no kind, so {@code includeClassic}
+ * is a separate flag rather than a value in {@code kinds}.
+ */
+public record ApiProductKindFilter(Set<ApiProductKind> kinds, boolean includeClassic) {
+    public ApiProductKindFilter {
+        kinds = kinds == null ? Set.of() : Set.copyOf(kinds);
+    }
+
+    public static ApiProductKindFilter any() {
+        return new ApiProductKindFilter(EnumSet.allOf(ApiProductKind.class), true);
+    }
+
+    public static ApiProductKindFilter classicOnly() {
+        return new ApiProductKindFilter(Set.of(), true);
+    }
+
+    public boolean matches(ApiProduct apiProduct) {
+        return apiProduct.getKind() == null ? includeClassic : kinds.contains(apiProduct.getKind());
+    }
+
+    /**
+     * The specialized kinds a store-backed search must hide: every kind not explicitly included. A new
+     * {@link ApiProductKind} is therefore excluded from a classic listing until it is opted in.
+     */
+    public Set<ApiProductKind> excludedKinds() {
+        var excluded = EnumSet.allOf(ApiProductKind.class);
+        excluded.removeAll(kinds);
+        return excluded;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductSearchQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductSearchQueryService.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.api_product.query_service;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.ApiProductKind;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.Sortable;
@@ -31,7 +32,8 @@ public interface ApiProductSearchQueryService {
         String query,
         Set<String> ids,
         Pageable pageable,
-        Sortable sortable
+        Sortable sortable,
+        Set<ApiProductKind> excludedKinds
     );
 
     Page<GenericApiEntity> searchApis(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCase.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.ApiProductKindFilter;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.event.model.Event;
 import io.gravitee.apim.core.event.query_service.EventLatestQueryService;
@@ -54,6 +55,7 @@ public class GetApiProductsUseCase {
             Optional<ApiProduct> apiProduct = apiProductQueryService
                 .findById(input.apiProductId())
                 .filter(p -> p.getEnvironmentId().equals(input.environmentId()))
+                .filter(input.kindFilter()::matches)
                 .map(product -> addPrimaryOwnerToApiProduct(product, input.organizationId()))
                 .map(this::computeDeploymentState);
             return Output.single(apiProduct);
@@ -65,6 +67,7 @@ public class GetApiProductsUseCase {
 
         Set<ApiProduct> apiProducts = findAccessibleApiProducts(input)
             .stream()
+            .filter(input.kindFilter()::matches)
             .map(product -> addPrimaryOwnerToApiProduct(product, input.organizationId()))
             .map(this::computeDeploymentState)
             .collect(Collectors.toSet());
@@ -168,13 +171,34 @@ public class GetApiProductsUseCase {
         return current.size() == deployed.size() && current.containsAll(deployed);
     }
 
-    public record Input(String environmentId, String apiProductId, String organizationId, String userId, boolean isAdmin) {
+    public record Input(
+        String environmentId,
+        String apiProductId,
+        String organizationId,
+        String userId,
+        boolean isAdmin,
+        ApiProductKindFilter kindFilter
+    ) {
+        public Input {
+            kindFilter = kindFilter == null ? ApiProductKindFilter.any() : kindFilter;
+        }
+
         public static Input of(String environmentId, String organizationId, String userId, boolean isAdmin) {
-            return new Input(environmentId, null, organizationId, userId, isAdmin);
+            return new Input(environmentId, null, organizationId, userId, isAdmin, ApiProductKindFilter.any());
+        }
+
+        public static Input of(
+            String environmentId,
+            String organizationId,
+            String userId,
+            boolean isAdmin,
+            ApiProductKindFilter kindFilter
+        ) {
+            return new Input(environmentId, null, organizationId, userId, isAdmin, kindFilter);
         }
 
         public static Input of(String environmentId, String apiProductId, String organizationId) {
-            return new Input(environmentId, apiProductId, organizationId, null, false);
+            return new Input(environmentId, apiProductId, organizationId, null, false, ApiProductKindFilter.any());
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCase.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.api_product.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.ApiProductKindFilter;
 import io.gravitee.apim.core.api_product.query_service.ApiProductSearchQueryService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
@@ -70,7 +71,8 @@ public class SearchApiProductsUseCase {
                 input.query(),
                 ids,
                 input.pageable(),
-                input.sortable()
+                input.sortable(),
+                input.kindFilter().excludedKinds()
             )
         );
     }
@@ -83,8 +85,13 @@ public class SearchApiProductsUseCase {
         Pageable pageable,
         Sortable sortable,
         String userId,
-        boolean isAdmin
+        boolean isAdmin,
+        ApiProductKindFilter kindFilter
     ) {
+        public Input {
+            kindFilter = kindFilter == null ? ApiProductKindFilter.any() : kindFilter;
+        }
+
         public static Input of(
             String environmentId,
             String organizationId,
@@ -95,7 +102,31 @@ public class SearchApiProductsUseCase {
             String userId,
             boolean isAdmin
         ) {
-            return new Input(environmentId, organizationId, query != null ? query.trim() : null, ids, pageable, sortable, userId, isAdmin);
+            return of(environmentId, organizationId, query, ids, pageable, sortable, userId, isAdmin, ApiProductKindFilter.any());
+        }
+
+        public static Input of(
+            String environmentId,
+            String organizationId,
+            String query,
+            Set<String> ids,
+            Pageable pageable,
+            Sortable sortable,
+            String userId,
+            boolean isAdmin,
+            ApiProductKindFilter kindFilter
+        ) {
+            return new Input(
+                environmentId,
+                organizationId,
+                query != null ? query.trim() : null,
+                ids,
+                pageable,
+                sortable,
+                userId,
+                isAdmin,
+                kindFilter
+            );
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/crud_service/FlowCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/crud_service/FlowCrudService.java
@@ -30,6 +30,8 @@ public interface FlowCrudService {
 
     List<Flow> getPlanV4Flows(String planId);
 
+    Map<String, List<Flow>> getPlanV4Flows(Set<String> planIds);
+
     List<io.gravitee.definition.model.flow.Flow> getApiV2Flows(String apiId);
 
     List<io.gravitee.definition.model.flow.Flow> getPlanV2Flows(String planId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
@@ -214,6 +214,8 @@ public class CreatePlanDomainService {
         planValidatorDomainService.validatePlanSecurity(plan, auditInfo.organizationId(), auditInfo.environmentId(), null);
         planValidatorDomainService.validatePlanTagsAgainstApiProductTags(plan.getTags(), apiProduct.getTags());
         planValidatorDomainService.validateGeneralConditionsPageStatus(plan);
+        var incomingFlows = plan.getPlanDefinitionHttpV4() != null ? plan.getPlanDefinitionHttpV4().getFlows() : null;
+        var sanitizedFlows = incomingFlows == null ? null : flowValidationDomainService.validateAndSanitizeHttpV4(null, incomingFlows);
         var createdPlan = planCrudService.create(
             plan
                 .toBuilder()
@@ -226,6 +228,7 @@ public class CreatePlanDomainService {
                 .publishedAt(plan.isPublished() ? TimeProvider.now() : null)
                 .build()
         );
+        flowCrudService.savePlanFlows(createdPlan.getId(), sanitizedFlows);
         createApiProductAuditLog(createdPlan, auditInfo);
         return createdPlan;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
@@ -353,11 +353,20 @@ public class UpdatePlanDomainService {
         Plan existingPlan = planCrudService.getById(planToUpdate.getId());
         Plan updatePlan = existingPlan.update(planToUpdate);
 
-        if (!planSynchronizationService.checkSynchronized(existingPlan, List.of(), updatePlan, List.of())) {
+        var incomingFlows = planToUpdate.getPlanDefinitionHttpV4() != null ? planToUpdate.getPlanDefinitionHttpV4().getFlows() : null;
+        var sanitizedFlows = incomingFlows == null ? null : flowValidationDomainService.validateAndSanitizeHttpV4(null, incomingFlows);
+        var existingFlows = flowCrudService.getPlanV4Flows(existingPlan.getId());
+        var effectiveFlows = sanitizedFlows == null ? existingFlows : sanitizedFlows;
+
+        if (!planSynchronizationService.checkSynchronized(existingPlan, existingFlows, updatePlan, effectiveFlows)) {
             updatePlan.setNeedRedeployAt(Date.from(updatePlan.getUpdatedAt().toInstant()));
         }
 
         Plan updated = orderAwareUpdate(existingPlan, updatePlan);
+
+        if (sanitizedFlows != null) {
+            flowCrudService.savePlanFlows(updated.getId(), sanitizedFlows);
+        }
 
         createApiProductAuditLog(existingPlan, updated, auditInfo);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
@@ -109,6 +109,10 @@ public interface ApiAdapter {
     @Mapping(target = "lifecycleState", source = "api.apiLifecycleState")
     @Mapping(target = "resources", expression = "java(apiDefinitionV4 != null ? apiDefinitionV4.getResources() : null)")
     @Mapping(target = "responseTemplates", expression = "java(apiDefinitionV4 != null ? apiDefinitionV4.getResponseTemplates() : null)")
+    @Mapping(
+        target = "allowedInApiProducts",
+        expression = "java(apiDefinitionV4 != null ? apiDefinitionV4.getAllowedInApiProducts() : null)"
+    )
     UpdateApiEntity toUpdateApiEntity(Api api, io.gravitee.definition.model.v4.Api apiDefinitionV4);
 
     @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.api.model.NewApiMetadata;
 import io.gravitee.apim.core.api.model.import_definition.ApiDescriptor;
 import io.gravitee.apim.core.api.model.import_definition.PageExport;
 import io.gravitee.apim.core.api.model.import_definition.PlanDescriptor;
+import io.gravitee.apim.core.api_product.model.ApiProductComposition;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.integration.model.Integration;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
@@ -29,7 +30,6 @@ import io.gravitee.apim.core.metadata.model.Metadata;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.definition.model.ApiDefinition;
 import io.gravitee.definition.model.federation.FederatedApi;
-import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
@@ -180,7 +180,7 @@ public interface GraviteeDefinitionAdapter {
     }
 
     default Boolean exportedAllowedInApiProducts(io.gravitee.definition.model.v4.Api apiDefinition) {
-        if (apiDefinition == null || apiDefinition.getType() != ApiType.PROXY) {
+        if (apiDefinition == null || !ApiProductComposition.supports(apiDefinition.getType())) {
             return null;
         }
         return Boolean.TRUE.equals(apiDefinition.getAllowedInApiProducts());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/flow/FlowCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/flow/FlowCrudServiceImpl.java
@@ -82,6 +82,32 @@ public class FlowCrudServiceImpl extends TransactionalService implements FlowCru
     }
 
     @Override
+    public Map<String, List<Flow>> getPlanV4Flows(Set<String> planIds) {
+        if (planIds == null || planIds.isEmpty()) {
+            return Map.of();
+        }
+        try {
+            List<io.gravitee.repository.management.model.flow.Flow> repoFlows = flowRepository.findByReferences(
+                FlowReferenceType.PLAN,
+                planIds
+            );
+            return repoFlows
+                .stream()
+                .sorted(Comparator.comparing(io.gravitee.repository.management.model.flow.Flow::getOrder))
+                .collect(Collectors.groupingBy(io.gravitee.repository.management.model.flow.Flow::getReferenceId))
+                .entrySet()
+                .stream()
+                .collect(
+                    Collectors.toMap(Map.Entry::getKey, e ->
+                        e.getValue().stream().map(FlowAdapter.INSTANCE::toFlowV4).collect(Collectors.toList())
+                    )
+                );
+        } catch (TechnicalException ex) {
+            throw new TechnicalDomainException("An error occurs while trying to get v4 plan flows", ex);
+        }
+    }
+
+    @Override
     public List<io.gravitee.definition.model.flow.Flow> getApiV2Flows(String apiId) {
         return getV2(FlowReferenceType.API, apiId);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_key/ApiKeyQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_key/ApiKeyQueryServiceImpl.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -92,6 +93,26 @@ public class ApiKeyQueryServiceImpl implements ApiKeyQueryService {
         } catch (TechnicalException e) {
             throw new TechnicalManagementException(
                 "An error occurs while trying to find API keys by subscription id: " + subscriptionId,
+                e
+            );
+        }
+    }
+
+    @Override
+    public Stream<ApiKeyEntity> findBySubscriptions(Collection<String> subscriptionIds) {
+        if (subscriptionIds == null || subscriptionIds.isEmpty()) {
+            return Stream.empty();
+        }
+        ApiKeyCriteria criteria = ApiKeyCriteria.builder()
+            .subscriptions(Set.copyOf(subscriptionIds))
+            .includeRevoked(true)
+            .includeFederated(true)
+            .build();
+        try {
+            return apiKeyRepository.findByCriteriaUnordered(criteria).stream().map(ApiKeyAdapter.INSTANCE::toEntity);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException(
+                "An error occurs while trying to find API keys by subscription ids: " + subscriptionIds,
                 e
             );
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductSearchQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductSearchQueryServiceImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.infra.query_service.api_product;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TYPE_VALUE;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.ApiProductKind;
 import io.gravitee.apim.core.api_product.query_service.ApiProductSearchQueryService;
 import io.gravitee.apim.core.search.model.IndexableApiProduct;
 import io.gravitee.apim.core.utils.CollectionUtils;
@@ -27,11 +28,13 @@ import io.gravitee.rest.api.model.common.Sortable;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.impl.search.lucene.transformer.IndexableApiProductDocumentTransformer;
 import io.gravitee.rest.api.service.search.query.QueryBuilder;
 import io.gravitee.rest.api.service.v4.ApiProductSearchService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -54,7 +57,8 @@ public class ApiProductSearchQueryServiceImpl implements ApiProductSearchQuerySe
         String query,
         Set<String> ids,
         Pageable pageable,
-        Sortable sortable
+        Sortable sortable,
+        Set<ApiProductKind> excludedKinds
     ) {
         var executionContext = new ExecutionContext(organizationId, environmentId);
         QueryBuilder<IndexableApiProduct> queryBuilder = QueryBuilder.create(IndexableApiProduct.class);
@@ -67,6 +71,12 @@ public class ApiProductSearchQueryServiceImpl implements ApiProductSearchQuerySe
         }
         if (sortable != null) {
             queryBuilder.setSort(sortable);
+        }
+        if (CollectionUtils.isNotEmpty(excludedKinds)) {
+            queryBuilder.addExcludedFilter(
+                IndexableApiProductDocumentTransformer.FIELD_KIND,
+                excludedKinds.stream().map(Enum::name).collect(Collectors.toSet())
+            );
         }
 
         return apiProductSearchService.search(executionContext, queryBuilder, pageable);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiProductDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiProductDocumentSearcher.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.search.Indexable;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.ReferenceContext;
 import io.gravitee.rest.api.service.impl.search.SearchResult;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
@@ -144,12 +145,19 @@ public class ApiProductDocumentSearcher extends AbstractDocumentSearcher {
 
         try {
             final Optional<Query> baseFilterQuery = buildFilterQuery(query.getFilters(), Map.of(FIELD_TYPE_VALUE, FIELD_ID));
+            buildExcludedFilters(query.getExcludedFilters()).ifPresent(q -> mainQuery.add(q, BooleanClause.Occur.MUST_NOT));
             buildTextQuery(executionContext, query, baseFilterQuery).ifPresent(q ->
                 mainQuery.add(new BoostQuery(q, 4.0f), BooleanClause.Occur.SHOULD)
             );
             buildWildcardQuery(executionContext, query, baseFilterQuery).ifPresent(q -> mainQuery.add(q, BooleanClause.Occur.SHOULD));
 
-            if (!mainQuery.build().clauses().iterator().hasNext()) {
+            if (
+                mainQuery
+                    .build()
+                    .clauses()
+                    .stream()
+                    .noneMatch(c -> c.occur() != BooleanClause.Occur.MUST_NOT)
+            ) {
                 mainQuery.add(buildApiProductQuery(executionContext, baseFilterQuery).build(), BooleanClause.Occur.MUST);
             }
         } catch (ParseException pe) {
@@ -165,6 +173,21 @@ public class ApiProductDocumentSearcher extends AbstractDocumentSearcher {
             increaseMaxClauseCountIfNecessary(maxClauseCount);
             return search(finalQuery, query.getSort());
         }
+    }
+
+    private Optional<BooleanQuery> buildExcludedFilters(Map<String, Collection<String>> excludedFilters) {
+        if (excludedFilters == null || excludedFilters.isEmpty()) {
+            return Optional.empty();
+        }
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        excludedFilters
+            .entrySet()
+            .stream()
+            .filter(entry -> entry.getValue() != null && !entry.getValue().isEmpty())
+            .forEach(entry ->
+                entry.getValue().forEach(value -> builder.add(new TermQuery(new Term(entry.getKey(), value)), BooleanClause.Occur.SHOULD))
+            );
+        return Optional.of(builder.build());
     }
 
     private int getClauseCount(Query query) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiProductDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiProductDocumentTransformer.java
@@ -58,6 +58,7 @@ public class IndexableApiProductDocumentTransformer implements DocumentTransform
     public static final String FIELD_API_COUNT_SORTED = "apiCount_sorted";
     public static final String FIELD_CREATED_AT = "createdAt";
     public static final String FIELD_UPDATED_AT = "updatedAt";
+    public static final String FIELD_KIND = "kind";
 
     public static final Pattern SPECIAL_CHARS = Pattern.compile("[|\\-+!(){}^\"~*?:&\\/]");
 
@@ -101,6 +102,9 @@ public class IndexableApiProductDocumentTransformer implements DocumentTransform
 
         if (apiProduct.getCreatedAt() != null) {
             doc.add(new LongPoint(FIELD_CREATED_AT, apiProduct.getCreatedAt().toInstant().toEpochMilli()));
+        }
+        if (apiProduct.getKind() != null) {
+            doc.add(new StringField(FIELD_KIND, apiProduct.getKind().name(), Field.Store.NO));
         }
         if (apiProduct.getUpdatedAt() != null) {
             doc.add(new LongPoint(FIELD_UPDATED_AT, apiProduct.getUpdatedAt().toInstant().toEpochMilli()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -28,6 +28,7 @@ import static java.util.stream.Collectors.toSet;
 import io.gravitee.apim.core.api.model.ApiMetadata;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api_product.domain_service.RemoveApiFromApiProductsDomainService;
+import io.gravitee.apim.core.api_product.model.ApiProductComposition;
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.model.DefinitionContext;
@@ -267,7 +268,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext, userId, apiEntity.getPrimaryOwner());
         apiValidationService.validateAndSanitizeImportApiForCreation(executionContext, apiEntity, primaryOwner);
 
-        if (apiEntity.getDefinitionVersion() == DefinitionVersion.V4 && apiEntity.getType() != ApiType.PROXY) {
+        if (apiEntity.getDefinitionVersion() == DefinitionVersion.V4 && !ApiProductComposition.supports(apiEntity.getType())) {
             apiEntity.setAllowedInApiProducts(null);
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -20,6 +20,7 @@ import static io.gravitee.rest.api.model.WorkflowType.REVIEW;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api_product.model.ApiProductComposition;
 import io.gravitee.apim.infra.adapter.ApiAdapter;
 import io.gravitee.apim.infra.adapter.ApiAdapterDecorator;
 import io.gravitee.apim.infra.adapter.PrimaryOwnerAdapter;
@@ -192,7 +193,7 @@ public class ApiMapper {
 
                 apiEntity.setResponseTemplates(apiDefinition.getResponseTemplates());
 
-                if (apiDefinition.getType() == ApiType.PROXY) {
+                if (ApiProductComposition.supports(apiDefinition.getType())) {
                     apiEntity.setAllowedInApiProducts(Boolean.TRUE.equals(apiDefinition.getAllowedInApiProducts()));
                 }
             } catch (IOException ioe) {
@@ -552,10 +553,8 @@ public class ApiMapper {
             apiDefinition.setFlows(updateApiEntity.getFlows());
             apiDefinition.setResponseTemplates(updateApiEntity.getResponseTemplates());
             apiDefinition.setServices(updateApiEntity.getServices());
-            if (updateApiEntity.getType() == ApiType.PROXY) {
-                if (updateApiEntity.getAllowedInApiProducts() != null) {
-                    apiDefinition.setAllowedInApiProducts(updateApiEntity.getAllowedInApiProducts());
-                }
+            if (ApiProductComposition.supports(updateApiEntity.getType()) && updateApiEntity.getAllowedInApiProducts() != null) {
+                apiDefinition.setAllowedInApiProducts(updateApiEntity.getAllowedInApiProducts());
             }
 
             return objectMapper.writeValueAsString(apiDefinition);
@@ -637,7 +636,7 @@ public class ApiMapper {
             apiDefinition.setFlows(apiEntity.getFlows());
             apiDefinition.setResponseTemplates(apiEntity.getResponseTemplates());
             apiDefinition.setServices(apiEntity.getServices());
-            if (apiEntity.getType() == ApiType.PROXY && apiEntity.getAllowedInApiProducts() != null) {
+            if (ApiProductComposition.supports(apiEntity.getType()) && apiEntity.getAllowedInApiProducts() != null) {
                 apiDefinition.setAllowedInApiProducts(apiEntity.getAllowedInApiProducts());
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiKeyQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiKeyQueryServiceInMemory.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.rest.api.service.exceptions.SubscriptionNotFoundException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -106,6 +107,14 @@ public class ApiKeyQueryServiceInMemory implements ApiKeyQueryService, InMemoryA
     @Override
     public Stream<ApiKeyEntity> findBySubscription(String subscriptionId) {
         return storage.stream().filter(apiKey -> apiKey.getSubscriptions().contains(subscriptionId));
+    }
+
+    @Override
+    public Stream<ApiKeyEntity> findBySubscriptions(Collection<String> subscriptionIds) {
+        if (subscriptionIds == null || subscriptionIds.isEmpty()) {
+            return Stream.empty();
+        }
+        return storage.stream().filter(apiKey -> apiKey.getSubscriptions().stream().anyMatch(subscriptionIds::contains));
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductSearchQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductSearchQueryServiceInMemory.java
@@ -16,6 +16,7 @@
 package inmemory;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.ApiProductKind;
 import io.gravitee.apim.core.api_product.query_service.ApiProductSearchQueryService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
@@ -34,6 +35,7 @@ public class ApiProductSearchQueryServiceInMemory extends AbstractQueryServiceIn
 
     private String lastEnvironmentId;
     private String lastOrganizationId;
+    private Set<ApiProductKind> lastExcludedKinds;
 
     public String getLastEnvironmentId() {
         return lastEnvironmentId;
@@ -43,6 +45,10 @@ public class ApiProductSearchQueryServiceInMemory extends AbstractQueryServiceIn
         return lastOrganizationId;
     }
 
+    public Set<ApiProductKind> getLastExcludedKinds() {
+        return lastExcludedKinds;
+    }
+
     @Override
     public Page<ApiProduct> search(
         String environmentId,
@@ -50,10 +56,12 @@ public class ApiProductSearchQueryServiceInMemory extends AbstractQueryServiceIn
         String query,
         Set<String> ids,
         Pageable pageable,
-        Sortable sortable
+        Sortable sortable,
+        Set<ApiProductKind> excludedKinds
     ) {
         this.lastEnvironmentId = environmentId;
         this.lastOrganizationId = organizationId;
+        this.lastExcludedKinds = excludedKinds;
 
         int pageNumber = pageable != null ? pageable.getPageNumber() : 1;
         int pageSize = pageable != null ? pageable.getPageSize() : 10;
@@ -62,6 +70,13 @@ public class ApiProductSearchQueryServiceInMemory extends AbstractQueryServiceIn
             .stream()
             .filter(apiProduct -> Objects.equals(apiProduct.getEnvironmentId(), environmentId))
             .filter(apiProduct -> ids == null || ids.isEmpty() || (ids.contains(apiProduct.getId())))
+            .filter(
+                apiProduct ->
+                    excludedKinds == null ||
+                    excludedKinds.isEmpty() ||
+                    apiProduct.getKind() == null ||
+                    !excludedKinds.contains(apiProduct.getKind())
+            )
             .filter(apiProduct -> {
                 if (query == null || query.isBlank()) return true;
                 String queryLower = query.trim().toLowerCase();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/FlowCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/FlowCrudServiceInMemory.java
@@ -63,6 +63,15 @@ public class FlowCrudServiceInMemory implements FlowCrudService, InMemoryAlterna
     }
 
     @Override
+    public Map<String, List<Flow>> getPlanV4Flows(Set<String> planIds) {
+        Map<String, List<Flow>> result = new HashMap<>();
+        for (String planId : planIds) {
+            result.put(planId, planFlowsHttpV4.getOrDefault(planId, new ArrayList<>()));
+        }
+        return result;
+    }
+
+    @Override
     public List<io.gravitee.definition.model.flow.Flow> getApiV2Flows(String apiId) {
         return apiFlowsV2.getOrDefault(apiId, new ArrayList<>());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/RemoveApiFromApiProductsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/RemoveApiFromApiProductsDomainServiceTest.java
@@ -28,6 +28,7 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiProductCrudServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.model.ApiProductDeploymentPayload;
@@ -72,7 +73,12 @@ class RemoveApiFromApiProductsDomainServiceTest extends AbstractUseCaseTest {
             planQueryService,
             apiProductQueryService
         );
-        var deployApiProductDomainService = new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService);
+        var deployApiProductDomainService = new DeployApiProductDomainService(
+            planQueryService,
+            eventCrudService,
+            eventLatestCrudService,
+            new FlowCrudServiceInMemory()
+        );
         domainService = new RemoveApiFromApiProductsDomainService(
             apiProductQueryService,
             apiProductCrudService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/model/ApiProductKindFilterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/model/ApiProductKindFilterTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.EnumSet;
+import org.junit.jupiter.api.Test;
+
+class ApiProductKindFilterTest {
+
+    @Test
+    void classicOnly_excludes_every_specialized_kind() {
+        assertThat(ApiProductKindFilter.classicOnly().excludedKinds()).isEqualTo(EnumSet.allOf(ApiProductKind.class));
+    }
+
+    @Test
+    void any_excludes_no_kind() {
+        assertThat(ApiProductKindFilter.any().excludedKinds()).isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
@@ -31,6 +31,7 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiProductCrudServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
 import inmemory.MembershipCrudServiceInMemory;
@@ -151,7 +152,7 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
             new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
             apiProductIndexerDomainService,
             notificationConfigCrudService,
-            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService),
+            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService, new FlowCrudServiceInMemory()),
             groupQueryService,
             apiProductTagDomainService
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCaseTest.java
@@ -29,6 +29,7 @@ import inmemory.AbstractUseCaseTest;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
 import inmemory.TriggerNotificationDomainServiceInMemory;
@@ -50,6 +51,7 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class DeployApiProductUseCaseTest extends AbstractUseCaseTest {
 
@@ -57,6 +59,7 @@ class DeployApiProductUseCaseTest extends AbstractUseCaseTest {
     private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
     private final EventCrudService eventCrudService = mock(EventCrudService.class);
     private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
+    private final FlowCrudServiceInMemory flowCrudService = new FlowCrudServiceInMemory();
     private final LicenseManager licenseManager = mock(LicenseManager.class);
     private final TriggerNotificationDomainServiceInMemory triggerNotificationDomainService =
         new TriggerNotificationDomainServiceInMemory();
@@ -75,7 +78,7 @@ class DeployApiProductUseCaseTest extends AbstractUseCaseTest {
             apiProductQueryService,
             new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
             validateApiProductService,
-            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService),
+            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService, flowCrudService),
             triggerNotificationDomainService
         );
     }
@@ -99,6 +102,35 @@ class DeployApiProductUseCaseTest extends AbstractUseCaseTest {
         assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
             new ApiProductDeployedHookContext(productId, USER_ID)
         );
+    }
+
+    @Test
+    void should_hydrate_plan_flows_into_the_deployment_payload() {
+        var productId = "api-product-id";
+        var apiProduct = ApiProduct.builder().id(productId).name("Product").environmentId(ENV_ID).version("1.0.0").build();
+        apiProductQueryService.initWith(List.of(apiProduct));
+
+        var plan = PlanFixtures.HttpV4.anApiKey()
+            .toBuilder()
+            .id("tier-1")
+            .referenceId(productId)
+            .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .build();
+        planQueryService.initWith(List.of(plan));
+        flowCrudService.savePlanFlows(
+            "tier-1",
+            List.of(io.gravitee.definition.model.v4.flow.Flow.builder().name("budget").enabled(true).build())
+        );
+
+        deployApiProductUseCase.execute(new DeployApiProductUseCase.Input(productId, AUDIT_INFO));
+
+        var payloadCaptor = ArgumentCaptor.forClass(io.gravitee.apim.core.api_product.model.ApiProductDeploymentPayload.class);
+        verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), payloadCaptor.capture(), any());
+        var deployedPlans = payloadCaptor.getValue().getPlans();
+        assertThat(deployedPlans).hasSize(1);
+        assertThat(deployedPlans.get(0).getFlows())
+            .extracting(io.gravitee.definition.model.v4.flow.Flow::getName)
+            .containsExactly("budget");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainServiceTest.java
@@ -880,6 +880,62 @@ class UpdatePlanDomainServiceTest {
         }
 
         @Test
+        void should_keep_existing_flows_when_the_update_carries_none() {
+            var plan = givenExistingApiProductPlan(
+                PlanFixtures.HttpV4.anApiKey()
+                    .toBuilder()
+                    .id("plan-1")
+                    .referenceId(API_PRODUCT_ID)
+                    .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+                    .build()
+            );
+            var existingFlows = List.of(Flow.builder().name("Token budget").enabled(true).build());
+            flowCrudService.savePlanFlows("plan-1", existingFlows);
+
+            service.updatePlanForApiProduct(plan.toBuilder().name("updated name").build(), Map.of(), API_PRODUCT, AUDIT_INFO);
+
+            assertThat(flowCrudService.storage()).containsExactlyElementsOf(existingFlows);
+        }
+
+        @Test
+        void should_persist_flows_supplied_on_the_update() {
+            var plan = givenExistingApiProductPlan(
+                PlanFixtures.HttpV4.anApiKey()
+                    .toBuilder()
+                    .id("plan-1")
+                    .referenceId(API_PRODUCT_ID)
+                    .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+                    .build()
+            );
+            var newFlows = List.of(Flow.builder().name("Token budget").enabled(true).build());
+            var toUpdate = plan.toBuilder().build();
+            toUpdate.getPlanDefinitionHttpV4().setFlows(newFlows);
+
+            service.updatePlanForApiProduct(toUpdate, Map.of(), API_PRODUCT, AUDIT_INFO);
+
+            assertThat(flowCrudService.storage()).containsExactlyElementsOf(newFlows);
+        }
+
+        @Test
+        void should_clear_flows_when_the_update_supplies_an_empty_list() {
+            var plan = givenExistingApiProductPlan(
+                PlanFixtures.HttpV4.anApiKey()
+                    .toBuilder()
+                    .id("plan-1")
+                    .referenceId(API_PRODUCT_ID)
+                    .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+                    .build()
+            );
+            flowCrudService.savePlanFlows("plan-1", List.of(Flow.builder().name("Token budget").enabled(true).build()));
+            var toUpdate = plan.toBuilder().build();
+            toUpdate.getPlanDefinitionHttpV4().setFlows(List.of());
+
+            service.updatePlanForApiProduct(toUpdate, Map.of(), API_PRODUCT, AUDIT_INFO);
+
+            assertThat(flowCrudService.storage()).isEmpty();
+        }
+
+        @Test
         void should_create_an_audit_log() {
             // Given
             var plan = givenExistingApiProductPlan(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api_key/ApiKeyQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api_key/ApiKeyQueryServiceImplTest.java
@@ -366,6 +366,80 @@ public class ApiKeyQueryServiceImplTest {
     }
 
     @Nested
+    class FindBySubscriptionIds {
+
+        @Test
+        void should_return_empty_stream_without_hitting_repo_when_ids_are_empty() {
+            assertThat(service.findBySubscriptions(List.of())).isEmpty();
+            Mockito.verifyNoInteractions(apiKeyRepository);
+        }
+
+        @Test
+        void should_return_empty_stream_without_hitting_repo_when_ids_are_null() {
+            assertThat(service.findBySubscriptions(null)).isEmpty();
+            Mockito.verifyNoInteractions(apiKeyRepository);
+        }
+
+        @Test
+        void should_emit_one_query_with_subscriptions_in_clause_including_revoked_and_federated() throws TechnicalException {
+            when(apiKeyRepository.findByCriteriaUnordered(any(ApiKeyCriteria.class))).thenReturn(List.of());
+
+            service.findBySubscriptions(List.of("sub-a", "sub-b")).toList();
+
+            ArgumentCaptor<ApiKeyCriteria> captor = ArgumentCaptor.forClass(ApiKeyCriteria.class);
+            Mockito.verify(apiKeyRepository, Mockito.times(1)).findByCriteriaUnordered(captor.capture());
+            ApiKeyCriteria criteria = captor.getValue();
+            assertThat(criteria.getSubscriptions()).containsExactlyInAnyOrder("sub-a", "sub-b");
+            assertThat(criteria.isIncludeRevoked()).isTrue();
+            assertThat(criteria.isIncludeFederated()).isTrue();
+        }
+
+        @Test
+        void should_return_api_keys_and_adapt_them() throws TechnicalException {
+            when(apiKeyRepository.findByCriteriaUnordered(any(ApiKeyCriteria.class))).thenReturn(
+                List.of(anApiKeyForSubscription("sub-a").build())
+            );
+
+            var result = service.findBySubscriptions(List.of("sub-a"));
+
+            assertThat(result).containsExactly(
+                ApiKeyEntity.builder()
+                    .id("api-key-id")
+                    .subscriptions(List.of("sub-a"))
+                    .key("c080f684-2c35-40a1-903c-627c219e0567")
+                    .applicationId("application-id")
+                    .createdAt(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                    .updatedAt(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                    .expireAt(Instant.parse("2021-02-01T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                    .revokedAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                    .revoked(true)
+                    .paused(true)
+                    .daysToExpirationOnLastNotification(310)
+                    .build()
+            );
+        }
+
+        @Test
+        void should_query_once_regardless_of_subscription_count() throws TechnicalException {
+            when(apiKeyRepository.findByCriteriaUnordered(any(ApiKeyCriteria.class))).thenReturn(List.of());
+
+            service.findBySubscriptions(List.of("s1", "s2", "s3", "s4", "s5")).toList();
+
+            Mockito.verify(apiKeyRepository, Mockito.times(1)).findByCriteriaUnordered(any(ApiKeyCriteria.class));
+            Mockito.verify(apiKeyRepository, Mockito.never()).findBySubscription(Mockito.anyString());
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            when(apiKeyRepository.findByCriteriaUnordered(any(ApiKeyCriteria.class))).thenThrow(TechnicalException.class);
+
+            Throwable throwable = catchThrowable(() -> service.findBySubscriptions(List.of("sub-a")));
+
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
+        }
+    }
+
+    @Nested
     class FindExpiringApiKeys {
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiProductDocumentSearcherTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiProductDocumentSearcherTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.impl.search.lucene.searcher;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.ApiProductKind;
 import io.gravitee.apim.core.search.model.IndexableApiProduct;
 import io.gravitee.rest.api.model.search.Indexable;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -104,8 +105,45 @@ class ApiProductDocumentSearcherTest {
         assertThat(result.getDocuments()).contains("product-1");
     }
 
+    @Test
+    void should_still_return_classic_products_when_a_kind_is_excluded() throws Exception {
+        indexApiProduct("classic-1", "Classic Product", ENV_1, null);
+        indexApiProduct("workspace-1", "AI Workspace", ENV_1, ApiProductKind.AI_WORKSPACE);
+        indexWriter.commit();
+
+        ExecutionContext executionContext = new ExecutionContext(ORG_1, ENV_1);
+        var query = QueryBuilder.create(IndexableApiProduct.class)
+            .addExcludedFilter(IndexableApiProductDocumentTransformer.FIELD_KIND, Set.of(ApiProductKind.AI_WORKSPACE.name()))
+            .build();
+
+        var result = searcher.search(executionContext, query);
+
+        assertThat(result.getDocuments()).containsExactly("classic-1");
+    }
+
+    @Test
+    void should_exclude_the_kind_even_when_a_text_query_is_present() throws Exception {
+        indexApiProduct("classic-1", "Shared Product", ENV_1, null);
+        indexApiProduct("workspace-1", "Shared Product", ENV_1, ApiProductKind.AI_WORKSPACE);
+        indexWriter.commit();
+
+        ExecutionContext executionContext = new ExecutionContext(ORG_1, ENV_1);
+        var query = QueryBuilder.create(IndexableApiProduct.class)
+            .setQuery("Shared")
+            .addExcludedFilter(IndexableApiProductDocumentTransformer.FIELD_KIND, Set.of(ApiProductKind.AI_WORKSPACE.name()))
+            .build();
+
+        var result = searcher.search(executionContext, query);
+
+        assertThat(result.getDocuments()).containsExactly("classic-1");
+    }
+
     private void indexApiProduct(String id, String name, String environmentId) throws IOException {
-        ApiProduct apiProduct = ApiProduct.builder().id(id).environmentId(environmentId).name(name).build();
+        indexApiProduct(id, name, environmentId, null);
+    }
+
+    private void indexApiProduct(String id, String name, String environmentId, ApiProductKind kind) throws IOException {
+        ApiProduct apiProduct = ApiProduct.builder().id(id).environmentId(environmentId).name(name).kind(kind).build();
         IndexableApiProduct indexable = IndexableApiProduct.builder().apiProduct(apiProduct).build();
         Document doc = transformer.transform(indexable);
         indexWriter.addDocument(doc);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
@@ -342,6 +342,52 @@ public class ApiMapperTest {
     }
 
     @Test
+    public void shouldKeepAllowedInApiProductsOnUpdateForEveryApiProductComposableType() throws Exception {
+        Set<ApiType> composableTypes = Set.of(ApiType.PROXY, ApiType.LLM_PROXY);
+        for (ApiType type : ApiType.values()) {
+            UpdateApiEntity update = new UpdateApiEntity();
+            update.setId("id");
+            update.setName("name");
+            update.setApiVersion("1");
+            update.setDefinitionVersion(DefinitionVersion.V4);
+            update.setType(type);
+            update.setAllowedInApiProducts(true);
+
+            var definition = apiMapper.toRepository(GraviteeContext.getExecutionContext(), update).getDefinition();
+
+            if (composableTypes.contains(type)) {
+                assertThat(definition).as("%s must survive an update with the flag intact", type).contains("\"allowedInApiProducts\":true");
+            } else {
+                assertThat(definition).as("%s must not carry the flag", type).contains("\"allowedInApiProducts\":null");
+            }
+        }
+    }
+
+    @Test
+    public void shouldReadBackAllowedInApiProductsForEveryApiProductComposableType() throws Exception {
+        Set<ApiType> composableTypes = Set.of(ApiType.PROXY, ApiType.LLM_PROXY);
+        for (ApiType type : ApiType.values()) {
+            ApiEntity apiEntity = new ApiEntity();
+            apiEntity.setId("id");
+            apiEntity.setName("name");
+            apiEntity.setApiVersion("1");
+            apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+            apiEntity.setType(type);
+            apiEntity.setAllowedInApiProducts(true);
+
+            when(categoryMapper.toCategoryId(any(), any())).thenReturn(Set.of());
+
+            var definition = apiMapper.toRepository(GraviteeContext.getExecutionContext(), apiEntity).getDefinition();
+
+            if (composableTypes.contains(type)) {
+                assertThat(definition).as("%s must round-trip the flag", type).contains("\"allowedInApiProducts\":true");
+            } else {
+                assertThat(definition).as("%s must not carry the flag", type).contains("\"allowedInApiProducts\":null");
+            }
+        }
+    }
+
+    @Test
     public void shouldCreateEntityFromApiDefinition() throws JsonProcessingException {
         io.gravitee.definition.model.v4.Api apiDefinition = new io.gravitee.definition.model.v4.Api();
         apiDefinition.setDefinitionVersion(DefinitionVersion.V4);

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
     <gravitee-reactor-native-kafka.version>7.0.1</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.0.2</gravitee-reactor-mcp-proxy.version>
-    <gravitee-reactor-llm-proxy.version>3.1.0</gravitee-reactor-llm-proxy.version>
+    <gravitee-reactor-llm-proxy.version>3.1.1</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.0.0</gravitee-reactor-a2a-proxy.version>
     <gravitee-reactor-authz.version>1.0.0</gravitee-reactor-authz.version>
     <gravitee-reactor-edge.version>1.0.0</gravitee-reactor-edge.version>
@@ -346,7 +346,7 @@
     <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>
 
     <!-- Gamma plugins -->
-    <gravitee-gamma-module-aim.version>1.1.0-alpha.10</gravitee-gamma-module-aim.version>
+    <gravitee-gamma-module-aim.version>1.1.0-alpha.14</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.6.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>1.1.0</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.0.0</gravitee-gamma-module-esm.version>


### PR DESCRIPTION
## What

Introduces an `ApiProductKind` discriminator so an API Product can be a specialized kind (AI Workspace) **without a new table or refType**. Plain (kind-less) API Products behave exactly as before — verified.

## Changes

- `ApiProductKind`, `ApiProductKindFilter`, `ApiProductComposition`; specialized kinds are excluded from the classic API Product list and search.
- Hydrate v4 plan flows into the API Product deployment payload via a single bulk `FlowCrudService.getPlanV4Flows(Set)` lookup, so per-plan budget and rate-limit policies actually reach the gateway (no N+1).
- Persist v4 plan flows on API Product plan create and update.
- Resolve the product-plan policy manager through the ancestor-searching bean lookup (`getBeanNamesForType`) so **reactor plugins** (LLM proxy) receive product security. This was the root cause of a 401 on product-plan-only APIs: the plugin runs in a child Spring context and the direct `applicationContext.getBeanNamesForType(...)` returned empty.
- Bulk api-key lookup by subscription ids.
- Index and persist `allowedInApiProducts` for composable API types (`PROXY`, `LLM_PROXY`).
- Version bumps: `gravitee-reactor-llm-proxy` 3.1.1, `gravitee-gamma-module-aim` 1.1.0-alpha.14.

## Tests

140 affected unit tests pass (product deploy/flow hydration, plan create/update flow persistence, bulk api-key, lucene kind exclusion, mapper composable-type round-trip). Includes a regression test proving the ancestor-searching bean lookup resolves the policy manager from a child context.

## Compatibility

The `kind` discriminator is additive: `ApiProductKindFilter` defaults to `any()`, the lucene `kind` term is only added when present, and classic products carry no `kind` so they are never excluded.