### PR TITLE
feat: add API Product portal navigation flow

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
@@ -20,14 +20,17 @@ import {
   PortalNavigationFolder,
   PortalNavigationLink,
   PortalNavigationApi,
+  PortalNavigationApiProduct,
   NewPagePortalNavigationItem,
   NewFolderPortalNavigationItem,
   NewLinkPortalNavigationItem,
   NewApiPortalNavigationItem,
+  NewApiProductPortalNavigationItem,
   UpdatePagePortalNavigationItem,
   UpdateLinkPortalNavigationItem,
   UpdateFolderPortalNavigationItem,
   UpdateApiPortalNavigationItem,
+  UpdateApiProductPortalNavigationItem,
 } from './portalNavigationItem';
 import { PortalNavigationItemsResponse } from './portalNavigationItemsResponse';
 
@@ -113,6 +116,30 @@ export function fakePortalNavigationApi(overrides?: Partial<PortalNavigationApi>
     area: 'TOP_NAVBAR',
     apiId: 'api-1',
     published: true,
+    visibility: 'PUBLIC',
+  };
+
+  if (isFunction(overrides)) {
+    return overrides(base);
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+export function fakePortalNavigationApiProduct(overrides?: Partial<PortalNavigationApiProduct>): PortalNavigationApiProduct {
+  const base: PortalNavigationApiProduct = {
+    id: 'nav-api-product-1',
+    organizationId: 'org-1',
+    environmentId: 'env-1',
+    title: 'API Product',
+    type: 'API_PRODUCT',
+    order: 1,
+    area: 'TOP_NAVBAR',
+    apiProductId: 'api-product-1',
+    published: false,
     visibility: 'PUBLIC',
   };
 
@@ -216,6 +243,27 @@ export function fakeNewApiPortalNavigationItem(overrides?: Partial<NewApiPortalN
   };
 }
 
+export function fakeNewApiProductPortalNavigationItem(
+  overrides?: Partial<NewApiProductPortalNavigationItem>,
+): NewApiProductPortalNavigationItem {
+  const base: NewApiProductPortalNavigationItem = {
+    title: 'New API Product',
+    type: 'API_PRODUCT',
+    area: 'TOP_NAVBAR',
+    apiProductId: 'api-product-1',
+    visibility: 'PUBLIC',
+  };
+
+  if (isFunction(overrides)) {
+    return overrides(base);
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
 export function fakeUpdatePagePortalNavigationItem(overrides?: Partial<UpdatePagePortalNavigationItem>): UpdatePagePortalNavigationItem {
   const base: UpdatePagePortalNavigationItem = {
     published: false,
@@ -280,6 +328,26 @@ export function fakeUpdateApiPortalNavigationItem(overrides?: Partial<UpdateApiP
     title: '',
     visibility: 'PUBLIC',
     apiId: 'api-1',
+  };
+
+  if (isFunction(overrides)) {
+    return overrides(base);
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+export function fakeUpdateApiProductPortalNavigationItem(
+  overrides?: Partial<UpdateApiProductPortalNavigationItem>,
+): UpdateApiProductPortalNavigationItem {
+  const base: UpdateApiProductPortalNavigationItem = {
+    published: false,
+    type: 'API_PRODUCT',
+    title: 'Updated API Product',
+    visibility: 'PUBLIC',
   };
 
   if (isFunction(overrides)) {

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
@@ -16,7 +16,7 @@
 import type { PortalPageContentType } from '../portalPageContent/portalPageContent';
 
 export type PortalArea = 'HOMEPAGE' | 'TOP_NAVBAR';
-export type PortalNavigationItemType = 'PAGE' | 'FOLDER' | 'LINK' | 'API';
+export type PortalNavigationItemType = 'PAGE' | 'FOLDER' | 'LINK' | 'API' | 'API_PRODUCT';
 export type PortalVisibility = 'PUBLIC' | 'PRIVATE';
 
 interface BasePortalNavigationItem<T extends PortalNavigationItemType> {
@@ -46,7 +46,16 @@ export interface PortalNavigationApi extends BasePortalNavigationItem<'API'> {
   apiId: string;
 }
 
-export type PortalNavigationItem = PortalNavigationPage | PortalNavigationFolder | PortalNavigationLink | PortalNavigationApi;
+export interface PortalNavigationApiProduct extends BasePortalNavigationItem<'API_PRODUCT'> {
+  apiProductId: string;
+}
+
+export type PortalNavigationItem =
+  | PortalNavigationPage
+  | PortalNavigationFolder
+  | PortalNavigationLink
+  | PortalNavigationApi
+  | PortalNavigationApiProduct;
 
 interface BaseNewPortalNavigationItem<T extends PortalNavigationItemType> {
   title: string;
@@ -72,11 +81,16 @@ export interface NewApiPortalNavigationItem extends BaseNewPortalNavigationItem<
   apiId: string;
 }
 
+export interface NewApiProductPortalNavigationItem extends BaseNewPortalNavigationItem<'API_PRODUCT'> {
+  apiProductId: string;
+}
+
 export type NewPortalNavigationItem =
   | NewPagePortalNavigationItem
   | NewFolderPortalNavigationItem
   | NewLinkPortalNavigationItem
-  | NewApiPortalNavigationItem;
+  | NewApiPortalNavigationItem
+  | NewApiProductPortalNavigationItem;
 
 interface BaseUpdatePortalNavigationItem<T extends PortalNavigationItemType> {
   title: string;
@@ -99,8 +113,11 @@ export interface UpdateApiPortalNavigationItem extends BaseUpdatePortalNavigatio
   apiId: string;
 }
 
+export interface UpdateApiProductPortalNavigationItem extends BaseUpdatePortalNavigationItem<'API_PRODUCT'> {}
+
 export type UpdatePortalNavigationItem =
   | UpdatePagePortalNavigationItem
   | UpdateFolderPortalNavigationItem
   | UpdateLinkPortalNavigationItem
-  | UpdateApiPortalNavigationItem;
+  | UpdateApiPortalNavigationItem
+  | UpdateApiProductPortalNavigationItem;

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -151,6 +151,25 @@
         </button>
       }
 
+      @if (node.type === 'FOLDER') {
+        @let apiProductCreationAllowed = apiProductCreationAllowedByNodeId().get(node.id) ?? true;
+        <span
+          [matTooltip]="apiProductCreationAllowed ? '' : 'API Products cannot be nested inside another API Product'"
+          [matTooltipDisabled]="apiProductCreationAllowed"
+          matTooltipPosition="right"
+        >
+          <button
+            mat-menu-item
+            data-testid="add-api-product-button"
+            [disabled]="!apiProductCreationAllowed"
+            (click)="onCreate(node, 'API_PRODUCT')"
+          >
+            <mat-icon [svgIcon]="'API_PRODUCT' | portalNavigationItemIcon"></mat-icon>
+            Add API Product
+          </button>
+        </span>
+      }
+
       <button mat-menu-item (click)="onCreate(node, 'FOLDER')">
         <mat-icon [svgIcon]="'FOLDER' | portalNavigationItemIcon"></mat-icon>
         Add Folder

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -27,6 +27,7 @@ import { FlatTreeComponentHarness } from './flat-tree.component.harness';
 import { GioTestingModule } from '../../../shared/testing';
 import {
   fakePortalNavigationApi,
+  fakePortalNavigationApiProduct,
   fakePortalNavigationFolder,
   fakePortalNavigationLink,
   fakePortalNavigationPage,
@@ -74,6 +75,8 @@ describe('FlatTreeComponent', () => {
         return fakePortalNavigationLink({ id, title, order, parentId, published });
       case 'API':
         return fakePortalNavigationApi({ id, title, order, parentId, published });
+      case 'API_PRODUCT':
+        return fakePortalNavigationApiProduct({ id, title, order, parentId, published });
       case 'PAGE':
       default:
         return fakePortalNavigationPage({ id, title, order, parentId, published });
@@ -120,6 +123,19 @@ describe('FlatTreeComponent', () => {
     expect(tree[2].id).toBe('l1');
     expect(tree[2].type).toBe('LINK');
     expect(tree[2].children).toBeUndefined();
+  });
+
+  it('should render API Product as an expandable container', () => {
+    fixture.componentRef.setInput('links', [
+      makeItem('folder-1', 'FOLDER', 'Folder 1', 0),
+      makeItem('product-1', 'API_PRODUCT', 'Product 1', 0, 'folder-1'),
+      makeItem('api-1', 'API', 'API 1', 0, 'product-1'),
+    ]);
+    fixture.detectChanges();
+
+    const productNode = component.tree()[0].children?.[0];
+    expect(productNode?.type).toBe('API_PRODUCT');
+    expect(productNode?.children?.[0].type).toBe('API');
   });
 
   describe('Indentation after move', () => {
@@ -909,14 +925,33 @@ describe('FlatTreeComponent', () => {
       const addPageButton = await harness.getMenuItemByText('Add Page');
       const addFolderButton = await harness.getMenuItemByText('Add Folder');
       const addLinkButton = await harness.getMenuItemByText('Add Link');
+      const addApiProductButton = await harness.getMenuItemByTestId('add-api-product-button');
       const editButton = await harness.getMenuItemByTestId('edit-node-button');
       const deleteButton = await harness.getMenuItemByTestId('delete-node-button');
 
       expect(addPageButton).toBeTruthy();
       expect(addFolderButton).toBeTruthy();
       expect(addLinkButton).toBeTruthy();
+      expect(addApiProductButton).toBeTruthy();
+      expect(await addApiProductButton!.isDisabled()).toBe(false);
       expect(editButton).toBeNull();
       expect(deleteButton).toBeNull();
+    });
+
+    it('should disable Add API Product for a folder inside an API Product subtree', async () => {
+      setupPermissions(['environment-documentation-c']);
+      fixture = TestBed.createComponent(FlatTreeComponent);
+      component = fixture.componentInstance;
+      harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, FlatTreeComponentHarness);
+
+      fixture.componentRef.setInput('links', [
+        makeItem('folder-root', 'FOLDER', 'Root Folder', 0),
+        makeItem('product-1', 'API_PRODUCT', 'Product 1', 0, 'folder-root'),
+        makeItem('folder-nested', 'FOLDER', 'Nested Folder', 0, 'product-1'),
+      ]);
+      fixture.detectChanges();
+
+      expect(component.apiProductCreationAllowedByNodeId().get('folder-nested')).toBe(false);
     });
 
     const testCases = [

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -155,6 +155,36 @@ export class FlatTreeComponent {
     return parentByChildId;
   });
 
+  readonly apiProductCreationAllowedByNodeId = computed(() => {
+    const links = this.links();
+    const creationAllowedByNodeId = new Map<string, boolean>();
+
+    if (!links || !Array.isArray(links)) {
+      return creationAllowedByNodeId;
+    }
+
+    const itemsById = new Map<string, PortalNavigationItem>(links.map(item => [item.id, item]));
+
+    for (const link of links) {
+      let currentParent = link.parentId ? itemsById.get(link.parentId) : undefined;
+      const visitedParentIds = new Set<string>();
+      let hasApiProductAncestor = false;
+
+      while (currentParent && !visitedParentIds.has(currentParent.id)) {
+        visitedParentIds.add(currentParent.id);
+        if (currentParent.type === 'API_PRODUCT') {
+          hasApiProductAncestor = true;
+          break;
+        }
+        currentParent = currentParent.parentId ? itemsById.get(currentParent.parentId) : undefined;
+      }
+
+      creationAllowedByNodeId.set(link.id, !hasApiProductAncestor);
+    }
+
+    return creationAllowedByNodeId;
+  });
+
   publishStateByNodeId = computed(() => {
     const links = this.links();
     const publishStateByNodeId = new Map<string, PublishActionState>();
@@ -384,8 +414,7 @@ export class FlatTreeComponent {
   onDragStarted(event: CdkDragStart<SectionNode>) {
     const draggedNode = event.source.data;
 
-    // If it's a folder, find all its descendants to hide them
-    if (draggedNode.type === 'FOLDER' && draggedNode.children) {
+    if (this.isContainer(draggedNode) && draggedNode.children) {
       this.collapseNode(draggedNode);
     }
   }
@@ -469,7 +498,7 @@ export class FlatTreeComponent {
   }
 
   private isContainer(node: SectionNode): boolean {
-    return node.type === 'FOLDER' || node.type === 'API';
+    return node.type === 'FOLDER' || node.type === 'API' || node.type === 'API_PRODUCT';
   }
 
   // Reject the dragged node itself and its own descendants as targets: re-parenting a node under one
@@ -587,7 +616,7 @@ export class FlatTreeComponent {
         label: link.title,
         type,
         data: link,
-        children: type === 'FOLDER' || type === 'API' ? [] : undefined,
+        children: type === 'FOLDER' || type === 'API' || type === 'API_PRODUCT' ? [] : undefined,
         __order: link.order ?? 0,
         __parentId: link.parentId ?? null,
       } as ProcessingNode);

--- a/gravitee-apim-console-webui/src/portal/icon/portal-navigation-item-icon.pipe.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/icon/portal-navigation-item-icon.pipe.spec.ts
@@ -33,6 +33,7 @@ describe('PortalNavigationItemIconPipe', () => {
     ['LINK', 'gio:link'],
     ['FOLDER', 'gio:folder'],
     ['API', 'gio:folder-api'],
+    ['API_PRODUCT', 'gio:folder-api'],
   ] as const)('should map %s to %s', (type, expected) => {
     expect(pipe.transform(type)).toBe(expected);
   });

--- a/gravitee-apim-console-webui/src/portal/icon/portal-navigation-item-icon.pipe.ts
+++ b/gravitee-apim-console-webui/src/portal/icon/portal-navigation-item-icon.pipe.ts
@@ -22,6 +22,7 @@ const portalNavigationItemTypeToSvgIcon: Readonly<Record<PortalNavigationItemTyp
   LINK: 'gio:link',
   FOLDER: 'gio:folder',
   API: 'gio:folder-api',
+  API_PRODUCT: 'gio:folder-api',
 };
 
 @Pipe({

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-product-section-editor-dialog/api-product-section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-product-section-editor-dialog/api-product-section-editor-dialog.component.html
@@ -1,0 +1,118 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div mat-dialog-title class="title">{{ title }}</div>
+
+<form [formGroup]="form" (ngSubmit)="onSubmit()">
+  <mat-dialog-content class="mat-elevation-z0">
+    <div class="api-product-search-description-box">
+      <div class="selected-panel__title">API Products</div>
+      <div class="api-product-search-description">Pick the API Products you want to add to your navigation menu.</div>
+    </div>
+
+    @if (isLoading()) {
+      <span data-testid="api-product-picker-loading">Loading...</span>
+    }
+    <gio-table-wrapper [searchLabel]="'Search'" [length]="total" [filters]="filters" (filtersChange)="onFiltersChanged($event)">
+      <table mat-table [dataSource]="rows$ | async" aria-label="API Products picker table">
+        <ng-container matColumnDef="select">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let row">
+            @if (!row.isDisabled) {
+              <mat-checkbox
+                [checked]="isChecked(row.id)"
+                (change)="onApiProductSelectionChange(row, $event)"
+                [attr.data-testid]="'api-product-picker-checkbox-' + row.id"
+              ></mat-checkbox>
+            } @else {
+              <span class="already-added-label" [attr.data-testid]="'api-product-picker-already-added-' + row.id">Already added</span>
+            }
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef>Product name</th>
+          <td mat-cell *matCellDef="let row" [class.disabled]="row.isDisabled">{{ row.name }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="version">
+          <th mat-header-cell *matHeaderCellDef>Version</th>
+          <td mat-cell *matCellDef="let row" [class.disabled]="row.isDisabled">{{ row.version }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="description">
+          <th mat-header-cell *matHeaderCellDef>Description</th>
+          <td mat-cell *matCellDef="let row" [class.disabled]="row.isDisabled">{{ row.description }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="apiCount">
+          <th mat-header-cell *matHeaderCellDef>APIs</th>
+          <td mat-cell *matCellDef="let row" [class.disabled]="row.isDisabled">{{ row.apiCount }}</td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns" [class.disabled-row]="row.isDisabled"></tr>
+
+        <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+          <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
+            @if (hasLoadError()) {
+              <span data-testid="api-product-picker-load-error">Unable to load API Products.</span>
+            } @else if (total === 0) {
+              <span data-testid="api-product-picker-empty">No data to display.</span>
+            }
+          </td>
+        </tr>
+      </table>
+    </gio-table-wrapper>
+
+    <mat-expansion-panel class="selected-panel" [expanded]="selectedPanelExpanded()" (expandedChange)="selectedPanelExpanded.set($event)">
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          <div class="selected-panel__badge" [class.selected-panel__badge--zero]="selectedCount() === 0">{{ selectedCount() }}</div>
+          <div>API Products selected</div>
+        </mat-panel-title>
+      </mat-expansion-panel-header>
+
+      <div>
+        @if (selectedCount() === 0) {
+          <div>Select an API Product to add it to your navigation.</div>
+        } @else {
+          <mat-chip-set>
+            @for (apiProduct of selectedApiProducts(); track apiProduct.id) {
+              <mat-chip [removable]="true" (removed)="removeSelected(apiProduct.id)">
+                {{ apiProduct.name }}
+                <mat-icon matChipRemove>cancel</mat-icon>
+              </mat-chip>
+            }
+          </mat-chip-set>
+        }
+      </div>
+    </mat-expansion-panel>
+
+    <div class="selected-panel__title selected-panel__title--authentication">Authentication</div>
+    <span [matTooltip]="publicDisabledTooltip()" [matTooltipDisabled]="!publicDisabled()">
+      <mat-slide-toggle formControlName="isPrivate" aria-label="Require authentication to view selected API Products">
+        Authentication is required to view selected API Products.
+      </mat-slide-toggle>
+    </span>
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    <button mat-button type="button" (click)="close()">Cancel</button>
+    <button mat-flat-button color="primary" type="submit" [disabled]="!form.valid || formIsUnchanged()">Add</button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-product-section-editor-dialog/api-product-section-editor-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-product-section-editor-dialog/api-product-section-editor-dialog.component.scss
@@ -1,0 +1,59 @@
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use 'sass:map';
+
+$typography: map.get(gio.$mat-theme, typography);
+
+.title {
+  @include mat.m2-typography-level($typography, headline-6);
+}
+
+mat-dialog-content {
+  display: flex;
+  flex-flow: column;
+  gap: 8px;
+}
+
+.api-product-search-description-box {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 0 8px;
+}
+
+.selected-panel__title {
+  @include mat.m2-typography-level($typography, subtitle-2);
+  color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, darker80);
+
+  &--authentication {
+    margin-top: 8px;
+  }
+}
+
+.api-product-search-description,
+.already-added-label {
+  @include mat.m2-typography-level($typography, caption);
+  color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker80');
+}
+
+.disabled,
+.already-added-label {
+  color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker40');
+}
+
+.disabled-row {
+  opacity: 0.7;
+}
+
+.selected-panel {
+  &__badge {
+    min-width: 28px;
+    padding: 4px 8px;
+    margin-right: 8px;
+    border-radius: 16px;
+    background: mat.m2-get-color-from-palette(gio.$mat-accent-palette, 'default');
+    color: mat.m2-get-color-from-palette(gio.$mat-basic-palette, white);
+    @include gio.caption-2();
+    text-align: center;
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-product-section-editor-dialog/api-product-section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-product-section-editor-dialog/api-product-section-editor-dialog.component.spec.ts
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { Component, inject } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import {
+  ApiProductSectionEditorDialogComponent,
+  ApiProductSectionEditorDialogData,
+  ApiProductSectionEditorDialogResult,
+} from './api-product-section-editor-dialog.component';
+import { ApiProductSectionEditorDialogHarness } from './api-product-section-editor-dialog.harness';
+
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
+import { fakePortalNavigationFolder } from '../../../entities/management-api-v2';
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+
+@Component({
+  selector: 'test-host-component',
+  template: `<button (click)="openDialog()">Open</button>`,
+})
+class TestHostComponent {
+  private readonly matDialog = inject(MatDialog);
+
+  dialogValue?: ApiProductSectionEditorDialogResult;
+  dialogData: ApiProductSectionEditorDialogData = {
+    mode: 'create',
+    parentItem: fakePortalNavigationFolder({ area: 'TOP_NAVBAR' }),
+  };
+
+  openDialog(dialogData?: Partial<ApiProductSectionEditorDialogData>): void {
+    this.matDialog
+      .open<ApiProductSectionEditorDialogComponent, ApiProductSectionEditorDialogData, ApiProductSectionEditorDialogResult>(
+        ApiProductSectionEditorDialogComponent,
+        {
+          width: '800px',
+          data: { ...this.dialogData, ...dialogData },
+        },
+      )
+      .afterClosed()
+      .subscribe(result => {
+        this.dialogValue = result;
+      });
+  }
+}
+
+describe('ApiProductSectionEditorDialogComponent', () => {
+  const apiProducts: ApiProduct[] = [
+    { id: 'product-1', name: 'First Product', version: '1.0', description: 'First description', apiIds: ['api-1'] },
+    { id: 'product-2', name: 'Second Product', version: '2.0', description: 'Second description', apiIds: ['api-2', 'api-3'] },
+    { id: 'product-3', name: 'Third Product', version: '3.0', apiIds: [] },
+  ];
+
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+  let rootLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent, GioTestingModule, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should keep submit disabled when no API Product is selected', fakeAsync(() => {
+    component.openDialog();
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductSearchResponse(apiProducts);
+
+    let dialog!: ApiProductSectionEditorDialogHarness;
+    rootLoader.getHarness(ApiProductSectionEditorDialogHarness).then(harness => (dialog = harness));
+    tick();
+
+    dialog.isSubmitButtonDisabled().then(isDisabled => expect(isDisabled).toBe(true));
+    tick();
+  }));
+
+  it('should close without a result when cancelled', fakeAsync(() => {
+    component.openDialog();
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductSearchResponse(apiProducts);
+
+    let dialog!: ApiProductSectionEditorDialogHarness;
+    rootLoader.getHarness(ApiProductSectionEditorDialogHarness).then(harness => (dialog = harness));
+    tick();
+    dialog.clickCancelButton();
+    tick();
+
+    expect(component.dialogValue).toBeUndefined();
+  }));
+
+  it('should display loading and empty states', fakeAsync(() => {
+    component.openDialog();
+    fixture.detectChanges();
+
+    tick(350);
+    const request = expectApiProductSearchRequest();
+    let dialog!: ApiProductSectionEditorDialogHarness;
+    rootLoader.getHarness(ApiProductSectionEditorDialogHarness).then(harness => (dialog = harness));
+    tick();
+
+    dialog.getLoadingText().then(loadingText => expect(loadingText).toBe('Loading...'));
+    tick();
+
+    request.flush({ data: [], pagination: { totalCount: 0 } });
+    fixture.detectChanges();
+    tick();
+
+    dialog.getEmptyStateText().then(emptyStateText => expect(emptyStateText).toBe('No data to display.'));
+    tick();
+  }));
+
+  it('should search API Products once with the latest filters', fakeAsync(() => {
+    component.openDialog();
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductSearchResponse(apiProducts);
+
+    let dialog!: ApiProductSectionEditorDialogHarness;
+    rootLoader.getHarness(ApiProductSectionEditorDialogHarness).then(harness => (dialog = harness));
+    tick();
+
+    dialog.setSearchValue('Second');
+    tick(450);
+
+    const requests = httpTestingController.match(
+      req => req.method === 'POST' && req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search`,
+    );
+    expect(requests).toHaveLength(1);
+    expect(requests[0].request.body).toEqual({ query: 'Second' });
+    expect(requests[0].request.params.get('page')).toBe('1');
+    expect(requests[0].request.params.get('perPage')).toBe('10');
+
+    requests[0].flush({ data: [apiProducts[1]], pagination: { totalCount: 1 } });
+    fixture.detectChanges();
+    tick();
+  }));
+
+  it('should return selected products in selection order and allow removing a selection', fakeAsync(() => {
+    component.openDialog();
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductSearchResponse(apiProducts);
+
+    let checkboxes: MatCheckboxHarness[] = [];
+    rootLoader
+      .getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-product-picker-checkbox-"]' }))
+      .then(result => (checkboxes = result));
+    tick();
+
+    checkboxes[1].check();
+    checkboxes[0].check();
+    checkboxes[1].uncheck();
+    checkboxes[2].check();
+    tick();
+
+    let dialog!: ApiProductSectionEditorDialogHarness;
+    rootLoader.getHarness(ApiProductSectionEditorDialogHarness).then(harness => (dialog = harness));
+    tick();
+    dialog.clickSubmitButton();
+    tick();
+
+    expect(component.dialogValue).toEqual({
+      visibility: 'PUBLIC',
+      apiProducts: [
+        { id: 'product-1', name: 'First Product' },
+        { id: 'product-3', name: 'Third Product' },
+      ],
+    });
+  }));
+
+  it('should prevent selecting an already linked API Product', fakeAsync(() => {
+    component.openDialog({ existingApiProductIds: ['product-1'] });
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductSearchResponse(apiProducts);
+    tick();
+
+    let checkboxes: MatCheckboxHarness[] = [];
+    rootLoader
+      .getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-product-picker-checkbox-"]' }))
+      .then(result => (checkboxes = result));
+    let dialog!: ApiProductSectionEditorDialogHarness;
+    rootLoader.getHarness(ApiProductSectionEditorDialogHarness).then(harness => (dialog = harness));
+    tick();
+
+    expect(checkboxes).toHaveLength(2);
+    dialog.getAlreadyAddedLabel('product-1').then(label => expect(label).toBeTruthy());
+    tick();
+  }));
+
+  it('should force private visibility when parent is private', fakeAsync(() => {
+    component.openDialog({ parentItem: fakePortalNavigationFolder({ area: 'TOP_NAVBAR', visibility: 'PRIVATE' }) });
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductSearchResponse(apiProducts);
+
+    let dialog!: ApiProductSectionEditorDialogHarness;
+    rootLoader.getHarness(ApiProductSectionEditorDialogHarness).then(harness => (dialog = harness));
+    let checkboxes: MatCheckboxHarness[] = [];
+    rootLoader
+      .getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-product-picker-checkbox-"]' }))
+      .then(result => (checkboxes = result));
+    tick();
+
+    dialog.isAuthenticationToggleDisabled().then(isDisabled => expect(isDisabled).toBe(true));
+    dialog.isAuthenticationToggleChecked().then(isChecked => expect(isChecked).toBe(true));
+    checkboxes[0].check();
+    tick();
+    dialog.clickSubmitButton();
+    tick();
+
+    expect(component.dialogValue?.visibility).toBe('PRIVATE');
+  }));
+
+  it('should display a load error when API Product search fails', fakeAsync(() => {
+    component.openDialog();
+    fixture.detectChanges();
+
+    tick(350);
+    const request = expectApiProductSearchRequest();
+    request.flush('Server error', { status: 500, statusText: 'Internal Server Error' });
+    tick();
+
+    let dialog!: ApiProductSectionEditorDialogHarness;
+    rootLoader.getHarness(ApiProductSectionEditorDialogHarness).then(harness => (dialog = harness));
+    tick();
+    dialog.getLoadErrorText().then(errorText => expect(errorText).toBe('Unable to load API Products.'));
+    tick();
+  }));
+
+  function expectApiProductSearchRequest() {
+    const request = httpTestingController.expectOne(
+      req =>
+        req.method === 'POST' &&
+        req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search` &&
+        req.params.get('page') === '1' &&
+        req.params.get('perPage') === '10',
+    );
+    expect(request.request.body).toEqual({ query: '' });
+    return request;
+  }
+
+  function expectApiProductSearchResponse(response: ApiProduct[]): void {
+    expectApiProductSearchRequest().flush({
+      data: response,
+      pagination: { totalCount: response.length },
+    });
+    fixture.detectChanges();
+  }
+});

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-product-section-editor-dialog/api-product-section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-product-section-editor-dialog/api-product-section-editor-dialog.component.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AsyncPipe } from '@angular/common';
+import { Component, computed, HostListener, inject, OnInit, signal } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
+import { MatChipsModule } from '@angular/material/chips';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { isEqual } from 'lodash';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
+
+import { ApiProduct, ApiProductsResponse } from '../../../entities/management-api-v2/api-product';
+import { PortalNavigationItem, PortalVisibility } from '../../../entities/management-api-v2';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { getPublicVisibilityDisabledTooltip, isPublicVisibilityDisabled } from '../visibility-toggle.util';
+
+export interface ApiProductSectionEditorDialogData {
+  mode: 'create';
+  parentItem: PortalNavigationItem;
+  existingApiProductIds?: string[];
+}
+
+export interface SelectedApiProduct {
+  id: string;
+  name: string;
+}
+
+export interface ApiProductSectionEditorDialogResult {
+  visibility: PortalVisibility;
+  apiProducts: SelectedApiProduct[];
+}
+
+type ApiProductRow = SelectedApiProduct & {
+  version: string;
+  description: string;
+  apiCount: number;
+  isDisabled: boolean;
+};
+
+interface ApiProductSectionFormControls {
+  apiProductIds: FormControl<string[]>;
+  isPrivate: FormControl<boolean>;
+}
+
+interface ApiProductSectionFormValues {
+  apiProductIds: string[];
+  isPrivate: boolean;
+}
+
+type ApiProductSectionForm = FormGroup<ApiProductSectionFormControls>;
+
+@Component({
+  selector: 'api-product-section-editor-dialog',
+  imports: [
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSlideToggleModule,
+    MatTooltipModule,
+    MatIconModule,
+    MatCheckboxModule,
+    MatTableModule,
+    MatChipsModule,
+    MatExpansionModule,
+    AsyncPipe,
+    GioTableWrapperModule,
+  ],
+  templateUrl: './api-product-section-editor-dialog.component.html',
+  styleUrls: ['./api-product-section-editor-dialog.component.scss'],
+})
+export class ApiProductSectionEditorDialogComponent implements OnInit {
+  private readonly apiProductService = inject(ApiProductV2Service);
+  private readonly dialogData = inject<ApiProductSectionEditorDialogData>(MAT_DIALOG_DATA);
+  private readonly dialogRef = inject(MatDialogRef<ApiProductSectionEditorDialogComponent, ApiProductSectionEditorDialogResult>);
+
+  form!: ApiProductSectionForm;
+  initialFormValues!: ApiProductSectionFormValues;
+  readonly title = 'Add API Products';
+  readonly displayedColumns = ['select', 'name', 'version', 'description', 'apiCount'];
+  filters: GioTableWrapperFilters = {
+    pagination: { index: 1, size: 10 },
+    searchTerm: '',
+  };
+  total = 0;
+  readonly isLoading = signal(true);
+  readonly hasLoadError = signal(false);
+  readonly selectedPanelExpanded = signal(true);
+
+  private readonly filters$ = new BehaviorSubject<GioTableWrapperFilters>(this.filters);
+  private readonly selectedOrderedApiProducts = signal<SelectedApiProduct[]>([]);
+
+  readonly selectedCount = computed(() => this.selectedOrderedApiProducts().length);
+  readonly selectedApiProducts = computed(() => this.selectedOrderedApiProducts());
+  readonly publicDisabled = computed(() => isPublicVisibilityDisabled(this.dialogData.parentItem));
+  readonly publicDisabledTooltip = computed(() => getPublicVisibilityDisabledTooltip(this.dialogData.parentItem));
+
+  rows$!: Observable<ApiProductRow[]>;
+
+  @HostListener('window:beforeunload', ['$event'])
+  beforeUnloadHandler(event: BeforeUnloadEvent): void {
+    if (!this.formIsUnchanged()) {
+      event.preventDefault();
+    }
+  }
+
+  ngOnInit(): void {
+    this.form = new FormGroup<ApiProductSectionFormControls>({
+      apiProductIds: new FormControl<string[]>([], {
+        validators: [Validators.required],
+        nonNullable: true,
+      }),
+      isPrivate: new FormControl<boolean>(false, {
+        nonNullable: true,
+      }),
+    });
+
+    const disabledApiProductIds = new Set(this.dialogData.existingApiProductIds ?? []);
+
+    this.rows$ = this.filters$.pipe(
+      debounceTime(100),
+      distinctUntilChanged(isEqual),
+      tap(() => {
+        this.isLoading.set(true);
+        this.hasLoadError.set(false);
+      }),
+      switchMap(filters =>
+        this.apiProductService.search({ query: filters.searchTerm }, undefined, filters.pagination.index, filters.pagination.size).pipe(
+          catchError((): Observable<ApiProductsResponse> => {
+            this.hasLoadError.set(true);
+            return of({ data: [], pagination: undefined, links: undefined });
+          }),
+        ),
+      ),
+      tap(response => {
+        this.isLoading.set(false);
+        this.total = response.pagination?.totalCount ?? 0;
+      }),
+      map(response =>
+        (response.data ?? []).map((apiProduct: ApiProduct) => ({
+          id: apiProduct.id,
+          name: apiProduct.name,
+          version: apiProduct.version,
+          description: apiProduct.description ?? '',
+          apiCount: apiProduct.apiIds?.length ?? 0,
+          isDisabled: disabledApiProductIds.has(apiProduct.id),
+        })),
+      ),
+    );
+
+    this.syncVisibilityControlState();
+    this.initialFormValues = this.form.getRawValue();
+  }
+
+  onFiltersChanged(filters: GioTableWrapperFilters): void {
+    this.filters = { ...this.filters, ...filters };
+    this.filters$.next(this.filters);
+  }
+
+  isChecked(apiProductId: string): boolean {
+    return this.form.controls.apiProductIds.value.includes(apiProductId);
+  }
+
+  onApiProductSelectionChange(apiProduct: SelectedApiProduct, event: MatCheckboxChange): void {
+    if (event.checked) {
+      this.addApiProduct({ id: apiProduct.id, name: apiProduct.name });
+      return;
+    }
+
+    this.removeApiProduct(apiProduct.id);
+  }
+
+  removeSelected(apiProductId: string): void {
+    this.removeApiProduct(apiProductId);
+  }
+
+  onSubmit(): void {
+    if (!this.form.valid) {
+      return;
+    }
+
+    const formValues = this.form.getRawValue();
+    this.dialogRef.close({
+      visibility: formValues.isPrivate ? 'PRIVATE' : 'PUBLIC',
+      apiProducts: this.selectedOrderedApiProducts(),
+    });
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+
+  formIsUnchanged(): boolean {
+    return isEqual(this.form.getRawValue(), this.initialFormValues);
+  }
+
+  private addApiProduct(apiProduct: SelectedApiProduct): void {
+    const currentApiProductIds = this.form.controls.apiProductIds.value;
+    if (currentApiProductIds.includes(apiProduct.id)) {
+      return;
+    }
+
+    this.form.controls.apiProductIds.setValue([...currentApiProductIds, apiProduct.id]);
+    this.selectedOrderedApiProducts.update(selectedProducts => [...selectedProducts, apiProduct]);
+  }
+
+  private removeApiProduct(apiProductId: string): void {
+    const currentApiProductIds = this.form.controls.apiProductIds.value;
+    if (!currentApiProductIds.includes(apiProductId)) {
+      return;
+    }
+
+    this.form.controls.apiProductIds.setValue(currentApiProductIds.filter(id => id !== apiProductId));
+    this.selectedOrderedApiProducts.update(selectedProducts => selectedProducts.filter(product => product.id !== apiProductId));
+  }
+
+  private syncVisibilityControlState(): void {
+    const isPrivateControl = this.form.controls.isPrivate;
+
+    if (this.publicDisabled()) {
+      isPrivateControl.setValue(true, { emitEvent: false });
+      isPrivateControl.disable({ emitEvent: false });
+      return;
+    }
+
+    isPrivateControl.enable({ emitEvent: false });
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-product-section-editor-dialog/api-product-section-editor-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-product-section-editor-dialog/api-product-section-editor-dialog.harness.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { DivHarness, SpanHarness } from '@gravitee/ui-particles-angular/testing';
+
+import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
+
+export class ApiProductSectionEditorDialogHarness extends ComponentHarness {
+  static readonly hostSelector = 'api-product-section-editor-dialog';
+
+  private readonly locateCancelButton = this.locatorFor(MatButtonHarness.with({ text: 'Cancel' }));
+  private readonly locateSubmitButton = this.locatorFor(MatButtonHarness.with({ text: 'Add' }));
+  private readonly locateFormTitle = this.locatorFor(DivHarness.with({ selector: '[mat-dialog-title]' }));
+  private readonly locateAuthenticationToggle = this.locatorFor(MatSlideToggleHarness);
+  private readonly locateTableWrapper = this.locatorFor(GioTableWrapperHarness);
+  private readonly locateAlreadyAddedLabels = this.locatorForAll(
+    SpanHarness.with({ selector: '[data-testid^="api-product-picker-already-added-"]' }),
+  );
+  private readonly locateLoadError = this.locatorForOptional(
+    SpanHarness.with({ selector: '[data-testid="api-product-picker-load-error"]' }),
+  );
+  private readonly locateLoading = this.locatorForOptional(SpanHarness.with({ selector: '[data-testid="api-product-picker-loading"]' }));
+  private readonly locateEmptyState = this.locatorForOptional(SpanHarness.with({ selector: '[data-testid="api-product-picker-empty"]' }));
+
+  async clickCancelButton(): Promise<void> {
+    return (await this.locateCancelButton()).click();
+  }
+
+  async isSubmitButtonDisabled(): Promise<boolean> {
+    return (await this.locateSubmitButton()).isDisabled();
+  }
+
+  async clickSubmitButton(): Promise<void> {
+    return (await this.locateSubmitButton()).click();
+  }
+
+  async getDialogTitle(): Promise<string> {
+    return (await this.locateFormTitle()).getText();
+  }
+
+  async isAuthenticationToggleDisabled(): Promise<boolean> {
+    return (await this.locateAuthenticationToggle()).isDisabled();
+  }
+
+  async isAuthenticationToggleChecked(): Promise<boolean> {
+    return (await this.locateAuthenticationToggle()).isChecked();
+  }
+
+  async toggleAuthentication(): Promise<void> {
+    return (await this.locateAuthenticationToggle()).toggle();
+  }
+
+  async setSearchValue(value: string): Promise<void> {
+    return (await this.locateTableWrapper()).setSearchValue(value);
+  }
+
+  async getAlreadyAddedLabel(apiProductId: string): Promise<SpanHarness | null> {
+    const expectedDataTestId = `api-product-picker-already-added-${apiProductId}`;
+    for (const label of await this.locateAlreadyAddedLabels()) {
+      const host = await label.host();
+      if ((await host.getAttribute('data-testid')) === expectedDataTestId) {
+        return label;
+      }
+    }
+    return null;
+  }
+
+  async getLoadErrorText(): Promise<string | null> {
+    return (await this.locateLoadError())?.getText() ?? null;
+  }
+
+  async getLoadingText(): Promise<string | null> {
+    return (await this.locateLoading())?.getText() ?? null;
+  }
+
+  async getEmptyStateText(): Promise<string | null> {
+    return (await this.locateEmptyState())?.getText() ?? null;
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -106,6 +106,16 @@
               </span>
             </div>
           }
+          @if (selectedApiProductId()) {
+            <div class="panel-header__title__linked-api" data-testid="linked-api-product-header">
+              <span>Linked API Product:</span>
+              <span class="panel-header__title__linked-api__value">
+                {{
+                  selectedLinkedApiProductName.isLoading() ? 'Loading...' : (selectedLinkedApiProductName.value() ?? selectedApiProductId())
+                }}
+              </span>
+            </div>
+          }
         </div>
       }
       <div class="panel-header__actions" *gioPermission="{ anyOf: ['environment-documentation-u'] }">

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -25,7 +25,7 @@ import { Router } from '@angular/router';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { GioConfirmAndValidateDialogHarness, GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
-import { of } from 'rxjs';
+import { Observable, of, ReplaySubject } from 'rxjs';
 
 import SpyInstance = jest.SpyInstance;
 
@@ -33,6 +33,7 @@ import { findFirstAvailablePage, PortalNavigationItemsComponent } from './portal
 import { PortalNavigationItemsHarness } from './portal-navigation-items.harness';
 import { SectionEditorDialogHarness } from './section-editor-dialog/section-editor-dialog.harness';
 import { ApiSectionEditorDialogHarness } from './api-section-editor-dialog/api-section-editor-dialog.harness';
+import { ApiProductSectionEditorDialogHarness } from './api-product-section-editor-dialog/api-product-section-editor-dialog.harness';
 import { OpenApiConfigDialogHarness } from './openapi-config-dialog/openapi-config-dialog.harness';
 import { PublishNavigationItemDialogHarness } from './publish-navigation-item-dialog/publish-navigation-item-dialog.harness';
 
@@ -44,11 +45,13 @@ import {
   fakeNewPagePortalNavigationItem,
   fakePortalPageContent,
   fakePortalNavigationApi,
+  fakePortalNavigationApiProduct,
   fakePortalNavigationFolder,
   fakePortalNavigationItemsResponse,
   fakePortalNavigationLink,
   fakePortalNavigationPage,
   fakeUpdateApiPortalNavigationItem,
+  fakeUpdateApiProductPortalNavigationItem,
   fakeUpdatePagePortalNavigationItem,
   NewPortalNavigationItem,
   PortalNavigationItem,
@@ -66,10 +69,14 @@ import {
 import { SectionNode } from '../components/flat-tree/flat-tree.component';
 import { SnackBarService } from '../../services-ngx/snack-bar.service';
 import { PortalPageContentService } from '../../services-ngx/portal-page-content.service';
+import { ApiProduct } from '../../entities/management-api-v2/api-product';
 
 type PortalNavigationItemsComponentPrivateMethods = {
   validateAsyncApiSpec: () => boolean;
   onSave: () => void;
+  refreshNavigationItems: () => Observable<PortalNavigationItem[]>;
+  refreshMenuList: { next: (value: number) => void };
+  menuLinks$: Observable<PortalNavigationItem[]>;
 };
 
 describe('PortalNavigationItemsComponent', () => {
@@ -107,6 +114,7 @@ describe('PortalNavigationItemsComponent', () => {
 
   afterEach(() => {
     flushPendingLinkedApiSearchRequests();
+    flushPendingLinkedApiProductRequests();
     httpTestingController.verify();
     jest.clearAllMocks();
   });
@@ -2706,6 +2714,116 @@ describe('PortalNavigationItemsComponent', () => {
     });
   });
 
+  describe('creating API Product navigation items in bulk', () => {
+    const folder = fakePortalNavigationFolder({ id: 'product-folder-1', title: 'API Product Folder', area: 'TOP_NAVBAR' });
+    const apiProducts: ApiProduct[] = [
+      { id: 'product-1', name: 'First Product', version: '1.0', apiIds: ['api-1'] },
+      { id: 'product-2', name: 'Second Product', version: '2.0', apiIds: ['api-2', 'api-3'] },
+    ];
+
+    beforeEach(async () => {
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder] }));
+    });
+
+    it('should create one API Product item per selection in a single ordered bulk request', async () => {
+      const createdProducts = apiProducts.map((apiProduct, index) =>
+        fakePortalNavigationApiProduct({
+          id: `nav-product-${index + 1}`,
+          apiProductId: apiProduct.id,
+          title: apiProduct.name,
+          parentId: folder.id,
+          order: index,
+        }),
+      );
+
+      component.onNodeMenuAction({
+        action: 'create',
+        itemType: 'API_PRODUCT',
+        node: { id: folder.id, label: folder.title, type: folder.type, data: folder },
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expectApiProductSearchResponse(apiProducts);
+
+      const checkboxes = await rootLoader.getAllHarnesses(
+        MatCheckboxHarness.with({ selector: '[data-testid^="api-product-picker-checkbox-"]' }),
+      );
+      await checkboxes[1].check();
+      await checkboxes[0].check();
+
+      const dialog = await rootLoader.getHarness(ApiProductSectionEditorDialogHarness);
+      await dialog.clickSubmitButton();
+
+      expectCreateNavigationItemsInBulk(
+        [apiProducts[1], apiProducts[0]].map(apiProduct => ({
+          title: apiProduct.name,
+          type: 'API_PRODUCT',
+          area: 'TOP_NAVBAR',
+          parentId: folder.id,
+          visibility: 'PUBLIC',
+          apiProductId: apiProduct.id,
+        })),
+        fakePortalNavigationItemsResponse({ items: [createdProducts[1], createdProducts[0]] }),
+      );
+
+      httpTestingController.expectNone({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/_default-pages`,
+      });
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, ...createdProducts] }));
+
+      expect(routerSpy).toHaveBeenCalledWith(['.'], expect.objectContaining({ queryParams: { navId: createdProducts[0].id } }));
+    });
+
+    it('should refresh the tree and show an actionable error after a partial bulk conflict', async () => {
+      const errorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+
+      component.onNodeMenuAction({
+        action: 'create',
+        itemType: 'API_PRODUCT',
+        node: { id: folder.id, label: folder.title, type: folder.type, data: folder },
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expectApiProductSearchResponse(apiProducts);
+      const checkboxes = await rootLoader.getAllHarnesses(
+        MatCheckboxHarness.with({ selector: '[data-testid^="api-product-picker-checkbox-"]' }),
+      );
+      await checkboxes[0].check();
+      await (await rootLoader.getHarness(ApiProductSectionEditorDialogHarness)).clickSubmitButton();
+
+      const request = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/_bulk`,
+      });
+      request.flush({ message: 'Conflict' }, { status: 409, statusText: 'Conflict' });
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder] }));
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(errorSpy).toHaveBeenCalledWith('Unable to add API Products because one or more products are already in the navigation');
+      expect(document.body.textContent).toContain('one or more products are already in the navigation');
+    });
+
+    it('should subscribe to menu links before triggering a refresh', () => {
+      const replayedMenuLinks = new ReplaySubject<PortalNavigationItem[]>(1);
+      replayedMenuLinks.next([]);
+      const refreshedItems = [folder];
+      const privateInstance = privateComponent();
+      privateInstance.menuLinks$ = replayedMenuLinks.asObservable();
+      jest.spyOn(privateInstance.refreshMenuList, 'next').mockImplementation(() => replayedMenuLinks.next(refreshedItems));
+
+      let result: PortalNavigationItem[] | undefined;
+      privateInstance.refreshNavigationItems().subscribe(items => (result = items));
+
+      expect(result).toEqual(refreshedItems);
+    });
+  });
+
   function fakeSectionNode(sectionNode: Partial<SectionNode>): SectionNode {
     return {
       id: 'node-1',
@@ -2818,6 +2936,21 @@ describe('PortalNavigationItemsComponent', () => {
     fixture.detectChanges();
   }
 
+  function expectApiProductSearchResponse(apiProducts: ApiProduct[]) {
+    const req = httpTestingController.expectOne(request => {
+      return (
+        request.method === 'POST' &&
+        request.url === `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search` &&
+        request.params.get('page') === '1' &&
+        request.params.get('perPage') === '10'
+      );
+    });
+
+    expect(req.request.body).toEqual({ query: '' });
+    req.flush({ data: apiProducts, pagination: { totalCount: apiProducts.length } });
+    fixture.detectChanges();
+  }
+
   function expectLinkedApiSearchResponse(apiId: string, apiName = apiId) {
     const req = httpTestingController.expectOne(request => {
       return (
@@ -2863,6 +2996,23 @@ describe('PortalNavigationItemsComponent', () => {
     });
 
     if (activeRequests.length > 0) {
+      fixture.detectChanges();
+    }
+  }
+
+  function flushPendingLinkedApiProductRequests() {
+    const requests = httpTestingController.match(request => {
+      return request.method === 'GET' && request.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/`);
+    });
+
+    requests
+      .filter(request => !request.cancelled)
+      .forEach(request => {
+        const apiProductId = request.request.url.split('/').pop() ?? 'api-product';
+        request.flush({ id: apiProductId, name: apiProductId, version: '1.0' });
+      });
+
+    if (requests.length > 0) {
       fixture.detectChanges();
     }
   }
@@ -3190,6 +3340,62 @@ describe('PortalNavigationItemsComponent', () => {
     });
   });
 
+  describe('editing an API Product item', () => {
+    const folder = fakePortalNavigationFolder({ id: 'folder-product-edit', title: 'Products', area: 'TOP_NAVBAR' });
+    const apiProductItem = fakePortalNavigationApiProduct({
+      id: 'api-product-nav-1',
+      apiProductId: 'api-product-1',
+      title: 'Technical Product Name',
+      parentId: folder.id,
+      order: 2,
+      published: false,
+      visibility: 'PUBLIC',
+    });
+
+    it('should display the linked API Product name and version in the selected item header', async () => {
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, apiProductItem] }));
+      const request = httpTestingController.expectOne({
+        method: 'GET',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${apiProductItem.apiProductId}`,
+      });
+      request.flush({ id: apiProductItem.apiProductId, name: 'Payments Product', version: '2.1' });
+      fixture.detectChanges();
+
+      expect(await harness.getLinkedApiProductHeaderText()).toContain('Linked API Product: Payments Product (2.1)');
+    });
+
+    it('should update the display name without sending apiProductId', async () => {
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, apiProductItem] }));
+      flushPendingLinkedApiProductRequests();
+
+      component.onNodeMenuAction({
+        action: 'edit',
+        itemType: 'API_PRODUCT',
+        node: { id: apiProductItem.id, label: apiProductItem.title, type: apiProductItem.type, data: apiProductItem },
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      await dialog.setTitleInputValue('Consumer Product Name');
+      await dialog.clickSubmitButton();
+
+      const updatedItem = fakePortalNavigationApiProduct({ ...apiProductItem, title: 'Consumer Product Name' });
+      expectPutPortalNavigationItem(
+        apiProductItem.id,
+        fakeUpdateApiProductPortalNavigationItem({
+          title: 'Consumer Product Name',
+          parentId: apiProductItem.parentId,
+          order: apiProductItem.order,
+          published: apiProductItem.published,
+          visibility: apiProductItem.visibility,
+        }),
+        updatedItem,
+      );
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, updatedItem] }));
+    });
+  });
+
   describe('navigation items load failure', () => {
     it('should show an empty tree when loading navigation items fails', async () => {
       httpTestingController
@@ -3331,6 +3537,47 @@ describe('PortalNavigationItemsComponent', () => {
         );
         await expectGetNavigationItems(fakeResponse);
       });
+    });
+  });
+
+  describe('publish action on API Product type node', () => {
+    const apiProduct = fakePortalNavigationApiProduct({
+      id: 'api-product-item-1',
+      title: 'API Product Item 1',
+      apiProductId: 'api-product-1',
+      published: false,
+    });
+    const fakeResponse = fakePortalNavigationItemsResponse({ items: [apiProduct] });
+
+    beforeEach(async () => {
+      await expectGetNavigationItems(fakeResponse);
+      flushPendingLinkedApiProductRequests();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    });
+
+    it('should publish with propagation without sending apiProductId', async () => {
+      const node = { id: apiProduct.id, label: apiProduct.title, type: apiProduct.type, data: apiProduct };
+      component.onNodeMenuAction({ action: 'publish', itemType: 'API_PRODUCT', node });
+
+      const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+      await dialog.checkPropagationCheckbox();
+      await dialog.confirm();
+      fixture.detectChanges();
+
+      expectPutPortalNavigationItem(
+        apiProduct.id,
+        fakeUpdateApiProductPortalNavigationItem({
+          title: apiProduct.title,
+          parentId: apiProduct.parentId,
+          order: apiProduct.order,
+          published: true,
+          visibility: apiProduct.visibility,
+        }),
+        apiProduct,
+        { propagatePublishToChildren: true },
+      );
+      await expectGetNavigationItems(fakeResponse);
     });
   });
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -28,7 +28,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { AbstractControl, FormControl, ReactiveFormsModule, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { rxResource, takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
-import { catchError, exhaustMap, filter, map, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { catchError, exhaustMap, filter, map, shareReplay, skip, switchMap, take, tap } from 'rxjs/operators';
 import { MatMenuItem, MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
@@ -49,6 +49,12 @@ import {
   ApiSectionEditorDialogComponent,
   ApiSectionEditorDialogData,
 } from './api-section-editor-dialog/api-section-editor-dialog.component';
+import {
+  ApiProductSectionEditorDialogComponent,
+  ApiProductSectionEditorDialogData,
+  ApiProductSectionEditorDialogResult,
+  SelectedApiProduct,
+} from './api-product-section-editor-dialog/api-product-section-editor-dialog.component';
 import { OpenApiConfigDialogComponent, OpenApiConfigDialogData } from './openapi-config-dialog/openapi-config-dialog.component';
 import {
   PublishNavigationItemDialogComponent,
@@ -63,6 +69,7 @@ import {
   NewPortalNavigationItem,
   PortalArea,
   PortalNavigationApi,
+  PortalNavigationApiProduct,
   PortalNavigationItem,
   PortalNavigationItemType,
   PortalNavigationLink,
@@ -77,6 +84,7 @@ import { GioPermissionModule } from '../../shared/components/gio-permission/gio-
 import { PortalNavigationItemService } from '../../services-ngx/portal-navigation-item.service';
 import { PortalPageContentService } from '../../services-ngx/portal-page-content.service';
 import { ApiV2Service } from '../../services-ngx/api-v2.service';
+import { ApiProductV2Service } from '../../services-ngx/api-product-v2.service';
 import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
 import { HasUnsavedChanges } from '../../shared/guards/has-unsaved-changes.guard';
 import { confirmDiscardChanges, normalizeContent } from '../../shared/utils/content.util';
@@ -86,6 +94,11 @@ import { OpenApiEditorComponent } from '../components/openapi-editor/openapi-edi
 
 type AsyncApiSpecValidationError = {
   message: string;
+};
+
+type ApiProductBulkCreateResult = {
+  createdItemId: string | null;
+  errorMessage?: string;
 };
 
 @Component({
@@ -119,6 +132,7 @@ type AsyncApiSpecValidationError = {
 })
 export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   private destroyRef = inject(DestroyRef);
+  private readonly apiProductService = inject(ApiProductV2Service);
 
   // UI State & Forms
   private isReadOnly = !inject(GioPermissionService).hasAnyMatching(['environment-documentation-u']);
@@ -175,6 +189,17 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   readonly selectedLinkedApiName = rxResource({
     params: () => this.selectedApiId(),
     stream: ({ params: apiId }) => (apiId ? this.apiService.resolveNameById(apiId) : of(null)),
+  });
+  readonly selectedApiProductId = computed(() => {
+    const selectedItem = this.selectedNavigationItem()?.data;
+    return selectedItem?.type === 'API_PRODUCT' ? selectedItem.apiProductId : null;
+  });
+  readonly selectedLinkedApiProductName = rxResource({
+    params: () => this.selectedApiProductId(),
+    stream: ({ params: apiProductId }) =>
+      apiProductId
+        ? this.apiProductService.get(apiProductId).pipe(map(apiProduct => `${apiProduct.name} (${apiProduct.version})`))
+        : of(null),
   });
   readonly selectedNavigationItemParent: Signal<SectionNode | null> = computed(() => {
     const selectedNavigationItem = this.selectedNavigationItem();
@@ -273,7 +298,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
 
   onAddSection(sectionType: PortalNavigationItemType) {
     this.checkUnsavedChangesAndRun(() => {
-      if (sectionType === 'API') {
+      if (sectionType === 'API' || sectionType === 'API_PRODUCT') {
         return;
       }
       this.manageSection(sectionType, 'create', 'TOP_NAVBAR');
@@ -293,6 +318,18 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         default: {
           if (event.itemType === 'API' && event.action !== 'edit') {
             this.createApiSection(event.node.data);
+            return;
+          }
+
+          if (event.itemType === 'API_PRODUCT' && event.action !== 'edit') {
+            if (!event.node.data) {
+              return;
+            }
+            if (this.isInsideApiProductSubtree(event.node.data)) {
+              this.snackBarService.error('API Products cannot be nested inside another API Product');
+              return;
+            }
+            this.createApiProductSection(event.node.data);
             return;
           }
 
@@ -332,6 +369,36 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         catchError(() => {
           this.snackBarService.error('Failed to create API navigation items');
           return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  private createApiProductSection(parentItem: PortalNavigationItem): void {
+    this.matDialog
+      .open<ApiProductSectionEditorDialogComponent, ApiProductSectionEditorDialogData, ApiProductSectionEditorDialogResult>(
+        ApiProductSectionEditorDialogComponent,
+        {
+          width: GIO_DIALOG_WIDTH.LARGE,
+          data: {
+            mode: 'create',
+            existingApiProductIds: this.extractApiProductIdsFromNavigationItems(),
+            parentItem,
+          },
+        },
+      )
+      .afterClosed()
+      .pipe(
+        filter((result): result is ApiProductSectionEditorDialogResult => !!result),
+        switchMap(result => this.createApiProductsInOrder(parentItem.id, result.apiProducts, result.visibility)),
+        switchMap(result => this.refreshNavigationItems().pipe(map(() => result))),
+        tap(result => {
+          if (result.errorMessage) {
+            this.snackBarService.error(result.errorMessage);
+          } else if (result.createdItemId) {
+            this.navigateToItemByNavId(result.createdItemId);
+          }
         }),
         takeUntilDestroyed(this.destroyRef),
       )
@@ -502,6 +569,49 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     );
   }
 
+  private createApiProductsInOrder(
+    parentId: string,
+    apiProducts: SelectedApiProduct[],
+    visibility: PortalVisibility,
+  ): Observable<ApiProductBulkCreateResult> {
+    if (!apiProducts.length) {
+      return of({ createdItemId: null });
+    }
+
+    const items: NewPortalNavigationItem[] = apiProducts.map(apiProduct => ({
+      title: apiProduct.name,
+      type: 'API_PRODUCT',
+      area: 'TOP_NAVBAR',
+      parentId,
+      visibility,
+      apiProductId: apiProduct.id,
+    }));
+
+    return this.portalNavigationItemsService.createNavigationItemsInBulk(items).pipe(
+      map(response => {
+        const createdApiProductItems = response.items?.filter((item): item is PortalNavigationApiProduct => item.type === 'API_PRODUCT');
+        return {
+          createdItemId: createdApiProductItems?.length ? createdApiProductItems[createdApiProductItems.length - 1].id : null,
+        };
+      }),
+      catchError(error => {
+        return of({
+          createdItemId: null,
+          errorMessage: this.getApiProductCreateErrorMessage(error),
+        });
+      }),
+    );
+  }
+
+  private refreshNavigationItems(): Observable<PortalNavigationItem[]> {
+    return new Observable(subscriber => {
+      const subscription = this.menuLinks$.pipe(skip(1), take(1)).subscribe(subscriber);
+      this.refreshMenuList.next(1);
+
+      return () => subscription.unsubscribe();
+    });
+  }
+
   private manageSection(
     type: PortalNavigationItemType,
     mode: SectionEditorDialogMode,
@@ -535,6 +645,16 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
           } else {
             if (!existingItem) {
               return EMPTY;
+            }
+            if (existingItem.type === 'API_PRODUCT') {
+              return this.update(existingItem.id, {
+                title: result.title,
+                type: 'API_PRODUCT',
+                parentId: existingItem.parentId,
+                order: existingItem.order,
+                published: existingItem.published,
+                visibility: result.visibility,
+              });
             }
             return this.update(existingItem.id, {
               title: result.title,
@@ -742,16 +862,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
       .afterClosed()
       .pipe(
         filter((result): result is PublishNavigationItemDialogResult => !!result?.confirmed),
-        switchMap(result =>
-          this.update(
-            navItem.id,
-            {
-              ...navItem,
-              published: !navItem.published,
-            },
-            result.propagatePublishToChildren,
-          ),
-        ),
+        switchMap(result => this.update(navItem.id, this.createPublicationUpdateItem(navItem), result.propagatePublishToChildren)),
         tap(() => this.refreshMenuList.next(1)),
         catchError(() => {
           this.snackBarService.error('Failed to update publication status');
@@ -760,6 +871,21 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
+  }
+
+  private createPublicationUpdateItem(navItem: PortalNavigationItem): UpdatePortalNavigationItem {
+    if (navItem.type === 'API_PRODUCT') {
+      return {
+        title: navItem.title,
+        type: 'API_PRODUCT',
+        parentId: navItem.parentId,
+        order: navItem.order,
+        published: !navItem.published,
+        visibility: navItem.visibility,
+      };
+    }
+
+    return { ...navItem, published: !navItem.published };
   }
 
   private confirmDeleteAction(event: NodeMenuActionEvent) {
@@ -824,16 +950,26 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     newOrder: number,
     navItem: PortalNavigationItem,
   ): Observable<PortalNavigationItem> {
-    const updateItem: UpdatePortalNavigationItem = {
-      title: navItem.title,
-      type: navItem.type,
-      published: navItem.published,
-      visibility: navItem.visibility,
-      url: (navItem as PortalNavigationLink).url,
-      apiId: (navItem as PortalNavigationApi).apiId,
-      parentId: newParentId ?? undefined,
-      order: newOrder,
-    };
+    const updateItem: UpdatePortalNavigationItem =
+      navItem.type === 'API_PRODUCT'
+        ? {
+            title: navItem.title,
+            type: 'API_PRODUCT',
+            published: navItem.published,
+            visibility: navItem.visibility,
+            parentId: newParentId ?? undefined,
+            order: newOrder,
+          }
+        : {
+            title: navItem.title,
+            type: navItem.type,
+            published: navItem.published,
+            visibility: navItem.visibility,
+            url: (navItem as PortalNavigationLink).url,
+            apiId: (navItem as PortalNavigationApi).apiId,
+            parentId: newParentId ?? undefined,
+            order: newOrder,
+          };
     return this.update(navItem.id, updateItem).pipe(
       tap(() => {
         this.refreshMenuList.next(1);
@@ -849,6 +985,45 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     return this.menuLinks()
       .filter(i => i.type === 'API')
       .map(i => i.apiId);
+  }
+
+  private extractApiProductIdsFromNavigationItems(): string[] {
+    return this.menuLinks()
+      .filter((item): item is PortalNavigationApiProduct => item.type === 'API_PRODUCT')
+      .map(item => item.apiProductId);
+  }
+
+  private isInsideApiProductSubtree(item: PortalNavigationItem): boolean {
+    const itemsById = new Map(this.menuLinks().map(menuItem => [menuItem.id, menuItem]));
+    let currentItem: PortalNavigationItem | undefined = item;
+    const visitedItemIds = new Set<string>();
+
+    while (currentItem && !visitedItemIds.has(currentItem.id)) {
+      visitedItemIds.add(currentItem.id);
+      if (currentItem.type === 'API_PRODUCT') {
+        return true;
+      }
+      currentItem = currentItem.parentId ? itemsById.get(currentItem.parentId) : undefined;
+    }
+
+    return false;
+  }
+
+  private getApiProductCreateErrorMessage(error: unknown): string {
+    if (!(error instanceof HttpErrorResponse)) {
+      return 'Failed to create API Product navigation items';
+    }
+
+    switch (error.status) {
+      case 400:
+        return 'Unable to add API Products because the selected placement or request is invalid';
+      case 404:
+        return 'Unable to add API Products because one or more products no longer exist';
+      case 409:
+        return 'Unable to add API Products because one or more products are already in the navigation';
+      default:
+        return 'Failed to create API Product navigation items';
+    }
   }
 }
 
@@ -877,7 +1052,7 @@ export function findFirstAvailablePage(
       if (element.type === 'PAGE') {
         return element;
       }
-      if (element.type === 'FOLDER' || element.type === 'API') {
+      if (element.type === 'FOLDER' || element.type === 'API' || element.type === 'API_PRODUCT') {
         const found = search(element);
         if (found) return found;
         return element;

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -49,6 +49,7 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   );
   private getTitle = this.locatorFor(DivHarness.with({ selector: '.panel-header__title' }));
   private readonly getLinkedApiHeader = this.locatorForOptional('[data-testid="linked-api-header"]');
+  private readonly getLinkedApiProductHeader = this.locatorForOptional('[data-testid="linked-api-product-header"]');
   private getPageNotFoundEmptyState = this.locatorForOptional(
     EmptyStateComponentHarness.with({
       title: 'Page Not Found',
@@ -245,6 +246,11 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   async getLinkedApiHeaderText(): Promise<string | null> {
     const linkedApiHeader = await this.getLinkedApiHeader();
     return linkedApiHeader?.text() ?? null;
+  }
+
+  async getLinkedApiProductHeaderText(): Promise<string | null> {
+    const linkedApiProductHeader = await this.getLinkedApiProductHeader();
+    return linkedApiProductHeader?.text() ?? null;
   }
 
   async editNodeById(id: string): Promise<void> {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.component.spec.ts
@@ -23,6 +23,7 @@ import { PublishNavigationItemDialogHarness } from './publish-navigation-item-di
 
 import {
   fakePortalNavigationApi,
+  fakePortalNavigationApiProduct,
   fakePortalNavigationFolder,
   fakePortalNavigationPage,
   PortalNavigationItem,
@@ -67,6 +68,13 @@ describe('PublishNavigationItemDialogComponent', () => {
     expect(await harness.isPropagationCheckboxVisible()).toBe(true);
     expect(await harness.getContentText()).toContain('Also publish all nested documentation');
     expect(await harness.getContentText()).not.toContain('and APIs');
+  });
+
+  it('should show propagation checkbox for publishing an API Product', async () => {
+    await createComponent(fakePortalNavigationApiProduct({ title: 'My Product', published: false }));
+
+    expect(await harness.isPropagationCheckboxVisible()).toBe(true);
+    expect(await harness.getContentText()).toContain('nested documentation and APIs');
   });
 
   it('should not show propagation checkbox for publishing a page', async () => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.component.ts
@@ -51,8 +51,13 @@ export class PublishNavigationItemDialogComponent {
     propagatePublishToChildren: new FormControl(false, { nonNullable: true }),
   });
 
-  readonly isContainer = computed(() => this.navItem().type === 'FOLDER' || this.navItem().type === 'API');
-  readonly typeLabel = computed(() => (this.navItem().type === 'API' ? 'API' : this.navItem().type.toLowerCase()));
+  readonly isContainer = computed(() => ['FOLDER', 'API', 'API_PRODUCT'].includes(this.navItem().type));
+  readonly typeLabel = computed(() => {
+    if (this.navItem().type === 'API_PRODUCT') {
+      return 'API Product';
+    }
+    return this.navItem().type === 'API' ? 'API' : this.navItem().type.toLowerCase();
+  });
   readonly isPublishing = computed(() => !this.navItem().published);
   readonly action = computed(() => (this.isPublishing() ? 'Publish' : 'Unpublish'));
   readonly showPropagationCheckbox = computed(() => this.isPublishing() && this.isContainer());
@@ -60,7 +65,7 @@ export class PublishNavigationItemDialogComponent {
   readonly pastAction = computed(() => `${this.action().toLowerCase()}ed`);
   readonly contentScope = computed(() => (this.isContainer() ? ' and its content ' : ' '));
   readonly propagatedItemsLabel = computed(() =>
-    this.navItem().type === 'FOLDER' ? 'nested documentation and APIs' : 'nested documentation',
+    this.navItem().type === 'API' ? 'nested documentation' : 'nested documentation and APIs',
   );
   readonly propagationCheckboxLabel = computed(() => `Also publish all ${this.propagatedItemsLabel()}`);
   readonly warning = computed(() => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
@@ -72,8 +72,8 @@ class TestHostComponent {
     const type = this.type();
 
     if (this.mode() === 'create') {
-      if (type === 'API') {
-        throw new Error('API items use ApiSectionEditorDialog in create mode');
+      if (type === 'API' || type === 'API_PRODUCT') {
+        throw new Error('API and API Product items use dedicated dialogs in create mode');
       }
 
       return { mode: 'create', type, parentItem: this.parentItem() };

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
@@ -43,7 +43,7 @@ import { getPublicVisibilityDisabledTooltip, isPublicVisibilityDisabled } from '
 
 export type SectionEditorDialogMode = 'create' | 'edit';
 
-export type SectionEditorDialogItemType = Exclude<PortalNavigationItemType, 'API'>;
+export type SectionEditorDialogItemType = Exclude<PortalNavigationItemType, 'API' | 'API_PRODUCT'>;
 
 interface SectionEditorDialogCreateData {
   mode: 'create';
@@ -82,6 +82,7 @@ export const PORTAL_PAGE_CONTENT_TYPE_OPTIONS: PortalPageTypeOption[] = [
 
 const TITLE_FIELD_LABEL_BY_TYPE: Record<PortalNavigationItemType, string> = {
   API: 'API Display Name',
+  API_PRODUCT: 'API Product Display Name',
   FOLDER: 'Folder Title',
   LINK: 'Link Title',
   PAGE: 'Page Title',

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
@@ -25,10 +25,12 @@ import {
   fakePortalNavigationFolder,
   fakePortalNavigationLink,
   fakePortalNavigationApi,
+  fakePortalNavigationApiProduct,
   fakeNewPagePortalNavigationItem,
   fakeNewFolderPortalNavigationItem,
   fakeNewLinkPortalNavigationItem,
   fakeNewApiPortalNavigationItem,
+  fakeNewApiProductPortalNavigationItem,
   fakeUpdateFolderPortalNavigationItem,
 } from '../entities/management-api-v2';
 
@@ -164,6 +166,33 @@ describe('PortalNavigationItemService', () => {
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/_bulk`,
       });
       expect(req.request.body).toEqual({ items: [] });
+      req.flush(fakeResponse);
+    });
+
+    it('should create multiple API Product navigation items in bulk', done => {
+      const items = [
+        fakeNewApiProductPortalNavigationItem({ apiProductId: 'product-1', title: 'Product 1' }),
+        fakeNewApiProductPortalNavigationItem({ apiProductId: 'product-2', title: 'Product 2' }),
+      ];
+      const fakeResponse = fakePortalNavigationItemsResponse({
+        items: [
+          fakePortalNavigationApiProduct({ id: 'nav-product-1', apiProductId: 'product-1', title: 'Product 1' }),
+          fakePortalNavigationApiProduct({ id: 'nav-product-2', apiProductId: 'product-2', title: 'Product 2' }),
+        ],
+      });
+
+      service.createNavigationItemsInBulk(items).subscribe(response => {
+        expect(response).toEqual(fakeResponse);
+        expect(response.items).toHaveLength(2);
+        expect(response.items.every(item => item.type === 'API_PRODUCT')).toBe(true);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/_bulk`,
+      });
+      expect(req.request.body).toEqual({ items });
       req.flush(fakeResponse);
     });
   });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-71

## Summary

Add the Console flow for creating API Product portal navigation entries using a dedicated multi-select dialog.

## Changes

- Add `API_PRODUCT` to the Console portal navigation model and fixtures.
- Add an **Add API Product** action next to the existing Add API action.
- Add a product-only selector supporting:
  - multiple selection,
  - search and pagination,
  - selected-product removal,
  - loading, empty, and error states,
  - private visibility,
  - disabled already-linked products.
- Submit selected products in order using a single `_bulk` request.
- Do not send `published` or invoke the API default-pages endpoint.
- Prevent API Products from being created at the root or inside another API Product subtree.
- Refresh the complete navigation tree after both successful and partially failed bulk operations.
- Navigate to the last created API Product after a successful refresh.
- Display the linked API Product name and version as read-only context.
- Ensure update operations do not send the immutable `apiProductId`.
- Add API Product container, icon, and publication propagation handling.

## Open modal

https://github.com/user-attachments/assets/5cbd3d41-28f6-47b5-9b58-5e7c2d7364ae

## Add

https://github.com/user-attachments/assets/90becb7f-d004-45ef-b6e6-4e8a80eb1131

## Added

https://github.com/user-attachments/assets/1c4e9cf1-98c9-4572-84e9-e7f5a7a11cc2


