### PR TITLE
feat: manage gamma repository classloader according to configuration

### DIFF
--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-handler/src/main/java/io/gravitee/plugin/gamma/internal/GammaModulePluginHandler.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-handler/src/main/java/io/gravitee/plugin/gamma/internal/GammaModulePluginHandler.java
@@ -43,6 +43,11 @@ public class GammaModulePluginHandler extends AbstractPluginHandler {
     @Value("${gamma.enabled:false}")
     protected boolean gammaEnabled = false;
 
+    @Value("${management.type:${repositories.management.type:mongodb}}")
+    protected String managementType;
+
+    private static final String JDBC = "jdbc";
+
     @Autowired
     protected PluginClassLoaderFactory<Plugin> pluginClassLoaderFactory;
 
@@ -57,10 +62,26 @@ public class GammaModulePluginHandler extends AbstractPluginHandler {
 
     @Override
     protected ClassLoader getClassLoader(Plugin plugin) {
-        return pluginClassLoaderFactory.getOrCreateClassLoader(
-            plugin,
-            applicationContext.getBean("managementMongoTemplate").getClass().getClassLoader()
-        );
+        return pluginClassLoaderFactory.getOrCreateClassLoader(plugin, managementRepositoryClassLoader());
+    }
+
+    /**
+     * Gamma module classloaders delegate to the management repository plugin's classloader so module code can
+     * link against the classes of the shared repository beans registered in the parent context:
+     * {@code graviteeDataSource} when APIM runs on JDBC, {@code managementMongoTemplate} on MongoDB.
+     * The backend is read from {@code management.type} (deprecated {@code repositories.management.type}
+     * fallback), reliable here because the handler lives in the root rest-api context.
+     *
+     * <p>Consequence for modules: Spring loads every type appearing in a configuration's {@code @Bean}
+     * signatures just to introspect it, so persistence types of the inactive backend must never appear in
+     * always-loaded configurations — hide them behind an {@code ImportSelector} returning configuration class
+     * <em>names</em> per backend (see the aim module's {@code AimPersistenceImportSelector}).</p>
+     */
+    private ClassLoader managementRepositoryClassLoader() {
+        if (JDBC.equalsIgnoreCase(managementType)) {
+            return applicationContext.getBean("graviteeDataSource").getClass().getClassLoader();
+        }
+        return applicationContext.getBean("managementMongoTemplate").getClass().getClassLoader();
     }
 
     @Override

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-handler/src/test/java/io/gravitee/plugin/gamma/internal/GammaModuleHandlerTest.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-handler/src/test/java/io/gravitee/plugin/gamma/internal/GammaModuleHandlerTest.java
@@ -85,8 +85,9 @@ class GammaModuleHandlerTest {
         when(deploymentContext.isPluginDeployable(any())).thenReturn(true);
         when(pluginDeploymentContextFactory.create()).thenReturn(deploymentContext);
 
-        // Default: managementMongoTemplate bean provides a classloader for plugin classloader factory.
+        // Default: mongodb mode, the managementMongoTemplate bean provides the anchor classloader.
         // Use a non-JDK object so getClass().getClassLoader() returns a non-null classloader.
+        handler.managementType = "mongodb";
         when(applicationContext.getBean("managementMongoTemplate")).thenReturn(applicationContext);
         PluginClassLoader pluginClassLoader = mock(PluginClassLoader.class);
         when(pluginClassLoaderFactory.getOrCreateClassLoader(any(Plugin.class), any(ClassLoader.class))).thenReturn(pluginClassLoader);
@@ -175,6 +176,30 @@ class GammaModuleHandlerTest {
         assertThat(manager.getRestResourceClasses()).hasSize(1);
         assertThat(manager.getResourceClass("test-plugin").getName()).isEqualTo(AGammaModuleRestClass.class.getName());
         verify(pluginContextFactory).create(any(GammaModulePluginHandler.GammaModulePluginContextConfigurer.class));
+    }
+
+    @Test
+    void should_anchor_classloader_on_datasource_when_management_type_is_jdbc() {
+        // JDBC mode: graviteeDataSource provides the anchor classloader.
+        handler.managementType = "jdbc";
+        when(applicationContext.getBean("graviteeDataSource")).thenReturn(applicationContext);
+
+        Plugin plugin = mock(Plugin.class);
+        PluginManifest manifest = mock(PluginManifest.class);
+        when(plugin.id()).thenReturn("test-plugin");
+        when(plugin.type()).thenReturn("gamma-module");
+        when(plugin.manifest()).thenReturn(manifest);
+        when(plugin.clazz()).thenReturn(AGammaModule.class.getName());
+        when(manifest.version()).thenReturn("1.0.0");
+        when(plugin.deployed()).thenReturn(true);
+
+        ApplicationContext pluginCtx = mock(ApplicationContext.class);
+        when(pluginCtx.getBeanDefinitionNames()).thenReturn(new String[0]);
+        when(pluginContextFactory.create(any(GammaModulePluginHandler.GammaModulePluginContextConfigurer.class))).thenReturn(pluginCtx);
+
+        handler.handle(plugin);
+
+        verify(pluginClassLoaderFactory).getOrCreateClassLoader(eq(plugin), eq(applicationContext.getClass().getClassLoader()));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-72
https://gravitee.atlassian.net/browse/FOUND-185

## What

Gamma module classloaders are anchored on the management repository plugin's classloader, but the anchor was hardcoded on the `managementMongoTemplate` bean — on `management.type=jdbc` that bean doesn't exist and **no gamma module could load at all**.

The handler now reads `management.type` (`repositories.management.type` fallback, `mongodb` default) and anchors on the matching shared bean's classloader: `graviteeDataSource` on jdbc, `managementMongoTemplate` otherwise.

## Notes

- Modules referencing spring-data-mongodb types in always-loaded configurations still fail to start in jdbc mode (contained per module, caught by the handler) — expected, they have no jdbc support anyway. The way out is selecting persistence configurations by class **name** per backend (`ImportSelector`, see aim's `AimPersistenceImportSelector`); documented in the handler javadoc.
- Mongodb mode behaviour unchanged.

## Testing

- `GammaModuleHandlerTest`: jdbc anchor covered by a new test, mongodb default updated.
- Validated end-to-end on a local postgres: aim module starts in jdbc mode, applies its Liquibase changelogs, A2A creation works.

## Related

- gravitee-gamma-module-aim PR (jdbc persistence foundation) — requires this change. https://github.com/gravitee-io/gravitee-gamma-module-aim/pull/526