### PR TITLE
feat(edge): introduce app-centric model in the API definition (EDGE-58)

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeApp.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeApp.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.edge;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * App-centric interception unit: a single application (e.g. Claude Code, Cursor) that owns the
+ * domains it talks to and the routes its intercepted traffic follows.
+ *
+ * @param name human-readable application identifier (e.g. {@code Claude Code}, {@code Cursor})
+ * @param domains vendor backend hostnames owned by this app, keyed for SNI/DNS interception
+ * @param routes path-to-api_path mappings applied to this app's intercepted traffic
+ * @param format usage-decoder format used to parse token usage from the response
+ *               (e.g. {@code anthropic-messages}, {@code openai-chat}), decoupled from the vendor label
+ * @param vendor vendor label reported upstream for accounting/attribution, independent of the decoder {@code format}
+ */
+public record EdgeApp(String name, List<DnsDomain> domains, List<RouteMapping> routes, String format, String vendor) implements
+    Serializable {}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeProxyDefinition.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeProxyDefinition.java
@@ -34,6 +34,21 @@ import lombok.ToString;
 @Builder
 public class EdgeProxyDefinition implements Serializable {
 
+    /**
+     * @deprecated legacy flat domain list; superseded by {@link #apps}. Kept for backward compatibility.
+     */
+    @Deprecated
     private List<DnsDomain> dnsDomains;
+
+    /**
+     * @deprecated legacy flat route list; superseded by {@link #apps}. Kept for backward compatibility.
+     */
+    @Deprecated
     private List<EdgeRoute> routes;
+
+    /**
+     * App-centric replacement for the legacy flat {@link #dnsDomains} + {@link #routes}: each entry
+     * groups an application's own domains and routes.
+     */
+    private List<EdgeApp> apps;
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeRoute.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeRoute.java
@@ -17,4 +17,10 @@ package io.gravitee.definition.model.v4.edge;
 
 import java.io.Serializable;
 
+/**
+ * @deprecated legacy route carrying its own {@code provider}; superseded by the app-centric model where
+ * an {@link EdgeApp} owns {@link RouteMapping} routes and the vendor/format lives on the app. Kept for
+ * backward compatibility.
+ */
+@Deprecated
 public record EdgeRoute(String pathPrefix, String apiPath, String provider) implements Serializable {}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/RouteMapping.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/RouteMapping.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.edge;
+
+import java.io.Serializable;
+
+/**
+ * Maps an intercepted request path to the gateway api_path it is forwarded to.
+ *
+ * @param pathPrefix incoming request path prefix that triggers this mapping
+ * @param apiPath gateway api_path the matched traffic is forwarded to
+ */
+public record RouteMapping(String pathPrefix, String apiPath) implements Serializable {}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/v4/edge/EdgeProxyDefinitionTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/v4/edge/EdgeProxyDefinitionTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.edge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("deprecation")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EdgeProxyDefinitionTest {
+
+    // Mirror the production GraviteeMapper's NON_NULL inclusion so serialization assertions match at-rest output.
+    private final ObjectMapper objectMapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+    @Test
+    void should_deserialize_legacy_payload_without_apps() throws Exception {
+        // Given
+        var json = """
+            {
+              "dnsDomains": [{ "name": "api.anthropic.com" }],
+              "routes": [{ "pathPrefix": "/v1/messages", "apiPath": "/anthropic", "provider": "anthropic" }]
+            }""";
+
+        // When
+        var definition = objectMapper.readValue(json, EdgeProxyDefinition.class);
+
+        // Then
+        assertThat(definition.getDnsDomains()).containsExactly(new DnsDomain("api.anthropic.com"));
+        assertThat(definition.getRoutes()).containsExactly(new EdgeRoute("/v1/messages", "/anthropic", "anthropic"));
+        assertThat(definition.getApps()).isNull();
+    }
+
+    @Test
+    void should_deserialize_app_centric_payload_without_legacy_fields() throws Exception {
+        // Given
+        var json = """
+            {
+              "apps": [
+                {
+                  "name": "Claude Code",
+                  "domains": [{ "name": "api.anthropic.com" }],
+                  "routes": [{ "pathPrefix": "/v1/messages", "apiPath": "/anthropic" }],
+                  "format": "anthropic-messages",
+                  "vendor": "anthropic"
+                }
+              ]
+            }""";
+
+        // When
+        var definition = objectMapper.readValue(json, EdgeProxyDefinition.class);
+
+        // Then
+        assertThat(definition.getDnsDomains()).isNull();
+        assertThat(definition.getRoutes()).isNull();
+        assertThat(definition.getApps()).hasSize(1);
+        var app = definition.getApps().get(0);
+        assertThat(app.name()).isEqualTo("Claude Code");
+        assertThat(app.domains()).containsExactly(new DnsDomain("api.anthropic.com"));
+        assertThat(app.routes()).containsExactly(new RouteMapping("/v1/messages", "/anthropic"));
+        assertThat(app.format()).isEqualTo("anthropic-messages");
+        assertThat(app.vendor()).isEqualTo("anthropic");
+    }
+
+    @Test
+    void should_deserialize_payload_with_both_legacy_and_app_fields() throws Exception {
+        // Given
+        var json = """
+            {
+              "dnsDomains": [{ "name": "api.anthropic.com" }],
+              "routes": [{ "pathPrefix": "/v1/messages", "apiPath": "/anthropic", "provider": "anthropic" }],
+              "apps": [
+                {
+                  "name": "Claude Code",
+                  "domains": [{ "name": "api.anthropic.com" }],
+                  "routes": [{ "pathPrefix": "/v1/messages", "apiPath": "/anthropic" }],
+                  "format": "anthropic-messages",
+                  "vendor": "anthropic"
+                }
+              ]
+            }""";
+
+        // When
+        var definition = objectMapper.readValue(json, EdgeProxyDefinition.class);
+
+        // Then
+        assertThat(definition.getDnsDomains()).containsExactly(new DnsDomain("api.anthropic.com"));
+        assertThat(definition.getRoutes()).containsExactly(new EdgeRoute("/v1/messages", "/anthropic", "anthropic"));
+        assertThat(definition.getApps()).hasSize(1);
+        assertThat(definition.getApps().get(0).name()).isEqualTo("Claude Code");
+    }
+
+    @Test
+    void should_omit_apps_from_serialized_legacy_definition() throws Exception {
+        // Given
+        var definition = EdgeProxyDefinition.builder()
+            .dnsDomains(List.of(new DnsDomain("api.anthropic.com")))
+            .routes(List.of(new EdgeRoute("/v1/messages", "/anthropic", "anthropic")))
+            .build();
+
+        // When
+        var json = objectMapper.writeValueAsString(definition);
+
+        // Then
+        assertThat(json).doesNotContain("apps");
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/EDGE-58

**Description**

Introduces the app-centric model in the shared Edge API definition, additively and backward-compatibly:
- new `EdgeApp` record (`{ name, domains, routes, format, vendor }`) and `RouteMapping` record (`{ pathPrefix, apiPath }`)
- new `apps` list on `EdgeProxyDefinition`
- legacy flat `dnsDomains` / `routes` and `EdgeRoute` kept but `@Deprecated`

No consumer behavior change: the new field is nullable and omitted from serialized output (production mapper is NON_NULL), so existing stored definitions round-trip unchanged. Daemon consumption, module UI, persistence and migration are handled by their own stories.

**Additional context**

Foundation story of the EDGE-6 epic. `format`/`vendor` semantics (decoder vs label) are finalized in EDGE-56.
