### PR TITLE
fix(repository): add authorization audit properties to Audit enum

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Audit.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Audit.java
@@ -81,6 +81,8 @@ public class Audit {
         CLUSTER,
         API_PRODUCT,
         CLIENT_CERTIFICATE,
+        AUTHORIZATION_POLICY,
+        AUTHORIZATION_ENTITY,
     }
 
     private String id;


### PR DESCRIPTION
## Description

The Console **Audit** screen returns HTTP 500 (`Unable to fulfil the request`) once an environment contains audit entries related to authorization policies/entities.

Root cause: two parallel `AuditProperties` enums drifted out of sync. Audit entries are written using the core enum `io.gravitee.apim.core.audit.model.AuditProperties` (which gained `AUTHORIZATION_POLICY` and `AUTHORIZATION_ENTITY`) but read back through `io.gravitee.repository.management.model.Audit.AuditProperties.valueOf()`, which lacked both constants — so `valueOf` throws.

Failing call sites: `AuditServiceImpl#getName`, `AuditMetadataQueryServiceImpl#fetchPropertyMetadata`.

Server error:
```
No enum constant io.gravitee.repository.management.model.Audit.AuditProperties.AUTHORIZATION_ENTITY
```

## Fix

Add `AUTHORIZATION_POLICY` and `AUTHORIZATION_ENTITY` to the repository `Audit.AuditProperties` enum. Both `valueOf` switches already have a `default` branch, so no case-handling changes are required.

## Affected versions

- **4.12.x** — affected (introduced here: the core enum gained the constants but the repository enum was not updated).
- 4.9.x / 4.10.x / 4.11.x — **not** affected; the authorization audit properties do not exist on those branches, so no such audit entry is ever written.

## Related

APIM-14742