### PR TITLE
fix(console): show every API type in the Observability requests widget

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/data-access/templates/http-proxy.template.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/data-access/templates/http-proxy.template.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HTTP_PROXY_TEMPLATE } from './http-proxy.template';
+import { LLM_TEMPLATE } from './llm.template';
+import { MCP_TEMPLATE } from './mcp.template';
+import { DashboardTemplate } from './dashboard-template.model';
+
+type TemplateWidget = NonNullable<DashboardTemplate['initialConfig']['widgets']>[number];
+
+const widgetsOf = (template: DashboardTemplate): TemplateWidget[] => template.initialConfig.widgets ?? [];
+
+const apiTypeFilters = (template: DashboardTemplate) =>
+  widgetsOf(template).flatMap(widget => (widget.request?.filters ?? []).filter(filter => filter.name === 'API_TYPE'));
+
+describe('Dashboard templates', () => {
+  it('should not pin the HTTP proxy dashboard to a single API type', () => {
+    expect(apiTypeFilters(HTTP_PROXY_TEMPLATE)).toEqual([]);
+  });
+
+  it('should leave the Requests widget free of a hardcoded API type', () => {
+    const requests = widgetsOf(HTTP_PROXY_TEMPLATE).find(widget => widget.id === 'proxy-requests');
+
+    expect(requests).toBeDefined();
+    expect(requests?.request?.filters ?? []).toEqual([]);
+  });
+
+  it.each([
+    ['LLM', LLM_TEMPLATE],
+    ['MCP', MCP_TEMPLATE],
+  ])('should keep the %s dashboard scoped to its own API type', (_name, template) => {
+    expect(apiTypeFilters(template as DashboardTemplate).length).toBeGreaterThan(0);
+  });
+});

--- a/gravitee-apim-console-webui/src/management/observability/data-access/templates/http-proxy.template.ts
+++ b/gravitee-apim-console-webui/src/management/observability/data-access/templates/http-proxy.template.ts
@@ -35,7 +35,6 @@ export const HTTP_PROXY_TEMPLATE: DashboardTemplate = {
         request: {
           type: 'measures',
           metrics: [{ name: 'HTTP_REQUESTS', measures: ['COUNT'] }],
-          filters: [{ name: 'API_TYPE', operator: 'EQ', value: 'HTTP_PROXY' }],
         },
       },
       {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14700

## Description

The Observability **Requests** widget pinned its query to `API_TYPE = HTTP_PROXY`, so it only ever counted proxy traffic. A v4 message API would populate every other widget on the dashboard while Requests stayed at `0`.

Selecting an API type in the UI made it worse rather than better — the chosen type was *appended* to the pinned one, and no request is both at once:

```json
"filters": [
  { "name": "API_TYPE", "operator": "EQ", "value": "HTTP_PROXY" },
  { "name": "API_TYPE", "operator": "EQ", "value": "MESSAGE" }
]
```

The pin was also the odd one out in its own template. `http-proxy.template.ts` has eight widgets and only `proxy-requests` constrained the API type:

| widget | API_TYPE filter |
| --- | --- |
| `proxy-requests` | **yes** ← removed here |
| `proxy-error-rate` | no |
| `proxy-average-latency` | no |
| `proxy-average-response-time` | no |
| `proxy-http-statuses` | no |
| `proxy-response-time` | no |
| `proxy-response-statuses` | no |
| `proxy-top-5-applications` | no |

That asymmetry is exactly what the report describes. Removing the filter lets the widget follow the dashboard filters like its neighbours: every API type when nothing is selected, the chosen types when something is.

## Additional context

**The type-scoped templates are deliberately left alone.** `llm.template.ts` and `mcp.template.ts` constrain `API_TYPE` on *every* widget (7 of them for MCP), which is a dashboard that is intentionally about one API type — not a widget disagreeing with the dashboard it sits on. The new spec pins that distinction so this fix does not get copied onto them by mistake.

`http-proxy.template.spec.ts` asserts the widget no longer hardcodes a type, and that LLM/MCP still do. Verified it fails against the unfixed template (2 of 4 assertions) rather than passing vacuously.

Observability suite: 14 files, 151 tests, all passing. ESLint and Prettier clean.

**One thing worth a reviewer's eye:** this template's `info` still reads *"For V4 proxy APIs only. V2 APIs are not supported."* Given seven of its eight widgets never constrained the API type, that text looks stale rather than a statement the widgets actually enforced. Out of scope here, but it may deserve its own ticket.
