### PR TITLE
feat(gamma): add dictionaries list UI in Platform Managment Page

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -16,7 +16,7 @@
 import { useModuleRouting } from '@gravitee/gamma-modules-sdk/routing';
 import { buildLinearBreadcrumbs, SidebarNavigation, useLayoutConfig } from '@gravitee/graphene-core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { type ReactElement, useMemo } from 'react';
 import { Navigate, Outlet, Route, Routes, useNavigate } from 'react-router-dom';
 
 import { PlatformToaster } from './PlatformToaster';
@@ -29,6 +29,7 @@ import { SecurityPlanTypesPage } from '../features/security-plan-types/SecurityP
 import { AccessManagementPage } from '../pages/AccessManagementPage';
 import { ApplicationDetailSubscriptionPage } from '../pages/ApplicationDetailSubscriptionPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
+import { DictionariesPage } from '../pages/DictionariesPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
 import { retryTransientRequest } from '../shared/api/queryRetry';
@@ -45,12 +46,22 @@ const queryClient = new QueryClient({
 
 const APPLICATION_DETAIL_TABS = flattenApplicationDetailNavItems(APPLICATION_NAV_GROUPS);
 
-function MetadataGuard() {
+function PermissionPageGuard({ permission, children }: Readonly<{ permission: string; children: ReactElement }>) {
     const permissionsReady = useEnvironmentPermissionsReady();
-    const canRead = useHasPermission({ anyOf: ['environment-metadata-r'] });
+    const canRead = useHasPermission({ anyOf: [permission] });
     if (!permissionsReady) return null;
     if (!canRead) return <Navigate to="applications" replace />;
-    return <MetadataPage />;
+    return children;
+}
+
+function isNavItemVisible(itemKey: string, permissionsReady: boolean, canReadMetadata: boolean, canReadDictionaries: boolean): boolean {
+    if (itemKey === 'metadata') {
+        return !permissionsReady || canReadMetadata;
+    }
+    if (itemKey === 'dictionaries') {
+        return !permissionsReady || canReadDictionaries;
+    }
+    return true;
 }
 
 function ModuleLayout() {
@@ -58,6 +69,7 @@ function ModuleLayout() {
 
     const permissionsReady = useEnvironmentPermissionsReady();
     const canReadMetadata = useHasPermission({ anyOf: ['environment-metadata-r'] });
+    const canReadDictionaries = useHasPermission({ anyOf: ['environment-dictionary-r'] });
 
     const navigate = useNavigate();
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
@@ -66,9 +78,9 @@ function ModuleLayout() {
         () =>
             NAV_GROUPS.map(group => ({
                 ...group,
-                items: group.items.filter(item => item.key !== 'metadata' || !permissionsReady || canReadMetadata),
+                items: group.items.filter(item => isNavItemVisible(item.key, permissionsReady, canReadMetadata, canReadDictionaries)),
             })).filter(group => group.items.length > 0),
-        [permissionsReady, canReadMetadata],
+        [permissionsReady, canReadMetadata, canReadDictionaries],
     );
 
     const breadcrumbs = useMemo(
@@ -109,7 +121,22 @@ export function AppRoutes() {
                             </Route>
                         </Route>
                         <Route path="access-management" element={<AccessManagementPage />} />
-                        <Route path="metadata" element={<MetadataGuard />} />
+                        <Route
+                            path="metadata"
+                            element={
+                                <PermissionPageGuard permission="environment-metadata-r">
+                                    <MetadataPage />
+                                </PermissionPageGuard>
+                            }
+                        />
+                        <Route
+                            path="dictionaries"
+                            element={
+                                <PermissionPageGuard permission="environment-dictionary-r">
+                                    <DictionariesPage />
+                                </PermissionPageGuard>
+                            }
+                        />
                         <Route path="security-plan-types" element={<SecurityPlanTypesPage />} />
                     </Route>
                 </Routes>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import type { NavGroup } from '@gravitee/graphene-core';
-import { AppWindowIcon, DatabaseIcon, KeyIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
+import { AppWindowIcon, BookOpenIcon, DatabaseIcon, KeyIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
 
 import { ROUTES } from './routes';
 
@@ -25,7 +25,10 @@ export const NAV_GROUPS: NavGroup[] = [
     },
     {
         label: 'APIs & Assets',
-        items: [{ key: 'metadata', title: ROUTES.metadata.label, icon: DatabaseIcon }],
+        items: [
+            { key: 'metadata', title: ROUTES.metadata.label, icon: DatabaseIcon },
+            { key: 'dictionaries', title: ROUTES.dictionaries.label, icon: BookOpenIcon },
+        ],
     },
     {
         label: 'System & Security',

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -15,7 +15,7 @@
  */
 import type { ModuleRouteConfig } from '@gravitee/gamma-modules-sdk/routing';
 
-export const ROUTE_KEYS: readonly string[] = ['applications', 'access-management', 'metadata', 'security-plan-types'];
+export const ROUTE_KEYS: readonly string[] = ['applications', 'access-management', 'metadata', 'dictionaries', 'security-plan-types'];
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
 const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
@@ -25,6 +25,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     'access-management': { path: 'access-management', label: 'Access Management' },
     'security-plan-types': { path: 'security-plan-types', label: 'Security Plan Types' },
     metadata: { path: 'metadata', label: 'Metadata' },
+    dictionaries: { path: 'dictionaries', label: 'Dictionaries' },
 };
 
 export const PLATFORM_ROUTE_CONFIG: ModuleRouteConfig<RouteKey> = {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.spec.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { DictionariesTable } from './DictionariesTable';
+import type { DictionaryListItem } from '../types/dictionary';
+
+const DICTIONARIES: DictionaryListItem[] = [
+    {
+        id: '1',
+        key: 'countries',
+        name: 'Countries',
+        type: 'MANUAL',
+        state: 'STOPPED',
+        updated_at: '2026-01-01T00:00:00.000Z',
+    },
+    {
+        id: '2',
+        key: 'remote-codes',
+        name: 'Remote Codes',
+        type: 'DYNAMIC',
+        state: 'STARTED',
+        updated_at: '2026-01-02T00:00:00.000Z',
+    },
+    {
+        id: '3',
+        key: 'status-map',
+        name: 'Status Map',
+        type: 'MANUAL',
+        state: 'STOPPED',
+    },
+];
+
+function renderTable(overrides: Partial<{ canEdit: boolean; canDelete: boolean; dictionaries: DictionaryListItem[] }> = {}) {
+    const onEdit = jest.fn();
+    const onDelete = jest.fn();
+    render(
+        <DictionariesTable
+            dictionaries={overrides.dictionaries ?? DICTIONARIES}
+            canEdit={overrides.canEdit ?? true}
+            canDelete={overrides.canDelete ?? true}
+            onEdit={onEdit}
+            onDelete={onDelete}
+        />,
+    );
+    return { onEdit, onDelete };
+}
+
+describe('DictionariesTable', () => {
+    describe('rendering', () => {
+        it('renders all dictionary rows', () => {
+            renderTable();
+            expect(screen.queryByText('Countries')).not.toBeNull();
+            expect(screen.queryByText('Remote Codes')).not.toBeNull();
+            expect(screen.queryByText('Status Map')).not.toBeNull();
+        });
+
+        it('shows the empty message when there are no dictionaries', () => {
+            renderTable({ dictionaries: [] });
+            expect(screen.queryByText('No dictionaries defined for this environment.')).not.toBeNull();
+        });
+    });
+
+    describe('search filtering', () => {
+        it('filters rows by name', () => {
+            renderTable();
+            fireEvent.change(screen.getByPlaceholderText('Search by key or name…'), { target: { value: 'remote' } });
+            expect(screen.queryByText('Remote Codes')).not.toBeNull();
+            expect(screen.queryByText('Countries')).toBeNull();
+        });
+
+        it('filters rows by key', () => {
+            renderTable();
+            fireEvent.change(screen.getByPlaceholderText('Search by key or name…'), { target: { value: 'status-map' } });
+            expect(screen.queryByText('Status Map')).not.toBeNull();
+            expect(screen.queryByText('Countries')).toBeNull();
+        });
+
+        it('shows the no-match message when search has no results', () => {
+            renderTable();
+            fireEvent.change(screen.getByPlaceholderText('Search by key or name…'), { target: { value: 'zzznomatch' } });
+            expect(screen.queryByText('No dictionaries match your search.')).not.toBeNull();
+        });
+
+        it('is case-insensitive', () => {
+            renderTable();
+            fireEvent.change(screen.getByPlaceholderText('Search by key or name…'), { target: { value: 'COUNTRIES' } });
+            expect(screen.queryByText('Countries')).not.toBeNull();
+        });
+    });
+
+    describe('permissions', () => {
+        it('hides the actions column when both canEdit and canDelete are false', () => {
+            renderTable({ canEdit: false, canDelete: false });
+            expect(screen.queryByRole('button', { name: 'Dictionary actions' })).toBeNull();
+        });
+
+        it('shows one action button per row when canEdit is true', () => {
+            renderTable({ canEdit: true, canDelete: false });
+            expect(screen.getAllByRole('button', { name: 'Dictionary actions' }).length).toBe(DICTIONARIES.length);
+        });
+
+        it('shows one action button per row when canDelete is true', () => {
+            renderTable({ canEdit: false, canDelete: true });
+            expect(screen.getAllByRole('button', { name: 'Dictionary actions' }).length).toBe(DICTIONARIES.length);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.tsx
@@ -1,0 +1,290 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    DataTable,
+    DataTableColumnHeader,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+    Input,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useMemo, useState } from 'react';
+
+import { DictionaryStateBadge } from './DictionaryStateBadge';
+import { DictionaryTypeBadge } from './DictionaryTypeBadge';
+import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+import type { TableSortingState } from '../../applications/utils/tableSort';
+import type { DictionaryListItem } from '../types/dictionary';
+import { formatDictionaryDate } from '../utils/formatDictionaryDate';
+
+const DEFAULT_PAGE_SIZE = 10;
+
+const SORTABLE_IDS = new Set(['key', 'name', 'type', 'state', 'updated_at', 'deployed_at']);
+const DATE_SORTABLE_IDS = new Set(['updated_at', 'deployed_at']);
+
+function toSortableTimestamp(value: unknown): number | null {
+    if (value === undefined || value === null || value === '') return null;
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+    }
+
+    const raw = String(value).trim();
+    if (/^\d+$/.test(raw)) {
+        const epoch = Number(raw);
+        return Number.isFinite(epoch) ? epoch : null;
+    }
+
+    const parsed = Date.parse(raw);
+    return Number.isNaN(parsed) ? null : parsed;
+}
+
+function compareDictionaryValues(field: string, left: unknown, right: unknown): number {
+    if (DATE_SORTABLE_IDS.has(field)) {
+        const leftTime = toSortableTimestamp(left);
+        const rightTime = toSortableTimestamp(right);
+        if (leftTime === null && rightTime === null) return 0;
+        if (leftTime === null) return 1;
+        if (rightTime === null) return -1;
+        return leftTime - rightTime;
+    }
+
+    return String(left ?? '').localeCompare(String(right ?? ''));
+}
+
+function sortDictionaries(items: DictionaryListItem[], sorting: TableSortingState): DictionaryListItem[] {
+    const active = sorting[0];
+    if (!active?.id || !SORTABLE_IDS.has(active.id)) return items;
+    const field = active.id as keyof DictionaryListItem;
+    const direction = active.desc ? -1 : 1;
+    return [...items].sort((a, b) => compareDictionaryValues(active.id, a[field], b[field]) * direction);
+}
+
+function filterDictionaries(dictionaries: DictionaryListItem[], search: string): DictionaryListItem[] {
+    const query = search.trim().toLowerCase();
+    if (!query) return dictionaries;
+    return dictionaries.filter(d => d.name.toLowerCase().includes(query) || (d.key ?? '').toLowerCase().includes(query));
+}
+
+function paginateDictionaries(items: DictionaryListItem[], page: number, pageSize: number): DictionaryListItem[] {
+    const start = (page - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+}
+
+function DictionaryActionsCell({
+    dictionary,
+    canEdit,
+    canDelete,
+    onEdit,
+    onDelete,
+}: Readonly<{
+    dictionary: DictionaryListItem;
+    canEdit: boolean;
+    canDelete: boolean;
+    onEdit: (dictionary: DictionaryListItem) => void;
+    onDelete: (dictionary: DictionaryListItem) => void;
+}>) {
+    return (
+        <div className="flex justify-end">
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon" className="size-8" aria-label="Dictionary actions">
+                        <MoreHorizontalIcon className="size-4" aria-hidden />
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                    {canEdit && (
+                        <DropdownMenuItem onSelect={() => onEdit(dictionary)}>
+                            <PencilIcon className="size-4 mr-2" aria-hidden />
+                            Edit
+                        </DropdownMenuItem>
+                    )}
+                    {canEdit && canDelete && <DropdownMenuSeparator />}
+                    {canDelete && (
+                        <DropdownMenuItem variant="destructive" onSelect={() => onDelete(dictionary)}>
+                            <Trash2Icon className="size-4 mr-2" aria-hidden />
+                            Delete
+                        </DropdownMenuItem>
+                    )}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
+    );
+}
+
+function buildColumns({
+    canEdit,
+    canDelete,
+    onEdit,
+    onDelete,
+}: {
+    canEdit: boolean;
+    canDelete: boolean;
+    onEdit: (dictionary: DictionaryListItem) => void;
+    onDelete: (dictionary: DictionaryListItem) => void;
+}): DataTableProps<DictionaryListItem>['columns'] {
+    const columns: DataTableProps<DictionaryListItem>['columns'] = [
+        {
+            id: 'key',
+            accessorKey: 'key',
+            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Key" />,
+            cell: ({ row }: ColCell<DictionaryListItem>) =>
+                row.original.key ? (
+                    <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">{row.original.key}</span>
+                ) : (
+                    <span className="text-sm text-muted-foreground">—</span>
+                ),
+        },
+        {
+            id: 'name',
+            accessorKey: 'name',
+            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Name" />,
+            cell: ({ row }: ColCell<DictionaryListItem>) => <span className="text-sm font-medium">{row.original.name}</span>,
+        },
+        {
+            id: 'type',
+            accessorKey: 'type',
+            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Type" />,
+            cell: ({ row }: ColCell<DictionaryListItem>) => <DictionaryTypeBadge type={row.original.type} />,
+        },
+        {
+            id: 'state',
+            accessorKey: 'state',
+            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="State" />,
+            cell: ({ row }: ColCell<DictionaryListItem>) => <DictionaryStateBadge state={row.original.state} />,
+        },
+        {
+            id: 'updated_at',
+            accessorKey: 'updated_at',
+            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Updated" />,
+            cell: ({ row }: ColCell<DictionaryListItem>) => (
+                <span className="whitespace-nowrap text-sm text-muted-foreground">{formatDictionaryDate(row.original.updated_at)}</span>
+            ),
+        },
+        {
+            id: 'deployed_at',
+            accessorKey: 'deployed_at',
+            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Deployed" />,
+            cell: ({ row }: ColCell<DictionaryListItem>) => (
+                <span className="whitespace-nowrap text-sm text-muted-foreground">{formatDictionaryDate(row.original.deployed_at)}</span>
+            ),
+        },
+    ];
+
+    if (canEdit || canDelete) {
+        columns.push({
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            size: 56,
+            enableSorting: false,
+            enableHiding: false,
+            cell: ({ row }: ColCell<DictionaryListItem>) => (
+                <DictionaryActionsCell
+                    dictionary={row.original}
+                    canEdit={canEdit}
+                    canDelete={canDelete}
+                    onEdit={onEdit}
+                    onDelete={onDelete}
+                />
+            ),
+        });
+    }
+
+    return columns;
+}
+
+export function DictionariesTable({
+    dictionaries,
+    canEdit,
+    canDelete,
+    onEdit,
+    onDelete,
+}: Readonly<{
+    dictionaries: DictionaryListItem[];
+    canEdit: boolean;
+    canDelete: boolean;
+    onEdit: (dictionary: DictionaryListItem) => void;
+    onDelete: (dictionary: DictionaryListItem) => void;
+}>) {
+    const [search, setSearch] = useState('');
+    const [sorting, setSorting] = useState<TableSortingState>([]);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+
+    const filtered = useMemo(() => filterDictionaries(dictionaries, search), [dictionaries, search]);
+    const sorted = useMemo(() => sortDictionaries(filtered, sorting), [filtered, sorting]);
+    const totalCount = sorted.length;
+    const paginatedData = useMemo(() => paginateDictionaries(sorted, page, pageSize), [sorted, page, pageSize]);
+
+    const columns = useMemo(() => buildColumns({ canEdit, canDelete, onEdit, onDelete }), [canEdit, canDelete, onEdit, onDelete]);
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function handleSortingChange(updater: TableSortingState | ((prev: TableSortingState) => TableSortingState)) {
+        setSorting(prev => {
+            if (typeof updater === 'function') {
+                return updater(prev);
+            }
+            return updater;
+        });
+        setPage(1);
+    }
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    return (
+        <div className="space-y-3">
+            <div className="relative max-w-sm">
+                <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
+                <Input
+                    className="pl-10"
+                    placeholder="Search by key or name…"
+                    value={search}
+                    onChange={e => handleSearchChange(e.target.value)}
+                />
+            </div>
+
+            <DataTable
+                columns={columns}
+                data={paginatedData}
+                sorting={sorting}
+                onSortingChange={handleSortingChange}
+                serverSide
+                pagination={{
+                    page,
+                    pageSize,
+                    totalCount,
+                    pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                    onPageChange: setPage,
+                    onPageSizeChange: handlePageSizeChange,
+                }}
+                emptyMessage={search.trim() ? 'No dictionaries match your search.' : 'No dictionaries defined for this environment.'}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryDeleteSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryDeleteSheet.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from '@gravitee/graphene-core';
+import { useCallback } from 'react';
+
+import type { DictionaryListItem } from '../types/dictionary';
+
+export function DictionaryDeleteSheet({
+    open,
+    dictionary,
+    onClose,
+    onConfirm,
+    isDeleting,
+}: Readonly<{
+    open: boolean;
+    dictionary: DictionaryListItem | undefined;
+    onClose: () => void;
+    onConfirm: () => void;
+    isDeleting: boolean;
+}>) {
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>Delete Dictionary</SheetTitle>
+                    <SheetDescription>This action cannot be undone.</SheetDescription>
+                </SheetHeader>
+
+                <div className="flex-1 px-1 py-4">
+                    <p className="text-sm text-muted-foreground">
+                        Are you sure you want to delete <span className="font-medium text-foreground">{dictionary?.name}</span>
+                        {dictionary?.key ? (
+                            <>
+                                {' '}
+                                <span className="font-mono text-xs bg-muted px-1 py-0.5 rounded">{dictionary.key}</span>
+                            </>
+                        ) : null}
+                        ? Policies that reference this dictionary will no longer resolve its values.
+                    </p>
+                </div>
+
+                <SheetFooter className="shrink-0 flex-row justify-end gap-2 border-t pt-4">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting}>
+                        {isDeleting ? 'Deleting…' : 'Delete'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryStateBadge.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryStateBadge.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Badge, cn } from '@gravitee/graphene-core';
+
+import type { DictionaryLifecycleState } from '../types/dictionary';
+
+const STATE_CONFIG: Record<DictionaryLifecycleState, { label: string; className: string }> = {
+    STARTED: { label: 'Started', className: 'bg-green-100 text-green-700 border-transparent' },
+    STOPPED: { label: 'Stopped', className: 'bg-muted text-muted-foreground border-transparent' },
+};
+
+export function DictionaryStateBadge({ state }: Readonly<{ state: DictionaryLifecycleState | undefined }>) {
+    if (!state) {
+        return <span className="text-sm text-muted-foreground">—</span>;
+    }
+    const config = STATE_CONFIG[state] ?? { label: state, className: '' };
+    return <Badge className={cn('font-normal text-xs', config.className)}>{config.label}</Badge>;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryTypeBadge.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryTypeBadge.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Badge, cn } from '@gravitee/graphene-core';
+
+import type { DictionaryType } from '../types/dictionary';
+
+const TYPE_CONFIG: Record<DictionaryType, { label: string; className: string }> = {
+    MANUAL: { label: 'Manual', className: 'bg-blue-100 text-blue-700 border-transparent' },
+    DYNAMIC: { label: 'Dynamic', className: 'bg-purple-100 text-purple-700 border-transparent' },
+};
+
+export function DictionaryTypeBadge({ type }: Readonly<{ type: DictionaryType }>) {
+    const config = TYPE_CONFIG[type] ?? { label: type, className: '' };
+    return <Badge className={cn('font-normal text-xs', config.className)}>{config.label}</Badge>;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useDictionaryMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useDictionaryMutations.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import {
+    createEnvironmentDictionary,
+    deleteEnvironmentDictionary,
+    deployEnvironmentDictionary,
+    startEnvironmentDictionary,
+    stopEnvironmentDictionary,
+    undeployEnvironmentDictionary,
+    updateEnvironmentDictionary,
+} from '../services/dictionaries';
+import type { NewDictionaryPayload, UpdateDictionaryPayload } from '../types/dictionary';
+import { dictionaryKeys } from '../utils/queryKeys';
+
+function useDictionaryMutation<TData>(mutationFn: (envId: string, data: TData) => Promise<unknown>) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (data: TData) => mutationFn(env!.id, data),
+        onSuccess: () => {
+            if (env?.id) {
+                void queryClient.invalidateQueries({ queryKey: dictionaryKeys.list(env.id) });
+            }
+        },
+    });
+}
+
+export function useCreateDictionary() {
+    return useDictionaryMutation<NewDictionaryPayload>(createEnvironmentDictionary);
+}
+
+export function useUpdateDictionary() {
+    return useDictionaryMutation<{ dictionaryId: string; data: UpdateDictionaryPayload }>((envId, { dictionaryId, data }) =>
+        updateEnvironmentDictionary(envId, dictionaryId, data),
+    );
+}
+
+export function useDeleteDictionary() {
+    return useDictionaryMutation<string>(deleteEnvironmentDictionary);
+}
+
+export function useDeployDictionary() {
+    return useDictionaryMutation<string>(deployEnvironmentDictionary);
+}
+
+export function useUndeployDictionary() {
+    return useDictionaryMutation<string>(undeployEnvironmentDictionary);
+}
+
+export function useStartDictionary() {
+    return useDictionaryMutation<string>(startEnvironmentDictionary);
+}
+
+export function useStopDictionary() {
+    return useDictionaryMutation<string>(stopEnvironmentDictionary);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useDictionaryPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useDictionaryPermissions.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+
+export function useDictionaryPermissions() {
+    const canRead = useHasPermission({ anyOf: ['environment-dictionary-r'] });
+    const canCreate = useHasPermission({ anyOf: ['environment-dictionary-c'] });
+    const canUpdate = useHasPermission({ anyOf: ['environment-dictionary-u'] });
+    const canDelete = useHasPermission({ anyOf: ['environment-dictionary-d'] });
+
+    return { canRead, canCreate, canUpdate, canDelete };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useEnvironmentDictionaries.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useEnvironmentDictionaries.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { listEnvironmentDictionaries } from '../services/dictionaries';
+import { dictionaryKeys } from '../utils/queryKeys';
+
+export function useEnvironmentDictionaries() {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: dictionaryKeys.list(env?.id ?? ''),
+        queryFn: () => listEnvironmentDictionaries(env!.id),
+        enabled: Boolean(env),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/services/dictionaries.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/services/dictionaries.spec.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    createEnvironmentDictionary,
+    deleteEnvironmentDictionary,
+    deployEnvironmentDictionary,
+    getEnvironmentDictionary,
+    listEnvironmentDictionaries,
+    startEnvironmentDictionary,
+    stopEnvironmentDictionary,
+    undeployEnvironmentDictionary,
+    updateEnvironmentDictionary,
+} from './dictionaries';
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { NewDictionaryPayload, UpdateDictionaryPayload } from '../types/dictionary';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonV1Env: jest.fn(),
+}));
+
+const mockApimFetchJsonV1Env = jest.mocked(apimFetchJsonV1Env);
+
+describe('dictionaries service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonV1Env.mockResolvedValue(undefined);
+    });
+
+    describe('listEnvironmentDictionaries', () => {
+        it('calls GET on the configuration/dictionaries resource', async () => {
+            await listEnvironmentDictionaries('env-1');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries');
+        });
+    });
+
+    describe('getEnvironmentDictionary', () => {
+        it('calls GET on the keyed resource path', async () => {
+            await getEnvironmentDictionary('env-1', 'dict-1');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries/dict-1');
+        });
+
+        it('URL-encodes the dictionary id in the path', async () => {
+            await getEnvironmentDictionary('env-1', 'id with spaces');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries/id%20with%20spaces');
+        });
+    });
+
+    describe('createEnvironmentDictionary', () => {
+        it('calls POST with a MANUAL payload', async () => {
+            const payload: NewDictionaryPayload = {
+                key: 'countries',
+                name: 'Countries',
+                description: 'Country codes',
+                type: 'MANUAL',
+                properties: { FR: 'France' },
+            };
+            await createEnvironmentDictionary('env-1', payload);
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries', {
+                method: 'POST',
+                body: JSON.stringify(payload),
+            });
+        });
+
+        it('calls POST with a DYNAMIC payload including provider and trigger', async () => {
+            const payload: NewDictionaryPayload = {
+                key: 'remote-codes',
+                name: 'Remote Codes',
+                type: 'DYNAMIC',
+                provider: {
+                    type: 'HTTP',
+                    configuration: {
+                        url: 'https://example.com/dict',
+                        method: 'GET',
+                        specification: '[]',
+                        useSystemProxy: false,
+                    },
+                },
+                trigger: { rate: 5, unit: 'MINUTES' },
+            };
+            await createEnvironmentDictionary('env-1', payload);
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries', {
+                method: 'POST',
+                body: JSON.stringify(payload),
+            });
+        });
+    });
+
+    describe('updateEnvironmentDictionary', () => {
+        it('calls PUT with the serialized payload', async () => {
+            const payload: UpdateDictionaryPayload = {
+                name: 'Countries',
+                description: 'Updated',
+                type: 'MANUAL',
+                properties: { FR: 'France', DE: 'Germany' },
+            };
+            await updateEnvironmentDictionary('env-1', 'dict-1', payload);
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries/dict-1', {
+                method: 'PUT',
+                body: JSON.stringify(payload),
+            });
+        });
+    });
+
+    describe('deleteEnvironmentDictionary', () => {
+        it('calls DELETE on the keyed resource path', async () => {
+            await deleteEnvironmentDictionary('env-1', 'dict-1');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries/dict-1', {
+                method: 'DELETE',
+            });
+        });
+    });
+
+    describe('deployEnvironmentDictionary', () => {
+        it('calls POST on the _deploy sub-resource', async () => {
+            await deployEnvironmentDictionary('env-1', 'dict-1');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries/dict-1/_deploy', {
+                method: 'POST',
+                body: JSON.stringify({}),
+            });
+        });
+    });
+
+    describe('undeployEnvironmentDictionary', () => {
+        it('calls POST on the _undeploy sub-resource', async () => {
+            await undeployEnvironmentDictionary('env-1', 'dict-1');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries/dict-1/_undeploy', {
+                method: 'POST',
+                body: JSON.stringify({}),
+            });
+        });
+    });
+
+    describe('startEnvironmentDictionary', () => {
+        it('calls POST with action=START', async () => {
+            await startEnvironmentDictionary('env-1', 'dict-1');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries/dict-1?action=START', {
+                method: 'POST',
+                body: JSON.stringify({}),
+            });
+        });
+    });
+
+    describe('stopEnvironmentDictionary', () => {
+        it('calls POST with action=STOP', async () => {
+            await stopEnvironmentDictionary('env-1', 'dict-1');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries/dict-1?action=STOP', {
+                method: 'POST',
+                body: JSON.stringify({}),
+            });
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/services/dictionaries.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/services/dictionaries.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type {
+    Dictionary,
+    DictionaryLifecycleAction,
+    DictionaryListItem,
+    NewDictionaryPayload,
+    UpdateDictionaryPayload,
+} from '../types/dictionary';
+
+export async function listEnvironmentDictionaries(environmentId: string): Promise<DictionaryListItem[]> {
+    return apimFetchJsonV1Env<DictionaryListItem[]>(environmentId, '/configuration/dictionaries');
+}
+
+export async function getEnvironmentDictionary(environmentId: string, dictionaryId: string): Promise<Dictionary> {
+    return apimFetchJsonV1Env<Dictionary>(environmentId, `/configuration/dictionaries/${encodeURIComponent(dictionaryId)}`);
+}
+
+export async function createEnvironmentDictionary(environmentId: string, data: NewDictionaryPayload): Promise<Dictionary> {
+    return apimFetchJsonV1Env<Dictionary>(environmentId, '/configuration/dictionaries', {
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+}
+
+export async function updateEnvironmentDictionary(
+    environmentId: string,
+    dictionaryId: string,
+    data: UpdateDictionaryPayload,
+): Promise<Dictionary> {
+    return apimFetchJsonV1Env<Dictionary>(environmentId, `/configuration/dictionaries/${encodeURIComponent(dictionaryId)}`, {
+        method: 'PUT',
+        body: JSON.stringify(data),
+    });
+}
+
+export async function deleteEnvironmentDictionary(environmentId: string, dictionaryId: string): Promise<void> {
+    return apimFetchJsonV1Env<void>(environmentId, `/configuration/dictionaries/${encodeURIComponent(dictionaryId)}`, {
+        method: 'DELETE',
+    });
+}
+
+export async function deployEnvironmentDictionary(environmentId: string, dictionaryId: string): Promise<Dictionary> {
+    return apimFetchJsonV1Env<Dictionary>(environmentId, `/configuration/dictionaries/${encodeURIComponent(dictionaryId)}/_deploy`, {
+        method: 'POST',
+        body: JSON.stringify({}),
+    });
+}
+
+export async function undeployEnvironmentDictionary(environmentId: string, dictionaryId: string): Promise<Dictionary> {
+    return apimFetchJsonV1Env<Dictionary>(environmentId, `/configuration/dictionaries/${encodeURIComponent(dictionaryId)}/_undeploy`, {
+        method: 'POST',
+        body: JSON.stringify({}),
+    });
+}
+
+export async function startEnvironmentDictionary(environmentId: string, dictionaryId: string): Promise<Dictionary> {
+    return changeDictionaryLifecycle(environmentId, dictionaryId, 'START');
+}
+
+export async function stopEnvironmentDictionary(environmentId: string, dictionaryId: string): Promise<Dictionary> {
+    return changeDictionaryLifecycle(environmentId, dictionaryId, 'STOP');
+}
+
+async function changeDictionaryLifecycle(
+    environmentId: string,
+    dictionaryId: string,
+    action: DictionaryLifecycleAction,
+): Promise<Dictionary> {
+    return apimFetchJsonV1Env<Dictionary>(
+        environmentId,
+        `/configuration/dictionaries/${encodeURIComponent(dictionaryId)}?action=${action}`,
+        {
+            method: 'POST',
+            body: JSON.stringify({}),
+        },
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/types/dictionary.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/types/dictionary.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type DictionaryType = 'MANUAL' | 'DYNAMIC';
+
+export type DictionaryLifecycleState = 'STARTED' | 'STOPPED';
+
+/** Jackson `TimeUnit` enum names used by Management API. */
+export type DictionaryTriggerUnit = 'NANOSECONDS' | 'MICROSECONDS' | 'MILLISECONDS' | 'SECONDS' | 'MINUTES' | 'HOURS' | 'DAYS';
+
+export interface DictionaryTrigger {
+    rate: number;
+    unit: DictionaryTriggerUnit;
+}
+
+export interface DictionaryHttpProviderConfiguration {
+    url?: string;
+    method?: string;
+    headers?: Array<{ name?: string; value?: string }>;
+    body?: string;
+    specification?: string;
+    useSystemProxy?: boolean;
+}
+
+export interface DictionaryProvider {
+    type: string;
+    configuration: DictionaryHttpProviderConfiguration | Record<string, unknown>;
+}
+
+/**
+ * List item from GET /configuration/dictionaries.
+ * Note: `properties` is a count; `provider` is the provider type string.
+ */
+export interface DictionaryListItem {
+    id: string;
+    key?: string;
+    name: string;
+    description?: string;
+    type: DictionaryType;
+    state?: DictionaryLifecycleState;
+    provider?: string;
+    properties?: number;
+    created_at?: string | number;
+    updated_at?: string | number;
+    deployed_at?: string | number;
+}
+
+/**
+ * Detail entity from GET/POST/PUT /configuration/dictionaries/{id}.
+ * Note: `properties` is the key→value map; `provider` is the full object.
+ */
+export interface Dictionary {
+    id: string;
+    key?: string;
+    name: string;
+    description?: string;
+    type: DictionaryType;
+    state?: DictionaryLifecycleState;
+    properties?: Record<string, string>;
+    provider?: DictionaryProvider | null;
+    trigger?: DictionaryTrigger | null;
+    created_at?: string | number;
+    updated_at?: string | number;
+    deployed_at?: string | number;
+}
+
+export interface NewDictionaryPayload {
+    key?: string;
+    name: string;
+    description?: string;
+    type: DictionaryType;
+    properties?: Record<string, string>;
+    provider?: DictionaryProvider;
+    trigger?: DictionaryTrigger;
+}
+
+export interface UpdateDictionaryPayload {
+    name: string;
+    description?: string;
+    type: DictionaryType;
+    properties?: Record<string, string>;
+    provider?: DictionaryProvider;
+    trigger?: DictionaryTrigger;
+}
+
+export type DictionaryLifecycleAction = 'START' | 'STOP';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/utils/formatDictionaryDate.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/utils/formatDictionaryDate.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { formatApplicationDateTime } from '../../applications/utils/applicationFormatters';
+
+export function formatDictionaryDate(value: number | string | undefined): string {
+    return formatApplicationDateTime(value);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/utils/queryKeys.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const dictionaryKeys = {
+    all: ['environment-dictionaries'] as const,
+    list: (envId: string) => [...dictionaryKeys.all, 'list', envId] as const,
+    detail: (envId: string, dictionaryId: string) => [...dictionaryKeys.all, 'detail', envId, dictionaryId] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Skeleton } from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+
+import { DictionariesTable } from '../features/dictionaries/components/DictionariesTable';
+import { DictionaryDeleteSheet } from '../features/dictionaries/components/DictionaryDeleteSheet';
+import { useDeleteDictionary } from '../features/dictionaries/hooks/useDictionaryMutations';
+import { useDictionaryPermissions } from '../features/dictionaries/hooks/useDictionaryPermissions';
+import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
+import type { DictionaryListItem } from '../features/dictionaries/types/dictionary';
+import { notify } from '../shared/notify';
+
+type SheetState = { type: 'closed' } | { type: 'delete'; dictionary: DictionaryListItem };
+
+export function DictionariesPage() {
+    const { canCreate, canUpdate, canDelete } = useDictionaryPermissions();
+    const { data: dictionaries = [], isLoading, isError } = useEnvironmentDictionaries();
+    const deleteMutation = useDeleteDictionary();
+
+    const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
+
+    function closeSheet() {
+        setSheet({ type: 'closed' });
+    }
+
+    function handleCreate() {
+        // Create form lands in FOUND-7; keep CTA visible and gated for Story 2 parity.
+        notify.info('Create dictionary form will be available in the next story (FOUND-7).');
+    }
+
+    function handleEdit(_dictionary: DictionaryListItem) {
+        notify.info('Edit dictionary form will be available in the next story (FOUND-9).');
+    }
+
+    async function handleDelete() {
+        if (sheet.type !== 'delete') return;
+        try {
+            await deleteMutation.mutateAsync(sheet.dictionary.id);
+            notify.success('Dictionary deleted successfully');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to delete dictionary');
+        }
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-start justify-between">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Dictionaries</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Manage environment lookup data that API policies can reference at runtime.
+                    </p>
+                </div>
+                {canCreate && (
+                    <Button className="shrink-0" onClick={handleCreate}>
+                        <PlusIcon className="size-4" aria-hidden />
+                        Add Dictionary
+                    </Button>
+                )}
+            </div>
+
+            {isLoading ? (
+                <div className="space-y-2">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                        <Skeleton key={i} className="h-12 w-full rounded-md" />
+                    ))}
+                </div>
+            ) : isError ? (
+                <div className="flex items-center justify-center p-8">
+                    <p className="text-sm text-muted-foreground">Failed to load dictionaries. Please refresh and try again.</p>
+                </div>
+            ) : (
+                <DictionariesTable
+                    dictionaries={dictionaries}
+                    canEdit={canUpdate}
+                    canDelete={canDelete}
+                    onEdit={handleEdit}
+                    onDelete={d => setSheet({ type: 'delete', dictionary: d })}
+                />
+            )}
+
+            <DictionaryDeleteSheet
+                open={sheet.type === 'delete'}
+                dictionary={sheet.type === 'delete' ? sheet.dictionary : undefined}
+                onClose={closeSheet}
+                onConfirm={handleDelete}
+                isDeleting={deleteMutation.isPending}
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-6

## Description

- Add Gamma Platform Dictionaries under APIs & Assets, mirroring the Metadata pattern (FOUND-6).
- Introduce a Management API v1 client (apimFetchJsonV1Env → /configuration/dictionaries) with typed models, React Query keys, and mutations.
- Ship env-scoped list UI: search by key/name, type/state badges, permission gating (environment-dictionary-*), and delete confirmation.
- Create/Edit forms are intentionally deferred ([FOUND-7](https://gravitee.atlassian.net/browse/FOUND-7) / [FOUND-9](https://gravitee.atlassian.net/browse/FOUND-9)); CTAs are gated and show a placeholder toast for now.
- No new Gamma backend; reuses existing Management API / gateway dictionary runtime. Env switcher is out of scope.


## Additional context

<img width="1725" height="923" alt="Screenshot 2026-07-22 at 4 41 10 PM" src="https://github.com/user-attachments/assets/14c023c3-4fed-446b-b64d-da984f7685ce" />




[FOUND-7]: https://gravitee.atlassian.net/browse/FOUND-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-9]: https://gravitee.atlassian.net/browse/FOUND-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ