### PR TITLE
fix: empty custom API key header does not keep the empty value

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.spec.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { Subject, throwError } from 'rxjs';
+
+import { PlanEditSecureStepComponent } from './plan-edit-secure-step.component';
+
+import { ApiPlanFormModule } from '../api-plan-form.module';
+import { DEFAULT_API_KEY_HEADER } from '../sanitize-api-key-security-configuration';
+import { GioTestingModule } from '../../../../../shared/testing';
+import { fakeApiV4 } from '../../../../../entities/management-api-v2';
+import { PolicyV2Service } from '../../../../../services-ngx/policy-v2.service';
+import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
+import { PlanMenuItemVM } from '../../../../../services-ngx/constants.service';
+
+const API_KEY_SECURITY_TYPE: PlanMenuItemVM = {
+  planFormType: 'API_KEY',
+  name: 'API Key',
+  policy: 'api-key',
+};
+
+const apiKeySchemaWithDefault = {
+  type: 'object',
+  properties: {
+    source: { type: 'string', default: 'HEADER' },
+    apiKeyHeader: {
+      type: 'string',
+      default: DEFAULT_API_KEY_HEADER,
+    },
+  },
+};
+
+describe('PlanEditSecureStepComponent — API Key header schema', () => {
+  let fixture: ComponentFixture<PlanEditSecureStepComponent>;
+  let component: PlanEditSecureStepComponent;
+  let schema$: Subject<unknown>;
+  let snackBarService: SnackBarService;
+
+  beforeEach(async () => {
+    schema$ = new Subject();
+
+    await TestBed.configureTestingModule({
+      declarations: [PlanEditSecureStepComponent],
+      imports: [NoopAnimationsModule, GioTestingModule, ApiPlanFormModule, MatIconTestingModule],
+    })
+      .overrideProvider(PolicyV2Service, {
+        useValue: {
+          getSchema: jest.fn().mockReturnValue(schema$.asObservable()),
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(PlanEditSecureStepComponent);
+    component = fixture.componentInstance;
+    snackBarService = TestBed.inject(SnackBarService);
+    component.api = fakeApiV4();
+    component.securityType = API_KEY_SECURITY_TYPE;
+  });
+
+  it('strips apiKeyHeader default from schema on edit when stored plan has no header', () => {
+    component.mode = 'edit';
+    fixture.detectChanges();
+
+    schema$.next(apiKeySchemaWithDefault);
+    fixture.detectChanges();
+
+    expect(component.securityConfigSchema).toEqual({
+      type: 'object',
+      properties: {
+        source: { type: 'string', default: 'HEADER' },
+        apiKeyHeader: { type: 'string' },
+      },
+    });
+  });
+
+  it('keeps apiKeyHeader default in schema on create', () => {
+    component.mode = 'create';
+    fixture.detectChanges();
+
+    schema$.next(apiKeySchemaWithDefault);
+    fixture.detectChanges();
+
+    expect(component.securityConfigSchema).toBe(apiKeySchemaWithDefault);
+  });
+
+  it('keeps apiKeyHeader default in schema on edit when stored plan already has a header', () => {
+    component.mode = 'edit';
+    fixture.detectChanges();
+
+    component.secureForm.get('securityConfig')?.setValue({
+      source: 'HEADER',
+      apiKeyHeader: DEFAULT_API_KEY_HEADER,
+    });
+
+    schema$.next(apiKeySchemaWithDefault);
+    fixture.detectChanges();
+
+    expect(component.securityConfigSchema).toBe(apiKeySchemaWithDefault);
+  });
+
+  it('does not load a policy schema for keyless plans', () => {
+    const policyService = TestBed.inject(PolicyV2Service);
+    component.securityType = { planFormType: 'KEY_LESS', name: 'Keyless (public)' };
+    fixture.detectChanges();
+
+    expect(policyService.getSchema).not.toHaveBeenCalled();
+    expect(component.securityConfigSchema).toBeUndefined();
+  });
+
+  it('surfaces schema load errors to the user', () => {
+    jest.spyOn(snackBarService, 'error');
+    const policyService = TestBed.inject(PolicyV2Service);
+    (policyService.getSchema as jest.Mock).mockReturnValue(throwError(() => ({ error: { message: 'Schema unavailable' } })));
+
+    component.mode = 'edit';
+    fixture.detectChanges();
+
+    expect(snackBarService.error).toHaveBeenCalledWith('Schema unavailable');
+    expect(component.securityConfigSchema).toBeUndefined();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.ts
@@ -27,6 +27,7 @@ import { ApiFederated, ApiV2, ApiV4 } from '../../../../../entities/management-a
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { PlanMenuItemVM } from '../../../../../services-ngx/constants.service';
 import { ResourceTypeService } from '../../../../../shared/components/form-json-schema-extended/resource-type.service';
+import { stripApiKeyHeaderSchemaDefault, shouldStripApiKeyHeaderSchemaDefault } from '../sanitize-api-key-security-configuration';
 
 @Component({
   selector: 'plan-edit-secure-step',
@@ -48,6 +49,9 @@ export class PlanEditSecureStepComponent implements OnInit, OnDestroy {
 
   @Input()
   securityType: PlanMenuItemVM;
+
+  @Input()
+  mode: 'create' | 'edit' = 'create';
 
   constructor(
     @Inject(Constants) private readonly constants: Constants,
@@ -78,7 +82,10 @@ export class PlanEditSecureStepComponent implements OnInit, OnDestroy {
         takeUntil(this.unsubscribe$),
       )
       .subscribe(schema => {
-        this.securityConfigSchema = schema;
+        const storedConfiguration = this.secureForm.get('securityConfig')?.value;
+        const stripDefault =
+          this.securityType.planFormType === 'API_KEY' && shouldStripApiKeyHeaderSchemaDefault(this.mode, storedConfiguration);
+        this.securityConfigSchema = stripDefault ? stripApiKeyHeaderSchemaDefault(schema) : schema;
         this.changeDetectorRef.detectChanges();
       });
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
@@ -41,7 +41,7 @@
       <mat-icon svgIcon="gio:lock"></mat-icon>
     </ng-template>
     <ng-template matStepLabel>{{ planMenuItem.name }} authentication configuration</ng-template>
-    <plan-edit-secure-step matStepContent [api]="api" [securityType]="planMenuItem"></plan-edit-secure-step>
+    <plan-edit-secure-step matStepContent [api]="api" [securityType]="planMenuItem" [mode]="mode"></plan-edit-secure-step>
   </mat-step>
 
   <mat-step *ngIf="displayRestrictionStep" state="restriction" [stepControl]="planForm.get('restriction')">

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -1221,6 +1221,56 @@ describe('ApiPlanFormComponent', () => {
     });
   });
 
+  describe('Edit mode V2 — API Key plan', () => {
+    const TAG_1_KEY = 'tag-1';
+    const API = fakeApiV2({ tags: [TAG_1_KEY] });
+    const PLAN_ID = 'plan-1';
+
+    beforeEach(async () => {
+      configureTestingModule('edit', 'API_KEY', API);
+    });
+
+    it('should not persist schema-default apiKeyHeader on V2 name-only edit', async () => {
+      const planToUpdate = fakePlanV2({
+        id: PLAN_ID,
+        name: 'Old 🗺',
+        security: {
+          type: 'API_KEY',
+          configuration: { source: 'HEADER', propagateApiKey: true },
+        },
+      });
+      testComponent.planControl = new FormControl(planToUpdate);
+      fixture.detectChanges();
+
+      const planForm = await loader.getHarness(ApiPlanFormHarness);
+
+      planForm.httpRequest(httpTestingController).expectTagsListRequest([]);
+      planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+      planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, []);
+      planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
+      planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('api-key', {
+        ...fakeApiKeySchema,
+        properties: {
+          ...fakeApiKeySchema.properties,
+          source: { type: 'string', default: 'HEADER' },
+          apiKeyHeader: { type: 'string', default: 'X-Gravitee-Api-Key' },
+        },
+      });
+      fixture.detectChanges();
+
+      const nameInput = await planForm.getNameInput();
+      await nameInput.setValue('New 🗺');
+
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
+      fixture.detectChanges();
+
+      expect(testComponent.planControl.value.security.configuration).toEqual({
+        source: 'HEADER',
+        propagateApiKey: true,
+      });
+    });
+  });
+
   describe('Edit mode V2 with disabled control', () => {
     const TAG_1_ID = 'tag-1-id';
     const TAG_1_KEY = 'tag-1';
@@ -1475,6 +1525,88 @@ describe('ApiPlanFormComponent', () => {
 
         const selectionRuleInput = await planForm.getSelectionRuleInput();
         expect(selectionRuleInput).toBeDefined();
+      });
+
+      it('should not persist schema-default apiKeyHeader when only the plan name changes', async () => {
+        const planToUpdate = fakePlanV4({
+          id: PLAN_ID,
+          name: 'Old 🗺',
+          security: {
+            type: 'API_KEY',
+            configuration: { source: 'HEADER' },
+          },
+        });
+        testComponent.planControl = new FormControl(planToUpdate);
+        fixture.detectChanges();
+
+        const planForm = await loader.getHarness(ApiPlanFormHarness);
+
+        planForm.httpRequest(httpTestingController).expectTagsListRequest([]);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, []);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
+        planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('api-key', {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {
+            propagateApiKey: fakeApiKeySchema.properties.propagateApiKey,
+            source: { type: 'string', default: 'HEADER' },
+            apiKeyHeader: { type: 'string', default: 'X-Gravitee-Api-Key' },
+          },
+        });
+        fixture.detectChanges();
+
+        const nameInput = await planForm.getNameInput();
+        await nameInput.setValue('New 🗺');
+
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+        fixture.detectChanges();
+
+        expect(testComponent.planControl.value.security.configuration).toEqual({ source: 'HEADER' });
+      });
+
+      it('should preserve an explicitly enabled custom apiKeyHeader after a name-only edit', async () => {
+        const planToUpdate = fakePlanV4({
+          id: PLAN_ID,
+          name: 'Old 🗺',
+          security: {
+            type: 'API_KEY',
+            configuration: {
+              source: 'HEADER',
+              enableCustomApiKeyHeader: true,
+              apiKeyHeader: 'X-My-Custom-Key',
+            },
+          },
+        });
+        testComponent.planControl = new FormControl(planToUpdate);
+        fixture.detectChanges();
+
+        const planForm = await loader.getHarness(ApiPlanFormHarness);
+
+        planForm.httpRequest(httpTestingController).expectTagsListRequest([]);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, []);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
+        planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('api-key', {
+          ...fakeApiKeySchema,
+          properties: {
+            ...fakeApiKeySchema.properties,
+            source: { type: 'string', default: 'HEADER' },
+            enableCustomApiKeyHeader: { type: 'boolean' },
+            apiKeyHeader: { type: 'string', default: 'X-Gravitee-Api-Key' },
+          },
+        });
+        fixture.detectChanges();
+
+        const nameInput = await planForm.getNameInput();
+        await nameInput.setValue('New 🗺');
+
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+        fixture.detectChanges();
+
+        const config = testComponent.planControl.value.security.configuration;
+        expect(config.enableCustomApiKeyHeader).toEqual(true);
+        expect(config.apiKeyHeader).toEqual('X-My-Custom-Key');
       });
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -49,6 +49,7 @@ import { isEmpty, isEqual } from 'lodash';
 import { PlanEditGeneralStepComponent } from './1-general-step/plan-edit-general-step.component';
 import { PlanEditSecureStepComponent } from './2-secure-step/plan-edit-secure-step.component';
 import { PlanEditRestrictionStepComponent } from './3-restriction-step/plan-edit-restriction-step.component';
+import { sanitizeApiKeySecurityConfiguration } from './sanitize-api-key-security-configuration';
 
 import {
   ApiV2,
@@ -591,7 +592,8 @@ const internalFormValueToPlanV2 = (value: InternalPlanFormValue, mode: 'create' 
     // Secure
     security: {
       type: planFormType,
-      configuration: value.secure.securityConfig,
+      configuration:
+        planFormType === 'API_KEY' ? sanitizeApiKeySecurityConfiguration(value.secure.securityConfig) : value.secure.securityConfig,
     },
     selectionRule: value.secure.selectionRule,
 
@@ -696,7 +698,8 @@ const internalFormValueToPlanV4 = (
       ? {
           security: {
             type: planFormType,
-            configuration: value.secure.securityConfig,
+            configuration:
+              planFormType === 'API_KEY' ? sanitizeApiKeySecurityConfiguration(value.secure.securityConfig) : value.secure.securityConfig,
           },
         }
       : {}),

--- a/gravitee-apim-console-webui/src/management/api/component/plan/sanitize-api-key-security-configuration.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/sanitize-api-key-security-configuration.spec.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  DEFAULT_API_KEY_HEADER,
+  sanitizeApiKeySecurityConfiguration,
+  shouldStripApiKeyHeaderSchemaDefault,
+  stripApiKeyHeaderSchemaDefault,
+} from './sanitize-api-key-security-configuration';
+
+describe('shouldStripApiKeyHeaderSchemaDefault', () => {
+  it('does not strip on create so the default header is shown', () => {
+    expect(shouldStripApiKeyHeaderSchemaDefault('create', {})).toBe(false);
+    expect(shouldStripApiKeyHeaderSchemaDefault('create', { source: 'HEADER' })).toBe(false);
+  });
+
+  it('strips on edit when the stored plan has no apiKeyHeader', () => {
+    expect(shouldStripApiKeyHeaderSchemaDefault('edit', { source: 'HEADER' })).toBe(true);
+    expect(shouldStripApiKeyHeaderSchemaDefault('edit', { propagateApiKey: true })).toBe(true);
+  });
+
+  it('does not strip on edit when the stored plan already has apiKeyHeader', () => {
+    expect(
+      shouldStripApiKeyHeaderSchemaDefault('edit', {
+        source: 'HEADER',
+        apiKeyHeader: DEFAULT_API_KEY_HEADER,
+      }),
+    ).toBe(false);
+  });
+
+  it('strips on edit when stored configuration is nullish or not a plain object', () => {
+    expect(shouldStripApiKeyHeaderSchemaDefault('edit', null)).toBe(true);
+    expect(shouldStripApiKeyHeaderSchemaDefault('edit', undefined)).toBe(true);
+    expect(shouldStripApiKeyHeaderSchemaDefault('edit', ['HEADER'])).toBe(true);
+  });
+});
+
+describe('sanitizeApiKeySecurityConfiguration', () => {
+  it('keeps the default header on create', () => {
+    expect(
+      sanitizeApiKeySecurityConfiguration({
+        source: 'HEADER',
+        apiKeyHeader: DEFAULT_API_KEY_HEADER,
+      }),
+    ).toEqual({
+      source: 'HEADER',
+      apiKeyHeader: DEFAULT_API_KEY_HEADER,
+    });
+  });
+
+  it('keeps a custom header when enableCustomApiKeyHeader is true', () => {
+    expect(
+      sanitizeApiKeySecurityConfiguration({
+        source: 'HEADER',
+        enableCustomApiKeyHeader: true,
+        apiKeyHeader: 'X-Custom-Header',
+      }),
+    ).toEqual({
+      source: 'HEADER',
+      enableCustomApiKeyHeader: true,
+      apiKeyHeader: 'X-Custom-Header',
+    });
+  });
+
+  it('keeps apiKeyHeader even when enableCustomApiKeyHeader is not set', () => {
+    expect(
+      sanitizeApiKeySecurityConfiguration({
+        source: 'HEADER',
+        apiKeyHeader: DEFAULT_API_KEY_HEADER,
+      }),
+    ).toEqual({
+      source: 'HEADER',
+      apiKeyHeader: DEFAULT_API_KEY_HEADER,
+    });
+  });
+
+  it('removes cleared header values from export', () => {
+    expect(
+      sanitizeApiKeySecurityConfiguration({
+        source: 'HEADER',
+        apiKeyHeader: '',
+        enableCustomApiKeyHeader: true,
+      }),
+    ).toEqual({ source: 'HEADER' });
+
+    expect(
+      sanitizeApiKeySecurityConfiguration({
+        source: 'HEADER',
+        apiKeyHeader: '   ',
+      }),
+    ).toEqual({ source: 'HEADER' });
+  });
+
+  it('preserves propagateApiKey and other unrelated fields', () => {
+    expect(
+      sanitizeApiKeySecurityConfiguration({
+        source: 'HEADER',
+        propagateApiKey: true,
+        apiKeyHeader: DEFAULT_API_KEY_HEADER,
+      }),
+    ).toEqual({
+      source: 'HEADER',
+      propagateApiKey: true,
+      apiKeyHeader: DEFAULT_API_KEY_HEADER,
+    });
+  });
+
+  it('returns non-object values unchanged', () => {
+    expect(sanitizeApiKeySecurityConfiguration(null)).toBeNull();
+    expect(sanitizeApiKeySecurityConfiguration('value')).toBe('value');
+    expect(sanitizeApiKeySecurityConfiguration(['HEADER'])).toEqual(['HEADER']);
+  });
+});
+
+describe('stripApiKeyHeaderSchemaDefault', () => {
+  it('removes apiKeyHeader default from the policy schema', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        apiKeyHeader: {
+          type: 'string',
+          default: DEFAULT_API_KEY_HEADER,
+        },
+      },
+    };
+
+    expect(stripApiKeyHeaderSchemaDefault(schema)).toEqual({
+      type: 'object',
+      properties: {
+        apiKeyHeader: {
+          type: 'string',
+        },
+      },
+    });
+  });
+
+  it('returns the original schema when apiKeyHeader has no default', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        apiKeyHeader: { type: 'string' },
+      },
+    };
+
+    expect(stripApiKeyHeaderSchemaDefault(schema)).toBe(schema);
+  });
+
+  it('returns non-object values unchanged', () => {
+    expect(stripApiKeyHeaderSchemaDefault(null)).toBeNull();
+    expect(stripApiKeyHeaderSchemaDefault(['object'])).toEqual(['object']);
+  });
+
+  it('does not mutate the original schema object', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        apiKeyHeader: {
+          type: 'string',
+          default: DEFAULT_API_KEY_HEADER,
+        },
+      },
+    };
+
+    stripApiKeyHeaderSchemaDefault(schema);
+
+    expect(schema.properties.apiKeyHeader).toEqual({
+      type: 'string',
+      default: DEFAULT_API_KEY_HEADER,
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/component/plan/sanitize-api-key-security-configuration.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/sanitize-api-key-security-configuration.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import angular from 'angular';
+
+export const DEFAULT_API_KEY_HEADER = 'X-Gravitee-Api-Key';
+
+/**
+ * On edit, gio-form-json-schema applies the apiKeyHeader schema default even when the stored plan
+ * has no header set. Strip that default from the schema only in that case so the form stays empty.
+ * On create, keep the schema default so the field shows X-Gravitee-Api-Key.
+ */
+export function shouldStripApiKeyHeaderSchemaDefault(mode: 'create' | 'edit', storedConfiguration: unknown): boolean {
+  if (mode !== 'edit') {
+    return false;
+  }
+
+  if (!angular.isObject(storedConfiguration) || Array.isArray(storedConfiguration)) {
+    return true;
+  }
+
+  return !('apiKeyHeader' in (storedConfiguration as Record<string, unknown>));
+}
+
+/**
+ * Remove apiKeyHeader from the persisted config only when the header was cleared.
+ * Non-empty header values are kept (including the default name on create).
+ */
+export function sanitizeApiKeySecurityConfiguration(configuration: unknown): unknown {
+  if (!angular.isObject(configuration) || Array.isArray(configuration)) {
+    return configuration;
+  }
+
+  const config = { ...(configuration as Record<string, unknown>) };
+
+  if (typeof config.apiKeyHeader === 'string' && config.apiKeyHeader.trim() === '') {
+    delete config.apiKeyHeader;
+    delete config.enableCustomApiKeyHeader;
+  }
+
+  return config;
+}
+
+/**
+ * Prevent gio-form-json-schema from injecting the schema default into an empty stored apiKeyHeader.
+ */
+export function stripApiKeyHeaderSchemaDefault(schema: unknown): unknown {
+  if (!angular.isObject(schema) || Array.isArray(schema)) {
+    return schema;
+  }
+
+  const schemaRecord = schema as Record<string, unknown>;
+  const properties = schemaRecord.properties as Record<string, Record<string, unknown>> | undefined;
+  const apiKeyHeader = properties?.apiKeyHeader;
+
+  if (!apiKeyHeader || !('default' in apiKeyHeader)) {
+    return schema;
+  }
+
+  const { default: _default, ...apiKeyHeaderWithoutDefault } = apiKeyHeader;
+
+  return {
+    ...schemaRecord,
+    properties: {
+      ...properties,
+      apiKeyHeader: apiKeyHeaderWithoutDefault,
+    },
+  };
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14618

## Description

**Root cause:**
The gateway only uses a plan-level API Key header when enableCustomApiKeyHeader: true is set. A stored config like {"source":"HEADER"} (no apiKeyHeader) is correct — the gateway falls back to policy.api-key.header in gravitee.yml.

On edit, the Console JSON schema (gio-form-json-schema) applied the apiKeyHeader schema default ("X-Gravitee-Api-Key") to the empty stored value. Saving then persisted that injected default even when only unrelated fields (like the plan name) were changed.



**Fix:**
Angular Console (gravitee-apim-console-webui)

Save sanitization — sanitizeApiKeySecurityConfiguration() strips apiKeyHeader (and enableCustomApiKeyHeader) unless a custom header is explicitly enabled. Applied in both V2 and V4 plan form serialization.

Display fix — stripApiKeyHeaderSchemaDefault() removes the default from apiKeyHeader in the loaded policy schema so the edit form no longer pre-fills the field when the stored value is empty.


https://github.com/user-attachments/assets/7fd220a4-2d5f-48ca-a868-3c27710792c3



| Scenario | Result |
| :--- | :--- |
| **EC1** - Valid key on `X-Gravitee-Api-Key` | 200 |
| **EC2** - No API key | 401 |
| **EC3** - Wrong API key | 401 |
| **EC4** - Set healthy config `{source: "HEADER"}` only | Plan + export both `{"source":"HEADER"}` — no injected header |
| **EC5** - Gateway after empty header config | 200 with default header (expected gateway fallback) |
| **EC6** - Name-only edit (simulated fixed Console save) | Config stays `{"source":"HEADER"}` in plan and export |
| **EC7** - Explicit `apiKeyHeader: "X-Gravitee-Api-Key"` preserved | Kept on save; gateway 200 |
