### PR TITLE
fix(console): map HTTP Path log filter to the URI search param

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
@@ -639,8 +639,11 @@ describe('EnvLogsComponent', () => {
       req.flush(EMPTY_RESPONSE);
     }));
 
-    it('should pass URI (HTTP Path) filter from store to search request', fakeAsync(() => {
-      setupWithFilter('URI', 'HTTP Path', ['/v1/test/test2']);
+    it('should map the HTTP Path filter (stored as HTTP_PATH) to the URI search param', fakeAsync(() => {
+      // The console "HTTP Path" filter carries the store field name HTTP_PATH (the backend
+      // field code); the search API expects it as the URI filter. Seeding the real field name
+      // (not a fictional 'URI' field) is what makes this test catch the mapping.
+      setupWithFilter('HTTP_PATH', 'HTTP Path', ['/v1/test/test2']);
 
       const req = httpTestingController.expectOne({ method: 'POST', url: SEARCH_URL });
       expect(req.request.body.filters).toEqual(

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
@@ -242,7 +242,7 @@ export class EnvLogsComponent {
       entrypoints: filterMap.get('ENTRYPOINT'),
       errorKeys: filterMap.get('ERROR_KEY'),
       apiProductIds: filterMap.get('API_PRODUCT'),
-      uri: filterMap.get('URI')?.[0],
+      uri: filterMap.get('HTTP_PATH')?.[0],
       bodyText: filterMap.get('PAYLOAD')?.[0],
     };
   }


### PR DESCRIPTION
## Problem

In the environment observability logs, the **HTTP Path** filter had no effect — adding it returned the same (unfiltered) result set. Reported after PR #18555, which introduced the mapping but keyed it on the wrong name.

## Root cause

`buildSearchParam` reads the store filters into a map keyed by the filter's **store field name**, then looks up the path with `filterMap.get('URI')`. But the console never stores a filter named `URI`: the "HTTP Path" filter carries the backend field code **`HTTP_PATH`** (see `FilterSpec.Name` — the enum has `HTTP_PATH` / `HTTP_PATH_MAPPING`, no `URI`).

So `get('URI')` always returned `undefined`, the path value was dropped, and the search ran unfiltered.

`URI` *does* exist — but only on the **output** side: the search API accepts the path as `{ name: 'URI' }`. `buildSearchParam` bridges input→output; only the input lookup key was wrong.

## Fix

Read the filter under its real store name (`HTTP_PATH`); the outgoing param still emits `uri` → `{ name: 'URI' }`, unchanged.

## Test

The existing test seeded a fictional `URI` store field, so it passed against the broken lookup. It now seeds `HTTP_PATH` like the real UI — which is what makes it catch the mapping.

https://gravitee.atlassian.net/browse/APIM-14697