### PR TITLE
chore(deps): bump gravitee-entrypoint-webhook to 8.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
     <gravitee-entrypoint-http-get.version>3.0.0</gravitee-entrypoint-http-get.version>
     <gravitee-entrypoint-http-post.version>3.0.0</gravitee-entrypoint-http-post.version>
     <gravitee-entrypoint-sse.version>6.0.0</gravitee-entrypoint-sse.version>
-    <gravitee-entrypoint-webhook.version>8.0.0</gravitee-entrypoint-webhook.version>
+    <gravitee-entrypoint-webhook.version>8.0.1</gravitee-entrypoint-webhook.version>
     <gravitee-entrypoint-websocket.version>3.0.0</gravitee-entrypoint-websocket.version>
     <gravitee-entrypoint-agent-to-agent.version>2.0.0</gravitee-entrypoint-agent-to-agent.version>
     <gravitee-entrypoint-mcp-tool-server.version>2.0.2</gravitee-entrypoint-mcp-tool-server.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14523

**Description**

RFC 7617 requires Base64-encoding the raw "{clientId}:{clientSecret}" string. URLEncoder.encode() was applied before Base64, corrupting secrets containing +, /, =, @, or spaces and causing 401 invalid_client from
OAuth2 token endpoints.

**Additional context**

### Before and After Video

https://github.com/user-attachments/assets/2e025249-b52b-4654-88d6-c17674a359c6

- RFC 6749 §2.3.1 says client_id / client_secret should be application/x-www-form-urlencoded before being used as the Basic username/password.
- RFC 7617 (HTTP Basic) and common AS behavior expect Base64 of the raw `clientId:clientSecret` (same as `curl -u`).
- Strict servers that form-decode the Basic credentials would prefer the encode step; most real token endpoints do not decode, and URL-encoding before Base64 broke credentials containing `+`, `/`, `=`, etc. (APIM-14523 → 401 invalid_client).
**Decision:** omit URL-encoding for `client_secret_basic` (interop / curl -u). Keep URL-encoding for `client_secret_post` body params only.
Tracked in [APIM-14523](https://gravitee.atlassian.net/browse/APIM-14523); same note added on the Jira ticket so this isn’t “fixed back” later.


[APIM-14523]: https://gravitee.atlassian.net/browse/APIM-14523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
