### PR TITLE
fix(gateway): stop losing distributed sync events during bulk syncs

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncService.java
@@ -43,12 +43,15 @@ import io.gravitee.node.api.Node;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.repository.distributedsync.api.DistributedEventRepository;
 import io.gravitee.repository.distributedsync.api.DistributedSyncStateRepository;
+import io.gravitee.repository.distributedsync.model.DistributedEvent;
 import io.gravitee.repository.distributedsync.model.DistributedEventType;
 import io.gravitee.repository.distributedsync.model.DistributedSyncAction;
 import io.gravitee.repository.distributedsync.model.DistributedSyncState;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import java.util.Date;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -59,6 +62,15 @@ import lombok.RequiredArgsConstructor;
 @CustomLog
 @RequiredArgsConstructor
 public class DefaultDistributedSyncService implements DistributedSyncService {
+
+    /**
+     * Maximum number of concurrent Redis writes per distributed deployable. A single API deployable
+     * can fan out into one event per subscription and API key; an unbounded fan-out overflows the
+     * Redis client waiting queue (max-waiting-handlers) during bulk syncs.
+     */
+    static final int WRITE_MAX_CONCURRENCY = 32;
+
+    private final AtomicBoolean distributionFailed = new AtomicBoolean();
 
     private final Node node;
     private final ClusterManager clusterManager;
@@ -116,6 +128,14 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
     public Completable storeState(final long fromTime, final long toTime) {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
+                if (distributionFailed.getAndSet(false)) {
+                    return Completable.error(
+                        new DistributedSyncException(
+                            "Some distributed events could not be written to the distributed sync repository. " +
+                                "The sync state is not stored so the time window is replayed on the next sync cycle."
+                        )
+                    );
+                }
                 return distributedSyncStateRepository.createOrUpdate(
                     DistributedSyncState.builder()
                         .clusterId(clusterManager.clusterId())
@@ -135,10 +155,8 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing API reactor event for {}", deployable.id());
-                return apiMapper
-                    .to(deployable)
-                    .flatMapCompletable(distributedEventRepository::createOrUpdate)
-                    .andThen(
+                return trackFailure(
+                    distribute(apiMapper.to(deployable)).andThen(
                         Completable.defer(() -> {
                             if (deployable.syncAction() == SyncAction.UNDEPLOY) {
                                 return distributedEventRepository.updateAll(
@@ -150,7 +168,10 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
                             }
                             return Completable.complete();
                         })
-                    );
+                    ),
+                    "API reactor",
+                    deployable.id()
+                );
             }
             log.debug("Not a primary node, skipping API reactor event distribution");
             return Completable.complete();
@@ -162,7 +183,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing subscription event for {}", deployable.id());
-                return subscriptionMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return trackFailure(distribute(subscriptionMapper.to(deployable)), "subscription", deployable.id());
             }
             log.debug("Not a primary node, skipping subscription event distribution");
             return Completable.complete();
@@ -174,7 +195,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing API key event for {}", deployable.id());
-                return apiKeyMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return trackFailure(distribute(apiKeyMapper.to(deployable)), "API key", deployable.id());
             }
             log.debug("Not a primary node, skipping API key event distribution");
             return Completable.complete();
@@ -186,7 +207,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing organization event for {}", deployable.id());
-                return organizationMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return trackFailure(distribute(organizationMapper.to(deployable)), "organization", deployable.id());
             }
             log.debug("Not a primary node, skipping organization event distribution");
             return Completable.complete();
@@ -198,7 +219,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing dictionary event for {}", deployable.id());
-                return dictionaryMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return trackFailure(distribute(dictionaryMapper.to(deployable)), "dictionary", deployable.id());
             }
             log.debug("Not a primary node, skipping dictionary event distribution");
             return Completable.complete();
@@ -210,7 +231,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing license event for organization {}", deployable.id());
-                return licenseMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return trackFailure(distribute(licenseMapper.to(deployable)), "license", deployable.id());
             }
             log.debug("Not a primary node, skipping license event distribution");
             return Completable.complete();
@@ -222,7 +243,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing access point event for {}", deployable.id());
-                return accessPointMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return trackFailure(distribute(accessPointMapper.to(deployable)), "access point", deployable.id());
             }
             log.debug("Not a primary node, skipping access point event distribution");
             return Completable.complete();
@@ -234,7 +255,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing shared policy group event for {}", deployable.id());
-                return sharedPolicyGroupMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return trackFailure(distribute(sharedPolicyGroupMapper.to(deployable)), "shared policy group", deployable.id());
             }
             log.debug("Not a primary node, skipping shared policy group event distribution");
             return Completable.complete();
@@ -246,7 +267,7 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing API product event for {}", deployable.id());
-                return apiProductMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return trackFailure(distribute(apiProductMapper.to(deployable)), "API product", deployable.id());
             }
             log.debug("Not a primary node, skipping API product event distribution");
             return Completable.complete();
@@ -258,10 +279,31 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
         return Completable.defer(() -> {
             if (isPrimaryNode()) {
                 log.debug("Node is primary, distributing node metadata event for {}", deployable.id());
-                return nodeMetadataMapper.to(deployable).flatMapCompletable(distributedEventRepository::createOrUpdate);
+                return trackFailure(distribute(nodeMetadataMapper.to(deployable)), "node metadata", deployable.id());
             }
             log.debug("Not a primary node, skipping node metadata event distribution");
             return Completable.complete();
+        });
+    }
+
+    private Completable distribute(final Flowable<DistributedEvent> events) {
+        return events.flatMapCompletable(distributedEventRepository::createOrUpdate, false, WRITE_MAX_CONCURRENCY);
+    }
+
+    private Completable distribute(final Maybe<DistributedEvent> event) {
+        return distribute(event.toFlowable());
+    }
+
+    /**
+     * A failed distribution must not be silently dropped: the repository synchronizers isolate
+     * (un)deployment errors per item, so without this flag the sync window would advance and the
+     * missing events would never reach the secondary gateways. {@link #storeState(long, long)}
+     * checks the flag and fails the cycle so the same window is replayed.
+     */
+    private Completable trackFailure(final Completable distribution, final String eventType, final String id) {
+        return distribution.doOnError(throwable -> {
+            distributionFailed.set(true);
+            log.error("Unable to distribute {} event for [{}], the sync time window will be replayed", eventType, id, throwable);
         });
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncService.java
@@ -301,9 +301,14 @@ public class DefaultDistributedSyncService implements DistributedSyncService {
      * checks the flag and fails the cycle so the same window is replayed.
      */
     private Completable trackFailure(final Completable distribution, final String eventType, final String id) {
-        return distribution.doOnError(throwable -> {
+        return distribution.onErrorResumeNext(throwable -> {
             distributionFailed.set(true);
-            log.error("Unable to distribute {} event for [{}], the sync time window will be replayed", eventType, id, throwable);
+            return Completable.error(
+                new DistributedSyncException(
+                    "Unable to distribute %s event for [%s], the sync time window will be replayed".formatted(eventType, id),
+                    throwable
+                )
+            );
         });
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncServiceTest.java
@@ -403,7 +403,7 @@ class DefaultDistributedSyncServiceTest {
             cut
                 .distributeIfNeeded(SingleSubscriptionDeployable.builder().subscription(new Subscription()).build())
                 .test()
-                .assertError(RuntimeException.class);
+                .assertError(DistributedSyncException.class);
 
             cut.storeState(1L, 2L).test().assertError(DistributedSyncException.class);
             verify(distributedSyncStateRepository, never()).createOrUpdate(any());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/service/DefaultDistributedSyncServiceTest.java
@@ -42,6 +42,7 @@ import io.gravitee.gateway.services.sync.process.distributed.mapper.NodeMetadata
 import io.gravitee.gateway.services.sync.process.distributed.mapper.OrganizationMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.SharedPolicyGroupMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.SubscriptionMapper;
+import io.gravitee.gateway.services.sync.process.distributed.model.DistributedSyncException;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.accesspoint.AccessPointDeployable;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.ApiReactorDeployable;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.apikey.SingleApiKeyDeployable;
@@ -62,7 +63,10 @@ import io.gravitee.repository.distributedsync.model.DistributedSyncAction;
 import io.gravitee.repository.distributedsync.model.DistributedSyncState;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -359,6 +363,54 @@ class DefaultDistributedSyncServiceTest {
         void should_not_call_repository_when_distributing_api_product() {
             cut.distributeIfNeeded(ApiProductReactorDeployable.builder().apiProductId("product-id").build()).test().assertComplete();
             verifyNoInteractions(distributedEventRepository);
+        }
+    }
+
+    @Nested
+    class DistributionResilience {
+
+        @Test
+        void should_cap_concurrent_event_writes() {
+            List<Subscription> subscriptions = IntStream.range(0, 100)
+                .mapToObj(i -> {
+                    Subscription subscription = new Subscription();
+                    subscription.setId("subscription-" + i);
+                    return subscription;
+                })
+                .toList();
+            ApiReactorDeployable deployable = ApiReactorDeployable.builder()
+                .apiId("api-id")
+                .syncAction(SyncAction.DEPLOY)
+                .subscriptions(subscriptions)
+                .build();
+            AtomicInteger subscribed = new AtomicInteger();
+            when(distributedEventRepository.createOrUpdate(any())).thenReturn(
+                Completable.never().doOnSubscribe(disposable -> subscribed.incrementAndGet())
+            );
+
+            var observer = cut.distributeIfNeeded(deployable).test();
+
+            observer.assertNotComplete();
+            assertThat(subscribed.get()).isEqualTo(DefaultDistributedSyncService.WRITE_MAX_CONCURRENCY);
+            observer.dispose();
+        }
+
+        @Test
+        void should_fail_store_state_and_replay_window_after_a_distribution_failure() {
+            when(distributedEventRepository.createOrUpdate(any())).thenReturn(
+                Completable.error(new RuntimeException("Redis waiting queue is full"))
+            );
+            cut
+                .distributeIfNeeded(SingleSubscriptionDeployable.builder().subscription(new Subscription()).build())
+                .test()
+                .assertError(RuntimeException.class);
+
+            cut.storeState(1L, 2L).test().assertError(DistributedSyncException.class);
+            verify(distributedSyncStateRepository, never()).createOrUpdate(any());
+
+            // The failure flag is reset: the next cycle can store its state again
+            when(distributedSyncStateRepository.createOrUpdate(any())).thenReturn(Completable.complete());
+            cut.storeState(1L, 2L).test().assertComplete();
         }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/vertx/RedisClient.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/vertx/RedisClient.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.redis.ratelimit.RedisRateLimitRepository;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
 import io.vertx.redis.client.RedisOptions;
@@ -131,12 +132,17 @@ public class RedisClient {
         return loops.computeIfAbsent(currentLoopKey(), k -> new LoopRedis());
     }
 
-    private static int currentLoopKey() {
+    static int currentLoopKey() {
         Context context = Vertx.currentContext();
         if (context == null) {
             return FALLBACK_LOOP_KEY;
         }
-        return System.identityHashCode(context.owner());
+        if (context instanceof ContextInternal contextInternal) {
+            // Key on the underlying event loop: contexts (including per-request duplicates) come and
+            // go, but all the ones running on the same event loop must share the same connection.
+            return System.identityHashCode(contextInternal.nettyEventLoop());
+        }
+        return System.identityHashCode(context);
     }
 
     private void startConnectLoop(final LoopRedis loop, final int retry) {

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientLoopKeyTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientLoopKeyTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.vertx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.VertxInternal;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * The Redis connection is opened per event loop: every context running on the same event loop
+ * (including per-request duplicated contexts) must resolve to the same connection key, while
+ * contexts on different event loops must not share one.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisClientLoopKeyTest {
+
+    private final Vertx vertx = Vertx.vertx();
+
+    @AfterAll
+    void tear_down() {
+        vertx.close();
+    }
+
+    @Test
+    void should_use_a_distinct_key_per_event_loop() throws Exception {
+        ContextInternal context = eventLoopContext();
+        ContextInternal otherLoopContext = eventLoopContext();
+        while (otherLoopContext.nettyEventLoop() == context.nettyEventLoop()) {
+            otherLoopContext = eventLoopContext();
+        }
+
+        assertThat(keyOn(context)).isNotEqualTo(keyOn(otherLoopContext));
+    }
+
+    @Test
+    void should_share_the_key_between_contexts_of_the_same_event_loop() throws Exception {
+        ContextInternal context = eventLoopContext();
+        ContextInternal sameLoopContext = eventLoopContext();
+        while (sameLoopContext.nettyEventLoop() != context.nettyEventLoop()) {
+            sameLoopContext = eventLoopContext();
+        }
+
+        assertThat(keyOn(context)).isEqualTo(keyOn(sameLoopContext));
+    }
+
+    @Test
+    void should_share_the_key_with_duplicated_contexts() throws Exception {
+        ContextInternal context = eventLoopContext();
+
+        assertThat(keyOn(context.duplicate())).isEqualTo(keyOn(context));
+    }
+
+    private ContextInternal eventLoopContext() {
+        return ((VertxInternal) vertx).createEventLoopContext();
+    }
+
+    private int keyOn(final ContextInternal context) throws Exception {
+        CompletableFuture<Integer> key = new CompletableFuture<>();
+        context.runOnContext(v -> key.complete(RedisClient.currentLoopKey()));
+        return key.get(10, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14672

## Description

Follow-up to #18626 (which fixed the distributed sync **read** path). This PR fixes the **write** path on the primary node, root cause of the bulk-sync field report: *5,000 APIs deployed locally, only 832 with data in Redis, logs full of `Redis waiting queue is full`, no surfaced sync failure*.

### `fix(redis): key the per-event-loop connection on the event loop, not the Vertx instance`

`RedisClient.currentLoopKey()` used `System.identityHashCode(context.owner())` — but `Context.owner()` returns the shared **Vertx instance**, so every event loop mapped to the same connection entry. The whole process (rate-limit + distributed sync) serialized on **one TCP connection** with a single `max-waiting-handlers = 1024` in-flight cap, silently defeating the per-event-loop connection feature. The key is now the netty event loop (per-request duplicated contexts still share their loop's connection).

### `fix(gateway): stop losing distributed sync events during bulk syncs`

Two compounding problems on the primary's distribution path:

1. **Unbounded write fan-out** — `distributeIfNeeded` used a `flatMapCompletable` with unlimited concurrency; a single API deployable fans out into one Redis write per subscription and API key (× the parallel deployer pool). Thousands of concurrent HSETs overflow the client-side waiting queue → `Redis waiting queue is full` (Redis itself is healthy; the queue is in the vertx client). Writes are now capped at **32 concurrent commands per deployable**, letting backpressure pace the stream.
2. **Silent data loss** — the repository synchronizers isolate per-item errors (`onErrorResumeNext → empty`), so a failed distribution was logged, dropped, and the sync window advanced anyway: the events were **never re-emitted** and secondary gateways diverged permanently. Distribution failures are now tracked and fail `storeState`, so the sync state is not persisted and **the same time window is replayed on the next 5s cycle** — the sync manager already handles this (window not advanced, throttled error logging), no synchronizer changes needed.

## Additional context

- Root-cause analysis of the field report: with the old code, each queue-full error dropped one API's whole event batch; the `X apis synchronized` counter only counts survivors — consistent with 5,000 → 832 → "178 synchronized".
- New tests: connection-key semantics per event loop / same loop / duplicated context; write-concurrency cap; `storeState` failing after a distribution failure then recovering (window replay).
- Full module test suites green: repository-redis (63), gateway-services-sync (404).
