### PR TITLE
chore(deps): bundle cost-ratelimit policy and bump AI plugin versions

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -2211,6 +2211,19 @@
                 </dependency>
                 <dependency>
                     <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-cost-ratelimit</artifactId>
+                    <version>${gravitee-policy-cost-ratelimit.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
                     <artifactId>gravitee-policy-mcp-acl</artifactId>
                     <version>${gravitee-policy-mcp-acl.version}</version>
                     <type>zip</type>

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
     <gravitee-reactor-native-kafka.version>7.1.0-alpha.1</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.0.2</gravitee-reactor-mcp-proxy.version>
-    <gravitee-reactor-llm-proxy.version>3.1.1</gravitee-reactor-llm-proxy.version>
+    <gravitee-reactor-llm-proxy.version>3.2.0</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.0.0</gravitee-reactor-a2a-proxy.version>
     <gravitee-reactor-authz.version>1.0.0</gravitee-reactor-authz.version>
     <gravitee-reactor-edge.version>1.0.0</gravitee-reactor-edge.version>
@@ -339,14 +339,15 @@
     <gravitee-policy-kafka-rules.version>1.1.2</gravitee-policy-kafka-rules.version>
     <gravitee-policy-kafka-namespace.version>1.0.0</gravitee-policy-kafka-namespace.version>
     <gravitee-policy-offloading.version>1.1.0</gravitee-policy-offloading.version>
-    <gravitee-policy-token-ratelimit.version>1.0.0</gravitee-policy-token-ratelimit.version>
+    <gravitee-policy-token-ratelimit.version>1.1.0</gravitee-policy-token-ratelimit.version>
+    <gravitee-policy-cost-ratelimit.version>1.1.0</gravitee-policy-cost-ratelimit.version>
     <gravitee-policy-mcp-acl.version>1.0.4</gravitee-policy-mcp-acl.version>
     <gravitee-policy-pii-filtering.version>2.2.0</gravitee-policy-pii-filtering.version>
     <gravitee-policy-native-ipfiltering.version>1.0.1</gravitee-policy-native-ipfiltering.version>
     <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>
 
     <!-- Gamma plugins -->
-    <gravitee-gamma-module-aim.version>1.1.0-alpha.14</gravitee-gamma-module-aim.version>
+    <gravitee-gamma-module-aim.version>1.4.0</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.6.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>1.1.0</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.0.0</gravitee-gamma-module-esm.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-144

## Description

Ship the cost-ratelimit policy on the gateway so AI Workspace tier budgets can enforce a dollar ceiling, and align the AI/LLM plugins with the release line that supports it.


- Add gravitee-policy-cost-ratelimit 1.1.0 to the distribution bundle.
- Bump gravitee-policy-token-ratelimit 1.0.0 -> 1.1.0 (same release train
  as cost-ratelimit).
- Bump gravitee-gamma-module-aim 1.1.0-alpha.14 -> 1.4.0.
- Bump gravitee-reactor-llm-proxy 3.1.1 -> 3.2.0.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

