### PR TITLE
Apim 14635 OIDC bff with review fixes

### DIFF
--- a/gravitee-apim-console-webui/src/auth/auth.service.spec.ts
+++ b/gravitee-apim-console-webui/src/auth/auth.service.spec.ts
@@ -121,7 +121,7 @@ describe('AuthService', () => {
   it('should skip SSO callback when no authorization code is present', done => {
     localStorage.setItem('user-provider-id-selected', 'google');
 
-    service.completeOidcLoginIfPresent().subscribe(() => {
+    service.checkAuth().subscribe(() => {
       done();
     });
 
@@ -139,15 +139,16 @@ describe('AuthService', () => {
       origin: 'http://localhost',
     };
 
-    service.completeOidcLoginIfPresent().subscribe(() => {
+    service.checkAuth().subscribe(() => {
       done();
     });
 
     httpTestingController.expectNone(`${BASE_URL}/auth/oauth2/google`);
   });
 
-  it('should exchange authorization code when completing OIDC login from SSO provider', done => {
+  it('should exchange authorization code on checkAuth from SSO provider', done => {
     localStorage.setItem('user-provider-id-selected', 'google');
+    sessionStorage.setItem('oidc-redirect-uri', 'http://localhost/console');
     jest.spyOn(window.history, 'replaceState').mockImplementation(() => {});
     const navigateSpy = jest.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
     const state = seedOidcTransaction();
@@ -159,9 +160,10 @@ describe('AuthService', () => {
       origin: 'http://localhost',
     };
 
-    service.completeOidcLoginIfPresent().subscribe(() => {
+    service.checkAuth().subscribe(() => {
       expect(navigateSpy).toHaveBeenCalledWith('/home', { replaceUrl: true });
       expect(sessionStorage.getItem('oidc-code-processed:auth-code')).toEqual('1');
+      expect(sessionStorage.getItem('oidc-redirect-uri')).toBeNull();
       done();
     });
 
@@ -250,7 +252,7 @@ describe('AuthService', () => {
       origin: 'http://localhost',
     };
 
-    service.completeOidcLoginIfPresent().subscribe({
+    service.checkAuth().subscribe({
       error: () => {
         expect(localStorage.getItem('user-provider-id-selected')).toBeNull();
         httpTestingController.expectNone(`${BASE_URL}/auth/oauth2/google`);

--- a/gravitee-apim-console-webui/src/auth/auth.service.spec.ts
+++ b/gravitee-apim-console-webui/src/auth/auth.service.spec.ts
@@ -216,6 +216,31 @@ describe('AuthService', () => {
     expect(hrefSetter).toHaveBeenCalledWith('https://idp.example.com/logout');
   });
 
+  it('should skip non-https logout_url and navigate to login', done => {
+    const hrefSetter = jest.fn();
+    const navigateSpy = jest.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      origin: 'http://localhost',
+      pathname: '/console',
+    };
+    Object.defineProperty(window.location, 'href', {
+      configurable: true,
+      set: hrefSetter,
+      get: () => '',
+    });
+
+    service.logout().subscribe(() => {
+      expect(hrefSetter).not.toHaveBeenCalled();
+      expect(navigateSpy).toHaveBeenCalledWith('/_login');
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${BASE_URL}/user/logout`);
+    req.flush({ logout_url: 'http://idp.example.com/logout' });
+  });
+
   it('should not redirect on logout when disableRedirect is set', done => {
     const navigateSpy = jest.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
 

--- a/gravitee-apim-console-webui/src/auth/auth.service.spec.ts
+++ b/gravitee-apim-console-webui/src/auth/auth.service.spec.ts
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+
+import { AuthService } from './auth.service';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
+import { Constants } from '../entities/Constants';
+import { SocialIdentityProvider } from '../entities/organization/socialIdentityProvider';
+
+const IDENTITY_PROVIDER: SocialIdentityProvider = {
+  id: 'google',
+  name: 'Google',
+  clientId: 'client-id',
+  authorizationEndpoint: 'https://idp.example.com/auth',
+  scopes: ['openid'],
+};
+
+const BASE_URL = CONSTANTS_TESTING.org!.baseURL!;
+
+function seedOidcTransaction(
+  overrides: Partial<{ state: string; redirectUrl: string; providerId: string; redirectUri: string; codeVerifier: string }> = {},
+) {
+  const transaction = {
+    state: 'oauth-state',
+    redirectUrl: '/home',
+    providerId: 'google',
+    redirectUri: 'http://localhost/console',
+    codeVerifier: 'test-code-verifier',
+    ...overrides,
+  };
+  sessionStorage.setItem('oidc-transaction', JSON.stringify(transaction));
+  return transaction.state;
+}
+
+const CONSTANTS_WITH_IDP: Constants = {
+  ...CONSTANTS_TESTING,
+  org: {
+    ...CONSTANTS_TESTING.org!,
+    identityProviders: [IDENTITY_PROVIDER],
+  },
+};
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpTestingController: HttpTestingController;
+  let router: Router;
+
+  beforeEach(() => {
+    Object.assign(globalThis.crypto, {
+      getRandomValues: (array: Uint8Array) => {
+        for (let i = 0; i < array.length; i++) {
+          array[i] = i % 256;
+        }
+        return array;
+      },
+      subtle: {
+        digest: jest.fn().mockResolvedValue(new Uint8Array(32).fill(7)),
+      },
+    });
+
+    TestBed.configureTestingModule({
+      imports: [GioTestingModule],
+      providers: [{ provide: Constants, useValue: CONSTANTS_WITH_IDP }],
+    });
+    service = TestBed.inject(AuthService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    router = TestBed.inject(Router);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  it('should redirect for SSO', done => {
+    const hrefSetter = jest.fn();
+
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      origin: 'http://localhost',
+      pathname: '/console',
+    };
+    Object.defineProperty(window.location, 'href', {
+      configurable: true,
+      set: hrefSetter,
+      get: () => '',
+    });
+
+    service.loginWithProvider('google', 'redirectUrl').subscribe(() => {
+      expect(localStorage.getItem('user-provider-id-selected')).toEqual('google');
+      expect(hrefSetter).toHaveBeenCalledWith(expect.stringContaining('https://idp.example.com/auth'));
+      expect(hrefSetter).toHaveBeenCalledWith(expect.stringContaining('code_challenge='));
+      expect(hrefSetter).toHaveBeenCalledWith(expect.stringContaining('code_challenge_method=S256'));
+      expect(hrefSetter).toHaveBeenCalledWith(expect.stringContaining('client_id=client-id'));
+      expect(hrefSetter.mock.calls[0][0]).not.toContain('state=redirectUrl');
+      done();
+    });
+  });
+
+  it('should throw when SSO provider is not found', () => {
+    expect(() => service.loginWithProvider('unknown', '/')).toThrow('Identity provider unknown not found!');
+  });
+
+  it('should skip SSO callback when no authorization code is present', done => {
+    localStorage.setItem('user-provider-id-selected', 'google');
+
+    service.completeOidcLoginIfPresent().subscribe(() => {
+      done();
+    });
+
+    httpTestingController.expectNone(`${BASE_URL}/auth/oauth2/google`);
+  });
+
+  it('should skip SSO callback when authorization code was already processed', done => {
+    localStorage.setItem('user-provider-id-selected', 'google');
+    sessionStorage.setItem('oidc-code-processed:auth-code', '1');
+
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      search: '?code=auth-code&state=%2Fhome',
+      pathname: '/',
+      origin: 'http://localhost',
+    };
+
+    service.completeOidcLoginIfPresent().subscribe(() => {
+      done();
+    });
+
+    httpTestingController.expectNone(`${BASE_URL}/auth/oauth2/google`);
+  });
+
+  it('should exchange authorization code when completing OIDC login from SSO provider', done => {
+    localStorage.setItem('user-provider-id-selected', 'google');
+    jest.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+    const navigateSpy = jest.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+    const state = seedOidcTransaction();
+
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      search: `?code=auth-code&state=${state}`,
+      pathname: '/console',
+      origin: 'http://localhost',
+    };
+
+    service.completeOidcLoginIfPresent().subscribe(() => {
+      expect(navigateSpy).toHaveBeenCalledWith('/home', { replaceUrl: true });
+      expect(sessionStorage.getItem('oidc-code-processed:auth-code')).toEqual('1');
+      done();
+    });
+
+    const oauthReq = httpTestingController.expectOne(`${BASE_URL}/auth/oauth2/google`);
+    expect(oauthReq.request.method).toBe('POST');
+    expect(oauthReq.request.body).toContain('code=auth-code');
+    expect(oauthReq.request.body).toContain('client_id=client-id');
+    expect(oauthReq.request.body).toContain('code_verifier=test-code-verifier');
+    oauthReq.flush('');
+
+    const userReq = httpTestingController.expectOne(`${BASE_URL}/user`);
+    userReq.flush({ id: 'user-1' });
+  });
+
+  it('should call /user/logout and navigate to login', done => {
+    localStorage.setItem('user-provider-id-selected', 'google');
+    const navigateSpy = jest.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+
+    service.logout().subscribe(() => {
+      expect(navigateSpy).toHaveBeenCalledWith('/_login');
+      expect(localStorage.getItem('user-provider-id-selected')).toBeNull();
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${BASE_URL}/user/logout`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body.post_logout_redirect_uri).toContain('/_login');
+    req.flush({});
+  });
+
+  it('should redirect to IdP logout URL when returned by server', () => {
+    const hrefSetter = jest.fn();
+
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      origin: 'http://localhost',
+      pathname: '/console',
+    };
+    Object.defineProperty(window.location, 'href', {
+      configurable: true,
+      set: hrefSetter,
+      get: () => '',
+    });
+
+    service.logout().subscribe();
+
+    const req = httpTestingController.expectOne(`${BASE_URL}/user/logout`);
+    req.flush({ logout_url: 'https://idp.example.com/logout' });
+
+    expect(hrefSetter).toHaveBeenCalledWith('https://idp.example.com/logout');
+  });
+
+  it('should not redirect on logout when disableRedirect is set', done => {
+    const navigateSpy = jest.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+
+    service.logout({ disableRedirect: true }).subscribe(() => {
+      expect(navigateSpy).not.toHaveBeenCalled();
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${BASE_URL}/user/logout`);
+    req.flush({});
+  });
+
+  it('should login with username and password', done => {
+    const navigateSpy = jest.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+
+    service.loginWithApim({ username: 'username', password: 'password' }, '/home').subscribe(() => {
+      expect(navigateSpy).toHaveBeenCalledWith('/home');
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${BASE_URL}/user/login`);
+    expect(req.request.headers.get('Authorization')).toEqual('Basic dXNlcm5hbWU6cGFzc3dvcmQ=');
+    req.flush(null);
+  });
+
+  it('should reject SSO callback with invalid state', done => {
+    localStorage.setItem('user-provider-id-selected', 'google');
+    jest.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      search: '?code=auth-code&state=invalid-state',
+      pathname: '/console',
+      origin: 'http://localhost',
+    };
+
+    service.completeOidcLoginIfPresent().subscribe({
+      error: () => {
+        expect(localStorage.getItem('user-provider-id-selected')).toBeNull();
+        httpTestingController.expectNone(`${BASE_URL}/auth/oauth2/google`);
+        done();
+      },
+    });
+  });
+
+  it('should redirect to login with current url on logout', done => {
+    Object.defineProperty(router, 'routerState', {
+      configurable: true,
+      value: { snapshot: { url: '/apis' } },
+    });
+    const navigateSpy = jest.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+
+    service.logout({ redirectToCurrentUrl: true }).subscribe(() => {
+      expect(navigateSpy).toHaveBeenCalledWith('/_login?redirect=/apis');
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${BASE_URL}/user/logout`);
+    req.flush({});
+  });
+
+  it('should complete logout when server returns an error', done => {
+    const navigateSpy = jest.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+
+    service.logout().subscribe(() => {
+      expect(navigateSpy).toHaveBeenCalledWith('/_login');
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${BASE_URL}/user/logout`);
+    req.flush('Server error', { status: 500, statusText: 'Server error' });
+  });
+});

--- a/gravitee-apim-console-webui/src/auth/auth.service.ts
+++ b/gravitee-apim-console-webui/src/auth/auth.service.ts
@@ -20,7 +20,13 @@ import { from, Observable, of, throwError } from 'rxjs';
 import { catchError, finalize, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { LocationStrategy } from '@angular/common';
 
-import { clearOidcTransaction, consumeOidcTransaction, OidcTransaction, storeOidcTransaction } from './oidc-transaction.util';
+import {
+  clearOidcTransaction,
+  consumeOidcTransaction,
+  isSafeOidcLogoutUrl,
+  OidcTransaction,
+  storeOidcTransaction,
+} from './oidc-transaction.util';
 
 import { Constants } from '../entities/Constants';
 import { CurrentUserService } from '../services-ngx/current-user.service';
@@ -173,8 +179,8 @@ export class AuthService {
           this.currentUserService.clearCurrent();
           this.providerIdSelectedStore = null;
 
-          if (logoutResponse?.logout_url) {
-            window.location.href = logoutResponse.logout_url;
+          if (isSafeOidcLogoutUrl(logoutResponse?.logout_url)) {
+            window.location.href = logoutResponse.logout_url!;
             return of(undefined);
           }
 

--- a/gravitee-apim-console-webui/src/auth/auth.service.ts
+++ b/gravitee-apim-console-webui/src/auth/auth.service.ts
@@ -15,27 +15,27 @@
  */
 import { Inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { UserManager, WebStorageStateStore, Log } from 'oidc-client-ts';
 import { Router } from '@angular/router';
-import { from, Observable, of } from 'rxjs';
-import { catchError, map, switchMap } from 'rxjs/operators';
+import { from, Observable, of, throwError } from 'rxjs';
+import { catchError, finalize, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { LocationStrategy } from '@angular/common';
 
+import { clearOidcTransaction, consumeOidcTransaction, OidcTransaction, storeOidcTransaction } from './oidc-transaction.util';
+
 import { Constants } from '../entities/Constants';
-import { CsrfInterceptor } from '../shared/interceptors/csrf.interceptor';
-import { HeaderXRequestedWithInterceptor } from '../shared/interceptors/header-x-requested-with.interceptor';
 import { CurrentUserService } from '../services-ngx/current-user.service';
 import { CustomUserFields } from '../entities/customUserFields';
-import { environment } from '../environments/environment';
+import { SocialIdentityProvider } from '../entities/organization/socialIdentityProvider';
 
 const USER_PROVIDER_ID_SELECTED = 'user-provider-id-selected';
+const OIDC_REDIRECT_URI_KEY = 'oidc-redirect-uri';
+const OIDC_CODE_PROCESSED_PREFIX = 'oidc-code-processed:';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
-  private oidcManagers: Record<string, UserManager> = {};
-
+  private oidcCallbackInFlight: Observable<void> | null = null;
   private set providerIdSelectedStore(providerId: string | null) {
     if (!providerId) {
       localStorage.removeItem(USER_PROVIDER_ID_SELECTED);
@@ -54,105 +54,98 @@ export class AuthService {
     private readonly router: Router,
     private readonly currentUserService: CurrentUserService,
     private readonly locationStrategy: LocationStrategy,
-  ) {
-    if (!environment.production) {
-      Log.setLogger(console);
-      Log.setLevel(Log.DEBUG);
-    }
-
-    // Initialize manager for each identity provider
-    constants.org.identityProviders?.forEach(idp => {
-      this.oidcManagers[idp.id] = new UserManager({
-        authority: idp.authorizationEndpoint,
-        client_id: idp.clientId,
-        redirect_uri: `${(window.location.origin + window.location.pathname).replace(/\/$/, '')}`,
-        scope: idp.scopes?.join(idp.scopeDelimiter ?? ' '),
-        response_type: 'code',
-        post_logout_redirect_uri: `${(window.location.origin + window.location.pathname).replace(/\/$/, '') + this.locationStrategy.prepareExternalUrl('/_login')}`,
-        userStore: new WebStorageStateStore({ store: window.localStorage }),
-        loadUserInfo: false,
-        extraHeaders: {
-          // Needed for Gravitee APIM POST method
-          [CsrfInterceptor.xsrfTokenHeaderName]: CsrfInterceptor.xsrfToken,
-          [HeaderXRequestedWithInterceptor.xRequestedWithHeaderName]: HeaderXRequestedWithInterceptor.xRequestedWithValue,
-        },
-        fetchRequestCredentials: 'include',
-        response_mode: 'query',
-
-        metadata: {
-          introspection_endpoint: idp.tokenIntrospectionEndpoint,
-          authorization_endpoint: idp.authorizationEndpoint,
-          end_session_endpoint:
-            idp.userLogoutEndpoint ??
-            `${(window.location.origin + window.location.pathname).replace(/\/$/, '') + this.locationStrategy.prepareExternalUrl('/_login')}`,
-          token_endpoint: `${constants.org.baseURL}/auth/oauth2/${idp.id}`,
-        },
-      });
-    });
-  }
+  ) {}
 
   checkAuth(): Observable<void> {
-    return new Observable<void>(observer => {
-      const providerIdSelected = this.providerIdSelectedStore;
-      if (!providerIdSelected) {
-        // No provider selected, we can't check auth
-        observer.next();
-        observer.complete();
-        return;
-      }
+    const providerIdSelected = this.providerIdSelectedStore;
+    const urlParams = new URLSearchParams(window.location.search);
+    const authorizationCode = urlParams.get('code');
+    const state = urlParams.get('state');
 
-      const oidcManager = this.oidcManagers[providerIdSelected];
-      if (!oidcManager) {
-        observer.error(new Error(`Identity provider ${providerIdSelected} not found!`));
-        return;
-      }
+    if (!providerIdSelected || !authorizationCode) {
+      return of(undefined);
+    }
 
-      oidcManager
-        .getUser()
-        .then(user => {
-          // If user still logged in
-          if (user && !user.expired) {
-            return user;
-          }
-          // If user not logged in, try call signinRedirectCallback
-          return oidcManager.signinRedirectCallback().then(user => {
-            const redirectUrl = (user.state as string) ?? '/';
-            return this.router.navigateByUrl(redirectUrl).then(() => user);
-          });
-        })
-        .then(_user => {
-          // Ok we are authenticated
-          observer.next();
-          observer.complete();
-        })
-        .catch(error => {
-          // KO User should restart authentication
-          this.providerIdSelectedStore = null;
-          observer.error(error);
-        });
-    });
+    const processedKey = `${OIDC_CODE_PROCESSED_PREFIX}${authorizationCode}`;
+    if (sessionStorage.getItem(processedKey)) {
+      return of(undefined);
+    }
+
+    if (this.oidcCallbackInFlight) {
+      return this.oidcCallbackInFlight;
+    }
+
+    const transaction = consumeOidcTransaction(state);
+    if (!transaction || transaction.providerId !== providerIdSelected) {
+      this.providerIdSelectedStore = null;
+      sessionStorage.removeItem(OIDC_REDIRECT_URI_KEY);
+      clearOidcTransaction();
+      return throwError(() => new Error('Invalid OIDC state'));
+    }
+
+    // Remove ?code= from the URL before the exchange so route guards cannot trigger a second redemption.
+    this.clearOidcQueryParams();
+
+    this.oidcCallbackInFlight = this.completeOidcCallback(providerIdSelected, authorizationCode, transaction).pipe(
+      tap(() => sessionStorage.setItem(processedKey, '1')),
+      finalize(() => {
+        this.oidcCallbackInFlight = null;
+      }),
+      shareReplay(1),
+      catchError(error => {
+        this.providerIdSelectedStore = null;
+        sessionStorage.removeItem(OIDC_REDIRECT_URI_KEY);
+        clearOidcTransaction();
+        return throwError(() => error);
+      }),
+    );
+
+    return this.oidcCallbackInFlight;
   }
 
   loginWithProvider(providerId: string, redirectUrl: string): Observable<void> {
-    if (!this.oidcManagers[providerId]) {
+    const identityProvider = this.constants.org.identityProviders?.find(idp => idp.id === providerId);
+    if (!identityProvider) {
       throw new Error(`Identity provider ${providerId} not found!`);
     }
+
+    return from(this.redirectToIdentityProvider(identityProvider, providerId, redirectUrl));
+  }
+
+  private async redirectToIdentityProvider(
+    identityProvider: SocialIdentityProvider,
+    providerId: string,
+    redirectUrl: string,
+  ): Promise<void> {
     this.providerIdSelectedStore = providerId;
 
-    return from(
-      this.oidcManagers[providerId].signinRedirect({
-        state: redirectUrl,
-      }),
-    );
+    const redirectUri = this.getRedirectUri();
+    sessionStorage.setItem(OIDC_REDIRECT_URI_KEY, redirectUri);
+
+    const { state, codeChallenge } = await storeOidcTransaction({
+      providerId,
+      redirectUrl: redirectUrl ?? '/',
+      redirectUri,
+    });
+
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: identityProvider.clientId!,
+      redirect_uri: redirectUri,
+      scope: identityProvider.scopes?.join(identityProvider.scopeDelimiter ?? ' ') ?? 'openid',
+      state,
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+    });
+
+    window.location.href = `${identityProvider.authorizationEndpoint}?${params.toString()}`;
   }
 
   loginWithApim({ username, password }: { username: string; password: string }, redirectUrl: string): Observable<void> {
     this.providerIdSelectedStore = null;
 
     return this.http
-      .post<{
-        access_token: string;
-      }>(
+      .post<void>(
         `${this.constants.org.baseURL}/user/login`,
         {},
         {
@@ -162,51 +155,40 @@ export class AuthService {
         },
       )
       .pipe(
-        switchMap(_response => {
-          return this.router.navigateByUrl(redirectUrl ?? '/');
-        }),
-        map(() => null),
+        switchMap(() => this.router.navigateByUrl(redirectUrl ?? '/')),
+        map(() => undefined),
       );
   }
 
   logout(options: { disableRedirect?: boolean; redirectToCurrentUrl?: boolean } = {}) {
-    return this.http.post(`${this.constants.org.baseURL}/user/logout`, {}).pipe(
-      catchError(() => {
-        // If logout failed, we can continue
-        return of({});
-      }),
-      switchMap(() => {
-        this.currentUserService.clearCurrent();
+    const postLogoutRedirectUri = this.getPostLogoutRedirectUri();
 
-        const oidcManager = this.oidcManagers[this.providerIdSelectedStore];
-        if (!oidcManager) {
-          return of({});
-        }
-        this.providerIdSelectedStore = null;
+    return this.http
+      .post<{ logout_url?: string }>(`${this.constants.org.baseURL}/user/logout`, {
+        post_logout_redirect_uri: postLogoutRedirectUri,
+      })
+      .pipe(
+        catchError(() => of({} as { logout_url?: string })),
+        switchMap(logoutResponse => {
+          this.currentUserService.clearCurrent();
+          this.providerIdSelectedStore = null;
 
-        return from(oidcManager.getUser()).pipe(
-          switchMap(user =>
-            from([
-              oidcManager.removeUser(),
-              oidcManager.signoutRedirect(user ? { id_token_hint: user.id_token } : {}).catch(() => null),
-              oidcManager.clearStaleState(),
-            ]),
-          ),
-        );
-      }),
-      switchMap(() => {
-        if (!options.disableRedirect) {
-          // If not logged with provider or if signoutRedirect() not configured for selected provider
-          // redirect to login page
-
-          if (options.redirectToCurrentUrl) {
-            return this.router.navigateByUrl(`/_login?redirect=${this.router.routerState.snapshot.url}`);
+          if (logoutResponse?.logout_url) {
+            window.location.href = logoutResponse.logout_url;
+            return of(undefined);
           }
 
-          return this.router.navigateByUrl('/_login');
-        }
-      }),
-    );
+          if (!options.disableRedirect) {
+            if (options.redirectToCurrentUrl) {
+              return this.router.navigateByUrl(`/_login?redirect=${this.router.routerState.snapshot.url}`);
+            }
+
+            return this.router.navigateByUrl('/_login');
+          }
+
+          return of(undefined);
+        }),
+      );
   }
 
   signUpCustomUserFields(): Observable<CustomUserFields> {
@@ -238,6 +220,56 @@ export class AuthService {
       firstname: userToReset.firstName,
       lastname: userToReset.lastName,
     });
+  }
+
+  private completeOidcCallback(providerId: string, authorizationCode: string, transaction: OidcTransaction): Observable<void> {
+    const identityProvider = this.constants.org.identityProviders?.find(idp => idp.id === providerId);
+    if (!identityProvider) {
+      return throwError(() => new Error(`Identity provider ${providerId} not found!`));
+    }
+
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: authorizationCode,
+      redirect_uri: transaction.redirectUri,
+      client_id: identityProvider.clientId!,
+      code_verifier: transaction.codeVerifier,
+    });
+
+    return this.http
+      .post(`${this.constants.org.baseURL}/auth/oauth2/${providerId}`, body.toString(), {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        responseType: 'text',
+      })
+      .pipe(
+        switchMap(() => {
+          sessionStorage.removeItem(OIDC_REDIRECT_URI_KEY);
+          // Drop any cached anonymous /user response before validating the new session cookie.
+          this.currentUserService.clearCurrent();
+          return this.currentUserService.current();
+        }),
+        switchMap(user => {
+          if (!user) {
+            return throwError(() => new Error('OIDC login failed'));
+          }
+
+          const redirectUrl = transaction.redirectUrl || '/';
+          return from(this.router.navigateByUrl(redirectUrl, { replaceUrl: true }));
+        }),
+        map(() => undefined),
+      );
+  }
+
+  private getRedirectUri(): string {
+    return `${(window.location.origin + window.location.pathname).replace(/\/$/, '')}`;
+  }
+
+  private clearOidcQueryParams() {
+    window.history.replaceState({}, '', window.location.pathname);
+  }
+
+  private getPostLogoutRedirectUri(): string {
+    return `${this.getRedirectUri() + this.locationStrategy.prepareExternalUrl('/_login')}`;
   }
 }
 

--- a/gravitee-apim-console-webui/src/auth/is-logged-in.guard.ts
+++ b/gravitee-apim-console-webui/src/auth/is-logged-in.guard.ts
@@ -38,7 +38,7 @@ export const IsLoggedInGuard: CanActivateFn = (_route: ActivatedRouteSnapshot, s
   const constants = inject(Constants);
   const ajsCurrentUserService: any = inject(AjsCurrentUserService);
 
-  return authService.checkAuth().pipe(
+  return authService.completeOidcLoginIfPresent().pipe(
     switchMap(() => currentUserService.current()),
     map(user => {
       if (!user) {

--- a/gravitee-apim-console-webui/src/auth/is-not-logged-in.guard.ts
+++ b/gravitee-apim-console-webui/src/auth/is-not-logged-in.guard.ts
@@ -27,7 +27,7 @@ export const IsNotLoggedInGuard: CanActivateFn = (route: ActivatedRouteSnapshot,
   const currentUserService = inject(CurrentUserService);
   const router = inject(Router);
 
-  return authService.checkAuth().pipe(
+  return authService.completeOidcLoginIfPresent().pipe(
     switchMap(() => currentUserService.current()),
     map(user => {
       return !!user;

--- a/gravitee-apim-console-webui/src/auth/oidc-transaction.util.spec.ts
+++ b/gravitee-apim-console-webui/src/auth/oidc-transaction.util.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { clearOidcTransaction, consumeOidcTransaction, storeOidcTransaction } from './oidc-transaction.util';
+
+const OIDC_TRANSACTION_STORAGE_KEY = 'oidc-transaction';
+
+async function computeExpectedCodeChallenge(codeVerifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
+  const binary = Array.from(new Uint8Array(digest), byte => String.fromCodePoint(byte)).join('');
+
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+describe('oidc-transaction.util', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  describe('storeOidcTransaction', () => {
+    it('should persist transaction and return state with PKCE S256 challenge', async () => {
+      const result = await storeOidcTransaction({
+        providerId: 'google',
+        redirectUrl: '/home',
+        redirectUri: 'http://localhost/console',
+      });
+
+      expect(result.state).toBeTruthy();
+      expect(result.codeChallenge).toBeTruthy();
+
+      const stored = JSON.parse(sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY)!);
+      expect(stored).toEqual({
+        state: result.state,
+        redirectUrl: '/home',
+        providerId: 'google',
+        redirectUri: 'http://localhost/console',
+        codeVerifier: stored.codeVerifier,
+      });
+      expect(stored.codeVerifier).toBeTruthy();
+      expect(result.codeChallenge).toEqual(await computeExpectedCodeChallenge(stored.codeVerifier));
+    });
+  });
+
+  describe('consumeOidcTransaction', () => {
+    it('should return null when state is missing', () => {
+      expect(consumeOidcTransaction(null)).toBeNull();
+      expect(consumeOidcTransaction('')).toBeNull();
+    });
+
+    it('should return null when no transaction is stored', () => {
+      expect(consumeOidcTransaction('oauth-state')).toBeNull();
+    });
+
+    it('should return null when stored transaction is invalid JSON', () => {
+      sessionStorage.setItem(OIDC_TRANSACTION_STORAGE_KEY, '{invalid-json');
+
+      expect(consumeOidcTransaction('oauth-state')).toBeNull();
+    });
+
+    it('should return null when state does not match', async () => {
+      await storeOidcTransaction({
+        providerId: 'google',
+        redirectUrl: '/home',
+        redirectUri: 'http://localhost/console',
+      });
+
+      expect(consumeOidcTransaction('wrong-state')).toBeNull();
+      expect(sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY)).toBeTruthy();
+    });
+
+    it('should return transaction and clear storage when state matches', async () => {
+      const { state } = await storeOidcTransaction({
+        providerId: 'google',
+        redirectUrl: '/home',
+        redirectUri: 'http://localhost/console',
+      });
+
+      const transaction = consumeOidcTransaction(state);
+
+      expect(transaction).toEqual(
+        expect.objectContaining({
+          state,
+          redirectUrl: '/home',
+          providerId: 'google',
+          redirectUri: 'http://localhost/console',
+        }),
+      );
+      expect(transaction?.codeVerifier).toBeTruthy();
+      expect(sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe('clearOidcTransaction', () => {
+    it('should remove stored transaction', async () => {
+      await storeOidcTransaction({
+        providerId: 'google',
+        redirectUrl: '/home',
+        redirectUri: 'http://localhost/console',
+      });
+
+      clearOidcTransaction();
+
+      expect(sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY)).toBeNull();
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/auth/oidc-transaction.util.spec.ts
+++ b/gravitee-apim-console-webui/src/auth/oidc-transaction.util.spec.ts
@@ -16,10 +16,10 @@
 import { clearOidcTransaction, consumeOidcTransaction, storeOidcTransaction } from './oidc-transaction.util';
 
 const OIDC_TRANSACTION_STORAGE_KEY = 'oidc-transaction';
+const MOCK_DIGEST = new Uint8Array(32).fill(7);
 
-async function computeExpectedCodeChallenge(codeVerifier: string): Promise<string> {
-  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
-  const binary = Array.from(new Uint8Array(digest), byte => String.fromCodePoint(byte)).join('');
+function encodeBase64Url(bytes: Uint8Array): string {
+  const binary = Array.from(bytes, byte => String.fromCodePoint(byte)).join('');
 
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 }
@@ -27,6 +27,17 @@ async function computeExpectedCodeChallenge(codeVerifier: string): Promise<strin
 describe('oidc-transaction.util', () => {
   beforeEach(() => {
     sessionStorage.clear();
+    Object.assign(globalThis.crypto, {
+      getRandomValues: (array: Uint8Array) => {
+        for (let i = 0; i < array.length; i++) {
+          array[i] = i % 256;
+        }
+        return array;
+      },
+      subtle: {
+        digest: jest.fn().mockResolvedValue(MOCK_DIGEST.buffer),
+      },
+    });
   });
 
   describe('storeOidcTransaction', () => {
@@ -49,7 +60,7 @@ describe('oidc-transaction.util', () => {
         codeVerifier: stored.codeVerifier,
       });
       expect(stored.codeVerifier).toBeTruthy();
-      expect(result.codeChallenge).toEqual(await computeExpectedCodeChallenge(stored.codeVerifier));
+      expect(result.codeChallenge).toEqual(encodeBase64Url(MOCK_DIGEST));
     });
   });
 

--- a/gravitee-apim-console-webui/src/auth/oidc-transaction.util.spec.ts
+++ b/gravitee-apim-console-webui/src/auth/oidc-transaction.util.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { clearOidcTransaction, consumeOidcTransaction, storeOidcTransaction } from './oidc-transaction.util';
+import { clearOidcTransaction, consumeOidcTransaction, isSafeOidcLogoutUrl, storeOidcTransaction } from './oidc-transaction.util';
 
 const OIDC_TRANSACTION_STORAGE_KEY = 'oidc-transaction';
 const MOCK_DIGEST = new Uint8Array(32).fill(7);
@@ -124,6 +124,16 @@ describe('oidc-transaction.util', () => {
       clearOidcTransaction();
 
       expect(sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe('isSafeOidcLogoutUrl', () => {
+    it('should allow https URLs only', () => {
+      expect(isSafeOidcLogoutUrl('https://idp.example.com/logout')).toBe(true);
+      expect(isSafeOidcLogoutUrl('http://idp.example.com/logout')).toBe(false);
+      expect(isSafeOidcLogoutUrl('javascript:alert(1)')).toBe(false);
+      expect(isSafeOidcLogoutUrl('not-a-url')).toBe(false);
+      expect(isSafeOidcLogoutUrl(undefined)).toBe(false);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/auth/oidc-transaction.util.ts
+++ b/gravitee-apim-console-webui/src/auth/oidc-transaction.util.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface OidcTransaction {
+  state: string;
+  redirectUrl: string;
+  providerId: string;
+  redirectUri: string;
+  codeVerifier: string;
+}
+
+const OIDC_TRANSACTION_STORAGE_KEY = 'oidc-transaction';
+
+export async function storeOidcTransaction(input: {
+  providerId: string;
+  redirectUrl: string;
+  redirectUri: string;
+}): Promise<{ state: string; codeChallenge: string }> {
+  const codeVerifier = generateCodeVerifier();
+  const state = generateRandomState();
+  const codeChallenge = await computeS256CodeChallenge(codeVerifier);
+
+  const transaction: OidcTransaction = {
+    state,
+    redirectUrl: input.redirectUrl,
+    providerId: input.providerId,
+    redirectUri: input.redirectUri,
+    codeVerifier,
+  };
+
+  sessionStorage.setItem(OIDC_TRANSACTION_STORAGE_KEY, JSON.stringify(transaction));
+
+  return { state, codeChallenge };
+}
+
+export function consumeOidcTransaction(receivedState: string | null): OidcTransaction | null {
+  if (!receivedState) {
+    return null;
+  }
+
+  const raw = sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  let transaction: OidcTransaction;
+  try {
+    transaction = JSON.parse(raw) as OidcTransaction;
+  } catch {
+    return null;
+  }
+
+  if (transaction.state !== receivedState) {
+    return null;
+  }
+
+  sessionStorage.removeItem(OIDC_TRANSACTION_STORAGE_KEY);
+  return transaction;
+}
+
+export function clearOidcTransaction(): void {
+  sessionStorage.removeItem(OIDC_TRANSACTION_STORAGE_KEY);
+}
+
+function generateCodeVerifier(): string {
+  const random = new Uint8Array(32);
+  crypto.getRandomValues(random);
+  return base64UrlEncode(random);
+}
+
+function generateRandomState(): string {
+  const random = new Uint8Array(16);
+  crypto.getRandomValues(random);
+  return base64UrlEncode(random);
+}
+
+async function computeS256CodeChallenge(codeVerifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  const binary = Array.from(bytes, byte => String.fromCodePoint(byte)).join('');
+
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}

--- a/gravitee-apim-console-webui/src/auth/oidc-transaction.util.ts
+++ b/gravitee-apim-console-webui/src/auth/oidc-transaction.util.ts
@@ -75,6 +75,18 @@ export function clearOidcTransaction(): void {
   sessionStorage.removeItem(OIDC_TRANSACTION_STORAGE_KEY);
 }
 
+/** Guard before assigning server-provided logout_url to window.location. */
+export function isSafeOidcLogoutUrl(url: string | null | undefined): boolean {
+  if (!url) {
+    return false;
+  }
+  try {
+    return new URL(url).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 function generateCodeVerifier(): string {
   const random = new Uint8Array(32);
   crypto.getRandomValues(random);

--- a/gravitee-apim-console-webui/src/auth/oidc-transaction.util.ts
+++ b/gravitee-apim-console-webui/src/auth/oidc-transaction.util.ts
@@ -93,7 +93,10 @@ async function computeS256CodeChallenge(codeVerifier: string): Promise<string> {
 }
 
 function base64UrlEncode(bytes: Uint8Array): string {
-  const binary = Array.from(bytes, byte => String.fromCodePoint(byte)).join('');
+  let binary = '';
+  bytes.forEach(byte => {
+    binary += String.fromCharCode(byte);
+  });
 
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }

--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
@@ -108,7 +108,7 @@ export class ApiDynamicPropertiesV4Component implements OnInit, OnDestroy {
           const configControl = this.form.controls.configuration;
           const originalMarkAsDirty = configControl.markAsDirty.bind(configControl);
           configControl.markAsDirty = () => {};
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
           ((window as any).__zone_symbol__setTimeout || setTimeout)(() => {
             configControl.markAsDirty = originalMarkAsDirty;
             this.initialFormValue = this.form.getRawValue();

--- a/gravitee-apim-portal-webui-next/src/app/app.config.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.config.ts
@@ -21,7 +21,6 @@ import { MAT_DIALOG_DEFAULT_OPTIONS } from '@angular/material/dialog';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, Router, withComponentInputBinding, withRouterConfig } from '@angular/router';
 import { GioIconsModule } from '@gravitee/ui-particles-angular';
-import { provideOAuthClient } from 'angular-oauth2-oidc';
 import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
 import { catchError, combineLatest, Observable, switchMap } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
@@ -50,7 +49,7 @@ function initApp(
           themeService.loadTheme(),
           configService.loadConfiguration(),
           portalNavigationItemsService.loadTopNavBarItems(),
-          authService.load().pipe(switchMap(_ => currentUserService.loadUser())),
+          authService.completeOidcLoginIfPresent().pipe(switchMap(_ => currentUserService.loadUser())),
         ]),
       ),
       catchError(error => {
@@ -65,7 +64,6 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes, withComponentInputBinding(), withRouterConfig({ paramsInheritanceStrategy: 'always' })),
     provideHttpClient(withInterceptors([httpRequestInterceptor, csrfInterceptor])),
     provideAnimations(),
-    provideOAuthClient(),
     importProvidersFrom(GioIconsModule),
     provideAppInitializer(() => {
       const initializerFn = initApp(

--- a/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.ts
@@ -23,7 +23,6 @@ import { MatCardModule } from '@angular/material/card';
 import { MatError, MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { OAuthModule } from 'angular-oauth2-oidc';
 import { map, switchMap, tap } from 'rxjs';
 
 import { MobileClassDirective } from '../../directives/mobile-class.directive';
@@ -46,7 +45,6 @@ import { PortalNavigationItemsService } from '../../services/portal-navigation-i
     ReactiveFormsModule,
     MatError,
     RouterLink,
-    OAuthModule,
     AsyncPipe,
     MobileClassDirective,
   ],

--- a/gravitee-apim-portal-webui-next/src/app/log-out/log-out.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/log-out/log-out.component.ts
@@ -16,7 +16,7 @@
 import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-import { switchMap, tap } from 'rxjs';
+import { EMPTY, Observable, switchMap, tap } from 'rxjs';
 
 import { AuthService } from '../../services/auth.service';
 import { CurrentUserService } from '../../services/current-user.service';
@@ -43,13 +43,21 @@ export class LogOutComponent implements OnInit {
         .logout()
         .pipe(
           tap(_ => this.currentUserService.clear()),
-          switchMap(_ => this.portalNavigationItemsService.loadTopNavBarItems()),
-          tap(_ => this.router.navigate([''])),
+          switchMap(logoutResponse => this.handleLogoutResponse(logoutResponse)),
           takeUntilDestroyed(this.destroyRef),
         )
         .subscribe();
     } else {
       this.router.navigate(['']);
     }
+  }
+
+  private handleLogoutResponse(logoutResponse: { logout_url?: string }): Observable<unknown> {
+    if (logoutResponse?.logout_url) {
+      window.location.href = logoutResponse.logout_url;
+      return EMPTY;
+    }
+
+    return this.portalNavigationItemsService.loadTopNavBarItems().pipe(tap(() => this.router.navigate([''])));
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/log-out/log-out.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/log-out/log-out.component.ts
@@ -20,6 +20,7 @@ import { EMPTY, Observable, switchMap, tap } from 'rxjs';
 
 import { AuthService } from '../../services/auth.service';
 import { CurrentUserService } from '../../services/current-user.service';
+import { isSafeOidcLogoutUrl } from '../../services/oidc-transaction.util';
 import { PortalNavigationItemsService } from '../../services/portal-navigation-items.service';
 
 @Component({
@@ -53,8 +54,8 @@ export class LogOutComponent implements OnInit {
   }
 
   private handleLogoutResponse(logoutResponse: { logout_url?: string }): Observable<unknown> {
-    if (logoutResponse?.logout_url) {
-      window.location.href = logoutResponse.logout_url;
+    if (isSafeOidcLogoutUrl(logoutResponse?.logout_url)) {
+      window.location.href = logoutResponse.logout_url!;
       return EMPTY;
     }
 

--- a/gravitee-apim-portal-webui-next/src/guards/auth.guard.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/auth.guard.spec.ts
@@ -15,17 +15,16 @@
  */
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute, CanActivateFn, Router } from '@angular/router';
-import { OAuthService } from 'angular-oauth2-oidc';
 
 import { authGuard } from './auth.guard';
 import { fakeUser } from '../entities/user/user.fixtures';
+import { OIDC_REDIRECT_STATE_KEY } from '../services/auth.service';
 import { ConfigService } from '../services/config.service';
 import { CurrentUserService } from '../services/current-user.service';
 import { AppTestingModule } from '../testing/app-testing.module';
 
 describe('authGuard', () => {
   let currentUserService: CurrentUserService;
-  let oauthService: OAuthService;
   let activatedRoute: ActivatedRoute;
   let configService: ConfigService;
   let router: Router;
@@ -36,10 +35,10 @@ describe('authGuard', () => {
       imports: [AppTestingModule],
     });
     currentUserService = TestBed.inject(CurrentUserService);
-    oauthService = TestBed.inject(OAuthService);
     activatedRoute = TestBed.inject(ActivatedRoute);
     configService = TestBed.inject(ConfigService);
     router = TestBed.inject(Router);
+    sessionStorage.clear();
   });
 
   it('should allow authenticated user', () => {
@@ -56,10 +55,10 @@ describe('authGuard', () => {
     const parseUrl = jest.spyOn(router, 'parseUrl');
     const createUrlTree = jest.spyOn(router, 'createUrlTree');
     currentUserService.user.set(fakeUser());
-    oauthService.state = encodeURIComponent('/redirectPath');
+    sessionStorage.setItem(OIDC_REDIRECT_STATE_KEY, encodeURIComponent('/redirectPath'));
 
     expect(executeGuard(activatedRoute.snapshot, { url: '', root: activatedRoute.snapshot })).toBeTruthy();
-    expect(oauthService.state).toEqual('');
+    expect(sessionStorage.getItem(OIDC_REDIRECT_STATE_KEY)).toBeNull();
     expect(parseUrl).toHaveBeenCalledWith('/redirectPath');
     expect(createUrlTree).not.toHaveBeenCalled();
   });

--- a/gravitee-apim-portal-webui-next/src/guards/auth.guard.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/auth.guard.ts
@@ -15,9 +15,9 @@
  */
 import { inject } from '@angular/core';
 import { CanActivateFn, Router, RouterStateSnapshot } from '@angular/router';
-import { OAuthService } from 'angular-oauth2-oidc';
 import { isEmpty } from 'lodash';
 
+import { OIDC_REDIRECT_STATE_KEY } from '../services/auth.service';
 import { ConfigService } from '../services/config.service';
 import { CurrentUserService } from '../services/current-user.service';
 
@@ -34,10 +34,9 @@ function checkUserAuthenticated() {
 }
 
 function getOAuthRedirectPath() {
-  const oAuthService = inject(OAuthService);
-  const redirectPath = decodeURIComponent(oAuthService.state ?? '');
-  oAuthService.state = '';
-  return redirectPath;
+  const redirectPath = sessionStorage.getItem(OIDC_REDIRECT_STATE_KEY) ?? '';
+  sessionStorage.removeItem(OIDC_REDIRECT_STATE_KEY);
+  return decodeURIComponent(redirectPath);
 }
 
 function forceLogin(state: RouterStateSnapshot) {

--- a/gravitee-apim-portal-webui-next/src/services/auth.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/auth.service.spec.ts
@@ -15,24 +15,56 @@
  */
 import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { OAuthService } from 'angular-oauth2-oidc';
 import { of } from 'rxjs';
 
 import { AuthService } from './auth.service';
 import { IdentityProviderService } from './identity-provider.service';
 import { IdentityProvider } from '../entities/configuration/identity-provider';
-import { AppTestingModule, IdentityProviderServiceStub, OAuthServiceStub, TESTING_BASE_URL } from '../testing/app-testing.module';
+import { AppTestingModule, IdentityProviderServiceStub, TESTING_BASE_URL } from '../testing/app-testing.module';
+
+function seedOidcTransaction(
+  overrides: Partial<{ state: string; redirectUrl: string; providerId: string; redirectUri: string; codeVerifier: string }> = {},
+) {
+  const transaction = {
+    state: 'oauth-state',
+    redirectUrl: '/home',
+    providerId: 'google',
+    redirectUri: 'http://localhost',
+    codeVerifier: 'test-code-verifier',
+    ...overrides,
+  };
+  sessionStorage.setItem('oidc-transaction', JSON.stringify(transaction));
+  return transaction.state;
+}
 
 describe('AuthService', () => {
   let service: AuthService;
   let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
+    Object.assign(globalThis.crypto, {
+      getRandomValues: (array: Uint8Array) => {
+        for (let i = 0; i < array.length; i++) {
+          array[i] = i % 256;
+        }
+        return array;
+      },
+      subtle: {
+        digest: jest.fn().mockResolvedValue(new Uint8Array(32).fill(7)),
+      },
+    });
+
     TestBed.configureTestingModule({
       imports: [AppTestingModule],
     });
     service = TestBed.inject(AuthService);
     httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    sessionStorage.clear();
+    localStorage.clear();
   });
 
   it('should call log in endpoint', done => {
@@ -48,65 +80,90 @@ describe('AuthService', () => {
     req.flush(token);
   });
 
-  it('should redirect for SSO', () => {
-    const idp = { id: 'google', name: 'Google' };
+  it('should redirect for SSO', async () => {
+    const idp = {
+      id: 'google',
+      name: 'Google',
+      authorizationEndpoint: 'https://idp.example.com/auth',
+      client_id: 'client-id',
+      scopes: ['openid'],
+    };
     const redirectUrl = 'redirectUrl';
+    const hrefSetter = jest.fn();
 
-    const storeProviderId = jest.spyOn(service, 'storeProviderId').mockReturnValue();
-    const initCodeFlow = jest.spyOn(TestBed.inject(OAuthService) as unknown as OAuthServiceStub, 'initCodeFlow').mockReturnValue();
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      origin: 'http://localhost',
+      pathname: '/',
+    };
+    Object.defineProperty(window.location, 'href', {
+      configurable: true,
+      set: hrefSetter,
+      get: () => '',
+    });
 
     service.authenticateSSO(idp, redirectUrl);
+    await new Promise(resolve => setTimeout(resolve, 0));
 
-    expect(initCodeFlow).toHaveBeenCalledWith(redirectUrl);
-    expect(storeProviderId).toHaveBeenCalled();
+    expect(localStorage.getItem('user-provider-id')).toEqual('google');
+    expect(hrefSetter).toHaveBeenCalledWith(expect.stringContaining('https://idp.example.com/auth'));
+    expect(hrefSetter).toHaveBeenCalledWith(expect.stringContaining('code_challenge='));
+    expect(hrefSetter).toHaveBeenCalledWith(expect.stringContaining('code_challenge_method=S256'));
+    expect(hrefSetter.mock.calls[0][0]).not.toContain('state=redirectUrl');
   });
 
-  it('should call /auth/logout and, when providerId exists, call oauthService.logOut and removeProviderId', () => {
-    jest.spyOn(service, 'getProviderId').mockReturnValue('google');
-    const logOutSpy = jest.spyOn(TestBed.inject(OAuthService) as unknown as OAuthServiceStub, 'logOut').mockReturnValue();
-    const removeProviderIdSpy = jest.spyOn(service, 'removeProviderId');
+  it('should call /auth/logout and remove provider id', () => {
+    localStorage.setItem('user-provider-id', 'google');
 
     service.logout().subscribe();
 
     const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/auth/logout`);
     expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual({});
+    expect(req.request.body.post_logout_redirect_uri).toBeDefined();
     req.flush({});
 
-    expect(logOutSpy).toHaveBeenCalled();
-    expect(removeProviderIdSpy).toHaveBeenCalled();
+    expect(localStorage.getItem('user-provider-id')).toBeNull();
   });
 
-  it('should NOT call logOut nor removeProviderId when providerId is missing', () => {
-    jest.spyOn(service, 'getProviderId').mockReturnValue(null);
-    const logOutSpy = jest.spyOn(TestBed.inject(OAuthService) as unknown as OAuthServiceStub, 'logOut').mockReturnValue();
-    const removeProviderIdSpy = jest.spyOn(service, 'removeProviderId');
-
-    service.logout().subscribe();
-
-    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/auth/logout`);
-    req.flush({});
-
-    expect(logOutSpy).not.toHaveBeenCalled();
-    expect(removeProviderIdSpy).not.toHaveBeenCalled();
-  });
-
-  it('should retrieve token on load from SSO provider', done => {
-    const idp = { id: 'google', name: 'Google' } as IdentityProvider;
-
-    const getProviderId = jest.spyOn(service, 'getProviderId').mockReturnValue(idp.id!);
-    const getPortalIdentityProvider = jest
-      .spyOn(TestBed.inject(IdentityProviderService) as unknown as IdentityProviderServiceStub, 'getPortalIdentityProvider')
-      .mockReturnValue(of(idp));
-    const tryLoginCodeFlow = jest
-      .spyOn(TestBed.inject(OAuthService) as unknown as OAuthServiceStub, 'tryLoginCodeFlow')
-      .mockResolvedValue();
+  it('should skip SSO callback when no authorization code is present', done => {
+    localStorage.setItem('user-provider-id', 'google');
 
     service.load().subscribe(() => {
-      expect(getProviderId).toHaveBeenCalled();
-      expect(getPortalIdentityProvider).toHaveBeenCalledWith(idp.id);
-      expect(tryLoginCodeFlow).toHaveBeenCalled();
       done();
     });
+
+    httpTestingController.expectNone(`${TESTING_BASE_URL}/auth/oauth2/google`);
+  });
+
+  it('should exchange authorization code on load from SSO provider', done => {
+    const idp = { id: 'google', name: 'Google', client_id: 'client-id' } as IdentityProvider;
+
+    localStorage.setItem('user-provider-id', 'google');
+    jest
+      .spyOn(TestBed.inject(IdentityProviderService) as unknown as IdentityProviderServiceStub, 'getPortalIdentityProvider')
+      .mockReturnValue(of(idp));
+    jest.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+    const state = seedOidcTransaction();
+
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      search: `?code=auth-code&state=${state}`,
+      pathname: '/',
+      origin: 'http://localhost',
+    };
+
+    service.load().subscribe(() => {
+      expect(sessionStorage.getItem('oidc-redirect-state')).toEqual('/home');
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/auth/oauth2/google`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toContain('code=auth-code');
+    expect(req.request.body).toContain('code_verifier=test-code-verifier');
+    req.flush('');
+
+    const userReq = httpTestingController.expectOne(`${TESTING_BASE_URL}/user`);
+    userReq.flush({ id: 'user-1' });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/auth.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/auth.service.spec.ts
@@ -128,11 +128,31 @@ describe('AuthService', () => {
   it('should skip SSO callback when no authorization code is present', done => {
     localStorage.setItem('user-provider-id', 'google');
 
-    service.load().subscribe(() => {
+    service.completeOidcLoginIfPresent().subscribe(() => {
       done();
     });
 
     httpTestingController.expectNone(`${TESTING_BASE_URL}/auth/oauth2/google`);
+  });
+
+  it('should reject SSO callback with invalid state', done => {
+    localStorage.setItem('user-provider-id', 'google');
+    jest.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      search: '?code=auth-code&state=invalid-state',
+      pathname: '/',
+      origin: 'http://localhost',
+    };
+
+    service.completeOidcLoginIfPresent().subscribe({
+      error: () => {
+        expect(localStorage.getItem('user-provider-id')).toBeNull();
+        httpTestingController.expectNone(`${TESTING_BASE_URL}/auth/oauth2/google`);
+        done();
+      },
+    });
   });
 
   it('should exchange authorization code on load from SSO provider', done => {
@@ -152,7 +172,7 @@ describe('AuthService', () => {
       origin: 'http://localhost',
     };
 
-    service.load().subscribe(() => {
+    service.completeOidcLoginIfPresent().subscribe(() => {
       expect(sessionStorage.getItem('oidc-redirect-state')).toEqual('/home');
       done();
     });

--- a/gravitee-apim-portal-webui-next/src/services/auth.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/auth.service.ts
@@ -15,14 +15,18 @@
  */
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { OAuthService } from 'angular-oauth2-oidc';
-import { catchError, map, Observable, switchMap, tap } from 'rxjs';
-import { fromPromise } from 'rxjs/internal/observable/innerFrom';
-import { of } from 'rxjs/internal/observable/of';
+import { catchError, finalize, map, Observable, of, shareReplay, switchMap, tap, throwError } from 'rxjs';
 
 import { ConfigService } from './config.service';
+import { CurrentUserService } from './current-user.service';
 import { IdentityProviderService } from './identity-provider.service';
+import { clearOidcTransaction, consumeOidcTransaction, OidcTransaction, storeOidcTransaction } from './oidc-transaction.util';
 import { IdentityProvider } from '../entities/configuration/identity-provider';
+
+export const OIDC_REDIRECT_STATE_KEY = 'oidc-redirect-state';
+const USER_PROVIDER_ID_KEY = 'user-provider-id';
+const OIDC_REDIRECT_URI_KEY = 'oidc-redirect-uri';
+const OIDC_CODE_PROCESSED_PREFIX = 'oidc-code-processed:';
 
 interface Token {
   token_type: string;
@@ -33,11 +37,13 @@ interface Token {
   providedIn: 'root',
 })
 export class AuthService {
+  private oidcCallbackInFlight: Observable<unknown> | null = null;
+
   constructor(
     private readonly http: HttpClient,
     private readonly configService: ConfigService,
-    private readonly oauthService: OAuthService,
     private readonly identityProviderService: IdentityProviderService,
+    private readonly currentUserService: CurrentUserService,
   ) {}
 
   login(username: string, password: string) {
@@ -52,92 +58,155 @@ export class AuthService {
     );
   }
 
-  logout(): Observable<unknown> {
-    return this.http.post<Token>(`${this.configService.baseURL}/auth/logout`, {}).pipe(
-      tap(_ => {
-        const providerId = this.getProviderId();
-        if (providerId) {
-          this.oauthService.logOut();
+  logout(): Observable<{ logout_url?: string }> {
+    const postLogoutRedirectUri = this.getRedirectUri();
+
+    return this.http
+      .post<{ logout_url?: string }>(`${this.configService.baseURL}/auth/logout`, {
+        post_logout_redirect_uri: postLogoutRedirectUri,
+      })
+      .pipe(
+        catchError(() => of({})),
+        map(response => {
           this.removeProviderId();
-        }
-      }),
-    );
+          return response;
+        }),
+      );
   }
 
   authenticateSSO(provider: IdentityProvider, redirectUrl: string) {
-    if (provider) {
-      this.storeProviderId(provider.id!);
-      this._configure(provider);
-      this.oauthService.initCodeFlow(redirectUrl);
+    if (!provider?.id || !provider.authorizationEndpoint || !provider.client_id) {
+      return;
     }
+
+    void this.redirectToIdentityProvider(provider, redirectUrl);
   }
 
   storeProviderId(providerId: string) {
-    localStorage.setItem('user-provider-id', providerId);
+    localStorage.setItem(USER_PROVIDER_ID_KEY, providerId);
   }
 
   getProviderId(): string | null {
-    return localStorage.getItem('user-provider-id')!;
+    return localStorage.getItem(USER_PROVIDER_ID_KEY);
   }
+
   removeProviderId() {
-    localStorage.removeItem('user-provider-id');
+    localStorage.removeItem(USER_PROVIDER_ID_KEY);
   }
 
   load() {
     const providerId = this.getProviderId();
-    if (providerId) {
-      return this._fetchProviderAndConfigure(providerId).pipe(
-        switchMap(() => {
-          return fromPromise(
-            this.oauthService.tryLoginCodeFlow({
-              // 📝 The clear of the hash doesn't work correctly and keeps a piece of string which distorts angular routing and
-              // displays a 404. Disabling it solves the problem and the clear will be done with an angular internal redirection.
-              preventClearHashAfterLogin: true,
-            }),
-          );
-        }),
-      );
-    } else {
+    const urlParams = new URLSearchParams(window.location.search);
+    const authorizationCode = urlParams.get('code');
+    const state = urlParams.get('state');
+
+    if (!providerId || !authorizationCode) {
       return of(undefined);
     }
-  }
 
-  private _fetchProviderAndConfigure(providerId: string) {
-    return this.identityProviderService.getPortalIdentityProvider(providerId).pipe(
-      map(identityProvider => {
-        if (identityProvider) {
-          this._configure(identityProvider);
-        }
+    const processedKey = `${OIDC_CODE_PROCESSED_PREFIX}${authorizationCode}`;
+    if (sessionStorage.getItem(processedKey)) {
+      return of(undefined);
+    }
+
+    if (this.oidcCallbackInFlight) {
+      return this.oidcCallbackInFlight;
+    }
+
+    const transaction = consumeOidcTransaction(state);
+    if (!transaction || transaction.providerId !== providerId) {
+      this.removeProviderId();
+      sessionStorage.removeItem(OIDC_REDIRECT_URI_KEY);
+      clearOidcTransaction();
+      return of(undefined);
+    }
+
+    this.clearOidcQueryParams();
+
+    this.oidcCallbackInFlight = this.identityProviderService.getPortalIdentityProvider(providerId).pipe(
+      switchMap(identityProvider => this.completeOidcCallback(identityProvider, authorizationCode, transaction)),
+      tap(() => sessionStorage.setItem(processedKey, '1')),
+      finalize(() => {
+        this.oidcCallbackInFlight = null;
       }),
-      catchError(() => of(undefined)),
+      shareReplay(1),
+      catchError(() => {
+        this.removeProviderId();
+        sessionStorage.removeItem(OIDC_REDIRECT_URI_KEY);
+        clearOidcTransaction();
+        return of(undefined);
+      }),
     );
+
+    return this.oidcCallbackInFlight;
   }
 
-  private _configure(provider: IdentityProvider) {
-    const redirectUri =
-      window.location.origin + (window.location.pathname === '/' ? '' : window.location.pathname.replace('/user/logout', '/'));
-    this.oauthService.configure({
-      clientId: provider.client_id,
-      loginUrl: provider.authorizationEndpoint,
-      tokenEndpoint: this.configService.baseURL + '/auth/oauth2/' + provider.id,
-      requireHttps: false,
-      issuer: provider.tokenIntrospectionEndpoint,
-      logoutUrl: provider.userLogoutEndpoint,
-      postLogoutRedirectUri: redirectUri,
-      scope: provider.scopes?.join(' '),
-      responseType: 'code',
+  private async redirectToIdentityProvider(provider: IdentityProvider, redirectUrl: string): Promise<void> {
+    this.storeProviderId(provider.id!);
+    const redirectUri = this.getRedirectUri();
+    sessionStorage.setItem(OIDC_REDIRECT_URI_KEY, redirectUri);
+
+    const { state, codeChallenge } = await storeOidcTransaction({
+      providerId: provider.id!,
+      redirectUrl,
       redirectUri,
-      /*
-       added because with our current OIDC configuration, we don't know the real issuer.
-       For example, with keycloak, the issuer is "https://[host]:[port]/auth/realms/[realm_id].
-       But in our configuration, we only have these endpoints:
-        - https://[host]:[port]/auth/realms/[realm_id]/protocol/openid-connect/token
-        - https://[host]:[port]/auth/realms/[realm_id]/protocol/openid-connect/token/introspect
-        - https://[host]:[port]/auth/realms/[realm_id]/protocol/openid-connect/auth
-        - https://[host]:[port]/auth/realms/[realm_id]/protocol/openid-connect/userinfo
-        - https://[host]:[port]/auth/realms/[realm_id]/protocol/openid-connect/logout
-       */
-      skipIssuerCheck: true,
     });
+
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: provider.client_id!,
+      redirect_uri: redirectUri,
+      scope: provider.scopes?.join(' ') ?? 'openid',
+      state,
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+    });
+
+    window.location.href = `${provider.authorizationEndpoint}?${params.toString()}`;
+  }
+
+  private completeOidcCallback(identityProvider: IdentityProvider, authorizationCode: string, transaction: OidcTransaction) {
+    if (!identityProvider?.id || !identityProvider.client_id) {
+      return throwError(() => new Error(`Identity provider ${identityProvider?.id} not found!`));
+    }
+
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: authorizationCode,
+      redirect_uri: transaction.redirectUri,
+      client_id: identityProvider.client_id,
+      code_verifier: transaction.codeVerifier,
+    });
+
+    return this.http
+      .post(`${this.configService.baseURL}/auth/oauth2/${identityProvider.id}`, body.toString(), {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        responseType: 'text',
+      })
+      .pipe(
+        switchMap(() => {
+          sessionStorage.removeItem(OIDC_REDIRECT_URI_KEY);
+          return this.currentUserService.loadUser();
+        }),
+        map(user => {
+          if (!user) {
+            throw new Error('OIDC login failed');
+          }
+
+          if (transaction.redirectUrl) {
+            sessionStorage.setItem(OIDC_REDIRECT_STATE_KEY, transaction.redirectUrl);
+          }
+
+          return undefined;
+        }),
+      );
+  }
+
+  private getRedirectUri(): string {
+    return window.location.origin + (window.location.pathname === '/' ? '' : window.location.pathname.replace('/user/logout', '/'));
+  }
+
+  private clearOidcQueryParams() {
+    window.history.replaceState({}, '', window.location.pathname);
   }
 }

--- a/gravitee-apim-portal-webui-next/src/services/auth.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/auth.service.ts
@@ -94,7 +94,7 @@ export class AuthService {
     localStorage.removeItem(USER_PROVIDER_ID_KEY);
   }
 
-  load() {
+  completeOidcLoginIfPresent() {
     const providerId = this.getProviderId();
     const urlParams = new URLSearchParams(window.location.search);
     const authorizationCode = urlParams.get('code');
@@ -118,7 +118,7 @@ export class AuthService {
       this.removeProviderId();
       sessionStorage.removeItem(OIDC_REDIRECT_URI_KEY);
       clearOidcTransaction();
-      return of(undefined);
+      return throwError(() => new Error('Invalid OIDC state'));
     }
 
     this.clearOidcQueryParams();

--- a/gravitee-apim-portal-webui-next/src/services/oidc-transaction.util.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/oidc-transaction.util.spec.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { clearOidcTransaction, consumeOidcTransaction, storeOidcTransaction } from './oidc-transaction.util';
+
+const OIDC_TRANSACTION_STORAGE_KEY = 'oidc-transaction';
+const MOCK_DIGEST = new Uint8Array(32).fill(7);
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  const binary = Array.from(bytes, byte => String.fromCodePoint(byte)).join('');
+
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+describe('oidc-transaction.util', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    Object.assign(globalThis.crypto, {
+      getRandomValues: (array: Uint8Array) => {
+        for (let i = 0; i < array.length; i++) {
+          array[i] = i % 256;
+        }
+        return array;
+      },
+      subtle: {
+        digest: jest.fn().mockResolvedValue(MOCK_DIGEST.buffer),
+      },
+    });
+  });
+
+  describe('storeOidcTransaction', () => {
+    it('should persist transaction and return state with PKCE S256 challenge', async () => {
+      const result = await storeOidcTransaction({
+        providerId: 'google',
+        redirectUrl: '/home',
+        redirectUri: 'http://localhost',
+      });
+
+      expect(result.state).toBeTruthy();
+      expect(result.codeChallenge).toBeTruthy();
+
+      const stored = JSON.parse(sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY)!);
+      expect(stored).toEqual({
+        state: result.state,
+        redirectUrl: '/home',
+        providerId: 'google',
+        redirectUri: 'http://localhost',
+        codeVerifier: stored.codeVerifier,
+      });
+      expect(stored.codeVerifier).toBeTruthy();
+      expect(result.codeChallenge).toEqual(encodeBase64Url(MOCK_DIGEST));
+    });
+  });
+
+  describe('consumeOidcTransaction', () => {
+    it('should return null when state is missing', () => {
+      expect(consumeOidcTransaction(null)).toBeNull();
+      expect(consumeOidcTransaction('')).toBeNull();
+    });
+
+    it('should return null when no transaction is stored', () => {
+      expect(consumeOidcTransaction('oauth-state')).toBeNull();
+    });
+
+    it('should return null when stored transaction is invalid JSON', () => {
+      sessionStorage.setItem(OIDC_TRANSACTION_STORAGE_KEY, '{invalid-json');
+
+      expect(consumeOidcTransaction('oauth-state')).toBeNull();
+    });
+
+    it('should return null when state does not match', async () => {
+      await storeOidcTransaction({
+        providerId: 'google',
+        redirectUrl: '/home',
+        redirectUri: 'http://localhost',
+      });
+
+      expect(consumeOidcTransaction('wrong-state')).toBeNull();
+      expect(sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY)).toBeTruthy();
+    });
+
+    it('should return transaction and clear storage when state matches', async () => {
+      const { state } = await storeOidcTransaction({
+        providerId: 'google',
+        redirectUrl: '/home',
+        redirectUri: 'http://localhost',
+      });
+
+      const transaction = consumeOidcTransaction(state);
+
+      expect(transaction).toEqual(
+        expect.objectContaining({
+          state,
+          redirectUrl: '/home',
+          providerId: 'google',
+          redirectUri: 'http://localhost',
+        }),
+      );
+      expect(transaction?.codeVerifier).toBeTruthy();
+      expect(sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe('clearOidcTransaction', () => {
+    it('should remove stored transaction', async () => {
+      await storeOidcTransaction({
+        providerId: 'google',
+        redirectUrl: '/home',
+        redirectUri: 'http://localhost',
+      });
+
+      clearOidcTransaction();
+
+      expect(sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY)).toBeNull();
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/oidc-transaction.util.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/oidc-transaction.util.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { clearOidcTransaction, consumeOidcTransaction, storeOidcTransaction } from './oidc-transaction.util';
+import { clearOidcTransaction, consumeOidcTransaction, isSafeOidcLogoutUrl, storeOidcTransaction } from './oidc-transaction.util';
 
 const OIDC_TRANSACTION_STORAGE_KEY = 'oidc-transaction';
 const MOCK_DIGEST = new Uint8Array(32).fill(7);
@@ -124,6 +124,15 @@ describe('oidc-transaction.util', () => {
       clearOidcTransaction();
 
       expect(sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe('isSafeOidcLogoutUrl', () => {
+    it('should allow https URLs only', () => {
+      expect(isSafeOidcLogoutUrl('https://idp.example.com/logout')).toBe(true);
+      expect(isSafeOidcLogoutUrl('http://idp.example.com/logout')).toBe(false);
+      expect(isSafeOidcLogoutUrl('javascript:alert(1)')).toBe(false);
+      expect(isSafeOidcLogoutUrl(undefined)).toBe(false);
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/oidc-transaction.util.ts
+++ b/gravitee-apim-portal-webui-next/src/services/oidc-transaction.util.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface OidcTransaction {
+  state: string;
+  redirectUrl: string;
+  providerId: string;
+  redirectUri: string;
+  codeVerifier: string;
+}
+
+const OIDC_TRANSACTION_STORAGE_KEY = 'oidc-transaction';
+
+export async function storeOidcTransaction(input: {
+  providerId: string;
+  redirectUrl: string;
+  redirectUri: string;
+}): Promise<{ state: string; codeChallenge: string }> {
+  const codeVerifier = generateCodeVerifier();
+  const state = generateRandomState();
+  const codeChallenge = await computeS256CodeChallenge(codeVerifier);
+
+  const transaction: OidcTransaction = {
+    state,
+    redirectUrl: input.redirectUrl,
+    providerId: input.providerId,
+    redirectUri: input.redirectUri,
+    codeVerifier,
+  };
+
+  sessionStorage.setItem(OIDC_TRANSACTION_STORAGE_KEY, JSON.stringify(transaction));
+
+  return { state, codeChallenge };
+}
+
+export function consumeOidcTransaction(receivedState: string | null): OidcTransaction | null {
+  if (!receivedState) {
+    return null;
+  }
+
+  const raw = sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  let transaction: OidcTransaction;
+  try {
+    transaction = JSON.parse(raw) as OidcTransaction;
+  } catch {
+    return null;
+  }
+
+  if (transaction.state !== receivedState) {
+    return null;
+  }
+
+  sessionStorage.removeItem(OIDC_TRANSACTION_STORAGE_KEY);
+  return transaction;
+}
+
+export function clearOidcTransaction(): void {
+  sessionStorage.removeItem(OIDC_TRANSACTION_STORAGE_KEY);
+}
+
+function generateCodeVerifier(): string {
+  const random = new Uint8Array(32);
+  crypto.getRandomValues(random);
+  return base64UrlEncode(random);
+}
+
+function generateRandomState(): string {
+  const random = new Uint8Array(16);
+  crypto.getRandomValues(random);
+  return base64UrlEncode(random);
+}
+
+async function computeS256CodeChallenge(codeVerifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  const binary = Array.from(bytes, byte => String.fromCodePoint(byte)).join('');
+
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}

--- a/gravitee-apim-portal-webui-next/src/services/oidc-transaction.util.ts
+++ b/gravitee-apim-portal-webui-next/src/services/oidc-transaction.util.ts
@@ -93,7 +93,10 @@ async function computeS256CodeChallenge(codeVerifier: string): Promise<string> {
 }
 
 function base64UrlEncode(bytes: Uint8Array): string {
-  const binary = Array.from(bytes, byte => String.fromCodePoint(byte)).join('');
+  let binary = '';
+  bytes.forEach(byte => {
+    binary += String.fromCharCode(byte);
+  });
 
-  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }

--- a/gravitee-apim-portal-webui-next/src/services/oidc-transaction.util.ts
+++ b/gravitee-apim-portal-webui-next/src/services/oidc-transaction.util.ts
@@ -75,6 +75,18 @@ export function clearOidcTransaction(): void {
   sessionStorage.removeItem(OIDC_TRANSACTION_STORAGE_KEY);
 }
 
+/** Guard before assigning server-provided logout_url to window.location. */
+export function isSafeOidcLogoutUrl(url: string | null | undefined): boolean {
+  if (!url) {
+    return false;
+  }
+  try {
+    return new URL(url).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 function generateCodeVerifier(): string {
   const random = new Uint8Array(32);
   crypto.getRandomValues(random);

--- a/gravitee-apim-portal-webui-next/src/testing/app-testing.module.ts
+++ b/gravitee-apim-portal-webui-next/src/testing/app-testing.module.ts
@@ -18,7 +18,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Injectable, NgModule } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Router } from '@angular/router';
-import { OAuthService } from 'angular-oauth2-oidc';
 import { Observable } from 'rxjs/internal/Observable';
 import { of } from 'rxjs/internal/observable/of';
 
@@ -81,20 +80,6 @@ export class IdentityProviderServiceStub {
   }
 }
 
-@Injectable()
-export class OAuthServiceStub {
-  initCodeFlow() {
-    // nothing to do
-  }
-  tryLoginCodeFlow(): Promise<void> {
-    return Promise.resolve();
-  }
-  configure() {
-    // nothing to do
-  }
-  logOut(): void {}
-}
-
 /**
  * To avoid error during unit tests that navigation happens outside the ngZone
  */
@@ -110,10 +95,6 @@ export class TestRouterModule {
     {
       provide: ConfigService,
       useClass: ConfigServiceStub,
-    },
-    {
-      provide: OAuthService,
-      useClass: OAuthServiceStub,
     },
     {
       provide: IdentityProviderService,

--- a/gravitee-apim-portal-webui/src/app/app.module.ts
+++ b/gravitee-apim-portal-webui/src/app/app.module.ts
@@ -167,7 +167,7 @@ export function initApp(
   return () =>
     configurationService.load().then(() => {
       return authService
-        .load()
+        .completeOidcLoginIfPresent()
         .then(() => currentUserService.load().then(() => translationService.load().then(() => reCaptchaService.load())));
     });
 }

--- a/gravitee-apim-portal-webui/src/app/services/auth-guard.service.ts
+++ b/gravitee-apim-portal-webui/src/app/services/auth-guard.service.ts
@@ -15,27 +15,19 @@
  */
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router, UrlTree } from '@angular/router';
-import { OAuthService } from 'angular-oauth2-oidc';
 
 import { Role } from '../model/role.enum';
 
+import { OIDC_REDIRECT_STATE_KEY } from './auth.service';
 import { CurrentUserService } from './current-user.service';
 
 /**
  * Checks whether the user can activate a route based on authentication and expected user role.
- *
- * @param {ActivatedRouteSnapshot} route - The activated route snapshot.
- * @param {CurrentUserService} currentUserService - Service to get the current user information.
- * @param {Router} router - The router service.
- * @param {OAuthService} oauthService - The OAuth service for authentication and authorization.
- *
- * @return {Promise<boolean | UrlTree>} A promise that resolves to either `true` if the user can activate the route or a `UrlTree` object representing a redirect URL.
  */
 export function canActivateBasedOnAuth(
   route: ActivatedRouteSnapshot,
   currentUserService: CurrentUserService,
   router: Router,
-  oauthService: OAuthService,
 ): Promise<boolean | UrlTree> {
   if (route && route.data) {
     const expectedRole = route.data.expectedRole;
@@ -43,8 +35,7 @@ export function canActivateBasedOnAuth(
       return new Promise(resolve => {
         const user = currentUserService.get().getValue();
         if ((expectedRole === Role.AUTH_USER && user == null) || (expectedRole === Role.GUEST && user)) {
-          // 📝 Check OAuth state to find redirectUrl if exist
-          resolve(router.parseUrl(decodeURIComponent(oauthService.state ?? '/')));
+          resolve(router.parseUrl(getOAuthRedirectPath() || '/'));
         } else {
           resolve(true);
         }
@@ -55,9 +46,14 @@ export function canActivateBasedOnAuth(
   return Promise.resolve(true);
 }
 
+function getOAuthRedirectPath(): string {
+  const redirectPath = sessionStorage.getItem(OIDC_REDIRECT_STATE_KEY) ?? '';
+  sessionStorage.removeItem(OIDC_REDIRECT_STATE_KEY);
+  return decodeURIComponent(redirectPath);
+}
+
 export const authGuard = ((route: ActivatedRouteSnapshot): Promise<boolean | UrlTree> => {
   const currentUserService: CurrentUserService = inject(CurrentUserService);
   const router: Router = inject(Router);
-  const oauthService: OAuthService = inject(OAuthService);
-  return canActivateBasedOnAuth(route, currentUserService, router, oauthService);
+  return canActivateBasedOnAuth(route, currentUserService, router);
 }) satisfies CanActivateFn;

--- a/gravitee-apim-portal-webui/src/app/services/auth.service.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/services/auth.service.spec.ts
@@ -138,7 +138,7 @@ describe('AuthService', () => {
     currentUserService.load = jest.fn().mockResolvedValue(true);
     currentUserService.getUser = jest.fn().mockReturnValue({ id: 'user-1' });
 
-    const loadPromise = spectator.service.load();
+    const loadPromise = spectator.service.completeOidcLoginIfPresent();
 
     const oauthReq = httpTestingController.expectOne(`${BASE_URL}/auth/oauth2/google`);
     expect(oauthReq.request.method).toBe('POST');
@@ -150,6 +150,22 @@ describe('AuthService', () => {
 
     expect(sessionStorage.getItem('oidc-redirect-state')).toEqual('/home');
     expect(currentUserService.load).toHaveBeenCalled();
+  });
+
+  it('should reject SSO callback with invalid state', async () => {
+    localStorage.setItem('user-provider-id', 'google');
+    jest.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      search: '?code=auth-code&state=invalid-state',
+      pathname: '/',
+      origin: 'http://localhost:4000',
+    };
+
+    await expect(spectator.service.completeOidcLoginIfPresent()).rejects.toThrow('Invalid OIDC state');
+    expect(localStorage.getItem('user-provider-id')).toBeNull();
+    httpTestingController.expectNone(`${BASE_URL}/auth/oauth2/google`);
   });
 
   it('should call /auth/logout and navigate home when no logout_url is returned', async () => {

--- a/gravitee-apim-portal-webui/src/app/services/auth.service.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/services/auth.service.spec.ts
@@ -13,23 +13,182 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+
+import { AuthenticationService, PortalService } from '../../../projects/portal-webclient-sdk/src/lib';
 
 import { AuthService } from './auth.service';
+import { ConfigurationService } from './configuration.service';
+import { CurrentUserService } from './current-user.service';
+import { NotificationService } from './notification.service';
+
+const BASE_URL = 'http://localhost:8083/portal/environments/DEFAULT';
+
+function seedOidcTransaction(
+  overrides: Partial<{ state: string; redirectUrl: string; providerId: string; redirectUri: string; codeVerifier: string }> = {},
+) {
+  const transaction = {
+    state: 'oauth-state',
+    redirectUrl: '/home',
+    providerId: 'google',
+    redirectUri: 'http://localhost:4000',
+    codeVerifier: 'test-code-verifier',
+    ...overrides,
+  };
+  sessionStorage.setItem('oidc-transaction', JSON.stringify(transaction));
+  return transaction.state;
+}
 
 describe('AuthService', () => {
-  let service: SpectatorService<AuthService>;
+  let spectator: SpectatorService<AuthService>;
+  let httpTestingController: HttpTestingController;
+
   const createService = createServiceFactory({
     service: AuthService,
-    imports: [HttpClientTestingModule],
+    imports: [HttpClientTestingModule, RouterTestingModule],
+    mocks: [ConfigurationService, CurrentUserService, NotificationService, PortalService, AuthenticationService],
+    providers: [],
   });
 
   beforeEach(() => {
-    service = createService();
+    Object.assign(globalThis.crypto, {
+      getRandomValues: (array: Uint8Array) => {
+        for (let i = 0; i < array.length; i++) {
+          array[i] = i % 256;
+        }
+        return array;
+      },
+      subtle: {
+        digest: jest.fn().mockResolvedValue(new Uint8Array(32).fill(7)),
+      },
+    });
+
+    spectator = createService({
+      providers: [
+        {
+          provide: ConfigurationService,
+          useValue: {
+            get: (key: string) => (key === 'baseURL' ? BASE_URL : undefined),
+          },
+        },
+      ],
+    });
+    httpTestingController = spectator.inject(HttpTestingController);
+    spectator
+      .inject(PortalService)
+      .getPortalIdentityProvider.mockReturnValue(of({ id: 'google', client_id: 'client-id', scopes: ['openid'] }));
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  afterEach(() => {
+    httpTestingController.verify();
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  it('should redirect for SSO with PKCE', async () => {
+    const hrefSetter = jest.fn();
+
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      origin: 'http://localhost:4000',
+      pathname: '/',
+    };
+    Object.defineProperty(window.location, 'href', {
+      configurable: true,
+      set: hrefSetter,
+      get: () => '',
+    });
+
+    spectator.service.authenticate(
+      {
+        id: 'google',
+        authorizationEndpoint: 'https://idp.example.com/auth',
+        client_id: 'client-id',
+        scopes: ['openid'],
+      },
+      '/catalog',
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(localStorage.getItem('user-provider-id')).toEqual('google');
+    expect(hrefSetter).toHaveBeenCalledWith(expect.stringContaining('https://idp.example.com/auth'));
+    expect(hrefSetter).toHaveBeenCalledWith(expect.stringContaining('code_challenge='));
+    expect(hrefSetter).toHaveBeenCalledWith(expect.stringContaining('code_challenge_method=S256'));
+    expect(hrefSetter.mock.calls[0][0]).not.toContain('state=/catalog');
+  });
+
+  it('should exchange authorization code on load from SSO provider', async () => {
+    localStorage.setItem('user-provider-id', 'google');
+    jest.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+    const state = seedOidcTransaction();
+
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      search: `?code=auth-code&state=${state}`,
+      pathname: '/',
+      origin: 'http://localhost:4000',
+    };
+
+    const currentUserService = spectator.inject(CurrentUserService);
+    currentUserService.load = jest.fn().mockResolvedValue(true);
+    currentUserService.getUser = jest.fn().mockReturnValue({ id: 'user-1' });
+
+    const loadPromise = spectator.service.load();
+
+    const oauthReq = httpTestingController.expectOne(`${BASE_URL}/auth/oauth2/google`);
+    expect(oauthReq.request.method).toBe('POST');
+    expect(oauthReq.request.body).toContain('code=auth-code');
+    expect(oauthReq.request.body).toContain('code_verifier=test-code-verifier');
+    oauthReq.flush('');
+
+    await loadPromise;
+
+    expect(sessionStorage.getItem('oidc-redirect-state')).toEqual('/home');
+    expect(currentUserService.load).toHaveBeenCalled();
+  });
+
+  it('should call /auth/logout and navigate home when no logout_url is returned', async () => {
+    const router = spectator.inject(Router);
+    const navigateSpy = jest.spyOn(router, 'navigate').mockResolvedValue(true);
+    const currentUserService = spectator.inject(CurrentUserService);
+
+    const logoutPromise = spectator.service.logout();
+
+    const req = httpTestingController.expectOne(`${BASE_URL}/auth/logout`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body.post_logout_redirect_uri).toBeDefined();
+    req.flush({});
+
+    await logoutPromise;
+
+    expect(currentUserService.revokeUser).toHaveBeenCalled();
+    expect(navigateSpy).toHaveBeenCalledWith(['']);
+  });
+
+  it('should redirect to IdP logout URL when returned by server', () => {
+    const hrefSetter = jest.fn();
+
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      origin: 'http://localhost:4000',
+      pathname: '/',
+    };
+    Object.defineProperty(window.location, 'href', {
+      configurable: true,
+      set: hrefSetter,
+      get: () => '',
+    });
+
+    spectator.service.logout();
+
+    const req = httpTestingController.expectOne(`${BASE_URL}/auth/logout`);
+    req.flush({ logout_url: 'https://idp.example.com/logout' });
+
+    expect(hrefSetter).toHaveBeenCalledWith('https://idp.example.com/logout');
   });
 });

--- a/gravitee-apim-portal-webui/src/app/services/auth.service.ts
+++ b/gravitee-apim-portal-webui/src/app/services/auth.service.ts
@@ -13,59 +13,100 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpClient } from '@angular/common/http';
 import { Injectable, Injector } from '@angular/core';
-import { OAuthService } from 'angular-oauth2-oidc';
 import { Router } from '@angular/router';
 
-import { AuthenticationService, PortalService } from '../../../projects/portal-webclient-sdk/src/lib';
+import { AuthenticationService, IdentityProvider, PortalService } from '../../../projects/portal-webclient-sdk/src/lib';
 
+import { clearOidcTransaction, consumeOidcTransaction, OidcTransaction, storeOidcTransaction } from './oidc-transaction.util';
+import { ConfigurationService } from './configuration.service';
 import { CurrentUserService } from './current-user.service';
 import { NotificationService } from './notification.service';
-import { ConfigurationService } from './configuration.service';
+
+export const OIDC_REDIRECT_STATE_KEY = 'oidc-redirect-state';
+const USER_PROVIDER_ID_KEY = 'user-provider-id';
+const OIDC_REDIRECT_URI_KEY = 'oidc-redirect-uri';
+const OIDC_CODE_PROCESSED_PREFIX = 'oidc-code-processed:';
+
+interface LogoutResponse {
+  logout_url?: string;
+}
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
+  private oidcCallbackInFlight: Promise<boolean> | null = null;
   private authenticationService: AuthenticationService;
   private portalService: PortalService;
   private router: Router;
 
   constructor(
-    private configurationService: ConfigurationService,
-    private oauthService: OAuthService,
-    private currentUserService: CurrentUserService,
-    private notificationService: NotificationService,
-    private injector: Injector,
+    private readonly configurationService: ConfigurationService,
+    private readonly http: HttpClient,
+    private readonly currentUserService: CurrentUserService,
+    private readonly notificationService: NotificationService,
+    private readonly injector: Injector,
   ) {}
 
-  load() {
-    // lazy injection to wait for base path injection and router init
-    this.authenticationService = this.injector.get(AuthenticationService);
-    this.portalService = this.injector.get(PortalService);
-    this.router = this.injector.get(Router);
-    return new Promise(resolve => {
-      if (this.getProviderId()) {
-        this._fetchProviderAndConfigure().then(() => {
-          this.oauthService
-            .tryLoginCodeFlow({
-              // 📝 The clear of the hash doesn't work correctly and keeps a piece of string which distorts angular routing and
-              // displays a 404. Disabling it solves the problem and the clear will be done with an angular internal redirection.
-              preventClearHashAfterLogin: true,
-            })
-            .finally(() => resolve(true));
-        });
-      } else {
-        resolve(true);
-      }
-    });
+  load(): Promise<boolean> {
+    this.ensureSdkServices();
+
+    const providerId = this.getProviderId();
+    const urlParams = new URLSearchParams(window.location.search);
+    const authorizationCode = urlParams.get('code');
+    const state = urlParams.get('state');
+
+    if (!providerId || !authorizationCode) {
+      return Promise.resolve(true);
+    }
+
+    const processedKey = `${OIDC_CODE_PROCESSED_PREFIX}${authorizationCode}`;
+    if (sessionStorage.getItem(processedKey)) {
+      return Promise.resolve(true);
+    }
+
+    if (this.oidcCallbackInFlight) {
+      return this.oidcCallbackInFlight;
+    }
+
+    const transaction = consumeOidcTransaction(state);
+    if (!transaction || transaction.providerId !== providerId) {
+      this.removeProviderId();
+      sessionStorage.removeItem(OIDC_REDIRECT_URI_KEY);
+      clearOidcTransaction();
+      return Promise.resolve(true);
+    }
+
+    this.clearOidcQueryParams();
+
+    this.oidcCallbackInFlight = this.completeOidcCallback(providerId, authorizationCode, transaction)
+      .then(() => {
+        sessionStorage.setItem(processedKey, '1');
+        return true;
+      })
+      .catch(() => {
+        this.removeProviderId();
+        sessionStorage.removeItem(OIDC_REDIRECT_URI_KEY);
+        clearOidcTransaction();
+        return true;
+      })
+      .finally(() => {
+        this.oidcCallbackInFlight = null;
+      });
+
+    return this.oidcCallbackInFlight;
   }
 
   login(username: string, password: string, redirectUrl = ''): Promise<boolean> {
+    this.ensureSdkServices();
+
     return new Promise(resolve => {
       const authorization: string = 'Basic ' + this.encode(`${username}:${password}`);
       return this.authenticationService.login({ authorization }).subscribe(
         () => {
+          this.removeProviderId();
           this.currentUserService.load().then(() => {
             this.router.navigate([redirectUrl]);
           });
@@ -80,9 +121,6 @@ export class AuthService {
   }
 
   encode = str => {
-    // first we use encodeURIComponent to get percent-encoded UTF-8,
-    // then we convert the percent encodings into raw bytes which
-    // can be fed into btoa.
     return btoa(
       encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function toSolidBytes(match, p1) {
         return String.fromCharCode(Number('0x' + p1));
@@ -90,99 +128,143 @@ export class AuthService {
     );
   };
 
-  authenticate(provider, redirectUrl: string) {
-    if (provider) {
-      this.storeProviderId(provider.id);
-      this._configure(provider);
-      // 📝 Save `redirectUrl` into OAuth state to retrieve it after redirect
-      this.oauthService.initCodeFlow(redirectUrl);
+  authenticate(provider: IdentityProvider, redirectUrl: string) {
+    if (provider?.id && provider.authorizationEndpoint && provider.client_id) {
+      void this.redirectToIdentityProvider(provider, redirectUrl);
     }
   }
 
   logout(): Promise<boolean> {
+    this.ensureSdkServices();
+
     return new Promise(resolve => {
-      if (this.getProviderId()) {
-        this._fetchProviderAndConfigure().finally(() => {
-          this._logout(resolve);
-        });
-      } else {
-        this._logout(resolve);
-      }
-    });
-  }
-
-  private _logout(resolve) {
-    this.authenticationService
-      .logout()
-      .toPromise()
-      .then(() => {
-        this.currentUserService.revokeUser();
-        if (this.getProviderId()) {
-          this.oauthService.logOut();
-          this.removeProviderId();
-        }
-        this.router.navigate(['']);
-      })
-      .catch(() => resolve(false))
-      .finally(() => resolve(true));
-  }
-
-  private _configure(provider) {
-    const redirectUri =
-      window.location.origin + (window.location.pathname === '/' ? '' : window.location.pathname.replace('/user/logout', '/'));
-    this.oauthService.configure({
-      clientId: provider.client_id,
-      loginUrl: provider.authorizationEndpoint,
-      tokenEndpoint: this.configurationService.get('baseURL') + '/auth/oauth2/' + provider.id,
-      requireHttps: false,
-      issuer: provider.tokenIntrospectionEndpoint,
-      logoutUrl: provider.userLogoutEndpoint,
-      postLogoutRedirectUri: redirectUri,
-      scope: provider.scopes.join(' '),
-      responseType: 'code',
-      redirectUri,
-      /*
-       added because with our current OIDC configuration, we don't know the real issuer.
-       For example, with keycloak, the issuer is "https://[host]:[port]/auth/realms/[realm_id].
-       But in our configuration, we only have these endpoints:
-        - https://[host]:[port]/auth/realms/[realm_id]/protocol/openid-connect/token
-        - https://[host]:[port]/auth/realms/[realm_id]/protocol/openid-connect/token/introspect
-        - https://[host]:[port]/auth/realms/[realm_id]/protocol/openid-connect/auth
-        - https://[host]:[port]/auth/realms/[realm_id]/protocol/openid-connect/userinfo
-        - https://[host]:[port]/auth/realms/[realm_id]/protocol/openid-connect/logout
-       */
-      skipIssuerCheck: true,
-    });
-  }
-
-  private _fetchProviderAndConfigure(): Promise<boolean> {
-    return new Promise<boolean>(resolve => {
-      this.portalService
-        .getPortalIdentityProvider({ identityProviderId: this.getProviderId() })
-        .toPromise()
-        .then(
-          identityProvider => {
-            if (identityProvider) {
-              this._configure(identityProvider);
-              resolve(true);
-            } else {
-              resolve(false);
-            }
-          },
-          () => resolve(false),
-        );
+      this.performLogout()
+        .catch(() => resolve(false))
+        .finally(() => resolve(true));
     });
   }
 
   removeProviderId() {
-    localStorage.removeItem('user-provider-id');
+    localStorage.removeItem(USER_PROVIDER_ID_KEY);
   }
 
-  storeProviderId(providerId) {
-    localStorage.setItem('user-provider-id', providerId);
+  storeProviderId(providerId: string) {
+    localStorage.setItem(USER_PROVIDER_ID_KEY, providerId);
   }
 
-  getProviderId(): string {
-    return localStorage.getItem('user-provider-id');
+  getProviderId(): string | null {
+    return localStorage.getItem(USER_PROVIDER_ID_KEY);
+  }
+
+  private async redirectToIdentityProvider(provider: IdentityProvider, redirectUrl: string): Promise<void> {
+    this.storeProviderId(provider.id);
+    const redirectUri = this.getRedirectUri();
+    sessionStorage.setItem(OIDC_REDIRECT_URI_KEY, redirectUri);
+
+    const { state, codeChallenge } = await storeOidcTransaction({
+      providerId: provider.id,
+      redirectUrl,
+      redirectUri,
+    });
+
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: provider.client_id,
+      redirect_uri: redirectUri,
+      scope: provider.scopes?.join(' ') ?? 'openid',
+      state,
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+    });
+
+    window.location.href = `${provider.authorizationEndpoint}?${params.toString()}`;
+  }
+
+  private completeOidcCallback(providerId: string, authorizationCode: string, transaction: OidcTransaction): Promise<void> {
+    return this.fetchIdentityProvider(providerId).then(identityProvider => {
+      if (!identityProvider?.id || !identityProvider.client_id) {
+        return Promise.reject(new Error(`Identity provider ${providerId} not found!`));
+      }
+
+      const body = new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: authorizationCode,
+        redirect_uri: transaction.redirectUri,
+        client_id: identityProvider.client_id,
+        code_verifier: transaction.codeVerifier,
+      });
+
+      const baseURL = this.configurationService.get('baseURL');
+
+      return this.http
+        .post(`${baseURL}/auth/oauth2/${identityProvider.id}`, body.toString(), {
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          responseType: 'text',
+          withCredentials: true,
+        })
+        .toPromise()
+        .then(() => {
+          sessionStorage.removeItem(OIDC_REDIRECT_URI_KEY);
+          return this.currentUserService.load();
+        })
+        .then(() => {
+          const user = this.currentUserService.getUser();
+          if (!user) {
+            return Promise.reject(new Error('OIDC login failed'));
+          }
+
+          if (transaction.redirectUrl) {
+            sessionStorage.setItem(OIDC_REDIRECT_STATE_KEY, transaction.redirectUrl);
+          }
+        });
+    });
+  }
+
+  private performLogout(): Promise<void> {
+    const baseURL = this.configurationService.get('baseURL');
+    const postLogoutRedirectUri = this.getRedirectUri();
+
+    return this.http
+      .post<LogoutResponse>(`${baseURL}/auth/logout`, { post_logout_redirect_uri: postLogoutRedirectUri }, { withCredentials: true })
+      .toPromise()
+      .catch((): LogoutResponse => ({}))
+      .then(logoutResponse => {
+        this.currentUserService.revokeUser();
+        this.removeProviderId();
+
+        const logoutUrl = logoutResponse?.logout_url;
+        if (logoutUrl) {
+          window.location.href = logoutUrl;
+          return;
+        }
+
+        return this.router.navigate(['']).then(() => undefined);
+      });
+  }
+
+  private fetchIdentityProvider(providerId: string): Promise<IdentityProvider | null> {
+    this.ensureSdkServices();
+
+    return this.portalService
+      .getPortalIdentityProvider({ identityProviderId: providerId })
+      .toPromise()
+      .then(identityProvider => identityProvider ?? null)
+      .catch(() => null);
+  }
+
+  private getRedirectUri(): string {
+    return window.location.origin + (window.location.pathname === '/' ? '' : window.location.pathname.replace('/user/logout', '/'));
+  }
+
+  private clearOidcQueryParams() {
+    window.history.replaceState({}, '', window.location.pathname);
+  }
+
+  private ensureSdkServices() {
+    if (!this.authenticationService) {
+      this.authenticationService = this.injector.get(AuthenticationService);
+      this.portalService = this.injector.get(PortalService);
+      this.router = this.injector.get(Router);
+    }
   }
 }

--- a/gravitee-apim-portal-webui/src/app/services/auth.service.ts
+++ b/gravitee-apim-portal-webui/src/app/services/auth.service.ts
@@ -19,7 +19,13 @@ import { Router } from '@angular/router';
 
 import { AuthenticationService, IdentityProvider, PortalService } from '../../../projects/portal-webclient-sdk/src/lib';
 
-import { clearOidcTransaction, consumeOidcTransaction, OidcTransaction, storeOidcTransaction } from './oidc-transaction.util';
+import {
+  clearOidcTransaction,
+  consumeOidcTransaction,
+  isSafeOidcLogoutUrl,
+  OidcTransaction,
+  storeOidcTransaction,
+} from './oidc-transaction.util';
 import { ConfigurationService } from './configuration.service';
 import { CurrentUserService } from './current-user.service';
 import { NotificationService } from './notification.service';
@@ -50,7 +56,7 @@ export class AuthService {
     private readonly injector: Injector,
   ) {}
 
-  load(): Promise<boolean> {
+  completeOidcLoginIfPresent(): Promise<boolean> {
     this.ensureSdkServices();
 
     const providerId = this.getProviderId();
@@ -76,7 +82,7 @@ export class AuthService {
       this.removeProviderId();
       sessionStorage.removeItem(OIDC_REDIRECT_URI_KEY);
       clearOidcTransaction();
-      return Promise.resolve(true);
+      return Promise.reject(new Error('Invalid OIDC state'));
     }
 
     this.clearOidcQueryParams();
@@ -233,8 +239,8 @@ export class AuthService {
         this.removeProviderId();
 
         const logoutUrl = logoutResponse?.logout_url;
-        if (logoutUrl) {
-          window.location.href = logoutUrl;
+        if (isSafeOidcLogoutUrl(logoutUrl)) {
+          window.location.href = logoutUrl!;
           return;
         }
 

--- a/gravitee-apim-portal-webui/src/app/services/nav-route.service.ts
+++ b/gravitee-apim-portal-webui/src/app/services/nav-route.service.ts
@@ -16,7 +16,6 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRoute, NavigationExtras, Route, Router, Routes } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { OAuthService } from 'angular-oauth2-oidc';
 
 import { CurrentUserService } from './current-user.service';
 import { canAccessFeature } from './feature-guard.service';
@@ -42,7 +41,6 @@ export class NavRouteService {
     private readonly translateService: TranslateService,
     private readonly currentUserService: CurrentUserService,
     private readonly config: ConfigurationService,
-    private readonly oauthService: OAuthService,
   ) {}
 
   async getUserNav(): Promise<INavRoute[]> {
@@ -120,7 +118,7 @@ export class NavRouteService {
           .filter(child => canAccessFeature(child, this.config, this.router) === true)
           .filter(child => checkPermission(child, this.currentUserService, this.router) === true)
           .map(async child => {
-            const hasAuth = await canActivateBasedOnAuth(child, this.currentUserService, this.router, this.oauthService);
+            const hasAuth = await canActivateBasedOnAuth(child, this.currentUserService, this.router);
             if (hasAuth === true) {
               let path = `${_parentPath}/${child.path}`;
               // remove trailing slash to allow empty path

--- a/gravitee-apim-portal-webui/src/app/services/oidc-transaction.util.ts
+++ b/gravitee-apim-portal-webui/src/app/services/oidc-transaction.util.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface OidcTransaction {
+  state: string;
+  redirectUrl: string;
+  providerId: string;
+  redirectUri: string;
+  codeVerifier: string;
+}
+
+const OIDC_TRANSACTION_STORAGE_KEY = 'oidc-transaction';
+
+export async function storeOidcTransaction(input: {
+  providerId: string;
+  redirectUrl: string;
+  redirectUri: string;
+}): Promise<{ state: string; codeChallenge: string }> {
+  const codeVerifier = generateCodeVerifier();
+  const state = generateRandomState();
+  const codeChallenge = await computeS256CodeChallenge(codeVerifier);
+
+  const transaction: OidcTransaction = {
+    state,
+    redirectUrl: input.redirectUrl,
+    providerId: input.providerId,
+    redirectUri: input.redirectUri,
+    codeVerifier,
+  };
+
+  sessionStorage.setItem(OIDC_TRANSACTION_STORAGE_KEY, JSON.stringify(transaction));
+
+  return { state, codeChallenge };
+}
+
+export function consumeOidcTransaction(receivedState: string | null): OidcTransaction | null {
+  if (!receivedState) {
+    return null;
+  }
+
+  const raw = sessionStorage.getItem(OIDC_TRANSACTION_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  let transaction: OidcTransaction;
+  try {
+    transaction = JSON.parse(raw) as OidcTransaction;
+  } catch {
+    return null;
+  }
+
+  if (transaction.state !== receivedState) {
+    return null;
+  }
+
+  sessionStorage.removeItem(OIDC_TRANSACTION_STORAGE_KEY);
+  return transaction;
+}
+
+export function clearOidcTransaction(): void {
+  sessionStorage.removeItem(OIDC_TRANSACTION_STORAGE_KEY);
+}
+
+function generateCodeVerifier(): string {
+  const random = new Uint8Array(32);
+  crypto.getRandomValues(random);
+  return base64UrlEncode(random);
+}
+
+function generateRandomState(): string {
+  const random = new Uint8Array(16);
+  crypto.getRandomValues(random);
+  return base64UrlEncode(random);
+}
+
+async function computeS256CodeChallenge(codeVerifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  const binary = Array.from(bytes, byte => String.fromCodePoint(byte)).join('');
+
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}

--- a/gravitee-apim-portal-webui/src/app/services/oidc-transaction.util.ts
+++ b/gravitee-apim-portal-webui/src/app/services/oidc-transaction.util.ts
@@ -75,6 +75,18 @@ export function clearOidcTransaction(): void {
   sessionStorage.removeItem(OIDC_TRANSACTION_STORAGE_KEY);
 }
 
+/** Guard before assigning server-provided logout_url to window.location. */
+export function isSafeOidcLogoutUrl(url: string | null | undefined): boolean {
+  if (!url) {
+    return false;
+  }
+  try {
+    return new URL(url).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 function generateCodeVerifier(): string {
   const random = new Uint8Array(32);
   crypto.getRandomValues(random);

--- a/gravitee-apim-portal-webui/src/app/services/oidc-transaction.util.ts
+++ b/gravitee-apim-portal-webui/src/app/services/oidc-transaction.util.ts
@@ -93,7 +93,10 @@ async function computeS256CodeChallenge(codeVerifier: string): Promise<string> {
 }
 
 function base64UrlEncode(bytes: Uint8Array): string {
-  const binary = Array.from(bytes, byte => String.fromCodePoint(byte)).join('');
+  let binary = '';
+  bytes.forEach(byte => {
+    binary += String.fromCharCode(byte);
+  });
 
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }

--- a/gravitee-apim-portal-webui/src/app/shared/shared.module.ts
+++ b/gravitee-apim-portal-webui/src/app/shared/shared.module.ts
@@ -19,7 +19,6 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateCompiler, TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
-import { OAuthModule } from 'angular-oauth2-oidc';
 import { TranslateMessageFormatCompiler } from 'ngx-translate-messageformat-compiler';
 
 import { GvCheckboxControlValueAccessorDirective } from '../directives/gv-checkbox-control-value-accessor.directive';
@@ -59,7 +58,6 @@ import { ApiLabelsPipe } from '../pipes/api-labels.pipe';
   exports: [
     HttpClientModule,
     ReactiveFormsModule,
-    OAuthModule,
     GvFormControlDirective,
     SafePipe,
     MarkdownDescriptionPipe,
@@ -71,7 +69,6 @@ import { ApiLabelsPipe } from '../pipes/api-labels.pipe';
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    OAuthModule.forRoot(),
     TranslateModule.forChild({
       loader: {
         provide: TranslateLoader,

--- a/gravitee-apim-portal-webui/src/setup-jest.ts
+++ b/gravitee-apim-portal-webui/src/setup-jest.ts
@@ -17,15 +17,11 @@ import './jest-global-mocks';
 
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { defineGlobalsInjections } from '@ngneat/spectator';
-import { mockProvider } from '@ngneat/spectator/jest';
-import { OAuthService } from 'angular-oauth2-oidc';
 
 import { TranslateTestingModule } from './app/test/translate-testing-module';
 
-// mocks globally available for every test
 defineGlobalsInjections({
   imports: [TranslateTestingModule],
-  providers: [mockProvider(OAuthService)],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 });
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/TokenEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/TokenEntity.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.rest.api.management.rest.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
@@ -27,12 +26,6 @@ public class TokenEntity {
     private TokenType type;
     private String token;
     private String state;
-
-    @JsonProperty("access_token")
-    private String accessToken;
-
-    @JsonProperty("id_token")
-    private String idToken;
 
     public TokenType getType() {
         return type;
@@ -58,22 +51,6 @@ public class TokenEntity {
         this.state = state;
     }
 
-    public String getAccessToken() {
-        return accessToken;
-    }
-
-    public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
-    }
-
-    public String getIdToken() {
-        return idToken;
-    }
-
-    public void setIdToken(String idToken) {
-        this.idToken = idToken;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -89,21 +66,6 @@ public class TokenEntity {
 
     @Override
     public String toString() {
-        return (
-            "TokenEntity{" +
-            "type='" +
-            type +
-            '\'' +
-            ", token='" +
-            token +
-            '\'' +
-            ", access_token='" +
-            accessToken +
-            '\'' +
-            ", id_token='" +
-            idToken +
-            '\'' +
-            '}'
-        );
+        return ("TokenEntity{" + "type='" + type + '\'' + ", token='" + token + '\'' + '}');
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/provider/PayloadInputBodyReader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/provider/PayloadInputBodyReader.java
@@ -61,6 +61,7 @@ public class PayloadInputBodyReader implements MessageBodyReader<PayloadInput> {
                 payloadInput.setRedirect_uri(getParam(params, "redirect_uri"));
                 payloadInput.setCode_verifier(getParam(params, "code_verifier"));
                 payloadInput.setClient_id(getParam(params, "client_id"));
+                payloadInput.setState(getParam(params, "state"));
             }
             return payloadInput;
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/AbstractAuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/AbstractAuthenticationResource.java
@@ -95,16 +95,28 @@ public abstract class AbstractAuthenticationResource {
         return MAPPER.readValue(response, new TypeReference<Map<String, Object>>() {});
     }
 
-    protected Response connectUser(String userId, final String state, final HttpServletResponse servletResponse) {
+    protected Response connectUser(
+        String userId,
+        final String state,
+        final HttpServletResponse servletResponse,
+        final String accessToken,
+        final String idToken
+    ) {
         UserEntity user = userService.connect(GraviteeContext.getExecutionContext(), userId);
-        return this.connectUserInternal(user, state, servletResponse);
+        return this.connectUserInternal(user, state, servletResponse, accessToken, idToken);
     }
 
     protected void connectUser(UserEntity user, final HttpServletResponse servletResponse) {
-        this.connectUserInternal(user, null, servletResponse);
+        this.connectUserInternal(user, null, servletResponse, null, null);
     }
 
-    protected Response connectUserInternal(UserEntity user, final String state, final HttpServletResponse servletResponse) {
+    protected Response connectUserInternal(
+        UserEntity user,
+        final String state,
+        final HttpServletResponse servletResponse,
+        final String accessToken,
+        final String idToken
+    ) {
         TokenEntity tokenEntity = generateToken(user, state, null);
 
         final Cookie bearerCookie = cookieGenerator.generate(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/AbstractAuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/AbstractAuthenticationResource.java
@@ -38,7 +38,6 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.JWTHelper;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.time.Duration;
@@ -96,29 +95,17 @@ public abstract class AbstractAuthenticationResource {
         return MAPPER.readValue(response, new TypeReference<Map<String, Object>>() {});
     }
 
-    protected Response connectUser(
-        String userId,
-        final String state,
-        final HttpServletResponse servletResponse,
-        final String accessToken,
-        final String idToken
-    ) {
+    protected Response connectUser(String userId, final String state, final HttpServletResponse servletResponse) {
         UserEntity user = userService.connect(GraviteeContext.getExecutionContext(), userId);
-        return this.connectUserInternal(user, state, servletResponse, accessToken, idToken);
+        return this.connectUserInternal(user, state, servletResponse);
     }
 
     protected void connectUser(UserEntity user, final HttpServletResponse servletResponse) {
-        this.connectUserInternal(user, null, servletResponse, null, null);
+        this.connectUserInternal(user, null, servletResponse);
     }
 
-    protected Response connectUserInternal(
-        UserEntity user,
-        final String state,
-        final HttpServletResponse servletResponse,
-        final String accessToken,
-        final String idToken
-    ) {
-        TokenEntity tokenEntity = generateToken(user, state, accessToken, idToken, null);
+    protected Response connectUserInternal(UserEntity user, final String state, final HttpServletResponse servletResponse) {
+        TokenEntity tokenEntity = generateToken(user, state, null);
 
         final Cookie bearerCookie = cookieGenerator.generate(
             TokenAuthenticationFilter.AUTH_COOKIE_NAME,
@@ -130,16 +117,10 @@ public abstract class AbstractAuthenticationResource {
     }
 
     protected TokenEntity generateToken(final UserEntity user, final Integer expireAfter) {
-        return generateToken(user, null, null, null, expireAfter);
+        return generateToken(user, null, expireAfter);
     }
 
-    protected TokenEntity generateToken(
-        final UserEntity user,
-        final String state,
-        final String accessToken,
-        final String idToken,
-        final Integer expireAfter
-    ) {
+    protected TokenEntity generateToken(final UserEntity user, final String state, final Integer expireAfter) {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         final UserDetails userDetails = (UserDetails) authentication.getPrincipal();
@@ -191,11 +172,6 @@ public abstract class AbstractAuthenticationResource {
         final TokenEntity tokenEntity = new TokenEntity();
         tokenEntity.setType(BEARER);
         tokenEntity.setToken(token);
-        if (idToken != null) {
-            tokenEntity.setAccessToken(accessToken);
-            tokenEntity.setIdToken(idToken);
-        }
-
         if (state != null && !state.isEmpty()) {
             tokenEntity.setState(state);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.management.rest.utils.BlindTrustManager;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationReferenceType;
 import io.gravitee.rest.api.model.configuration.identity.SocialIdentityProviderEntity;
+import io.gravitee.rest.api.security.oidc.OidcLogoutService;
 import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
 import io.gravitee.rest.api.service.SocialIdentityProviderService;
 import io.gravitee.rest.api.service.builder.JerseyClientBuilder;
@@ -95,6 +96,9 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
 
     @Autowired
     private AuthoritiesProvider authoritiesProvider;
+
+    @Autowired
+    private OidcLogoutService oidcLogoutService;
 
     private Client client;
 
@@ -254,7 +258,16 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
         // Step 3. Process the authenticated user.
         final String userInfo = getResponseEntityAsString(response);
         if (response.getStatus() == Response.Status.OK.getStatusCode()) {
-            return processUser(socialProvider, servletResponse, userInfo, state, accessToken, idToken);
+            UserEntity user = userService.createOrUpdateUserFromSocialIdentityProvider(
+                GraviteeContext.getExecutionContext(),
+                socialProvider,
+                userInfo,
+                accessToken,
+                idToken
+            );
+            oidcLogoutService.storeOidcSession(servletResponse, socialProvider.getId(), idToken);
+            setOidcAuthenticationContext(user);
+            return connectUser(user.getId(), state, servletResponse);
         } else {
             log.error("User info failed with status {}: {}\n{}", response.getStatus(), response.getStatusInfo(), userInfo);
         }
@@ -262,30 +275,12 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
         return Response.status(response.getStatusInfo()).build();
     }
 
-    private Response processUser(
-        final SocialIdentityProviderEntity socialProvider,
-        final HttpServletResponse servletResponse,
-        final String userInfo,
-        final String state,
-        final String accessToken,
-        final String idToken
-    ) {
-        UserEntity user = userService.createOrUpdateUserFromSocialIdentityProvider(
-            GraviteeContext.getExecutionContext(),
-            socialProvider,
-            userInfo,
-            accessToken,
-            idToken
-        );
-
+    private void setOidcAuthenticationContext(final UserEntity user) {
         final Set<GrantedAuthority> authorities = authoritiesProvider.retrieveAuthorities(user.getId());
 
-        //set user to Authentication Context
         UserDetails userDetails = new UserDetails(user.getId(), "", authorities);
         userDetails.setEmail(user.getEmail());
         userDetails.setOrganizationId(user.getOrganizationId());
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null, authorities));
-
-        return connectUser(user.getId(), state, servletResponse, accessToken, idToken);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -258,16 +258,7 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
         // Step 3. Process the authenticated user.
         final String userInfo = getResponseEntityAsString(response);
         if (response.getStatus() == Response.Status.OK.getStatusCode()) {
-            UserEntity user = userService.createOrUpdateUserFromSocialIdentityProvider(
-                GraviteeContext.getExecutionContext(),
-                socialProvider,
-                userInfo,
-                accessToken,
-                idToken
-            );
-            oidcLogoutService.storeOidcSession(servletResponse, socialProvider.getId(), idToken);
-            setOidcAuthenticationContext(user);
-            return connectUser(user.getId(), state, servletResponse);
+            return processUser(socialProvider, servletResponse, userInfo, state, accessToken, idToken);
         } else {
             log.error("User info failed with status {}: {}\n{}", response.getStatus(), response.getStatusInfo(), userInfo);
         }
@@ -275,12 +266,34 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
         return Response.status(response.getStatusInfo()).build();
     }
 
-    private void setOidcAuthenticationContext(final UserEntity user) {
+    private Response processUser(
+        final SocialIdentityProviderEntity socialProvider,
+        final HttpServletResponse servletResponse,
+        final String userInfo,
+        final String state,
+        final String accessToken,
+        final String idToken
+    ) {
+        UserEntity user = userService.createOrUpdateUserFromSocialIdentityProvider(
+            GraviteeContext.getExecutionContext(),
+            socialProvider,
+            userInfo,
+            accessToken,
+            idToken
+        );
+
+        // Persist the IdP id_token in an encrypted HttpOnly cookie (client-held, not readable by JS) instead of returning it
+        // to the browser. It's only needed later for RP-initiated logout (APIM-14635).
+        oidcLogoutService.storeOidcSession(servletResponse, socialProvider.getId(), idToken);
+
         final Set<GrantedAuthority> authorities = authoritiesProvider.retrieveAuthorities(user.getId());
 
+        //set user to Authentication Context
         UserDetails userDetails = new UserDetails(user.getId(), "", authorities);
         userDetails.setEmail(user.getEmail());
         userDetails.setOrganizationId(user.getOrganizationId());
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null, authorities));
+
+        return connectUser(user.getId(), state, servletResponse, accessToken, idToken);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
@@ -448,11 +448,17 @@ public class CurrentUserResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response logoutCurrentUser(OidcLogoutPayload payload) {
         String origin = request == null ? null : request.getHeader("Origin");
-        IdentityProviderActivationService.ActivationTarget activationTarget = new IdentityProviderActivationService.ActivationTarget(
-            GraviteeContext.getCurrentOrganization(),
-            IdentityProviderActivationReferenceType.ORGANIZATION
+        Optional<OidcLogoutResult> result = oidcLogoutService.performLogout(
+            request,
+            response,
+            cookieGenerator.generate(TokenAuthenticationFilter.AUTH_COOKIE_NAME, null),
+            new IdentityProviderActivationService.ActivationTarget(
+                GraviteeContext.getCurrentOrganization(),
+                IdentityProviderActivationReferenceType.ORGANIZATION
+            ),
+            payload,
+            origin
         );
-        Optional<OidcLogoutResult> result = oidcLogoutService.performLogout(request, response, activationTarget, payload, origin);
         return result.map(oidcLogoutResult -> ok(oidcLogoutResult).build()).orElseGet(() -> ok().build());
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
@@ -49,6 +49,7 @@ import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationReferenceType;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.security.filter.TokenAuthenticationFilter;
+import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.rest.api.security.oidc.OidcLogoutPayload;
 import io.gravitee.rest.api.security.oidc.OidcLogoutResult;
 import io.gravitee.rest.api.security.oidc.OidcLogoutService;
@@ -154,6 +155,9 @@ public class CurrentUserResource extends AbstractResource {
 
     @Inject
     private OidcLogoutService oidcLogoutService;
+
+    @Inject
+    private InstallationAccessQueryService installationAccessQueryService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -447,19 +451,33 @@ public class CurrentUserResource extends AbstractResource {
     @Operation(summary = "Logout")
     @Produces(MediaType.APPLICATION_JSON)
     public Response logoutCurrentUser(OidcLogoutPayload payload) {
-        String origin = request == null ? null : request.getHeader("Origin");
+        Cookie clearAuthCookie = cookieGenerator.generate(TokenAuthenticationFilter.AUTH_COOKIE_NAME, null);
+        IdentityProviderActivationService.ActivationTarget activationTarget = new IdentityProviderActivationService.ActivationTarget(
+            GraviteeContext.getCurrentOrganization(),
+            IdentityProviderActivationReferenceType.ORGANIZATION
+        );
+        List<String> allowedRedirectUriPrefixes = resolveAllowedRedirectUriPrefixes(
+            installationAccessQueryService.getConsoleUrls(GraviteeContext.getCurrentOrganization())
+        );
         Optional<OidcLogoutResult> result = oidcLogoutService.performLogout(
             request,
             response,
-            cookieGenerator.generate(TokenAuthenticationFilter.AUTH_COOKIE_NAME, null),
-            new IdentityProviderActivationService.ActivationTarget(
-                GraviteeContext.getCurrentOrganization(),
-                IdentityProviderActivationReferenceType.ORGANIZATION
-            ),
+            clearAuthCookie,
+            activationTarget,
             payload,
-            origin
+            allowedRedirectUriPrefixes
         );
         return result.map(oidcLogoutResult -> ok(oidcLogoutResult).build()).orElseGet(() -> ok().build());
+    }
+
+    private List<String> resolveAllowedRedirectUriPrefixes(List<String> configuredPublicUrls) {
+        List<String> allowed = new ArrayList<>(OidcLogoutService.nonBlank(configuredPublicUrls));
+        String origin = request == null ? null : request.getHeader("Origin");
+        // Origin is secondary validation only: never expands the allowlist beyond configured Console URLs.
+        if (origin != null && !origin.isBlank() && !allowed.isEmpty() && !OidcLogoutService.isAllowedRedirectUri(origin, allowed)) {
+            log.warn("Rejected logout Origin header that does not match configured console URLs: {}", origin);
+        }
+        return allowed;
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
@@ -46,8 +46,12 @@ import io.gravitee.rest.api.model.TaskEntity;
 import io.gravitee.rest.api.model.UpdateUserEntity;
 import io.gravitee.rest.api.model.UrlPictureEntity;
 import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationReferenceType;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.security.filter.TokenAuthenticationFilter;
+import io.gravitee.rest.api.security.oidc.OidcLogoutPayload;
+import io.gravitee.rest.api.security.oidc.OidcLogoutResult;
+import io.gravitee.rest.api.security.oidc.OidcLogoutService;
 import io.gravitee.rest.api.security.utils.ImageUtils;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.TagService;
@@ -57,6 +61,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.JWTHelper;
 import io.gravitee.rest.api.service.common.JWTHelper.Claims;
+import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -66,6 +71,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -122,6 +128,9 @@ public class CurrentUserResource extends AbstractResource {
     @Context
     private HttpServletResponse response;
 
+    @Context
+    private HttpServletRequest request;
+
     @Inject
     private TaskService taskService;
 
@@ -142,6 +151,9 @@ public class CurrentUserResource extends AbstractResource {
 
     @Inject
     private GroupRepository groupRepository;
+
+    @Inject
+    private OidcLogoutService oidcLogoutService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -273,7 +285,7 @@ public class CurrentUserResource extends AbstractResource {
     public Response deleteCurrentUser() {
         if (isAuthenticated()) {
             userService.delete(GraviteeContext.getExecutionContext(), getAuthenticatedUser());
-            logoutCurrentUser();
+            logoutCurrentUser(null);
             return Response.noContent().build();
         } else {
             return status(Response.Status.UNAUTHORIZED).build();
@@ -433,9 +445,15 @@ public class CurrentUserResource extends AbstractResource {
     @POST
     @Path("/logout")
     @Operation(summary = "Logout")
-    public Response logoutCurrentUser() {
-        response.addCookie(cookieGenerator.generate(TokenAuthenticationFilter.AUTH_COOKIE_NAME, null));
-        return ok().build();
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response logoutCurrentUser(OidcLogoutPayload payload) {
+        String origin = request == null ? null : request.getHeader("Origin");
+        IdentityProviderActivationService.ActivationTarget activationTarget = new IdentityProviderActivationService.ActivationTarget(
+            GraviteeContext.getCurrentOrganization(),
+            IdentityProviderActivationReferenceType.ORGANIZATION
+        );
+        Optional<OidcLogoutResult> result = oidcLogoutService.performLogout(request, response, activationTarget, payload, origin);
+        return result.map(oidcLogoutResult -> ok(oidcLogoutResult).build()).orElseGet(() -> ok().build());
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResourceTest.java
@@ -324,14 +324,7 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
 
         DecodedJWT jwt = jwtVerifier.verify(token);
 
-        assertEquals(jwt.getSubject(), "janedoe@example.com");
-
-        assertEquals(jwt.getClaim("firstname").asString(), "Jane");
-        assertEquals(jwt.getClaim("iss").asString(), "gravitee-management-auth");
-        assertEquals(jwt.getClaim("sub").asString(), "janedoe@example.com");
-        assertEquals(jwt.getClaim("email").asString(), "janedoe@example.com");
-        assertEquals(jwt.getClaim("lastname").asString(), "Doe");
-        assertEquals(jwt.getClaim("org").asString(), "my-org");
+        verifyJwtClaims(jwt);
     }
 
     private void verifyJwtTokenIsNotPresent(Response response)
@@ -345,6 +338,52 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
         payload.add("redirect_uri", redirectUri);
         payload.add("code", code);
         return payload;
+    }
+
+    @Test
+    public void shouldConnectNewUserWithoutExposingIdpTokensInResponseBody() throws Exception {
+        mockDefaultEnvironment();
+        mockExchangeAuthorizationCodeForAccessTokenWithIdToken();
+
+        final String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        mockUserInfo(okJson(userInfo));
+
+        UserEntity createdUser = mockUserEntity();
+        mockUserCreation(identityProvider, userInfo, createdUser);
+
+        when(userService.createOrUpdateUserFromSocialIdentityProvider(any(), eq(identityProvider), any(), any(), any())).thenReturn(
+            createdUser
+        );
+        when(userService.connect(any(), eq("janedoe@example.com"))).thenReturn(createdUser);
+
+        final MultivaluedMap<String, String> payload = createPayload("the_client_id", "http://localhost/callback", "CoDe", "StAtE");
+        payload.add("state", "StAtE");
+
+        Response response = orgTarget().request().post(form(payload));
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        String responseBody = response.readEntity(String.class);
+        assertFalse(responseBody.contains("id_token"));
+        assertFalse(responseBody.contains("\"access_token\""));
+
+        TokenEntity responseToken = new com.fasterxml.jackson.databind.ObjectMapper().readValue(responseBody, TokenEntity.class);
+        assertEquals("BEARER", responseToken.getType().name());
+        assertNotNull(responseToken.getToken());
+        assertEquals("StAtE", responseToken.getState());
+
+        DecodedJWT jwt = JWT.require(Algorithm.HMAC256("myJWT4Gr4v1t33_S3cr3t")).build().verify(responseToken.getToken());
+        verifyJwtClaims(jwt);
+    }
+
+    private void verifyJwtClaims(DecodedJWT jwt) {
+        assertEquals(jwt.getSubject(), "janedoe@example.com");
+        assertEquals(jwt.getClaim("firstname").asString(), "Jane");
+        assertEquals(jwt.getClaim("iss").asString(), "gravitee-management-auth");
+        assertEquals(jwt.getClaim("sub").asString(), "janedoe@example.com");
+        assertEquals(jwt.getClaim("email").asString(), "janedoe@example.com");
+        assertEquals(jwt.getClaim("lastname").asString(), "Doe");
+        assertEquals(jwt.getClaim("org").asString(), "my-org");
     }
 
     @Test
@@ -508,6 +547,23 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
                 .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON_TYPE.toString()))
                 .withRequestBody(equalTo(tokenRequestBody))
                 .willReturn(okJson(IOUtils.toString(read("/oauth2/json/token_response_body.json"), Charset.defaultCharset())))
+        );
+    }
+
+    private void mockExchangeAuthorizationCodeForAccessTokenWithIdToken() throws IOException {
+        String tokenRequestBody =
+            "code=CoDe&" +
+            "grant_type=authorization_code&" +
+            "redirect_uri=http%3A%2F%2Flocalhost%2Fcallback&" +
+            "client_secret=the_client_secret&" +
+            "client_id=the_client_id&" +
+            "code_verifier=";
+
+        stubFor(
+            post("/token")
+                .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON_TYPE.toString()))
+                .withRequestBody(equalTo(tokenRequestBody))
+                .willReturn(okJson(IOUtils.toString(read("/oauth2/json/token_response_body_with_id_token.json"), Charset.defaultCharset())))
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -208,6 +208,7 @@ import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.GroupRepository;
 import io.gravitee.rest.api.security.authentication.AuthenticationProvider;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
+import io.gravitee.rest.api.security.oidc.OidcLogoutService;
 import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
 import io.gravitee.rest.api.service.AccessControlService;
 import io.gravitee.rest.api.service.AlertAnalyticsService;
@@ -282,6 +283,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockEnvironment;
 
 @Configuration
@@ -425,6 +427,15 @@ public class ResourceContextConfiguration {
     @Bean
     public CookieGenerator jwtCookieGenerator() {
         return mock(CookieGenerator.class);
+    }
+
+    @Bean
+    public OidcLogoutService oidcLogoutService(
+        CookieGenerator jwtCookieGenerator,
+        Environment environment,
+        SocialIdentityProviderService socialIdentityProviderService
+    ) {
+        return new OidcLogoutService(jwtCookieGenerator, environment, socialIdentityProviderService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/resources/oauth2/json/token_response_body_with_id_token.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/resources/oauth2/json/token_response_body_with_id_token.json
@@ -1,0 +1,6 @@
+{
+  "access_token": "2YotnFZFEjr1zCsicMWpAA",
+  "id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.idp-token",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/SecurityManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/SecurityManagementConfiguration.java
@@ -19,8 +19,10 @@ import io.gravitee.rest.api.management.security.config.BasicSecurityConfigurerAd
 import io.gravitee.rest.api.security.authentication.AuthenticationProviderManager;
 import io.gravitee.rest.api.security.authentication.impl.AuthenticationProviderManagerImpl;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
+import io.gravitee.rest.api.security.oidc.OidcLogoutService;
 import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
 import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.SocialIdentityProviderService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -49,5 +51,14 @@ public class SecurityManagementConfiguration extends GlobalAuthenticationConfigu
     @Bean
     public AuthoritiesProvider authoritiesProvider(MembershipService membershipService) {
         return new AuthoritiesProvider(membershipService);
+    }
+
+    @Bean
+    public OidcLogoutService oidcLogoutService(
+        CookieGenerator jwtCookieGenerator,
+        Environment environment,
+        SocialIdentityProviderService socialIdentityProviderService
+    ) {
+        return new OidcLogoutService(jwtCookieGenerator, environment, socialIdentityProviderService);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/PayloadInputBodyReader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/provider/PayloadInputBodyReader.java
@@ -62,6 +62,7 @@ public class PayloadInputBodyReader implements MessageBodyReader<PayloadInput> {
                 payloadInput.setRedirectUri(getParam(params, "redirect_uri"));
                 payloadInput.setCodeVerifier(getParam(params, "code_verifier"));
                 payloadInput.setClientId(getParam(params, "client_id"));
+                payloadInput.setState(getParam(params, "state"));
             }
             return payloadInput;
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AuthResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AuthResource.java
@@ -150,11 +150,17 @@ public class AuthResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response logout(OidcLogoutPayload payload) {
         String origin = request == null ? null : request.getHeader("Origin");
-        IdentityProviderActivationService.ActivationTarget activationTarget = new IdentityProviderActivationService.ActivationTarget(
-            GraviteeContext.getCurrentEnvironment(),
-            IdentityProviderActivationReferenceType.ENVIRONMENT
+        Optional<OidcLogoutResult> result = oidcLogoutService.performLogout(
+            request,
+            response,
+            cookieGenerator.generate(null),
+            new IdentityProviderActivationService.ActivationTarget(
+                GraviteeContext.getCurrentEnvironment(),
+                IdentityProviderActivationReferenceType.ENVIRONMENT
+            ),
+            payload,
+            origin
         );
-        Optional<OidcLogoutResult> result = oidcLogoutService.performLogout(request, response, activationTarget, payload, origin);
         return result.map(oidcLogoutResult -> ok(oidcLogoutResult).build()).orElseGet(() -> ok().build());
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AuthResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AuthResource.java
@@ -21,6 +21,7 @@ import static jakarta.ws.rs.core.Response.ok;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.common.util.Maps;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
@@ -53,6 +54,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.security.core.Authentication;
@@ -62,6 +64,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class AuthResource extends AbstractResource {
 
     @Context
@@ -81,6 +84,9 @@ public class AuthResource extends AbstractResource {
 
     @Autowired
     private OidcLogoutService oidcLogoutService;
+
+    @Autowired
+    private InstallationAccessQueryService installationAccessQueryService;
 
     @POST
     @Path("/login")
@@ -149,19 +155,33 @@ public class AuthResource extends AbstractResource {
     @Path("/logout")
     @Produces(MediaType.APPLICATION_JSON)
     public Response logout(OidcLogoutPayload payload) {
-        String origin = request == null ? null : request.getHeader("Origin");
+        Cookie clearAuthCookie = cookieGenerator.generate(null);
+        IdentityProviderActivationService.ActivationTarget activationTarget = new IdentityProviderActivationService.ActivationTarget(
+            GraviteeContext.getCurrentEnvironment(),
+            IdentityProviderActivationReferenceType.ENVIRONMENT
+        );
+        List<String> allowedRedirectUriPrefixes = resolveAllowedRedirectUriPrefixes(
+            installationAccessQueryService.getPortalUrls(GraviteeContext.getCurrentEnvironment())
+        );
         Optional<OidcLogoutResult> result = oidcLogoutService.performLogout(
             request,
             response,
-            cookieGenerator.generate(null),
-            new IdentityProviderActivationService.ActivationTarget(
-                GraviteeContext.getCurrentEnvironment(),
-                IdentityProviderActivationReferenceType.ENVIRONMENT
-            ),
+            clearAuthCookie,
+            activationTarget,
             payload,
-            origin
+            allowedRedirectUriPrefixes
         );
         return result.map(oidcLogoutResult -> ok(oidcLogoutResult).build()).orElseGet(() -> ok().build());
+    }
+
+    private List<String> resolveAllowedRedirectUriPrefixes(List<String> configuredPublicUrls) {
+        List<String> allowed = new ArrayList<>(OidcLogoutService.nonBlank(configuredPublicUrls));
+        String origin = request == null ? null : request.getHeader("Origin");
+        // Origin is secondary validation only: never expands the allowlist beyond configured Portal URLs.
+        if (origin != null && !origin.isBlank() && !allowed.isEmpty() && !OidcLogoutService.isAllowedRedirectUri(origin, allowed)) {
+            log.warn("Rejected logout Origin header that does not match configured portal URLs: {}", origin);
+        }
+        return allowed;
     }
 
     @Path("/oauth2/{identity}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AuthResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AuthResource.java
@@ -27,14 +27,20 @@ import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationReferenceType;
 import io.gravitee.rest.api.portal.rest.model.Token;
 import io.gravitee.rest.api.portal.rest.model.Token.TokenTypeEnum;
 import io.gravitee.rest.api.portal.rest.resource.auth.ConsoleAuthenticationResource;
 import io.gravitee.rest.api.portal.rest.resource.auth.OAuth2AuthenticationResource;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
+import io.gravitee.rest.api.security.oidc.OidcLogoutPayload;
+import io.gravitee.rest.api.security.oidc.OidcLogoutResult;
+import io.gravitee.rest.api.security.oidc.OidcLogoutService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.JWTHelper.Claims;
+import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -64,11 +70,17 @@ public class AuthResource extends AbstractResource {
     @Context
     private HttpServletResponse response;
 
+    @Context
+    private HttpServletRequest request;
+
     @Autowired
     private ConfigurableEnvironment environment;
 
     @Autowired
     private CookieGenerator cookieGenerator;
+
+    @Autowired
+    private OidcLogoutService oidcLogoutService;
 
     @POST
     @Path("/login")
@@ -135,9 +147,15 @@ public class AuthResource extends AbstractResource {
 
     @POST
     @Path("/logout")
-    public Response logout() {
-        response.addCookie(cookieGenerator.generate(null));
-        return ok().build();
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response logout(OidcLogoutPayload payload) {
+        String origin = request == null ? null : request.getHeader("Origin");
+        IdentityProviderActivationService.ActivationTarget activationTarget = new IdentityProviderActivationService.ActivationTarget(
+            GraviteeContext.getCurrentEnvironment(),
+            IdentityProviderActivationReferenceType.ENVIRONMENT
+        );
+        Optional<OidcLogoutResult> result = oidcLogoutService.performLogout(request, response, activationTarget, payload, origin);
+        return result.map(oidcLogoutResult -> ok(oidcLogoutResult).build()).orElseGet(() -> ok().build());
     }
 
     @Path("/oauth2/{identity}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/AbstractAuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/AbstractAuthenticationResource.java
@@ -92,17 +92,11 @@ abstract class AbstractAuthenticationResource {
     }
 
     protected void connectUser(String userId, final HttpServletResponse servletResponse) {
-        this.connectUser(userId, null, servletResponse, null, null);
+        this.connectUser(userId, null, servletResponse);
     }
 
-    protected Response connectUser(
-        String userId,
-        final String state,
-        final HttpServletResponse servletResponse,
-        final String accessToken,
-        final String idToken
-    ) {
-        Token token = generateToken(userId, state, accessToken, idToken);
+    protected Response connectUser(String userId, final String state, final HttpServletResponse servletResponse) {
+        Token token = generateToken(userId, state);
 
         final Cookie bearerCookie = cookieGenerator.generate("Bearer%20" + token.getToken());
         servletResponse.addCookie(bearerCookie);
@@ -111,7 +105,7 @@ abstract class AbstractAuthenticationResource {
     }
 
     @NonNull
-    private Token generateToken(final String userId, final String state, final String accessToken, final String idToken) {
+    private Token generateToken(final String userId, final String state) {
         UserEntity user = userService.connect(GraviteeContext.getExecutionContext(), userId);
 
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -162,10 +156,6 @@ abstract class AbstractAuthenticationResource {
         final Token tokenEntity = new Token();
         tokenEntity.setTokenType(TokenTypeEnum.BEARER);
         tokenEntity.setToken(sign);
-        if (idToken != null) {
-            tokenEntity.setAccessToken(accessToken);
-            tokenEntity.setIdToken(idToken);
-        }
 
         if (state != null && !state.isEmpty()) {
             tokenEntity.setState(state);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/AbstractAuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/AbstractAuthenticationResource.java
@@ -92,10 +92,16 @@ abstract class AbstractAuthenticationResource {
     }
 
     protected void connectUser(String userId, final HttpServletResponse servletResponse) {
-        this.connectUser(userId, null, servletResponse);
+        this.connectUser(userId, null, servletResponse, null, null);
     }
 
-    protected Response connectUser(String userId, final String state, final HttpServletResponse servletResponse) {
+    protected Response connectUser(
+        String userId,
+        final String state,
+        final HttpServletResponse servletResponse,
+        final String accessToken,
+        final String idToken
+    ) {
         Token token = generateToken(userId, state);
 
         final Cookie bearerCookie = cookieGenerator.generate("Bearer%20" + token.getToken());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -234,16 +234,7 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
         // Step 3. Process the authenticated user.
         final String userInfo = getResponseEntityAsString(response);
         if (response.getStatus() == Response.Status.OK.getStatusCode()) {
-            UserEntity user = userService.createOrUpdateUserFromSocialIdentityProvider(
-                GraviteeContext.getExecutionContext(),
-                socialProvider,
-                userInfo,
-                accessToken,
-                idToken
-            );
-            oidcLogoutService.storeOidcSession(servletResponse, socialProvider.getId(), idToken);
-            setOidcAuthenticationContext(user);
-            return connectUser(user.getId(), state, servletResponse);
+            return processUser(socialProvider, servletResponse, userInfo, state, accessToken, idToken);
         } else {
             log.error("User info failed with status {}: {}\n{}", response.getStatus(), response.getStatusInfo(), userInfo);
         }
@@ -251,12 +242,35 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
         return Response.status(response.getStatusInfo()).build();
     }
 
-    private void setOidcAuthenticationContext(final UserEntity user) {
+    private Response processUser(
+        final SocialIdentityProviderEntity socialProvider,
+        final HttpServletResponse servletResponse,
+        final String userInfo,
+        final String state,
+        final String accessToken,
+        final String idToken
+    ) {
+        UserEntity user = userService.createOrUpdateUserFromSocialIdentityProvider(
+            GraviteeContext.getExecutionContext(),
+            socialProvider,
+            userInfo,
+            accessToken,
+            idToken
+        );
+        String userId = user.getId();
+
+        // Persist the IdP id_token in an encrypted HttpOnly cookie (client-held, not readable by JS) instead of returning it
+        // to the browser. It's only needed later for RP-initiated logout (APIM-14635).
+        oidcLogoutService.storeOidcSession(servletResponse, socialProvider.getId(), idToken);
+
         final Set<GrantedAuthority> authorities = authoritiesProvider.retrieveAuthorities(user.getId());
 
-        UserDetails userDetails = new UserDetails(user.getId(), "", authorities);
+        //set user to Authentication Context
+        UserDetails userDetails = new UserDetails(userId, "", authorities);
         userDetails.setEmail(user.getEmail());
         userDetails.setOrganizationId(user.getOrganizationId());
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null, authorities));
+
+        return connectUser(userId, state, servletResponse, accessToken, idToken);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivat
 import io.gravitee.rest.api.model.configuration.identity.SocialIdentityProviderEntity;
 import io.gravitee.rest.api.portal.rest.model.PayloadInput;
 import io.gravitee.rest.api.portal.rest.utils.BlindTrustManager;
+import io.gravitee.rest.api.security.oidc.OidcLogoutService;
 import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
 import io.gravitee.rest.api.service.SocialIdentityProviderService;
 import io.gravitee.rest.api.service.builder.JerseyClientBuilder;
@@ -73,6 +74,9 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
 
     @Autowired
     private AuthoritiesProvider authoritiesProvider;
+
+    @Autowired
+    private OidcLogoutService oidcLogoutService;
 
     private Client client;
 
@@ -230,7 +234,16 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
         // Step 3. Process the authenticated user.
         final String userInfo = getResponseEntityAsString(response);
         if (response.getStatus() == Response.Status.OK.getStatusCode()) {
-            return processUser(socialProvider, servletResponse, userInfo, state, accessToken, idToken);
+            UserEntity user = userService.createOrUpdateUserFromSocialIdentityProvider(
+                GraviteeContext.getExecutionContext(),
+                socialProvider,
+                userInfo,
+                accessToken,
+                idToken
+            );
+            oidcLogoutService.storeOidcSession(servletResponse, socialProvider.getId(), idToken);
+            setOidcAuthenticationContext(user);
+            return connectUser(user.getId(), state, servletResponse);
         } else {
             log.error("User info failed with status {}: {}\n{}", response.getStatus(), response.getStatusInfo(), userInfo);
         }
@@ -238,31 +251,12 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
         return Response.status(response.getStatusInfo()).build();
     }
 
-    private Response processUser(
-        final SocialIdentityProviderEntity socialProvider,
-        final HttpServletResponse servletResponse,
-        final String userInfo,
-        final String state,
-        final String accessToken,
-        final String idToken
-    ) {
-        UserEntity user = userService.createOrUpdateUserFromSocialIdentityProvider(
-            GraviteeContext.getExecutionContext(),
-            socialProvider,
-            userInfo,
-            accessToken,
-            idToken
-        );
-        String userId = user.getId();
-
+    private void setOidcAuthenticationContext(final UserEntity user) {
         final Set<GrantedAuthority> authorities = authoritiesProvider.retrieveAuthorities(user.getId());
 
-        //set user to Authentication Context
-        UserDetails userDetails = new UserDetails(userId, "", authorities);
+        UserDetails userDetails = new UserDetails(user.getId(), "", authorities);
         userDetails.setEmail(user.getEmail());
         userDetails.setOrganizationId(user.getOrganizationId());
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null, authorities));
-
-        return connectUser(userId, state, servletResponse, accessToken, idToken);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -3700,15 +3700,26 @@ paths:
             operationId: logout
             description: |
                 User need to be authenticated to logout.
+                For OIDC login, the IdP id_token is stored in an encrypted HttpOnly cookie (not exposed to JavaScript or JSON responses) and an optional RP-initiated logout URL may be returned.
+            requestBody:
+                required: false
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/OidcLogoutPayload"
             responses:
                 200:
-                    description: An empty cookie
+                    description: Logged out. Returns an IdP logout URL when RP-initiated logout applies.
                     headers:
                         set-cookie:
-                            description: Empty cookie
+                            description: Empty auth and OIDC session cookies
                             schema:
                                 type: string
                                 example: Auth-Graviteeio-APIM=;Path=/;Expires=Thu, 01-Jan-1970 00:00:00 GMT;Max-Age=0;HttpOnly
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/OidcLogoutResult"
                 500:
                     $ref: "#/components/responses/InternalServerError"
     /auth/oauth2/{identity}:
@@ -3724,6 +3735,7 @@ paths:
             operationId: exchangeAuthorizationCode
             description: |
                 Used to get a gravitee token from an Authorization code (PayloadInput.code). Portal API authenticates the user with the specified IDP ({identity} path param).
+                For OIDC login, IdP access_token and id_token are not returned to the browser (APIM-14635). The APIM session JWT is returned in the response body as type and token, also set as an HttpOnly cookie; state is included when provided.
             requestBody:
                 description: OAuth2 payload for authentication.
                 content:
@@ -6022,12 +6034,22 @@ components:
                         - BEARER
                 token:
                     type: string
+                    description: APIM session JWT. Returned in the response body for OIDC login and also set as an HttpOnly cookie. IdP access_token and id_token are omitted (APIM-14635).
                 state:
                     type: string
-                access_token:
+        OidcLogoutPayload:
+            properties:
+                identity_provider_id:
                     type: string
-                id_token:
+                    description: Optional identity provider id. When omitted, the value stored at login time is used.
+                post_logout_redirect_uri:
                     type: string
+                    description: Requested post-logout redirect URI. Must match the request Origin.
+        OidcLogoutResult:
+            properties:
+                logout_url:
+                    type: string
+                    description: RP-initiated logout URL built from the encrypted IdP id_token read from the HttpOnly cookie (Path=/).
         Category:
             properties:
                 id:
@@ -8380,7 +8402,7 @@ components:
                     schema:
                         $ref: "#/components/schemas/ErrorResponse"
         AuthSuccess:
-            description: Auth token in payload and bearer in cookie
+            description: APIM session JWT in response body and HttpOnly auth cookie. For OIDC login, IdP access_token and id_token are not returned (APIM-14635).
             headers:
                 set-cookie:
                     description: Auth cookie

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -6044,7 +6044,7 @@ components:
                     description: Optional identity provider id. When omitted, the value stored at login time is used.
                 post_logout_redirect_uri:
                     type: string
-                    description: Requested post-logout redirect URI. Must match the request Origin.
+                    description: Requested post-logout redirect URI. Must match a configured Portal public URL.
         OidcLogoutResult:
             properties:
                 logout_url:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -237,6 +237,7 @@ import io.gravitee.rest.api.portal.rest.mapper.TicketMapper;
 import io.gravitee.rest.api.portal.rest.mapper.UserMapper;
 import io.gravitee.rest.api.security.authentication.AuthenticationProvider;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
+import io.gravitee.rest.api.security.oidc.OidcLogoutService;
 import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
 import io.gravitee.rest.api.service.AccessControlService;
 import io.gravitee.rest.api.service.AnalyticsService;
@@ -295,6 +296,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockEnvironment;
 
 @Configuration
@@ -425,6 +427,16 @@ public class ResourceContextConfiguration {
     @Bean
     public SocialIdentityProviderService socialIdentityProviderService() {
         return mock(SocialIdentityProviderService.class);
+    }
+
+    @Bean
+    public OidcLogoutService oidcLogoutService(
+        CookieGenerator jwtCookieGenerator,
+        SocialIdentityProviderService socialIdentityProviderService
+    ) {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("jwt.secret", "myJWT4Gr4v1t33_S3cr3t");
+        return new OidcLogoutService(jwtCookieGenerator, environment, socialIdentityProviderService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/SecurityPortalConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/SecurityPortalConfiguration.java
@@ -19,8 +19,10 @@ import io.gravitee.rest.api.portal.security.config.BasicSecurityConfigurerAdapte
 import io.gravitee.rest.api.security.authentication.AuthenticationProviderManager;
 import io.gravitee.rest.api.security.authentication.impl.AuthenticationProviderManagerImpl;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
+import io.gravitee.rest.api.security.oidc.OidcLogoutService;
 import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
 import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.SocialIdentityProviderService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -49,5 +51,14 @@ public class SecurityPortalConfiguration extends GlobalAuthenticationConfigurerA
     @Bean
     public AuthoritiesProvider authoritiesProvider(MembershipService membershipService) {
         return new AuthoritiesProvider(membershipService);
+    }
+
+    @Bean
+    public OidcLogoutService oidcLogoutService(
+        CookieGenerator jwtCookieGenerator,
+        Environment environment,
+        SocialIdentityProviderService socialIdentityProviderService
+    ) {
+        return new OidcLogoutService(jwtCookieGenerator, environment, socialIdentityProviderService);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcCookieNames.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcCookieNames.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.oidc;
+
+public final class OidcCookieNames {
+
+    public static final String ID_TOKEN_COOKIE = "Auth-Graviteeio-APIM-IdToken";
+    public static final String IDENTITY_PROVIDER_COOKIE = "Auth-Graviteeio-APIM-IdP";
+    public static final int MAX_COOKIE_VALUE_BYTES = 3800;
+
+    private OidcCookieNames() {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcIdTokenCookieCipher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcIdTokenCookieCipher.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.oidc;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.CustomLog;
+
+@CustomLog
+public class OidcIdTokenCookieCipher {
+
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH = 128;
+    private static final byte FORMAT_GZIP = 1;
+    private static final byte[] KEY_DERIVATION_DOMAIN = "gravitee-apim-oidc-id-token-cookie-v1".getBytes(StandardCharsets.UTF_8);
+
+    private final String secret;
+
+    public OidcIdTokenCookieCipher(String secret) {
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalArgumentException("OIDC id_token cookie encryption secret must not be blank");
+        }
+        this.secret = secret;
+    }
+
+    public Optional<String> encrypt(String idToken) {
+        if (idToken == null || idToken.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            new SecureRandom().nextBytes(iv);
+
+            byte[] plaintext = gzip(idToken.getBytes(StandardCharsets.UTF_8));
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, deriveKey(), new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+            byte[] ciphertext = cipher.doFinal(plaintext);
+
+            ByteBuffer buffer = ByteBuffer.allocate(1 + iv.length + ciphertext.length);
+            buffer.put(FORMAT_GZIP);
+            buffer.put(iv);
+            buffer.put(ciphertext);
+            String encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(buffer.array());
+            if (encoded.length() > OidcCookieNames.MAX_COOKIE_VALUE_BYTES) {
+                log.error(
+                    "OIDC id_token cookie exceeds size limit ({} > {} bytes). " +
+                        "IdP logout will proceed without id_token_hint for this session.",
+                    encoded.length(),
+                    OidcCookieNames.MAX_COOKIE_VALUE_BYTES
+                );
+                return Optional.empty();
+            }
+            return Optional.of(encoded);
+        } catch (Exception e) {
+            log.warn("Unable to encrypt OIDC id_token for cookie storage", e);
+            return Optional.empty();
+        }
+    }
+
+    public Optional<String> decrypt(String encryptedValue) {
+        if (encryptedValue == null || encryptedValue.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            byte[] payload = Base64.getUrlDecoder().decode(encryptedValue);
+            if (payload.length <= GCM_IV_LENGTH) {
+                return Optional.empty();
+            }
+
+            byte format = payload[0];
+            ByteBuffer buffer;
+            if (format == FORMAT_GZIP) {
+                if (payload.length <= 1 + GCM_IV_LENGTH) {
+                    return Optional.empty();
+                }
+                buffer = ByteBuffer.wrap(payload, 1, payload.length - 1);
+            } else {
+                // Legacy payloads stored IV as the first bytes without a format marker.
+                buffer = ByteBuffer.wrap(payload);
+            }
+
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            buffer.get(iv);
+            byte[] ciphertext = new byte[buffer.remaining()];
+            buffer.get(ciphertext);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, deriveKey(), new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+            byte[] decrypted = cipher.doFinal(ciphertext);
+
+            if (format == FORMAT_GZIP) {
+                return Optional.of(new String(gunzip(decrypted), StandardCharsets.UTF_8));
+            }
+            return Optional.of(new String(decrypted, StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            log.debug("Unable to decrypt OIDC id_token cookie", e);
+            return Optional.empty();
+        }
+    }
+
+    private static byte[] gzip(byte[] input) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(output)) {
+            gzipOutputStream.write(input);
+        }
+        return output.toByteArray();
+    }
+
+    private static byte[] gunzip(byte[] input) throws Exception {
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(input);
+        try (GZIPInputStream gzipInputStream = new GZIPInputStream(byteArrayInputStream)) {
+            return gzipInputStream.readAllBytes();
+        }
+    }
+
+    private SecretKeySpec deriveKey() throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        digest.update(secret.getBytes(StandardCharsets.UTF_8));
+        digest.update(KEY_DERIVATION_DOMAIN);
+        return new SecretKeySpec(digest.digest(), "AES");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcIdTokenCookieCipherSecrets.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcIdTokenCookieCipherSecrets.java
@@ -15,9 +15,11 @@
  */
 package io.gravitee.rest.api.security.oidc;
 
+import lombok.CustomLog;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
 
+@CustomLog
 public final class OidcIdTokenCookieCipherSecrets {
 
     public static final String DEDICATED_SECRET_PROPERTY = "oidc.id-token-cookie.secret";
@@ -33,6 +35,12 @@ public final class OidcIdTokenCookieCipherSecrets {
 
         String jwtSecret = environment.getProperty(JWT_SECRET_FALLBACK_PROPERTY);
         if (StringUtils.hasText(jwtSecret)) {
+            log.warn(
+                "Property '{}' is not set; falling back to '{}' for OIDC id_token cookie encryption. " +
+                    "Prefer a dedicated secret so session signing and cookie encryption keys stay separate.",
+                DEDICATED_SECRET_PROPERTY,
+                JWT_SECRET_FALLBACK_PROPERTY
+            );
             return jwtSecret.trim();
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcIdTokenCookieCipherSecrets.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcIdTokenCookieCipherSecrets.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.oidc;
+
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
+
+public final class OidcIdTokenCookieCipherSecrets {
+
+    public static final String DEDICATED_SECRET_PROPERTY = "oidc.id-token-cookie.secret";
+    static final String JWT_SECRET_FALLBACK_PROPERTY = "jwt.secret";
+
+    private OidcIdTokenCookieCipherSecrets() {}
+
+    public static String resolveRequired(Environment environment) {
+        String dedicatedSecret = environment.getProperty(DEDICATED_SECRET_PROPERTY);
+        if (StringUtils.hasText(dedicatedSecret)) {
+            return dedicatedSecret.trim();
+        }
+
+        String jwtSecret = environment.getProperty(JWT_SECRET_FALLBACK_PROPERTY);
+        if (StringUtils.hasText(jwtSecret)) {
+            return jwtSecret.trim();
+        }
+
+        throw new IllegalStateException(
+            "OIDC id_token cookie encryption secret is not configured. " +
+                "Set '" +
+                DEDICATED_SECRET_PROPERTY +
+                "' (recommended) or '" +
+                JWT_SECRET_FALLBACK_PROPERTY +
+                "'."
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcLogoutPayload.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcLogoutPayload.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.oidc;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OidcLogoutPayload {
+
+    @JsonProperty("identity_provider_id")
+    private String identityProviderId;
+
+    @JsonProperty("post_logout_redirect_uri")
+    private String postLogoutRedirectUri;
+
+    public String getIdentityProviderId() {
+        return identityProviderId;
+    }
+
+    public void setIdentityProviderId(String identityProviderId) {
+        this.identityProviderId = identityProviderId;
+    }
+
+    public String getPostLogoutRedirectUri() {
+        return postLogoutRedirectUri;
+    }
+
+    public void setPostLogoutRedirectUri(String postLogoutRedirectUri) {
+        this.postLogoutRedirectUri = postLogoutRedirectUri;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcLogoutResult.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcLogoutResult.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.oidc;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OidcLogoutResult {
+
+    @JsonProperty("logout_url")
+    private String logoutUrl;
+
+    public String getLogoutUrl() {
+        return logoutUrl;
+    }
+
+    public void setLogoutUrl(String logoutUrl) {
+        this.logoutUrl = logoutUrl;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcLogoutService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcLogoutService.java
@@ -71,18 +71,12 @@ public class OidcLogoutService {
         Cookie clearAuthCookie,
         IdentityProviderActivationService.ActivationTarget activationTarget,
         OidcLogoutPayload payload,
-        String originHeader
+        Collection<String> allowedRedirectUriPrefixes
     ) {
-        response.addCookie(clearAuthCookie); // 1. Clear APIM session (same as master)
+        response.addCookie(clearAuthCookie);
 
-        Optional<String> logoutUrl = buildLogoutUrl(
-            // 2. Build OIDC logout URL
-            request,
-            activationTarget,
-            payload,
-            originHeader != null ? List.of(originHeader) : List.of()
-        );
-        clearOidcSession(response); // 3. Clear OIDC session
+        Optional<String> logoutUrl = buildLogoutUrl(request, activationTarget, payload, nonBlank(allowedRedirectUriPrefixes));
+        clearOidcSession(response);
 
         return logoutUrl.map(url -> {
             OidcLogoutResult result = new OidcLogoutResult();
@@ -152,13 +146,16 @@ public class OidcLogoutService {
             return false;
         }
         try {
-            String candidateOrigin = URI.create(redirectUri.trim()).getScheme() + "://" + URI.create(redirectUri.trim()).getAuthority();
+            String candidateOrigin = toOrigin(redirectUri.trim());
+            if (candidateOrigin == null) {
+                return false;
+            }
             for (String allowed : allowedPrefixes) {
                 if (!StringUtils.hasText(allowed)) {
                     continue;
                 }
-                String allowedOrigin = URI.create(allowed.trim()).getScheme() + "://" + URI.create(allowed.trim()).getAuthority();
-                if (candidateOrigin.equalsIgnoreCase(allowedOrigin)) {
+                String allowedOrigin = toOrigin(allowed.trim());
+                if (allowedOrigin != null && candidateOrigin.equalsIgnoreCase(allowedOrigin)) {
                     return true;
                 }
             }
@@ -166,6 +163,14 @@ public class OidcLogoutService {
             log.debug("Invalid post_logout_redirect_uri: {}", redirectUri, e);
         }
         return false;
+    }
+
+    private static String toOrigin(String uri) {
+        URI parsed = URI.create(uri);
+        if (parsed.getScheme() == null || parsed.getAuthority() == null) {
+            return null;
+        }
+        return parsed.getScheme() + "://" + parsed.getAuthority();
     }
 
     static String buildEndSessionUrl(String logoutEndpoint, String clientId, String idTokenHint, String postLogoutRedirectUri) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcLogoutService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcLogoutService.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.oidc;
+
+import io.gravitee.rest.api.model.configuration.identity.SocialIdentityProviderEntity;
+import io.gravitee.rest.api.security.cookies.CookieGenerator;
+import io.gravitee.rest.api.service.SocialIdentityProviderService;
+import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import lombok.CustomLog;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.WebUtils;
+
+@CustomLog
+public class OidcLogoutService {
+
+    private final CookieGenerator cookieGenerator;
+    private final SocialIdentityProviderService socialIdentityProviderService;
+    private final OidcIdTokenCookieCipher cipher;
+
+    public OidcLogoutService(
+        CookieGenerator cookieGenerator,
+        Environment environment,
+        SocialIdentityProviderService socialIdentityProviderService
+    ) {
+        this.cookieGenerator = cookieGenerator;
+        this.socialIdentityProviderService = socialIdentityProviderService;
+        this.cipher = new OidcIdTokenCookieCipher(OidcIdTokenCookieCipherSecrets.resolveRequired(environment));
+    }
+
+    public void storeOidcSession(HttpServletResponse response, String identityProviderId, String idToken) {
+        if (!StringUtils.hasText(identityProviderId) || !StringUtils.hasText(idToken)) {
+            return;
+        }
+        cipher
+            .encrypt(idToken)
+            .ifPresent(encrypted -> response.addCookie(cookieGenerator.generate(OidcCookieNames.ID_TOKEN_COOKIE, encrypted, true)));
+        response.addCookie(cookieGenerator.generate(OidcCookieNames.IDENTITY_PROVIDER_COOKIE, identityProviderId, true));
+    }
+
+    public void clearOidcSession(HttpServletResponse response) {
+        response.addCookie(cookieGenerator.generate(OidcCookieNames.ID_TOKEN_COOKIE, null));
+        response.addCookie(cookieGenerator.generate(OidcCookieNames.IDENTITY_PROVIDER_COOKIE, null));
+    }
+
+    public Optional<OidcLogoutResult> performLogout(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        IdentityProviderActivationService.ActivationTarget activationTarget,
+        OidcLogoutPayload payload,
+        String originHeader
+    ) {
+        response.addCookie(cookieGenerator.generate(null));
+
+        Optional<String> logoutUrl = buildLogoutUrl(
+            request,
+            activationTarget,
+            payload,
+            originHeader != null ? List.of(originHeader) : List.of()
+        );
+        clearOidcSession(response);
+
+        return logoutUrl.map(url -> {
+            OidcLogoutResult result = new OidcLogoutResult();
+            result.setLogoutUrl(url);
+            return result;
+        });
+    }
+
+    public Optional<String> buildLogoutUrl(
+        HttpServletRequest request,
+        IdentityProviderActivationService.ActivationTarget activationTarget,
+        OidcLogoutPayload payload,
+        Collection<String> allowedRedirectUriPrefixes
+    ) {
+        String identityProviderId = payload != null && StringUtils.hasText(payload.getIdentityProviderId())
+            ? payload.getIdentityProviderId()
+            : readIdentityProviderId(request);
+        if (!StringUtils.hasText(identityProviderId)) {
+            return Optional.empty();
+        }
+
+        SocialIdentityProviderEntity identityProvider = socialIdentityProviderService.findById(identityProviderId, activationTarget);
+        if (identityProvider == null || !StringUtils.hasText(identityProvider.getUserLogoutEndpoint())) {
+            return Optional.empty();
+        }
+
+        String postLogoutRedirectUri = resolvePostLogoutRedirectUri(
+            payload != null ? payload.getPostLogoutRedirectUri() : null,
+            allowedRedirectUriPrefixes
+        );
+        String idTokenHint = readIdTokenHint(request);
+
+        return Optional.of(
+            buildEndSessionUrl(identityProvider.getUserLogoutEndpoint(), identityProvider.getClientId(), idTokenHint, postLogoutRedirectUri)
+        );
+    }
+
+    private String readCookieValue(HttpServletRequest request, String cookieName) {
+        Cookie cookie = WebUtils.getCookie(request, cookieName);
+        return cookie != null && StringUtils.hasText(cookie.getValue()) ? cookie.getValue() : null;
+    }
+
+    private String readIdentityProviderId(HttpServletRequest request) {
+        return readCookieValue(request, OidcCookieNames.IDENTITY_PROVIDER_COOKIE);
+    }
+
+    private String readIdTokenHint(HttpServletRequest request) {
+        String encryptedValue = readCookieValue(request, OidcCookieNames.ID_TOKEN_COOKIE);
+        if (encryptedValue == null) {
+            return null;
+        }
+        return cipher.decrypt(encryptedValue).orElse(null);
+    }
+
+    private String resolvePostLogoutRedirectUri(String requestedUri, Collection<String> allowedRedirectUriPrefixes) {
+        if (StringUtils.hasText(requestedUri) && isAllowedRedirectUri(requestedUri, allowedRedirectUriPrefixes)) {
+            return requestedUri;
+        }
+        if (StringUtils.hasText(requestedUri)) {
+            log.warn("Rejected post_logout_redirect_uri: {}", requestedUri);
+        }
+        return allowedRedirectUriPrefixes.stream().filter(StringUtils::hasText).findFirst().orElse(null);
+    }
+
+    static boolean isAllowedRedirectUri(String redirectUri, Collection<String> allowedPrefixes) {
+        if (!StringUtils.hasText(redirectUri) || allowedPrefixes == null || allowedPrefixes.isEmpty()) {
+            return false;
+        }
+        try {
+            String candidateOrigin = URI.create(redirectUri.trim()).getScheme() + "://" + URI.create(redirectUri.trim()).getAuthority();
+            for (String allowed : allowedPrefixes) {
+                if (!StringUtils.hasText(allowed)) {
+                    continue;
+                }
+                String allowedOrigin = URI.create(allowed.trim()).getScheme() + "://" + URI.create(allowed.trim()).getAuthority();
+                if (candidateOrigin.equalsIgnoreCase(allowedOrigin)) {
+                    return true;
+                }
+            }
+        } catch (IllegalArgumentException e) {
+            log.debug("Invalid post_logout_redirect_uri: {}", redirectUri, e);
+        }
+        return false;
+    }
+
+    static String buildEndSessionUrl(String logoutEndpoint, String clientId, String idTokenHint, String postLogoutRedirectUri) {
+        boolean usesAmTargetUrl = logoutEndpoint != null && logoutEndpoint.contains("target_url=");
+        StringBuilder url = new StringBuilder(logoutEndpoint);
+        char separator = logoutEndpoint.contains("?") ? '&' : '?';
+
+        if (usesAmTargetUrl && StringUtils.hasText(postLogoutRedirectUri)) {
+            url.append(encode(postLogoutRedirectUri));
+            separator = '&';
+        }
+
+        if (StringUtils.hasText(idTokenHint)) {
+            url.append(separator).append("id_token_hint=").append(encode(idTokenHint));
+            separator = '&';
+        }
+        if (StringUtils.hasText(clientId)) {
+            url.append(separator).append("client_id=").append(encode(clientId));
+            separator = '&';
+        }
+        if (StringUtils.hasText(postLogoutRedirectUri) && !usesAmTargetUrl) {
+            url.append(separator).append("post_logout_redirect_uri=").append(encode(postLogoutRedirectUri));
+        }
+        return url.toString();
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcLogoutService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/oidc/OidcLogoutService.java
@@ -68,19 +68,21 @@ public class OidcLogoutService {
     public Optional<OidcLogoutResult> performLogout(
         HttpServletRequest request,
         HttpServletResponse response,
+        Cookie clearAuthCookie,
         IdentityProviderActivationService.ActivationTarget activationTarget,
         OidcLogoutPayload payload,
         String originHeader
     ) {
-        response.addCookie(cookieGenerator.generate(null));
+        response.addCookie(clearAuthCookie); // 1. Clear APIM session (same as master)
 
         Optional<String> logoutUrl = buildLogoutUrl(
+            // 2. Build OIDC logout URL
             request,
             activationTarget,
             payload,
             originHeader != null ? List.of(originHeader) : List.of()
         );
-        clearOidcSession(response);
+        clearOidcSession(response); // 3. Clear OIDC session
 
         return logoutUrl.map(url -> {
             OidcLogoutResult result = new OidcLogoutResult();
@@ -167,14 +169,8 @@ public class OidcLogoutService {
     }
 
     static String buildEndSessionUrl(String logoutEndpoint, String clientId, String idTokenHint, String postLogoutRedirectUri) {
-        boolean usesAmTargetUrl = logoutEndpoint != null && logoutEndpoint.contains("target_url=");
         StringBuilder url = new StringBuilder(logoutEndpoint);
         char separator = logoutEndpoint.contains("?") ? '&' : '?';
-
-        if (usesAmTargetUrl && StringUtils.hasText(postLogoutRedirectUri)) {
-            url.append(encode(postLogoutRedirectUri));
-            separator = '&';
-        }
 
         if (StringUtils.hasText(idTokenHint)) {
             url.append(separator).append("id_token_hint=").append(encode(idTokenHint));
@@ -184,7 +180,7 @@ public class OidcLogoutService {
             url.append(separator).append("client_id=").append(encode(clientId));
             separator = '&';
         }
-        if (StringUtils.hasText(postLogoutRedirectUri) && !usesAmTargetUrl) {
+        if (StringUtils.hasText(postLogoutRedirectUri)) {
             url.append(separator).append("post_logout_redirect_uri=").append(encode(postLogoutRedirectUri));
         }
         return url.toString();
@@ -192,5 +188,9 @@ public class OidcLogoutService {
 
     private static String encode(String value) {
         return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    public static List<String> nonBlank(Collection<String> values) {
+        return values == null ? List.of() : values.stream().filter(StringUtils::hasText).toList();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/oidc/OidcIdTokenCookieCipherSecretsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/oidc/OidcIdTokenCookieCipherSecretsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class OidcIdTokenCookieCipherSecretsTest {
+
+    @Test
+    void should_prefer_dedicated_secret_over_jwt_secret() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty(OidcIdTokenCookieCipherSecrets.DEDICATED_SECRET_PROPERTY, "dedicated-secret");
+        environment.setProperty(OidcIdTokenCookieCipherSecrets.JWT_SECRET_FALLBACK_PROPERTY, "jwt-secret");
+
+        assertThat(OidcIdTokenCookieCipherSecrets.resolveRequired(environment)).isEqualTo("dedicated-secret");
+    }
+
+    @Test
+    void should_fall_back_to_jwt_secret_when_dedicated_secret_is_missing() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty(OidcIdTokenCookieCipherSecrets.JWT_SECRET_FALLBACK_PROPERTY, "jwt-secret");
+
+        assertThat(OidcIdTokenCookieCipherSecrets.resolveRequired(environment)).isEqualTo("jwt-secret");
+    }
+
+    @Test
+    void should_fail_when_no_secret_is_configured() {
+        assertThatThrownBy(() -> OidcIdTokenCookieCipherSecrets.resolveRequired(new MockEnvironment()))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining(OidcIdTokenCookieCipherSecrets.DEDICATED_SECRET_PROPERTY)
+            .hasMessageContaining(OidcIdTokenCookieCipherSecrets.JWT_SECRET_FALLBACK_PROPERTY);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/oidc/OidcIdTokenCookieCipherTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/oidc/OidcIdTokenCookieCipherTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class OidcIdTokenCookieCipherTest {
+
+    private final OidcIdTokenCookieCipher cipher = new OidcIdTokenCookieCipher("test-secret");
+
+    @Test
+    void should_round_trip_encrypt_and_decrypt() {
+        Optional<String> encrypted = cipher.encrypt("some.id.token");
+
+        assertThat(encrypted).isPresent();
+        assertThat(encrypted.get()).doesNotContain("some.id.token");
+
+        assertThat(cipher.decrypt(encrypted.get())).contains("some.id.token");
+    }
+
+    @Test
+    void should_produce_different_ciphertext_for_same_input() {
+        // IV is randomized per call, so two encryptions of the same token must differ
+        Optional<String> first = cipher.encrypt("some.id.token");
+        Optional<String> second = cipher.encrypt("some.id.token");
+
+        assertThat(first).isPresent();
+        assertThat(second).isPresent();
+        assertThat(first.get()).isNotEqualTo(second.get());
+    }
+
+    @Test
+    void should_return_empty_for_blank_or_null_input() {
+        assertThat(cipher.encrypt(null)).isEmpty();
+        assertThat(cipher.encrypt("")).isEmpty();
+        assertThat(cipher.encrypt("   ")).isEmpty();
+
+        assertThat(cipher.decrypt(null)).isEmpty();
+        assertThat(cipher.decrypt("")).isEmpty();
+    }
+
+    @Test
+    void should_fail_to_decrypt_with_different_secret() {
+        Optional<String> encrypted = cipher.encrypt("some.id.token");
+        assertThat(encrypted).isPresent();
+
+        OidcIdTokenCookieCipher otherCipher = new OidcIdTokenCookieCipher("different-secret");
+        assertThat(otherCipher.decrypt(encrypted.get())).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_for_garbage_input() {
+        assertThat(cipher.decrypt("not-a-valid-encrypted-payload")).isEmpty();
+    }
+
+    @Test
+    void should_encrypt_large_id_token_within_cookie_limit() {
+        String largeIdToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." + "a".repeat(5000) + ".signature";
+
+        Optional<String> encrypted = cipher.encrypt(largeIdToken);
+
+        assertThat(encrypted).isPresent();
+        assertThat(encrypted.get().length()).isLessThanOrEqualTo(OidcCookieNames.MAX_COOKIE_VALUE_BYTES);
+        assertThat(cipher.decrypt(encrypted.get())).contains(largeIdToken);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/oidc/OidcLogoutServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/oidc/OidcLogoutServiceTest.java
@@ -17,8 +17,6 @@ package io.gravitee.rest.api.security.oidc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.service.SocialIdentityProviderService;
@@ -63,21 +61,6 @@ class OidcLogoutServiceTest {
     }
 
     @Test
-    void should_build_gravitee_am_logout_url_with_target_url() {
-        String url = OidcLogoutService.buildEndSessionUrl(
-            "https://am.example.com/my-domain/logout?target_url=",
-            "apim-client",
-            "id-token-value",
-            "http://localhost:4101"
-        );
-
-        assertThat(url).startsWith("https://am.example.com/my-domain/logout?target_url=http");
-        assertThat(url).contains("id_token_hint=id-token-value");
-        assertThat(url).contains("client_id=apim-client");
-        assertThat(url).doesNotContain("post_logout_redirect_uri=");
-    }
-
-    @Test
     void should_validate_post_logout_redirect_uri() {
         assertThat(OidcLogoutService.isAllowedRedirectUri("http://localhost:4100/home", List.of("http://localhost:4100"))).isTrue();
         assertThat(OidcLogoutService.isAllowedRedirectUri("https://evil.example.com/", List.of("http://localhost:4100"))).isFalse();
@@ -88,13 +71,11 @@ class OidcLogoutServiceTest {
         MockEnvironment environment = new MockEnvironment();
         environment.setProperty("jwt.secret", "test-secret");
         OidcLogoutService service = new OidcLogoutService(cookieGenerator, environment, socialIdentityProviderService);
-        var clearAuthCookie = new Cookie("Auth-Graviteeio-APIM", null);
-        when(cookieGenerator.generate(null)).thenReturn(clearAuthCookie);
+        Cookie clearAuthCookie = new Cookie("Auth-Graviteeio-APIM", null);
 
-        Optional<OidcLogoutResult> result = service.performLogout(request, response, null, null, "http://localhost:4100");
+        Optional<OidcLogoutResult> result = service.performLogout(request, response, clearAuthCookie, null, null, "http://localhost:4100");
 
         assertThat(result).isEmpty();
-        verify(response).addCookie(clearAuthCookie);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/oidc/OidcLogoutServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/oidc/OidcLogoutServiceTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.security.cookies.CookieGenerator;
+import io.gravitee.rest.api.service.SocialIdentityProviderService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.env.MockEnvironment;
+
+@ExtendWith(MockitoExtension.class)
+class OidcLogoutServiceTest {
+
+    @Mock
+    private CookieGenerator cookieGenerator;
+
+    @Mock
+    private SocialIdentityProviderService socialIdentityProviderService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Test
+    void should_build_end_session_url_with_id_token_hint() {
+        String url = OidcLogoutService.buildEndSessionUrl(
+            "https://idp.example.com/logout",
+            "apim-client",
+            "id-token-value",
+            "http://localhost:4100/"
+        );
+
+        assertThat(url).contains("id_token_hint=id-token-value");
+        assertThat(url).contains("client_id=apim-client");
+        assertThat(url).contains("post_logout_redirect_uri=");
+    }
+
+    @Test
+    void should_build_gravitee_am_logout_url_with_target_url() {
+        String url = OidcLogoutService.buildEndSessionUrl(
+            "https://am.example.com/my-domain/logout?target_url=",
+            "apim-client",
+            "id-token-value",
+            "http://localhost:4101"
+        );
+
+        assertThat(url).startsWith("https://am.example.com/my-domain/logout?target_url=http");
+        assertThat(url).contains("id_token_hint=id-token-value");
+        assertThat(url).contains("client_id=apim-client");
+        assertThat(url).doesNotContain("post_logout_redirect_uri=");
+    }
+
+    @Test
+    void should_validate_post_logout_redirect_uri() {
+        assertThat(OidcLogoutService.isAllowedRedirectUri("http://localhost:4100/home", List.of("http://localhost:4100"))).isTrue();
+        assertThat(OidcLogoutService.isAllowedRedirectUri("https://evil.example.com/", List.of("http://localhost:4100"))).isFalse();
+    }
+
+    @Test
+    void should_perform_logout_without_idp_redirect_when_no_provider_is_known() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("jwt.secret", "test-secret");
+        OidcLogoutService service = new OidcLogoutService(cookieGenerator, environment, socialIdentityProviderService);
+        var clearAuthCookie = new Cookie("Auth-Graviteeio-APIM", null);
+        when(cookieGenerator.generate(null)).thenReturn(clearAuthCookie);
+
+        Optional<OidcLogoutResult> result = service.performLogout(request, response, null, null, "http://localhost:4100");
+
+        assertThat(result).isEmpty();
+        verify(response).addCookie(clearAuthCookie);
+    }
+
+    @Test
+    void should_fail_to_start_when_no_encryption_secret_is_configured() {
+        assertThatThrownBy(() -> new OidcLogoutService(cookieGenerator, new MockEnvironment(), socialIdentityProviderService))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining(OidcIdTokenCookieCipherSecrets.DEDICATED_SECRET_PROPERTY);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/oidc/OidcLogoutServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/oidc/OidcLogoutServiceTest.java
@@ -73,7 +73,14 @@ class OidcLogoutServiceTest {
         OidcLogoutService service = new OidcLogoutService(cookieGenerator, environment, socialIdentityProviderService);
         Cookie clearAuthCookie = new Cookie("Auth-Graviteeio-APIM", null);
 
-        Optional<OidcLogoutResult> result = service.performLogout(request, response, clearAuthCookie, null, null, "http://localhost:4100");
+        Optional<OidcLogoutResult> result = service.performLogout(
+            request,
+            response,
+            clearAuthCookie,
+            null,
+            null,
+            List.of("http://localhost:4100")
+        );
 
         assertThat(result).isEmpty();
     }


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-14635

## Description
stop exposing IdP `access_token` and `id_token` to the browser after OIDC login to Console, Dev Portal Next, and legacy Portal.

We adopt a **pragmatic BFF (Backend for Frontend)** pattern: APIM performs the OIDC code exchange server-side and stores the IdP `id_token` in an **encrypted HttpOnly cookie** in the browser. This is **not** a strict server-side session — encrypted token material remains client-side, but is inaccessible to JavaScript.

**What changes for security:**
- Plaintext IdP tokens are **not** exposed in JSON response bodies or to JavaScript (`localStorage` / application code).
- The IdP `id_token` is stored **encrypted** in an HttpOnly cookie (`Auth-Graviteeio-APIM-IdToken`).
- That cookie uses path `/` (default `jwt.cookie-path`), so it is sent on every API request to the REST API.

**Important:** Unlike a strict cookie-only BFF, this PR **still returns the Gravitee session JWT** (`type` + `token`) in the OIDC login JSON response — same as master for the APIM token. Only IdP tokens are removed from the response body.

---

### Problem (before)

On OIDC login, `POST /auth/oauth2/{idp}` returned:

```json
{
  "type": "BEARER",
  "token": "<gravitee-jwt>",
  "access_token": "<idp-access-token>",
  "id_token": "<idp-id-token>",
  "state": "..."
}
```

Console used **`oidc-client-ts`**, Portal Next used **`angular-oauth2-oidc`**, and legacy Portal used **`angular-oauth2-oidc`**. Those libraries stored IdP tokens in **`localStorage`** and used `id_token` for IdP logout (`id_token_hint`).

Security concern: IdP tokens were visible in DevTools (Network + Application tab) even though day-to-day API calls only used the HttpOnly `Auth-Graviteeio-APIM` cookie.

---

### Behaviour comparison

#### Login (OIDC)

**Before**
```
Browser → IdP → Browser (?code=)
Browser library → POST /auth/oauth2/{idp}
APIM → JSON with Gravitee JWT + IdP access_token + id_token
Library → stores IdP tokens in localStorage
API calls → HttpOnly cookie
```

**After**
```
Browser → IdP → Browser (?code=)
Browser → POST /auth/oauth2/{idp} (code + PKCE verifier, credentials: include)
APIM → Set-Cookie (session JWT + encrypted IdP id_token in HttpOnly cookies)
APIM → JSON { type, token, state }  ← no IdP tokens
Browser → GET /user (cookie) → logged in
```

#### Logout (OIDC)

**Before**
```
POST /logout → clear APIM cookie
Browser library reads id_token from localStorage → IdP logout
```

**After**
```
POST /logout { post_logout_redirect_uri }
APIM → clear cookies, build logout URL from encrypted id_token cookie
APIM → { logout_url: "https://idp/.../logout?id_token_hint=..." }  (when available)
Browser → redirect to IdP
```

---

### Architecture: pros and cons

**Pros**
- Meets security requirement: plaintext IdP tokens never reach JavaScript or login response bodies
- Login and IdP logout work end-to-end for typical token sizes
- Server-side code exchange unchanged (client secret never in browser)
- Covers Console, Portal Next, and legacy Portal
- Backward-compatible logout API (empty `POST /logout` still returns 200)
- Keeps Gravitee `token` in OIDC JSON for clients that expect it (less breaking than cookie-only BFF)
- PKCE (S256) and cryptographically random OAuth state restored in all three frontends

**Cons**
- **Breaking API change:** OIDC response no longer includes IdP `access_token` / `id_token` — external integrators must migrate
- Encrypted IdP token material remains in a **client-side** HttpOnly cookie (not a server-side session store)
- More code than backend-only fix (~50 files, new security module, frontend rewrite)
- Custom OIDC flow (no `oidc-client-ts` / `angular-oauth2-oidc` for token handling) — we own redirect/callback edge cases
- IdP logout with `id_token_hint` is **conditional** on cookie size limit (3800 chars)
- `logout_url` redirect flagged by Aikido XSS scanner — URL is server-built from configured IdP endpoint (false positive; ignored with justification)

---

## Additional context

https://github.com/user-attachments/assets/9b68f0f2-d2d4-4717-b675-ab61e6f7e000
