### PR TITLE
feat: support API product navigation items in management API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForApiNavigati
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.BaseUpdatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApiProduct;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
@@ -28,6 +29,7 @@ import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.PortalPageContentType;
 import io.gravitee.rest.api.management.v2.rest.model.SeedDefaultPagesRequest;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApi;
+import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApiProduct;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationPage;
@@ -35,9 +37,7 @@ import java.util.List;
 import java.util.UUID;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingConstants;
 import org.mapstruct.Named;
-import org.mapstruct.ValueMapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -67,6 +67,13 @@ public interface PortalNavigationItemsMapper {
     @Mapping(target = "rootId", source = "rootId", qualifiedByName = "portalNavigationItemIdToUuid")
     io.gravitee.rest.api.management.v2.rest.model.PortalNavigationApi map(io.gravitee.apim.core.portal_page.model.PortalNavigationApi api);
 
+    @Mapping(target = "type", constant = "API_PRODUCT")
+    @Mapping(target = "apiProductId", source = "apiProductId")
+    @Mapping(target = "rootId", source = "rootId", qualifiedByName = "portalNavigationItemIdToUuid")
+    io.gravitee.rest.api.management.v2.rest.model.PortalNavigationApiProduct map(
+        io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct apiProduct
+    );
+
     default List<PortalNavigationItem> map(List<io.gravitee.apim.core.portal_page.model.PortalNavigationItem> items) {
         return items.stream().map(this::map).toList();
     }
@@ -77,6 +84,7 @@ public interface PortalNavigationItemsMapper {
             case io.gravitee.apim.core.portal_page.model.PortalNavigationPage page -> new PortalNavigationItem(map(page));
             case io.gravitee.apim.core.portal_page.model.PortalNavigationLink link -> new PortalNavigationItem(map(link));
             case io.gravitee.apim.core.portal_page.model.PortalNavigationApi api -> new PortalNavigationItem(map(api));
+            case io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct apiProduct -> new PortalNavigationItem(map(apiProduct));
         };
     }
 
@@ -107,6 +115,10 @@ public interface PortalNavigationItemsMapper {
         io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi api
     );
 
+    @Mapping(target = "contentType", constant = "GRAVITEE_MARKDOWN")
+    @Mapping(target = "apiProductId", source = "apiProductId")
+    io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem map(CreatePortalNavigationApiProduct apiProduct);
+
     default io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem map(
         BaseCreatePortalNavigationItem createPortalNavigationItem
     ) {
@@ -115,6 +127,7 @@ public interface PortalNavigationItemsMapper {
             case CreatePortalNavigationPage page -> map(page);
             case CreatePortalNavigationLink link -> map(link);
             case CreatePortalNavigationApi api -> map(api);
+            case CreatePortalNavigationApiProduct apiProduct -> map(apiProduct);
             default -> throw new TechnicalDomainException(
                 String.format("Unknown PortalNavigationItem class %s", createPortalNavigationItem.getClass().getSimpleName())
             );
@@ -157,8 +170,6 @@ public interface PortalNavigationItemsMapper {
         return io.gravitee.apim.core.portal_page.model.PortalPageContentType.valueOf(type.name());
     }
 
-    // API_PRODUCT domain support is added by the follow-up backend task.
-    @ValueMapping(source = "API_PRODUCT", target = MappingConstants.THROW_EXCEPTION)
     io.gravitee.apim.core.portal_page.model.PortalNavigationItemType map(
         io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType type
     );
@@ -171,6 +182,7 @@ public interface PortalNavigationItemsMapper {
             case UpdatePortalNavigationPage page -> map(page);
             case UpdatePortalNavigationLink link -> map(link);
             case UpdatePortalNavigationApi api -> map(api);
+            case UpdatePortalNavigationApiProduct apiProduct -> map(apiProduct);
             default -> throw new TechnicalDomainException(
                 String.format("Unknown PortalNavigationItem class %s", updatePortalNavigationItem.getClass().getSimpleName())
             );
@@ -192,4 +204,6 @@ public interface PortalNavigationItemsMapper {
     io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem map(
         io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApi api
     );
+
+    io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem map(UpdatePortalNavigationApiProduct apiProduct);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PortalNavigationItemsFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PortalNavigationItemsFixtures.java
@@ -24,12 +24,15 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItem;
+import io.gravitee.rest.api.management.v2.rest.model.BaseUpdatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApiProduct;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
 import io.gravitee.rest.api.management.v2.rest.model.PortalVisibility;
+import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApiProduct;
 import java.util.UUID;
 
 public class PortalNavigationItemsFixtures {
@@ -97,6 +100,26 @@ public class PortalNavigationItemsFixtures {
             .order(3)
             .parentId(parentId)
             .visibility(PortalVisibility.PUBLIC);
+    }
+
+    public static BaseCreatePortalNavigationItem aCreatePortalNavigationApiProduct() {
+        return new CreatePortalNavigationApiProduct()
+            .apiProductId(UUID.fromString("00000000-0000-0000-0000-000000000019"))
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .id(UUID.fromString("00000000-0000-0000-0000-000000000018"))
+            .title("My API Product")
+            .area(io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR)
+            .order(4)
+            .visibility(PortalVisibility.PUBLIC);
+    }
+
+    public static BaseUpdatePortalNavigationItem anUpdatePortalNavigationApiProduct() {
+        return new UpdatePortalNavigationApiProduct()
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .title("Updated API Product")
+            .order(1)
+            .published(false)
+            .visibility(PortalVisibility.PRIVATE);
     }
 
     public static BaseCreatePortalNavigationItem aPrivateCreatePortalNavigationPage() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -22,6 +22,7 @@ import fixtures.core.model.PortalNavigationItemFixtures;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.rest.api.management.v2.rest.model.BasePortalNavigationItem;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApiProduct;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
@@ -127,6 +128,19 @@ class PortalNavigationItemsMapperTest {
         }
 
         @Test
+        void should_map_portal_navigation_api_product() {
+            var apiProduct = PortalNavigationItemFixtures.anApiProduct();
+
+            var result = mapper.map(apiProduct);
+
+            assertThat(result).isInstanceOf(io.gravitee.rest.api.management.v2.rest.model.PortalNavigationApiProduct.class);
+            assertThat(result.getId()).isEqualTo(UUID.fromString(PortalNavigationItemFixtures.API_PRODUCT_ID));
+            assertThat(result.getType()).isEqualTo(PortalNavigationItemType.API_PRODUCT);
+            assertThat(result.getApiProductId()).isEqualTo(UUID.fromString(apiProduct.getApiProductId()));
+            assertThat(result.getRootId()).isEqualTo(apiProduct.getRootId().id());
+        }
+
+        @Test
         void should_map_list_of_portal_navigation_items() {
             var items = PortalNavigationItemFixtures.sampleNavigationItems();
 
@@ -207,24 +221,47 @@ class PortalNavigationItemsMapperTest {
         }
 
         @Test
+        void should_map_create_portal_navigation_api_product() {
+            final var apiProduct = PortalNavigationItemsFixtures.aCreatePortalNavigationApiProduct();
+
+            var result = mapper.map(apiProduct);
+
+            assertThat(result.getType()).isEqualTo(io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.API_PRODUCT);
+            assertThat(result.getApiProductId()).isEqualTo(((CreatePortalNavigationApiProduct) apiProduct).getApiProductId().toString());
+        }
+
+        @Test
+        void should_map_update_portal_navigation_api_product_without_product_relinking_field() {
+            final var apiProduct = PortalNavigationItemsFixtures.anUpdatePortalNavigationApiProduct();
+
+            var result = mapper.map(apiProduct);
+
+            assertThat(result.getType()).isEqualTo(io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.API_PRODUCT);
+            assertThat(result.getTitle()).isEqualTo("Updated API Product");
+            assertThat(result.getPublished()).isFalse();
+        }
+
+        @Test
         void should_map_bulk_create_portal_navigation_items() {
             final var page = PortalNavigationItemsFixtures.aCreatePortalNavigationPage();
             final var folder = PortalNavigationItemsFixtures.aCreatePortalNavigationFolder();
             final var link = PortalNavigationItemsFixtures.aCreatePortalNavigationLink();
             final var api = PortalNavigationItemsFixtures.aCreatePortalNavigationApi();
+            final var apiProduct = PortalNavigationItemsFixtures.aCreatePortalNavigationApiProduct();
 
-            final var requestItems = java.util.List.of(page, folder, link, api);
+            final var requestItems = java.util.List.of(page, folder, link, api, apiProduct);
 
             final var result = mapper.mapCreatePortalNavigationItems(requestItems);
 
-            assertThat(result).hasSize(4);
+            assertThat(result).hasSize(5);
             assertThat(result)
                 .extracting(io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem::getType)
                 .containsExactly(
                     io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.PAGE,
                     io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.FOLDER,
                     io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.LINK,
-                    io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.API
+                    io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.API,
+                    io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.API_PRODUCT
                 );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -15,12 +15,14 @@
  */
 package io.gravitee.rest.api.portal.rest.mapper;
 
+import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.OpenApiConfiguration;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -57,6 +59,9 @@ public interface PortalNavigationItemMapper {
             case PortalNavigationLink link -> map(link);
             case PortalNavigationPage page -> map(page);
             case PortalNavigationApi api -> map(api);
+            case PortalNavigationApiProduct ignored -> throw new TechnicalDomainException(
+                "API Product navigation items are not yet supported by the Portal API"
+            );
         };
         var wrappedItem = new io.gravitee.rest.api.portal.rest.model.PortalNavigationItem();
         wrappedItem.setActualInstance(baseItem);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapperTest.java
@@ -16,11 +16,15 @@
 package io.gravitee.rest.api.portal.rest.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
 import io.gravitee.rest.api.portal.rest.model.PortalNavigationFolder;
 import io.gravitee.rest.api.portal.rest.model.PortalNavigationLink;
@@ -74,5 +78,25 @@ class PortalNavigationItemMapperTest {
         PortalPageContentId pageId = PortalNavigationFixtures.randomPageId();
         String pageJson = PortalNavigationItemMapper.INSTANCE.map(pageId);
         assertThat(pageJson).isEqualTo(pageId.json());
+    }
+
+    @Test
+    void should_reject_api_product_not_yet_supported_by_portal_api() {
+        var apiProduct = PortalNavigationApiProduct.builder()
+            .id(PortalNavigationFixtures.randomNavigationId())
+            .organizationId("org")
+            .environmentId("env")
+            .title("API Product")
+            .segment("api-product")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(1)
+            .apiProductId("api-product-id")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+
+        assertThatThrownBy(() -> PortalNavigationItemMapper.INSTANCE.getBasePortalNavigationItem(apiProduct))
+            .isInstanceOf(TechnicalDomainException.class)
+            .hasMessage("API Product navigation items are not yet supported by the Portal API");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationTreeWalker.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationTreeWalker.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal.domain_service.navigation;
 
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -84,6 +85,7 @@ public final class PortalNavigationTreeWalker {
             case PortalNavigationFolder f -> visitor.visitFolder(f, parentPath);
             case PortalNavigationPage p -> visitor.visitPage(p, parentPath);
             case PortalNavigationApi a -> visitor.visitApi(a, parentPath);
+            case PortalNavigationApiProduct p -> visitor.visitApiProduct(p, parentPath);
             case PortalNavigationLink l -> visitor.visitLink(l, parentPath);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationVisitor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationVisitor.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal.domain_service.navigation;
 
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
@@ -28,6 +29,8 @@ public interface PortalNavigationVisitor {
     default void visitPage(PortalNavigationPage page, NavigationPath parentPath) {}
 
     default void visitApi(PortalNavigationApi api, NavigationPath parentPath) {}
+
+    default void visitApiProduct(PortalNavigationApiProduct apiProduct, NavigationPath parentPath) {}
 
     default void visitLink(PortalNavigationLink link, NavigationPath parentPath) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/TypeConsistencyRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/TypeConsistencyRule.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.domain_service.validation;
 
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
@@ -41,6 +42,7 @@ public class TypeConsistencyRule implements UpdatePortalNavigationItemValidation
             case PortalNavigationPage ignored -> PortalNavigationItemType.PAGE;
             case PortalNavigationLink ignored -> PortalNavigationItemType.LINK;
             case PortalNavigationApi ignored -> PortalNavigationItemType.API;
+            case PortalNavigationApiProduct ignored -> PortalNavigationItemType.API_PRODUCT;
         };
         if (existingType != toUpdate.getType()) {
             throw InvalidPortalNavigationItemDataException.typeMismatch(toUpdate.getType().toString(), existingType.toString());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/CreatePortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/CreatePortalNavigationItem.java
@@ -41,6 +41,7 @@ public final class CreatePortalNavigationItem {
 
     private String url;
     private String apiId;
+    private String apiProductId;
     private PortalVisibility visibility;
     private Boolean published;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationApiProduct.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.model;
+
+import jakarta.annotation.Nonnull;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder(toBuilder = true)
+public final class PortalNavigationApiProduct extends PortalNavigationItem implements PortalNavigationItemContainer {
+
+    private static final PortalNavigationItemType TYPE = PortalNavigationItemType.API_PRODUCT;
+
+    @Nonnull
+    private final String apiProductId;
+
+    PortalNavigationApiProduct(
+        @Nonnull PortalNavigationItemId id,
+        @Nonnull String organizationId,
+        @Nonnull String environmentId,
+        @Nonnull String title,
+        @Nonnull PortalArea area,
+        @Nonnull Integer order,
+        @Nonnull String apiProductId,
+        @Nonnull Boolean published,
+        @Nonnull PortalVisibility visibility
+    ) {
+        super(id, organizationId, environmentId, title, area, order, published, visibility);
+        this.apiProductId = apiProductId;
+    }
+
+    @Override
+    public PortalNavigationItemType getType() {
+        return TYPE;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -26,7 +26,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @SuperBuilder(toBuilder = true)
 public abstract sealed class PortalNavigationItem
-    permits PortalNavigationPage, PortalNavigationLink, PortalNavigationFolder, PortalNavigationApi {
+    permits PortalNavigationPage, PortalNavigationLink, PortalNavigationFolder, PortalNavigationApi, PortalNavigationApiProduct {
 
     @Nonnull
     private final PortalNavigationItemId id;
@@ -150,6 +150,7 @@ public abstract sealed class PortalNavigationItem
         final var contentId = item.getPortalPageContentId();
         final var url = item.getUrl();
         final var apiId = item.getApiId();
+        final var apiProductId = item.getApiProductId();
         final var order = item.getOrder();
         final var visibility = null != item.getVisibility() ? item.getVisibility() : PortalVisibility.PUBLIC;
         final var published = null != item.getPublished() ? item.getPublished() : false;
@@ -159,6 +160,17 @@ public abstract sealed class PortalNavigationItem
             case PAGE -> new PortalNavigationPage(id, organizationId, environmentId, title, area, order, contentId, published, visibility);
             case LINK -> new PortalNavigationLink(id, organizationId, environmentId, title, area, order, url, published, visibility);
             case API -> new PortalNavigationApi(id, organizationId, environmentId, title, area, order, apiId, published, visibility);
+            case API_PRODUCT -> new PortalNavigationApiProduct(
+                id,
+                organizationId,
+                environmentId,
+                title,
+                area,
+                order,
+                apiProductId,
+                published,
+                visibility
+            );
         };
         newItem.setSegment(segmentFor(item));
         if (parent == null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemQueryCriteria.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemQueryCriteria.java
@@ -30,5 +30,6 @@ public class PortalNavigationItemQueryCriteria {
     private Boolean published;
     private PortalVisibility visibility;
     private Set<String> apiIds;
+    private Set<String> apiProductIds;
     private PortalNavigationItemType type;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemType.java
@@ -20,4 +20,5 @@ public enum PortalNavigationItemType {
     FOLDER,
     LINK,
     API,
+    API_PRODUCT,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
@@ -41,7 +41,7 @@ public interface PortalNavigationItemAdapter {
             case PAGE -> portalNavigationPageFromRepository(portalNavigationItem);
             case LINK -> portalNavigationLinkFromRepository(portalNavigationItem);
             case API -> portalNavigationApiFromRepository(portalNavigationItem);
-            case API_PRODUCT -> throw new IllegalStateException("API product navigation items are not supported by the REST domain");
+            case API_PRODUCT -> portalNavigationApiProductFromRepository(portalNavigationItem);
         };
     }
 
@@ -70,6 +70,11 @@ public interface PortalNavigationItemAdapter {
         io.gravitee.repository.management.model.PortalNavigationItem portalNavigationItem
     );
 
+    @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
+    PortalNavigationApiProduct portalNavigationApiProductFromRepository(
+        io.gravitee.repository.management.model.PortalNavigationItem portalNavigationItem
+    );
+
     @Mapping(target = "portalPageContentId", expression = "java(parsePortalPageContentId(portalNavigationItem.getConfiguration()))")
     @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
     PortalNavigationPage portalNavigationPageFromRepository(
@@ -79,6 +84,7 @@ public interface PortalNavigationItemAdapter {
     default io.gravitee.repository.management.model.PortalNavigationItem toRepository(PortalNavigationItem portalNavigationItem) {
         return switch (portalNavigationItem) {
             case PortalNavigationApi api -> toRepository(api);
+            case PortalNavigationApiProduct apiProduct -> toRepository(apiProduct);
             case PortalNavigationPage page -> toRepository(page);
             case PortalNavigationLink link -> toRepository(link);
             case PortalNavigationFolder folder -> toRepository(folder);
@@ -101,12 +107,17 @@ public interface PortalNavigationItemAdapter {
     @Mapping(target = "configuration", expression = "java(configurationOf(portalNavigationItem))")
     io.gravitee.repository.management.model.PortalNavigationItem toRepository(PortalNavigationApi portalNavigationItem);
 
+    @Mapping(target = "type", expression = "java(mapType(portalNavigationItem))")
+    @Mapping(target = "configuration", expression = "java(configurationOf(portalNavigationItem))")
+    io.gravitee.repository.management.model.PortalNavigationItem toRepository(PortalNavigationApiProduct portalNavigationItem);
+
     default io.gravitee.repository.management.model.PortalNavigationItem.Type mapType(PortalNavigationItem portalNavigationItem) {
         return switch (portalNavigationItem) {
             case PortalNavigationFolder ignored -> io.gravitee.repository.management.model.PortalNavigationItem.Type.FOLDER;
             case PortalNavigationPage ignored -> io.gravitee.repository.management.model.PortalNavigationItem.Type.PAGE;
             case PortalNavigationLink ignored -> io.gravitee.repository.management.model.PortalNavigationItem.Type.LINK;
             case PortalNavigationApi ignored -> io.gravitee.repository.management.model.PortalNavigationItem.Type.API;
+            case PortalNavigationApiProduct ignored -> io.gravitee.repository.management.model.PortalNavigationItem.Type.API_PRODUCT;
         };
     }
 
@@ -125,6 +136,7 @@ public interface PortalNavigationItemAdapter {
                 }
                 case PortalNavigationFolder ignored -> OBJECT_MAPPER.writeValueAsString(new HashMap<>());
                 case PortalNavigationApi ignored -> OBJECT_MAPPER.writeValueAsString(new HashMap<>());
+                case PortalNavigationApiProduct ignored -> OBJECT_MAPPER.writeValueAsString(new HashMap<>());
             };
         } catch (Exception e) {
             throw new IllegalArgumentException("Failed to serialize configuration for PortalNavigationItem", e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
@@ -17,6 +17,7 @@ package fixtures.core.model;
 
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -35,6 +36,7 @@ public class PortalNavigationItemFixtures {
     public static final String FOLDER_ID = "00000000-0000-0000-0000-000000000015";
     public static final String LINK_ID = "00000000-0000-0000-0000-000000000016";
     public static final String API_ID = "00000000-0000-0000-0000-000000000017";
+    public static final String API_PRODUCT_ID = "00000000-0000-0000-0000-000000000018";
 
     public static final String APIS_ID = "00000000-0000-0000-0000-000000000001";
     private static final String GUIDES_ID = "00000000-0000-0000-0000-000000000002";
@@ -237,6 +239,37 @@ public class PortalNavigationItemFixtures {
             .area(PortalArea.TOP_NAVBAR)
             .order(3)
             .apiId("apiId")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    public static PortalNavigationApiProduct anApiProduct(String id, String title, PortalNavigationItemId parentId, String apiProductId) {
+        return PortalNavigationApiProduct.builder()
+            .id(PortalNavigationItemId.of(id))
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title(title)
+            .segment(PortalNavigationItem.slugify(title).value())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .apiProductId(apiProductId)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .parentId(parentId)
+            .build();
+    }
+
+    public static PortalNavigationApiProduct anApiProduct() {
+        return PortalNavigationApiProduct.builder()
+            .id(PortalNavigationItemId.of(API_PRODUCT_ID))
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title("My API Product")
+            .segment("my-api-product")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(4)
+            .apiProductId("00000000-0000-0000-0000-000000000019")
             .published(true)
             .visibility(PortalVisibility.PUBLIC)
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/model/PortalNavigationItemsRepositoryFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/model/PortalNavigationItemsRepositoryFixtures.java
@@ -128,6 +128,25 @@ public class PortalNavigationItemsRepositoryFixtures {
             .build();
     }
 
+    public static PortalNavigationItem anApiProduct(String id, String title, String apiProductId, String parentId) {
+        return PortalNavigationItem.builder()
+            .id(id)
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title(title)
+            .segment(title)
+            .type(Type.API_PRODUCT)
+            .area(Area.TOP_NAVBAR)
+            .order(0)
+            .parentId(parentId)
+            .rootId(parentId == null ? id : parentId)
+            .configuration("{}")
+            .published(true)
+            .visibility(Visibility.PUBLIC)
+            .apiProductId(apiProductId)
+            .build();
+    }
+
     /** RootId value when domain model uses PortalNavigationItemId.zero(). */
     public static final String ROOT_ID_ZERO = "00000000-0000-0000-0000-000000000000";
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemsQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemsQueryServiceInMemory.java
@@ -17,6 +17,7 @@ package inmemory;
 
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
@@ -83,7 +84,11 @@ public class PortalNavigationItemsQueryServiceInMemory
                     (criteria.getType() == null || matchesType(item, criteria.getType())) &&
                     (criteria.getApiIds() == null ||
                         criteria.getApiIds().isEmpty() ||
-                        (item instanceof PortalNavigationApi api && criteria.getApiIds().contains(api.getApiId())))
+                        (item instanceof PortalNavigationApi api && criteria.getApiIds().contains(api.getApiId()))) &&
+                    (criteria.getApiProductIds() == null ||
+                        criteria.getApiProductIds().isEmpty() ||
+                        (item instanceof PortalNavigationApiProduct apiProduct &&
+                            criteria.getApiProductIds().contains(apiProduct.getApiProductId())))
             )
             .toList();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationTreeWalkerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationTreeWalkerTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -74,6 +75,28 @@ class PortalNavigationTreeWalkerTest {
         assertThat(visited).isEmpty();
     }
 
+    @Test
+    void walk_visits_api_product_and_its_children() {
+        var apiProduct = apiProduct(ROOT, null, "product", 0);
+        var items = List.<PortalNavigationItem>of(apiProduct, folder(CHILD_A, ROOT, "child", 0));
+        var visited = new ArrayList<String>();
+        var visitor = new PortalNavigationVisitor() {
+            @Override
+            public void visitApiProduct(PortalNavigationApiProduct product, NavigationPath parentPath) {
+                visited.add(product.getSegment());
+            }
+
+            @Override
+            public void visitFolder(PortalNavigationFolder folder, NavigationPath parentPath) {
+                visited.add(parentPath.path() + "/" + folder.getSegment());
+            }
+        };
+
+        PortalNavigationTreeWalker.walk(items, visitor);
+
+        assertThat(visited).containsExactly("product", "/product/child");
+    }
+
     private static PortalNavigationFolder folder(PortalNavigationItemId id, PortalNavigationItemId parentId, String segment, int order) {
         return PortalNavigationFolder.builder()
             .id(id)
@@ -84,6 +107,27 @@ class PortalNavigationTreeWalkerTest {
             .area(PortalArea.TOP_NAVBAR)
             .order(order)
             .parentId(parentId)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    private static PortalNavigationApiProduct apiProduct(
+        PortalNavigationItemId id,
+        PortalNavigationItemId parentId,
+        String segment,
+        int order
+    ) {
+        return PortalNavigationApiProduct.builder()
+            .id(id)
+            .organizationId("organization-id")
+            .environmentId("environment-id")
+            .title(segment)
+            .segment(segment)
+            .area(PortalArea.TOP_NAVBAR)
+            .order(order)
+            .parentId(parentId)
+            .apiProductId("00000000-0000-0000-0000-000000000020")
             .published(true)
             .visibility(PortalVisibility.PUBLIC)
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/TypeConsistencyRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/TypeConsistencyRuleTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TypeConsistencyRuleTest {
+
+    private final TypeConsistencyRule rule = new TypeConsistencyRule();
+
+    @Test
+    void should_accept_api_product_update_type() {
+        var existing = PortalNavigationItemFixtures.anApiProduct();
+        var update = UpdatePortalNavigationItem.builder().type(PortalNavigationItemType.API_PRODUCT).build();
+
+        assertThatCode(() -> rule.validate(update, existing, UpdateValidationContext.empty())).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_reject_api_product_type_change() {
+        var existing = PortalNavigationItemFixtures.anApiProduct();
+        var update = UpdatePortalNavigationItem.builder().type(PortalNavigationItemType.FOLDER).build();
+
+        assertThatThrownBy(() -> rule.validate(update, existing, UpdateValidationContext.empty()))
+            .isInstanceOf(InvalidPortalNavigationItemDataException.class)
+            .hasMessage("Navigation item type cannot be changed or is mismatched (expected API_PRODUCT, got FOLDER).");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationItemTest {
+
+    @Test
+    void should_create_unpublished_api_product_container() {
+        var create = CreatePortalNavigationItem.builder()
+            .title("Product documentation")
+            .segment("product-documentation")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .apiProductId("00000000-0000-0000-0000-000000000020")
+            .build();
+
+        var item = PortalNavigationItem.from(create, "organization-id", "environment-id", null);
+
+        assertThat(item).isInstanceOf(PortalNavigationApiProduct.class).isInstanceOf(PortalNavigationItemContainer.class);
+        var apiProduct = (PortalNavigationApiProduct) item;
+        assertThat(apiProduct.getApiProductId()).isEqualTo("00000000-0000-0000-0000-000000000020");
+        assertThat(apiProduct.getPublished()).isFalse();
+        assertThat(apiProduct.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
+        assertThat(apiProduct.isRoot()).isTrue();
+    }
+
+    @Test
+    void should_preserve_api_product_id_during_update() {
+        var apiProduct = fixtures.core.model.PortalNavigationItemFixtures.anApiProduct();
+        var originalApiProductId = apiProduct.getApiProductId();
+        var update = UpdatePortalNavigationItem.builder()
+            .title("Updated product documentation")
+            .order(1)
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .published(false)
+            .visibility(PortalVisibility.PRIVATE)
+            .build();
+
+        apiProduct.update(update);
+
+        assertThat(apiProduct.getApiProductId()).isEqualTo(originalApiProductId);
+        assertThat(apiProduct.getTitle()).isEqualTo("Updated product documentation");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
@@ -139,6 +139,24 @@ class PortalNavigationItemAdapterTest {
         }
 
         @Test
+        void should_map_api_product_to_entity() {
+            var repositoryItem = PortalNavigationItemsRepositoryFixtures.anApiProduct(
+                "550e8400-e29b-41d4-a716-446655440020",
+                "My API Product",
+                "550e8400-e29b-41d4-a716-446655440021",
+                null
+            );
+
+            var entity = adapter.toEntity(repositoryItem);
+
+            assertThat(entity).isInstanceOf(PortalNavigationApiProduct.class);
+            var apiProduct = (PortalNavigationApiProduct) entity;
+            assertThat(apiProduct.getId()).isEqualTo(PortalNavigationItemId.of("550e8400-e29b-41d4-a716-446655440020"));
+            assertThat(apiProduct.getApiProductId()).isEqualTo("550e8400-e29b-41d4-a716-446655440021");
+            assertThat(apiProduct.getRootId()).isEqualTo(PortalNavigationItemId.of("550e8400-e29b-41d4-a716-446655440020"));
+        }
+
+        @Test
         void should_map_blank_or_empty_rootId_to_zero() {
             // Given - repository item with empty rootId (rootId is non-nullable; empty/blank still mapped defensively)
             var repositoryItem = PortalNavigationItemsRepositoryFixtures.aFolder(
@@ -338,6 +356,24 @@ class PortalNavigationItemAdapterTest {
             assertThat(repositoryItem.getApiId()).isEqualTo("apiId");
             assertThat(repositoryItem.isPublished()).isTrue();
             assertThat(repositoryItem.getVisibility()).isEqualTo(PortalNavigationItem.Visibility.PUBLIC);
+        }
+
+        @Test
+        void should_map_api_product_to_repository() {
+            var entity = PortalNavigationItemFixtures.anApiProduct(
+                "550e8400-e29b-41d4-a716-446655440022",
+                "My API Product",
+                null,
+                "550e8400-e29b-41d4-a716-446655440023"
+            );
+
+            var repositoryItem = adapter.toRepository((io.gravitee.apim.core.portal_page.model.PortalNavigationItem) entity);
+
+            assertThat(repositoryItem.getId()).isEqualTo("550e8400-e29b-41d4-a716-446655440022");
+            assertThat(repositoryItem.getType()).isEqualTo(PortalNavigationItem.Type.API_PRODUCT);
+            assertThat(repositoryItem.getApiProductId()).isEqualTo("550e8400-e29b-41d4-a716-446655440023");
+            assertThat(repositoryItem.getConfiguration()).isEqualTo("{}");
+            assertThat(repositoryItem.getRootId()).isEqualTo("00000000-0000-0000-0000-000000000000");
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_page/PortalNavigationItemsQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_page/PortalNavigationItemsQueryServiceImplTest.java
@@ -35,6 +35,7 @@ import io.gravitee.repository.management.api.PortalNavigationItemRepository;
 import io.gravitee.repository.management.api.search.PortalNavigationItemCriteria;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -232,6 +233,7 @@ class PortalNavigationItemsQueryServiceImplTest {
                 .published(true)
                 .root(true)
                 .visibility(PortalVisibility.PRIVATE)
+                .apiProductIds(Set.of("api-product-id"))
                 .build();
 
             var domainItem = PortalNavigationItemFixtures.aPage(PortalNavigationItemId.random().json(), "Test Item", parentId);
@@ -257,6 +259,29 @@ class PortalNavigationItemsQueryServiceImplTest {
             assertThat(capturedCriteria.getPublished()).isTrue();
             assertThat(capturedCriteria.getRoot()).isTrue();
             assertThat(capturedCriteria.getVisibility()).isEqualTo("PRIVATE");
+            assertThat(capturedCriteria.getApiProductIds()).containsExactly("api-product-id");
+        }
+
+        @Test
+        void should_round_trip_api_product_results() throws TechnicalException {
+            var repoItem = PortalNavigationItemsRepositoryFixtures.anApiProduct(
+                "00000000-0000-0000-0000-000000000020",
+                "Product",
+                "00000000-0000-0000-0000-000000000021",
+                null
+            );
+            var criteria = PortalNavigationItemQueryCriteria.builder()
+                .environmentId(PortalNavigationItemsRepositoryFixtures.ENV_ID)
+                .apiProductIds(Set.of(repoItem.getApiProductId()))
+                .build();
+            when(repository.searchByCriteria(any())).thenReturn(List.of(repoItem));
+
+            var result = service.search(criteria);
+
+            assertThat(result).singleElement().isInstanceOf(io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct.class);
+            assertThat(
+                ((io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct) result.getFirst()).getApiProductId()
+            ).isEqualTo(repoItem.getApiProductId());
         }
 
         @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-56

## Description

Adds Management API support for `API_PRODUCT` portal navigation items, building on the repository and persistence support already merged into `master`.

## Changes

- Add the `PortalNavigationApiProduct` domain model.
- Map API product navigation items between repository, domain, and Management API v2 models.
- Support `API_PRODUCT` in navigation tree traversal and type validation.
- Extend navigation query criteria and in-memory test services.
- Add fixtures and tests covering mapping, validation, traversal, and querying.
