### PR TITLE
fix(APIM-14729): allow observability dashboard filters without DASHBOARD update permission

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-viewer.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-viewer.component.html
@@ -43,7 +43,6 @@
       <div class="observability-dashboard-viewer__filters-row">
         <gd-dynamic-filter-bar
           [conditions]="filtersStore.conditions()"
-          [editable]="canEditFilters()"
           (addRequested)="openAddFilter()"
           (editRequested)="openEditFilter($event.index, $event.condition)"
           (removeRequested)="filtersStore.remove($event)"

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-viewer.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-viewer.component.spec.ts
@@ -143,22 +143,83 @@ describe('DashboardViewerComponent', () => {
     expect(component.filtersStore.conditions()).toEqual([condition]);
   });
 
-  it('should not open dialog when user lacks edit permission', () => {
-    matDialogMock.open.mockClear();
-    permissionMock.hasAnyMatching.mockReturnValue(false);
-    const freshFixture = TestBed.createComponent(DashboardViewerComponent);
-    freshFixture.componentRef.setInput('dashboard', MOCK_DASHBOARD);
-    freshFixture.detectChanges();
-    freshFixture.componentInstance.openAddFilter();
-    expect(matDialogMock.open).not.toHaveBeenCalled();
-  });
+  // Filters are transient query state — DashboardFiltersStore never persists them — so every filter
+  // interaction must stay available without environment-dashboard-u (APIM-14729).
+  //
+  // Two distinct guards are at work here, and they are not equally strong:
+  //  - the permission stub only catches re-introduction of the removed
+  //    hasAnyMatching(['environment-dashboard-u']) gate; the component no longer injects
+  //    GioPermissionService, so on its own it asserts nothing about the component;
+  //  - the DOM-driven assertions are what catch a re-gate by any other mechanism, since add / edit /
+  //    remove / clear are all rendered off gd-dynamic-filter-bar's `editable` input. Anything that
+  //    makes that input falsy fails all four tests below.
+  describe('when the user has no dashboard permission', () => {
+    const API_CONDITION = { field: 'API', label: 'API', operator: 'EQ' as const, values: ['id-1'] };
+    const APPLICATION_CONDITION = { field: 'APPLICATION', label: 'Application', operator: 'EQ' as const, values: ['app-1'] };
 
-  it('should hide add button when editable is false', async () => {
-    permissionMock.hasAnyMatching.mockReturnValue(false);
-    fixture = TestBed.createComponent(DashboardViewerComponent);
-    fixture.componentRef.setInput('dashboard', MOCK_DASHBOARD);
-    fixture.detectChanges();
-    const addBtn = fixture.debugElement.query(By.css('.gd-dynamic-filter-bar__add-btn'));
-    expect(addBtn).toBeNull();
+    let fixtureWithoutPermission: ComponentFixture<DashboardViewerComponent>;
+    let viewerWithoutPermission: DashboardViewerComponent;
+
+    beforeEach(() => {
+      matDialogMock.open.mockClear();
+      permissionMock.hasAnyMatching.mockReturnValue(false);
+      fixtureWithoutPermission = TestBed.createComponent(DashboardViewerComponent);
+      viewerWithoutPermission = fixtureWithoutPermission.componentInstance;
+      fixtureWithoutPermission.componentRef.setInput('dashboard', MOCK_DASHBOARD);
+      fixtureWithoutPermission.detectChanges();
+    });
+
+    function seedConditions(...conditions: (typeof API_CONDITION)[]): void {
+      conditions.forEach(condition => viewerWithoutPermission.filtersStore.add(condition));
+      fixtureWithoutPermission.detectChanges();
+    }
+
+    it('should allow adding a filter', () => {
+      matDialogMock.open.mockReturnValue({ afterClosed: () => of(API_CONDITION) });
+
+      const addBtn = fixtureWithoutPermission.debugElement.query(By.css('.gd-dynamic-filter-bar__add-btn'));
+      expect(addBtn).toBeTruthy();
+      addBtn.nativeElement.click();
+
+      expect(viewerWithoutPermission.filtersStore.conditions()).toEqual([API_CONDITION]);
+    });
+
+    it('should allow editing a filter', () => {
+      seedConditions(API_CONDITION);
+      const editedCondition = { ...API_CONDITION, values: ['id-2'] };
+      matDialogMock.open.mockReturnValue({ afterClosed: () => of(editedCondition) });
+
+      const chip = fixtureWithoutPermission.debugElement.query(By.css('gd-filter-chip mat-chip'));
+      expect(chip).toBeTruthy();
+      chip.nativeElement.click();
+
+      expect(matDialogMock.open).toHaveBeenCalledWith(
+        AddFilterDialogComponent,
+        expect.objectContaining({
+          data: expect.objectContaining({ existingCondition: API_CONDITION }),
+        }),
+      );
+      expect(viewerWithoutPermission.filtersStore.conditions()).toEqual([editedCondition]);
+    });
+
+    it('should allow removing a single filter', () => {
+      seedConditions(API_CONDITION, APPLICATION_CONDITION);
+
+      const removeIcon = fixtureWithoutPermission.debugElement.query(By.css('gd-filter-chip .mat-mdc-chip-remove'));
+      expect(removeIcon).toBeTruthy();
+      removeIcon.nativeElement.click();
+
+      expect(viewerWithoutPermission.filtersStore.conditions()).toEqual([APPLICATION_CONDITION]);
+    });
+
+    it('should allow clearing all filters', () => {
+      seedConditions(API_CONDITION, APPLICATION_CONDITION);
+
+      const clearBtn = fixtureWithoutPermission.debugElement.query(By.css('.gd-dynamic-filter-bar__clear-btn'));
+      expect(clearBtn).toBeTruthy();
+      clearBtn.nativeElement.click();
+
+      expect(viewerWithoutPermission.filtersStore.conditions()).toEqual([]);
+    });
   });
 });

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-viewer.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-viewer.component.ts
@@ -30,7 +30,7 @@ import {
   timeFrames,
 } from '@gravitee/gravitee-dashboard';
 
-import { Component, computed, DestroyRef, inject, Injector, input, output } from '@angular/core';
+import { Component, DestroyRef, inject, Injector, input, output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
@@ -39,7 +39,6 @@ import { DashboardFiltersStore } from './dashboard-filters.store';
 import { FilterLabelResolver } from './filter-label.resolver';
 
 import { ObservabilityFiltersApiService } from '../../../data-access/observability-filters-api.service';
-import { GioPermissionService } from '../../../../../shared/components/gio-permission/gio-permission.service';
 import { Constants } from '../../../../../entities/Constants';
 
 @Component({
@@ -70,14 +69,10 @@ export class DashboardViewerComponent {
   private readonly dialog = inject(MatDialog);
   private readonly injector = inject(Injector);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly permissionService = inject(GioPermissionService);
-
-  readonly canEditFilters = computed(() => this.permissionService.hasAnyMatching(['environment-dashboard-u']));
 
   protected readonly timeFrames = [...timeFrames, ...customTimeFrames];
 
   openAddFilter(): void {
-    if (!this.canEditFilters()) return;
     const { from, to } = this.filtersStore.timeRangeEpoch();
     this.dialog
       .open<AddFilterDialogComponent, AddFilterDialogData, FilterCondition>(AddFilterDialogComponent, {
@@ -95,7 +90,6 @@ export class DashboardViewerComponent {
   }
 
   openEditFilter(index: number, condition: FilterCondition): void {
-    if (!this.canEditFilters()) return;
     const { from, to } = this.filtersStore.timeRangeEpoch();
     this.dialog
       .open<AddFilterDialogComponent, AddFilterDialogData, FilterCondition>(AddFilterDialogComponent, {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14729
## Description

Users with the stock API_PUBLISHER environment role can open an Observability dashboard but can't filter it — Add filter is hidden, chips are read-only, and Clear is gone. The filter bar was wired to environment-dashboard-u in #16628, which effectively requires DASHBOARD: UPDATE just to read data through a filter.

Frontend only, 3 files, all in dashboard-viewer:

- removed the canEditFilters computed, the GioPermissionService injection, and the early-return guards in openAddFilter() / openEditFilter()
- dropped [editable]="canEditFilters()" — the lib input already defaults to true
- replaced the two specs that asserted the old gating with one regression test: with hasAnyMatching stubbed to false, the Add button renders and clicking it opens the dialog

Dashboard editing is untouched — rename, add widget, edit layout and delete stay gated on environment-dashboard-u in dashboard-detail.component.ts:60-62.

Testing

- dashboard-viewer.component.spec.ts — 6/6 passing
- Confirmed the new test is a real guard: with the production changes stashed (old gating restored) it fails; with them applied it passes
- ESLint and tsc clean on the changed files
- 
## Additional context

Before
<img width="1491" height="586" alt="Screenshot 2026-07-21 at 5 27 17 PM" src="https://github.com/user-attachments/assets/38765aab-d3eb-4589-a72c-71882e38af98" />

After
<img width="1488" height="549" alt="Screenshot 2026-07-21 at 5 28 40 PM" src="https://github.com/user-attachments/assets/cb3a3007-2bb5-4fcd-83a6-5944fdb6678b" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

