### PR TITLE
fix(tracing): report distinct-trace total so trace search paginates past page 1

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/api/TracingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/api/TracingRepository.java
@@ -15,12 +15,12 @@
  */
 package io.gravitee.repository.tracing.api;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.tracing.model.Trace;
 import io.gravitee.repository.tracing.model.TraceSearchCriteria;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -40,12 +40,18 @@ public interface TracingRepository {
     /**
      * List traces matching the given filter. The returned {@link Trace} entries carry summary fields only;
      * {@code spans} is always empty — call {@link #getTrace(QueryContext, String, Map)} to fetch a trace's spans.
+     * <p>
+     * The result is a {@link Page} whose {@link Page#getContent() content} is the matching traces (bounded by
+     * {@code criteria.limit()} and the implementation's own cap) and whose {@link Page#getTotalElements() total}
+     * is the number of distinct traces matching the filter — the value callers need to drive pagination. An
+     * implementation MAY cap the reported total at the maximum it can actually serve, so callers never page past
+     * reachable results.
      *
      * @param queryContext caller's org/env, used to resolve tenant-aware indices/headers
      * @param criteria filter (attribute filters, resource-attribute filters, time window, limit)
-     * @return list of matching traces; emits an empty list when no trace matches
+     * @return page of matching traces with the total distinct-trace count; empty content + zero total when none match
      */
-    Single<List<Trace>> searchTraces(QueryContext queryContext, TraceSearchCriteria criteria);
+    Single<Page<Trace>> searchTraces(QueryContext queryContext, TraceSearchCriteria criteria);
 
     /**
      * Fetch a single trace by id, including its full span tree.

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepository.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.elasticsearch.client.Client;
 import io.gravitee.elasticsearch.model.Aggregation;
 import io.gravitee.elasticsearch.model.SearchHit;
@@ -69,6 +70,9 @@ public class ElasticsearchTracingRepository implements TracingRepository {
     /** Span-attribute key set by both backends so callers don't have to know about backend-specific status fields. */
     private static final String OTEL_STATUS_CODE_ATTR = "otel.status_code";
 
+    /** ES aggregation JSON key naming the field to aggregate on — shared by the terms, min and cardinality aggs. */
+    private static final String AGG_FIELD_KEY = "field";
+
     private static final JsonNodeFactory JSON = JsonNodeFactory.instance;
 
     private final String indexTemplate;
@@ -80,7 +84,7 @@ public class ElasticsearchTracingRepository implements TracingRepository {
     }
 
     @Override
-    public Single<List<Trace>> searchTraces(QueryContext queryContext, TraceSearchCriteria criteria) {
+    public Single<Page<Trace>> searchTraces(QueryContext queryContext, TraceSearchCriteria criteria) {
         String index = resolveIndex(indexTemplate, queryContext);
         String body = buildSearchTracesBody(criteria);
         return client.search(index, null, body).map(ElasticsearchTracingRepository::parseSearchTracesResponse);
@@ -128,7 +132,7 @@ public class ElasticsearchTracingRepository implements TracingRepository {
         ObjectNode aggs = JSON.objectNode();
         ObjectNode tracesAgg = JSON.objectNode();
         ObjectNode termsAgg = JSON.objectNode();
-        termsAgg.put("field", "trace_id");
+        termsAgg.put(AGG_FIELD_KEY, "trace_id");
         // Bound caller-supplied limit so a runaway value can't trip ES's max_buckets circuit breaker.
         termsAgg.put("size", Math.min(criteria.limit(), MAX_SEARCH_RESULTS));
         ObjectNode order = JSON.objectNode();
@@ -143,6 +147,9 @@ public class ElasticsearchTracingRepository implements TracingRepository {
         tracesAgg.set("aggs", subAggs);
 
         aggs.set("traces", tracesAgg);
+        // Distinct-trace count for pagination: the terms agg only returns the first N buckets, so a sibling
+        // cardinality agg on trace_id gives the true number of matching traces (independent of the terms size).
+        aggs.set("total_traces", cardinalityAgg("trace_id"));
         root.set("aggs", aggs);
         return root.toString();
     }
@@ -257,8 +264,16 @@ public class ElasticsearchTracingRepository implements TracingRepository {
     private static ObjectNode minAgg(String field) {
         ObjectNode agg = JSON.objectNode();
         ObjectNode min = JSON.objectNode();
-        min.put("field", field);
+        min.put(AGG_FIELD_KEY, field);
         agg.set("min", min);
+        return agg;
+    }
+
+    private static ObjectNode cardinalityAgg(String field) {
+        ObjectNode agg = JSON.objectNode();
+        ObjectNode cardinality = JSON.objectNode();
+        cardinality.put(AGG_FIELD_KEY, field);
+        agg.set("cardinality", cardinality);
         return agg;
     }
 
@@ -303,13 +318,13 @@ public class ElasticsearchTracingRepository implements TracingRepository {
         return agg;
     }
 
-    private static List<Trace> parseSearchTracesResponse(SearchResponse response) {
+    private static Page<Trace> parseSearchTracesResponse(SearchResponse response) {
         if (response.getAggregations() == null) {
-            return List.of();
+            return emptyTracePage();
         }
         Aggregation tracesAgg = response.getAggregations().get("traces");
         if (tracesAgg == null || tracesAgg.getBuckets() == null) {
-            return List.of();
+            return emptyTracePage();
         }
 
         List<Trace> traces = new ArrayList<>(tracesAgg.getBuckets().size());
@@ -319,7 +334,18 @@ public class ElasticsearchTracingRepository implements TracingRepository {
                 traces.add(trace);
             }
         }
-        return traces;
+
+        // Distinct-trace total from the cardinality agg, capped at what this backend can actually serve — the terms
+        // agg / fetch-and-slice can't reach past MAX_SEARCH_RESULTS, so callers never page past reachable results.
+        Aggregation totalAgg = response.getAggregations().get("total_traces");
+        long distinct = totalAgg != null && totalAgg.getValue() != null ? totalAgg.getValue().longValue() : traces.size();
+        long total = Math.min(distinct, MAX_SEARCH_RESULTS);
+
+        return new Page<>(traces, 0, traces.size(), total);
+    }
+
+    private static Page<Trace> emptyTracePage() {
+        return new Page<>(List.of(), 0, 0, 0L);
     }
 
     private static Trace parseTraceBucket(JsonNode bucket) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepositoryTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.elasticsearch.client.Client;
 import io.gravitee.elasticsearch.model.Aggregation;
 import io.gravitee.elasticsearch.model.SearchHit;
@@ -104,6 +105,8 @@ class ElasticsearchTracingRepositoryTest {
             .containsEntry("resource.attributes.gravitee.environment.id", "test-env");
         assertThat(body.path("aggs").path("traces").path("terms").path("field").asText()).isEqualTo("trace_id");
         assertThat(body.path("aggs").path("traces").path("terms").path("size").asInt()).isEqualTo(5);
+        // Sibling cardinality agg drives the distinct-trace total used for pagination.
+        assertThat(body.path("aggs").path("total_traces").path("cardinality").path("field").asText()).isEqualTo("trace_id");
     }
 
     @Test
@@ -125,12 +128,14 @@ class ElasticsearchTracingRepositoryTest {
     @Test
     void searchTraces_should_map_aggregation_buckets_to_traces() {
         SearchResponse response = new SearchResponse();
-        response.setAggregations(Map.of("traces", buildTracesAggregation()));
+        response.setAggregations(Map.of("traces", buildTracesAggregation(), "total_traces", cardinalityAggregation(1.0f)));
         when(client.search(any(), any(), any())).thenReturn(Single.just(response));
 
         TraceSearchCriteria criteria = new TraceSearchCriteria(Map.of(), 20, null, null, Map.of());
-        List<Trace> traces = repository.searchTraces(QUERY_CONTEXT, criteria).blockingGet();
+        Page<Trace> page = repository.searchTraces(QUERY_CONTEXT, criteria).blockingGet();
+        List<Trace> traces = page.getContent();
 
+        assertThat(page.getTotalElements()).isEqualTo(1L);
         assertThat(traces).hasSize(1);
         Trace trace = traces.get(0);
         assertThat(trace.traceId()).isEqualTo("a1b2c3d4");
@@ -328,15 +333,52 @@ class ElasticsearchTracingRepositoryTest {
     }
 
     @Test
-    void searchTraces_should_emit_empty_list_when_aggregation_missing() {
+    void searchTraces_should_emit_empty_page_when_aggregation_missing() {
         SearchResponse response = new SearchResponse();
         when(client.search(any(), any(), any())).thenReturn(Single.just(response));
 
-        List<Trace> traces = repository
+        Page<Trace> page = repository
             .searchTraces(QUERY_CONTEXT, new TraceSearchCriteria(Map.of(), 20, null, null, Map.of()))
             .blockingGet();
 
-        assertThat(traces).isEmpty();
+        assertThat(page.getContent()).isEmpty();
+        assertThat(page.getTotalElements()).isZero();
+    }
+
+    @Test
+    void searchTraces_should_report_distinct_trace_total_from_cardinality_agg() {
+        SearchResponse response = new SearchResponse();
+        response.setAggregations(Map.of("traces", buildTracesAggregation(), "total_traces", cardinalityAggregation(75.0f)));
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        Page<Trace> page = repository
+            .searchTraces(QUERY_CONTEXT, new TraceSearchCriteria(Map.of(), 20, null, null, Map.of()))
+            .blockingGet();
+
+        // The total is the distinct-trace cardinality (75) — not the size of the returned slice — so callers can
+        // derive the real page count.
+        assertThat(page.getTotalElements()).isEqualTo(75L);
+    }
+
+    @Test
+    void searchTraces_should_cap_reported_total_at_max_search_results() {
+        SearchResponse response = new SearchResponse();
+        response.setAggregations(Map.of("traces", buildTracesAggregation(), "total_traces", cardinalityAggregation(500.0f)));
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        Page<Trace> page = repository
+            .searchTraces(QUERY_CONTEXT, new TraceSearchCriteria(Map.of(), 20, null, null, Map.of()))
+            .blockingGet();
+
+        // 500 distinct traces exist, but the terms agg / fetch-and-slice can only serve 200 — cap the reported total
+        // so the UI never advertises pages it can't fill.
+        assertThat(page.getTotalElements()).isEqualTo(200L);
+    }
+
+    private static Aggregation cardinalityAggregation(float value) {
+        Aggregation agg = new Aggregation();
+        agg.setValue(value);
+        return agg;
     }
 
     private static Aggregation buildTracesAggregation() {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingTestRepositoryInitializer.java
@@ -23,7 +23,6 @@ import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.config.TestRepositoryInitializer;
 import io.gravitee.repository.tracing.TracingRepositoryTest.Fixtures;
 import io.gravitee.repository.tracing.api.TracingRepository;
-import io.gravitee.repository.tracing.model.Trace;
 import io.gravitee.repository.tracing.model.TraceSearchCriteria;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -36,7 +35,6 @@ import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -143,8 +141,8 @@ public class ElasticsearchTracingTestRepositoryInitializer implements TestReposi
             .atMost(QUERYABLE_POLL_TIMEOUT)
             .pollInterval(QUERYABLE_POLL_INTERVAL)
             .until(() -> {
-                List<Trace> traces = tracingRepository.searchTraces(queryContext, criteria).blockingGet();
-                return traces.size() >= 2;
+                var page = tracingRepository.searchTraces(queryContext, criteria).blockingGet();
+                return page.getContent().size() >= 2;
             });
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/tracing/NoOpTracingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/tracing/NoOpTracingRepository.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.noop.tracing;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.tracing.api.TracingRepository;
 import io.gravitee.repository.tracing.model.Trace;
@@ -36,8 +37,8 @@ import java.util.Map;
 public class NoOpTracingRepository implements TracingRepository {
 
     @Override
-    public Single<List<Trace>> searchTraces(QueryContext queryContext, TraceSearchCriteria criteria) {
-        return Single.just(List.of());
+    public Single<Page<Trace>> searchTraces(QueryContext queryContext, TraceSearchCriteria criteria) {
+        return Single.just(new Page<>(List.of(), 0, 0, 0L));
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/tracing/NoOpTracingRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/tracing/NoOpTracingRepositoryTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.tracing.model.Trace;
 import io.gravitee.repository.tracing.model.TraceSearchCriteria;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -29,15 +28,16 @@ public class NoOpTracingRepositoryTest {
     private final NoOpTracingRepository repository = new NoOpTracingRepository();
 
     @Test
-    public void searchTraces_should_return_empty_list() {
-        List<Trace> traces = repository
+    public void searchTraces_should_return_empty_page() {
+        var page = repository
             .searchTraces(
                 new QueryContext("org#1", "env#1"),
                 new TraceSearchCriteria(Map.of(), 100, null, null, Map.of("gravitee.api.id", "api-1"))
             )
             .blockingGet();
 
-        assertThat(traces).isEmpty();
+        assertThat(page.getContent()).isEmpty();
+        assertThat(page.getTotalElements()).isZero();
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/tracing/TracingRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/tracing/TracingRepositoryTest.java
@@ -23,7 +23,6 @@ import io.gravitee.repository.tracing.api.TracingRepository;
 import io.gravitee.repository.tracing.model.Trace;
 import io.gravitee.repository.tracing.model.TraceSearchCriteria;
 import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,23 +68,26 @@ public abstract class TracingRepositoryTest extends AbstractRepositoryTest {
 
     @Test
     public void should_search_traces_matching_service_tag() {
-        List<Trace> traces = tracingRepository
+        var page = tracingRepository
             .searchTraces(QUERY_CONTEXT, new TraceSearchCriteria(Map.of("service.name", Fixtures.SERVICE_NAME), 20, null, null, Map.of()))
             .blockingGet();
 
-        assertThat(traces).extracting(Trace::traceId).containsExactlyInAnyOrder(Fixtures.TRACE_OK_ID, Fixtures.TRACE_ERROR_ID);
+        assertThat(page.getContent()).extracting(Trace::traceId).containsExactlyInAnyOrder(Fixtures.TRACE_OK_ID, Fixtures.TRACE_ERROR_ID);
+        // The SPI reports the distinct-trace total (not the slice size), so callers can paginate.
+        assertThat(page.getTotalElements()).isEqualTo(2L);
     }
 
     @Test
-    public void should_return_empty_list_when_no_trace_matches() {
-        List<Trace> traces = tracingRepository
+    public void should_return_empty_page_when_no_trace_matches() {
+        var page = tracingRepository
             .searchTraces(
                 QUERY_CONTEXT,
                 new TraceSearchCriteria(Map.of("service.name", "service-that-does-not-exist"), 20, null, null, Map.of())
             )
             .blockingGet();
 
-        assertThat(traces).isEmpty();
+        assertThat(page.getContent()).isEmpty();
+        assertThat(page.getTotalElements()).isZero();
     }
 
     @Test

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/TracingPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/TracingPortAdapter.java
@@ -68,8 +68,11 @@ public class TracingPortAdapter implements TracingPort {
         // The SPI is non-blocking (Single) but the use case wants a List — block here, at the boundary
         // between reactive infra and synchronous core. Acceptable trade-off: a REST request is already a
         // blocking unit of work and the trace search is bounded by the indexed window + the agg limit.
-        List<io.gravitee.repository.tracing.model.Trace> fullPage = tracingRepository.searchTraces(queryContext, criteria).blockingGet();
-        long total = fullPage.size();
+        Page<io.gravitee.repository.tracing.model.Trace> spiPage = tracingRepository.searchTraces(queryContext, criteria).blockingGet();
+        List<io.gravitee.repository.tracing.model.Trace> fullPage = spiPage.getContent();
+        // Total distinct traces matching the filter (from the SPI's cardinality agg), capped by the SPI at what it can
+        // actually serve — so pageCount reflects the reachable pages, not just the size of this fetched slice.
+        long total = spiPage.getTotalElements();
 
         int fromIndex = Math.min(page * perPage, fullPage.size());
         int toIndex = Math.min(fromIndex + perPage, fullPage.size());


### PR DESCRIPTION
## Problem
The trace explorer showed only one page regardless of how many traces matched. `searchTraces` returned a bare `List<Trace>`, so the gamma adapter derived the total from the fetched slice size (`== perPage`) — `pageCount` was always 1.

## Fix
- Elasticsearch `searchTraces` adds a `cardinality(trace_id)` aggregation; the SPI now returns `Page<Trace>` carrying the distinct-trace total, **capped at `MAX_SEARCH_RESULTS` (200)** so no unreachable pages are advertised.
- The gamma adapter uses that total for the paginated response; `NoOpTracingRepository` returns an empty page.
- No lib/frontend change — the `{ data, pagination: { totalCount } }` wire contract is unchanged.

## Tests
Added/updated Elasticsearch unit tests (distinct total, 200 cap, empty page) and the repository contract test.

