### PR TITLE
perf(gateway): stream distributed sync events with a RediSearch cursor

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/fetcher/DistributedEventFetcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/fetcher/DistributedEventFetcher.java
@@ -24,18 +24,18 @@ import io.gravitee.repository.distributedsync.model.DistributedEventType;
 import io.gravitee.repository.distributedsync.model.DistributedSyncAction;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RequiredArgsConstructor
 public class DistributedEventFetcher {
+
+    // bulkItems sizes the downstream deployment batches; events themselves are cheap to fetch,
+    // so read them by larger batches to limit the number of repository round trips.
+    private static final int MIN_FETCH_BATCH_SIZE = 1000;
 
     private final DistributedEventRepository distributedEventRepository;
 
@@ -43,24 +43,26 @@ public class DistributedEventFetcher {
     @Accessors(fluent = true)
     private final int bulkItems;
 
+    public DistributedEventFetcher(final DistributedEventRepository distributedEventRepository, final int bulkItems) {
+        if (bulkItems <= 0) {
+            throw new IllegalArgumentException("bulkItems must be > 0 (got " + bulkItems + ")");
+        }
+        this.distributedEventRepository = distributedEventRepository;
+        this.bulkItems = bulkItems;
+    }
+
     public Flowable<DistributedEvent> fetchLatest(
         final Long from,
         final Long to,
         final DistributedEventType type,
         final Set<DistributedSyncAction> syncActions
     ) {
-        AtomicBoolean lastPage = new AtomicBoolean();
-        AtomicLong page = new AtomicLong(0L);
         DistributedEventCriteria distributedEventCriteria = DistributedEventCriteria.builder()
             .from(from == null ? -1 : from - TIMEFRAME_DELAY)
             .to(to == null ? -1 : to + TIMEFRAME_DELAY)
             .type(type)
             .syncActions(syncActions)
             .build();
-        return Flowable.just(page)
-            .map(AtomicLong::getAndIncrement)
-            .flatMap(nextPage -> distributedEventRepository.search(distributedEventCriteria, nextPage, (long) bulkItems))
-            .switchIfEmpty(Flowable.fromAction(() -> lastPage.set(true)))
-            .repeatUntil(lastPage::get);
+        return distributedEventRepository.searchAll(distributedEventCriteria, Math.max(bulkItems, MIN_FETCH_BATCH_SIZE));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/fetcher/DistributedEventFetcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/fetcher/DistributedEventFetcherTest.java
@@ -15,13 +15,19 @@
  */
 package io.gravitee.gateway.services.sync.process.distributed.fetcher;
 
+import static io.gravitee.gateway.services.sync.process.repository.DefaultSyncManager.TIMEFRAME_DELAY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.repository.distributedsync.api.DistributedEventRepository;
+import io.gravitee.repository.distributedsync.api.search.DistributedEventCriteria;
 import io.gravitee.repository.distributedsync.model.DistributedEvent;
 import io.gravitee.repository.distributedsync.model.DistributedEventType;
+import io.gravitee.repository.distributedsync.model.DistributedSyncAction;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +35,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -51,27 +58,45 @@ class DistributedEventFetcherTest {
     }
 
     @Test
-    void should_fetch_latest_event() {
-        DistributedEvent distributedEvent = DistributedEvent.builder().build();
-        when(distributedEventRepository.search(any(), any(), any()))
-            .thenReturn(Flowable.just(distributedEvent))
-            .thenReturn(Flowable.empty());
-        cut.fetchLatest(null, null, DistributedEventType.API, Set.of()).test().assertValueCount(1).assertValue(distributedEvent);
-    }
-
-    @Test
-    void should_fetch_latest_event_and_complete_when_no_more_page() {
-        cut = new DistributedEventFetcher(distributedEventRepository, 1);
+    void should_fetch_latest_events() {
         DistributedEvent distributedEvent1 = DistributedEvent.builder().id("1").build();
         DistributedEvent distributedEvent2 = DistributedEvent.builder().id("2").build();
-        when(distributedEventRepository.search(any(), eq(0L), eq(1L))).thenReturn(Flowable.just(distributedEvent1));
-        when(distributedEventRepository.search(any(), eq(1L), eq(1L))).thenReturn(Flowable.just(distributedEvent2));
-        when(distributedEventRepository.search(any(), eq(2L), eq(1L))).thenReturn(Flowable.empty());
+        when(distributedEventRepository.searchAll(any(), eq(1000L))).thenReturn(Flowable.just(distributedEvent1, distributedEvent2));
         cut
             .fetchLatest(null, null, DistributedEventType.API, Set.of())
             .test()
             .assertValueAt(0, distributedEvent1)
             .assertValueAt(1, distributedEvent2)
             .assertComplete();
+    }
+
+    @Test
+    void should_search_with_criteria_based_on_timeframe() {
+        when(distributedEventRepository.searchAll(any(), eq(1000L))).thenReturn(Flowable.empty());
+        cut
+            .fetchLatest(1000L, 2000L, DistributedEventType.SUBSCRIPTION, Set.of(DistributedSyncAction.DEPLOY))
+            .test()
+            .assertNoValues()
+            .assertComplete();
+
+        ArgumentCaptor<DistributedEventCriteria> criteriaCaptor = ArgumentCaptor.forClass(DistributedEventCriteria.class);
+        verify(distributedEventRepository).searchAll(criteriaCaptor.capture(), eq(1000L));
+        DistributedEventCriteria criteria = criteriaCaptor.getValue();
+        assertThat(criteria.getFrom()).isEqualTo(1000L - TIMEFRAME_DELAY);
+        assertThat(criteria.getTo()).isEqualTo(2000L + TIMEFRAME_DELAY);
+        assertThat(criteria.getType()).isEqualTo(DistributedEventType.SUBSCRIPTION);
+        assertThat(criteria.getSyncActions()).containsExactly(DistributedSyncAction.DEPLOY);
+    }
+
+    @Test
+    void should_fetch_with_bulk_items_when_above_the_minimum_batch_size() {
+        cut = new DistributedEventFetcher(distributedEventRepository, 50_000);
+        when(distributedEventRepository.searchAll(any(), eq(50_000L))).thenReturn(Flowable.empty());
+        cut.fetchLatest(null, null, DistributedEventType.API, Set.of()).test().assertComplete();
+    }
+
+    @Test
+    void should_reject_non_positive_bulk_items() {
+        assertThatThrownBy(() -> new DistributedEventFetcher(distributedEventRepository, 0)).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/distributedsync/api/DistributedEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/distributedsync/api/DistributedEventRepository.java
@@ -22,6 +22,8 @@ import io.gravitee.repository.distributedsync.model.DistributedSyncAction;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.Date;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -38,6 +40,27 @@ public interface DistributedEventRepository {
      * @return the {@link Flowable} of the latest events.
      */
     Flowable<DistributedEvent> search(final DistributedEventCriteria criteria, final Long page, final Long size);
+
+    /**
+     * Search for all {@link DistributedEvent} matching the corresponding criteria, fetched from the repository by batch of <code>batchSize</code>.
+     * <p>
+     * Events are emitted without any ordering guarantee. Implementations are encouraged to override this method
+     * when the underlying storage offers a more efficient way to stream large result sets than offset-based paging.
+     *
+     * @param criteria Criteria to search for {@link DistributedEvent}.
+     * @param batchSize number of events to fetch per query.
+     *
+     * @return the {@link Flowable} of all matching events.
+     */
+    default Flowable<DistributedEvent> searchAll(final DistributedEventCriteria criteria, final long batchSize) {
+        return Flowable.defer(() -> {
+            AtomicLong page = new AtomicLong();
+            AtomicBoolean lastPage = new AtomicBoolean();
+            return Flowable.defer(() -> search(criteria, page.getAndIncrement(), batchSize))
+                .switchIfEmpty(Flowable.fromAction(() -> lastPage.set(true)))
+                .repeatUntil(lastPage::get);
+        });
+    }
 
     /**
      * This method allows to create or update a distributed event if it does not exist in database or update it if it's present (replace old values by new ones).

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/distributedsync/api/DistributedEventRepositorySearchAllTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/distributedsync/api/DistributedEventRepositorySearchAllTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.distributedsync.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.distributedsync.api.search.DistributedEventCriteria;
+import io.gravitee.repository.distributedsync.model.DistributedEvent;
+import io.gravitee.repository.distributedsync.model.DistributedEventType;
+import io.gravitee.repository.distributedsync.model.DistributedSyncAction;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DistributedEventRepositorySearchAllTest {
+
+    private final AtomicInteger searchCalls = new AtomicInteger();
+
+    private DistributedEventRepository repositoryOf(final List<DistributedEvent> events) {
+        return new DistributedEventRepository() {
+            @Override
+            public Flowable<DistributedEvent> search(DistributedEventCriteria criteria, Long page, Long size) {
+                searchCalls.incrementAndGet();
+                return Flowable.fromIterable(events.stream().skip(page * size).limit(size).toList());
+            }
+
+            @Override
+            public Completable createOrUpdate(DistributedEvent distributedEvent) {
+                return Completable.complete();
+            }
+
+            @Override
+            public Completable updateAll(DistributedEventType refType, String refId, DistributedSyncAction syncAction, Date updateAt) {
+                return Completable.complete();
+            }
+        };
+    }
+
+    @Test
+    void should_page_through_all_events_until_an_empty_page() {
+        List<DistributedEvent> events = IntStream.range(0, 5)
+            .mapToObj(i -> DistributedEvent.builder().id(String.valueOf(i)).build())
+            .toList();
+
+        repositoryOf(events).searchAll(null, 2L).test().assertValueSequence(events).assertComplete();
+
+        // pages of 2: [0,1], [2,3], [4] and the empty page ending the loop
+        assertThat(searchCalls).hasValue(4);
+    }
+
+    @Test
+    void should_complete_without_event_when_nothing_matches() {
+        repositoryOf(List.of()).searchAll(null, 2L).test().assertNoValues().assertComplete();
+
+        assertThat(searchCalls).hasValue(1);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/distributedsync/RedisDistributedEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/distributedsync/RedisDistributedEventRepository.java
@@ -26,6 +26,8 @@ import io.gravitee.repository.redis.vertx.RedisClient;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.Future;
+import io.vertx.redis.client.RedisAPI;
 import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 import java.time.Instant;
@@ -34,7 +36,10 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.CustomLog;
 
 /**
@@ -48,6 +53,7 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
     private static final String REDIS_KEY_PREFIX = "distributed_event" + REDIS_KEY_SEPARATOR;
     private static final String REDIS_SEARCH_RESULTS_FIELD = "results";
     private static final String REDIS_RESPONSE_ATTRIBUTES_FIELD = "extra_attributes";
+    private static final long NO_CURSOR = -1;
 
     private final RedisClient redisClient;
 
@@ -64,22 +70,37 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
 
     @Override
     public Flowable<DistributedEvent> search(final DistributedEventCriteria criteria, final Long page, final Long size) {
-        return Single.defer(() ->
-            Single.fromCompletionStage(
-                redisClient
-                    .redisApi()
-                    .flatMap(redisAPI -> redisAPI.ftSearch(buildSearchArgs(criteria, page, size)))
-                    .toCompletionStage()
-                    .toCompletableFuture()
-            )
-        )
+        return send(redisAPI -> redisAPI.ftSearch(buildSearchArgs(criteria, page, size)))
             .filter(response -> response.type() == ResponseType.MULTI)
-            .flattenStreamAsFlowable(response ->
-                getSearchResults(response)
-                    .stream()
-                    .filter(item -> item.type() == ResponseType.MULTI)
-                    .map(this::mapSearchResponse)
-            );
+            .flattenStreamAsFlowable(this::mapSearchResults);
+    }
+
+    /**
+     * Streams all matching events through a RediSearch cursor: {@code FT.AGGREGATE ... WITHCURSOR} runs the query
+     * once and returns the first batch along with a cursor id, then each subsequent batch is fetched with
+     * {@code FT.CURSOR READ} until the returned cursor id is 0. Every batch is served in constant time whatever
+     * its position in the result set, so the overall cost stays linear with the number of events.
+     * <p>
+     * If the stream terminates before the cursor is exhausted (error or cancellation), the cursor is explicitly
+     * deleted to free the server-side resource.
+     */
+    @Override
+    public Flowable<DistributedEvent> searchAll(final DistributedEventCriteria criteria, final long batchSize) {
+        return Flowable.defer(() -> {
+            AtomicLong cursorId = new AtomicLong(NO_CURSOR);
+            return send(redisAPI ->
+                cursorId.get() == NO_CURSOR
+                    ? redisAPI.ftAggregate(buildAggregateArgs(criteria, batchSize))
+                    : redisAPI.ftCursor(List.of("READ", REDIS_INDEX_NAME, String.valueOf(cursorId.get())))
+            )
+                .flattenStreamAsFlowable(response -> {
+                    // A cursor response is a 2-element array: the search results and the next cursor id (0 when exhausted)
+                    cursorId.set(response.get(1).toLong());
+                    return mapSearchResults(response.get(0));
+                })
+                .repeatUntil(() -> cursorId.get() == 0)
+                .doFinally(() -> closeCursor(cursorId.get()));
+        });
     }
 
     @Override
@@ -119,14 +140,18 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
     }
 
     private Completable createOrUpdateKey(final String key, final DistributedEvent distributedEvent) {
-        return Completable.defer(() ->
-            Completable.fromCompletionStage(
-                redisClient
-                    .redisApi()
-                    .flatMap(redisAPI -> redisAPI.hset(buildUpdateArgs(key, distributedEvent)))
-                    .toCompletionStage()
-            )
-        );
+        return send(redisAPI -> redisAPI.hset(buildUpdateArgs(key, distributedEvent))).ignoreElement();
+    }
+
+    private Single<Response> send(final Function<RedisAPI, Future<Response>> command) {
+        return Single.defer(() -> Single.fromCompletionStage(redisClient.redisApi().flatMap(command).toCompletionStage()));
+    }
+
+    private Stream<DistributedEvent> mapSearchResults(final Response searchResults) {
+        return getSearchResults(searchResults)
+            .stream()
+            .filter(item -> item.type() == ResponseType.MULTI)
+            .map(this::mapSearchResponse);
     }
 
     private List<String> buildSearchIndex() {
@@ -163,6 +188,32 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
             args.add(String.valueOf(size));
         }
         return args;
+    }
+
+    private List<String> buildAggregateArgs(final DistributedEventCriteria criteria, final long batchSize) {
+        return List.of(
+            REDIS_INDEX_NAME,
+            buildSearchQuery(criteria),
+            "LOAD",
+            "5",
+            "@" + DistributedEvent.Fields.id,
+            "@" + DistributedEvent.Fields.payload,
+            "@" + DistributedEvent.Fields.type,
+            "@" + DistributedEvent.Fields.syncAction,
+            "@" + DistributedEvent.Fields.updatedAt,
+            "WITHCURSOR",
+            "COUNT",
+            String.valueOf(batchSize)
+        );
+    }
+
+    private void closeCursor(final long cursorId) {
+        if (cursorId > 0) {
+            redisClient
+                .redisApi()
+                .flatMap(redisAPI -> redisAPI.ftCursor(List.of("DEL", REDIS_INDEX_NAME, String.valueOf(cursorId))))
+                .onFailure(throwable -> log.debug("Unable to close distributed-event cursor {}", cursorId, throwable));
+        }
     }
 
     private String buildSearchQuery(final DistributedEventCriteria criteria) {

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/distributedsync/RedisDistributedEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/distributedsync/RedisDistributedEventRepository.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -54,6 +53,9 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
     private static final String REDIS_SEARCH_RESULTS_FIELD = "results";
     private static final String REDIS_RESPONSE_ATTRIBUTES_FIELD = "extra_attributes";
     private static final long NO_CURSOR = -1;
+    private static final String SCAN_BATCH_SIZE = "1000";
+    // Keep well below the redis client waiting queue (max-waiting-handlers) to leave room for other commands
+    private static final int UPDATE_MAX_CONCURRENCY = 32;
 
     private final RedisClient redisClient;
 
@@ -116,27 +118,24 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
         final Date updatedAt
     ) {
         String matchingKey = REDIS_KEY_PREFIX + refType.name() + REDIS_KEY_SEPARATOR + refId + "*";
-        AtomicInteger cursor = new AtomicInteger(0);
-        return Single.defer(() ->
-            Single.fromCompletionStage(
-                redisClient
-                    .redisApi()
-                    .flatMap(redisAPI -> redisAPI.scan(List.of(String.valueOf(cursor.get()), "MATCH", matchingKey)))
-                    .toCompletionStage()
-            )
-        )
-            .filter(response -> response.type() == ResponseType.MULTI)
-            .flattenStreamAsFlowable(response -> {
-                Integer nextCursor = response.get(0).toInteger();
-                cursor.set(nextCursor);
-                Response keys = response.get(1);
-                return keys.stream();
-            })
-            .map(Response::toString)
-            .repeatUntil(() -> cursor.get() == 0)
-            .flatMapCompletable(key ->
-                createOrUpdateKey(key, DistributedEvent.builder().syncAction(syncAction).updatedAt(updatedAt).build())
-            );
+        return Completable.defer(() -> {
+            // SCAN cursors are unsigned 64-bit values
+            AtomicLong cursor = new AtomicLong(0);
+            return send(redisAPI -> redisAPI.scan(List.of(String.valueOf(cursor.get()), "MATCH", matchingKey, "COUNT", SCAN_BATCH_SIZE)))
+                .filter(response -> response.type() == ResponseType.MULTI)
+                .flattenStreamAsFlowable(response -> {
+                    cursor.set(response.get(0).toLong());
+                    Response keys = response.get(1);
+                    return keys.stream();
+                })
+                .map(Response::toString)
+                .repeatUntil(() -> cursor.get() == 0)
+                .flatMapCompletable(
+                    key -> createOrUpdateKey(key, DistributedEvent.builder().syncAction(syncAction).updatedAt(updatedAt).build()),
+                    false,
+                    UPDATE_MAX_CONCURRENCY
+                );
+        });
     }
 
     private Completable createOrUpdateKey(final String key, final DistributedEvent distributedEvent) {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/distributedsync/DistributedEventRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/distributedsync/DistributedEventRepositoryTest.java
@@ -330,6 +330,50 @@ public class DistributedEventRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void should_stream_all_distributed_events_by_batch() throws InterruptedException {
+        var events = distributedEventRepository.searchAll(null, 2L).test().await().assertComplete().assertValueCount(6).values();
+
+        assertThat(events).extracting(DistributedEvent::getId).containsExactlyInAnyOrder("1", "2", "3", "4", "5", "DEFAULT");
+        assertThat(events)
+            .filteredOn(distributedEvent -> distributedEvent.getId().equals("5"))
+            .singleElement()
+            .satisfies(distributedEvent -> {
+                assertThat(distributedEvent.getPayload()).isEqualTo("payload");
+                assertThat(distributedEvent.getType()).isEqualTo(DistributedEventType.SUBSCRIPTION);
+                assertThat(distributedEvent.getSyncAction()).isEqualTo(DistributedSyncAction.DEPLOY);
+                assertThat(distributedEvent.getUpdatedAt()).isEqualTo(Instant.parse("2023-06-24T15:25:34.051Z"));
+            });
+    }
+
+    @Test
+    public void should_stream_all_distributed_events_matching_criteria() throws InterruptedException {
+        var events = distributedEventRepository
+            .searchAll(
+                DistributedEventCriteria.builder()
+                    .type(DistributedEventType.API)
+                    .syncActions(Set.of(DistributedSyncAction.DEPLOY, DistributedSyncAction.UNDEPLOY))
+                    .build(),
+                1L
+            )
+            .test()
+            .await()
+            .assertComplete()
+            .values();
+
+        assertThat(events).extracting(DistributedEvent::getId).containsExactlyInAnyOrder("1", "2");
+    }
+
+    @Test
+    public void should_stream_no_distributed_event_when_nothing_matches() throws InterruptedException {
+        distributedEventRepository
+            .searchAll(DistributedEventCriteria.builder().from(Instant.parse("2100-01-01T00:00:00.000Z").toEpochMilli()).build(), 2L)
+            .test()
+            .await()
+            .assertNoValues()
+            .assertComplete();
+    }
+
+    @Test
     public void should_update_all_related_to_api() throws InterruptedException {
         Date updateAt = new Date();
         distributedEventRepository


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14741
https://gravitee.atlassian.net/browse/APIM-14727

## Description

Customer-reported issue: distributed sync of ~3.5M subscriptions from Redis takes 4–5 min for the initial sync, with each successive batch query slower than the last (batch size 50,000).

Root cause is RediSearch offset pagination: `FT.SEARCH ... SORTBY updatedAt LIMIT offset,count` re-executes the full query and sort for every page, making the total cost quadratic in the number of events. On top of that, the default `MAXSEARCHRESULTS` (1M) rejects offsets past 1M, and the 500ms `search-timeout` can silently truncate pages.

### `perf(gateway): stream distributed sync events with a RediSearch cursor`

- New `DistributedEventRepository#searchAll(criteria, batchSize)` with a default offset-paging implementation, preserving binary compatibility for third-party repository plugins.
- Redis implementation overrides it with the native cursor API (`FT.AGGREGATE ... WITHCURSOR` + `FT.CURSOR READ`): the query executes once, each batch is retrieved in constant time, no result-count ceiling. `SORTBY` is dropped — sync deployers already process events in parallel and inter-type ordering is handled by the sync manager.
- `DistributedEventFetcher` delegates to `searchAll` instead of its page loop, reading by batches of at least 1000 regardless of `bulk_items` (which keeps sizing the downstream deployment batches), and fails fast on a non-positive `bulk_items` configuration.

### `fix(gateway): make distributed sync updateAll scale with large keyspaces`

- `SCAN` now uses `COUNT 1000` instead of the default 10 (350k round trips → 3.5k for a 3.5M keyspace) and a 64-bit cursor.
- The per-key `HSET` writes are bounded to 32 concurrent commands: previously an undeploy touching >1024 events overflowed the Redis client waiting queue ("Redis waiting queue full") and the undeploy never reached secondary gateways.

## Additional context

- Covered by new unit tests (interface default, fetcher) and 3 new integration tests in `DistributedEventRepositoryTest` (run against redis-stack testcontainers, all green).
- `search(criteria, page, size)` is kept as-is for interface compatibility but no longer has internal callers.