### PR TITLE
feat: add dedicated EXPLORER role scope

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/MembershipReferenceType.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/MembershipReferenceType.java
@@ -29,4 +29,5 @@ public enum MembershipReferenceType {
     INTEGRATION,
     CLUSTER,
     API_PRODUCT,
+    EXPLORER,
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/MembershipRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/MembershipRepositoryTest.java
@@ -303,6 +303,26 @@ public class MembershipRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void shouldCreateExplorerConnectionMembership() throws TechnicalException {
+        Membership membership = new Membership(
+            "explorer_conn1_user1",
+            "user1",
+            MembershipMemberType.USER,
+            "explorer-connection-1",
+            MembershipReferenceType.EXPLORER,
+            "EXPLORER_OWNER"
+        );
+
+        Membership created = membershipRepository.create(membership);
+
+        assertThat(created).isNotNull();
+        Optional<Membership> found = membershipRepository.findById("explorer_conn1_user1");
+        assertThat(found).isPresent();
+        assertThat(found.get().getReferenceType()).isEqualTo(MembershipReferenceType.EXPLORER);
+        assertThat(found.get().getReferenceId()).isEqualTo("explorer-connection-1");
+    }
+
+    @Test
     public void shouldFindByIds() throws TechnicalException {
         Set<Membership> memberships = membershipRepository.findByIds(Set.of("api1_user_findByIds", "api2_user_findByIds", "unknown"));
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/RoleRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/RoleRepositoryTest.java
@@ -96,6 +96,25 @@ public class RoleRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void shouldCreateExplorerScopedRole() throws Exception {
+        final Role role = new Role();
+        role.setId("EXPLORER_to_create");
+        role.setName("explorer to create");
+        role.setScope(RoleScope.EXPLORER);
+        role.setReferenceId(REFERENCE_ID);
+        role.setReferenceType(REFERENCE_TYPE);
+        role.setPermissions(new int[] { 3 });
+
+        boolean presentBefore = roleRepository.findById("EXPLORER_to_create").isPresent();
+        Role newRole = roleRepository.create(role);
+        boolean presentAfter = roleRepository.findById("EXPLORER_to_create").isPresent();
+
+        assertFalse(presentBefore, "must not exists before creation");
+        assertTrue(presentAfter, "must exists after creation");
+        assertEquals(RoleScope.EXPLORER, newRole.getScope(), "Invalid scope");
+    }
+
+    @Test
     public void shouldUpdate() throws Exception {
         final Role role = new Role();
         role.setId("ENVIRONMENT_to_update");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1985,6 +1985,7 @@ components:
         - CLUSTER
         - API_PRODUCT
         - AI_CATALOG
+        - EXPLORER
     Member:
       type: object
       properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResource.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
+import io.gravitee.rest.api.model.permissions.ExplorerPermission;
 import io.gravitee.rest.api.model.permissions.IntegrationPermission;
 import io.gravitee.rest.api.model.permissions.OrganizationPermission;
 import io.swagger.v3.oas.annotations.Operation;
@@ -87,6 +88,10 @@ public class RoleScopesResource extends AbstractResource {
         roles.put(
             RoleScope.AI_CATALOG.name(),
             stream(AiCatalogPermission.values()).map(AiCatalogPermission::getName).sorted().collect(toList())
+        );
+        roles.put(
+            RoleScope.EXPLORER.name(),
+            stream(ExplorerPermission.values()).map(ExplorerPermission::getName).sorted().collect(toList())
         );
         return roles;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
@@ -71,11 +71,11 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
             "DOCUMENTATION",
             "EDGE_CONFIGURATION",
             "ENTRYPOINT",
+            "EXPLORER",
             "GROUP",
             "IDENTITY_PROVIDER_ACTIVATION",
             "INSTANCE",
             "INTEGRATION",
-            "KAFKA_EXPLORER",
             "MESSAGE",
             "METADATA",
             "NOTIFICATION",
@@ -122,7 +122,9 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
         "CLUSTER",
         List.of("ANALYTICS", "CONFIGURATION", "DEFINITION", "MEMBER"),
         "AI_CATALOG",
-        List.of("DEFINITION", "MEMBER")
+        List.of("DEFINITION", "MEMBER"),
+        "EXPLORER",
+        List.of("CONFIGURATION", "MEMBER")
     );
 
     @Override
@@ -138,7 +140,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
 
         assertAll(
             () -> assertEquals(HttpStatusCode.OK_200, response.getStatus()),
-            () -> assertThat(resultRoleScopes.size()).isEqualTo(8),
+            () -> assertThat(resultRoleScopes.size()).isEqualTo(9),
             () ->
                 assertThat(resultRoleScopes.keySet()).containsExactlyInAnyOrder(
                     "ORGANIZATION",
@@ -148,7 +150,8 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
                     "INTEGRATION",
                     "CLUSTER",
                     "API_PRODUCT",
-                    "AI_CATALOG"
+                    "AI_CATALOG",
+                    "EXPLORER"
                 ),
             () -> assertThat(resultRoleScopes.get("ORGANIZATION")).isEqualTo(EXPECTED_ROLE_SCOPES.get("ORGANIZATION")),
             () -> assertThat(resultRoleScopes.get("ENVIRONMENT")).isEqualTo(EXPECTED_ROLE_SCOPES.get("ENVIRONMENT")),
@@ -156,7 +159,8 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
             () -> assertThat(resultRoleScopes.get("APPLICATION")).isEqualTo(EXPECTED_ROLE_SCOPES.get("APPLICATION")),
             () -> assertThat(resultRoleScopes.get("INTEGRATION")).isEqualTo(EXPECTED_ROLE_SCOPES.get("INTEGRATION")),
             () -> assertThat(resultRoleScopes.get("CLUSTER")).isEqualTo(EXPECTED_ROLE_SCOPES.get("CLUSTER")),
-            () -> assertThat(resultRoleScopes.get("AI_CATALOG")).isEqualTo(EXPECTED_ROLE_SCOPES.get("AI_CATALOG"))
+            () -> assertThat(resultRoleScopes.get("AI_CATALOG")).isEqualTo(EXPECTED_ROLE_SCOPES.get("AI_CATALOG")),
+            () -> assertThat(resultRoleScopes.get("EXPLORER")).isEqualTo(EXPECTED_ROLE_SCOPES.get("EXPLORER"))
         );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MembershipReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MembershipReferenceType.java
@@ -38,7 +38,8 @@ public enum MembershipReferenceType {
             RoleScope.APPLICATION,
             RoleScope.INTEGRATION,
             RoleScope.CLUSTER,
-            RoleScope.AI_CATALOG
+            RoleScope.AI_CATALOG,
+            RoleScope.EXPLORER
         )
     ),
     ENVIRONMENT(EnumSet.allOf(RoleScope.class)),
@@ -46,7 +47,8 @@ public enum MembershipReferenceType {
     PLATFORM(EnumSet.allOf(RoleScope.class)),
     INTEGRATION(EnumSet.allOf(RoleScope.class)),
     CLUSTER(EnumSet.allOf(RoleScope.class)),
-    AI_CATALOG(EnumSet.of(RoleScope.AI_CATALOG));
+    AI_CATALOG(EnumSet.of(RoleScope.AI_CATALOG)),
+    EXPLORER(EnumSet.of(RoleScope.EXPLORER));
 
     private final EnumSet<RoleScope> roleScopes;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
@@ -61,7 +61,7 @@ public enum EnvironmentPermission implements Permission {
     AUTHZ_PDP("AUTHZ_PDP", 4900),
     AUTHZ_SCHEMA("AUTHZ_SCHEMA", 5000),
     AI_CATALOG("AI_CATALOG", 5100),
-    KAFKA_EXPLORER("KAFKA_EXPLORER", 5200);
+    EXPLORER("EXPLORER", 5200);
 
     String name;
     int mask;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/ExplorerPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/ExplorerPermission.java
@@ -13,22 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.management.model;
+package io.gravitee.rest.api.model.permissions;
 
-/**
- * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum RoleScope {
-    API,
-    APPLICATION,
-    GROUP,
-    ENVIRONMENT,
-    ORGANIZATION,
-    PLATFORM,
-    INTEGRATION,
-    CLUSTER,
-    API_PRODUCT,
-    AI_CATALOG,
-    EXPLORER,
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(enumAsRef = true)
+public enum ExplorerPermission implements Permission {
+    CONFIGURATION("CONFIGURATION", 1000),
+    MEMBER("MEMBER", 1100);
+
+    final String name;
+    final int mask;
+
+    ExplorerPermission(String name, int mask) {
+        this.name = name;
+        this.mask = mask;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int getMask() {
+        return mask;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/Permission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/Permission.java
@@ -48,6 +48,8 @@ public interface Permission {
                 return ApiProductPermission.values();
             case AI_CATALOG:
                 return AiCatalogPermission.values();
+            case EXPLORER:
+                return ExplorerPermission.values();
             default:
                 throw new IllegalArgumentException("[" + scope + "] are not a RolePermission");
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -101,7 +101,7 @@ public enum RolePermission {
     ENVIRONMENT_AUTHZ_PDP(RoleScope.ENVIRONMENT, EnvironmentPermission.AUTHZ_PDP),
     ENVIRONMENT_AUTHZ_SCHEMA(RoleScope.ENVIRONMENT, EnvironmentPermission.AUTHZ_SCHEMA),
     ENVIRONMENT_AI_CATALOG(RoleScope.ENVIRONMENT, EnvironmentPermission.AI_CATALOG),
-    ENVIRONMENT_KAFKA_EXPLORER(RoleScope.ENVIRONMENT, EnvironmentPermission.KAFKA_EXPLORER),
+    ENVIRONMENT_EXPLORER(RoleScope.ENVIRONMENT, EnvironmentPermission.EXPLORER),
 
     ORGANIZATION_USERS(RoleScope.ORGANIZATION, OrganizationPermission.USER),
     ORGANIZATION_USERS_TOKEN(RoleScope.ORGANIZATION, OrganizationPermission.USER_TOKEN),
@@ -135,7 +135,10 @@ public enum RolePermission {
     API_PRODUCT_MEMBER(RoleScope.API_PRODUCT, ApiProductPermission.MEMBER),
 
     AI_CATALOG_DEFINITION(RoleScope.AI_CATALOG, AiCatalogPermission.DEFINITION),
-    AI_CATALOG_MEMBER(RoleScope.AI_CATALOG, AiCatalogPermission.MEMBER);
+    AI_CATALOG_MEMBER(RoleScope.AI_CATALOG, AiCatalogPermission.MEMBER),
+
+    EXPLORER_CONFIGURATION(RoleScope.EXPLORER, ExplorerPermission.CONFIGURATION),
+    EXPLORER_MEMBER(RoleScope.EXPLORER, ExplorerPermission.MEMBER);
 
     final RoleScope scope;
     final Permission permission;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RoleScope.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RoleScope.java
@@ -33,4 +33,5 @@ public enum RoleScope {
     CLUSTER,
     API_PRODUCT,
     AI_CATALOG,
+    EXPLORER,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-rest/src/main/java/io/gravitee/rest/api/rest/filter/PermissionsFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-rest/src/main/java/io/gravitee/rest/api/rest/filter/PermissionsFilter.java
@@ -54,6 +54,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
     private static final String CLUSTER_ID_PARAM = "clusterId";
     private static final String API_PRODUCT_ID_PARAM = "apiProductId";
     private static final String CATALOG_ID_PARAM = "catalogId";
+    private static final String EXPLORER_CONNECTION_ID_PARAM = "connectionId";
 
     @Context
     protected ResourceInfo resourceInfo;
@@ -91,6 +92,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
             case CLUSTER -> hasPermission(executionContext, permission, getId(CLUSTER_ID_PARAM, requestContext));
             case API_PRODUCT -> hasPermission(executionContext, permission, getId(API_PRODUCT_ID_PARAM, requestContext));
             case AI_CATALOG -> hasPermission(executionContext, permission, getId(CATALOG_ID_PARAM, requestContext));
+            case EXPLORER -> hasPermission(executionContext, permission, getId(EXPLORER_CONNECTION_ID_PARAM, requestContext));
             case PLATFORM -> false;
         };
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/MembershipReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/MembershipReferenceType.java
@@ -33,7 +33,8 @@ public enum MembershipReferenceType {
     PLATFORM(EnumSet.allOf(RoleScope.class)),
     INTEGRATION(EnumSet.allOf(RoleScope.class)),
     CLUSTER(EnumSet.allOf(RoleScope.class)),
-    AI_CATALOG(EnumSet.of(RoleScope.AI_CATALOG));
+    AI_CATALOG(EnumSet.of(RoleScope.AI_CATALOG)),
+    EXPLORER(EnumSet.of(RoleScope.EXPLORER));
 
     private final EnumSet<RoleScope> roleScopes;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/RoleScope.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/RoleScope.java
@@ -30,4 +30,5 @@ public enum RoleScope {
     CLUSTER,
     API_PRODUCT,
     AI_CATALOG,
+    EXPLORER,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Membership.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Membership.java
@@ -53,6 +53,7 @@ public class Membership {
         INTEGRATION,
         CLUSTER,
         API_PRODUCT,
+        EXPLORER,
     }
 
     public boolean isGroupUser() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Role.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Role.java
@@ -51,5 +51,6 @@ public class Role {
         CLUSTER,
         API_PRODUCT,
         AI_CATALOG,
+        EXPLORER,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
@@ -27,6 +27,7 @@ import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
+import io.gravitee.rest.api.model.permissions.ExplorerPermission;
 import io.gravitee.rest.api.model.permissions.IntegrationPermission;
 import io.gravitee.rest.api.model.permissions.OrganizationPermission;
 import java.util.Arrays;
@@ -65,7 +66,7 @@ public interface DefaultRoleEntityDefinition {
             .put(EnvironmentPermission.TENANT.getName(), new char[] { READ.getId() })
             .put(EnvironmentPermission.PLATFORM.getName(), new char[] { READ.getId() })
             .put(EnvironmentPermission.CLUSTER.getName(), new char[] { READ.getId() })
-            .put(EnvironmentPermission.KAFKA_EXPLORER.getName(), new char[] { READ.getId() })
+            .put(EnvironmentPermission.EXPLORER.getName(), new char[] { READ.getId() })
             .build()
     );
 
@@ -331,6 +332,27 @@ public interface DefaultRoleEntityDefinition {
         false,
         Arrays.stream(ClusterPermission.values()).collect(
             toMap(ClusterPermission::getName, cp -> new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+        )
+    );
+
+    NewRoleEntity EXPLORER_ROLE_USER = new NewRoleEntity(
+        "USER",
+        "Default Explorer Role. Created by Gravitee.io.",
+        EXPLORER,
+        true,
+        Maps.<String, char[]>builder()
+            .put(ExplorerPermission.CONFIGURATION.getName(), new char[] { READ.getId() })
+            .put(ExplorerPermission.MEMBER.getName(), new char[] { READ.getId() })
+            .build()
+    );
+
+    NewRoleEntity EXPLORER_ROLE_OWNER = new NewRoleEntity(
+        "OWNER",
+        "Default Explorer Role. Created by Gravitee.io.",
+        EXPLORER,
+        false,
+        Arrays.stream(ExplorerPermission.values()).collect(
+            toMap(ExplorerPermission::getName, ep -> new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
         )
     );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
@@ -52,7 +52,8 @@ public class PermissionServiceImpl extends AbstractService implements Permission
         Pair.of(RoleScope.GROUP, MembershipReferenceType.GROUP),
         Pair.of(RoleScope.INTEGRATION, MembershipReferenceType.INTEGRATION),
         Pair.of(RoleScope.CLUSTER, MembershipReferenceType.CLUSTER),
-        Pair.of(RoleScope.AI_CATALOG, MembershipReferenceType.AI_CATALOG)
+        Pair.of(RoleScope.AI_CATALOG, MembershipReferenceType.AI_CATALOG),
+        Pair.of(RoleScope.EXPLORER, MembershipReferenceType.EXPLORER)
     );
 
     @Autowired

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -30,6 +30,8 @@ import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DE
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DEFAULT_ROLE_APPLICATION_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DEFAULT_ROLE_ENVIRONMENT_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DEFAULT_ROLE_ORGANIZATION_USER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.EXPLORER_ROLE_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.EXPLORER_ROLE_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_AI_CATALOG_OWNER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_AI_CATALOG_USER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_OWNER;
@@ -62,6 +64,7 @@ import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
+import io.gravitee.rest.api.model.permissions.ExplorerPermission;
 import io.gravitee.rest.api.model.permissions.GroupPermission;
 import io.gravitee.rest.api.model.permissions.IntegrationPermission;
 import io.gravitee.rest.api.model.permissions.OrganizationPermission;
@@ -130,7 +133,9 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
         Map.entry("<CLUSTER> USER", CLUSTER_ROLE_USER),
         Map.entry("<CLUSTER> OWNER", CLUSTER_ROLE_OWNER),
         Map.entry("<AI_CATALOG> OWNER", ROLE_AI_CATALOG_OWNER),
-        Map.entry("<AI_CATALOG> USER", ROLE_AI_CATALOG_USER)
+        Map.entry("<AI_CATALOG> USER", ROLE_AI_CATALOG_USER),
+        Map.entry("<EXPLORER> OWNER", EXPLORER_ROLE_OWNER),
+        Map.entry("<EXPLORER> USER", EXPLORER_ROLE_USER)
     );
 
     @Lazy
@@ -622,6 +627,14 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 SystemRole.PRIMARY_OWNER,
                 RoleScope.AI_CATALOG,
                 AiCatalogPermission.values(),
+                organizationId
+            );
+            // EXPLORER - PRIMARY_OWNER
+            createOrUpdateSystemRole(
+                executionContext,
+                SystemRole.PRIMARY_OWNER,
+                RoleScope.EXPLORER,
+                ExplorerPermission.values(),
                 organizationId
             );
         } catch (TechnicalManagementException ex) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/DefaultOrganizationAdminRoleInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/DefaultOrganizationAdminRoleInitializer.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.impl.upgrade.initializer;
 import io.gravitee.rest.api.model.permissions.AiCatalogPermission;
 import io.gravitee.rest.api.model.permissions.ClusterPermission;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
+import io.gravitee.rest.api.model.permissions.ExplorerPermission;
 import io.gravitee.rest.api.model.permissions.IntegrationPermission;
 import io.gravitee.rest.api.model.permissions.OrganizationPermission;
 import io.gravitee.rest.api.model.permissions.RoleScope;
@@ -75,6 +76,13 @@ public class DefaultOrganizationAdminRoleInitializer extends OrganizationInitial
             SystemRole.PRIMARY_OWNER,
             RoleScope.AI_CATALOG,
             AiCatalogPermission.values(),
+            executionContext.getOrganizationId()
+        );
+        roleService.createOrUpdateSystemRole(
+            executionContext,
+            SystemRole.PRIMARY_OWNER,
+            RoleScope.EXPLORER,
+            ExplorerPermission.values(),
             executionContext.getOrganizationId()
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ExplorerRolesUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ExplorerRolesUpgrader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.model.permissions.RoleScope.EXPLORER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.EXPLORER_ROLE_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.EXPLORER_ROLE_USER;
+
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+@CustomLog
+public class ExplorerRolesUpgrader implements Upgrader {
+
+    private final RoleService roleService;
+
+    private final OrganizationRepository organizationRepository;
+
+    @Autowired
+    public ExplorerRolesUpgrader(RoleService roleService, @Lazy OrganizationRepository organizationRepository) {
+        this.roleService = roleService;
+        this.organizationRepository = organizationRepository;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
+            organizationRepository
+                .findAll()
+                .forEach(organization -> {
+                    ExecutionContext executionContext = new ExecutionContext(organization);
+                    initializeExplorerRoles(executionContext);
+                    roleService.createOrUpdateSystemRoles(executionContext, executionContext.getOrganizationId());
+                });
+            return true;
+        });
+    }
+
+    private void initializeExplorerRoles(ExecutionContext executionContext) {
+        if (shouldCreateRole(executionContext, EXPLORER_ROLE_OWNER.getName())) {
+            log.info("     - <EXPLORER> OWNER");
+            roleService.create(executionContext, EXPLORER_ROLE_OWNER);
+        }
+        if (shouldCreateRole(executionContext, EXPLORER_ROLE_USER.getName())) {
+            log.info("     - <EXPLORER> USER");
+            roleService.create(executionContext, EXPLORER_ROLE_USER);
+        }
+    }
+
+    private boolean shouldCreateRole(final ExecutionContext executionContext, String roleName) {
+        return roleService.findByScopeAndName(EXPLORER, roleName, executionContext.getOrganizationId()).isEmpty();
+    }
+
+    @Override
+    public int getOrder() {
+        return UpgraderOrder.EXPLORER_ROLES_UPGRADER;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/KafkaExplorerPermissionUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/KafkaExplorerPermissionUpgrader.java
@@ -32,10 +32,10 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 /**
- * One-shot upgrader that seeds the new {@code KAFKA_EXPLORER} environment permission on existing installations.
+ * One-shot upgrader that seeds the new {@code EXPLORER} environment permission on existing installations.
  * <ul>
  *   <li>Every non-system {@code ENVIRONMENT} role that carries {@code CLUSTER} ACLs gets the same ACLs copied to
- *       {@code KAFKA_EXPLORER} ({@code putIfAbsent} — pre-existing values are preserved), so users who could use
+ *       {@code EXPLORER} ({@code putIfAbsent} — pre-existing values are preserved), so users who could use
  *       the Kafka explorer through {@code ENVIRONMENT_CLUSTER} keep their access when endpoints switch to the
  *       dedicated permission.</li>
  *   <li>System roles are refreshed via {@code createOrUpdateSystemRoles} so ADMIN gains the new permission.</li>
@@ -48,7 +48,7 @@ import org.springframework.stereotype.Component;
 public class KafkaExplorerPermissionUpgrader implements Upgrader {
 
     private static final String CLUSTER_PERMISSION = EnvironmentPermission.CLUSTER.getName();
-    private static final String KAFKA_EXPLORER_PERMISSION = EnvironmentPermission.KAFKA_EXPLORER.getName();
+    private static final String EXPLORER_PERMISSION = EnvironmentPermission.EXPLORER.getName();
 
     private final RoleService roleService;
     private final OrganizationRepository organizationRepository;
@@ -84,19 +84,19 @@ public class KafkaExplorerPermissionUpgrader implements Upgrader {
         if (
             actualPermissions == null ||
             !actualPermissions.containsKey(CLUSTER_PERMISSION) ||
-            actualPermissions.containsKey(KAFKA_EXPLORER_PERMISSION)
+            actualPermissions.containsKey(EXPLORER_PERMISSION)
         ) {
             return;
         }
 
         Map<String, char[]> expectedPermissions = new HashMap<>(actualPermissions);
-        expectedPermissions.put(KAFKA_EXPLORER_PERMISSION, actualPermissions.get(CLUSTER_PERMISSION).clone());
+        expectedPermissions.put(EXPLORER_PERMISSION, actualPermissions.get(CLUSTER_PERMISSION).clone());
 
         UpdateRoleEntity expectedRole = UpdateRoleEntity.from(role);
         expectedRole.setPermissions(expectedPermissions);
 
         roleService.update(executionContext, expectedRole);
-        log.info("Copied CLUSTER ACLs to KAFKA_EXPLORER on role: {}", role.getName());
+        log.info("Copied CLUSTER ACLs to EXPLORER on role: {}", role.getName());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -82,4 +82,5 @@ public class UpgraderOrder {
     public static final int GAMMA_AUTHZ_ROLES_UPGRADER = 957;
     public static final int AI_CATALOG_ROLES_UPGRADER = 958;
     public static final int KAFKA_EXPLORER_PERMISSION_UPGRADER = 959;
+    public static final int EXPLORER_ROLES_UPGRADER = 960;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_CreateOrUpdateSystemRolesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_CreateOrUpdateSystemRolesTest.java
@@ -75,14 +75,14 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
 
         roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
 
-        verify(mockRoleRepository, times(9)).findByScopeAndNameAndReferenceIdAndReferenceType(
+        verify(mockRoleRepository, times(10)).findByScopeAndNameAndReferenceIdAndReferenceType(
             any(),
             anyString(),
             eq(REFERENCE_ID),
             eq(REFERENCE_TYPE)
         );
         verify(mockRoleRepository, never()).update(any());
-        verify(mockRoleRepository, times(9)).create(any());
+        verify(mockRoleRepository, times(10)).create(any());
     }
 
     @Test
@@ -127,7 +127,7 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
 
         roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
 
-        verify(mockRoleRepository, times(9)).findByScopeAndNameAndReferenceIdAndReferenceType(
+        verify(mockRoleRepository, times(10)).findByScopeAndNameAndReferenceIdAndReferenceType(
             any(),
             anyString(),
             eq(REFERENCE_ID),
@@ -189,7 +189,7 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
 
         roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
 
-        verify(mockRoleRepository, times(9)).findByScopeAndNameAndReferenceIdAndReferenceType(
+        verify(mockRoleRepository, times(10)).findByScopeAndNameAndReferenceIdAndReferenceType(
             any(),
             anyString(),
             eq(REFERENCE_ID),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ExplorerRolesUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ExplorerRolesUpgraderTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.model.permissions.RoleScope.EXPLORER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.EXPLORER_ROLE_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.EXPLORER_ROLE_USER;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Organization;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
+public class ExplorerRolesUpgraderTest {
+
+    @InjectMocks
+    ExplorerRolesUpgrader upgrader;
+
+    @Mock
+    RoleService roleService;
+
+    @Mock
+    OrganizationRepository organizationRepository;
+
+    @Test
+    public void upgrade_should_fail_because_of_exception() throws TechnicalException {
+        assertThrows(UpgraderException.class, () -> {
+            when(organizationRepository.findAll()).thenThrow(new RuntimeException());
+            upgrader.upgrade();
+        });
+    }
+
+    @Test
+    public void shouldCreateExplorerRolesWhenNotPresent() throws UpgraderException, TechnicalException {
+        String organizationId = GraviteeContext.getDefaultOrganization();
+        Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(organizationId);
+        when(organizationRepository.findAll()).thenReturn(Set.of(organization));
+
+        ExecutionContext expectedExecutionContext = new ExecutionContext(organization);
+        when(roleService.findByScopeAndName(eq(EXPLORER), eq(EXPLORER_ROLE_OWNER.getName()), eq(organizationId))).thenReturn(
+            Optional.empty()
+        );
+        when(roleService.findByScopeAndName(eq(EXPLORER), eq(EXPLORER_ROLE_USER.getName()), eq(organizationId))).thenReturn(
+            Optional.empty()
+        );
+
+        upgrader.upgrade();
+
+        verify(roleService).create(expectedExecutionContext, EXPLORER_ROLE_OWNER);
+        verify(roleService).create(expectedExecutionContext, EXPLORER_ROLE_USER);
+        verify(roleService).createOrUpdateSystemRoles(expectedExecutionContext, organizationId);
+    }
+
+    @Test
+    public void shouldNotCreateExplorerRolesWhenAlreadyPresent() throws UpgraderException, TechnicalException {
+        String organizationId = GraviteeContext.getDefaultOrganization();
+        Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(organizationId);
+        when(organizationRepository.findAll()).thenReturn(Set.of(organization));
+
+        when(roleService.findByScopeAndName(eq(EXPLORER), eq(EXPLORER_ROLE_OWNER.getName()), eq(organizationId))).thenReturn(
+            Optional.of(new RoleEntity())
+        );
+        when(roleService.findByScopeAndName(eq(EXPLORER), eq(EXPLORER_ROLE_USER.getName()), eq(organizationId))).thenReturn(
+            Optional.of(new RoleEntity())
+        );
+
+        upgrader.upgrade();
+
+        verify(roleService, never()).create(any(), eq(EXPLORER_ROLE_OWNER));
+        verify(roleService, never()).create(any(), eq(EXPLORER_ROLE_USER));
+        verify(roleService).createOrUpdateSystemRoles(any(), eq(organizationId));
+    }
+
+    @Test
+    public void test_order() {
+        Assertions.assertEquals(UpgraderOrder.EXPLORER_ROLES_UPGRADER, upgrader.getOrder());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/KafkaExplorerPermissionUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/KafkaExplorerPermissionUpgraderTest.java
@@ -47,7 +47,7 @@ import org.mockito.quality.Strictness;
 public class KafkaExplorerPermissionUpgraderTest {
 
     private static final String CLUSTER = EnvironmentPermission.CLUSTER.getName();
-    private static final String KAFKA_EXPLORER = EnvironmentPermission.KAFKA_EXPLORER.getName();
+    private static final String EXPLORER = EnvironmentPermission.EXPLORER.getName();
     private static final char[] CLUSTER_ACLS = { 'C', 'R', 'U', 'D' };
     private static final String ORG_A = "org-a";
     private static final String ORG_B = "org-b";
@@ -75,7 +75,7 @@ public class KafkaExplorerPermissionUpgraderTest {
         verify(roleService).update(any(ExecutionContext.class), updated.capture());
 
         Map<String, char[]> permissions = updated.getValue().getPermissions();
-        assertThat(permissions.get(KAFKA_EXPLORER)).isEqualTo(CLUSTER_ACLS);
+        assertThat(permissions.get(EXPLORER)).isEqualTo(CLUSTER_ACLS);
         assertThat(permissions.get(CLUSTER)).isEqualTo(CLUSTER_ACLS);
 
         verify(roleService).createOrUpdateSystemRoles(any(ExecutionContext.class), eq(orgId));
@@ -101,7 +101,7 @@ public class KafkaExplorerPermissionUpgraderTest {
         mockOrganizations(orgId);
 
         char[] customAcls = { 'R' };
-        RoleEntity role = roleWithPermissions("role-id", Map.of(CLUSTER, CLUSTER_ACLS, KAFKA_EXPLORER, customAcls));
+        RoleEntity role = roleWithPermissions("role-id", Map.of(CLUSTER, CLUSTER_ACLS, EXPLORER, customAcls));
         when(roleService.findByScope(ENVIRONMENT, orgId)).thenReturn(List.of(role));
 
         assertThat(upgrader.upgrade()).isTrue();


### PR DESCRIPTION
## Context

Kafka Explorer connections need to be shareable per-resource like Clusters — granting a member/group **explore** access to a connection without **config/delete**, and hiding the config from explore-only users. This adds a dedicated `EXPLORER` role scope to APIM core (the gamma esm module will consume it in a follow-up PR).

## What changes

- **New `EXPLORER` scope** (per-connection membership, modelled on `CLUSTER`): `RoleScope.EXPLORER` (model, repository-api, core), `ExplorerPermission { CONFIGURATION, MEMBER }`, `RolePermission.EXPLORER_CONFIGURATION` / `EXPLORER_MEMBER`, `Permission.findByScope`.
  - `CONFIGURATION[R]` = explore / use the connection · `[U/D]` = manage config · `MEMBER` = share.
- **Membership**: `MembershipReferenceType.EXPLORER` (generic — a future MQTT explorer reuses the same scope/refType), wired in `PermissionServiceImpl` and resolved on the `connectionId` path param in `PermissionsFilter`.
- **Default & system roles**: `EXPLORER` OWNER / USER default roles, `ExplorerRolesUpgrader`, and the `EXPLORER` `PRIMARY_OWNER` system role (both `RoleServiceImpl` and `DefaultOrganizationAdminRoleInitializer`).
- **Env umbrella permission renamed** `KAFKA_EXPLORER` → `EXPLORER` (gates menu visibility + connection creation, like `ENVIRONMENT_CLUSTER`).
- **Exposed** through `RoleScopesResource`. Persists as the enum name in both JDBC and MongoDB (no int mapping / no Liquibase constraint); round-trip coverage added in the shared repository test suite.

## Follow-up (gamma esm, separate PR)

Swap the explorer resources' `@Permissions` to the new scope, add per-connection membership + members / permissions endpoints and the management screens. Note: the explore endpoints carry `connectionId`/`clusterId` in the request body, so per-connection enforcement there must be programmatic (the annotation filter only reads path/query params).