### PR TITLE
fix(authz-sync): isolate authz synchronizer failures from the shared sync cycle

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AbstractAuthzReactorSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AbstractAuthzReactorSynchronizer.java
@@ -63,6 +63,7 @@ public abstract class AbstractAuthzReactorSynchronizer<D extends AuthzScopedDepl
     private final Map<String, D> pendingDeploys = new ConcurrentHashMap<>();
     private final Map<String, D> pendingUndeploys = new ConcurrentHashMap<>();
     private final Map<String, Integer> pendingAttempts = new ConcurrentHashMap<>();
+    private final AuthzResyncWindow resyncWindow = new AuthzResyncWindow();
 
     protected AbstractAuthzReactorSynchronizer(
         LatestEventFetcher eventsFetcher,
@@ -105,11 +106,12 @@ public abstract class AbstractAuthzReactorSynchronizer<D extends AuthzScopedDepl
         AtomicLong launchTime = new AtomicLong();
         AtomicLong processed = new AtomicLong();
         Set<String> attemptedThisCycle = ConcurrentHashMap.newKeySet();
-        boolean initialSync = from == null || from.longValue() == -1L;
+        Long effectiveFrom = resyncWindow.effectiveFrom(from);
+        boolean initialSync = effectiveFrom == null || effectiveFrom.longValue() == -1L;
 
         return eventsFetcher
             .fetchLatest(
-                from,
+                effectiveFrom,
                 to,
                 eventProperty(),
                 environments,
@@ -125,6 +127,9 @@ public abstract class AbstractAuthzReactorSynchronizer<D extends AuthzScopedDepl
             .andThen(retryPending(attemptedThisCycle))
             .andThen(commitIfAny())
             .doOnComplete(() -> {
+                if (resyncWindow.markSucceeded()) {
+                    log.info("{} synchronization recovered, missed window has been re-fetched", pluralLabel());
+                }
                 String msg = String.format(
                     "%s %s synchronized in %sms",
                     processed.get(),
@@ -136,6 +141,19 @@ public abstract class AbstractAuthzReactorSynchronizer<D extends AuthzScopedDepl
                 } else {
                     log.debug(msg);
                 }
+            })
+            .onErrorResumeNext(t -> {
+                if (resyncWindow.markFailed(effectiveFrom)) {
+                    log.error(
+                        "{} synchronization failed; isolating from the sync cycle, window from {} will be re-fetched next cycle",
+                        pluralLabel(),
+                        effectiveFrom,
+                        t
+                    );
+                } else {
+                    log.warn("{} synchronization still failing: {}", pluralLabel(), t.toString());
+                }
+                return Completable.complete();
             });
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizer.java
@@ -95,6 +95,8 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
 
     private final Map<String, Integer> pendingProvisionAttempts = new ConcurrentHashMap<>();
 
+    private final AuthzResyncWindow resyncWindow = new AuthzResyncWindow();
+
     /** Re-drive counter for {@link #pendingHydrations}, capped at {@link #MAX_PENDING_ATTEMPTS} so a
      *  permanently failing hydration stops re-driving every cycle instead of retrying forever. */
     private final Map<String, Integer> pendingHydrationAttempts = new ConcurrentHashMap<>();
@@ -140,11 +142,12 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
         AtomicLong launchTime = new AtomicLong();
         AtomicLong processed = new AtomicLong();
         ConcurrentLinkedQueue<AuthzPdpProvisionDeployable> provisionedScopes = new ConcurrentLinkedQueue<>();
-        boolean initialSync = from == null || from.longValue() == -1L;
+        Long effectiveFrom = resyncWindow.effectiveFrom(from);
+        boolean initialSync = effectiveFrom == null || effectiveFrom.longValue() == -1L;
 
         return eventsFetcher
             .fetchLatest(
-                from,
+                effectiveFrom,
                 to,
                 Event.EventProperties.AUTHZ_PDP_ID,
                 environments,
@@ -160,6 +163,9 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
             .andThen(retryPending(provisionedScopes))
             .andThen(hydrate(provisionedScopes))
             .doOnComplete(() -> {
+                if (resyncWindow.markSucceeded()) {
+                    log.info("Authz PDP synchronization recovered, missed window has been re-fetched");
+                }
                 String msg = String.format(
                     "%s authz PDP provisioning commands relayed in %sms",
                     processed.get(),
@@ -170,6 +176,18 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
                 } else {
                     log.debug(msg);
                 }
+            })
+            .onErrorResumeNext(t -> {
+                if (resyncWindow.markFailed(effectiveFrom)) {
+                    log.error(
+                        "Authz PDP synchronization failed; isolating from the sync cycle, window from {} will be re-fetched next cycle",
+                        effectiveFrom,
+                        t
+                    );
+                } else {
+                    log.warn("Authz PDP synchronization still failing: {}", t.toString());
+                }
+                return Completable.complete();
             });
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzResyncWindow.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzResyncWindow.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Tracks the {@code from} bound of a failed authz sync window so the synchronizer can swallow the
+ * failure — keeping the shared sync cycle (and everything ordered after authz: API, subscription,
+ * api-key) alive — and still re-fetch the missed window itself on the next cycle. The global cycle
+ * cursor advances on swallowed failures, so without this the failed window's events would be lost
+ * and the engine would drift from the control plane. A failed initial sync ({@code from = -1})
+ * re-runs as an initial fetch next cycle.
+ */
+class AuthzResyncWindow {
+
+    private static final long NONE = Long.MIN_VALUE;
+
+    private final AtomicLong retryFrom = new AtomicLong(NONE);
+
+    /** The {@code from} to fetch with this cycle: the caller's window widened to cover a previously
+     *  failed window, {@code -1} (full initial fetch) when either is an initial sync. */
+    Long effectiveFrom(Long from) {
+        long pending = retryFrom.get();
+        if (pending == NONE) {
+            return from;
+        }
+        if (pending == -1L || from == null || from == -1L) {
+            return -1L;
+        }
+        return Math.min(pending, from);
+    }
+
+    /** Record a failed window; returns {@code true} on the first failure after a success (log loudly once). */
+    boolean markFailed(Long effectiveFrom) {
+        long failedFrom = effectiveFrom == null ? -1L : effectiveFrom;
+        long previous = retryFrom.getAndSet(failedFrom);
+        return previous == NONE;
+    }
+
+    /** Clear any pending window; returns {@code true} when this success recovered from a failure. */
+    boolean markSucceeded() {
+        return retryFrom.getAndSet(NONE) != NONE;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSyncCycleIsolationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSyncCycleIsolationTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.services.sync.process.common.deployer.AuthzEntityDeployer;
+import io.gravitee.gateway.services.sync.process.common.deployer.AuthzPolicyDeployer;
+import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
+import io.gravitee.gateway.services.sync.process.distributed.service.NoopDistributedSyncService;
+import io.gravitee.gateway.services.sync.process.repository.fetcher.LatestEventFetcher;
+import io.gravitee.node.api.Node;
+import io.gravitee.repository.management.model.Event;
+import io.gravitee.repository.management.model.EventType;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.rxjava3.core.Vertx;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * An authz synchronizer failure must never fail the shared sync cycle: authz runs at order 8-10,
+ * before API(12)/SUBSCRIPTION(13)/API_KEY(14), and a propagated error would both stop API sync from
+ * progressing and pin the cycle window. Instead the synchronizer swallows the error and re-fetches
+ * its own missed window on the next cycle.
+ */
+class AuthzSyncCycleIsolationTest {
+
+    private final LatestEventFetcher fetcher = mock(LatestEventFetcher.class);
+    private final AuthzEnginePort enginePort = mock(AuthzEnginePort.class);
+    private final DeployerFactory deployerFactory = mock(DeployerFactory.class);
+
+    private Vertx vertx;
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+        NoopDistributedSyncService distributedSyncService = new NoopDistributedSyncService();
+        lenient().when(fetcher.bulkItems()).thenReturn(10);
+        lenient().when(enginePort.commit()).thenReturn(Completable.complete());
+        lenient().when(enginePort.addOrUpdateEntity(any(), any(), any(), any(), any(), anyLong())).thenReturn(Completable.complete());
+        lenient().when(enginePort.commitScope(any(), any())).thenReturn(Completable.complete());
+        lenient().when(deployerFactory.createAuthzEntityDeployer()).thenReturn(new AuthzEntityDeployer(enginePort, distributedSyncService));
+        lenient().when(deployerFactory.createAuthzPolicyDeployer()).thenReturn(new AuthzPolicyDeployer(enginePort, distributedSyncService));
+    }
+
+    @AfterEach
+    void tearDown() {
+        vertx.close().blockingAwait();
+    }
+
+    @Test
+    void entity_fetch_error_does_not_fail_the_cycle() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.error(new RuntimeException("db down")));
+
+        entitySynchronizer().synchronize(1_000L, 2_000L, Set.of("env-1")).test().await().assertComplete();
+    }
+
+    @Test
+    void policy_fetch_error_does_not_fail_the_cycle() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.error(new RuntimeException("db down")));
+
+        policySynchronizer().synchronize(1_000L, 2_000L, Set.of("env-1")).test().await().assertComplete();
+    }
+
+    @Test
+    void pdp_fetch_error_does_not_fail_the_cycle() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.error(new RuntimeException("db down")));
+
+        pdpSynchronizer().synchronize(1_000L, 2_000L, Set.of("env-1")).test().await().assertComplete();
+    }
+
+    @Test
+    void entity_refetches_failed_window_on_next_cycle() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any()))
+            .thenReturn(Flowable.error(new RuntimeException("db down")))
+            .thenReturn(Flowable.empty());
+        AuthzEntitySynchronizer synchronizer = entitySynchronizer();
+
+        synchronizer.synchronize(1_000L, 2_000L, Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(6_000L, 7_000L, Set.of("env-1")).test().await().assertComplete();
+
+        assertThat(fetchedFroms()).containsExactly(1_000L, 1_000L);
+    }
+
+    @Test
+    void entity_returns_to_live_window_after_recovery() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any()))
+            .thenReturn(Flowable.error(new RuntimeException("db down")))
+            .thenReturn(Flowable.empty());
+        AuthzEntitySynchronizer synchronizer = entitySynchronizer();
+
+        synchronizer.synchronize(1_000L, 2_000L, Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(6_000L, 7_000L, Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(11_000L, 12_000L, Set.of("env-1")).test().await().assertComplete();
+
+        assertThat(fetchedFroms()).containsExactly(1_000L, 1_000L, 11_000L);
+    }
+
+    @Test
+    void entity_initial_fetch_error_redoes_initial_fetch_on_next_cycle() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any()))
+            .thenReturn(Flowable.error(new RuntimeException("db down")))
+            .thenReturn(Flowable.empty());
+        AuthzEntitySynchronizer synchronizer = entitySynchronizer();
+
+        synchronizer.synchronize(-1L, 2_000L, Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(6_000L, 7_000L, Set.of("env-1")).test().await().assertComplete();
+
+        assertThat(fetchedFroms()).containsExactly(-1L, -1L);
+        assertThat(fetchedTypes().get(1)).containsExactly(EventType.PUBLISH_AUTHZ_ENTITY);
+    }
+
+    @Test
+    void entity_keeps_widened_window_across_repeated_failures() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any()))
+            .thenReturn(Flowable.error(new RuntimeException("db down")))
+            .thenReturn(Flowable.error(new RuntimeException("db still down")))
+            .thenReturn(Flowable.empty());
+        AuthzEntitySynchronizer synchronizer = entitySynchronizer();
+
+        synchronizer.synchronize(1_000L, 2_000L, Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(6_000L, 7_000L, Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(11_000L, 12_000L, Set.of("env-1")).test().await().assertComplete();
+
+        assertThat(fetchedFroms()).containsExactly(1_000L, 1_000L, 1_000L);
+    }
+
+    @Test
+    void pdp_refetches_failed_window_on_next_cycle() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any()))
+            .thenReturn(Flowable.error(new RuntimeException("db down")))
+            .thenReturn(Flowable.empty());
+        AuthzPdpSynchronizer synchronizer = pdpSynchronizer();
+
+        synchronizer.synchronize(1_000L, 2_000L, Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(6_000L, 7_000L, Set.of("env-1")).test().await().assertComplete();
+
+        assertThat(fetchedFroms()).containsExactly(1_000L, 1_000L);
+    }
+
+    @Test
+    void pdp_returns_to_live_window_after_recovery() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any()))
+            .thenReturn(Flowable.error(new RuntimeException("db down")))
+            .thenReturn(Flowable.empty());
+        AuthzPdpSynchronizer synchronizer = pdpSynchronizer();
+
+        synchronizer.synchronize(1_000L, 2_000L, Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(6_000L, 7_000L, Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(11_000L, 12_000L, Set.of("env-1")).test().await().assertComplete();
+
+        assertThat(fetchedFroms()).containsExactly(1_000L, 1_000L, 11_000L);
+    }
+
+    @Test
+    void entity_recovered_window_events_are_deployed() throws InterruptedException {
+        Event missed = new Event();
+        missed.setId("evt-missed");
+        missed.setType(EventType.PUBLISH_AUTHZ_ENTITY);
+        missed.setPayload(
+            "{\"entityId\":\"custom.x\",\"kind\":\"RESOURCE\",\"attributes\":{},\"parents\":[],\"environmentId\":\"env-1\",\"targetPdpIds\":[\"default\"]}"
+        );
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any()))
+            .thenReturn(Flowable.error(new RuntimeException("db down")))
+            .thenReturn(Flowable.just(List.of(missed)));
+        AuthzEntitySynchronizer synchronizer = entitySynchronizer();
+
+        synchronizer.synchronize(1_000L, 2_000L, Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(6_000L, 7_000L, Set.of("env-1")).test().await().assertComplete();
+
+        verify(enginePort).addOrUpdateEntity(eq("env-1"), any(), any(), any(), any(), anyLong());
+        verify(enginePort, atLeastOnce()).commit();
+    }
+
+    private List<Long> fetchedFroms() {
+        ArgumentCaptor<Long> from = ArgumentCaptor.forClass(Long.class);
+        verify(fetcher, atLeastOnce()).fetchLatest(from.capture(), any(), any(), any(), any());
+        return from.getAllValues();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Set<EventType>> fetchedTypes() {
+        ArgumentCaptor<Set<EventType>> types = ArgumentCaptor.forClass(Set.class);
+        verify(fetcher, atLeastOnce()).fetchLatest(any(), any(), any(), any(), types.capture());
+        return types.getAllValues();
+    }
+
+    private AuthzEntitySynchronizer entitySynchronizer() {
+        return new AuthzEntitySynchronizer(
+            fetcher,
+            new AuthzEntityMapper(new ObjectMapper()),
+            deployerFactory,
+            enginePort,
+            new AuthzScopePlacement(),
+            executor(),
+            executor()
+        );
+    }
+
+    private AuthzPolicySynchronizer policySynchronizer() {
+        return new AuthzPolicySynchronizer(
+            fetcher,
+            new AuthzPolicyMapper(new ObjectMapper()),
+            deployerFactory,
+            enginePort,
+            new AuthzScopePlacement(),
+            executor(),
+            executor()
+        );
+    }
+
+    private AuthzPdpSynchronizer pdpSynchronizer() {
+        Node node = mock(Node.class);
+        GatewayConfiguration gatewayConfiguration = mock(GatewayConfiguration.class);
+        lenient().when(node.id()).thenReturn("gw-1");
+        lenient().when(gatewayConfiguration.shardingTags()).thenReturn(Optional.empty());
+        return new AuthzPdpSynchronizer(
+            fetcher,
+            new AuthzPdpMapper(new ObjectMapper()),
+            policySynchronizer(),
+            entitySynchronizer(),
+            node,
+            gatewayConfiguration,
+            vertx,
+            new AuthzHostedScopes(),
+            executor(),
+            executor(),
+            new AuthzAppliedRevisions()
+        );
+    }
+
+    private static ThreadPoolExecutor executor() {
+        return new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AUTHZ-50

## Description

With `gamma.enabled=true` the three authz synchronizers run at order 8/9/10, before `API(12)`, `SUBSCRIPTION(13)` and `API_KEY(14)`, inside the single sequential sync cycle. Almost every authz error path is swallowed internally, but an `events_latest` fetch error (`LatestEventFetcher.fetchLatest`) propagates out of `synchronize()` and fails the whole cycle: `nextFromTime` never advances, so API / subscription / api-key changes stop reaching the gateway while the error persists, and the pinned, growing window re-applies authz events every cycle.

This PR makes authz sync invisible to the shared cycle:

- `AuthzResyncWindow` (new): per-synchronizer record of the failed window's `from`.
- `AbstractAuthzReactorSynchronizer` / `AuthzPdpSynchronizer`: `synchronize()` now ends with `onErrorResumeNext` — the error is logged (first failure ERROR with stack trace, repeats one-line WARN, recovery INFO) and swallowed, and the next cycle re-fetches from `min(pendingFrom, from)` (a failed initial sync re-runs as a full initial fetch). At-least-once delivery of authz events is preserved without holding the shared cursor.

Note on the convention asymmetry: core synchronizers intentionally propagate fetch errors because the shared cursor is their only at-least-once mechanism. Authz self-isolates instead — it keeps at-least-once via its private resync window, and as a non-core feature it must not degrade core APIM sync.

### Operational semantics changes (intentional)

- **Readiness:** `SyncProcessProbe` keys on `syncDone()`, which now flips true even if the authz initial sync failed — a restarted gateway goes READY with empty authz engines (PEP fails closed, denying authz-protected traffic) until the next cycle recovers, instead of never becoming ready and holding API/subscription/api-key sync hostage. This is precisely the fix for the all-replica-restart outage mode.
- **Observability:** isolated authz failures no longer surface in `/sync` (`lastOnError`) nor go through the in-cycle `retrySynchronizer` retries — the next-cycle re-fetch (default 5s) replaces them, and gateway logs are the signal (ERROR once → WARN per cycle → INFO on recovery). A follow-up may expose the pending resync window in `/sync` for monitoring.
- Under a persistent failure the window pins and re-fetches `[pendingFrom, now]` every cycle — bounded per-cycle cost (`events_latest` is latest-per-document) and required for at-least-once. The window is process-local; a crash during an outage is covered by the initial full re-sync.

## Additional context

- Repro: make the authz `events_latest` read fail (e.g. transient DB error) on a `gamma.enabled` gateway — before this change every sync cycle fails and API/subscription/api-key sync stalls; after, the cycle completes and authz catches up on its own once the DB recovers.
- Independently reviewed; review verified operator ordering (`doOnComplete` before `onErrorResumeNext`), window arithmetic vs `TIMEFRAME_DELAY`, and interplay with `AuthzAppliedRevisions`, pending maps and commit re-arm. Review-driven additions: PDP live-window recovery test and an end-to-end recovered-window-deploys test.
- New `AuthzSyncCycleIsolationTest` (10 tests, written first — the original 8 previously failing with the error propagating). Module suite: 665 tests green (`mvn verify`, incl. arch rules).
- Master does not yet contain the change-gate from #18369 (4.12.x-only); the master port of that PR and of this fix will follow separately.