### PR TITLE
fix: http 500 on api product api update

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -487,6 +487,7 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
             }
 
             query.append(sortable.order() == null || sortable.order().equals(Order.ASC) ? " asc " : " desc ");
+            query.append(", a.id asc ");
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
@@ -56,13 +56,7 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
     public Page<ApiMongo> search(ApiCriteria criteria, Sortable sortable, Pageable pageable, ApiFieldFilter apiFieldFilter) {
         final Query query = buildQuery(apiFieldFilter, criteria == null ? emptyList() : List.of(criteria));
 
-        Sort sort;
-        if (sortable == null) {
-            sort = Sort.by(ASC, "name");
-        } else {
-            Sort.Direction sortOrder = sortable.order().equals(Order.ASC) ? ASC : Sort.Direction.DESC;
-            sort = Sort.by(sortOrder, FieldUtils.toCamelCase(sortable.field()));
-        }
+        Sort sort = buildSort(sortable);
 
         long total = mongoQueries.countOrTimeout(mongoTemplate, query, ApiMongo.class);
 
@@ -84,13 +78,7 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
         query.fields().include("_id");
         fillQuery(query, apiCriteria);
 
-        Sort sort;
-        if (sortable == null) {
-            sort = Sort.by(ASC, "name");
-        } else {
-            Sort.Direction sortOrder = sortable.order().equals(Order.ASC) ? ASC : Sort.Direction.DESC;
-            sort = Sort.by(sortOrder, FieldUtils.toCamelCase(sortable.field()));
-        }
+        Sort sort = buildSort(sortable);
 
         // Get total count before adding pagination to the query
         long total = mongoQueries.countOrTimeout(mongoTemplate, query, ApiMongo.class);
@@ -201,6 +189,18 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
             }
         }
         return query;
+    }
+
+    /**
+     * Stable sort for offset pagination used by streamed search (batch size 100).
+     * Tie-break on id to avoid duplicate or skipped rows when primary sort keys collide.
+     */
+    private Sort buildSort(Sortable sortable) {
+        if (sortable == null) {
+            return Sort.by(ASC, "name", "id");
+        }
+        Sort.Direction sortOrder = sortable.order().equals(Order.ASC) ? ASC : Sort.Direction.DESC;
+        return Sort.by(sortOrder, FieldUtils.toCamelCase(sortable.field())).and(Sort.by(ASC, "id"));
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImplTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImplTest.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.mongodb.management.internal.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.mongodb.MongoExecutionTimeoutException;
@@ -30,8 +31,10 @@ import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.lang.reflect.Field;
 import java.util.List;
 import lombok.SneakyThrows;
+import org.bson.Document;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.mongodb.UncategorizedMongoDbException;
@@ -64,6 +67,27 @@ class ApiMongoRepositoryImplTest {
 
         assertThat(page.getTotalElements()).isEqualTo(-1L);
         assertThat(page.getContent()).extracting(ApiMongo::getId).containsExactly("api-1");
+    }
+
+    @Test
+    @SneakyThrows
+    void search_uses_stable_sort_with_id_tie_breaker_when_sortable_is_null() {
+        when(mongoTemplate.count(any(Query.class), eq(ApiMongo.class))).thenReturn(0L);
+        when(mongoTemplate.find(any(Query.class), eq(ApiMongo.class))).thenReturn(List.of());
+        ApiMongoRepositoryImpl repository = buildRepository();
+
+        repository.search(
+            new ApiCriteria.Builder().build(),
+            null,
+            new PageableBuilder().pageNumber(0).pageSize(10).build(),
+            ApiFieldFilter.allFields()
+        );
+
+        ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+        verify(mongoTemplate).find(queryCaptor.capture(), eq(ApiMongo.class));
+        Document sortObject = queryCaptor.getValue().getSortObject();
+        assertThat(sortObject.get("name")).isEqualTo(1);
+        assertThat(sortObject.get("id")).isEqualTo(1);
     }
 
     @SneakyThrows

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiRepositoryTest.java
@@ -693,6 +693,39 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void shouldStreamSearchWithoutDuplicateIdsWhenManyApisShareSameName() throws TechnicalException {
+        String sharedName = "stream-sort-repro-" + UUID.randomUUID();
+        List<String> ids = new ArrayList<>();
+        for (int i = 0; i < 105; i++) {
+            Api api = new Api();
+            String id = "stream-sort-" + i + "-" + UUID.randomUUID();
+            api.setId(id);
+            api.setEnvironmentId("DEFAULT");
+            api.setName(sharedName);
+            api.setVersion("1");
+            api.setLifecycleState(STOPPED);
+            api.setVisibility(PRIVATE);
+            api.setDefinition("{}");
+            api.setCreatedAt(new Date());
+            api.setUpdatedAt(new Date());
+            apiRepository.create(api);
+            ids.add(id);
+        }
+
+        try {
+            ApiCriteria criteria = new ApiCriteria.Builder().ids(ids).environmentId("DEFAULT").build();
+            List<String> streamedIds = apiRepository.search(criteria, null, ApiFieldFilter.defaultFields(), 100).map(Api::getId).toList();
+
+            assertThat(streamedIds).doesNotHaveDuplicates();
+            assertThat(streamedIds).containsExactlyInAnyOrderElementsOf(ids);
+        } finally {
+            for (String id : ids) {
+                apiRepository.delete(id);
+            }
+        }
+    }
+
+    @Test
     public void shouldFindIdByEnvironmentIdAndCrossId() throws TechnicalException {
         Optional<String> optApiId = apiRepository.findIdByEnvironmentIdAndCrossId("ENV6", "searched-crossId2");
         assertTrue(optApiId.isPresent());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ValidateApiProductService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ValidateApiProductService.java
@@ -69,7 +69,9 @@ public class ValidateApiProductService {
         ApiSearchCriteria criteria = ApiSearchCriteria.builder().ids(apiIds).environmentId(environmentId).build();
         ApiFieldFilter fieldFilter = ApiFieldFilter.builder().definitionExcluded(false).pictureExcluded(true).build();
 
-        Map<String, Api> foundApis = apiQueryService.search(criteria, null, fieldFilter).collect(Collectors.toMap(Api::getId, api -> api));
+        Map<String, Api> foundApis = apiQueryService
+            .search(criteria, null, fieldFilter)
+            .collect(Collectors.toMap(Api::getId, api -> api, (existing, duplicate) -> existing));
 
         List<String> nonExistentApiIds = apiIds
             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ValidateApiProductServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ValidateApiProductServiceTest.java
@@ -149,6 +149,14 @@ class ValidateApiProductServiceTest {
 
             assertThatCode(() -> validateApiProductService.validateApiIdsForProduct(ENV_ID, List.of("api-1"))).doesNotThrowAnyException();
         }
+
+        @Test
+        void should_handle_duplicate_search_results_without_error() {
+            Api api = createV4ProxyApi("api-1", true);
+            apiCrudService.initWith(List.of(api, api));
+
+            assertThatCode(() -> validateApiProductService.validateApiIdsForProduct(ENV_ID, List.of("api-1"))).doesNotThrowAnyException();
+        }
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
@@ -315,6 +315,31 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
     }
 
     @Test
+    void should_update_product_when_api_search_returns_duplicate_records() {
+        givenPublishedApiProductPlan();
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .apiIds(Set.of())
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        Api api1 = createV4ProxyApi("api-1", true);
+        apiCrudService.initWith(List.of(api1, api1));
+
+        var toUpdate = UpdateApiProduct.builder().apiIds(Set.of("api-1")).build();
+
+        var input = new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO);
+        var output = updateApiProductUseCase.execute(input);
+
+        assertThat(output.apiProduct().getApiIds()).containsExactly("api-1");
+        verify(apiProductIndexerDomainService).index(any(), eq(output.apiProduct()), any());
+    }
+
+    @Test
     void should_clear_all_apis_when_empty_apiIds_provided() {
         ApiProduct existing = ApiProduct.builder()
             .id("api-product-id")


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14738

## Description

Fixes HTTP 500 when batch-updating an API Product (PUT .../api-products/{id} with a large apiIds list).

**Root cause**: ValidateApiProductService.validateApiIdsForProduct() used Collectors.toMap(Api::getId, api -> api) without a merge function. If apiQueryService.search() emits the same API ID more than once, Java throws IllegalStateException: Duplicate key ... (attempted merging values Api(...) and Api(...)), which is mapped to 500 by ThrowableMapper.
**Fix**: keep the first occurrence:
.collect(Collectors.toMap(Api::getId, api -> api, (existing, duplicate) -> existing));
Safe for this path: validation only needs existence / V4 / allowedInApiProducts. Duplicate search hits do not change the outcome.

Customer evidence : MAPI logs show the exact Duplicate key c661a03d-... / alm_exchange + ThrowableMapper - Internal error. Atlas shows a single Mongo document for that _id (not duplicate DB rows). Single-API PUT succeeds; request-body ID dedupe also succeeds.
