### PR TITLE
ci: build APIM Chainguard FIPS product images (Azure-only)

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -171,9 +171,15 @@ const ssh = {
 
 const docker = {
   version: 'default',
+  // Base images passed as the BASE_IMAGE build-arg to Dockerfile.chainguard when building
+  // the FIPS-140-3 variant. Java: BC-FIPS providers + bcfks keystore. Nginx: FIPS-validated
+  // OpenSSL (used by the UI images, which serve static content over plain HTTP — TLS is
+  // terminated upstream — so this is a compliance base, not a functional TLS change).
+  fipsJavaBaseImage: 'graviteeio.azurecr.io/java:21-chainguard-fips',
+  fipsNginxBaseImage: 'graviteeio.azurecr.io/nginx:1.30-chainguard-fips',
 };
 
-export type Variant = 'alpine' | 'debian' | 'chainguard';
+export type Variant = 'alpine' | 'debian' | 'chainguard' | 'chainguard-fips';
 export const config = {
   aqua,
   artifactoryUrl,

--- a/.circleci/ci/src/jobs/job-build-docker-image.ts
+++ b/.circleci/ci/src/jobs/job-build-docker-image.ts
@@ -226,6 +226,63 @@ export class BuildDockerChainguardImageJob {
   }
 }
 
+export class BuildDockerChainguardFipsImageJob {
+  private static jobName = 'job-build-docker-chainguard-fips-image';
+
+  private static customParametersList = new parameters.CustomParametersList([
+    new parameters.CustomParameter('apim-project', 'string', '', 'the name of the project to build'),
+    new parameters.CustomParameter('apim-project-workdir', 'string', '', 'the directory of the project to build'),
+    new parameters.CustomParameter('docker-context', 'string', '', 'the name of context folder for docker build'),
+    new parameters.CustomParameter('docker-image-name', 'string', '', 'the name of the image'),
+    new parameters.CustomParameter(
+      'docker-fips-base-image',
+      'string',
+      '',
+      'the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)',
+    ),
+  ]);
+
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment, isProd: boolean): reusable.ParameterizedJob {
+    dynamicConfig.importOrb(orbs.keeper);
+
+    const createDockerContextCommand = CreateDockerContextCommand.get();
+    dynamicConfig.addReusableCommand(createDockerContextCommand);
+
+    // FIPS images are always published to the private Azure registry (never Docker Hub),
+    // and both the chainguard-fips base and the produced image live on azurecr — so a
+    // single azurecr login covers pull + push regardless of release mode.
+    // Register under a distinct command name ('cmd-docker-login-azurecr') so this azurecr
+    // login does not overwrite the shared 'cmd-docker-login' (Docker Hub) used by the
+    // isProd jobs sharing the same dynamicConfig in build-docker-images / full-release.
+    const dockerLoginCommand = DockerLoginCommand.get(dynamicConfig, environment, false, 'cmd-docker-login-azurecr');
+    dynamicConfig.addReusableCommand(dockerLoginCommand);
+    const dockerLogoutCommand = DockerLogoutCommand.get(environment, false, 'cmd-docker-logout-azurecr');
+    dynamicConfig.addReusableCommand(dockerLogoutCommand);
+
+    const parsedGraviteeioVersion = parse(environment.graviteeioVersion);
+    const dockerTags: string[] = dockerTagsArgument(environment, parsedGraviteeioVersion, isProd, 'chainguard-fips');
+
+    return new reusable.ParameterizedJob(
+      BuildDockerChainguardFipsImageJob.jobName,
+      BaseExecutor.create(),
+      BuildDockerChainguardFipsImageJob.customParametersList,
+      [
+        new commands.Checkout(),
+        new commands.workspace.Attach({ at: '.' }),
+        new commands.SetupRemoteDocker({ version: config.docker.version }),
+        new reusable.ReusedCommand(createDockerContextCommand),
+        new reusable.ReusedCommand(dockerLoginCommand),
+        new commands.Run({
+          name: 'Build Chainguard FIPS docker image for << parameters.apim-project >>',
+          command: `${dockerBuildCommand(environment, dockerTags, isProd, 'chainguard-fips')}`,
+          working_directory: '<< parameters.apim-project-workdir >>',
+        }),
+        new reusable.ReusedCommand(dockerLogoutCommand),
+      ],
+    );
+  }
+}
+
 function aquaSetupCommands() {
   return [
     new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
@@ -263,7 +320,8 @@ function dockerBuildCommand(environment: CircleCIEnvironment, dockerTags: string
   let dockerfile = 'docker/Dockerfile';
   if (variant === 'debian') {
     dockerfile = 'docker/Dockerfile.debian';
-  } else if (variant === 'chainguard') {
+  } else if (variant === 'chainguard' || variant === 'chainguard-fips') {
+    // The FIPS variant reuses the chainguard Dockerfile; only the BASE_IMAGE build-arg differs.
     dockerfile = 'docker/Dockerfile.chainguard';
   }
 
@@ -277,6 +335,12 @@ function dockerBuildCommand(environment: CircleCIEnvironment, dockerTags: string
   }
 
   command += ` --platform=linux/arm64,linux/amd64 -f ${dockerfile} \\\n`;
+
+  if (variant === 'chainguard-fips') {
+    // The FIPS base (java or nginx) is supplied per-component via the docker-fips-base-image
+    // job parameter; the chainguard Dockerfiles all read it through the BASE_IMAGE arg.
+    command += `--build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \\\n`;
+  }
 
   command += `${dockerTags.map((t) => `-t ${t}`).join(' ')} \\\n`;
   command += `<< parameters.docker-context >>`;
@@ -296,9 +360,14 @@ function dockerTagsArgument(
     suffix = '-debian';
   } else if (variant === 'chainguard') {
     suffix = '-chainguard';
+  } else if (variant === 'chainguard-fips') {
+    suffix = '-chainguard-fips';
   }
+  // FIPS images are never published to Docker Hub, only to the private Azure registry
+  // (even for a release). Keep the isProd version-tag logic but swap the registry stub.
+  const isFips = variant === 'chainguard-fips';
   if (isProd) {
-    const stub = `graviteeio/<< parameters.docker-image-name >>:`;
+    const stub = isFips ? `graviteeio.azurecr.io/<< parameters.docker-image-name >>:` : `graviteeio/<< parameters.docker-image-name >>:`;
 
     // Default tag
     tags.push(stub + graviteeioVersion.full + suffix);

--- a/.circleci/ci/src/pipelines/config-factory.ts
+++ b/.circleci/ci/src/pipelines/config-factory.ts
@@ -29,6 +29,7 @@ export function initDynamicConfig(): Config {
     'build_rpm',
     'build_docker_images',
     'build_chainguard_images',
+    'build_chainguard_fips_images',
     'release_notes_apim',
     'bridge_compatibility_tests',
     'publish_docker_images',

--- a/.circleci/ci/src/pipelines/pipeline-build-chainguard-fips-images.ts
+++ b/.circleci/ci/src/pipelines/pipeline-build-chainguard-fips-images.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CircleCIEnvironment } from './circleci-environment';
+import { Config } from '@circleci/circleci-config-sdk';
+import { isBlank, validateGraviteeioVersion } from '../utils';
+import { BuildChainguardFipsImagesWorkflow } from '../workflows';
+import { initDynamicConfig } from './config-factory';
+
+export function generateBuildChainguardFipsImagesConfig(environment: CircleCIEnvironment): Config {
+  validateGraviteeioVersion(environment.graviteeioVersion);
+
+  if (isBlank(environment.branch)) {
+    throw new Error('A branch (CIRCLE_BRANCH) must be specified');
+  }
+
+  const dynamicConfig = initDynamicConfig();
+  const workflow = BuildChainguardFipsImagesWorkflow.create(dynamicConfig, environment);
+  dynamicConfig.addWorkflow(workflow);
+  return dynamicConfig;
+}

--- a/.circleci/ci/src/pipelines/pipeline.ts
+++ b/.circleci/ci/src/pipelines/pipeline.ts
@@ -26,6 +26,7 @@ import { generateReleaseConfig } from './pipeline-release';
 import { generateBuildRpmConfig } from './pipeline-build-rpm';
 import { generateBuildDockerImagesConfig } from './pipeline-build-docker-images';
 import { generateBuildChainguardImagesConfig } from './pipeline-build-chainguard-images';
+import { generateBuildChainguardFipsImagesConfig } from './pipeline-build-chainguard-fips-images';
 import { generatePullRequestsConfig } from './pipeline-pull-requests';
 import { generateFullReleaseConfig } from './pipeline-full-release';
 import { generateHelmTestsConfig } from './pipeline-helm-tests';
@@ -42,6 +43,8 @@ export function buildCIPipeline(environment: CircleCIEnvironment): Config | null
       return generateBuildDockerImagesConfig(environment);
     case 'build_chainguard_images':
       return generateBuildChainguardImagesConfig(environment);
+    case 'build_chainguard_fips_images':
+      return generateBuildChainguardFipsImagesConfig(environment);
     case 'release_helm':
       return generateReleaseHelmConfig(environment);
     case 'full_release':

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-dry-run.yml
@@ -468,6 +468,48 @@ jobs:
           working_directory: << parameters.apim-project-workdir >>
       - cmd-docker-logout
       - cmd-docker-logout-azurecr
+  job-build-docker-chainguard-fips-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+      docker-fips-base-image:
+        type: string
+        default: ""
+        description: the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - run:
+          name: Build Chainguard FIPS docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-alpha.1-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-alpha-chainguard-fips \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout-azurecr
 workflows:
   build-docker-images:
     jobs:
@@ -599,6 +641,61 @@ workflows:
           apim-project-workdir: gravitee-apim-gateway
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
 orbs:
   keeper: gravitee-io/keeper@0.7.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-prerelease-no-dry-run.yml
@@ -468,6 +468,48 @@ jobs:
           working_directory: << parameters.apim-project-workdir >>
       - cmd-docker-logout
       - cmd-docker-logout-azurecr
+  job-build-docker-chainguard-fips-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+      docker-fips-base-image:
+        type: string
+        default: ""
+        description: the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - run:
+          name: Build Chainguard FIPS docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-alpha.1-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-alpha-chainguard-fips \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout-azurecr
 workflows:
   build-docker-images:
     jobs:
@@ -599,6 +641,61 @@ workflows:
           apim-project-workdir: gravitee-apim-gateway
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
 orbs:
   keeper: gravitee-io/keeper@0.7.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-dry-run.yml
@@ -468,6 +468,48 @@ jobs:
           working_directory: << parameters.apim-project-workdir >>
       - cmd-docker-logout
       - cmd-docker-logout-azurecr
+  job-build-docker-chainguard-fips-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+      docker-fips-base-image:
+        type: string
+        default: ""
+        description: the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - run:
+          name: Build Chainguard FIPS docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2-chainguard-fips \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout-azurecr
 workflows:
   build-docker-images:
     jobs:
@@ -599,6 +641,61 @@ workflows:
           apim-project-workdir: gravitee-apim-gateway
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
 orbs:
   keeper: gravitee-io/keeper@0.7.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run-as-latest.yml
@@ -468,6 +468,48 @@ jobs:
           working_directory: << parameters.apim-project-workdir >>
       - cmd-docker-logout
       - cmd-docker-logout-azurecr
+  job-build-docker-chainguard-fips-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+      docker-fips-base-image:
+        type: string
+        default: ""
+        description: the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - run:
+          name: Build Chainguard FIPS docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:latest-chainguard-fips \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout-azurecr
 workflows:
   build-docker-images:
     jobs:
@@ -599,6 +641,61 @@ workflows:
           apim-project-workdir: gravitee-apim-gateway
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
 orbs:
   keeper: gravitee-io/keeper@0.7.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-docker-images/build-docker-images-release-no-dry-run.yml
@@ -468,6 +468,48 @@ jobs:
           working_directory: << parameters.apim-project-workdir >>
       - cmd-docker-logout
       - cmd-docker-logout-azurecr
+  job-build-docker-chainguard-fips-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+      docker-fips-base-image:
+        type: string
+        default: ""
+        description: the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - run:
+          name: Build Chainguard FIPS docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2-chainguard-fips \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout-azurecr
 workflows:
   build-docker-images:
     jobs:
@@ -599,6 +641,61 @@ workflows:
           apim-project-workdir: gravitee-apim-gateway
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Backend build
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
 orbs:
   keeper: gravitee-io/keeper@0.7.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -486,6 +486,48 @@ jobs:
           working_directory: << parameters.apim-project-workdir >>
       - cmd-docker-logout
       - cmd-docker-logout-azurecr
+  job-build-docker-chainguard-fips-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+      docker-fips-base-image:
+        type: string
+        default: ""
+        description: the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - run:
+          name: Build Chainguard FIPS docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-alpha.1-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-alpha-chainguard-fips \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout-azurecr
   job-backend-build-and-publish-on-download-website:
     docker:
       - image: cimg/openjdk:21.0.9-node
@@ -871,6 +913,31 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-trigger-saas-docker-images-chainguard-fips:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger SaaS Docker images pipeline
+          command: |-
+            PIPELINE_ID=$(curl --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/cloud-distributions/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"project":"apim", "distribution":"prod", "branch-version":"4.2.x", "sha1":"784ff35", "release-version":"4.2.0-alpha.1", "dry-run":false, "os-distribution":"chainguard-fips"}}' | jq -r '.id')
+            echo "Pipeline triggered with ID: $PIPELINE_ID"
+            waitForPipelineCompletion() {
+                while true; do
+                    STATUS=$(curl --request GET --url "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" --header "Circle-Token: ${CIRCLE_TOKEN}" | jq -r '.items[].status')
+                    echo "Current status: $STATUS"
+                    if [[ "$STATUS" == "success" ]]; then
+                        echo "Pipeline completed successfully."
+                        break
+                    elif [[ "$STATUS" == "failed" ]]; then
+                        echo "Pipeline failed."
+                        exit 1
+                    fi
+                    sleep 30
+                done
+            }  
+            waitForPipelineCompletion
   job-trigger-apim-api-docs-pipeline:
     docker:
       - image: cimg/base:stable
@@ -1017,6 +1084,61 @@ workflows:
           apim-project-workdir: gravitee-apim-gateway
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard-fips docker image for APIM 4.2.0-alpha.1
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
       - job-release-commit-and-prepare-next-version:
           context:
             - cicd-orchestrator
@@ -1059,6 +1181,17 @@ workflows:
             - Build Gamma Console chainguard docker image for APIM 4.2.0-alpha.1
             - Build APIM Management API chainguard docker image for APIM 4.2.0-alpha.1
             - Build APIM Gateway chainguard docker image for APIM 4.2.0-alpha.1
+      - job-trigger-saas-docker-images-chainguard-fips:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger SaaS Chainguard FIPS Docker images creation
+          requires:
+            - Build APIM Management API chainguard-fips docker image for APIM 4.2.0-alpha.1
+            - Build APIM Gateway chainguard-fips docker image for APIM 4.2.0-alpha.1
+            - Build APIM Portal chainguard-fips docker image for APIM 4.2.0-alpha.1
+            - Build APIM Console chainguard-fips docker image for APIM 4.2.0-alpha.1
+            - Build Gamma Console chainguard-fips docker image for APIM 4.2.0-alpha.1
       - job-nexus-staging:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -486,6 +486,48 @@ jobs:
           working_directory: << parameters.apim-project-workdir >>
       - cmd-docker-logout
       - cmd-docker-logout-azurecr
+  job-build-docker-chainguard-fips-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+      docker-fips-base-image:
+        type: string
+        default: ""
+        description: the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - run:
+          name: Build Chainguard FIPS docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2-chainguard-fips \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout-azurecr
   job-backend-build-and-publish-on-download-website:
     docker:
       - image: cimg/openjdk:21.0.9-node
@@ -905,6 +947,31 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-trigger-saas-docker-images-chainguard-fips:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger SaaS Docker images pipeline
+          command: |-
+            PIPELINE_ID=$(curl --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/cloud-distributions/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"project":"apim", "distribution":"prod", "branch-version":"4.2.x", "sha1":"784ff35", "release-version":"4.2.0", "dry-run":true, "os-distribution":"chainguard-fips"}}' | jq -r '.id')
+            echo "Pipeline triggered with ID: $PIPELINE_ID"
+            waitForPipelineCompletion() {
+                while true; do
+                    STATUS=$(curl --request GET --url "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" --header "Circle-Token: ${CIRCLE_TOKEN}" | jq -r '.items[].status')
+                    echo "Current status: $STATUS"
+                    if [[ "$STATUS" == "success" ]]; then
+                        echo "Pipeline completed successfully."
+                        break
+                    elif [[ "$STATUS" == "failed" ]]; then
+                        echo "Pipeline failed."
+                        exit 1
+                    fi
+                    sleep 30
+                done
+            }  
+            waitForPipelineCompletion
   job-trigger-apim-api-docs-pipeline:
     docker:
       - image: cimg/base:stable
@@ -1051,6 +1118,61 @@ workflows:
           apim-project-workdir: gravitee-apim-gateway
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
       - job-release-commit-and-prepare-next-version:
           context:
             - cicd-orchestrator
@@ -1093,6 +1215,17 @@ workflows:
             - Build Gamma Console chainguard docker image for APIM 4.2.0
             - Build APIM Management API chainguard docker image for APIM 4.2.0
             - Build APIM Gateway chainguard docker image for APIM 4.2.0
+      - job-trigger-saas-docker-images-chainguard-fips:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger SaaS Chainguard FIPS Docker images creation
+          requires:
+            - Build APIM Management API chainguard-fips docker image for APIM 4.2.0
+            - Build APIM Gateway chainguard-fips docker image for APIM 4.2.0
+            - Build APIM Portal chainguard-fips docker image for APIM 4.2.0
+            - Build APIM Console chainguard-fips docker image for APIM 4.2.0
+            - Build Gamma Console chainguard-fips docker image for APIM 4.2.0
       - job-nexus-staging:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -486,6 +486,48 @@ jobs:
           working_directory: << parameters.apim-project-workdir >>
       - cmd-docker-logout
       - cmd-docker-logout-azurecr
+  job-build-docker-chainguard-fips-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+      docker-fips-base-image:
+        type: string
+        default: ""
+        description: the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - run:
+          name: Build Chainguard FIPS docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:latest-chainguard-fips \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout-azurecr
   job-backend-build-and-publish-on-download-website:
     docker:
       - image: cimg/openjdk:21.0.9-node
@@ -917,6 +959,31 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-trigger-saas-docker-images-chainguard-fips:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger SaaS Docker images pipeline
+          command: |-
+            PIPELINE_ID=$(curl --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/cloud-distributions/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"project":"apim", "distribution":"prod", "branch-version":"4.2.x", "sha1":"784ff35", "release-version":"4.2.0", "dry-run":false, "os-distribution":"chainguard-fips"}}' | jq -r '.id')
+            echo "Pipeline triggered with ID: $PIPELINE_ID"
+            waitForPipelineCompletion() {
+                while true; do
+                    STATUS=$(curl --request GET --url "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" --header "Circle-Token: ${CIRCLE_TOKEN}" | jq -r '.items[].status')
+                    echo "Current status: $STATUS"
+                    if [[ "$STATUS" == "success" ]]; then
+                        echo "Pipeline completed successfully."
+                        break
+                    elif [[ "$STATUS" == "failed" ]]; then
+                        echo "Pipeline failed."
+                        exit 1
+                    fi
+                    sleep 30
+                done
+            }  
+            waitForPipelineCompletion
   job-trigger-apim-api-docs-pipeline:
     docker:
       - image: cimg/base:stable
@@ -1063,6 +1130,61 @@ workflows:
           apim-project-workdir: gravitee-apim-gateway
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
       - job-release-commit-and-prepare-next-version:
           context:
             - cicd-orchestrator
@@ -1105,6 +1227,17 @@ workflows:
             - Build Gamma Console chainguard docker image for APIM 4.2.0
             - Build APIM Management API chainguard docker image for APIM 4.2.0
             - Build APIM Gateway chainguard docker image for APIM 4.2.0
+      - job-trigger-saas-docker-images-chainguard-fips:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger SaaS Chainguard FIPS Docker images creation
+          requires:
+            - Build APIM Management API chainguard-fips docker image for APIM 4.2.0
+            - Build APIM Gateway chainguard-fips docker image for APIM 4.2.0
+            - Build APIM Portal chainguard-fips docker image for APIM 4.2.0
+            - Build APIM Console chainguard-fips docker image for APIM 4.2.0
+            - Build Gamma Console chainguard-fips docker image for APIM 4.2.0
       - job-nexus-staging:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -486,6 +486,48 @@ jobs:
           working_directory: << parameters.apim-project-workdir >>
       - cmd-docker-logout
       - cmd-docker-logout-azurecr
+  job-build-docker-chainguard-fips-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+      docker-fips-base-image:
+        type: string
+        default: ""
+        description: the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - run:
+          name: Build Chainguard FIPS docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2-chainguard-fips \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout-azurecr
   job-backend-build-and-publish-on-download-website:
     docker:
       - image: cimg/openjdk:21.0.9-node
@@ -917,6 +959,31 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-trigger-saas-docker-images-chainguard-fips:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger SaaS Docker images pipeline
+          command: |-
+            PIPELINE_ID=$(curl --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/cloud-distributions/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"project":"apim", "distribution":"prod", "branch-version":"4.2.x", "sha1":"784ff35", "release-version":"4.2.0", "dry-run":false, "os-distribution":"chainguard-fips"}}' | jq -r '.id')
+            echo "Pipeline triggered with ID: $PIPELINE_ID"
+            waitForPipelineCompletion() {
+                while true; do
+                    STATUS=$(curl --request GET --url "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" --header "Circle-Token: ${CIRCLE_TOKEN}" | jq -r '.items[].status')
+                    echo "Current status: $STATUS"
+                    if [[ "$STATUS" == "success" ]]; then
+                        echo "Pipeline completed successfully."
+                        break
+                    elif [[ "$STATUS" == "failed" ]]; then
+                        echo "Pipeline failed."
+                        exit 1
+                    fi
+                    sleep 30
+                done
+            }  
+            waitForPipelineCompletion
   job-trigger-apim-api-docs-pipeline:
     docker:
       - image: cimg/base:stable
@@ -1063,6 +1130,61 @@ workflows:
           apim-project-workdir: gravitee-apim-gateway
           docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
           docker-image-name: apim-gateway
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard-fips docker image for APIM 4.2.0
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
       - job-release-commit-and-prepare-next-version:
           context:
             - cicd-orchestrator
@@ -1105,6 +1227,17 @@ workflows:
             - Build Gamma Console chainguard docker image for APIM 4.2.0
             - Build APIM Management API chainguard docker image for APIM 4.2.0
             - Build APIM Gateway chainguard docker image for APIM 4.2.0
+      - job-trigger-saas-docker-images-chainguard-fips:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger SaaS Chainguard FIPS Docker images creation
+          requires:
+            - Build APIM Management API chainguard-fips docker image for APIM 4.2.0
+            - Build APIM Gateway chainguard-fips docker image for APIM 4.2.0
+            - Build APIM Portal chainguard-fips docker image for APIM 4.2.0
+            - Build APIM Console chainguard-fips docker image for APIM 4.2.0
+            - Build Gamma Console chainguard-fips docker image for APIM 4.2.0
       - job-nexus-staging:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -136,6 +136,24 @@ commands:
           key: << parameters.apim-ui-project >>-cache-v1-{{ .Branch }}-{{ checksum "<< parameters.apim-ui-project-workdir >>/yarn.lock" }}
           paths:
             - ./<< parameters.apim-ui-project-workdir >>/node_modules
+  cmd-docker-login-azurecr:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Azure Container Registry
+          command: echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+    description: Login to Azure Container Registry
+  cmd-docker-logout-azurecr:
+    steps:
+      - run:
+          name: Logout from Azure Container Registry
+          command: docker logout graviteeio.azurecr.io
+    description: Logout from Azure Container Registry
 jobs:
   job-danger-js:
     docker:
@@ -1114,6 +1132,48 @@ jobs:
           command: yarn build
           working_directory: gravitee-apim-perf
       - cmd-notify-on-failure
+  job-build-docker-chainguard-fips-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+      docker-fips-base-image:
+        type: string
+        default: ""
+        description: the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - run:
+          name: Build Chainguard FIPS docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-784ff35-chainguard-fips \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout-azurecr
   job-community-build:
     docker:
       - image: cimg/openjdk:21.0.9-node
@@ -1620,6 +1680,61 @@ workflows:
             - Build APIM Gateway docker image
             - Build APIM Console docker image
             - Build APIM Portal docker image
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard-fips docker image
+          requires:
+            - Build backend
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard-fips docker image
+          requires:
+            - Build backend
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard-fips docker image
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard-fips docker image
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard-fips docker image
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
       - job-community-build:
           name: Check build as Community user
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -136,6 +136,24 @@ commands:
           key: << parameters.apim-ui-project >>-cache-v1-{{ .Branch }}-{{ checksum "<< parameters.apim-ui-project-workdir >>/yarn.lock" }}
           paths:
             - ./<< parameters.apim-ui-project-workdir >>/node_modules
+  cmd-docker-login-azurecr:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Azure Container Registry
+          command: echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+    description: Login to Azure Container Registry
+  cmd-docker-logout-azurecr:
+    steps:
+      - run:
+          name: Logout from Azure Container Registry
+          command: docker logout graviteeio.azurecr.io
+    description: Logout from Azure Container Registry
 jobs:
   job-danger-js:
     docker:
@@ -1114,6 +1132,48 @@ jobs:
           command: yarn build
           working_directory: gravitee-apim-perf
       - cmd-notify-on-failure
+  job-build-docker-chainguard-fips-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+      docker-fips-base-image:
+        type: string
+        default: ""
+        description: the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - run:
+          name: Build Chainguard FIPS docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35-chainguard-fips \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout-azurecr
   job-community-build:
     docker:
       - image: cimg/openjdk:21.0.9-node
@@ -1677,6 +1737,61 @@ workflows:
             - Build APIM Gateway docker image
             - Build APIM Console docker image
             - Build APIM Portal docker image
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard-fips docker image
+          requires:
+            - Build backend
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-rest-api
+          docker-context: gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target
+          docker-image-name: apim-management-api
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard-fips docker image
+          requires:
+            - Build backend
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-gateway
+          docker-context: gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target
+          docker-image-name: apim-gateway
+          docker-fips-base-image: graviteeio.azurecr.io/java:21-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard-fips docker image
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard-fips docker image
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard-fips docker image
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
       - job-community-build:
           name: Check build as Community user
           context:

--- a/.circleci/ci/src/workflows/index.ts
+++ b/.circleci/ci/src/workflows/index.ts
@@ -17,6 +17,7 @@ export * from './workflow-bridge-compatibility-tests';
 export * from './workflow-build-rpm';
 export * from './workflow-build-docker-images';
 export * from './workflow-build-chainguard-images';
+export * from './workflow-build-chainguard-fips-images';
 export * from './workflow-full-release';
 export * from './workflow-repositories-tests';
 export * from './workflow-package-bundle';

--- a/.circleci/ci/src/workflows/workflow-build-chainguard-fips-images.ts
+++ b/.circleci/ci/src/workflows/workflow-build-chainguard-fips-images.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Config, Workflow, workflow } from '@circleci/circleci-config-sdk';
+import { CircleCIEnvironment } from '../pipelines';
+import {
+  BackendBuildAndPublishOnDownloadWebsiteJob,
+  BuildDockerChainguardFipsImageJob,
+  ConsoleWebuiBuildJob,
+  GammaWebuiBuildJob,
+  PortalWebuiBuildJob,
+  SetupJob,
+} from '../jobs';
+import { config } from '../config';
+
+export class BuildChainguardFipsImagesWorkflow {
+  static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
+    const setupJob = SetupJob.create(dynamicConfig);
+    dynamicConfig.addJob(setupJob);
+    const consoleWebuiBuildJob = ConsoleWebuiBuildJob.create(dynamicConfig, environment);
+    dynamicConfig.addJob(consoleWebuiBuildJob);
+    const portalWebuiBuildJob = PortalWebuiBuildJob.create(dynamicConfig, environment);
+    dynamicConfig.addJob(portalWebuiBuildJob);
+    const gammaWebuiBuildJob = GammaWebuiBuildJob.create(dynamicConfig, environment);
+    dynamicConfig.addJob(gammaWebuiBuildJob);
+    const backendBuildJob = BackendBuildAndPublishOnDownloadWebsiteJob.create(dynamicConfig, environment, false);
+    dynamicConfig.addJob(backendBuildJob);
+    // isProd=false → azurecr with branch tags: this on-demand action is the test build.
+    const buildDockerChainguardFipsImageJob = BuildDockerChainguardFipsImageJob.create(dynamicConfig, environment, false);
+    dynamicConfig.addJob(buildDockerChainguardFipsImageJob);
+
+    const jobs = [
+      new workflow.WorkflowJob(setupJob, { context: config.jobContext, name: 'Setup' }),
+      // APIM Portal
+      new workflow.WorkflowJob(portalWebuiBuildJob, {
+        context: config.jobContext,
+        name: 'Build APIM Portal',
+        requires: ['Setup'],
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Portal chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build APIM Portal'],
+        'apim-project': config.components.portal.project,
+        'apim-project-workdir': config.components.portal.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.portal.image,
+        'docker-fips-base-image': config.docker.fipsNginxBaseImage,
+      }),
+
+      // APIM Console
+      new workflow.WorkflowJob(consoleWebuiBuildJob, {
+        context: config.jobContext,
+        name: 'Build APIM Console',
+        requires: ['Setup'],
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Console chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build APIM Console'],
+        'apim-project': config.components.console.project,
+        'apim-project-workdir': config.components.console.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.console.image,
+        'docker-fips-base-image': config.docker.fipsNginxBaseImage,
+      }),
+
+      // Gamma Console
+      new workflow.WorkflowJob(gammaWebuiBuildJob, {
+        context: config.jobContext,
+        name: 'Build Gamma Console',
+        requires: ['Setup'],
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build Gamma Console chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build Gamma Console'],
+        'apim-project': config.components.gamma.project,
+        'apim-project-workdir': config.components.gamma.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.gamma.image,
+        'docker-fips-base-image': config.docker.fipsNginxBaseImage,
+      }),
+
+      // APIM Backend (Java)
+      new workflow.WorkflowJob(backendBuildJob, {
+        context: config.jobContext,
+        name: 'Backend build',
+        requires: ['Setup'],
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Management API chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Backend build'],
+        'apim-project': config.components.managementApi.project,
+        'apim-project-workdir': config.components.managementApi.workdir,
+        'docker-context': 'gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target',
+        'docker-image-name': config.components.managementApi.image,
+        'docker-fips-base-image': config.docker.fipsJavaBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Gateway chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Backend build'],
+        'apim-project': config.components.gateway.project,
+        'apim-project-workdir': config.components.gateway.workdir,
+        'docker-context': 'gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target',
+        'docker-image-name': config.components.gateway.image,
+        'docker-fips-base-image': config.docker.fipsJavaBaseImage,
+      }),
+    ];
+
+    return new Workflow('build-chainguard-fips-images', jobs);
+  }
+}

--- a/.circleci/ci/src/workflows/workflow-build-docker-images.ts
+++ b/.circleci/ci/src/workflows/workflow-build-docker-images.ts
@@ -19,6 +19,7 @@ import {
   BackendBuildAndPublishOnDownloadWebsiteJob,
   BuildDockerBackendImageJob,
   BuildDockerChainguardImageJob,
+  BuildDockerChainguardFipsImageJob,
   BuildDockerWebUiImageJob,
   ConsoleWebuiBuildJob,
   GammaWebuiBuildJob,
@@ -45,6 +46,8 @@ export class BuildDockerImagesWorkflow {
     dynamicConfig.addJob(buildDockerBackendImageJob);
     const buildDockerChainguardImageJob = BuildDockerChainguardImageJob.create(dynamicConfig, environment, true);
     dynamicConfig.addJob(buildDockerChainguardImageJob);
+    const buildDockerChainguardFipsImageJob = BuildDockerChainguardFipsImageJob.create(dynamicConfig, environment, true);
+    dynamicConfig.addJob(buildDockerChainguardFipsImageJob);
 
     const jobs = [
       new workflow.WorkflowJob(setupJob, { context: config.jobContext, name: 'Setup' }),
@@ -166,6 +169,59 @@ export class BuildDockerImagesWorkflow {
         'apim-project-workdir': config.components.gateway.workdir,
         'docker-context': 'gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target',
         'docker-image-name': config.components.gateway.image,
+      }),
+
+      // Chainguard FIPS component images (Azure registry only, <version>-chainguard-fips).
+      // Java components use the java-fips base; the UIs use the nginx-fips base.
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Management API chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Backend build'],
+        'apim-project': config.components.managementApi.project,
+        'apim-project-workdir': config.components.managementApi.workdir,
+        'docker-context': 'gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target',
+        'docker-image-name': config.components.managementApi.image,
+        'docker-fips-base-image': config.docker.fipsJavaBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Gateway chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Backend build'],
+        'apim-project': config.components.gateway.project,
+        'apim-project-workdir': config.components.gateway.workdir,
+        'docker-context': 'gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target',
+        'docker-image-name': config.components.gateway.image,
+        'docker-fips-base-image': config.docker.fipsJavaBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Portal chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build APIM Portal'],
+        'apim-project': config.components.portal.project,
+        'apim-project-workdir': config.components.portal.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.portal.image,
+        'docker-fips-base-image': config.docker.fipsNginxBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Console chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build APIM Console'],
+        'apim-project': config.components.console.project,
+        'apim-project-workdir': config.components.console.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.console.image,
+        'docker-fips-base-image': config.docker.fipsNginxBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build Gamma Console chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build Gamma Console'],
+        'apim-project': config.components.gamma.project,
+        'apim-project-workdir': config.components.gamma.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.gamma.image,
+        'docker-fips-base-image': config.docker.fipsNginxBaseImage,
       }),
     ];
 

--- a/.circleci/ci/src/workflows/workflow-full-release.ts
+++ b/.circleci/ci/src/workflows/workflow-full-release.ts
@@ -18,6 +18,7 @@ import {
   BackendBuildAndPublishOnDownloadWebsiteJob,
   BuildDockerBackendImageJob,
   BuildDockerChainguardImageJob,
+  BuildDockerChainguardFipsImageJob,
   BuildDockerWebUiImageJob,
   ConsoleWebuiBuildJob,
   GammaWebuiBuildJob,
@@ -64,6 +65,10 @@ export class FullReleaseWorkflow {
     // alpine/debian variants; the private azurecr base is pulled via a second login.
     const buildDockerChainguardImageJob = BuildDockerChainguardImageJob.create(dynamicConfig, environment, true);
     dynamicConfig.addJob(buildDockerChainguardImageJob);
+    // FIPS component images: all components (gateway, management-api, portal, console, gamma),
+    // published to the private Azure registry only (<version>-chainguard-fips), never Docker Hub.
+    const buildDockerChainguardFipsImageJob = BuildDockerChainguardFipsImageJob.create(dynamicConfig, environment, true);
+    dynamicConfig.addJob(buildDockerChainguardFipsImageJob);
 
     const backendBuildAndPublishOnDownloadWebsiteJob = BackendBuildAndPublishOnDownloadWebsiteJob.create(dynamicConfig, environment, true);
     dynamicConfig.addJob(backendBuildAndPublishOnDownloadWebsiteJob);
@@ -91,6 +96,9 @@ export class FullReleaseWorkflow {
 
     const runTriggerSaasChainguardDockerImagesJob = TriggerSaasDockerImagesJob.create(environment, 'prod', 'chainguard');
     dynamicConfig.addJob(runTriggerSaasChainguardDockerImagesJob);
+
+    const runTriggerSaasChainguardFipsDockerImagesJob = TriggerSaasDockerImagesJob.create(environment, 'prod', 'chainguard-fips');
+    dynamicConfig.addJob(runTriggerSaasChainguardFipsDockerImagesJob);
 
     const triggerApimApiDocsPipelineJob = TriggerApimApiDocsPipelineJob.create(environment);
     dynamicConfig.addJob(triggerApimApiDocsPipelineJob);
@@ -224,6 +232,59 @@ export class FullReleaseWorkflow {
         'docker-image-name': config.components.gateway.image,
       }),
 
+      // Chainguard FIPS component images (Azure registry only, <version>-chainguard-fips).
+      // Java components use the java-fips base; the UIs use the nginx-fips base.
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Management API chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Backend build and publish on download website'],
+        'apim-project': config.components.managementApi.project,
+        'apim-project-workdir': config.components.managementApi.workdir,
+        'docker-context': 'gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target',
+        'docker-image-name': config.components.managementApi.image,
+        'docker-fips-base-image': config.docker.fipsJavaBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Gateway chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Backend build and publish on download website'],
+        'apim-project': config.components.gateway.project,
+        'apim-project-workdir': config.components.gateway.workdir,
+        'docker-context': 'gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target',
+        'docker-image-name': config.components.gateway.image,
+        'docker-fips-base-image': config.docker.fipsJavaBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Portal chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build APIM Portal'],
+        'apim-project': config.components.portal.project,
+        'apim-project-workdir': config.components.portal.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.portal.image,
+        'docker-fips-base-image': config.docker.fipsNginxBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Console chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build APIM Console'],
+        'apim-project': config.components.console.project,
+        'apim-project-workdir': config.components.console.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.console.image,
+        'docker-fips-base-image': config.docker.fipsNginxBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build Gamma Console chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+        requires: ['Build Gamma Console'],
+        'apim-project': config.components.gamma.project,
+        'apim-project-workdir': config.components.gamma.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.gamma.image,
+        'docker-fips-base-image': config.docker.fipsNginxBaseImage,
+      }),
+
       // Commit and set next version
       new workflow.WorkflowJob(releaseCommitAndPrepareNextVersionJob, {
         context: config.jobContext,
@@ -267,6 +328,19 @@ export class FullReleaseWorkflow {
           `Build Gamma Console chainguard docker image for APIM ${environment.graviteeioVersion}`,
           `Build APIM Management API chainguard docker image for APIM ${environment.graviteeioVersion}`,
           `Build APIM Gateway chainguard docker image for APIM ${environment.graviteeioVersion}`,
+        ],
+      }),
+
+      // Trigger SaaS Chainguard FIPS Docker images creation
+      new workflow.WorkflowJob(runTriggerSaasChainguardFipsDockerImagesJob, {
+        context: [...config.jobContext, 'keeper-orb-publishing'],
+        name: 'Trigger SaaS Chainguard FIPS Docker images creation',
+        requires: [
+          `Build APIM Management API chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+          `Build APIM Gateway chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+          `Build APIM Portal chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+          `Build APIM Console chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
+          `Build Gamma Console chainguard-fips docker image for APIM ${environment.graviteeioVersion}`,
         ],
       }),
 

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -22,6 +22,7 @@ import { BaseExecutor } from '../executors';
 import {
   BuildBackendJob,
   BuildDockerBackendImageJob,
+  BuildDockerChainguardFipsImageJob,
   BuildDockerWebUiImageJob,
   ChromaticConsoleJob,
   CommunityBuildBackendJob,
@@ -66,6 +67,7 @@ export class PullRequestsWorkflow {
       jobs.push(
         ...this.getCommonJobs(dynamicConfig, environment, false, false, shouldBuildDockerImages),
         ...this.getE2EJobs(dynamicConfig, environment),
+        ...(shouldBuildDockerImages ? this.getChainguardFipsJobs(dynamicConfig, environment) : []),
         ...this.getMasterAndSupportJobs(dynamicConfig, environment),
       );
     } else if (isE2EBranch(environment.branch)) {
@@ -567,6 +569,68 @@ export class PullRequestsWorkflow {
     }
 
     return jobs;
+  }
+
+  // FIPS product images built on support-branch/master PRs, pushed to the private Azure
+  // registry. Java components use the java-fips base; the UIs (nginx) use the nginx-fips base.
+  // Relies on the 'Build backend' / 'Build APIM Console|Portal', 'Build Gamma Console' jobs
+  // from getCommonJobs.
+  private static getChainguardFipsJobs(dynamicConfig: Config, environment: CircleCIEnvironment): workflow.WorkflowJob[] {
+    const buildDockerChainguardFipsImageJob = BuildDockerChainguardFipsImageJob.create(dynamicConfig, environment, false);
+    dynamicConfig.addJob(buildDockerChainguardFipsImageJob);
+
+    return [
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Management API chainguard-fips docker image`,
+        requires: ['Build backend'],
+        'apim-project': config.components.managementApi.project,
+        'apim-project-workdir': config.components.managementApi.workdir,
+        'docker-context': 'gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target',
+        'docker-image-name': config.components.managementApi.image,
+        'docker-fips-base-image': config.docker.fipsJavaBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Gateway chainguard-fips docker image`,
+        requires: ['Build backend'],
+        'apim-project': config.components.gateway.project,
+        'apim-project-workdir': config.components.gateway.workdir,
+        'docker-context': 'gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target',
+        'docker-image-name': config.components.gateway.image,
+        'docker-fips-base-image': config.docker.fipsJavaBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Console chainguard-fips docker image`,
+        requires: ['Build APIM Console'],
+        'apim-project': config.components.console.project,
+        'apim-project-workdir': config.components.console.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.console.image,
+        'docker-fips-base-image': config.docker.fipsNginxBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build APIM Portal chainguard-fips docker image`,
+        requires: ['Build APIM Portal'],
+        'apim-project': config.components.portal.project,
+        'apim-project-workdir': config.components.portal.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.portal.image,
+        'docker-fips-base-image': config.docker.fipsNginxBaseImage,
+      }),
+      new workflow.WorkflowJob(buildDockerChainguardFipsImageJob, {
+        context: config.jobContext,
+        name: `Build Gamma Console chainguard-fips docker image`,
+        requires: ['Build Gamma Console'],
+        'apim-project': config.components.gamma.project,
+        'apim-project-workdir': config.components.gamma.workdir,
+        'docker-context': '.',
+        'docker-image-name': config.components.gamma.image,
+        'docker-fips-base-image': config.docker.fipsNginxBaseImage,
+      }),
+    ];
   }
 
   private static getE2EJobs(dynamicConfig: Config, environment: CircleCIEnvironment): workflow.WorkflowJob[] {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ parameters:
                 build_rpm,
                 build_docker_images,
                 build_chainguard_images,
+                build_chainguard_fips_images,
                 release_notes_apim,
                 bridge_compatibility_tests,
                 publish_docker_images,

--- a/gravitee-apim-console-webui/docker/Dockerfile.chainguard
+++ b/gravitee-apim-console-webui/docker/Dockerfile.chainguard
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-FROM graviteeio.azurecr.io/nginx:1.30-chainguard
+# Override BASE_IMAGE to build the FIPS variant (graviteeio.azurecr.io/nginx:1.30-chainguard-fips)
+ARG BASE_IMAGE=graviteeio.azurecr.io/nginx:1.30-chainguard
+FROM ${BASE_IMAGE}
 LABEL maintainer="contact@graviteesource.com"
 
 ENV CONSOLE_BASE_HREF="/"

--- a/gravitee-apim-gateway/docker/Dockerfile.chainguard
+++ b/gravitee-apim-gateway/docker/Dockerfile.chainguard
@@ -15,7 +15,9 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio.azurecr.io/java:21-chainguard AS base
+# Override BASE_IMAGE to build the FIPS variant (graviteeio.azurecr.io/java:21-chainguard-fips)
+ARG BASE_IMAGE=graviteeio.azurecr.io/java:21-chainguard
+FROM ${BASE_IMAGE} AS base
 ENV GRAVITEEIO_HOME=/opt/graviteeio-gateway
 # Wolfi is glibc-based: no libc6-compat and no musl ld-linux symlink needed.
 # jemalloc is installed (as in the alpine/debian variants) so deployments that set

--- a/gravitee-apim-portal-webui/docker/Dockerfile.chainguard
+++ b/gravitee-apim-portal-webui/docker/Dockerfile.chainguard
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-FROM graviteeio.azurecr.io/nginx:1.30-chainguard
+# Override BASE_IMAGE to build the FIPS variant (graviteeio.azurecr.io/nginx:1.30-chainguard-fips)
+ARG BASE_IMAGE=graviteeio.azurecr.io/nginx:1.30-chainguard
+FROM ${BASE_IMAGE}
 LABEL maintainer="contact@graviteesource.com"
 
 EXPOSE 8080

--- a/gravitee-apim-rest-api/docker/Dockerfile.chainguard
+++ b/gravitee-apim-rest-api/docker/Dockerfile.chainguard
@@ -15,7 +15,9 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio.azurecr.io/java:21-chainguard AS base
+# Override BASE_IMAGE to build the FIPS variant (graviteeio.azurecr.io/java:21-chainguard-fips)
+ARG BASE_IMAGE=graviteeio.azurecr.io/java:21-chainguard
+FROM ${BASE_IMAGE} AS base
 ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
 
 # Second stage to add the folder and change the permissions and ownership

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/docker/Dockerfile.chainguard
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/docker/Dockerfile.chainguard
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-FROM graviteeio.azurecr.io/nginx:1.30-chainguard
+# Override BASE_IMAGE to build the FIPS variant (graviteeio.azurecr.io/nginx:1.30-chainguard-fips)
+ARG BASE_IMAGE=graviteeio.azurecr.io/nginx:1.30-chainguard
+FROM ${BASE_IMAGE}
 LABEL maintainer="contact@graviteesource.com"
 
 ENV GAMMA_CONSOLE_BASE_HREF="/"


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/ESM-109

**Description**

Adds a **`chainguard-fips`** variant of the APIM product images, built on the FIPS-140-3 Chainguard bases (`java:21-chainguard-fips` for the Java components, `nginx:1.30-chainguard-fips` for the UIs) and published to the private Azure registry only (never Docker Hub), even for a release.

- **All components**: gateway, management-api (java-fips base) **and** console, portal, gamma UIs (nginx-fips base). The UIs serve static content over plain HTTP (no TLS termination), so the FIPS nginx base is a compliance measure rather than a functional TLS change.
- The chainguard `Dockerfile`s are parameterized with a single **`BASE_IMAGE`** build-arg (default = the normal chainguard base); the FIPS base is supplied per component via a `docker-fips-base-image` job parameter. No new Dockerfile.
- **Azure registry only** — `-chainguard-fips` suffix, `graviteeio.azurecr.io`, version tags in release, branch tags in PR.

Wired into: pull requests on support branches / master, the `build_docker_images` and `full_release` pipelines, the `cloud-distributions` SaaS trigger (`os-distribution=chainguard-fips`), and a new on-demand `build_chainguard_fips_images` action.

**Additional context**

- CI generator tests pass (`npm test`, 100/100); generated resources validated with `circleci config validate`.
- Companion PRs: gravitee-docker#241 (nginx-fips base) and gravitee-io/cloud-distributions#52 (SaaS images).
- Known product-side limitation (unrelated to these images): the native Kafka SSL entrypoint fails under FIPS because `gravitee-common` hardcodes a `PKCS12` keystore type — tracked separately.
