### PR TITLE
feat(gamma): create manual dictionary with static properties

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -30,6 +30,7 @@ import { AccessManagementPage } from '../pages/AccessManagementPage';
 import { ApplicationDetailSubscriptionPage } from '../pages/ApplicationDetailSubscriptionPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { DictionariesPage } from '../pages/DictionariesPage';
+import { DictionaryDetailPage } from '../pages/DictionaryDetailPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
 import { retryTransientRequest } from '../shared/api/queryRetry';
@@ -46,11 +47,15 @@ const queryClient = new QueryClient({
 
 const APPLICATION_DETAIL_TABS = flattenApplicationDetailNavItems(APPLICATION_NAV_GROUPS);
 
-function PermissionPageGuard({ permission, children }: Readonly<{ permission: string; children: ReactElement }>) {
+function PermissionPageGuard({
+    permission,
+    unauthorizedTo = 'applications',
+    children,
+}: Readonly<{ permission: string; unauthorizedTo?: string; children: ReactElement }>) {
     const permissionsReady = useEnvironmentPermissionsReady();
     const canRead = useHasPermission({ anyOf: [permission] });
     if (!permissionsReady) return null;
-    if (!canRead) return <Navigate to="applications" replace />;
+    if (!canRead) return <Navigate to={unauthorizedTo} replace />;
     return children;
 }
 
@@ -129,14 +134,24 @@ export function AppRoutes() {
                                 </PermissionPageGuard>
                             }
                         />
-                        <Route
-                            path="dictionaries"
-                            element={
-                                <PermissionPageGuard permission="environment-dictionary-r">
-                                    <DictionariesPage />
-                                </PermissionPageGuard>
-                            }
-                        />
+                        <Route path="dictionaries">
+                            <Route
+                                index
+                                element={
+                                    <PermissionPageGuard permission="environment-dictionary-r" unauthorizedTo="../applications">
+                                        <DictionariesPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                            <Route
+                                path=":dictionaryId"
+                                element={
+                                    <PermissionPageGuard permission="environment-dictionary-r" unauthorizedTo="../../applications">
+                                        <DictionaryDetailPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                        </Route>
                         <Route path="security-plan-types" element={<SecurityPlanTypesPage />} />
                     </Route>
                 </Routes>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/AddDictionaryPropertySheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/AddDictionaryPropertySheet.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Field,
+    FieldLabel,
+    Input,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+} from '@gravitee/graphene-core';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+
+import { notify } from '../../../shared/notify';
+
+export function AddDictionaryPropertySheet({
+    open,
+    onClose,
+    onSubmit,
+    isSaving,
+    existingKeys,
+}: Readonly<{
+    open: boolean;
+    onClose: () => void;
+    onSubmit: (property: { key: string; value: string }) => Promise<void>;
+    isSaving: boolean;
+    existingKeys: string[];
+}>) {
+    const [key, setKey] = useState('');
+    const [value, setValue] = useState('');
+
+    useEffect(() => {
+        if (!open) return;
+        setKey('');
+        setValue('');
+    }, [open]);
+
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    const trimmedKey = key.trim();
+    const canSubmit = trimmedKey.length > 0 && !isSaving;
+
+    async function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        if (!canSubmit) return;
+        if (existingKeys.includes(trimmedKey)) {
+            notify.error(`Property key "${trimmedKey}" already exists`);
+            return;
+        }
+        await onSubmit({ key: trimmedKey, value });
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>Add Property</SheetTitle>
+                    <SheetDescription>Add a key/value entry to this dictionary.</SheetDescription>
+                </SheetHeader>
+
+                <form id="add-dictionary-property-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-1 py-4">
+                    <Field orientation="vertical" className="gap-1.5">
+                        <FieldLabel htmlFor="property-key">
+                            Key{' '}
+                            <span className="text-destructive" aria-hidden>
+                                *
+                            </span>
+                        </FieldLabel>
+                        <Input
+                            id="property-key"
+                            value={key}
+                            onChange={e => setKey(e.target.value)}
+                            placeholder="e.g. FRA"
+                            disabled={isSaving}
+                            required
+                            className="font-mono text-sm"
+                        />
+                    </Field>
+                    <Field orientation="vertical" className="gap-1.5">
+                        <FieldLabel htmlFor="property-value">Value</FieldLabel>
+                        <Input
+                            id="property-value"
+                            value={value}
+                            onChange={e => setValue(e.target.value)}
+                            placeholder="e.g. Frankfurt"
+                            disabled={isSaving}
+                        />
+                    </Field>
+                </form>
+
+                <SheetFooter className="shrink-0 flex-row justify-end gap-2 border-t pt-4">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="submit" form="add-dictionary-property-form" disabled={!canSubmit}>
+                        {isSaving ? 'Adding…' : 'Add'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/CreateDictionarySheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/CreateDictionarySheet.spec.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { CreateDictionarySheet } from './CreateDictionarySheet';
+import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
+
+function renderSheet({
+    open = true,
+    isSaving = false,
+    onSubmit = jest.fn().mockResolvedValue(undefined),
+}: {
+    open?: boolean;
+    isSaving?: boolean;
+    onSubmit?: jest.Mock;
+} = {}) {
+    const onClose = jest.fn();
+    render(<CreateDictionarySheet open={open} onClose={onClose} onSubmit={onSubmit} isSaving={isSaving} />);
+    return { onClose, onSubmit };
+}
+
+describe('CreateDictionarySheet', () => {
+    it('does not show sheet content when closed', () => {
+        renderSheet({ open: false });
+        expect(querySheetHeading('Create Dictionary')).toBeNull();
+    });
+
+    it('shows create title and no Key field', () => {
+        renderSheet();
+        expect(screen.getByRole('heading', { name: 'Create Dictionary' })).not.toBeNull();
+        expect(screen.queryByText('Define a new manual dictionary with a name and description.')).not.toBeNull();
+        expect(screen.queryByLabelText(/^Key/)).toBeNull();
+        expect(screen.getByText('Type')).not.toBeNull();
+        expect(screen.getByText('Manual')).not.toBeNull();
+    });
+
+    it('keeps Create disabled until name is valid', () => {
+        renderSheet();
+        const createBtn = screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement;
+        expect(createBtn.disabled).toBe(true);
+
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'ab' } });
+        expect(createBtn.disabled).toBe(true);
+        expect(screen.queryByText('Name must be at least 3 characters')).not.toBeNull();
+
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'Airport IATA Codes' } });
+        expect((screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('submits a MANUAL payload without key or properties', async () => {
+        const { onSubmit } = renderSheet();
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'Airport IATA Codes' } });
+        fireEvent.change(screen.getByLabelText(/^Description/), {
+            target: { value: 'IATA codes for airports' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith({
+                name: 'Airport IATA Codes',
+                description: 'IATA codes for airports',
+                type: 'MANUAL',
+            });
+        });
+    });
+
+    it('shows inline API error when create fails', async () => {
+        const onSubmit = jest
+            .fn()
+            .mockRejectedValue(new Error('A dictionary with name [Airport IATA Codes] already exists in this environment.'));
+        renderSheet({ onSubmit });
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'Airport IATA Codes' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+        await waitFor(() => {
+            expect(screen.queryByText('A dictionary with name [Airport IATA Codes] already exists in this environment.')).not.toBeNull();
+        });
+    });
+
+    it('shows Creating… while saving', () => {
+        renderSheet({ isSaving: true });
+        expect(screen.queryByRole('button', { name: 'Creating…' })).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/CreateDictionarySheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/CreateDictionarySheet.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Field,
+    FieldLabel,
+    Input,
+    ScrollArea,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+} from '@gravitee/graphene-core';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+
+import { extractErrorMessage } from '../../../shared/notify/extractErrorMessage';
+import type { NewDictionaryPayload } from '../types/dictionary';
+
+const NAME_MIN = 3;
+const NAME_MAX = 50;
+
+interface CreateDictionaryForm {
+    name: string;
+    description: string;
+}
+
+const EMPTY_FORM: CreateDictionaryForm = {
+    name: '',
+    description: '',
+};
+
+function getNameError(name: string): string | null {
+    const trimmed = name.trim();
+    if (!trimmed) return null;
+    if (trimmed.length < NAME_MIN) return `Name must be at least ${NAME_MIN} characters`;
+    if (trimmed.length > NAME_MAX) return `Name must be at most ${NAME_MAX} characters`;
+    return null;
+}
+
+export function CreateDictionarySheet({
+    open,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    onClose: () => void;
+    onSubmit: (data: NewDictionaryPayload) => Promise<void>;
+    isSaving: boolean;
+}>) {
+    const [form, setForm] = useState<CreateDictionaryForm>(EMPTY_FORM);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!open) return;
+        setForm(EMPTY_FORM);
+        setSubmitError(null);
+    }, [open]);
+
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    const nameError = getNameError(form.name);
+    const isNameValid = form.name.trim().length >= NAME_MIN && form.name.trim().length <= NAME_MAX;
+    const isValid = isNameValid && nameError === null;
+
+    async function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        if (!isValid || isSaving) return;
+
+        const payload: NewDictionaryPayload = {
+            name: form.name.trim(),
+            description: form.description.trim() || undefined,
+            type: 'MANUAL',
+        };
+
+        try {
+            setSubmitError(null);
+            await onSubmit(payload);
+        } catch (error) {
+            setSubmitError(extractErrorMessage(error, 'Failed to create dictionary'));
+        }
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '560px' }}>
+                <SheetHeader>
+                    <SheetTitle>Create Dictionary</SheetTitle>
+                    <SheetDescription>Define a new manual dictionary with a name and description.</SheetDescription>
+                </SheetHeader>
+
+                <ScrollArea className="min-h-0 flex-1">
+                    <form id="create-dictionary-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-1 py-4">
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="dictionary-name">
+                                Name{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            <Input
+                                id="dictionary-name"
+                                value={form.name}
+                                onChange={e => setForm(prev => ({ ...prev, name: e.target.value }))}
+                                placeholder="e.g. Airport IATA Codes"
+                                disabled={isSaving}
+                                required
+                                minLength={NAME_MIN}
+                                maxLength={NAME_MAX}
+                                aria-invalid={nameError !== null}
+                                aria-describedby={nameError !== null ? 'dictionary-name-error' : 'dictionary-name-hint'}
+                            />
+                            {nameError ? (
+                                <p id="dictionary-name-error" className="text-sm text-destructive" role="alert">
+                                    {nameError}
+                                </p>
+                            ) : (
+                                <p id="dictionary-name-hint" className="text-xs text-muted-foreground">
+                                    Max {NAME_MAX} characters.
+                                </p>
+                            )}
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="dictionary-description">Description</FieldLabel>
+                            <Input
+                                id="dictionary-description"
+                                value={form.description}
+                                onChange={e => setForm(prev => ({ ...prev, description: e.target.value }))}
+                                placeholder="Provide a description of the dictionary"
+                                disabled={isSaving}
+                            />
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel>Type</FieldLabel>
+                            <p id="dictionary-type" className="text-sm text-foreground">
+                                Manual
+                            </p>
+                            <p className="text-xs text-muted-foreground">Dynamic dictionaries will be available in a later story.</p>
+                        </Field>
+
+                        {submitError ? (
+                            <p className="text-sm text-destructive" role="alert">
+                                {submitError}
+                            </p>
+                        ) : null}
+                    </form>
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-col gap-2 border-t pt-4 sm:flex-col">
+                    <Button type="button" variant="outline" className="w-full" onClick={onClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="submit" form="create-dictionary-form" className="w-full" disabled={!isValid || isSaving}>
+                        {isSaving ? 'Creating…' : 'Create'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.spec.tsx
@@ -23,8 +23,10 @@ const DICTIONARIES: DictionaryListItem[] = [
         id: '1',
         key: 'countries',
         name: 'Countries',
+        description: 'ISO country lookup',
         type: 'MANUAL',
         state: 'STOPPED',
+        properties: 4,
         updated_at: '2026-01-01T00:00:00.000Z',
     },
     {
@@ -33,6 +35,7 @@ const DICTIONARIES: DictionaryListItem[] = [
         name: 'Remote Codes',
         type: 'DYNAMIC',
         state: 'STARTED',
+        properties: 3,
         updated_at: '2026-01-02T00:00:00.000Z',
     },
     {
@@ -41,22 +44,22 @@ const DICTIONARIES: DictionaryListItem[] = [
         name: 'Status Map',
         type: 'MANUAL',
         state: 'STOPPED',
+        properties: 0,
     },
 ];
 
-function renderTable(overrides: Partial<{ canEdit: boolean; canDelete: boolean; dictionaries: DictionaryListItem[] }> = {}) {
-    const onEdit = jest.fn();
+function renderTable(overrides: Partial<{ canDelete: boolean; dictionaries: DictionaryListItem[] }> = {}) {
+    const onOpen = jest.fn();
     const onDelete = jest.fn();
     render(
         <DictionariesTable
             dictionaries={overrides.dictionaries ?? DICTIONARIES}
-            canEdit={overrides.canEdit ?? true}
             canDelete={overrides.canDelete ?? true}
-            onEdit={onEdit}
+            onOpen={onOpen}
             onDelete={onDelete}
         />,
     );
-    return { onEdit, onDelete };
+    return { onOpen, onDelete };
 }
 
 describe('DictionariesTable', () => {
@@ -68,53 +71,101 @@ describe('DictionariesTable', () => {
             expect(screen.queryByText('Status Map')).not.toBeNull();
         });
 
+        it('shows description under name, or an em dash when missing', () => {
+            renderTable();
+            expect(screen.queryByText('ISO country lookup')).not.toBeNull();
+            expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+        });
+
+        it('truncates long descriptions with an ellipsis on one line', () => {
+            const longDescription = 'IATA codes for airports referenced by Lufthansa flight operations and partner systems across Europe';
+            renderTable({
+                dictionaries: [
+                    {
+                        id: '1',
+                        name: 'Airport IATA Codes',
+                        description: longDescription,
+                        type: 'MANUAL',
+                        properties: 4,
+                    },
+                ],
+            });
+            expect(screen.queryByText(longDescription)).toBeNull();
+            expect(screen.getByText(/IATA codes for airports referenced by Lufthansa/))
+                .textContent?.endsWith('…')
+                .toBe(true);
+        });
+
+        it('shows Dynamic status inline with type and has no State column', () => {
+            renderTable();
+            expect(screen.queryByText('Started')).not.toBeNull();
+            expect(screen.queryByRole('columnheader', { name: 'State' })).toBeNull();
+            expect(screen.queryByRole('columnheader', { name: 'Type' })).not.toBeNull();
+            expect(screen.queryByRole('columnheader', { name: 'Properties' })).not.toBeNull();
+        });
+
         it('shows the empty message when there are no dictionaries', () => {
             renderTable({ dictionaries: [] });
             expect(screen.queryByText('No dictionaries defined for this environment.')).not.toBeNull();
         });
     });
 
+    describe('name open', () => {
+        it('calls onOpen when the name cell is clicked', () => {
+            const { onOpen } = renderTable();
+            fireEvent.click(screen.getByRole('button', { name: /Countries/ }));
+            expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ id: '1', name: 'Countries' }));
+        });
+    });
+
     describe('search filtering', () => {
         it('filters rows by name', () => {
             renderTable();
-            fireEvent.change(screen.getByPlaceholderText('Search by key or name…'), { target: { value: 'remote' } });
+            fireEvent.change(screen.getByPlaceholderText('Search by key, name, or description…'), { target: { value: 'remote' } });
             expect(screen.queryByText('Remote Codes')).not.toBeNull();
             expect(screen.queryByText('Countries')).toBeNull();
         });
 
         it('filters rows by key', () => {
             renderTable();
-            fireEvent.change(screen.getByPlaceholderText('Search by key or name…'), { target: { value: 'status-map' } });
+            fireEvent.change(screen.getByPlaceholderText('Search by key, name, or description…'), { target: { value: 'status-map' } });
             expect(screen.queryByText('Status Map')).not.toBeNull();
+            expect(screen.queryByText('Countries')).toBeNull();
+        });
+
+        it('filters rows by description', () => {
+            renderTable({
+                dictionaries: [
+                    { id: '1', name: 'Countries', description: 'ISO country lookup', type: 'MANUAL', state: 'STOPPED' },
+                    { id: '2', name: 'Remote Codes', description: 'Partner status codes', type: 'DYNAMIC', state: 'STARTED' },
+                ],
+            });
+            fireEvent.change(screen.getByPlaceholderText('Search by key, name, or description…'), { target: { value: 'partner' } });
+            expect(screen.queryByText('Remote Codes')).not.toBeNull();
             expect(screen.queryByText('Countries')).toBeNull();
         });
 
         it('shows the no-match message when search has no results', () => {
             renderTable();
-            fireEvent.change(screen.getByPlaceholderText('Search by key or name…'), { target: { value: 'zzznomatch' } });
+            fireEvent.change(screen.getByPlaceholderText('Search by key, name, or description…'), { target: { value: 'zzznomatch' } });
             expect(screen.queryByText('No dictionaries match your search.')).not.toBeNull();
         });
 
         it('is case-insensitive', () => {
             renderTable();
-            fireEvent.change(screen.getByPlaceholderText('Search by key or name…'), { target: { value: 'COUNTRIES' } });
+            fireEvent.change(screen.getByPlaceholderText('Search by key, name, or description…'), { target: { value: 'COUNTRIES' } });
             expect(screen.queryByText('Countries')).not.toBeNull();
         });
     });
 
     describe('permissions', () => {
-        it('hides the actions column when both canEdit and canDelete are false', () => {
-            renderTable({ canEdit: false, canDelete: false });
+        it('hides the actions column when canDelete is false', () => {
+            renderTable({ canDelete: false });
             expect(screen.queryByRole('button', { name: 'Dictionary actions' })).toBeNull();
         });
 
-        it('shows one action button per row when canEdit is true', () => {
-            renderTable({ canEdit: true, canDelete: false });
-            expect(screen.getAllByRole('button', { name: 'Dictionary actions' }).length).toBe(DICTIONARIES.length);
-        });
-
         it('shows one action button per row when canDelete is true', () => {
-            renderTable({ canEdit: false, canDelete: true });
+            renderTable({ canDelete: true });
             expect(screen.getAllByRole('button', { name: 'Dictionary actions' }).length).toBe(DICTIONARIES.length);
         });
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.tsx
@@ -21,25 +21,27 @@ import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
-    DropdownMenuSeparator,
     DropdownMenuTrigger,
     Input,
     type DataTableProps,
 } from '@gravitee/graphene-core';
-import { MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { MoreHorizontalIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
 import { useMemo, useState } from 'react';
 
-import { DictionaryStateBadge } from './DictionaryStateBadge';
-import { DictionaryTypeBadge } from './DictionaryTypeBadge';
+import { DictionaryTypeLabel } from './DictionaryTypeLabel';
 import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
 import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
 import type { TableSortingState } from '../../applications/utils/tableSort';
+import { truncateLabel } from '../../shared/utils/truncateLabel';
 import type { DictionaryListItem } from '../types/dictionary';
 import { formatDictionaryDate } from '../utils/formatDictionaryDate';
 
+/** Keep name-column descriptions short so Type (incl. Dynamic · Started) stays visible. */
+const DESCRIPTION_MAX_LENGTH = 56;
+
 const DEFAULT_PAGE_SIZE = 10;
 
-const SORTABLE_IDS = new Set(['key', 'name', 'type', 'state', 'updated_at', 'deployed_at']);
+const SORTABLE_IDS = new Set(['name', 'type', 'properties', 'updated_at', 'deployed_at']);
 const DATE_SORTABLE_IDS = new Set(['updated_at', 'deployed_at']);
 
 function toSortableTimestamp(value: unknown): number | null {
@@ -59,6 +61,10 @@ function toSortableTimestamp(value: unknown): number | null {
 }
 
 function compareDictionaryValues(field: string, left: unknown, right: unknown): number {
+    if (field === 'properties') {
+        return (Number(left) || 0) - (Number(right) || 0);
+    }
+
     if (DATE_SORTABLE_IDS.has(field)) {
         const leftTime = toSortableTimestamp(left);
         const rightTime = toSortableTimestamp(right);
@@ -82,7 +88,12 @@ function sortDictionaries(items: DictionaryListItem[], sorting: TableSortingStat
 function filterDictionaries(dictionaries: DictionaryListItem[], search: string): DictionaryListItem[] {
     const query = search.trim().toLowerCase();
     if (!query) return dictionaries;
-    return dictionaries.filter(d => d.name.toLowerCase().includes(query) || (d.key ?? '').toLowerCase().includes(query));
+    return dictionaries.filter(
+        d =>
+            d.name.toLowerCase().includes(query) ||
+            (d.key ?? '').toLowerCase().includes(query) ||
+            (d.description ?? '').toLowerCase().includes(query),
+    );
 }
 
 function paginateDictionaries(items: DictionaryListItem[], page: number, pageSize: number): DictionaryListItem[] {
@@ -92,15 +103,9 @@ function paginateDictionaries(items: DictionaryListItem[], page: number, pageSiz
 
 function DictionaryActionsCell({
     dictionary,
-    canEdit,
-    canDelete,
-    onEdit,
     onDelete,
 }: Readonly<{
     dictionary: DictionaryListItem;
-    canEdit: boolean;
-    canDelete: boolean;
-    onEdit: (dictionary: DictionaryListItem) => void;
     onDelete: (dictionary: DictionaryListItem) => void;
 }>) {
     return (
@@ -112,19 +117,10 @@ function DictionaryActionsCell({
                     </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                    {canEdit && (
-                        <DropdownMenuItem onSelect={() => onEdit(dictionary)}>
-                            <PencilIcon className="size-4 mr-2" aria-hidden />
-                            Edit
-                        </DropdownMenuItem>
-                    )}
-                    {canEdit && canDelete && <DropdownMenuSeparator />}
-                    {canDelete && (
-                        <DropdownMenuItem variant="destructive" onSelect={() => onDelete(dictionary)}>
-                            <Trash2Icon className="size-4 mr-2" aria-hidden />
-                            Delete
-                        </DropdownMenuItem>
-                    )}
+                    <DropdownMenuItem variant="destructive" onSelect={() => onDelete(dictionary)}>
+                        <Trash2Icon className="size-4 mr-2" aria-hidden />
+                        Delete
+                    </DropdownMenuItem>
                 </DropdownMenuContent>
             </DropdownMenu>
         </div>
@@ -132,50 +128,54 @@ function DictionaryActionsCell({
 }
 
 function buildColumns({
-    canEdit,
     canDelete,
-    onEdit,
+    onOpen,
     onDelete,
 }: {
-    canEdit: boolean;
     canDelete: boolean;
-    onEdit: (dictionary: DictionaryListItem) => void;
+    onOpen: (dictionary: DictionaryListItem) => void;
     onDelete: (dictionary: DictionaryListItem) => void;
 }): DataTableProps<DictionaryListItem>['columns'] {
     const columns: DataTableProps<DictionaryListItem>['columns'] = [
         {
-            id: 'key',
-            accessorKey: 'key',
-            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Key" />,
-            cell: ({ row }: ColCell<DictionaryListItem>) =>
-                row.original.key ? (
-                    <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">{row.original.key}</span>
-                ) : (
-                    <span className="text-sm text-muted-foreground">—</span>
-                ),
-        },
-        {
             id: 'name',
             accessorKey: 'name',
             header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Name" />,
-            cell: ({ row }: ColCell<DictionaryListItem>) => <span className="text-sm font-medium">{row.original.name}</span>,
+            cell: ({ row }: ColCell<DictionaryListItem>) => {
+                const fullDescription = row.original.description?.trim() || '';
+                const description = fullDescription ? truncateLabel(fullDescription, DESCRIPTION_MAX_LENGTH) : '—';
+                return (
+                    <button
+                        type="button"
+                        className="min-w-0 space-y-0.5 text-left hover:underline focus-visible:outline-none focus-visible:underline"
+                        onClick={() => onOpen(row.original)}
+                    >
+                        <div className="truncate text-sm font-medium text-foreground">{row.original.name}</div>
+                        <div className="whitespace-nowrap text-xs text-muted-foreground" title={fullDescription || undefined}>
+                            {description}
+                        </div>
+                    </button>
+                );
+            },
         },
         {
             id: 'type',
             accessorKey: 'type',
             header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Type" />,
-            cell: ({ row }: ColCell<DictionaryListItem>) => <DictionaryTypeBadge type={row.original.type} />,
+            cell: ({ row }: ColCell<DictionaryListItem>) => <DictionaryTypeLabel type={row.original.type} state={row.original.state} />,
         },
         {
-            id: 'state',
-            accessorKey: 'state',
-            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="State" />,
-            cell: ({ row }: ColCell<DictionaryListItem>) => <DictionaryStateBadge state={row.original.state} />,
+            id: 'properties',
+            accessorKey: 'properties',
+            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Properties" />,
+            cell: ({ row }: ColCell<DictionaryListItem>) => (
+                <span className="text-sm text-muted-foreground">{row.original.properties ?? 0}</span>
+            ),
         },
         {
             id: 'updated_at',
             accessorKey: 'updated_at',
-            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Updated" />,
+            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Last Updated" />,
             cell: ({ row }: ColCell<DictionaryListItem>) => (
                 <span className="whitespace-nowrap text-sm text-muted-foreground">{formatDictionaryDate(row.original.updated_at)}</span>
             ),
@@ -183,29 +183,21 @@ function buildColumns({
         {
             id: 'deployed_at',
             accessorKey: 'deployed_at',
-            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Deployed" />,
+            header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Last Deployed" />,
             cell: ({ row }: ColCell<DictionaryListItem>) => (
                 <span className="whitespace-nowrap text-sm text-muted-foreground">{formatDictionaryDate(row.original.deployed_at)}</span>
             ),
         },
     ];
 
-    if (canEdit || canDelete) {
+    if (canDelete) {
         columns.push({
             id: 'actions',
             header: () => <span className="sr-only">Actions</span>,
             size: 56,
             enableSorting: false,
             enableHiding: false,
-            cell: ({ row }: ColCell<DictionaryListItem>) => (
-                <DictionaryActionsCell
-                    dictionary={row.original}
-                    canEdit={canEdit}
-                    canDelete={canDelete}
-                    onEdit={onEdit}
-                    onDelete={onDelete}
-                />
-            ),
+            cell: ({ row }: ColCell<DictionaryListItem>) => <DictionaryActionsCell dictionary={row.original} onDelete={onDelete} />,
         });
     }
 
@@ -214,15 +206,13 @@ function buildColumns({
 
 export function DictionariesTable({
     dictionaries,
-    canEdit,
     canDelete,
-    onEdit,
+    onOpen,
     onDelete,
 }: Readonly<{
     dictionaries: DictionaryListItem[];
-    canEdit: boolean;
     canDelete: boolean;
-    onEdit: (dictionary: DictionaryListItem) => void;
+    onOpen: (dictionary: DictionaryListItem) => void;
     onDelete: (dictionary: DictionaryListItem) => void;
 }>) {
     const [search, setSearch] = useState('');
@@ -235,7 +225,7 @@ export function DictionariesTable({
     const totalCount = sorted.length;
     const paginatedData = useMemo(() => paginateDictionaries(sorted, page, pageSize), [sorted, page, pageSize]);
 
-    const columns = useMemo(() => buildColumns({ canEdit, canDelete, onEdit, onDelete }), [canEdit, canDelete, onEdit, onDelete]);
+    const columns = useMemo(() => buildColumns({ canDelete, onOpen, onDelete }), [canDelete, onOpen, onDelete]);
 
     function handleSearchChange(value: string) {
         setSearch(value);
@@ -263,7 +253,7 @@ export function DictionariesTable({
                 <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
                 <Input
                     className="pl-10"
-                    placeholder="Search by key or name…"
+                    placeholder="Search by key, name, or description…"
                     value={search}
                     onChange={e => handleSearchChange(e.target.value)}
                 />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryTypeLabel.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryTypeLabel.spec.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+
+import { DictionaryTypeLabel } from './DictionaryTypeLabel';
+
+describe('DictionaryTypeLabel', () => {
+    it('renders Manual without status', () => {
+        render(<DictionaryTypeLabel type="MANUAL" state="STOPPED" />);
+        expect(screen.queryByText('Manual')).not.toBeNull();
+        expect(screen.queryByText('Started')).toBeNull();
+        expect(screen.queryByText('Stopped')).toBeNull();
+    });
+
+    it('renders Dynamic with Started status', () => {
+        render(<DictionaryTypeLabel type="DYNAMIC" state="STARTED" />);
+        expect(screen.getByText(/Dynamic/)).not.toBeNull();
+        expect(screen.queryByText('Started')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryTypeLabel.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryTypeLabel.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DictionaryLifecycleState, DictionaryType } from '../types/dictionary';
+
+const STATE_LABEL: Record<DictionaryLifecycleState, string> = {
+    STARTED: 'Started',
+    STOPPED: 'Stopped',
+};
+
+export function DictionaryTypeLabel({
+    type,
+    state,
+}: Readonly<{
+    type: DictionaryType;
+    state?: DictionaryLifecycleState;
+}>) {
+    if (type === 'MANUAL') {
+        return <span className="text-sm text-muted-foreground">Manual</span>;
+    }
+
+    const stateLabel = state ? (STATE_LABEL[state] ?? state) : undefined;
+    const stateClassName = state === 'STARTED' ? 'text-green-600' : 'text-muted-foreground';
+
+    return (
+        <span className="text-sm text-muted-foreground">
+            Dynamic
+            {stateLabel ? (
+                <>
+                    {' '}
+                    <span aria-hidden>·</span> <span className={stateClassName}>{stateLabel}</span>
+                </>
+            ) : null}
+        </span>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useDictionaryMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useDictionaryMutations.ts
@@ -26,49 +26,47 @@ import {
     undeployEnvironmentDictionary,
     updateEnvironmentDictionary,
 } from '../services/dictionaries';
-import type { NewDictionaryPayload, UpdateDictionaryPayload } from '../types/dictionary';
+import type { Dictionary, NewDictionaryPayload, UpdateDictionaryPayload } from '../types/dictionary';
 import { dictionaryKeys } from '../utils/queryKeys';
 
-function useDictionaryMutation<TData>(mutationFn: (envId: string, data: TData) => Promise<unknown>) {
+function useDictionaryMutation<TData, TResult>(mutationFn: (envId: string, data: TData) => Promise<TResult>) {
     const env = useEnvironment();
     const queryClient = useQueryClient();
 
     return useMutation({
         mutationFn: (data: TData) => mutationFn(env!.id, data),
         onSuccess: () => {
-            if (env?.id) {
-                void queryClient.invalidateQueries({ queryKey: dictionaryKeys.list(env.id) });
-            }
+            void queryClient.invalidateQueries({ queryKey: dictionaryKeys.all });
         },
     });
 }
 
 export function useCreateDictionary() {
-    return useDictionaryMutation<NewDictionaryPayload>(createEnvironmentDictionary);
+    return useDictionaryMutation<NewDictionaryPayload, Dictionary>(createEnvironmentDictionary);
 }
 
 export function useUpdateDictionary() {
-    return useDictionaryMutation<{ dictionaryId: string; data: UpdateDictionaryPayload }>((envId, { dictionaryId, data }) =>
+    return useDictionaryMutation<{ dictionaryId: string; data: UpdateDictionaryPayload }, Dictionary>((envId, { dictionaryId, data }) =>
         updateEnvironmentDictionary(envId, dictionaryId, data),
     );
 }
 
 export function useDeleteDictionary() {
-    return useDictionaryMutation<string>(deleteEnvironmentDictionary);
+    return useDictionaryMutation<string, void>(deleteEnvironmentDictionary);
 }
 
 export function useDeployDictionary() {
-    return useDictionaryMutation<string>(deployEnvironmentDictionary);
+    return useDictionaryMutation<string, Dictionary>(deployEnvironmentDictionary);
 }
 
 export function useUndeployDictionary() {
-    return useDictionaryMutation<string>(undeployEnvironmentDictionary);
+    return useDictionaryMutation<string, Dictionary>(undeployEnvironmentDictionary);
 }
 
 export function useStartDictionary() {
-    return useDictionaryMutation<string>(startEnvironmentDictionary);
+    return useDictionaryMutation<string, Dictionary>(startEnvironmentDictionary);
 }
 
 export function useStopDictionary() {
-    return useDictionaryMutation<string>(stopEnvironmentDictionary);
+    return useDictionaryMutation<string, Dictionary>(stopEnvironmentDictionary);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useEnvironmentDictionary.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useEnvironmentDictionary.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { getEnvironmentDictionary } from '../services/dictionaries';
+import { dictionaryKeys } from '../utils/queryKeys';
+
+export function useEnvironmentDictionary(dictionaryId: string | undefined) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: dictionaryKeys.detail(env?.id ?? '', dictionaryId ?? ''),
+        queryFn: () => getEnvironmentDictionary(env!.id, dictionaryId!),
+        enabled: Boolean(env && dictionaryId),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.tsx
@@ -17,20 +17,24 @@
 import { Button, Skeleton } from '@gravitee/graphene-core';
 import { PlusIcon } from '@gravitee/graphene-core/icons';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
+import { CreateDictionarySheet } from '../features/dictionaries/components/CreateDictionarySheet';
 import { DictionariesTable } from '../features/dictionaries/components/DictionariesTable';
 import { DictionaryDeleteSheet } from '../features/dictionaries/components/DictionaryDeleteSheet';
-import { useDeleteDictionary } from '../features/dictionaries/hooks/useDictionaryMutations';
+import { useCreateDictionary, useDeleteDictionary } from '../features/dictionaries/hooks/useDictionaryMutations';
 import { useDictionaryPermissions } from '../features/dictionaries/hooks/useDictionaryPermissions';
 import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
-import type { DictionaryListItem } from '../features/dictionaries/types/dictionary';
+import type { DictionaryListItem, NewDictionaryPayload } from '../features/dictionaries/types/dictionary';
 import { notify } from '../shared/notify';
 
-type SheetState = { type: 'closed' } | { type: 'delete'; dictionary: DictionaryListItem };
+type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'delete'; dictionary: DictionaryListItem };
 
 export function DictionariesPage() {
-    const { canCreate, canUpdate, canDelete } = useDictionaryPermissions();
+    const navigate = useNavigate();
+    const { canCreate, canDelete } = useDictionaryPermissions();
     const { data: dictionaries = [], isLoading, isError } = useEnvironmentDictionaries();
+    const createMutation = useCreateDictionary();
     const deleteMutation = useDeleteDictionary();
 
     const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
@@ -39,13 +43,15 @@ export function DictionariesPage() {
         setSheet({ type: 'closed' });
     }
 
-    function handleCreate() {
-        // Create form lands in FOUND-7; keep CTA visible and gated for Story 2 parity.
-        notify.info('Create dictionary form will be available in the next story (FOUND-7).');
+    async function handleCreate(data: NewDictionaryPayload) {
+        const created = await createMutation.mutateAsync(data);
+        notify.success('Dictionary created successfully');
+        closeSheet();
+        navigate(created.id);
     }
 
-    function handleEdit(_dictionary: DictionaryListItem) {
-        notify.info('Edit dictionary form will be available in the next story (FOUND-9).');
+    function handleOpen(dictionary: DictionaryListItem) {
+        navigate(dictionary.id);
     }
 
     async function handleDelete() {
@@ -69,7 +75,7 @@ export function DictionariesPage() {
                     </p>
                 </div>
                 {canCreate && (
-                    <Button className="shrink-0" onClick={handleCreate}>
+                    <Button className="shrink-0" onClick={() => setSheet({ type: 'create' })}>
                         <PlusIcon className="size-4" aria-hidden />
                         Add Dictionary
                     </Button>
@@ -89,12 +95,18 @@ export function DictionariesPage() {
             ) : (
                 <DictionariesTable
                     dictionaries={dictionaries}
-                    canEdit={canUpdate}
                     canDelete={canDelete}
-                    onEdit={handleEdit}
+                    onOpen={handleOpen}
                     onDelete={d => setSheet({ type: 'delete', dictionary: d })}
                 />
             )}
+
+            <CreateDictionarySheet
+                open={sheet.type === 'create'}
+                onClose={closeSheet}
+                onSubmit={handleCreate}
+                isSaving={createMutation.isPending}
+            />
 
             <DictionaryDeleteSheet
                 open={sheet.type === 'delete'}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionaryDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionaryDetailPage.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Skeleton } from '@gravitee/graphene-core';
+import { ArrowLeftIcon, BookOpenIcon, CalendarIcon, ClockIcon, CloudUploadIcon, PlusIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { AddDictionaryPropertySheet } from '../features/dictionaries/components/AddDictionaryPropertySheet';
+import { DictionaryTypeBadge } from '../features/dictionaries/components/DictionaryTypeBadge';
+import { useDeployDictionary, useUpdateDictionary } from '../features/dictionaries/hooks/useDictionaryMutations';
+import { useDictionaryPermissions } from '../features/dictionaries/hooks/useDictionaryPermissions';
+import { useEnvironmentDictionary } from '../features/dictionaries/hooks/useEnvironmentDictionary';
+import { formatDictionaryDate } from '../features/dictionaries/utils/formatDictionaryDate';
+import { notify } from '../shared/notify';
+
+export function DictionaryDetailPage() {
+    const { dictionaryId } = useParams<{ dictionaryId: string }>();
+    const navigate = useNavigate();
+    const { canUpdate } = useDictionaryPermissions();
+    const { data: dictionary, isLoading, isError } = useEnvironmentDictionary(dictionaryId);
+    const updateMutation = useUpdateDictionary();
+    const deployMutation = useDeployDictionary();
+    const [addPropertyOpen, setAddPropertyOpen] = useState(false);
+
+    const properties = dictionary?.properties ?? {};
+    const propertyEntries = Object.entries(properties);
+    const propertyCount = propertyEntries.length;
+    const canEditManualProperties = canUpdate && dictionary?.type === 'MANUAL';
+
+    async function handleAddProperty(property: { key: string; value: string }) {
+        if (!dictionary || dictionary.type !== 'MANUAL') return;
+        try {
+            await updateMutation.mutateAsync({
+                dictionaryId: dictionary.id,
+                data: {
+                    name: dictionary.name,
+                    description: dictionary.description,
+                    type: dictionary.type,
+                    properties: { ...properties, [property.key]: property.value },
+                    provider: dictionary.provider ?? undefined,
+                    trigger: dictionary.trigger ?? undefined,
+                },
+            });
+            notify.success('Property added successfully');
+            setAddPropertyOpen(false);
+        } catch (error) {
+            notify.error(error, 'Failed to add property');
+            throw error;
+        }
+    }
+
+    async function handleDeploy() {
+        if (!dictionary) return;
+        try {
+            await deployMutation.mutateAsync(dictionary.id);
+            notify.success('Dictionary deployed successfully');
+        } catch (error) {
+            notify.error(error, 'Failed to deploy dictionary');
+        }
+    }
+
+    if (isLoading) {
+        return (
+            <div className="space-y-4">
+                <Skeleton className="h-8 w-48" />
+                <Skeleton className="h-40 w-full rounded-xl" />
+                <Skeleton className="h-56 w-full rounded-xl" />
+            </div>
+        );
+    }
+
+    if (isError || !dictionary) {
+        return (
+            <div className="space-y-4">
+                <Button type="button" variant="ghost" className="gap-1.5 px-0" onClick={() => navigate('..')}>
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                    Back to Dictionaries
+                </Button>
+                <p className="text-sm text-muted-foreground">Dictionary not found or failed to load.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <Button type="button" variant="ghost" className="gap-1.5 px-0 text-muted-foreground" asChild>
+                <Link to="..">
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                    Back to Dictionaries
+                </Link>
+            </Button>
+
+            <section className="rounded-xl border bg-card p-5">
+                <div className="flex items-start justify-between gap-4">
+                    <div className="flex min-w-0 items-start gap-3">
+                        <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-700">
+                            <BookOpenIcon className="size-5" aria-hidden />
+                        </div>
+                        <div className="min-w-0 space-y-3">
+                            <div className="space-y-1">
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <h1 className="text-xl font-semibold tracking-tight">{dictionary.name}</h1>
+                                    <DictionaryTypeBadge type={dictionary.type} />
+                                </div>
+                                {dictionary.description?.trim() ? (
+                                    <p className="text-sm text-muted-foreground">{dictionary.description}</p>
+                                ) : null}
+                            </div>
+                            <div className="grid gap-4 sm:grid-cols-2">
+                                <div className="space-y-1">
+                                    <div className="text-xs text-muted-foreground">Dictionary Key</div>
+                                    <div className="inline-flex rounded-md bg-muted px-2 py-1 font-mono text-xs">
+                                        {dictionary.key || dictionary.id}
+                                    </div>
+                                </div>
+                                <div className="space-y-1">
+                                    <div className="text-xs text-muted-foreground">Properties</div>
+                                    <div className="text-sm font-medium">
+                                        {propertyCount} {propertyCount === 1 ? 'entry' : 'entries'}
+                                    </div>
+                                </div>
+                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                    <ClockIcon className="size-4 shrink-0" aria-hidden />
+                                    <span>
+                                        <span className="text-xs">Last Updated</span>
+                                        <div className="text-foreground">{formatDictionaryDate(dictionary.updated_at)}</div>
+                                    </span>
+                                </div>
+                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                    <CalendarIcon className="size-4 shrink-0" aria-hidden />
+                                    <span>
+                                        <span className="text-xs">Last Deployed</span>
+                                        <div className="text-foreground">{formatDictionaryDate(dictionary.deployed_at)}</div>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    {canEditManualProperties ? (
+                        <Button
+                            type="button"
+                            variant="outline"
+                            className="shrink-0 gap-1.5"
+                            onClick={handleDeploy}
+                            disabled={deployMutation.isPending}
+                        >
+                            <CloudUploadIcon className="size-4" aria-hidden />
+                            {deployMutation.isPending ? 'Deploying…' : 'Deploy'}
+                        </Button>
+                    ) : null}
+                </div>
+            </section>
+
+            <section className="space-y-4 rounded-xl border bg-card p-5">
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <h2 className="text-base font-semibold">Properties</h2>
+                        <p className="text-sm text-muted-foreground">
+                            {dictionary.type === 'DYNAMIC'
+                                ? 'Values managed by the dictionary provider.'
+                                : 'Key/value entries that make up this dictionary.'}
+                        </p>
+                    </div>
+                    {canEditManualProperties ? (
+                        <Button type="button" className="shrink-0 gap-1.5" onClick={() => setAddPropertyOpen(true)}>
+                            <PlusIcon className="size-4" aria-hidden />
+                            Add Property
+                        </Button>
+                    ) : null}
+                </div>
+
+                {propertyCount === 0 ? (
+                    <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed px-6 py-16 text-center">
+                        <BookOpenIcon className="size-10 text-muted-foreground/40" aria-hidden />
+                        <p className="text-sm text-muted-foreground">
+                            {dictionary.type === 'DYNAMIC'
+                                ? 'No properties yet. Values will appear when the provider syncs this dictionary.'
+                                : 'No properties yet. Add key/value entries to this dictionary.'}
+                        </p>
+                    </div>
+                ) : (
+                    <div className="overflow-hidden rounded-lg border">
+                        <table className="w-full text-sm">
+                            <thead className="bg-muted/50 text-left text-muted-foreground">
+                                <tr>
+                                    <th className="px-4 py-2 font-medium">Key</th>
+                                    <th className="px-4 py-2 font-medium">Value</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {propertyEntries.map(([key, value]) => (
+                                    <tr key={key} className="border-t">
+                                        <td className="px-4 py-2 font-mono text-xs">{key}</td>
+                                        <td className="px-4 py-2">{value}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </section>
+
+            {canEditManualProperties ? (
+                <AddDictionaryPropertySheet
+                    open={addPropertyOpen}
+                    onClose={() => setAddPropertyOpen(false)}
+                    onSubmit={handleAddProperty}
+                    isSaving={updateMutation.isPending}
+                    existingKeys={Object.keys(properties)}
+                />
+            ) : null}
+        </div>
+    );
+}


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/FOUND-7

## Summary
- Add **Create Dictionary** sheet for MANUAL dictionaries (name, optional description; type is read-only Manual).
- Create payload is `{ name, description?, type: 'MANUAL' }` — no key field and no properties on create.
- On success, navigate to the dictionary **detail** page; add/manage static properties there (Add Property), with Deploy gated to MANUAL.
- Wire **Add Dictionary** on the list to `POST /configuration/dictionaries`; surface create API errors inline and show a success toast.

https://github.com/user-attachments/assets/860c6a8c-7a32-4d14-ae4f-c67923e7bdfb


