### PR TITLE
feat: validate API Product navigation hierarchy

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -1141,7 +1141,11 @@ public class ResourceContextConfiguration {
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalPageContentQueryService portalPageContentQueryService
     ) {
-        return new PortalNavigationItemValidatorService(portalNavigationItemsQueryService, portalPageContentQueryService);
+        return new PortalNavigationItemValidatorService(
+            portalNavigationItemsQueryService,
+            portalPageContentQueryService,
+            mock(io.gravitee.apim.core.api_product.query_service.ApiProductQueryService.class)
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -1364,9 +1364,14 @@ public class ResourceContextConfiguration {
     @Bean
     public PortalNavigationItemValidatorService portalNavigationItemValidatorService(
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
-        PortalPageContentQueryService portalPageContentQueryService
+        PortalPageContentQueryService portalPageContentQueryService,
+        io.gravitee.apim.core.api_product.query_service.ApiProductQueryService apiProductQueryService
     ) {
-        return new PortalNavigationItemValidatorService(portalNavigationItemsQueryService, portalPageContentQueryService);
+        return new PortalNavigationItemValidatorService(
+            portalNavigationItemsQueryService,
+            portalPageContentQueryService,
+            apiProductQueryService
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -1337,7 +1337,11 @@ public class ResourceContextConfiguration {
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalPageContentQueryService portalPageContentQueryService
     ) {
-        return new PortalNavigationItemValidatorService(portalNavigationItemsQueryService, portalPageContentQueryService);
+        return new PortalNavigationItemValidatorService(
+            portalNavigationItemsQueryService,
+            portalPageContentQueryService,
+            mock(io.gravitee.apim.core.api_product.query_service.ApiProductQueryService.class)
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -1247,7 +1247,11 @@ public class ResourceContextConfiguration {
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalPageContentQueryService portalPageContentQueryService
     ) {
-        return new PortalNavigationItemValidatorService(portalNavigationItemsQueryService, portalPageContentQueryService);
+        return new PortalNavigationItemValidatorService(
+            portalNavigationItemsQueryService,
+            portalPageContentQueryService,
+            mock(io.gravitee.apim.core.api_product.query_service.ApiProductQueryService.class)
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
@@ -16,12 +16,16 @@
 package io.gravitee.apim.core.portal_page.domain_service;
 
 import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.portal_page.domain_service.validation.ApiItemCreateRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.ApiItemUpdateRule;
+import io.gravitee.apim.core.portal_page.domain_service.validation.ApiProductItemCreateRule;
+import io.gravitee.apim.core.portal_page.domain_service.validation.ApiProductItemUpdateRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.BulkCreatePortalNavigationItemValidationRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.CreatePortalNavigationItemValidationRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.CreateValidationContext;
 import io.gravitee.apim.core.portal_page.domain_service.validation.DuplicateApiIdsInPayloadRule;
+import io.gravitee.apim.core.portal_page.domain_service.validation.DuplicateApiProductIdsInPayloadRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.HomepageUniquenessRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.LinkUrlRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.PageContentExistsRule;
@@ -32,18 +36,16 @@ import io.gravitee.apim.core.portal_page.domain_service.validation.UniqueItemIdR
 import io.gravitee.apim.core.portal_page.domain_service.validation.UpdatePortalNavigationItemValidationRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.UpdateValidationContext;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -57,10 +59,11 @@ public class PortalNavigationItemValidatorService {
 
     public PortalNavigationItemValidatorService(
         PortalNavigationItemsQueryService navigationItemsQueryService,
-        PortalPageContentQueryService pageContentQueryService
+        PortalPageContentQueryService pageContentQueryService,
+        ApiProductQueryService apiProductQueryService
     ) {
         this.navigationItemsQueryService = navigationItemsQueryService;
-        this.bulkCreateRules = List.of(new DuplicateApiIdsInPayloadRule());
+        this.bulkCreateRules = List.of(new DuplicateApiIdsInPayloadRule(), new DuplicateApiProductIdsInPayloadRule());
 
         // Rules applied on both update and create
         var titleRequiredRule = new TitleRequiredRule();
@@ -72,25 +75,35 @@ public class PortalNavigationItemValidatorService {
             new HomepageUniquenessRule(navigationItemsQueryService),
             new PageContentExistsRule(pageContentQueryService),
             titleRequiredRule,
-            new ApiItemCreateRule(),
+            new ApiItemCreateRule(apiProductQueryService),
+            new ApiProductItemCreateRule(apiProductQueryService),
             linkUrlRule,
             parentRule
         );
-        this.updateRules = List.of(new TypeConsistencyRule(), titleRequiredRule, new ApiItemUpdateRule(), parentRule, linkUrlRule);
+        this.updateRules = List.of(
+            new TypeConsistencyRule(),
+            titleRequiredRule,
+            new ApiItemUpdateRule(apiProductQueryService),
+            new ApiProductItemUpdateRule(),
+            parentRule,
+            linkUrlRule
+        );
     }
 
     public void validateAll(List<CreatePortalNavigationItem> items, String environmentId) {
-        Set<String> seenApiIdsInPayload = new HashSet<>();
-        CreateValidationContext ctx = new CreateValidationContext(List.of(), Map.of(), seenApiIdsInPayload);
-        for (BulkCreatePortalNavigationItemValidationRule rule : bulkCreateRules) {
-            rule.validate(items, environmentId, ctx);
-        }
-
-        List<PortalNavigationItem> navigationItems = hasApiItems(items) ? fetchAllNavigationItems(environmentId) : List.of();
+        List<PortalNavigationItem> navigationItems = hasApiOrApiProductItems(items) ? fetchAllNavigationItems(environmentId) : List.of();
         Map<PortalNavigationItemId, PortalNavigationItem> itemsById = navigationItems
             .stream()
             .collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity()));
-        ctx = new CreateValidationContext(navigationItems, itemsById, seenApiIdsInPayload);
+        Map<PortalNavigationItemId, CreatePortalNavigationItem> pendingItemsById = items
+            .stream()
+            .filter(item -> item.getId() != null)
+            .collect(Collectors.toMap(CreatePortalNavigationItem::getId, Function.identity(), (first, ignored) -> first));
+        CreateValidationContext ctx = new CreateValidationContext(navigationItems, itemsById, pendingItemsById);
+
+        for (BulkCreatePortalNavigationItemValidationRule rule : bulkCreateRules) {
+            rule.validate(items, environmentId, ctx);
+        }
 
         for (CreatePortalNavigationItem item : items) {
             for (CreatePortalNavigationItemValidationRule rule : createRules) {
@@ -102,26 +115,13 @@ public class PortalNavigationItemValidatorService {
     }
 
     public void validateOne(CreatePortalNavigationItem item, String environmentId) {
-        Set<String> seenApiIdsInPayload = new HashSet<>();
-        List<PortalNavigationItem> navigationItems = item.getType() == PortalNavigationItemType.API
-            ? fetchAllNavigationItems(environmentId)
-            : List.of();
-        Map<PortalNavigationItemId, PortalNavigationItem> itemsById = navigationItems
-            .stream()
-            .collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity()));
-        CreateValidationContext ctx = new CreateValidationContext(navigationItems, itemsById, seenApiIdsInPayload);
-
-        for (CreatePortalNavigationItemValidationRule rule : createRules) {
-            if (rule.appliesTo(item)) {
-                rule.validate(item, environmentId, ctx);
-            }
-        }
+        validateAll(List.of(item), environmentId);
     }
 
     public void validateToUpdate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
         List<PortalNavigationItem> navigationItems;
         Map<PortalNavigationItemId, PortalNavigationItem> itemsById;
-        if (existingItem instanceof PortalNavigationApi) {
+        if (existingItem instanceof PortalNavigationItemContainer) {
             navigationItems = fetchAllNavigationItems(existingItem.getEnvironmentId());
             itemsById = navigationItems.stream().collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity()));
         } else {
@@ -142,7 +142,9 @@ public class PortalNavigationItemValidatorService {
         return navigationItemsQueryService.search(criteria);
     }
 
-    private boolean hasApiItems(List<CreatePortalNavigationItem> items) {
-        return items.stream().anyMatch(item -> item.getType() == PortalNavigationItemType.API);
+    private boolean hasApiOrApiProductItems(List<CreatePortalNavigationItem> items) {
+        return items
+            .stream()
+            .anyMatch(item -> item.getType() == PortalNavigationItemType.API || item.getType() == PortalNavigationItemType.API_PRODUCT);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiItemCreateRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiItemCreateRule.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.portal_page.domain_service.validation;
 
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
@@ -24,12 +26,17 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
  * For API type: parentId required, area TOP_NAVBAR, apiId required, apiId not already used, no API in ancestors.
  */
+@RequiredArgsConstructor
 public class ApiItemCreateRule implements CreatePortalNavigationItemValidationRule {
+
+    private final ApiProductQueryService apiProductQueryService;
 
     @Override
     public boolean appliesTo(CreatePortalNavigationItem item) {
@@ -53,17 +60,40 @@ public class ApiItemCreateRule implements CreatePortalNavigationItemValidationRu
         if (apiId == null || apiId.isBlank()) {
             throw InvalidPortalNavigationItemDataException.fieldIsEmpty("apiId");
         }
-        if (isApiIdAlreadyUsed(apiId, navigationItems)) {
+        var targetApiProductId = ApiProductAncestorValidation.findApiProductId(parentId, ctx);
+        if (isApiIdAlreadyUsed(apiId, targetApiProductId.orElse(null), navigationItems, itemsById)) {
             throw InvalidPortalNavigationItemDataException.apiIdAlreadyExists(apiId);
         }
-        ApiAncestorValidation.ensureNoApiInAncestors(parentId, itemsById);
+        ApiAncestorValidation.ensureNoApiInAncestors(parentId, ctx);
+        targetApiProductId.ifPresent(apiProductId -> validateApiProductMembership(apiId, apiProductId, environmentId));
     }
 
-    private static boolean isApiIdAlreadyUsed(@NonNull String apiId, List<PortalNavigationItem> navigationItems) {
+    private static boolean isApiIdAlreadyUsed(
+        @NonNull String apiId,
+        String targetApiProductId,
+        List<PortalNavigationItem> navigationItems,
+        Map<PortalNavigationItemId, PortalNavigationItem> itemsById
+    ) {
         return navigationItems
             .stream()
             .filter(PortalNavigationApi.class::isInstance)
             .map(PortalNavigationApi.class::cast)
-            .anyMatch(apiItem -> apiId.equals(apiItem.getApiId()));
+            .filter(apiItem -> apiId.equals(apiItem.getApiId()))
+            .anyMatch(apiItem ->
+                Objects.equals(
+                    targetApiProductId,
+                    ApiProductAncestorValidation.findApiProductId(apiItem.getParentId(), itemsById).orElse(null)
+                )
+            );
+    }
+
+    private void validateApiProductMembership(String apiId, String apiProductId, String environmentId) {
+        var apiProduct = apiProductQueryService
+            .findById(apiProductId)
+            .filter(product -> environmentId.equals(product.getEnvironmentId()))
+            .orElseThrow(() -> new ApiProductNotFoundException(apiProductId));
+        if (apiProduct.getApiIds() == null || !apiProduct.getApiIds().contains(apiId)) {
+            throw InvalidPortalNavigationItemDataException.apiDoesNotBelongToApiProduct(apiId, apiProductId);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiItemUpdateRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiItemUpdateRule.java
@@ -15,19 +15,24 @@
  */
 package io.gravitee.apim.core.portal_page.domain_service.validation;
 
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
-import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
 
 /**
- * For existing API items: validates parentId required, area TOP_NAVBAR, no API in ancestors.
- * Does not check apiId uniqueness (apiId cannot be updated).
+ * For existing API items: validates parentId required, area TOP_NAVBAR, no API in ancestors, contextual uniqueness, and product membership.
  */
+@RequiredArgsConstructor
 public class ApiItemUpdateRule implements UpdatePortalNavigationItemValidationRule {
+
+    private final ApiProductQueryService apiProductQueryService;
 
     @Override
     public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
@@ -45,5 +50,41 @@ public class ApiItemUpdateRule implements UpdatePortalNavigationItemValidationRu
             throw InvalidPortalNavigationItemDataException.apiMustBeInTopNavbar();
         }
         ApiAncestorValidation.ensureNoApiInAncestors(payloadParentId, ctx.itemsById());
+
+        var targetApiProductId = ApiProductAncestorValidation.findApiProductId(payloadParentId, ctx);
+        validateUniqueness(existingItem, targetApiProductId.orElse(null), ctx);
+        targetApiProductId.ifPresent(apiProductId ->
+            validateApiProductMembership(((PortalNavigationApi) existingItem).getApiId(), apiProductId, existingItem.getEnvironmentId())
+        );
+    }
+
+    private static void validateUniqueness(PortalNavigationItem existingItem, String targetApiProductId, UpdateValidationContext ctx) {
+        var apiId = ((PortalNavigationApi) existingItem).getApiId();
+        boolean alreadyExists = ctx
+            .navigationItems()
+            .stream()
+            .filter(PortalNavigationApi.class::isInstance)
+            .map(PortalNavigationApi.class::cast)
+            .filter(apiItem -> !apiItem.getId().equals(existingItem.getId()))
+            .filter(apiItem -> apiId.equals(apiItem.getApiId()))
+            .anyMatch(apiItem ->
+                Objects.equals(
+                    targetApiProductId,
+                    ApiProductAncestorValidation.findApiProductId(apiItem.getParentId(), ctx.itemsById()).orElse(null)
+                )
+            );
+        if (alreadyExists) {
+            throw InvalidPortalNavigationItemDataException.apiIdAlreadyExists(apiId);
+        }
+    }
+
+    private void validateApiProductMembership(String apiId, String apiProductId, String environmentId) {
+        var apiProduct = apiProductQueryService
+            .findById(apiProductId)
+            .filter(product -> environmentId.equals(product.getEnvironmentId()))
+            .orElseThrow(() -> new ApiProductNotFoundException(apiProductId));
+        if (apiProduct.getApiIds() == null || !apiProduct.getApiIds().contains(apiId)) {
+            throw InvalidPortalNavigationItemDataException.apiDoesNotBelongToApiProduct(apiId, apiProductId);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiProductAncestorValidation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiProductAncestorValidation.java
@@ -17,57 +17,73 @@ package io.gravitee.apim.core.portal_page.domain_service.validation;
 
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import java.util.Map;
+import java.util.Optional;
 
-/**
- * Shared validation: ensures no API item appears in the parent hierarchy (used by create and update API rules).
- */
-public final class ApiAncestorValidation {
+public final class ApiProductAncestorValidation {
 
-    private ApiAncestorValidation() {}
+    private ApiProductAncestorValidation() {}
 
-    public static void ensureNoApiInAncestors(
+    public static void ensureNoApiProductInAncestors(PortalNavigationItemId parentId, CreateValidationContext ctx) {
+        ensureNoApiProductInAncestors(findApiProductId(parentId, ctx));
+    }
+
+    public static void ensureNoApiProductInAncestors(PortalNavigationItemId parentId, UpdateValidationContext ctx) {
+        ensureNoApiProductInAncestors(findApiProductId(parentId, ctx));
+    }
+
+    private static void ensureNoApiProductInAncestors(Optional<String> apiProductId) {
+        if (apiProductId.isPresent()) {
+            throw InvalidPortalNavigationItemDataException.parentHierarchyContainsApiProduct();
+        }
+    }
+
+    public static Optional<String> findApiProductId(PortalNavigationItemId parentId, CreateValidationContext ctx) {
+        return findApiProductId(parentId, ctx.itemsById(), ctx.pendingItemsById());
+    }
+
+    public static Optional<String> findApiProductId(PortalNavigationItemId parentId, UpdateValidationContext ctx) {
+        return findApiProductId(parentId, ctx.itemsById(), Map.of());
+    }
+
+    public static Optional<String> findApiProductId(
         PortalNavigationItemId parentId,
         Map<PortalNavigationItemId, PortalNavigationItem> itemsById
     ) {
-        ensureNoApiInAncestors(parentId, itemsById, Map.of());
+        return findApiProductId(parentId, itemsById, Map.of());
     }
 
-    public static void ensureNoApiInAncestors(PortalNavigationItemId parentId, CreateValidationContext ctx) {
-        ensureNoApiInAncestors(parentId, ctx.itemsById(), ctx.pendingItemsById());
-    }
-
-    private static void ensureNoApiInAncestors(
+    private static Optional<String> findApiProductId(
         PortalNavigationItemId parentId,
         Map<PortalNavigationItemId, PortalNavigationItem> itemsById,
         Map<PortalNavigationItemId, CreatePortalNavigationItem> pendingItemsById
     ) {
-        if (parentId == null) {
-            return;
-        }
         ParentHierarchyValidation.ensureAcyclic(parentId, itemsById, pendingItemsById);
 
         var currentId = parentId;
         while (currentId != null) {
             var pendingItem = pendingItemsById.get(currentId);
             if (pendingItem != null) {
-                if (pendingItem.getType() == PortalNavigationItemType.API) {
-                    throw InvalidPortalNavigationItemDataException.parentHierarchyContainsApi();
+                if (pendingItem.getType() == PortalNavigationItemType.API_PRODUCT) {
+                    return Optional.ofNullable(pendingItem.getApiProductId());
                 }
                 currentId = pendingItem.getParentId();
                 continue;
             }
+
             var currentItem = itemsById.get(currentId);
             if (currentItem == null) {
-                return;
+                return Optional.empty();
             }
-            if (currentItem.getType() == PortalNavigationItemType.API) {
-                throw InvalidPortalNavigationItemDataException.parentHierarchyContainsApi();
+            if (currentItem instanceof PortalNavigationApiProduct apiProduct) {
+                return Optional.of(apiProduct.getApiProductId());
             }
             currentId = currentItem.getParentId();
         }
+        return Optional.empty();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiProductItemCreateRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiProductItemCreateRule.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.portal_page.exception.ApiProductNavigationItemAlreadyExistsException;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ApiProductItemCreateRule implements CreatePortalNavigationItemValidationRule {
+
+    private final ApiProductQueryService apiProductQueryService;
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getType() == PortalNavigationItemType.API_PRODUCT;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        var apiProductId = item.getApiProductId();
+        if (apiProductId == null || apiProductId.isBlank()) {
+            throw InvalidPortalNavigationItemDataException.fieldIsEmpty("apiProductId");
+        }
+        if (item.getParentId() == null) {
+            throw InvalidPortalNavigationItemDataException.fieldIsEmpty("parentId");
+        }
+        if (item.getArea() != PortalArea.TOP_NAVBAR) {
+            throw InvalidPortalNavigationItemDataException.apiProductMustBeInTopNavbar();
+        }
+
+        apiProductQueryService
+            .findById(apiProductId)
+            .filter(apiProduct -> environmentId.equals(apiProduct.getEnvironmentId()))
+            .orElseThrow(() -> new ApiProductNotFoundException(apiProductId));
+
+        boolean alreadyExists = ctx
+            .navigationItems()
+            .stream()
+            .filter(PortalNavigationApiProduct.class::isInstance)
+            .map(PortalNavigationApiProduct.class::cast)
+            .anyMatch(apiProductItem -> apiProductId.equals(apiProductItem.getApiProductId()));
+        if (alreadyExists) {
+            throw new ApiProductNavigationItemAlreadyExistsException(apiProductId);
+        }
+
+        ApiAncestorValidation.ensureNoApiInAncestors(item.getParentId(), ctx);
+        ApiProductAncestorValidation.ensureNoApiProductInAncestors(item.getParentId(), ctx);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiProductItemUpdateRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiProductItemUpdateRule.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+
+/**
+ * For existing API Product items: validates parentId required, area TOP_NAVBAR, and no API or API Product in ancestors.
+ */
+public class ApiProductItemUpdateRule implements UpdatePortalNavigationItemValidationRule {
+
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        return existingItem instanceof PortalNavigationApiProduct;
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        var parentId = toUpdate.getParentId();
+        if (parentId == null) {
+            throw InvalidPortalNavigationItemDataException.fieldIsEmpty("parentId");
+        }
+        if (existingItem.getArea() != PortalArea.TOP_NAVBAR) {
+            throw InvalidPortalNavigationItemDataException.apiProductMustBeInTopNavbar();
+        }
+
+        ApiAncestorValidation.ensureNoApiInAncestors(parentId, ctx.itemsById());
+        ApiProductAncestorValidation.ensureNoApiProductInAncestors(parentId, ctx);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/CreateValidationContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/CreateValidationContext.java
@@ -15,12 +15,11 @@
  */
 package io.gravitee.apim.core.portal_page.domain_service.validation;
 
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Context built once per create validation (single or bulk) to hold shared data and avoid repeated fetches.
@@ -28,9 +27,9 @@ import java.util.Set;
 public record CreateValidationContext(
     List<PortalNavigationItem> navigationItems,
     Map<PortalNavigationItemId, PortalNavigationItem> itemsById,
-    Set<String> seenApiIdsInPayload
+    Map<PortalNavigationItemId, CreatePortalNavigationItem> pendingItemsById
 ) {
     public static CreateValidationContext empty() {
-        return new CreateValidationContext(List.of(), Map.of(), new HashSet<>());
+        return new CreateValidationContext(List.of(), Map.of(), Map.of());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/DuplicateApiIdsInPayloadRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/DuplicateApiIdsInPayloadRule.java
@@ -18,16 +18,18 @@ package io.gravitee.apim.core.portal_page.domain_service.validation;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 
 /**
- * Bulk create rule: ensures no duplicate apiIds among API items in the request.
+ * Bulk create rule: ensures no duplicate apiIds in the same navigation context among API items in the request.
  */
 public class DuplicateApiIdsInPayloadRule implements BulkCreatePortalNavigationItemValidationRule {
 
     @Override
     public void validate(List<CreatePortalNavigationItem> items, String environmentId, CreateValidationContext ctx) {
-        var seenApiIds = ctx.seenApiIdsInPayload();
+        var seenApiReferences = new HashSet<ApiReference>();
         for (CreatePortalNavigationItem item : items) {
             if (item.getType() != PortalNavigationItemType.API) {
                 continue;
@@ -36,9 +38,16 @@ public class DuplicateApiIdsInPayloadRule implements BulkCreatePortalNavigationI
             if (apiId == null || apiId.isBlank()) {
                 continue;
             }
-            if (!seenApiIds.add(apiId)) {
+            var apiProductId = ApiProductAncestorValidation.findApiProductId(item.getParentId(), ctx).orElse(null);
+            if (!seenApiReferences.add(new ApiReference(apiId, apiProductId))) {
                 throw InvalidPortalNavigationItemDataException.apiIdAlreadyExists(apiId);
             }
+        }
+    }
+
+    private record ApiReference(String apiId, String apiProductId) {
+        private ApiReference {
+            Objects.requireNonNull(apiId);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/DuplicateApiProductIdsInPayloadRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/DuplicateApiProductIdsInPayloadRule.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.ApiProductNavigationItemAlreadyExistsException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import java.util.HashSet;
+import java.util.List;
+
+public class DuplicateApiProductIdsInPayloadRule implements BulkCreatePortalNavigationItemValidationRule {
+
+    @Override
+    public void validate(List<CreatePortalNavigationItem> items, String environmentId, CreateValidationContext ctx) {
+        var seenApiProductIds = new HashSet<String>();
+        items
+            .stream()
+            .filter(item -> item.getType() == PortalNavigationItemType.API_PRODUCT)
+            .map(CreatePortalNavigationItem::getApiProductId)
+            .filter(apiProductId -> apiProductId != null && !apiProductId.isBlank())
+            .forEach(apiProductId -> {
+                if (!seenApiProductIds.add(apiProductId)) {
+                    throw new ApiProductNavigationItemAlreadyExistsException(apiProductId);
+                }
+            });
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentHierarchyValidation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentHierarchyValidation.java
@@ -19,53 +19,47 @@ import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDa
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import java.util.HashSet;
 import java.util.Map;
 
-/**
- * Shared validation: ensures no API item appears in the parent hierarchy (used by create and update API rules).
- */
-public final class ApiAncestorValidation {
+public final class ParentHierarchyValidation {
 
-    private ApiAncestorValidation() {}
+    private ParentHierarchyValidation() {}
 
-    public static void ensureNoApiInAncestors(
-        PortalNavigationItemId parentId,
-        Map<PortalNavigationItemId, PortalNavigationItem> itemsById
-    ) {
-        ensureNoApiInAncestors(parentId, itemsById, Map.of());
-    }
-
-    public static void ensureNoApiInAncestors(PortalNavigationItemId parentId, CreateValidationContext ctx) {
-        ensureNoApiInAncestors(parentId, ctx.itemsById(), ctx.pendingItemsById());
-    }
-
-    private static void ensureNoApiInAncestors(
+    public static void ensureAcyclic(
         PortalNavigationItemId parentId,
         Map<PortalNavigationItemId, PortalNavigationItem> itemsById,
         Map<PortalNavigationItemId, CreatePortalNavigationItem> pendingItemsById
     ) {
-        if (parentId == null) {
-            return;
+        ensureAcyclic(null, parentId, itemsById, pendingItemsById);
+    }
+
+    public static void ensureAcyclic(
+        PortalNavigationItemId itemId,
+        PortalNavigationItemId parentId,
+        Map<PortalNavigationItemId, PortalNavigationItem> itemsById,
+        Map<PortalNavigationItemId, CreatePortalNavigationItem> pendingItemsById
+    ) {
+        var visited = new HashSet<PortalNavigationItemId>();
+        if (itemId != null) {
+            visited.add(itemId);
         }
-        ParentHierarchyValidation.ensureAcyclic(parentId, itemsById, pendingItemsById);
 
         var currentId = parentId;
         while (currentId != null) {
+            if (!visited.add(currentId)) {
+                throw InvalidPortalNavigationItemDataException.cyclicParentHierarchy();
+            }
+
             var pendingItem = pendingItemsById.get(currentId);
             if (pendingItem != null) {
-                if (pendingItem.getType() == PortalNavigationItemType.API) {
-                    throw InvalidPortalNavigationItemDataException.parentHierarchyContainsApi();
-                }
                 currentId = pendingItem.getParentId();
                 continue;
             }
+
             var currentItem = itemsById.get(currentId);
             if (currentItem == null) {
                 return;
-            }
-            if (currentItem.getType() == PortalNavigationItemType.API) {
-                throw InvalidPortalNavigationItemDataException.parentHierarchyContainsApi();
             }
             currentId = currentItem.getParentId();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRule.java
@@ -24,14 +24,17 @@ import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 /**
- * When parentId is set, ensures parent exists, is a folder or API, and matches the item's area (create and update).
+ * When parentId is set, ensures parent exists, is a container, and matches the item's area (create and update).
  */
 @RequiredArgsConstructor
 public class ParentRule implements CreatePortalNavigationItemValidationRule, UpdatePortalNavigationItemValidationRule {
@@ -45,12 +48,51 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
 
     @Override
     public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        var pendingParent = ctx.pendingItemsById().get(item.getParentId());
+        if (pendingParent != null) {
+            validatePendingParent(item, pendingParent, ctx);
+            return;
+        }
         validateParent(
             item.getParentId(),
             item.getArea(),
             environmentId,
             item.getPublished() != null ? item.getPublished() : false,
             item.getVisibility()
+        );
+    }
+
+    private void validatePendingParent(
+        CreatePortalNavigationItem item,
+        CreatePortalNavigationItem parentItem,
+        CreateValidationContext ctx
+    ) {
+        ParentHierarchyValidation.ensureAcyclic(item.getId(), item.getParentId(), ctx.itemsById(), ctx.pendingItemsById());
+
+        var parentId = parentItem.getId().toString();
+        if (!isContainer(parentItem.getType())) {
+            throw new ParentTypeMismatchException(parentId);
+        }
+        if (!Objects.equals(parentItem.getArea(), item.getArea())) {
+            throw new ParentAreaMismatchException(parentId);
+        }
+
+        boolean itemPublished = Boolean.TRUE.equals(item.getPublished());
+        boolean parentPublished = Boolean.TRUE.equals(parentItem.getPublished());
+        if (itemPublished && !parentPublished) {
+            throw InvalidPortalNavigationItemDataException.parentMustBePublished(parentId);
+        }
+
+        var itemVisibility = item.getVisibility() != null ? item.getVisibility() : PortalVisibility.PUBLIC;
+        var parentVisibility = parentItem.getVisibility() != null ? parentItem.getVisibility() : PortalVisibility.PUBLIC;
+        if (PortalVisibility.PUBLIC.equals(itemVisibility) && PortalVisibility.PRIVATE.equals(parentVisibility)) {
+            throw InvalidPortalNavigationItemDataException.parentMustBePublic(parentId);
+        }
+    }
+
+    private boolean isContainer(PortalNavigationItemType type) {
+        return (
+            type == PortalNavigationItemType.FOLDER || type == PortalNavigationItemType.API || type == PortalNavigationItemType.API_PRODUCT
         );
     }
 
@@ -61,6 +103,8 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
 
     @Override
     public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        ParentHierarchyValidation.ensureAcyclic(existingItem.getId(), toUpdate.getParentId(), ctx.itemsById(), Map.of());
+
         validateParent(
             toUpdate.getParentId(),
             existingItem.getArea(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/ApiProductNavigationItemAlreadyExistsException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/ApiProductNavigationItemAlreadyExistsException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.exception;
+
+import io.gravitee.apim.core.exception.ConflictDomainException;
+
+public class ApiProductNavigationItemAlreadyExistsException extends ConflictDomainException {
+
+    public ApiProductNavigationItemAlreadyExistsException(String apiProductId) {
+        super("An API Product navigation item already exists for API Product %s.".formatted(apiProductId));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
@@ -37,6 +37,10 @@ public class InvalidPortalNavigationItemDataException extends ValidationDomainEx
         return new InvalidPortalNavigationItemDataException("API items can only be added to TOP_NAVBAR area.");
     }
 
+    public static InvalidPortalNavigationItemDataException apiProductMustBeInTopNavbar() {
+        return new InvalidPortalNavigationItemDataException("API Product items can only be added to TOP_NAVBAR area.");
+    }
+
     public static InvalidPortalNavigationItemDataException apiIdAlreadyExists(String apiId) {
         return new InvalidPortalNavigationItemDataException(
             "The apiId %s is already used by another API navigation item.".formatted(apiId)
@@ -45,6 +49,18 @@ public class InvalidPortalNavigationItemDataException extends ValidationDomainEx
 
     public static InvalidPortalNavigationItemDataException parentHierarchyContainsApi() {
         return new InvalidPortalNavigationItemDataException("Parent hierarchy cannot include API items.");
+    }
+
+    public static InvalidPortalNavigationItemDataException parentHierarchyContainsApiProduct() {
+        return new InvalidPortalNavigationItemDataException("Parent hierarchy cannot include API Product items.");
+    }
+
+    public static InvalidPortalNavigationItemDataException cyclicParentHierarchy() {
+        return new InvalidPortalNavigationItemDataException("Cyclic dependency detected in parent hierarchy.");
+    }
+
+    public static InvalidPortalNavigationItemDataException apiDoesNotBelongToApiProduct(String apiId, String apiProductId) {
+        return new InvalidPortalNavigationItemDataException("API %s does not belong to API Product %s.".formatted(apiId, apiProductId));
     }
 
     public static InvalidPortalNavigationItemDataException parentMustBePublished(String parentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/CreatePortalNavigationItemValidatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/CreatePortalNavigationItemValidatorServiceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.domain_service;
 
 import static fixtures.core.model.PortalNavigationItemFixtures.API1_FOLDER_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.APIS_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.API_PRODUCT_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.ENV_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.ORG_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.PAGE11_ID;
@@ -26,8 +27,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import fixtures.core.model.PortalPageContentFixtures;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.portal_page.exception.HomepageAlreadyExistsException;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.InvalidUrlFormatException;
@@ -46,6 +49,7 @@ import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -58,6 +62,7 @@ class CreatePortalNavigationItemValidatorServiceTest {
 
     private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
     private PortalPageContentQueryServiceInMemory pageContentQueryService;
+    private ApiProductQueryServiceInMemory apiProductQueryService;
     private PortalNavigationItemValidatorService validatorService;
 
     @BeforeEach
@@ -66,7 +71,12 @@ class CreatePortalNavigationItemValidatorServiceTest {
 
         pageContentQueryService = new PortalPageContentQueryServiceInMemory();
         navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory(storage);
-        validatorService = new PortalNavigationItemValidatorService(navigationItemsQueryService, pageContentQueryService);
+        apiProductQueryService = new ApiProductQueryServiceInMemory();
+        validatorService = new PortalNavigationItemValidatorService(
+            navigationItemsQueryService,
+            pageContentQueryService,
+            apiProductQueryService
+        );
         navigationItemsQueryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
         pageContentQueryService.initWith(PortalPageContentFixtures.samplePortalPageContents());
     }
@@ -300,6 +310,104 @@ class CreatePortalNavigationItemValidatorServiceTest {
         }
 
         @Test
+        void should_validate_api_item_below_product_when_api_belongs_to_product() {
+            apiProductQueryService.initWith(
+                List.of(
+                    ApiProduct.builder().id("00000000-0000-0000-0000-000000000019").environmentId(ENV_ID).apiIds(Set.of("api-1")).build()
+                )
+            );
+            navigationItemsQueryService
+                .storage()
+                .add(
+                    PortalNavigationItemFixtures.anApiProduct(
+                        API_PRODUCT_ID,
+                        "Product",
+                        PortalNavigationItemId.of(APIS_ID),
+                        "00000000-0000-0000-0000-000000000019"
+                    )
+                );
+            var createPortalNavigationItem = CreatePortalNavigationItem.builder()
+                .type(PortalNavigationItemType.API)
+                .title("API 1 in product")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .parentId(PortalNavigationItemId.of(API_PRODUCT_ID))
+                .apiId("api-1")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                .build();
+
+            assertDoesNotThrow(() -> validatorService.validateOne(createPortalNavigationItem, ENV_ID));
+        }
+
+        @Test
+        void should_validate_api_item_below_folder_nested_in_product_when_api_belongs_to_product() {
+            var apiProductReference = "00000000-0000-0000-0000-000000000019";
+            apiProductQueryService.initWith(
+                List.of(ApiProduct.builder().id(apiProductReference).environmentId(ENV_ID).apiIds(Set.of("api-1")).build())
+            );
+            var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+                API_PRODUCT_ID,
+                "Product",
+                PortalNavigationItemId.of(APIS_ID),
+                apiProductReference
+            );
+            var nestedFolder = PortalNavigationItemFixtures.aFolder(
+                "00000000-0000-0000-0000-000000000020",
+                "Product APIs",
+                apiProduct.getId()
+            );
+            navigationItemsQueryService.storage().addAll(List.of(apiProduct, nestedFolder));
+            var createPortalNavigationItem = CreatePortalNavigationItem.builder()
+                .type(PortalNavigationItemType.API)
+                .title("API 1 in product folder")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .parentId(nestedFolder.getId())
+                .apiId("api-1")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                .build();
+
+            assertDoesNotThrow(() -> validatorService.validateOne(createPortalNavigationItem, ENV_ID));
+        }
+
+        @Test
+        void should_reject_api_item_below_product_when_api_does_not_belong_to_product() {
+            apiProductQueryService.initWith(
+                List.of(
+                    ApiProduct.builder()
+                        .id("00000000-0000-0000-0000-000000000019")
+                        .environmentId(ENV_ID)
+                        .apiIds(Set.of("allowed-api"))
+                        .build()
+                )
+            );
+            navigationItemsQueryService
+                .storage()
+                .add(
+                    PortalNavigationItemFixtures.anApiProduct(
+                        API_PRODUCT_ID,
+                        "Product",
+                        PortalNavigationItemId.of(APIS_ID),
+                        "00000000-0000-0000-0000-000000000019"
+                    )
+                );
+            var createPortalNavigationItem = CreatePortalNavigationItem.builder()
+                .type(PortalNavigationItemType.API)
+                .title("Other API")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .parentId(PortalNavigationItemId.of(API_PRODUCT_ID))
+                .apiId("other-api")
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                .build();
+
+            var exception = assertThrows(InvalidPortalNavigationItemDataException.class, () ->
+                validatorService.validateOne(createPortalNavigationItem, ENV_ID)
+            );
+            assertThat(exception.getMessage()).contains("other-api", "00000000-0000-0000-0000-000000000019");
+        }
+
+        @Test
         void should_validate_all_when_payload_is_valid() {
             // Given
             final var firstCreateApiPortalNavigationItem = CreatePortalNavigationItem.builder()
@@ -405,6 +513,32 @@ class CreatePortalNavigationItemValidatorServiceTest {
 
     @Nested
     class ValidateParent {
+
+        @Test
+        void should_fail_when_bulk_payload_contains_cyclic_parent_hierarchy() {
+            var firstFolderId = PortalNavigationItemId.of("00000000-0000-0000-0000-000000000201");
+            var secondFolderId = PortalNavigationItemId.of("00000000-0000-0000-0000-000000000202");
+            var firstFolder = CreatePortalNavigationItem.builder()
+                .id(firstFolderId)
+                .type(PortalNavigationItemType.FOLDER)
+                .title("First folder")
+                .area(PortalArea.TOP_NAVBAR)
+                .parentId(secondFolderId)
+                .build();
+            var secondFolder = CreatePortalNavigationItem.builder()
+                .id(secondFolderId)
+                .type(PortalNavigationItemType.FOLDER)
+                .title("Second folder")
+                .area(PortalArea.TOP_NAVBAR)
+                .parentId(firstFolderId)
+                .build();
+
+            var exception = assertThrows(InvalidPortalNavigationItemDataException.class, () ->
+                validatorService.validateAll(List.of(firstFolder, secondFolder), ENV_ID)
+            );
+
+            assertThat(exception.getMessage()).isEqualTo("Cyclic dependency detected in parent hierarchy.");
+        }
 
         @Test
         void should_fail_when_parent_is_not_found() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/AncestorValidationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/AncestorValidationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AncestorValidationTest {
+
+    private static final PortalNavigationItemId FIRST_FOLDER_ID = PortalNavigationItemId.of("00000000-0000-0000-0000-000000000201");
+    private static final PortalNavigationItemId SECOND_FOLDER_ID = PortalNavigationItemId.of("00000000-0000-0000-0000-000000000202");
+
+    @Test
+    void should_reject_cycle_when_checking_api_ancestors() {
+        var context = cyclicContext();
+
+        assertThatThrownBy(() -> ApiAncestorValidation.ensureNoApiInAncestors(FIRST_FOLDER_ID, context))
+            .isInstanceOf(InvalidPortalNavigationItemDataException.class)
+            .hasMessage("Cyclic dependency detected in parent hierarchy.");
+    }
+
+    @Test
+    void should_reject_cycle_when_resolving_api_product_ancestor() {
+        var context = cyclicContext();
+
+        assertThatThrownBy(() -> ApiProductAncestorValidation.findApiProductId(FIRST_FOLDER_ID, context))
+            .isInstanceOf(InvalidPortalNavigationItemDataException.class)
+            .hasMessage("Cyclic dependency detected in parent hierarchy.");
+    }
+
+    private static CreateValidationContext cyclicContext() {
+        var firstFolder = folder(FIRST_FOLDER_ID, SECOND_FOLDER_ID);
+        var secondFolder = folder(SECOND_FOLDER_ID, FIRST_FOLDER_ID);
+        return new CreateValidationContext(
+            List.of(),
+            Map.of(),
+            Map.of(firstFolder.getId(), firstFolder, secondFolder.getId(), secondFolder)
+        );
+    }
+
+    private static CreatePortalNavigationItem folder(PortalNavigationItemId id, PortalNavigationItemId parentId) {
+        return CreatePortalNavigationItem.builder()
+            .id(id)
+            .type(PortalNavigationItemType.FOLDER)
+            .title("Folder")
+            .area(PortalArea.TOP_NAVBAR)
+            .parentId(parentId)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiProductItemCreateRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiProductItemCreateRuleTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.ApiProductQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.portal_page.exception.ApiProductNavigationItemAlreadyExistsException;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiProductItemCreateRuleTest {
+
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String API_PRODUCT_ID = "00000000-0000-0000-0000-000000000101";
+    private static final String PARENT_ID = "00000000-0000-0000-0000-000000000102";
+
+    private ApiProductQueryServiceInMemory apiProductQueryService;
+    private ApiProductItemCreateRule rule;
+
+    @BeforeEach
+    void setUp() {
+        apiProductQueryService = new ApiProductQueryServiceInMemory();
+        apiProductQueryService.initWith(
+            List.of(ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENVIRONMENT_ID).apiIds(Set.of()).build())
+        );
+        rule = new ApiProductItemCreateRule(apiProductQueryService);
+    }
+
+    @Test
+    void should_accept_product_below_non_product_container() {
+        assertThatCode(() -> rule.validate(apiProductItem(), ENVIRONMENT_ID, CreateValidationContext.empty())).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_reject_product_without_parent() {
+        var item = apiProductItem().toBuilder().parentId(null).build();
+
+        assertThatThrownBy(() -> rule.validate(item, ENVIRONMENT_ID, CreateValidationContext.empty()))
+            .isInstanceOf(InvalidPortalNavigationItemDataException.class)
+            .hasMessage("The parentId field is required and cannot be blank.");
+    }
+
+    @Test
+    void should_reject_product_outside_top_navbar() {
+        var item = apiProductItem().toBuilder().area(PortalArea.HOMEPAGE).build();
+
+        assertThatThrownBy(() -> rule.validate(item, ENVIRONMENT_ID, CreateValidationContext.empty())).isInstanceOf(
+            InvalidPortalNavigationItemDataException.class
+        );
+    }
+
+    @Test
+    void should_reject_product_from_another_environment() {
+        assertThatThrownBy(() -> rule.validate(apiProductItem(), "other-environment", CreateValidationContext.empty())).isInstanceOf(
+            ApiProductNotFoundException.class
+        );
+    }
+
+    @Test
+    void should_reject_nested_product_in_pending_payload() {
+        var parent = apiProductItem().toBuilder().id(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000103")).build();
+        var nested = apiProductItem().toBuilder().parentId(parent.getId()).build();
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(parent.getId(), parent));
+
+        assertThatThrownBy(() -> rule.validate(nested, ENVIRONMENT_ID, ctx)).isInstanceOf(InvalidPortalNavigationItemDataException.class);
+    }
+
+    @Test
+    void should_reject_existing_product_reference() {
+        var existing = PortalNavigationItemFixtures.anApiProduct("00000000-0000-0000-0000-000000000104", "Product", null, API_PRODUCT_ID);
+        var ctx = new CreateValidationContext(List.of(existing), Map.of(existing.getId(), existing), Map.of());
+
+        assertThatThrownBy(() -> rule.validate(apiProductItem(), ENVIRONMENT_ID, ctx)).isInstanceOf(
+            ApiProductNavigationItemAlreadyExistsException.class
+        );
+    }
+
+    @Test
+    void should_reject_existing_product_reference_before_validating_ancestors() {
+        var existing = PortalNavigationItemFixtures.anApiProduct("00000000-0000-0000-0000-000000000104", "Product", null, API_PRODUCT_ID);
+        var parent = apiProductItem().toBuilder().id(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000105")).build();
+        var ctx = new CreateValidationContext(List.of(existing), Map.of(existing.getId(), existing), Map.of(parent.getId(), parent));
+
+        assertThatThrownBy(() ->
+            rule.validate(apiProductItem().toBuilder().parentId(parent.getId()).build(), ENVIRONMENT_ID, ctx)
+        ).isInstanceOf(ApiProductNavigationItemAlreadyExistsException.class);
+    }
+
+    @Test
+    void should_reject_duplicate_product_references_in_bulk_payload() {
+        var first = apiProductItem();
+        var second = apiProductItem().toBuilder().id(PortalNavigationItemId.random()).build();
+
+        assertThatThrownBy(() ->
+            new DuplicateApiProductIdsInPayloadRule().validate(List.of(first, second), ENVIRONMENT_ID, CreateValidationContext.empty())
+        ).isInstanceOf(ApiProductNavigationItemAlreadyExistsException.class);
+    }
+
+    private static CreatePortalNavigationItem apiProductItem() {
+        return CreatePortalNavigationItem.builder()
+            .id(PortalNavigationItemId.random())
+            .title("Product")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .parentId(PortalNavigationItemId.of(PARENT_ID))
+            .apiProductId(API_PRODUCT_ID)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemsUseCaseTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
@@ -62,7 +63,8 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
         final var crudService = new PortalNavigationItemsCrudServiceInMemory(storage);
         queryService = new PortalNavigationItemsQueryServiceInMemory(storage);
         final var pageContentQueryService = new PortalPageContentQueryServiceInMemory();
-        validatorService = new PortalNavigationItemValidatorService(queryService, pageContentQueryService);
+        final var apiProductQueryService = new ApiProductQueryServiceInMemory();
+        validatorService = new PortalNavigationItemValidatorService(queryService, pageContentQueryService, apiProductQueryService);
         final var pageContentCrudService = new PortalPageContentCrudServiceInMemory();
         final var apiCrudService = new ApiCrudServiceInMemory();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
@@ -76,9 +77,11 @@ class CreatePortalNavigationItemUseCaseTest {
         PortalPageContentQueryServiceInMemory pageContentQueryService = new PortalPageContentQueryServiceInMemory(
             pageContentCrudService.storage()
         );
+        ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
         PortalNavigationItemValidatorService validatorService = new PortalNavigationItemValidatorService(
             queryService,
-            pageContentQueryService
+            pageContentQueryService,
+            apiProductQueryService
         );
         domainService = new PortalNavigationItemDomainService(crudService, queryService, pageContentCrudService, apiCrudService);
         useCase = new CreatePortalNavigationItemUseCase(domainService, validatorService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCaseTest.java
@@ -19,6 +19,7 @@ import static fixtures.core.model.PortalNavigationItemFixtures.API1_FOLDER_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.API1_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.API2_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.APIS_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.API_PRODUCT_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.CATEGORY1_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.ENV_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.LINK1_ID;
@@ -29,16 +30,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.ParentNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -47,6 +51,7 @@ import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -62,6 +67,7 @@ class UpdatePortalNavigationItemUseCaseTest {
     private PortalNavigationItemValidatorService validatorService;
     private PortalNavigationItemDomainService domainService;
     private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
 
     @BeforeEach
     void setUp() {
@@ -74,11 +80,159 @@ class UpdatePortalNavigationItemUseCaseTest {
             pageContentCrudService.storage()
         );
 
-        validatorService = new PortalNavigationItemValidatorService(queryService, pageContentQueryService);
+        validatorService = new PortalNavigationItemValidatorService(queryService, pageContentQueryService, apiProductQueryService);
         domainService = new PortalNavigationItemDomainService(crudService, queryService, pageContentCrudService, apiCrudService);
         useCase = new UpdatePortalNavigationItemUseCase(queryService, validatorService, domainService);
 
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
+    }
+
+    @Test
+    void should_move_api_below_product_when_api_belongs_to_product() {
+        var productReferenceId = "00000000-0000-0000-0000-000000000019";
+        apiProductQueryService.initWith(
+            List.of(ApiProduct.builder().id(productReferenceId).environmentId(ENV_ID).apiIds(Set.of("api-1")).build())
+        );
+        var product = PortalNavigationItemFixtures.anApiProduct(
+            API_PRODUCT_ID,
+            "Product",
+            PortalNavigationItemId.of(APIS_ID),
+            productReferenceId
+        );
+        queryService.storage().add(product);
+        var existing = queryService.findByIdAndEnvironmentId(ENV_ID, PortalNavigationItemId.of(API1_ID));
+        var toUpdate = UpdatePortalNavigationItem.builder()
+            .type(PortalNavigationItemType.API)
+            .title(existing.getTitle())
+            .order(0)
+            .parentId(product.getId())
+            .published(existing.getPublished())
+            .visibility(existing.getVisibility())
+            .build();
+
+        var output = useCase.execute(
+            UpdatePortalNavigationItemUseCase.Input.builder()
+                .organizationId(ORG_ID)
+                .environmentId(ENV_ID)
+                .navigationItemId(existing.getId().toString())
+                .updatePortalNavigationItem(toUpdate)
+                .build()
+        );
+
+        assertThat(output.updatedItem().getParentId()).isEqualTo(product.getId());
+    }
+
+    @Test
+    void should_reject_moving_api_below_product_when_api_does_not_belong_to_product() {
+        var productReferenceId = "00000000-0000-0000-0000-000000000019";
+        apiProductQueryService.initWith(
+            List.of(ApiProduct.builder().id(productReferenceId).environmentId(ENV_ID).apiIds(Set.of("other-api")).build())
+        );
+        var product = PortalNavigationItemFixtures.anApiProduct(
+            API_PRODUCT_ID,
+            "Product",
+            PortalNavigationItemId.of(APIS_ID),
+            productReferenceId
+        );
+        queryService.storage().add(product);
+        var existing = queryService.findByIdAndEnvironmentId(ENV_ID, PortalNavigationItemId.of(API1_ID));
+        var toUpdate = UpdatePortalNavigationItem.builder()
+            .type(PortalNavigationItemType.API)
+            .title(existing.getTitle())
+            .order(0)
+            .parentId(product.getId())
+            .published(existing.getPublished())
+            .visibility(existing.getVisibility())
+            .build();
+
+        assertThrows(InvalidPortalNavigationItemDataException.class, () ->
+            useCase.execute(
+                UpdatePortalNavigationItemUseCase.Input.builder()
+                    .organizationId(ORG_ID)
+                    .environmentId(ENV_ID)
+                    .navigationItemId(existing.getId().toString())
+                    .updatePortalNavigationItem(toUpdate)
+                    .build()
+            )
+        );
+    }
+
+    @Test
+    void should_move_api_product_between_regular_folders() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            "00000000-0000-0000-0000-000000000203",
+            "Product",
+            PortalNavigationItemId.of(APIS_ID),
+            "00000000-0000-0000-0000-000000000204"
+        );
+        queryService.storage().add(apiProduct);
+        var targetParentId = PortalNavigationItemId.of(CATEGORY1_ID);
+
+        var output = useCase.execute(updateApiProductInput(apiProduct, targetParentId));
+
+        assertThat(output.updatedItem().getParentId()).isEqualTo(targetParentId);
+    }
+
+    @Test
+    void should_reject_moving_api_product_to_root() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            "00000000-0000-0000-0000-000000000205",
+            "Product",
+            PortalNavigationItemId.of(APIS_ID),
+            "00000000-0000-0000-0000-000000000206"
+        );
+        queryService.storage().add(apiProduct);
+
+        var exception = assertThrows(InvalidPortalNavigationItemDataException.class, () ->
+            useCase.execute(updateApiProductInput(apiProduct, null))
+        );
+
+        assertThat(exception.getMessage()).isEqualTo("The parentId field is required and cannot be blank.");
+    }
+
+    @Test
+    void should_reject_moving_api_product_into_another_api_product_subtree() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            "00000000-0000-0000-0000-000000000207",
+            "Product",
+            PortalNavigationItemId.of(APIS_ID),
+            "00000000-0000-0000-0000-000000000208"
+        );
+        var parentApiProduct = PortalNavigationItemFixtures.anApiProduct(
+            "00000000-0000-0000-0000-000000000209",
+            "Parent product",
+            PortalNavigationItemId.of(APIS_ID),
+            "00000000-0000-0000-0000-000000000210"
+        );
+        var nestedFolder = PortalNavigationItemFixtures.aFolder(
+            "00000000-0000-0000-0000-000000000211",
+            "Nested folder",
+            parentApiProduct.getId()
+        );
+        queryService.storage().addAll(List.of(apiProduct, parentApiProduct, nestedFolder));
+
+        var exception = assertThrows(InvalidPortalNavigationItemDataException.class, () ->
+            useCase.execute(updateApiProductInput(apiProduct, nestedFolder.getId()))
+        );
+
+        assertThat(exception.getMessage()).isEqualTo("Parent hierarchy cannot include API Product items.");
+    }
+
+    @Test
+    void should_reject_moving_api_product_into_api_subtree() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            "00000000-0000-0000-0000-000000000212",
+            "Product",
+            PortalNavigationItemId.of(APIS_ID),
+            "00000000-0000-0000-0000-000000000213"
+        );
+        queryService.storage().add(apiProduct);
+
+        var exception = assertThrows(InvalidPortalNavigationItemDataException.class, () ->
+            useCase.execute(updateApiProductInput(apiProduct, PortalNavigationItemId.of(API1_FOLDER_ID)))
+        );
+
+        assertThat(exception.getMessage()).isEqualTo("Parent hierarchy cannot include API items.");
     }
 
     @Test
@@ -525,6 +679,35 @@ class UpdatePortalNavigationItemUseCaseTest {
     class ParentChange {
 
         @Test
+        void should_reject_moving_container_below_its_descendant() {
+            var parentFolder = PortalNavigationItemFixtures.aFolder("00000000-0000-0000-0000-000000000214", "Parent folder");
+            var childFolder = PortalNavigationItemFixtures.aFolder(
+                "00000000-0000-0000-0000-000000000215",
+                "Child folder",
+                parentFolder.getId()
+            );
+            crudService.initWith(List.of(parentFolder, childFolder));
+            queryService.initWith(List.copyOf(crudService.storage()));
+            var toUpdate = UpdatePortalNavigationItem.builder()
+                .type(PortalNavigationItemType.FOLDER)
+                .title(parentFolder.getTitle())
+                .parentId(childFolder.getId())
+                .published(parentFolder.getPublished())
+                .visibility(parentFolder.getVisibility())
+                .build();
+            var input = UpdatePortalNavigationItemUseCase.Input.builder()
+                .organizationId(ORG_ID)
+                .environmentId(ENV_ID)
+                .navigationItemId(parentFolder.getId().toString())
+                .updatePortalNavigationItem(toUpdate)
+                .build();
+
+            var exception = assertThrows(InvalidPortalNavigationItemDataException.class, () -> useCase.execute(input));
+
+            assertThat(exception.getMessage()).isEqualTo("Cyclic dependency detected in parent hierarchy.");
+        }
+
+        @Test
         void should_update_rootId_and_propagate_to_children_when_non_root_item_moves_to_different_non_root_parent() {
             // Given — sampleNavigationItems: APIS (root) → CATEGORY1 (child, rootId=APIS_ID, has children incl. PAGE11)
             // Find the second root folder (guides) which has a different rootId
@@ -664,6 +847,26 @@ class UpdatePortalNavigationItemUseCaseTest {
             .parentId(folder.getParentId())
             .published(published)
             .visibility(folder.getVisibility())
+            .build();
+    }
+
+    private UpdatePortalNavigationItemUseCase.Input updateApiProductInput(
+        PortalNavigationApiProduct apiProduct,
+        PortalNavigationItemId parentId
+    ) {
+        var toUpdate = UpdatePortalNavigationItem.builder()
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .title(apiProduct.getTitle())
+            .order(apiProduct.getOrder())
+            .parentId(parentId)
+            .published(apiProduct.getPublished())
+            .visibility(apiProduct.getVisibility())
+            .build();
+        return UpdatePortalNavigationItemUseCase.Input.builder()
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .navigationItemId(apiProduct.getId().toString())
+            .updatePortalNavigationItem(toUpdate)
             .build();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-74

## Summary

- validate API Product navigation references, placement, hierarchy, and uniqueness
- support API Product items as navigation containers
- enforce API membership within API Product subtrees
- scope API navigation uniqueness to standalone and individual product contexts
- support pending parent relationships during bulk validation

## Scope

This PR implements the validation foundation for creating and updating API Product navigation trees.

Automatic generation of API navigation children is intentionally delivered in a stacked follow-up PR.

No HTTP contract or persistence changes are included.
