### PR TITLE
feat: integrate API Product documentation tree

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -144,7 +144,7 @@
         Add Page
       </button>
 
-      @if (node.type === 'FOLDER') {
+      @if (node.type === 'FOLDER' || node.type === 'API_PRODUCT') {
         <button mat-menu-item (click)="onCreate(node, 'API')">
           <mat-icon [svgIcon]="'API' | portalNavigationItemIcon"></mat-icon>
           Add API

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -137,14 +137,14 @@
 }
 
 <ng-template #menuItems let-node>
-  @if (node.type === 'FOLDER' || node.type === 'API') {
+  @if (node.type === 'FOLDER' || node.type === 'API' || node.type === 'API_PRODUCT') {
     @if (canCreate) {
       <button mat-menu-item (click)="onCreate(node, 'PAGE')">
         <mat-icon [svgIcon]="'PAGE' | portalNavigationItemIcon"></mat-icon>
         Add Page
       </button>
 
-      @if (node.type != 'API') {
+      @if (node.type === 'FOLDER') {
         <button mat-menu-item (click)="onCreate(node, 'API')">
           <mat-icon [svgIcon]="'API' | portalNavigationItemIcon"></mat-icon>
           Add API

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -151,23 +151,11 @@
         </button>
       }
 
-      @if (node.type === 'FOLDER') {
-        @let apiProductCreationAllowed = apiProductCreationAllowedByNodeId().get(node.id) ?? true;
-        <span
-          [matTooltip]="apiProductCreationAllowed ? '' : 'API Products cannot be nested inside another API Product'"
-          [matTooltipDisabled]="apiProductCreationAllowed"
-          matTooltipPosition="right"
-        >
-          <button
-            mat-menu-item
-            data-testid="add-api-product-button"
-            [disabled]="!apiProductCreationAllowed"
-            (click)="onCreate(node, 'API_PRODUCT')"
-          >
-            <mat-icon [svgIcon]="'API_PRODUCT' | portalNavigationItemIcon"></mat-icon>
-            Add API Product
-          </button>
-        </span>
+      @if (node.type === 'FOLDER' && (apiProductCreationAllowedByNodeId().get(node.id) ?? true)) {
+        <button mat-menu-item data-testid="add-api-product-button" (click)="onCreate(node, 'API_PRODUCT')">
+          <mat-icon [svgIcon]="'API_PRODUCT' | portalNavigationItemIcon"></mat-icon>
+          Add API Product
+        </button>
       }
 
       <button mat-menu-item (click)="onCreate(node, 'FOLDER')">

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -959,7 +959,7 @@ describe('FlatTreeComponent', () => {
       expect(deleteButton).toBeNull();
     });
 
-    it('should disable Add API Product for a folder inside an API Product subtree', async () => {
+    it('should hide Add API Product for a folder inside an API Product subtree', async () => {
       setupPermissions(['environment-documentation-c']);
       fixture = TestBed.createComponent(FlatTreeComponent);
       component = fixture.componentInstance;
@@ -971,8 +971,13 @@ describe('FlatTreeComponent', () => {
         makeItem('folder-nested', 'FOLDER', 'Nested Folder', 0, 'product-1'),
       ]);
       fixture.detectChanges();
+      await fixture.whenStable();
 
-      expect(component.apiProductCreationAllowedByNodeId().get('folder-nested')).toBe(false);
+      expandTree();
+      const moreActionsButton = await harness['getMoreActionsButtonById']('folder-nested')();
+      await moreActionsButton.click();
+
+      expect(await harness.getMenuItemByTestId('add-api-product-button')).toBeNull();
     });
 
     const testCases = [

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -892,7 +892,7 @@ describe('FlatTreeComponent', () => {
       expect(await harness.getMenuItemByText('Add Page')).toBeTruthy();
       expect(await harness.getMenuItemByText('Add Folder')).toBeTruthy();
       expect(await harness.getMenuItemByText('Add Link')).toBeTruthy();
-      expect(await harness.getMenuItemByText('Add API')).toBeNull();
+      expect(await harness.getMenuItemByText('Add API')).toBeTruthy();
       expect(await harness.getMenuItemByTestId('add-api-product-button')).toBeNull();
     });
 

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -875,6 +875,27 @@ describe('FlatTreeComponent', () => {
       expect(moreActionsButton).toBeTruthy();
     });
 
+    it('should show documentation actions for an API Product if user has create permission', async () => {
+      setupPermissions(['environment-documentation-c']);
+      fixture = TestBed.createComponent(FlatTreeComponent);
+      component = fixture.componentInstance;
+      harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, FlatTreeComponentHarness);
+
+      fixture.componentRef.setInput('links', [makeItem('product-1', 'API_PRODUCT', 'Product 1', 0, 'folder-1')]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const moreActionsButton = await harness['getMoreActionsButtonById']('product-1')();
+      expect(moreActionsButton).toBeTruthy();
+      await moreActionsButton.click();
+
+      expect(await harness.getMenuItemByText('Add Page')).toBeTruthy();
+      expect(await harness.getMenuItemByText('Add Folder')).toBeTruthy();
+      expect(await harness.getMenuItemByText('Add Link')).toBeTruthy();
+      expect(await harness.getMenuItemByText('Add API')).toBeNull();
+      expect(await harness.getMenuItemByTestId('add-api-product-button')).toBeNull();
+    });
+
     it('should NOT show more actions button for page if user ONLY has create permission', async () => {
       setupPermissions(['environment-documentation-c']);
       fixture = TestBed.createComponent(FlatTreeComponent);

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -361,7 +361,7 @@ export class FlatTreeComponent {
   }
 
   canShowMoreActions(node: FlatTreeNode): boolean {
-    if (node.type === 'FOLDER' && this.canCreate) {
+    if ((node.type === 'FOLDER' || node.type === 'API_PRODUCT') && this.canCreate) {
       return true;
     }
     return this.canUpdate || this.canDelete;

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.ts
@@ -38,10 +38,16 @@ import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wra
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { getPublicVisibilityDisabledTooltip, isPublicVisibilityDisabled } from '../visibility-toggle.util';
 
+export interface ApiProductNavigationContext {
+  navigationItemId: string;
+  apiProductId: string;
+}
+
 export interface ApiSectionEditorDialogData {
   mode: 'create';
   parentItem?: PortalNavigationItem;
   existingApiIds?: string[];
+  apiProductContext?: ApiProductNavigationContext;
 }
 
 export interface ApiSectionEditorDialogResult {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -3521,7 +3521,7 @@ describe('PortalNavigationItemsComponent', () => {
 
       component.onNodeMoved({ node, newParentId: null, newOrder: 0 });
 
-      expect(errorSpy).toHaveBeenCalledWith('API Product must remain under a folder outside another API Product');
+      expect(errorSpy).toHaveBeenCalledWith('API Product must be placed under a folder');
       await expectGetNavigationItems(fakeResponse);
     });
 
@@ -3546,7 +3546,7 @@ describe('PortalNavigationItemsComponent', () => {
 
       component.onNodeMoved({ node, newParentId: nestedFolder.id, newOrder: 0 });
 
-      expect(errorSpy).toHaveBeenCalledWith('API Product must remain under a folder outside another API Product');
+      expect(errorSpy).toHaveBeenCalledWith('API Product cannot be nested inside another API Product');
       await expectGetNavigationItems(fakeResponse);
     });
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -1211,6 +1211,121 @@ describe('PortalNavigationItemsComponent', () => {
     });
   });
 
+  describe('adding documentation under an API Product from tree node "More actions" menu', () => {
+    const folder = fakePortalNavigationFolder({ id: 'products-folder', title: 'Products' });
+    const apiProduct = fakePortalNavigationApiProduct({
+      id: 'api-product-nav-1',
+      apiProductId: 'api-product-1',
+      title: 'Payments Product',
+      parentId: folder.id,
+      visibility: 'PRIVATE',
+    });
+    const fakeResponse = fakePortalNavigationItemsResponse({ items: [folder, apiProduct] });
+    const node: SectionNode = {
+      id: apiProduct.id,
+      label: apiProduct.title,
+      type: apiProduct.type,
+      data: apiProduct,
+    };
+
+    beforeEach(async () => {
+      await expectGetNavigationItems(fakeResponse);
+      flushPendingLinkedApiProductRequests();
+      await fixture.whenStable();
+    });
+
+    it('creates a private Gravitee Markdown page under the API Product', async () => {
+      component.onNodeMenuAction({ action: 'create', itemType: 'PAGE', node });
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      const authenticationToggle = await dialog.getAuthenticationToggle();
+      expect(await authenticationToggle.isChecked()).toBe(true);
+      expect(await authenticationToggle.isDisabled()).toBe(true);
+
+      const title = 'Product overview';
+      await dialog.setTitleInputValue(title);
+      await dialog.clickSubmitButton();
+
+      const createdItem = fakePortalNavigationPage({
+        id: 'product-page-1',
+        title,
+        parentId: apiProduct.id,
+        visibility: 'PRIVATE',
+        portalPageContentId: 'product-page-content-1',
+      });
+      expectCreateNavigationItem(
+        fakeNewPagePortalNavigationItem({
+          title,
+          area: 'TOP_NAVBAR',
+          parentId: apiProduct.id,
+          visibility: 'PRIVATE',
+          contentType: 'GRAVITEE_MARKDOWN',
+        }),
+        createdItem,
+      );
+      await expectGetNavigationItems(fakeResponse);
+    });
+
+    it('creates a folder under the API Product', async () => {
+      component.onNodeMenuAction({ action: 'create', itemType: 'FOLDER', node });
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      const title = 'Guides';
+      await dialog.setTitleInputValue(title);
+      await dialog.clickSubmitButton();
+
+      const createdItem = fakePortalNavigationFolder({
+        id: 'product-folder-1',
+        title,
+        parentId: apiProduct.id,
+        visibility: 'PRIVATE',
+      });
+      expectCreateNavigationItem(
+        fakeNewFolderPortalNavigationItem({
+          title,
+          area: 'TOP_NAVBAR',
+          parentId: apiProduct.id,
+          visibility: 'PRIVATE',
+        }),
+        createdItem,
+      );
+      await expectGetNavigationItems(fakeResponse);
+    });
+
+    it('creates a link under the API Product', async () => {
+      component.onNodeMenuAction({ action: 'create', itemType: 'LINK', node });
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      const title = 'Support';
+      const url = 'https://example.com/support';
+      await dialog.setTitleInputValue(title);
+      await dialog.setUrlInputValue(url);
+      await dialog.clickSubmitButton();
+
+      const createdItem = fakePortalNavigationLink({
+        id: 'product-link-1',
+        title,
+        url,
+        parentId: apiProduct.id,
+        visibility: 'PRIVATE',
+      });
+      expectCreateNavigationItem(
+        fakeNewLinkPortalNavigationItem({
+          title,
+          url,
+          area: 'TOP_NAVBAR',
+          parentId: apiProduct.id,
+          visibility: 'PRIVATE',
+        }),
+        createdItem,
+      );
+      await expectGetNavigationItems(fakeResponse);
+    });
+  });
+
   describe('selecting a navigation item', () => {
     beforeEach(async () => {
       const fakeResponse = fakePortalNavigationItemsResponse({
@@ -3265,6 +3380,85 @@ describe('PortalNavigationItemsComponent', () => {
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [apiItem1, apiItem2] }));
 
       expect(document.body.textContent).toContain('API cannot be moved under an API navigation item');
+    });
+  });
+
+  describe('moving an API Product node', () => {
+    const sourceFolder = fakePortalNavigationFolder({ id: 'source-folder', title: 'Source folder' });
+    const targetFolder = fakePortalNavigationFolder({ id: 'target-folder', title: 'Target folder' });
+    const apiProduct = fakePortalNavigationApiProduct({
+      id: 'api-product-nav-1',
+      title: 'Payments Product',
+      apiProductId: 'api-product-1',
+      parentId: sourceFolder.id,
+      order: 1,
+      published: false,
+      visibility: 'PUBLIC',
+    });
+    const node: SectionNode = {
+      id: apiProduct.id,
+      label: apiProduct.title,
+      type: apiProduct.type,
+      data: apiProduct,
+    };
+
+    it('should reject moving the API Product to the tree root', async () => {
+      const fakeResponse = fakePortalNavigationItemsResponse({ items: [sourceFolder, apiProduct] });
+      const errorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+      await expectGetNavigationItems(fakeResponse);
+      flushPendingLinkedApiProductRequests();
+
+      component.onNodeMoved({ node, newParentId: null, newOrder: 0 });
+
+      expect(errorSpy).toHaveBeenCalledWith('API Product must remain under a folder outside another API Product');
+      await expectGetNavigationItems(fakeResponse);
+    });
+
+    it('should reject moving the API Product into another API Product subtree', async () => {
+      const parentApiProduct = fakePortalNavigationApiProduct({
+        id: 'parent-api-product-nav',
+        apiProductId: 'api-product-2',
+        title: 'Parent Product',
+        parentId: targetFolder.id,
+      });
+      const nestedFolder = fakePortalNavigationFolder({
+        id: 'nested-product-folder',
+        title: 'Nested product folder',
+        parentId: parentApiProduct.id,
+      });
+      const fakeResponse = fakePortalNavigationItemsResponse({
+        items: [sourceFolder, targetFolder, apiProduct, parentApiProduct, nestedFolder],
+      });
+      const errorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+      await expectGetNavigationItems(fakeResponse);
+      flushPendingLinkedApiProductRequests();
+
+      component.onNodeMoved({ node, newParentId: nestedFolder.id, newOrder: 0 });
+
+      expect(errorSpy).toHaveBeenCalledWith('API Product must remain under a folder outside another API Product');
+      await expectGetNavigationItems(fakeResponse);
+    });
+
+    it('should move the API Product between regular folders without sending apiProductId', async () => {
+      const fakeResponse = fakePortalNavigationItemsResponse({ items: [sourceFolder, targetFolder, apiProduct] });
+      await expectGetNavigationItems(fakeResponse);
+      flushPendingLinkedApiProductRequests();
+
+      component.onNodeMoved({ node, newParentId: targetFolder.id, newOrder: 0 });
+
+      const movedApiProduct = fakePortalNavigationApiProduct({ ...apiProduct, parentId: targetFolder.id, order: 0 });
+      expectPutPortalNavigationItem(
+        apiProduct.id,
+        fakeUpdateApiProductPortalNavigationItem({
+          title: apiProduct.title,
+          parentId: targetFolder.id,
+          order: 0,
+          published: apiProduct.published,
+          visibility: apiProduct.visibility,
+        }),
+        movedApiProduct,
+      );
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourceFolder, targetFolder, movedApiProduct] }));
     });
   });
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -3350,6 +3350,117 @@ describe('PortalNavigationItemsComponent', () => {
     });
   });
 
+  describe('API Product context passed to API section dialog', () => {
+    async function openApiSectionDialog(parentItem: PortalNavigationItem): Promise<SpyInstance> {
+      const openSpy = jest.spyOn(TestBed.inject(MatDialog), 'open');
+      const parentNode: SectionNode = {
+        id: parentItem.id,
+        label: parentItem.title,
+        type: parentItem.type,
+        data: parentItem,
+      };
+
+      component.onNodeMenuAction({ action: 'create', itemType: 'API', node: parentNode });
+      fixture.detectChanges();
+      flushPendingLinkedApiProductRequests();
+      await fixture.whenStable();
+      expectApiSearchResponse([]);
+
+      return openSpy;
+    }
+
+    it('should pass API Product context when adding an API directly below the product', async () => {
+      const rootFolder = fakePortalNavigationFolder({ id: 'root-folder', title: 'Root folder' });
+      const apiProduct = fakePortalNavigationApiProduct({
+        id: 'product-navigation-item',
+        apiProductId: 'api-product-id',
+        title: 'API Product',
+        parentId: rootFolder.id,
+      });
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct] }));
+
+      const openSpy = await openApiSectionDialog(apiProduct);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            apiProductContext: {
+              navigationItemId: apiProduct.id,
+              apiProductId: apiProduct.apiProductId,
+            },
+          }),
+        }),
+      );
+    });
+
+    it('should pass the nearest API Product context when adding an API below nested folders', async () => {
+      const rootFolder = fakePortalNavigationFolder({ id: 'root-folder', title: 'Root folder' });
+      const apiProduct = fakePortalNavigationApiProduct({
+        id: 'product-navigation-item',
+        apiProductId: 'api-product-id',
+        title: 'API Product',
+        parentId: rootFolder.id,
+      });
+      const firstNestedFolder = fakePortalNavigationFolder({
+        id: 'first-nested-folder',
+        title: 'First nested folder',
+        parentId: apiProduct.id,
+      });
+      const secondNestedFolder = fakePortalNavigationFolder({
+        id: 'second-nested-folder',
+        title: 'Second nested folder',
+        parentId: firstNestedFolder.id,
+      });
+      await expectGetNavigationItems(
+        fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct, firstNestedFolder, secondNestedFolder] }),
+      );
+
+      const openSpy = await openApiSectionDialog(secondNestedFolder);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            apiProductContext: {
+              navigationItemId: apiProduct.id,
+              apiProductId: apiProduct.apiProductId,
+            },
+          }),
+        }),
+      );
+    });
+
+    it.each([
+      {
+        description: 'a standalone folder',
+        items: [fakePortalNavigationFolder({ id: 'standalone-folder', title: 'Standalone folder' })],
+      },
+      {
+        description: 'a folder whose parent is missing',
+        items: [fakePortalNavigationFolder({ id: 'orphan-folder', title: 'Orphan folder', parentId: 'missing-parent' })],
+      },
+      {
+        description: 'a folder in a cyclic hierarchy',
+        items: [
+          fakePortalNavigationFolder({ id: 'cycle-folder-1', title: 'Cycle folder 1', parentId: 'cycle-folder-2' }),
+          fakePortalNavigationFolder({ id: 'cycle-folder-2', title: 'Cycle folder 2', parentId: 'cycle-folder-1' }),
+        ],
+      },
+    ])('should not pass API Product context for $description', async ({ items }) => {
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items }));
+
+      const openSpy = await openApiSectionDialog(items[0]);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({ apiProductContext: undefined }),
+        }),
+      );
+    });
+  });
+
   describe('calling onAddSection with API type', () => {
     it('should not open any dialog when onAddSection is called with API type', async () => {
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [] }));

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -46,6 +46,7 @@ import {
   SectionEditorDialogMode,
 } from './section-editor-dialog/section-editor-dialog.component';
 import {
+  ApiProductNavigationContext,
   ApiSectionEditorDialogComponent,
   ApiSectionEditorDialogData,
 } from './api-section-editor-dialog/api-section-editor-dialog.component';
@@ -346,6 +347,8 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   }
 
   private createApiSection(existingItem?: PortalNavigationItem): void {
+    const apiProductContext = existingItem ? this.findApiProductNavigationContext(existingItem) : undefined;
+
     this.matDialog
       .open<ApiSectionEditorDialogComponent, ApiSectionEditorDialogData>(ApiSectionEditorDialogComponent, {
         width: GIO_DIALOG_WIDTH.LARGE,
@@ -353,6 +356,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
           mode: 'create',
           existingApiIds: this.extractApiIdsFromNavigationItems(),
           parentItem: existingItem,
+          apiProductContext,
         },
       })
       .afterClosed()
@@ -997,6 +1001,25 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     return this.menuLinks()
       .filter((item): item is PortalNavigationApiProduct => item.type === 'API_PRODUCT')
       .map(item => item.apiProductId);
+  }
+
+  private findApiProductNavigationContext(item: PortalNavigationItem): ApiProductNavigationContext | undefined {
+    const itemsById = new Map(this.menuLinks().map(menuItem => [menuItem.id, menuItem]));
+    const visitedItemIds = new Set<string>();
+    let currentItem: PortalNavigationItem | undefined = item;
+
+    while (currentItem && !visitedItemIds.has(currentItem.id)) {
+      visitedItemIds.add(currentItem.id);
+      if (currentItem.type === 'API_PRODUCT') {
+        return {
+          navigationItemId: currentItem.id,
+          apiProductId: currentItem.apiProductId,
+        };
+      }
+      currentItem = currentItem.parentId ? itemsById.get(currentItem.parentId) : undefined;
+    }
+
+    return undefined;
   }
 
   private isInsideApiProductSubtree(item: PortalNavigationItem): boolean {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -927,10 +927,13 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   onNodeMoved($event: NodeMovedEvent) {
     const { node, newParentId, newOrder } = $event;
 
-    if (node.type === 'API_PRODUCT' && !this.isValidApiProductParent(newParentId)) {
-      this.snackBarService.error('API Product must remain under a folder outside another API Product');
-      this.refreshMenuList.next(1);
-      return;
+    if (node.type === 'API_PRODUCT') {
+      const validationError = this.getApiProductMoveValidationError(newParentId);
+      if (validationError) {
+        this.snackBarService.error(validationError);
+        this.refreshMenuList.next(1);
+        return;
+      }
     }
 
     if (node.type === 'API' && newParentId) {
@@ -1038,13 +1041,19 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     return false;
   }
 
-  private isValidApiProductParent(parentId: string | null): boolean {
+  private getApiProductMoveValidationError(parentId: string | null): string | null {
     if (!parentId) {
-      return false;
+      return 'API Product must be placed under a folder';
     }
 
     const parent = this.menuLinks().find(item => item.id === parentId);
-    return parent?.type === 'FOLDER' && !this.isInsideApiProductSubtree(parent);
+    if (!parent) {
+      return 'API Product must be placed under a folder';
+    }
+    if (this.isInsideApiProductSubtree(parent)) {
+      return 'API Product cannot be nested inside another API Product';
+    }
+    return parent.type === 'FOLDER' ? null : 'API Product must be placed under a folder';
   }
 
   private getApiProductCreateErrorMessage(error: unknown): string {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -923,6 +923,12 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   onNodeMoved($event: NodeMovedEvent) {
     const { node, newParentId, newOrder } = $event;
 
+    if (node.type === 'API_PRODUCT' && !this.isValidApiProductParent(newParentId)) {
+      this.snackBarService.error('API Product must remain under a folder outside another API Product');
+      this.refreshMenuList.next(1);
+      return;
+    }
+
     if (node.type === 'API' && newParentId) {
       const parent = this.menuLinks().find(i => i.id === newParentId);
       if (parent?.type === 'API') {
@@ -1007,6 +1013,15 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     }
 
     return false;
+  }
+
+  private isValidApiProductParent(parentId: string | null): boolean {
+    if (!parentId) {
+      return false;
+    }
+
+    const parent = this.menuLinks().find(item => item.id === parentId);
+    return parent?.type === 'FOLDER' && !this.isInsideApiProductSubtree(parent);
   }
 
   private getApiProductCreateErrorMessage(error: unknown): string {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-75

## Summary

Integrate API Product navigation items with the existing Console documentation tree.

## Changes

- Add `Page`, `Folder`, and `Link` creation actions to API Product nodes.
- Keep `Add API Product` unavailable on API Product nodes.
- Reuse the existing documentation editor and visibility inheritance behavior.
- Prevent moving an API Product to the tree root or into another API Product subtree.
- Allow moving an API Product between regular folders without updating its immutable `apiProductId`.
- Add focused coverage for documentation creation and API Product move validation.

https://github.com/user-attachments/assets/0e2dee38-873e-4566-85a9-f993e2a35aa3



