### PR TITLE
feat: bootstrap API Product navigation APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PortalNavigationItemsFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PortalNavigationItemsFixtures.java
@@ -17,6 +17,7 @@ package fixtures;
 
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -110,6 +111,7 @@ public class PortalNavigationItemsFixtures {
             .title("My API Product")
             .area(io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR)
             .order(4)
+            .parentId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
             .visibility(PortalVisibility.PUBLIC);
     }
 
@@ -195,6 +197,22 @@ public class PortalNavigationItemsFixtures {
             .area(PortalArea.TOP_NAVBAR)
             .order(3)
             .apiId("apiId")
+            .parentId(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000002"))
+            .visibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PUBLIC)
+            .published(false)
+            .build();
+    }
+
+    public static PortalNavigationItem aPortalNavigationApiProduct(String organizationId, String environmentId) {
+        return PortalNavigationApiProduct.builder()
+            .id(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000018"))
+            .organizationId(organizationId)
+            .environmentId(environmentId)
+            .title("My API Product")
+            .segment(PortalNavigationItem.slugify("My API Product").value())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(4)
+            .apiProductId("00000000-0000-0000-0000-000000000019")
             .parentId(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000002"))
             .visibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PUBLIC)
             .published(false)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_BulkCreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_BulkCreateTest.java
@@ -126,13 +126,15 @@ class PortalNavigationItemsResource_BulkCreateTest extends AbstractResourceTest 
         final var page = (CreatePortalNavigationPage) PortalNavigationItemsFixtures.aCreatePortalNavigationPage();
         final var folder = (CreatePortalNavigationFolder) PortalNavigationItemsFixtures.aCreatePortalNavigationFolder();
         final var link = (CreatePortalNavigationLink) PortalNavigationItemsFixtures.aCreatePortalNavigationLink();
+        final var apiProduct = PortalNavigationItemsFixtures.aCreatePortalNavigationApiProduct();
 
-        final var request = new BaseCreatePortalNavigationItems().items(List.of(page, folder, link));
+        final var request = new BaseCreatePortalNavigationItems().items(List.of(page, folder, link, apiProduct));
 
         final var output = List.of(
             PortalNavigationItemsFixtures.aPortalNavigationPage(ORGANIZATION, ENVIRONMENT),
             PortalNavigationItemsFixtures.aPortalNavigationFolder(ORGANIZATION, ENVIRONMENT),
-            PortalNavigationItemsFixtures.aPortalNavigationLink(ORGANIZATION, ENVIRONMENT)
+            PortalNavigationItemsFixtures.aPortalNavigationLink(ORGANIZATION, ENVIRONMENT),
+            PortalNavigationItemsFixtures.aPortalNavigationApiProduct(ORGANIZATION, ENVIRONMENT)
         );
         when(bulkCreatePortalNavigationItemUseCase.execute(any())).thenReturn(new BulkCreatePortalNavigationItemUseCase.Output(output));
 
@@ -145,14 +147,14 @@ class PortalNavigationItemsResource_BulkCreateTest extends AbstractResourceTest 
 
         final var body = response.readEntity(PortalNavigationItemsResponse.class);
         assertThat(body).isNotNull();
-        assertThat(body.getItems()).hasSize(3);
+        assertThat(body.getItems()).hasSize(4);
         assertThat(
             body
                 .getItems()
                 .stream()
                 .map(i -> ((BasePortalNavigationItem) i.getActualInstance()).getTitle())
                 .toList()
-        ).containsExactly(page.getTitle(), folder.getTitle(), link.getTitle());
+        ).containsExactly(page.getTitle(), folder.getTitle(), link.getTitle(), apiProduct.getTitle());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_CreateTest.java
@@ -30,6 +30,7 @@ import fixtures.core.model.PortalNavigationItemFixtures;
 import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApiProduct;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
@@ -228,6 +229,26 @@ class PortalNavigationItemsResource_CreateTest extends AbstractResourceTest {
             .hasFieldOrPropertyWithValue("area", io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR)
             .hasFieldOrPropertyWithValue("published", false)
             .hasFieldOrPropertyWithValue("visibility", io.gravitee.rest.api.management.v2.rest.model.PortalVisibility.PUBLIC);
+    }
+
+    @Test
+    void should_create_portal_navigation_api_product_and_return_only_the_product_root() {
+        final var apiProduct = PortalNavigationItemsFixtures.aCreatePortalNavigationApiProduct();
+        final var output = PortalNavigationItemsFixtures.aPortalNavigationApiProduct(ORGANIZATION, ENVIRONMENT);
+        when(createPortalNavigationItemUseCase.execute(any())).thenReturn(new CreatePortalNavigationItemUseCase.Output(output));
+
+        Response response = target.request().post(json(apiProduct));
+
+        assertThat(response).hasStatus(CREATED_201);
+        final var item = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.PortalNavigationApiProduct.class);
+        assertThat(item)
+            .isNotNull()
+            .hasFieldOrPropertyWithValue("id", apiProduct.getId())
+            .hasFieldOrPropertyWithValue("title", apiProduct.getTitle())
+            .hasFieldOrPropertyWithValue("type", PortalNavigationItemType.API_PRODUCT)
+            .hasFieldOrPropertyWithValue("apiProductId", ((CreatePortalNavigationApiProduct) apiProduct).getApiProductId())
+            .hasFieldOrPropertyWithValue("parentId", apiProduct.getParentId())
+            .hasFieldOrPropertyWithValue("published", false);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_GetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_GetTest.java
@@ -108,6 +108,37 @@ class PortalNavigationItemsResource_GetTest extends AbstractResourceTest {
     }
 
     @Test
+    void should_return_api_product_with_its_generated_api_child() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct();
+        apiProduct.markAsRoot();
+        var apiChild = PortalNavigationItemFixtures.anApi(
+            "00000000-0000-0000-0000-000000000020",
+            "Product API",
+            apiProduct.getId(),
+            "api-1"
+        );
+        apiChild.updateParent(apiProduct);
+        apiProduct.setEnvironmentId(ENVIRONMENT);
+        apiChild.setEnvironmentId(ENVIRONMENT);
+        portalNavigationItemsQueryService.initWith(java.util.List.of(apiProduct, apiChild));
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_DOCUMENTATION,
+                ENVIRONMENT,
+                RolePermissionAction.READ
+            )
+        ).thenReturn(true);
+
+        Response response = target.queryParam("area", PortalArea.TOP_NAVBAR).queryParam("loadChildren", true).request().get();
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(PortalNavigationItemsResponse.class)
+            .satisfies(entity -> assertThat(entity.getItems()).hasSize(2));
+    }
+
+    @Test
     void should_return_portal_navigation_items_with_parent_id() {
         // Given
         var allItems = PortalNavigationItemFixtures.sampleNavigationItems();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemCreationExpansionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemCreationExpansionDomainService.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class PortalNavigationItemCreationExpansionDomainService {
+
+    private static final Comparator<Api> API_COMPARATOR = Comparator.comparing(
+        Api::getName,
+        Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)
+    ).thenComparing(Api::getId);
+
+    private final ApiProductQueryService apiProductQueryService;
+    private final ApiCrudService apiCrudService;
+
+    public Expansion expand(List<CreatePortalNavigationItem> requestedItems, String environmentId) {
+        var itemsToCreate = new ArrayList<CreatePortalNavigationItem>();
+        var requestedItemIds = new ArrayList<PortalNavigationItemId>();
+
+        for (var requestedItem : requestedItems) {
+            var itemWithId = ensureId(requestedItem);
+            itemsToCreate.add(itemWithId);
+            requestedItemIds.add(itemWithId.getId());
+
+            if (itemWithId.getType() == PortalNavigationItemType.API_PRODUCT) {
+                itemsToCreate.addAll(createApiChildren(itemWithId, environmentId));
+            }
+        }
+
+        return new Expansion(List.copyOf(itemsToCreate), List.copyOf(requestedItemIds));
+    }
+
+    private List<CreatePortalNavigationItem> createApiChildren(CreatePortalNavigationItem root, String environmentId) {
+        var apiProductId = root.getApiProductId();
+        if (apiProductId == null || apiProductId.isBlank()) {
+            throw InvalidPortalNavigationItemDataException.fieldIsEmpty("apiProductId");
+        }
+
+        var apiProduct = apiProductQueryService
+            .findById(apiProductId)
+            .filter(product -> environmentId.equals(product.getEnvironmentId()))
+            .orElseThrow(() -> new ApiProductNotFoundException(apiProductId));
+        var apis = resolveApis(apiProduct, environmentId);
+        var visibility = root.getVisibility() != null ? root.getVisibility() : PortalVisibility.PUBLIC;
+
+        var children = new ArrayList<CreatePortalNavigationItem>(apis.size());
+        for (int order = 0; order < apis.size(); order++) {
+            var api = apis.get(order);
+            children.add(
+                CreatePortalNavigationItem.builder()
+                    .id(PortalNavigationItemId.random())
+                    .title(api.getName())
+                    .area(root.getArea())
+                    .order(order)
+                    .type(PortalNavigationItemType.API)
+                    .parentId(root.getId())
+                    .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                    .apiId(api.getId())
+                    .visibility(visibility)
+                    .published(false)
+                    .build()
+            );
+        }
+        return children;
+    }
+
+    private List<Api> resolveApis(ApiProduct apiProduct, String environmentId) {
+        Set<String> apiIds = apiProduct.getApiIds() != null ? apiProduct.getApiIds() : Set.of();
+        if (apiIds.isEmpty()) {
+            return List.of();
+        }
+
+        var apis = apiCrudService.findByIds(List.copyOf(apiIds));
+        var validApisById = apis
+            .stream()
+            .filter(api -> environmentId.equals(api.getEnvironmentId()))
+            .collect(Collectors.toMap(Api::getId, Function.identity(), (existing, duplicate) -> existing));
+
+        apiIds
+            .stream()
+            .filter(apiId -> !validApisById.containsKey(apiId))
+            .findFirst()
+            .ifPresent(apiId -> {
+                throw new ApiNotFoundException(apiId);
+            });
+
+        return validApisById.values().stream().sorted(API_COMPARATOR).toList();
+    }
+
+    private CreatePortalNavigationItem ensureId(CreatePortalNavigationItem item) {
+        return item.getId() != null ? item : item.toBuilder().id(PortalNavigationItemId.random()).build();
+    }
+
+    public record Expansion(List<CreatePortalNavigationItem> itemsToCreate, List<PortalNavigationItemId> requestedItemIds) {
+        public List<PortalNavigationItem> selectRequestedItems(List<PortalNavigationItem> createdItems) {
+            Map<PortalNavigationItemId, PortalNavigationItem> createdItemsById = createdItems
+                .stream()
+                .collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity()));
+            return requestedItemIds.stream().map(createdItemsById::get).toList();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemUseCase.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
@@ -30,21 +31,22 @@ public class BulkCreatePortalNavigationItemUseCase {
 
     private final PortalNavigationItemDomainService domainService;
     private final PortalNavigationItemValidatorService validatorService;
+    private final PortalNavigationItemCreationExpansionDomainService creationExpansionDomainService;
 
     public Output execute(Input input) {
-        final List<CreatePortalNavigationItem> itemsToCreate = input.items();
         final var organizationId = input.organizationId();
         final var environmentId = input.environmentId();
+        final var expansion = creationExpansionDomainService.expand(input.items(), environmentId);
 
         List<PortalNavigationItem> result = new LinkedList<>();
 
-        validatorService.validateAll(itemsToCreate, environmentId);
+        validatorService.validateAll(expansion.itemsToCreate(), environmentId);
 
-        for (CreatePortalNavigationItem itemToCreate : itemsToCreate) {
+        for (CreatePortalNavigationItem itemToCreate : expansion.itemsToCreate()) {
             result.add(domainService.create(organizationId, environmentId, itemToCreate));
         }
 
-        return new BulkCreatePortalNavigationItemUseCase.Output(result);
+        return new BulkCreatePortalNavigationItemUseCase.Output(expansion.selectRequestedItems(result));
     }
 
     public record Input(String organizationId, String environmentId, List<CreatePortalNavigationItem> items) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCase.java
@@ -16,10 +16,13 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -28,15 +31,21 @@ public class CreatePortalNavigationItemUseCase {
 
     private final PortalNavigationItemDomainService domainService;
     private final PortalNavigationItemValidatorService validatorService;
+    private final PortalNavigationItemCreationExpansionDomainService creationExpansionDomainService;
 
     public Output execute(Input input) {
-        final CreatePortalNavigationItem itemToCreate = input.item();
         final var organizationId = input.organizationId();
         final var environmentId = input.environmentId();
+        final var expansion = creationExpansionDomainService.expand(List.of(input.item()), environmentId);
 
-        validatorService.validateOne(itemToCreate, environmentId);
+        validatorService.validateAll(expansion.itemsToCreate(), environmentId);
 
-        return new CreatePortalNavigationItemUseCase.Output(domainService.create(organizationId, environmentId, itemToCreate));
+        var createdItems = new ArrayList<PortalNavigationItem>(expansion.itemsToCreate().size());
+        for (var itemToCreate : expansion.itemsToCreate()) {
+            createdItems.add(domainService.create(organizationId, environmentId, itemToCreate));
+        }
+
+        return new CreatePortalNavigationItemUseCase.Output(expansion.selectRequestedItems(createdItems).getFirst());
     }
 
     public record Input(String organizationId, String environmentId, CreatePortalNavigationItem item) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemCreationExpansionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemCreationExpansionDomainServiceTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationItemCreationExpansionDomainServiceTest {
+
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String API_PRODUCT_ID = "00000000-0000-0000-0000-000000000101";
+    private static final String PARENT_ID = "00000000-0000-0000-0000-000000000102";
+
+    private ApiProductQueryServiceInMemory apiProductQueryService;
+    private ApiCrudServiceInMemory apiCrudService;
+    private PortalNavigationItemCreationExpansionDomainService service;
+
+    @BeforeEach
+    void setUp() {
+        apiProductQueryService = new ApiProductQueryServiceInMemory();
+        apiCrudService = new ApiCrudServiceInMemory();
+        service = new PortalNavigationItemCreationExpansionDomainService(apiProductQueryService, apiCrudService);
+    }
+
+    @Test
+    void should_create_only_product_root_when_product_has_no_apis() {
+        apiProductQueryService.initWith(
+            List.of(ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENVIRONMENT_ID).apiIds(Set.of()).build())
+        );
+
+        var expansion = service.expand(List.of(apiProductItem()), ENVIRONMENT_ID);
+
+        assertThat(expansion.itemsToCreate())
+            .singleElement()
+            .satisfies(item -> {
+                assertThat(item.getId()).isNotNull();
+                assertThat(item.getType()).isEqualTo(PortalNavigationItemType.API_PRODUCT);
+            });
+        assertThat(expansion.requestedItemIds()).containsExactly(expansion.itemsToCreate().getFirst().getId());
+    }
+
+    @Test
+    void should_create_api_children_in_stable_name_and_id_order() {
+        apiProductQueryService.initWith(
+            List.of(
+                ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENVIRONMENT_ID).apiIds(Set.of("api-z", "api-a-2", "api-a-1")).build()
+            )
+        );
+        apiCrudService.initWith(
+            List.of(api("api-z", "Zulu", ENVIRONMENT_ID), api("api-a-2", "Alpha", ENVIRONMENT_ID), api("api-a-1", "alpha", ENVIRONMENT_ID))
+        );
+        var root = apiProductItem().toBuilder().visibility(PortalVisibility.PRIVATE).published(true).build();
+
+        var expansion = service.expand(List.of(root), ENVIRONMENT_ID);
+
+        var createdRoot = expansion.itemsToCreate().getFirst();
+        var children = expansion.itemsToCreate().subList(1, expansion.itemsToCreate().size());
+        assertThat(children).extracting(CreatePortalNavigationItem::getApiId).containsExactly("api-a-1", "api-a-2", "api-z");
+        assertThat(children).extracting(CreatePortalNavigationItem::getOrder).containsExactly(0, 1, 2);
+        assertThat(children).allSatisfy(child -> {
+            assertThat(child.getId()).isNotNull();
+            assertThat(child.getType()).isEqualTo(PortalNavigationItemType.API);
+            assertThat(child.getParentId()).isEqualTo(createdRoot.getId());
+            assertThat(child.getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
+            assertThat(child.getPublished()).isFalse();
+            assertThat(child.getContentType()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
+        });
+    }
+
+    @Test
+    void should_create_one_child_when_api_lookup_returns_duplicate_records() {
+        apiProductQueryService.initWith(
+            List.of(ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENVIRONMENT_ID).apiIds(Set.of("api-1")).build())
+        );
+        apiCrudService.initWith(List.of(api("api-1", "First result", ENVIRONMENT_ID), api("api-1", "Duplicate result", ENVIRONMENT_ID)));
+
+        var expansion = service.expand(List.of(apiProductItem()), ENVIRONMENT_ID);
+
+        assertThat(expansion.itemsToCreate().subList(1, expansion.itemsToCreate().size()))
+            .singleElement()
+            .satisfies(child -> {
+                assertThat(child.getApiId()).isEqualTo("api-1");
+                assertThat(child.getTitle()).isEqualTo("First result");
+            });
+    }
+
+    @Test
+    void should_reject_product_from_another_environment() {
+        apiProductQueryService.initWith(
+            List.of(ApiProduct.builder().id(API_PRODUCT_ID).environmentId("other-environment").apiIds(Set.of()).build())
+        );
+
+        assertThatThrownBy(() -> service.expand(List.of(apiProductItem()), ENVIRONMENT_ID)).isInstanceOf(ApiProductNotFoundException.class);
+    }
+
+    @Test
+    void should_reject_missing_api_before_returning_expansion() {
+        apiProductQueryService.initWith(
+            List.of(ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENVIRONMENT_ID).apiIds(Set.of("missing-api")).build())
+        );
+
+        assertThatThrownBy(() -> service.expand(List.of(apiProductItem()), ENVIRONMENT_ID)).isInstanceOf(ApiNotFoundException.class);
+    }
+
+    private static CreatePortalNavigationItem apiProductItem() {
+        return CreatePortalNavigationItem.builder()
+            .title("Product")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .parentId(PortalNavigationItemId.of(PARENT_ID))
+            .apiProductId(API_PRODUCT_ID)
+            .build();
+    }
+
+    private static Api api(String id, String name, String environmentId) {
+        return Api.builder().id(id).name(name).environmentId(environmentId).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemsUseCaseTest.java
@@ -22,9 +22,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiCrudServiceInMemory;
@@ -33,6 +35,9 @@ import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
@@ -44,6 +49,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -55,6 +61,9 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
     private BulkCreatePortalNavigationItemUseCase useCase;
     private PortalNavigationItemsQueryServiceInMemory queryService;
     private PortalNavigationItemValidatorService validatorService;
+    private PortalNavigationItemCreationExpansionDomainService creationExpansionDomainService;
+    private ApiProductQueryServiceInMemory apiProductQueryService;
+    private ApiCrudServiceInMemory apiCrudService;
 
     @BeforeEach
     void setUp() {
@@ -63,14 +72,36 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
         final var crudService = new PortalNavigationItemsCrudServiceInMemory(storage);
         queryService = new PortalNavigationItemsQueryServiceInMemory(storage);
         final var pageContentQueryService = new PortalPageContentQueryServiceInMemory();
-        final var apiProductQueryService = new ApiProductQueryServiceInMemory();
+        apiProductQueryService = new ApiProductQueryServiceInMemory();
         validatorService = new PortalNavigationItemValidatorService(queryService, pageContentQueryService, apiProductQueryService);
         final var pageContentCrudService = new PortalPageContentCrudServiceInMemory();
-        final var apiCrudService = new ApiCrudServiceInMemory();
+        apiCrudService = new ApiCrudServiceInMemory();
 
         final var domainService = new PortalNavigationItemDomainService(crudService, queryService, pageContentCrudService, apiCrudService);
-        useCase = new BulkCreatePortalNavigationItemUseCase(domainService, validatorService);
+        creationExpansionDomainService = new PortalNavigationItemCreationExpansionDomainService(apiProductQueryService, apiCrudService);
+        useCase = new BulkCreatePortalNavigationItemUseCase(domainService, validatorService, creationExpansionDomainService);
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
+    }
+
+    @Test
+    void should_bootstrap_multiple_products_and_return_only_requested_roots_in_request_order() {
+        apiProductQueryService.initWith(
+            List.of(
+                ApiProduct.builder().id("product-1").environmentId(ENV_ID).apiIds(Set.of("shared-api")).build(),
+                ApiProduct.builder().id("product-2").environmentId(ENV_ID).apiIds(Set.of("shared-api")).build()
+            )
+        );
+        apiCrudService.initWith(List.of(Api.builder().id("shared-api").name("Shared API").environmentId(ENV_ID).build()));
+        var firstProduct = productItem("product-1", "First product", 0);
+        var secondProduct = productItem("product-2", "Second product", 1);
+
+        var output = useCase.execute(new BulkCreatePortalNavigationItemUseCase.Input(ORG_ID, ENV_ID, List.of(firstProduct, secondProduct)));
+
+        assertThat(output.items())
+            .extracting(item -> ((io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct) item).getApiProductId())
+            .containsExactly("product-1", "product-2");
+        assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, output.items().get(0).getId())).hasSize(1);
+        assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, output.items().get(1).getId())).hasSize(1);
     }
 
     @Test
@@ -132,7 +163,7 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
     void should_fail_when_at_least_one_item_is_invalid_during_bulk_validation() {
         // Given
         final var domainService = mock(PortalNavigationItemDomainService.class);
-        final var useCase = new BulkCreatePortalNavigationItemUseCase(domainService, validatorService);
+        final var useCase = new BulkCreatePortalNavigationItemUseCase(domainService, validatorService, creationExpansionDomainService);
 
         final var validItem = CreatePortalNavigationItem.builder()
             .id(PortalNavigationItemId.random())
@@ -160,5 +191,54 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
         // Then
         assertThat(exception.getMessage()).isEqualTo("The parentId field is required and cannot be blank.");
         verify(domainService, never()).create(anyString(), anyString(), any(CreatePortalNavigationItem.class));
+    }
+
+    @Test
+    void should_stop_after_first_persistence_failure_without_compensating_previous_writes() {
+        var domainService = mock(PortalNavigationItemDomainService.class);
+        var validatorService = mock(PortalNavigationItemValidatorService.class);
+        var creationExpansionDomainService = mock(PortalNavigationItemCreationExpansionDomainService.class);
+        var rootId = PortalNavigationItemId.random();
+        var root = productItem("product-1", "Product", 0).toBuilder().id(rootId).build();
+        var firstChild = CreatePortalNavigationItem.builder()
+            .id(PortalNavigationItemId.random())
+            .type(PortalNavigationItemType.API)
+            .apiId("api-1")
+            .parentId(rootId)
+            .build();
+        var secondChild = firstChild.toBuilder().id(PortalNavigationItemId.random()).apiId("api-2").build();
+        var expansion = new PortalNavigationItemCreationExpansionDomainService.Expansion(
+            List.of(root, firstChild, secondChild),
+            List.of(rootId)
+        );
+        var persistedRoot = PortalNavigationItemFixtures.anApiProduct(
+            rootId.toString(),
+            "Product",
+            PortalNavigationItemId.of(APIS_ID),
+            "product-1"
+        );
+        when(creationExpansionDomainService.expand(List.of(root), ENV_ID)).thenReturn(expansion);
+        when(domainService.create(ORG_ID, ENV_ID, root)).thenReturn(persistedRoot);
+        when(domainService.create(ORG_ID, ENV_ID, firstChild)).thenThrow(new IllegalStateException("persistence failure"));
+        var useCase = new BulkCreatePortalNavigationItemUseCase(domainService, validatorService, creationExpansionDomainService);
+
+        assertThrows(IllegalStateException.class, () ->
+            useCase.execute(new BulkCreatePortalNavigationItemUseCase.Input(ORG_ID, ENV_ID, List.of(root)))
+        );
+
+        verify(domainService).create(ORG_ID, ENV_ID, root);
+        verify(domainService).create(ORG_ID, ENV_ID, firstChild);
+        verify(domainService, never()).create(anyString(), anyString(), eq(secondChild));
+    }
+
+    private static CreatePortalNavigationItem productItem(String apiProductId, String title, int order) {
+        return CreatePortalNavigationItem.builder()
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .apiProductId(apiProductId)
+            .title(title)
+            .area(PortalArea.TOP_NAVBAR)
+            .order(order)
+            .parentId(PortalNavigationItemId.of(APIS_ID))
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
@@ -32,6 +32,8 @@ import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
@@ -47,6 +49,7 @@ import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -66,6 +69,7 @@ class CreatePortalNavigationItemUseCaseTest {
     private PortalNavigationItemsQueryServiceInMemory queryService;
     private PortalPageContentCrudServiceInMemory pageContentCrudService;
     private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
 
     @BeforeEach
     void setUp() {
@@ -77,16 +81,48 @@ class CreatePortalNavigationItemUseCaseTest {
         PortalPageContentQueryServiceInMemory pageContentQueryService = new PortalPageContentQueryServiceInMemory(
             pageContentCrudService.storage()
         );
-        ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
         PortalNavigationItemValidatorService validatorService = new PortalNavigationItemValidatorService(
             queryService,
             pageContentQueryService,
             apiProductQueryService
         );
         domainService = new PortalNavigationItemDomainService(crudService, queryService, pageContentCrudService, apiCrudService);
-        useCase = new CreatePortalNavigationItemUseCase(domainService, validatorService);
+        useCase = new CreatePortalNavigationItemUseCase(
+            domainService,
+            validatorService,
+            new PortalNavigationItemCreationExpansionDomainService(apiProductQueryService, apiCrudService)
+        );
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
         apiCrudService.initWith(List.of(Api.builder().id("apiId").name("apiIdName").build()));
+    }
+
+    @Test
+    void should_create_product_and_its_api_children_but_return_only_product() {
+        apiProductQueryService.initWith(
+            List.of(ApiProduct.builder().id("product-id").environmentId(ENV_ID).apiIds(Set.of("api-1", "api-2")).build())
+        );
+        apiCrudService.initWith(
+            List.of(
+                Api.builder().id("api-1").name("Alpha").environmentId(ENV_ID).build(),
+                Api.builder().id("api-2").name("Beta").environmentId(ENV_ID).build()
+            )
+        );
+        var toCreate = CreatePortalNavigationItem.builder()
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .apiProductId("product-id")
+            .title("Product")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .parentId(PortalNavigationItemId.of(APIS_ID))
+            .build();
+
+        var output = useCase.execute(new CreatePortalNavigationItemUseCase.Input(ORG_ID, ENV_ID, toCreate));
+
+        assertThat(output.item().getType()).isEqualTo(PortalNavigationItemType.API_PRODUCT);
+        var children = queryService.findByParentIdAndEnvironmentId(ENV_ID, output.item().getId());
+        assertThat(children)
+            .extracting(item -> ((io.gravitee.apim.core.portal_page.model.PortalNavigationApi) item).getApiId())
+            .containsExactly("api-1", "api-2");
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-74

## Summary

- synchronously expand API Product navigation creation into an API Product root and linked API children
- support the same bootstrap behavior for single create and bulk create
- resolve and deterministically sort product APIs before persistence
- validate the complete expanded batch before the first write
- preserve the existing sequential partial-failure semantics
- return only the navigation items explicitly requested by the client

## Behavior

The generated structure is:

API_PRODUCT
└── API

The bootstrap does not directly create Overview, OpenAPI, AsyncAPI, or other documentation pages. Default API pages remain owned by the generic API documentation mechanism.

Products without APIs create only the API Product root.