### PR TITLE
fix(gateway): keep node not-ready when initial API sync fails

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapper.java
@@ -24,6 +24,7 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.edge.EdgeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.service.EnvironmentService;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.LifecycleState;
@@ -104,6 +105,10 @@ public class ApiMapper {
                 environmentService.fill(api.getEnvironmentId(), reactableApi);
 
                 return reactableApi;
+            } catch (SyncException e) {
+                // Transient enrichment failure: fail the sync so this event is retried instead of
+                // being silently dropped (which would leave the API undeployed until a restart).
+                throw e;
             } catch (Exception e) {
                 // Log the error and ignore this event.
                 log.warn("Unable to extract api definition from event [{}].", apiEvent.getId(), e);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiProductMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiProductMapper.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.service.EnvironmentService;
 import io.gravitee.repository.management.model.Event;
 import io.reactivex.rxjava3.core.Maybe;
@@ -89,6 +90,9 @@ public class ApiProductMapper {
                 environmentService.fill(payload.getEnvironmentId(), reactableApiProduct);
 
                 return reactableApiProduct;
+            } catch (SyncException e) {
+                // Transient enrichment failure: fail the sync so this event is retried instead of dropped.
+                throw e;
             } catch (Exception e) {
                 log.error("Unable to extract API Product definition from event [{}].", event.getId(), e);
                 return null;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/DebugMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/DebugMapper.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.services.sync.process.repository.mapper;
 
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.reactor.impl.ReactableEvent;
+import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.service.EnvironmentService;
 import io.gravitee.repository.management.model.Event;
 import io.reactivex.rxjava3.core.Maybe;
@@ -38,6 +39,9 @@ public class DebugMapper {
                 environmentService.fill(environmentId, reactableEvent);
 
                 return reactableEvent;
+            } catch (SyncException e) {
+                // Transient enrichment failure: fail the sync so this event is retried instead of dropped.
+                throw e;
             } catch (Exception e) {
                 // Log the error and ignore this event.
                 log.error("Unable to extract debug api definition from event [{}].", event.getId(), e);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/SharedPolicyGroupMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/SharedPolicyGroupMapper.java
@@ -20,6 +20,7 @@ import static io.gravitee.repository.management.model.Event.EventProperties.SHAR
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup;
 import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup;
+import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.service.EnvironmentService;
 import io.gravitee.repository.management.model.Event;
 import io.reactivex.rxjava3.core.Maybe;
@@ -62,6 +63,9 @@ public class SharedPolicyGroupMapper {
                 environmentService.fill(sharedPolicyGroupDefinition.getEnvironmentId(), reactableSharedPolicyGroup);
 
                 return reactableSharedPolicyGroup;
+            } catch (SyncException e) {
+                // Transient enrichment failure: fail the sync so this event is retried instead of dropped.
+                throw e;
             } catch (Exception e) {
                 // Log the error and ignore this event.
                 log.error("Unable to extract shared policy group definition from event [{}].", sharedPolicyGroupEvent.getId(), e);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/service/EnvironmentService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/service/EnvironmentService.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.sync.process.repository.service;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup;
 import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.model.Environment;
@@ -114,20 +115,31 @@ public class EnvironmentService {
                     loadOrganization(environment);
                     return environment;
                 }
+                // Environment genuinely absent: nothing to cache, deployment continues without enrichment.
+                return null;
+            } catch (SyncException e) {
+                // Transient failure while resolving the organization: do not cache a partial environment,
+                // propagate so the sync fails and is retried (self-heals once the repository recovers).
+                throw e;
             } catch (Exception e) {
-                log.warn("An error occurred fetching the environment '{}' and its organization.", envId, e);
+                // Transient failure while fetching the environment: do not cache, propagate for retry.
+                throw new SyncException(String.format("An error occurred fetching the environment '%s'.", envId), e);
             }
-            return null;
         });
     }
 
     private void loadOrganization(final Environment environment) {
-        organizations.computeIfAbsent(environment.getOrganizationId(), orgId -> {
+        final String organizationId = environment.getOrganizationId();
+        if (organizationId == null) {
+            return;
+        }
+        organizations.computeIfAbsent(organizationId, orgId -> {
             try {
+                // An absent organization resolves to null (not cached) and is tolerated; only a
+                // transient failure must fail the sync so the partial environment is never memoized.
                 return organizationRepository.findById(orgId).orElse(null);
             } catch (Exception e) {
-                log.warn("An error occurred fetching the organization '{}'.", orgId, e);
-                return null;
+                throw new SyncException(String.format("An error occurred fetching the organization '%s'.", orgId), e);
             }
         });
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/service/EnvironmentService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/service/EnvironmentService.java
@@ -106,41 +106,46 @@ public class EnvironmentService {
         }
     }
 
+    // The blocking repository calls are intentionally performed outside of ConcurrentHashMap#computeIfAbsent:
+    // holding a bin lock across I/O could starve other sync threads. A rare redundant fetch under contention
+    // is harmless, and a partial environment (organization not resolved) is never memoized.
     private Environment loadEnvironment(final String environmentId) {
-        return environments.computeIfAbsent(environmentId, envId -> {
-            try {
-                var environmentOpt = environmentRepository.findById(envId);
-                if (environmentOpt.isPresent()) {
-                    Environment environment = environmentOpt.get();
-                    loadOrganization(environment);
-                    return environment;
-                }
+        Environment cached = environments.get(environmentId);
+        if (cached != null) {
+            return cached;
+        }
+        try {
+            var environmentOpt = environmentRepository.findById(environmentId);
+            if (environmentOpt.isEmpty()) {
                 // Environment genuinely absent: nothing to cache, deployment continues without enrichment.
                 return null;
-            } catch (SyncException e) {
-                // Transient failure while resolving the organization: do not cache a partial environment,
-                // propagate so the sync fails and is retried (self-heals once the repository recovers).
-                throw e;
-            } catch (Exception e) {
-                // Transient failure while fetching the environment: do not cache, propagate for retry.
-                throw new SyncException(String.format("An error occurred fetching the environment '%s'.", envId), e);
             }
-        });
+            Environment environment = environmentOpt.get();
+            // Resolve the organization first so a transient failure propagates before the environment is cached.
+            loadOrganization(environment);
+            environments.put(environmentId, environment);
+            return environment;
+        } catch (SyncException e) {
+            // Transient failure while resolving the organization: do not cache a partial environment,
+            // propagate so the sync fails and is retried (self-heals once the repository recovers).
+            throw e;
+        } catch (Exception e) {
+            // Transient failure while fetching the environment: do not cache, propagate for retry.
+            throw new SyncException(String.format("An error occurred fetching the environment '%s'.", environmentId), e);
+        }
     }
 
     private void loadOrganization(final Environment environment) {
         final String organizationId = environment.getOrganizationId();
-        if (organizationId == null) {
+        if (organizationId == null || organizations.containsKey(organizationId)) {
             return;
         }
-        organizations.computeIfAbsent(organizationId, orgId -> {
-            try {
-                // An absent organization resolves to null (not cached) and is tolerated; only a
-                // transient failure must fail the sync so the partial environment is never memoized.
-                return organizationRepository.findById(orgId).orElse(null);
-            } catch (Exception e) {
-                throw new SyncException(String.format("An error occurred fetching the organization '%s'.", orgId), e);
-            }
-        });
+        try {
+            // An absent organization is tolerated (not cached); only a transient failure must fail the
+            // sync so the partial environment is never memoized.
+            organizationRepository.findById(organizationId).ifPresent(organization -> organizations.put(organizationId, organization));
+        } catch (Exception e) {
+            throw new SyncException(String.format("An error occurred fetching the organization '%s'.", organizationId), e);
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/AbstractApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/AbstractApiSynchronizer.java
@@ -89,9 +89,9 @@ public abstract class AbstractApiSynchronizer {
                     .runOn(Schedulers.from(syncDeployerExecutor))
                     .flatMap(deployable -> {
                         if (deployable.syncAction() == SyncAction.DEPLOY) {
-                            return deployApi(subscriptionDeployer, apiKeyDeployer, apiDeployer, deployable);
+                            return deployApi(initialSync, subscriptionDeployer, apiKeyDeployer, apiDeployer, deployable);
                         } else if (deployable.syncAction() == SyncAction.UNDEPLOY) {
-                            return undeployApi(subscriptionDeployer, apiKeyDeployer, apiDeployer, deployable);
+                            return undeployApi(initialSync, subscriptionDeployer, apiKeyDeployer, apiDeployer, deployable);
                         } else {
                             return Flowable.just(deployable);
                         }
@@ -152,6 +152,7 @@ public abstract class AbstractApiSynchronizer {
     }
 
     private Flowable<ApiReactorDeployable> deployApi(
+        final boolean initialSync,
         final SubscriptionDeployer subscriptionDeployer,
         final ApiKeyDeployer apiKeyDeployer,
         final ApiDeployer apiDeployer,
@@ -165,13 +166,11 @@ public abstract class AbstractApiSynchronizer {
             .andThen(apiKeyDeployer.doAfterDeployment(deployable))
             .andThen(apiDeployer.doAfterDeployment(deployable))
             .andThen(Flowable.just(deployable))
-            .onErrorResumeNext(throwable -> {
-                log.error(throwable.getMessage(), throwable);
-                return Flowable.empty();
-            });
+            .onErrorResumeNext(throwable -> resumeOnDeployError(initialSync, throwable));
     }
 
     private Flowable<ApiReactorDeployable> undeployApi(
+        final boolean initialSync,
         final SubscriptionDeployer subscriptionDeployer,
         final ApiKeyDeployer apiKeyDeployer,
         final ApiDeployer apiDeployer,
@@ -185,9 +184,20 @@ public abstract class AbstractApiSynchronizer {
             .andThen(apiKeyDeployer.doAfterUndeployment(deployable))
             .andThen(apiDeployer.doAfterUndeployment(deployable))
             .andThen(Flowable.just(deployable))
-            .onErrorResumeNext(throwable -> {
-                log.error(throwable.getMessage(), throwable);
-                return Flowable.empty();
-            });
+            .onErrorResumeNext(throwable -> resumeOnDeployError(initialSync, throwable));
+    }
+
+    /**
+     * On the initial sync the gateway has no routing table yet: a failed (un)deployment must fail the
+     * whole sync so the node stays not-ready (sync-process probe) and retries, instead of being marked
+     * ready with a partial or empty deployment. On incremental syncs a single failing API is isolated
+     * (logged and skipped) so it does not tear down an already-serving node.
+     */
+    private Flowable<ApiReactorDeployable> resumeOnDeployError(final boolean initialSync, final Throwable throwable) {
+        log.error(throwable.getMessage(), throwable);
+        if (initialSync) {
+            return Flowable.error(throwable);
+        }
+        return Flowable.empty();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/AbstractApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/AbstractApiSynchronizer.java
@@ -194,10 +194,12 @@ public abstract class AbstractApiSynchronizer {
      * (logged and skipped) so it does not tear down an already-serving node.
      */
     private Flowable<ApiReactorDeployable> resumeOnDeployError(final boolean initialSync, final Throwable throwable) {
-        log.error(throwable.getMessage(), throwable);
         if (initialSync) {
+            // Fail the sync; the error is logged once by the sync manager's error handler.
             return Flowable.error(throwable);
         }
+        // Incremental sync: isolate the failing API. Log here since the error is swallowed.
+        log.error("An error occurred while (un)deploying an API during synchronization", throwable);
         return Flowable.empty();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManagerTest.java
@@ -108,6 +108,40 @@ class DefaultSyncManagerTest {
     }
 
     @Test
+    void should_report_not_ready_until_initial_sync_succeeds() throws Exception {
+        try {
+            final TestScheduler testScheduler = new TestScheduler();
+            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+            RxJavaPlugins.setIoSchedulerHandler(s -> testScheduler);
+
+            AtomicInteger counter = new AtomicInteger(0);
+            // Fail the initial sync (and its inner retry), then succeed on the outer retry.
+            RepositorySynchronizer synchronizer = spy(
+                new FakeSynchronizer(
+                    Completable.defer(() ->
+                        counter.getAndIncrement() < 2 ? Completable.error(new RuntimeException("bridge 502")) : Completable.complete()
+                    ),
+                    1
+                )
+            );
+            synchronizers.add(synchronizer);
+
+            cut.start();
+
+            // Initial sync failed (bridge 502): the node must not be marked ready.
+            assertThat(cut.syncDone()).isFalse();
+
+            // The retries (bridge recovered) eventually succeed: the node becomes ready.
+            testScheduler.advanceTimeBy(30, TimeUnit.SECONDS);
+            testScheduler.triggerActions();
+            assertThat(cut.syncDone()).isTrue();
+            assertThat(counter.get()).isGreaterThanOrEqualTo(3);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
     void should_synchronize_sequentially_after_initial_synchronization() throws Exception {
         try {
             final TestScheduler testScheduler = new TestScheduler();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapperTest.java
@@ -30,6 +30,7 @@ import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.edge.EdgeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
+import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.service.EnvironmentService;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EnvironmentRepository;
@@ -242,6 +243,17 @@ class ApiMapperTest {
                 return true;
             })
             .assertComplete();
+    }
+
+    @Test
+    void should_propagate_error_when_environment_enrichment_fails_transiently() throws JsonProcessingException, TechnicalException {
+        Environment environment = new Environment();
+        environment.setOrganizationId("orga");
+        when(environmentRepository.findById(repoApiV4.getEnvironmentId())).thenReturn(Optional.of(environment));
+        when(organizationRepository.findById("orga")).thenThrow(new TechnicalException("bridge 502"));
+        Event event = new Event();
+        event.setPayload(objectMapper.writeValueAsString(repoApiV4));
+        cut.to(event).test().assertError(SyncException.class);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/service/EnvironmentServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/service/EnvironmentServiceTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.gateway.services.sync.process.common.model.SyncException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Environment;
+import io.gravitee.repository.management.model.Organization;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EnvironmentServiceTest {
+
+    private static final String ENV_ID = "env";
+    private static final String ORG_ID = "org";
+
+    @Mock
+    private EnvironmentRepository environmentRepository;
+
+    @Mock
+    private OrganizationRepository organizationRepository;
+
+    @Mock
+    private ReactableApi<?> reactableApi;
+
+    private EnvironmentService cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new EnvironmentService(environmentRepository, organizationRepository);
+    }
+
+    private Environment environment() {
+        Environment environment = new Environment();
+        environment.setId(ENV_ID);
+        environment.setOrganizationId(ORG_ID);
+        return environment;
+    }
+
+    private Organization organization() {
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        return organization;
+    }
+
+    @Test
+    void should_fill_environment_and_organization() throws TechnicalException {
+        when(environmentRepository.findById(ENV_ID)).thenReturn(Optional.of(environment()));
+        when(organizationRepository.findById(ORG_ID)).thenReturn(Optional.of(organization()));
+
+        cut.fill(ENV_ID, reactableApi);
+
+        verify(reactableApi).setEnvironmentId(ENV_ID);
+        verify(reactableApi).setOrganizationId(ORG_ID);
+    }
+
+    @Test
+    void should_leave_organization_null_when_organization_is_absent() throws TechnicalException {
+        when(environmentRepository.findById(ENV_ID)).thenReturn(Optional.of(environment()));
+        when(organizationRepository.findById(ORG_ID)).thenReturn(Optional.empty());
+
+        cut.fill(ENV_ID, reactableApi);
+
+        verify(reactableApi).setEnvironmentId(ENV_ID);
+        verify(reactableApi, never()).setOrganizationId(ORG_ID);
+    }
+
+    @Test
+    void should_propagate_when_organization_fetch_fails_transiently() throws TechnicalException {
+        when(environmentRepository.findById(ENV_ID)).thenReturn(Optional.of(environment()));
+        when(organizationRepository.findById(ORG_ID)).thenThrow(new TechnicalException("bridge 502"));
+
+        assertThatThrownBy(() -> cut.fill(ENV_ID, reactableApi)).isInstanceOf(SyncException.class);
+    }
+
+    @Test
+    void should_not_cache_environment_when_organization_fetch_fails() throws TechnicalException {
+        when(environmentRepository.findById(ENV_ID)).thenReturn(Optional.of(environment()));
+        // first fetch fails transiently, second fetch succeeds (bridge recovered)
+        when(organizationRepository.findById(ORG_ID))
+            .thenThrow(new TechnicalException("bridge 502"))
+            .thenReturn(Optional.of(organization()));
+
+        assertThatThrownBy(() -> cut.fill(ENV_ID, reactableApi)).isInstanceOf(SyncException.class);
+
+        // a subsequent sync must re-resolve the organization (no poisoned partial cache)
+        cut.fill(ENV_ID, reactableApi);
+
+        verify(reactableApi).setOrganizationId(ORG_ID);
+    }
+
+    @Test
+    void should_propagate_when_environment_fetch_fails_transiently() throws TechnicalException {
+        when(environmentRepository.findById(ENV_ID)).thenThrow(new TechnicalException("bridge 502"));
+
+        assertThatThrownBy(() -> cut.fill(ENV_ID, reactableApi)).isInstanceOf(SyncException.class);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/service/EnvironmentServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/service/EnvironmentServiceTest.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.sync.process.repository.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -85,6 +86,19 @@ class EnvironmentServiceTest {
 
         verify(reactableApi).setEnvironmentId(ENV_ID);
         verify(reactableApi).setOrganizationId(ORG_ID);
+    }
+
+    @Test
+    void should_cache_environment_and_organization_and_not_refetch_on_subsequent_calls() throws TechnicalException {
+        when(environmentRepository.findById(ENV_ID)).thenReturn(Optional.of(environment()));
+        when(organizationRepository.findById(ORG_ID)).thenReturn(Optional.of(organization()));
+
+        cut.fill(ENV_ID, reactableApi);
+        cut.fill(ENV_ID, reactableApi);
+
+        verify(environmentRepository, times(1)).findById(ENV_ID);
+        verify(organizationRepository, times(1)).findById(ORG_ID);
+        verify(reactableApi, times(2)).setOrganizationId(ORG_ID);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
@@ -391,6 +391,18 @@ class ApiSynchronizerTest {
         }
 
         @Test
+        void should_complete_initial_sync_when_api_deployment_succeeds() throws InterruptedException, JsonProcessingException {
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(publishEvent())));
+            when(apiManager.requiredActionFor(argThat(argument -> argument.getId().equals("api")))).thenReturn(ActionOnApi.DEPLOY);
+            // apiDeployer.deploy returns Completable.complete() from the base setup (no repository failure)
+
+            cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
+
+            verify(apiDeployer).deploy(any());
+            verify(apiDeployer).doAfterDeployment(any());
+        }
+
+        @Test
         void should_fail_initial_sync_when_api_deployment_fails() throws InterruptedException, JsonProcessingException {
             when(eventsFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(publishEvent())));
             when(apiManager.requiredActionFor(argThat(argument -> argument.getId().equals("api")))).thenReturn(ActionOnApi.DEPLOY);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
@@ -39,24 +39,29 @@ import io.gravitee.gateway.services.sync.process.common.deployer.ApiKeyDeployer;
 import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
 import io.gravitee.gateway.services.sync.process.common.deployer.SubscriptionDeployer;
 import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMapper;
+import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.fetcher.LatestEventFetcher;
 import io.gravitee.gateway.services.sync.process.repository.mapper.ApiKeyMapper;
 import io.gravitee.gateway.services.sync.process.repository.mapper.ApiMapper;
 import io.gravitee.gateway.services.sync.process.repository.service.EnvironmentService;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.Environment;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import io.gravitee.repository.management.model.LifecycleState;
+import io.gravitee.repository.management.model.Organization;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -409,6 +414,33 @@ class ApiSynchronizerTest {
             when(apiDeployer.deploy(any())).thenReturn(Completable.error(new RuntimeException("deploy boom")));
 
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertError(RuntimeException.class);
+        }
+
+        @Test
+        void should_recover_on_second_initial_sync_after_transient_bridge_failure()
+            throws InterruptedException, JsonProcessingException, TechnicalException {
+            Environment environment = new Environment();
+            environment.setId("env");
+            environment.setOrganizationId("orga");
+            Organization organization = new Organization();
+            organization.setId("orga");
+
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(publishEvent())));
+            when(apiManager.requiredActionFor(argThat(argument -> argument.getId().equals("api")))).thenReturn(ActionOnApi.DEPLOY);
+            when(environmentRepository.findById("env")).thenReturn(Optional.of(environment));
+            // Bridge 502 on the first initial sync, recovered on the second.
+            when(organizationRepository.findById("orga"))
+                .thenThrow(new TechnicalException("bridge 502"))
+                .thenReturn(Optional.of(organization));
+
+            // First initial sync fails: the node stays not-ready (the sync errors) and nothing is deployed.
+            cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertError(SyncException.class);
+            verify(apiDeployer, never()).deploy(any());
+
+            // Second initial sync (bridge recovered) completes and deploys the API: the node becomes ready.
+            cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
+            verify(apiDeployer).deploy(any());
+            verify(apiDeployer).doAfterDeployment(any());
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
@@ -354,6 +354,63 @@ class ApiSynchronizerTest {
     }
 
     @Nested
+    class DeployFailureTest {
+
+        private Api repoApi;
+
+        @BeforeEach
+        void init() throws JsonProcessingException {
+            io.gravitee.definition.model.v4.Api api = new io.gravitee.definition.model.v4.Api();
+            api.setId("api");
+            api.setDefinitionVersion(DefinitionVersion.V4);
+            PlanSecurity planSecurity = new PlanSecurity();
+            planSecurity.setType("api-key");
+            io.gravitee.definition.model.v4.plan.Plan plan = io.gravitee.definition.model.v4.plan.Plan.builder()
+                .id("planId")
+                .security(planSecurity)
+                .status(PlanStatus.PUBLISHED)
+                .build();
+            api.setPlans(List.of(plan));
+
+            repoApi = new Api();
+            repoApi.setId("api");
+            repoApi.setName("name");
+            repoApi.setLifecycleState(LifecycleState.STARTED);
+            repoApi.setEnvironmentId("env");
+            repoApi.setDefinitionVersion(DefinitionVersion.V4);
+            repoApi.setType(ApiType.PROXY);
+            repoApi.setDefinition(objectMapper.writeValueAsString(api));
+        }
+
+        private Event publishEvent() throws JsonProcessingException {
+            Event event = new Event();
+            event.setId("api");
+            event.setPayload(objectMapper.writeValueAsString(repoApi));
+            event.setType(PUBLISH_API);
+            return event;
+        }
+
+        @Test
+        void should_fail_initial_sync_when_api_deployment_fails() throws InterruptedException, JsonProcessingException {
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(publishEvent())));
+            when(apiManager.requiredActionFor(argThat(argument -> argument.getId().equals("api")))).thenReturn(ActionOnApi.DEPLOY);
+            when(apiDeployer.deploy(any())).thenReturn(Completable.error(new RuntimeException("deploy boom")));
+
+            cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertError(RuntimeException.class);
+        }
+
+        @Test
+        void should_skip_failed_api_on_incremental_sync() throws InterruptedException, JsonProcessingException {
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(publishEvent())));
+            when(apiManager.requiredActionFor(argThat(argument -> argument.getId().equals("api")))).thenReturn(ActionOnApi.DEPLOY);
+            when(apiDeployer.deploy(any())).thenReturn(Completable.error(new RuntimeException("deploy boom")));
+
+            long now = Instant.now().toEpochMilli();
+            cut.synchronize(now, now, Set.of()).test().await().assertComplete();
+        }
+    }
+
+    @Nested
     class ResyncMemberApisTest {
 
         @Test


### PR DESCRIPTION
## Problem

A transient repository error (e.g. a control-plane bridge `502`) while resolving an API's
organization during a gateway pod's **initial sync** caused a permanent, silent outage: the
environment was cached without its organization, every API deploy failed on a null organization,
the per-API errors were swallowed, and the sync still completed and marked the node **ready with
zero APIs**. Every request then returned `404 "No context-path matches the request URI."` until the
pod was manually restarted.

[APIM-14750](https://gravitee.atlassian.net/browse/APIM-14750)

## Root cause

1. `EnvironmentService` (a singleton) cached the environment even when its organization failed to
   load, and left `organizationId = null` — poisoning every later sync for the process lifetime.
2. Deploy then hit `DefaultLicenseManager.getOrganizationLicense(null)` → `NullPointerException`
   (fixed separately in gravitee-node — companion PR).
3. `AbstractApiSynchronizer` swallowed the per-API error and the sync completed, setting
   `syncReadyForProbe=true` and advancing its cursor — so the node reported healthy with an empty
   routing table and never retried the dropped APIs.

## Changes

- **EnvironmentService**: never cache a partial environment; propagate transient env/organization
  fetch failures. A genuinely absent organization keeps the previous null-organization behaviour.
- **Mappers** (Api / ApiProduct / SharedPolicyGroup / Debug): rethrow `SyncException` instead of
  swallowing it, so a transient enrichment failure fails the sync instead of dropping the event.
- **AbstractApiSynchronizer**: on the **initial** sync a failed (un)deployment fails the whole sync
  so the node stays not-ready (sync-process probe) and retries; **incremental** syncs keep per-API
  isolation so one bad API does not tear down a serving node.

## Tests

- New `EnvironmentServiceTest`, new mapper propagation test, new `ApiSynchronizerTest$DeployFailureTest`
  (initial sync fails / incremental sync skips).
- Full `gravitee-apim-gateway-services-sync` module: 631 tests green.

## Depends on

The null-org NPE guard in gravitee-node (`DefaultLicenseManager`) — companion PR. Once that release
is available, bump `gravitee-node.version` in this repo so the guard is in effect as a
defence-in-depth net.

## Follow-up (out of scope)

`SharedPolicyGroupSynchronizer`'s own deploy-stage error handling still isolates-always; only its
mapper enrichment now propagates. Worth aligning with the API initial-sync behaviour separately.


[APIM-14750]: https://gravitee.atlassian.net/browse/APIM-14750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ