### PR TITLE
fix(rest-api): validate email.from at save time (APIM-14772)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Email.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Email.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.rest.api.model.annotations.ParameterKey;
 import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.validator.ValidSenderAddress;
 import jakarta.validation.Valid;
 import java.util.List;
 
@@ -51,7 +52,13 @@ public class Email {
     @ParameterKey(Key.EMAIL_SUBJECT)
     private String subject;
 
+    /**
+     * Default sender address used when no branded sender matches. Optional: an absent value falls back to
+     * the {@link Key#EMAIL_FROM} default, so no {@code @NotBlank} here. When set, it must be a single
+     * address the SMTP send path can actually use — the same check the branded senders get.
+     */
     @ParameterKey(Key.EMAIL_FROM)
+    @ValidSenderAddress
     private String from;
 
     /**
@@ -142,8 +149,20 @@ public class Email {
         return from;
     }
 
+    /**
+     * Normalises at the write boundary, the way {@link #setBrandedSenders(List)} does: surrounding whitespace
+     * is trimmed, and a blank value becomes {@code null}.
+     * <p>
+     * Blank must not survive, or the constraint above does not actually close the reported gap: a blank value
+     * is <em>valid</em> to the constraint (the sender is optional), but it persists as an empty
+     * {@code email.from} parameter, and the send path reads it back as {@code ""} and hands it to
+     * {@code new InternetAddress("")}, which throws — an empty stored value does <em>not</em> fall back to the
+     * {@link Key#EMAIL_FROM} default the way an absent key does. Collapsing it to {@code null} here means only
+     * a real address, or nothing at all, can be stored.
+     */
     public void setFrom(String from) {
-        this.from = from;
+        final String trimmed = from == null ? null : from.trim();
+        this.from = trimmed == null || trimmed.isEmpty() ? null : trimmed;
     }
 
     @JsonIgnore

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/EmailFromValidationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/settings/EmailFromValidationTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Bean-validation coverage for the default sender address ({@code email.from}), which previously accepted any
+ * string and only failed at send time with an HTTP 500. Mirrors {@link BrandedSenderValidationTest}, which
+ * covers the same constraint on a branded sender's {@code from}.
+ *
+ * @author GraviteeSource Team
+ */
+class EmailFromValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    private static Email emailWithFrom(String from) {
+        var email = new Email();
+        email.setFrom(from);
+        return email;
+    }
+
+    @Test
+    void should_accept_a_valid_from() {
+        assertThat(validator.validate(emailWithFrom("noreply@gravitee.io"))).isEmpty();
+    }
+
+    @Test
+    void should_accept_from_with_display_name() {
+        assertThat(validator.validate(emailWithFrom("Gravitee <noreply@gravitee.io>"))).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "not-an-email", "foo@", "user@a..b.com", "user@.example.com" })
+    void should_reject_malformed_from(String from) {
+        assertThat(validator.validate(emailWithFrom(from))).anyMatch(v -> v.getPropertyPath().toString().equals("from"));
+    }
+
+    @Test
+    void should_reject_multi_address_from() {
+        // The send path resolves a single address, so a comma-separated list must not survive save — accepting
+        // it is what let a From through that delivery then rejected.
+        assertThat(validator.validate(emailWithFrom("noreply@gravitee.io, other@gravitee.io"))).anyMatch(v ->
+            v.getPropertyPath().toString().equals("from")
+        );
+    }
+
+    @Test
+    void should_report_a_readable_message_for_a_malformed_from() {
+        assertThat(validator.validate(emailWithFrom("not-an-email"))).anyMatch(v ->
+            v.getMessage().equals("must be a valid email address, optionally with a display name (e.g. \"Name <user@example.com>\")")
+        );
+    }
+
+    // --- an absent sender stays legal ---
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = { "", "   " })
+    void should_normalize_an_absent_from_to_null(String from) {
+        // The default sender is optional: leaving it unset falls back to the Key.EMAIL_FROM default, so this
+        // must stay valid — it is what a @NotBlank here would break. Blank is collapsed to null rather than
+        // merely accepted, because an empty value that reaches storage does NOT fall back: the send path reads
+        // "" and hands it to new InternetAddress(""), which throws — the same 500 this ticket is about.
+        var email = emailWithFrom(from);
+
+        assertThat(email.getFrom()).isNull();
+        assertThat(validator.validate(email)).isEmpty();
+    }
+
+    @Test
+    void should_trim_surrounding_whitespace_on_write() {
+        assertThat(emailWithFrom("  noreply@gravitee.io  ").getFrom()).isEqualTo("noreply@gravitee.io");
+    }
+
+    // --- @Valid cascade through the real save graph (settings entity -> email -> from) ---
+
+    @Test
+    void should_cascade_from_settings_entity_into_from() {
+        var settings = new ConsoleSettingsEntity();
+        settings.getEmail().setFrom("not-an-email");
+
+        assertThat(validator.validate(settings)).anyMatch(v -> v.getPropertyPath().toString().equals("email.from"));
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14772

## Description

Saving org/env email settings accepted a From that the SMTP send path can't use — a malformed or multi-address value persisted fine, then blew up at delivery (the 500). Adds @ValidSenderAddress to Email.from so save rejects it up front.

Same annotation the branded senders already use, so one check covers both malformed addresses and the multi-address case, via EmailAddresses.singleAddress — the same helper send-time matching uses.

Not @Email: that constraint rejects the Name <user@example.com> form, which is a legal and supported sender value here.

Deliberately no @NotBlank either: unlike a branded sender's From, email.from is optional — omitting it falls back to the Key.EMAIL_FROM default.

setFrom now trims and collapses blank to null. The annotation alone doesn't close the gap: blank is valid to the constraint (the sender is optional), but an empty value still persists as an empty email.from parameter, and the send path reads it back as "" and hands it to new InternetAddress("") — the same 500. An empty stored value does not fall back to the default the way an absent key does. Collapsing it to null means only a real address, or nothing at all, can be stored.

Covered by EmailFromValidationTest (13 cases): rejects not-an-email, foo@, user@a..b.com, user@.example.com, and the multi-address form; accepts a bare address and the Name <addr> form; asserts null/empty/blank all normalise to null and stay valid; asserts whitespace is trimmed; plus a cascade test asserting the violation lands on property path email.from.

## Additional context
<img width="1568" height="738" alt="validation" src="https://github.com/user-attachments/assets/b7a2430e-1c41-4467-aef0-0f8b18c8aa50" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

