### PR TITLE
feat(console): view failed probe details in V4 health check dashboard

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/healthCheck.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/healthCheck.fixture.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { ApiAvailability, ApiAverageResponseTime, ApiHealthResponseTimeOvertime, HealthCheckLogsResponse } from './healthCheck';
+import {
+  ApiAvailability,
+  ApiAverageResponseTime,
+  ApiHealthResponseTimeOvertime,
+  HealthCheckLogsResponse,
+  HealthCheckStep,
+} from './healthCheck';
 
 export function fakeApiHealthResponseTimeOvertime(attribute?: Partial<ApiHealthResponseTimeOvertime>): ApiHealthResponseTimeOvertime {
   const base: ApiHealthResponseTimeOvertime = {
@@ -62,6 +68,33 @@ export function fakeApiHealthAverageResponseTime(attribute?: Partial<ApiAverageR
   };
 }
 
+export function fakeHealthCheckStep(attribute?: Partial<HealthCheckStep>): HealthCheckStep {
+  const base: HealthCheckStep = {
+    name: 'default-step',
+    success: false,
+    message: 'Assertion not validated: status code is 503, expected 200',
+    request: {
+      uri: 'http://backend:8080/_health',
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    },
+    response: {
+      status: 503,
+      body: 'Service Unavailable',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    },
+  };
+
+  return {
+    ...base,
+    ...attribute,
+  };
+}
+
 export function fakeApiHealthCheckLogs(attribute?: Partial<HealthCheckLogsResponse>): HealthCheckLogsResponse {
   const base: HealthCheckLogsResponse = {
     data: [
@@ -72,7 +105,7 @@ export function fakeApiHealthCheckLogs(attribute?: Partial<HealthCheckLogsRespon
         gatewayId: 'sample-gateway-id',
         responseTime: 150,
         success: false,
-        steps: [],
+        steps: [fakeHealthCheckStep()],
       },
     ],
     pagination: {

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/healthCheck.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/healthCheck.fixture.ts
@@ -74,7 +74,7 @@ export function fakeHealthCheckStep(attribute?: Partial<HealthCheckStep>): Healt
     success: false,
     message: 'Assertion not validated: status code is 503, expected 200',
     request: {
-      uri: 'http://backend:8080/_health',
+      uri: 'https://backend:8080/_health',
       method: 'GET',
       headers: {
         Accept: 'application/json',

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/healthCheck.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/healthCheck.ts
@@ -66,7 +66,7 @@ export interface HealthCheckLog {
 
 export interface HealthCheckStep {
   name: string;
-  success: string;
+  success: boolean;
   message: string;
   request: HealthCheckStepRequest;
   response: HealthCheckStepResponse;

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/api-health-check-dashboard-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/api-health-check-dashboard-v4.component.spec.ts
@@ -217,6 +217,8 @@ describe('ApiHealthCheckDashboardV4Component', () => {
         timestamp: 'Timestamp',
         endpoint: 'Endpoint',
         gateway: 'Gateway',
+        responseTime: 'Response Time',
+        actions: '',
       },
     ]);
 
@@ -225,6 +227,8 @@ describe('ApiHealthCheckDashboardV4Component', () => {
         timestamp: '2024-11-13T15:50:41Z',
         endpoint: 'sample-endpoint-name',
         gateway: 'sample-gateway-id',
+        responseTime: '150ms',
+        actions: '',
       },
     ]);
 

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.component.html
@@ -1,0 +1,137 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<span mat-dialog-title>Failed Health Check Details</span>
+
+<mat-dialog-content>
+  <div class="summary">
+    <div class="summary__row">
+      <div class="summary__label">Timestamp:</div>
+      <div class="summary__value" data-testid="summary-timestamp">{{ log.timestamp }}</div>
+    </div>
+    <div class="summary__row">
+      <div class="summary__label">Endpoint:</div>
+      <div class="summary__value" data-testid="summary-endpoint">{{ log.endpointName }}</div>
+    </div>
+    <div class="summary__row">
+      <div class="summary__label">Gateway:</div>
+      <div class="summary__value" data-testid="summary-gateway">{{ log.gatewayId }}</div>
+    </div>
+    <div class="summary__row">
+      <div class="summary__label">Response Time:</div>
+      <div class="summary__value" data-testid="summary-response-time">{{ log.responseTime }}ms</div>
+    </div>
+  </div>
+
+  @for (stepViewModel of steps; track $index) {
+    <mat-expansion-panel class="log" [expanded]="true" data-testid="step">
+      <mat-expansion-panel-header class="log__header">
+        <mat-panel-title class="log__header__title" data-testid="step-name">{{ stepViewModel.step.name }}</mat-panel-title>
+      </mat-expansion-panel-header>
+
+      @if (stepViewModel.step.message) {
+        <div class="log__row">
+          <div class="log__row__cell">
+            <div class="log__row__property">Message:</div>
+            <div class="log__row__value" data-testid="step-message">{{ stepViewModel.step.message }}</div>
+          </div>
+        </div>
+      }
+
+      @if (stepViewModel.step.request; as request) {
+        <div class="log__section">
+          <div class="log__section__title">Request</div>
+          <div class="log__data">
+            <div class="log__row">
+              <div class="log__row__cell">
+                <div class="log__row__property">Method:</div>
+                <div class="log__row__value" data-testid="request-method">{{ request.method | lowercase }}</div>
+              </div>
+            </div>
+            <div class="log__row">
+              <div class="log__row__cell">
+                <div class="log__row__property">URI:</div>
+                <div class="log__row__value" data-testid="request-uri">{{ request.uri }}</div>
+              </div>
+            </div>
+            <div class="log__row">
+              <div class="log__row__cell">
+                <div class="log__row__property">Headers:</div>
+              </div>
+              @for (header of stepViewModel.requestHeaders; track header.name) {
+                <div class="log__row__sub-cell" data-testid="request-header">
+                  <div class="log__row__property" data-testid="header-name">{{ header.name }}:</div>
+                  <div class="log__row__value" data-testid="header-value">{{ header.value | maskSensitiveHeader: header.name }}</div>
+                </div>
+              } @empty {
+                <div class="log__row__sub-cell" data-testid="request-no-headers">
+                  <div class="log__row__value">No HTTP headers</div>
+                </div>
+              }
+            </div>
+          </div>
+        </div>
+      }
+
+      @if (stepViewModel.step.response; as response) {
+        <div class="log__section">
+          <div class="log__section__title">Response</div>
+          <div class="log__data">
+            <div class="log__row">
+              <div class="log__row__cell">
+                <div class="log__row__property">Status:</div>
+                <div
+                  class="log__row__value"
+                  data-testid="response-status"
+                  [class.gio-badge-warning]="response.status >= 400"
+                  [class.gio-badge-success]="response.status < 400"
+                >
+                  {{ response.status }}
+                </div>
+              </div>
+            </div>
+            <div class="log__row">
+              <div class="log__row__cell">
+                <div class="log__row__property">Headers:</div>
+              </div>
+              @for (header of stepViewModel.responseHeaders; track header.name) {
+                <div class="log__row__sub-cell" data-testid="response-header">
+                  <div class="log__row__property" data-testid="header-name">{{ header.name }}:</div>
+                  <div class="log__row__value" data-testid="header-value">{{ header.value | maskSensitiveHeader: header.name }}</div>
+                </div>
+              } @empty {
+                <div class="log__row__sub-cell" data-testid="response-no-headers">
+                  <div class="log__row__value">No HTTP headers</div>
+                </div>
+              }
+            </div>
+          </div>
+          @if (response.body) {
+            <body-accordion class="log__accordion" [body]="response.body" />
+          }
+        </div>
+      }
+    </mat-expansion-panel>
+  } @empty {
+    <div class="log__empty" data-testid="no-details">No details available for this probe.</div>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-flat-button [mat-dialog-close]="undefined" type="button" data-testid="close-button">Close</button>
+</mat-dialog-actions>

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.component.scss
@@ -1,0 +1,92 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+.summary {
+  margin-bottom: 16px;
+
+  &__row {
+    display: flex;
+    flex-direction: row;
+    margin: 4px 0;
+  }
+
+  &__label {
+    margin-right: 4px;
+    white-space: nowrap;
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+    @include mat.m2-typography-level($typography, body-2);
+  }
+
+  &__value {
+    word-break: break-all;
+    @include mat.m2-typography-level($typography, body-2);
+  }
+}
+
+.log {
+  background-color: mat.m2-get-color-from-palette(gio.$mat-basic-palette, white);
+  border-radius: 4px;
+  border: 1px solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker20');
+  margin: 8px 0;
+
+  &__header {
+    display: flex;
+    flex-direction: row;
+    border-radius: 4px 4px 0 0;
+    background-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'default');
+    padding: 16px 24px;
+
+    &__title {
+      @include mat.m2-typography-level($typography, body-1);
+    }
+  }
+
+  &__section {
+    margin-top: 16px;
+
+    &__title {
+      margin-bottom: 8px;
+      @include mat.m2-typography-level($typography, subtitle-2);
+    }
+  }
+
+  &__row {
+    margin: 8px 0;
+
+    &__cell {
+      display: flex;
+      flex-direction: row;
+    }
+
+    &__sub-cell {
+      margin: 8px 0 8px 12px;
+      display: flex;
+      flex-direction: row;
+    }
+
+    &__property {
+      margin-right: 4px;
+      white-space: nowrap;
+      color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+      @include mat.m2-typography-level($typography, body-2);
+    }
+
+    &__value {
+      word-break: break-all;
+      @include mat.m2-typography-level($typography, body-2);
+    }
+  }
+
+  &__accordion {
+    display: block;
+    margin: 0 -12px;
+  }
+
+  &__empty {
+    padding: 16px 0;
+    @include mat.m2-typography-level($typography, body-2);
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.component.spec.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+import { FailedHealthCheckDetailsDialogComponent } from './failed-health-check-details-dialog.component';
+import { FailedHealthCheckDetailsDialogHarness } from './failed-health-check-details-dialog.harness';
+
+import { fakeApiHealthCheckLogs, fakeHealthCheckStep } from '../../../../../../entities/management-api-v2/api/v4/healthCheck.fixture';
+import { HealthCheckLog } from '../../../../../../entities/management-api-v2/api/v4/healthCheck';
+
+describe('FailedHealthCheckDetailsDialogComponent', () => {
+  let fixture: ComponentFixture<FailedHealthCheckDetailsDialogComponent>;
+  let harness: FailedHealthCheckDetailsDialogHarness;
+
+  const aLog = (attribute?: Partial<HealthCheckLog>): HealthCheckLog => ({
+    ...fakeApiHealthCheckLogs().data[0],
+    ...attribute,
+  });
+
+  const init = async (log: HealthCheckLog) => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, MatIconTestingModule, FailedHealthCheckDetailsDialogComponent],
+      providers: [
+        { provide: MatDialogRef, useValue: { close: jest.fn() } },
+        { provide: MAT_DIALOG_DATA, useValue: log },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FailedHealthCheckDetailsDialogComponent);
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, FailedHealthCheckDetailsDialogHarness);
+  };
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  describe('summary', () => {
+    beforeEach(async () => await init(aLog()));
+
+    it('should_display_log_summary', async () => {
+      expect(await harness.getSummaryValue('timestamp')).toEqual('2024-11-13T15:50:41Z');
+      expect(await harness.getSummaryValue('endpoint')).toEqual('sample-endpoint-name');
+      expect(await harness.getSummaryValue('gateway')).toEqual('sample-gateway-id');
+      expect(await harness.getSummaryValue('response-time')).toEqual('150ms');
+    });
+  });
+
+  describe('step details', () => {
+    beforeEach(async () => await init(aLog()));
+
+    it('should_display_request_method_and_uri', async () => {
+      expect(await harness.getRequestMethod()).toEqual('get');
+      expect(await harness.getRequestUri()).toEqual('http://backend:8080/_health');
+    });
+
+    it('should_display_request_headers', async () => {
+      expect(await harness.getRequestHeaders()).toEqual([{ name: 'Accept', value: 'application/json' }]);
+    });
+
+    it('should_display_response_status', async () => {
+      expect(await harness.getResponseStatus()).toEqual('503');
+    });
+
+    it('should_display_response_headers', async () => {
+      expect(await harness.getResponseHeaders()).toEqual([{ name: 'Content-Type', value: 'text/plain' }]);
+    });
+
+    it('should_display_assertion_message', async () => {
+      expect(await harness.getStepMessages()).toEqual(['Assertion not validated: status code is 503, expected 200']);
+    });
+
+    it('should_display_response_body', async () => {
+      expect(await harness.hasBodySection()).toBe(true);
+    });
+  });
+
+  describe('sensitive headers', () => {
+    it('should_mask_sensitive_request_headers', async () => {
+      await init(
+        aLog({
+          steps: [
+            fakeHealthCheckStep({
+              request: {
+                uri: 'http://backend:8080/_health',
+                method: 'GET',
+                headers: {
+                  Authorization: 'Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature',
+                  Accept: 'application/json',
+                },
+              },
+            }),
+          ],
+        }),
+      );
+
+      expect(await harness.getRequestHeaders()).toEqual([
+        { name: 'Authorization', value: 'Bearer ••••••••ture' },
+        { name: 'Accept', value: 'application/json' },
+      ]);
+    });
+
+    it('should_mask_sensitive_response_headers', async () => {
+      await init(
+        aLog({
+          steps: [
+            fakeHealthCheckStep({
+              response: {
+                status: 503,
+                body: '',
+                headers: { 'Set-Cookie': 'sessionId=some-very-long-session-value; HttpOnly' },
+              },
+            }),
+          ],
+        }),
+      );
+
+      expect(await harness.getResponseHeaders()).toEqual([{ name: 'Set-Cookie', value: '••••••••' }]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should_display_no_headers_message_when_headers_are_empty', async () => {
+      await init(
+        aLog({
+          steps: [
+            fakeHealthCheckStep({
+              request: { uri: 'http://backend:8080/_health', method: 'GET', headers: {} },
+              response: { status: 503, body: 'Service Unavailable', headers: {} },
+            }),
+          ],
+        }),
+      );
+
+      expect(await harness.hasRequestNoHeadersMessage()).toBe(true);
+      expect(await harness.hasResponseNoHeadersMessage()).toBe(true);
+    });
+
+    it('should_not_display_body_section_when_body_is_absent', async () => {
+      await init(
+        aLog({
+          steps: [fakeHealthCheckStep({ response: { status: 503, body: undefined, headers: {} } })],
+        }),
+      );
+
+      expect(await harness.hasBodySection()).toBe(false);
+    });
+
+    it('should_display_one_section_per_step_when_multiple_steps', async () => {
+      await init(
+        aLog({
+          steps: [fakeHealthCheckStep({ name: 'first-step' }), fakeHealthCheckStep({ name: 'second-step' })],
+        }),
+      );
+
+      expect(await harness.getStepCount()).toEqual(2);
+      expect(await harness.getStepNames()).toEqual(['first-step', 'second-step']);
+    });
+
+    it('should_display_empty_state_when_no_steps', async () => {
+      await init(aLog({ steps: [] }));
+
+      expect(await harness.getStepCount()).toEqual(0);
+      expect(await harness.hasNoDetailsMessage()).toBe(true);
+    });
+
+    it('should_display_empty_state_when_steps_are_undefined', async () => {
+      await init(aLog({ steps: undefined }));
+
+      expect(await harness.hasNoDetailsMessage()).toBe(true);
+    });
+
+    it('should_not_render_message_row_when_message_is_absent', async () => {
+      await init(aLog({ steps: [fakeHealthCheckStep({ message: undefined })] }));
+
+      expect(await harness.getStepMessages()).toEqual([]);
+    });
+  });
+
+  describe('closing', () => {
+    beforeEach(async () => await init(aLog()));
+
+    it('should_close_dialog_when_close_button_clicked', async () => {
+      await harness.close();
+
+      expect(TestBed.inject(MatDialogRef).close).toHaveBeenCalled();
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.component.spec.ts
@@ -66,7 +66,7 @@ describe('FailedHealthCheckDetailsDialogComponent', () => {
 
     it('should_display_request_method_and_uri', async () => {
       expect(await harness.getRequestMethod()).toEqual('get');
-      expect(await harness.getRequestUri()).toEqual('http://backend:8080/_health');
+      expect(await harness.getRequestUri()).toEqual('https://backend:8080/_health');
     });
 
     it('should_display_request_headers', async () => {
@@ -97,7 +97,7 @@ describe('FailedHealthCheckDetailsDialogComponent', () => {
           steps: [
             fakeHealthCheckStep({
               request: {
-                uri: 'http://backend:8080/_health',
+                uri: 'https://backend:8080/_health',
                 method: 'GET',
                 headers: {
                   Authorization: 'Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature',
@@ -140,7 +140,7 @@ describe('FailedHealthCheckDetailsDialogComponent', () => {
         aLog({
           steps: [
             fakeHealthCheckStep({
-              request: { uri: 'http://backend:8080/_health', method: 'GET', headers: {} },
+              request: { uri: 'https://backend:8080/_health', method: 'GET', headers: {} },
               response: { status: 503, body: 'Service Unavailable', headers: {} },
             }),
           ],

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.component.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { LowerCasePipe } from '@angular/common';
+
+import { MaskSensitiveHeaderPipe } from './mask-sensitive-header.pipe';
+
+import { HealthCheckLog, HealthCheckStep } from '../../../../../../entities/management-api-v2/api/v4/healthCheck';
+import { BodyAccordionModule } from '../../../../api-traffic-v4/runtime-logs-details/components/components/api-runtime-logs-connection-log-details/components/response-body-accordion';
+
+export type FailedHealthCheckDetailsDialogData = HealthCheckLog;
+
+interface HeaderEntry {
+  name: string;
+  value: string;
+}
+
+interface StepViewModel {
+  step: HealthCheckStep;
+  requestHeaders: HeaderEntry[];
+  responseHeaders: HeaderEntry[];
+}
+
+function extractHeaderEntries(headers: Record<string, string> | undefined): HeaderEntry[] {
+  return Object.entries(headers ?? {}).map(([name, value]) => ({ name, value }));
+}
+
+@Component({
+  selector: 'failed-health-check-details-dialog',
+  imports: [MatDialogModule, MatButtonModule, MatExpansionModule, LowerCasePipe, BodyAccordionModule, MaskSensitiveHeaderPipe],
+  templateUrl: './failed-health-check-details-dialog.component.html',
+  styleUrl: './failed-health-check-details-dialog.component.scss',
+})
+export class FailedHealthCheckDetailsDialogComponent {
+  protected readonly log: FailedHealthCheckDetailsDialogData = inject(MAT_DIALOG_DATA);
+
+  protected readonly steps: StepViewModel[] = (this.log?.steps ?? []).map(step => ({
+    step,
+    requestHeaders: extractHeaderEntries(step.request?.headers),
+    responseHeaders: extractHeaderEntries(step.response?.headers),
+  }));
+}

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.component.ts
@@ -41,6 +41,14 @@ function extractHeaderEntries(headers: Record<string, string> | undefined): Head
   return Object.entries(headers ?? {}).map(([name, value]) => ({ name, value }));
 }
 
+function toStepViewModel(step: HealthCheckStep): StepViewModel {
+  return {
+    step,
+    requestHeaders: extractHeaderEntries(step.request?.headers),
+    responseHeaders: extractHeaderEntries(step.response?.headers),
+  };
+}
+
 @Component({
   selector: 'failed-health-check-details-dialog',
   imports: [MatDialogModule, MatButtonModule, MatExpansionModule, LowerCasePipe, BodyAccordionModule, MaskSensitiveHeaderPipe],
@@ -50,9 +58,5 @@ function extractHeaderEntries(headers: Record<string, string> | undefined): Head
 export class FailedHealthCheckDetailsDialogComponent {
   protected readonly log: FailedHealthCheckDetailsDialogData = inject(MAT_DIALOG_DATA);
 
-  protected readonly steps: StepViewModel[] = (this.log?.steps ?? []).map(step => ({
-    step,
-    requestHeaders: extractHeaderEntries(step.request?.headers),
-    responseHeaders: extractHeaderEntries(step.response?.headers),
-  }));
+  protected readonly steps: StepViewModel[] = (this.log?.steps ?? []).map(toStepViewModel);
 }

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.harness.ts
@@ -24,18 +24,18 @@ export interface RenderedHeader {
 }
 
 export class FailedHealthCheckDetailsDialogHarness extends ComponentHarness {
-  static hostSelector = 'failed-health-check-details-dialog';
+  static readonly hostSelector = 'failed-health-check-details-dialog';
 
-  private closeButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="close-button"]' }));
+  private readonly closeButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="close-button"]' }));
 
-  private stepPanels = this.locatorForAll(MatExpansionPanelHarness);
-  private stepMessages = this.locatorForAll(DivHarness.with({ selector: '[data-testid="step-message"]' }));
+  private readonly stepPanels = this.locatorForAll(MatExpansionPanelHarness);
+  private readonly stepMessages = this.locatorForAll(DivHarness.with({ selector: '[data-testid="step-message"]' }));
 
-  private requestNoHeaders = this.locatorForAll(DivHarness.with({ selector: '[data-testid="request-no-headers"]' }));
-  private responseNoHeaders = this.locatorForAll(DivHarness.with({ selector: '[data-testid="response-no-headers"]' }));
+  private readonly requestNoHeaders = this.locatorForAll(DivHarness.with({ selector: '[data-testid="request-no-headers"]' }));
+  private readonly responseNoHeaders = this.locatorForAll(DivHarness.with({ selector: '[data-testid="response-no-headers"]' }));
 
-  private bodyAccordions = this.locatorForAll('body-accordion');
-  private noDetails = this.locatorForAll(DivHarness.with({ selector: '[data-testid="no-details"]' }));
+  private readonly bodyAccordions = this.locatorForAll('body-accordion');
+  private readonly noDetails = this.locatorForAll(DivHarness.with({ selector: '[data-testid="no-details"]' }));
 
   async getStepCount(): Promise<number> {
     return (await this.stepPanels()).length;

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/failed-health-check-details-dialog.harness.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatExpansionPanelHarness } from '@angular/material/expansion/testing';
+import { DivHarness } from '@gravitee/ui-particles-angular/testing';
+
+export interface RenderedHeader {
+  name: string;
+  value: string;
+}
+
+export class FailedHealthCheckDetailsDialogHarness extends ComponentHarness {
+  static hostSelector = 'failed-health-check-details-dialog';
+
+  private closeButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="close-button"]' }));
+
+  private stepPanels = this.locatorForAll(MatExpansionPanelHarness);
+  private stepMessages = this.locatorForAll(DivHarness.with({ selector: '[data-testid="step-message"]' }));
+
+  private requestNoHeaders = this.locatorForAll(DivHarness.with({ selector: '[data-testid="request-no-headers"]' }));
+  private responseNoHeaders = this.locatorForAll(DivHarness.with({ selector: '[data-testid="response-no-headers"]' }));
+
+  private bodyAccordions = this.locatorForAll('body-accordion');
+  private noDetails = this.locatorForAll(DivHarness.with({ selector: '[data-testid="no-details"]' }));
+
+  async getStepCount(): Promise<number> {
+    return (await this.stepPanels()).length;
+  }
+
+  async getStepNames(): Promise<string[]> {
+    const panels = await this.stepPanels();
+    return parallel(() => panels.map(panel => panel.getTitle()));
+  }
+
+  async getStepMessages(): Promise<string[]> {
+    return this.collectTexts(this.stepMessages);
+  }
+
+  async getSummaryValue(field: 'timestamp' | 'endpoint' | 'gateway' | 'response-time'): Promise<string> {
+    return this.getTextByTestId(`summary-${field}`);
+  }
+
+  async getRequestMethod(): Promise<string> {
+    return this.getTextByTestId('request-method');
+  }
+
+  async getRequestUri(): Promise<string> {
+    return this.getTextByTestId('request-uri');
+  }
+
+  async getResponseStatus(): Promise<string> {
+    return this.getTextByTestId('response-status');
+  }
+
+  async getRequestHeaders(): Promise<RenderedHeader[]> {
+    return this.collectHeaders('request-header');
+  }
+
+  async getResponseHeaders(): Promise<RenderedHeader[]> {
+    return this.collectHeaders('response-header');
+  }
+
+  async hasRequestNoHeadersMessage(): Promise<boolean> {
+    return (await this.requestNoHeaders()).length > 0;
+  }
+
+  async hasResponseNoHeadersMessage(): Promise<boolean> {
+    return (await this.responseNoHeaders()).length > 0;
+  }
+
+  async hasBodySection(): Promise<boolean> {
+    return (await this.bodyAccordions()).length > 0;
+  }
+
+  async hasNoDetailsMessage(): Promise<boolean> {
+    return (await this.noDetails()).length > 0;
+  }
+
+  async close(): Promise<void> {
+    return this.closeButton().then(button => button.click());
+  }
+
+  private async getTextByTestId(testId: string): Promise<string> {
+    const element = await this.locatorFor(DivHarness.with({ selector: `[data-testid="${testId}"]` }))();
+    return element.getText();
+  }
+
+  /** Name and value live in sibling elements, so they are collected separately then paired by position. */
+  private async collectHeaders(rowTestId: string): Promise<RenderedHeader[]> {
+    const names = await this.collectTexts(
+      this.locatorForAll(DivHarness.with({ selector: `[data-testid="${rowTestId}"] [data-testid="header-name"]` })),
+    );
+    const values = await this.collectTexts(
+      this.locatorForAll(DivHarness.with({ selector: `[data-testid="${rowTestId}"] [data-testid="header-value"]` })),
+    );
+
+    return names.map((name, index) => ({ name: name.replace(/:$/, ''), value: values[index] }));
+  }
+
+  private async collectTexts(locator: () => Promise<DivHarness[]>): Promise<string[]> {
+    const elements = await locator();
+    return parallel(() => elements.map(element => element.getText()));
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/mask-sensitive-header.pipe.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/mask-sensitive-header.pipe.spec.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MaskSensitiveHeaderPipe } from './mask-sensitive-header.pipe';
+
+describe('MaskSensitiveHeaderPipe', () => {
+  let pipe: MaskSensitiveHeaderPipe;
+
+  beforeEach(() => {
+    pipe = new MaskSensitiveHeaderPipe();
+  });
+
+  describe('non sensitive headers', () => {
+    it('should_return_value_untouched_for_non_sensitive_header', () => {
+      expect(pipe.transform('application/json', 'Content-Type')).toEqual('application/json');
+    });
+  });
+
+  describe('sensitive headers', () => {
+    it('should_mask_value_and_keep_known_scheme', () => {
+      expect(pipe.transform('Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature', 'Authorization')).toEqual('Bearer ••••••••ture');
+    });
+
+    it('should_mask_basic_scheme', () => {
+      expect(pipe.transform('Basic dXNlcjpwYXNzd29yZA==', 'Authorization')).toEqual('Basic ••••••••');
+    });
+
+    it('should_detect_sensitive_header_regardless_of_case', () => {
+      expect(pipe.transform('Bearer some-very-long-token-value', 'AUTHORIZATION')).toEqual('Bearer ••••••••alue');
+      expect(pipe.transform('some-very-long-api-key-value', 'X-Api-Key')).toEqual('••••••••alue');
+    });
+
+    it('should_mask_proxy_authorization', () => {
+      expect(pipe.transform('Bearer some-very-long-token-value', 'Proxy-Authorization')).toEqual('Bearer ••••••••alue');
+    });
+
+    it('should_mask_gravitee_api_key', () => {
+      expect(pipe.transform('some-very-long-api-key-value', 'X-Gravitee-Api-Key')).toEqual('••••••••alue');
+    });
+
+    it('should_mask_value_without_scheme', () => {
+      expect(pipe.transform('some-very-long-api-key-value', 'X-Api-Key')).toEqual('••••••••alue');
+    });
+
+    it('should_not_treat_unknown_first_token_as_a_scheme', () => {
+      expect(pipe.transform('NotAScheme some-very-long-token', 'Authorization')).toEqual('••••••••oken');
+    });
+  });
+
+  describe('decodable credentials', () => {
+    it('should_never_reveal_suffix_of_basic_credentials', () => {
+      // The suffix of a base64 credential decodes to the plaintext tail of the password.
+      expect(pipe.transform('Basic dXNlcjpwYXNzd29yZGxvbmdlbm91Z2g=', 'Authorization')).toEqual('Basic ••••••••');
+    });
+
+    it('should_never_reveal_suffix_of_unpadded_basic_credentials', () => {
+      // 'admin:SuperSecretPass123' is a multiple of three bytes, so its base64 carries no padding at all
+      // and the four trailing characters decode to exactly '123', the tail of the password.
+      expect(pipe.transform('Basic YWRtaW46U3VwZXJTZWNyZXRQYXNzMTIz', 'Authorization')).toEqual('Basic ••••••••');
+    });
+
+    it('should_never_reveal_suffix_of_padded_base64_value_without_scheme', () => {
+      expect(pipe.transform('dXNlcjpwYXNzd29yZGxvbmdlbm91Z2g=', 'X-Api-Key')).toEqual('••••••••');
+    });
+  });
+
+  describe('suffix threshold', () => {
+    it('should_not_reveal_suffix_when_secret_is_too_short', () => {
+      expect(pipe.transform('short-secret', 'X-Api-Key')).toEqual('••••••••');
+      expect(pipe.transform('Bearer short-secret', 'Authorization')).toEqual('Bearer ••••••••');
+    });
+
+    it('should_not_reveal_suffix_at_exactly_the_threshold', () => {
+      expect(pipe.transform('a'.repeat(20), 'X-Api-Key')).toEqual('••••••••');
+    });
+
+    it('should_reveal_suffix_when_secret_is_longer_than_threshold', () => {
+      expect(pipe.transform('a-secret-value-longer-than-threshold', 'X-Api-Key')).toEqual('••••••••hold');
+    });
+  });
+
+  describe('mask length', () => {
+    it('should_use_a_fixed_mask_length_whatever_the_secret_length', () => {
+      const short = pipe.transform('0123456789abcdefghijklmn', 'X-Api-Key');
+      const long = pipe.transform('0123456789abcdefghijklmn'.repeat(20), 'X-Api-Key');
+
+      expect(short).toEqual('••••••••klmn');
+      expect(long).toEqual('••••••••klmn');
+    });
+  });
+
+  describe('cookies', () => {
+    it('should_fully_mask_cookie_without_revealing_any_suffix', () => {
+      expect(pipe.transform('sessionId=some-very-long-session-value; theme=dark', 'Cookie')).toEqual('••••••••');
+    });
+
+    it('should_fully_mask_set_cookie_without_revealing_any_suffix', () => {
+      expect(pipe.transform('sessionId=some-very-long-session-value; HttpOnly', 'Set-Cookie')).toEqual('••••••••');
+    });
+  });
+
+  describe('empty values', () => {
+    it('should_return_empty_value_untouched', () => {
+      expect(pipe.transform('', 'Authorization')).toEqual('');
+      expect(pipe.transform(null, 'Authorization')).toEqual(null);
+      expect(pipe.transform(undefined, 'Authorization')).toEqual(undefined);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/mask-sensitive-header.pipe.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/mask-sensitive-header.pipe.ts
@@ -16,13 +16,13 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 /** Headers whose value is masked but whose authentication scheme and trailing characters stay readable. */
-const PARTIALLY_MASKED_HEADERS = ['authorization', 'proxy-authorization', 'x-api-key', 'x-gravitee-api-key'];
+const PARTIALLY_MASKED_HEADERS = new Set(['authorization', 'proxy-authorization', 'x-api-key', 'x-gravitee-api-key']);
 
 /** Headers masked entirely: they hold several name=value pairs, a partial reveal would be both unreadable and leaky. */
-const FULLY_MASKED_HEADERS = ['cookie', 'set-cookie'];
+const FULLY_MASKED_HEADERS = new Set(['cookie', 'set-cookie']);
 
 /** Schemes are not secret and are valuable when diagnosing a 401 (a Basic sent where a Bearer is expected). */
-const KNOWN_SCHEMES = ['bearer', 'basic', 'digest', 'apikey', 'negotiate'];
+const KNOWN_SCHEMES = new Set(['bearer', 'basic', 'digest', 'apikey', 'negotiate']);
 
 /** Fixed width: a mask sized on the real value would disclose the secret length. */
 const MASK = '••••••••';
@@ -38,7 +38,7 @@ const SCHEME_SEPARATOR = /^(\S+)\s+(\S.*)$/;
  * whatever the encoding looks like: a credential whose byte length is a multiple of three carries no
  * padding at all, and its trailing characters then decode to the exact tail of the password.
  */
-const DECODABLE_SCHEMES = ['basic'];
+const DECODABLE_SCHEMES = new Set(['basic']);
 
 /** Same reasoning for a value carrying no scheme: base64 padding is the only hint that it is decodable. */
 const PADDED_BASE64 = /^[A-Za-z0-9+/]+={1,2}$/;
@@ -52,21 +52,21 @@ export class MaskSensitiveHeaderPipe implements PipeTransform {
 
     const normalizedName = headerName?.toLowerCase();
 
-    if (FULLY_MASKED_HEADERS.includes(normalizedName)) {
+    if (FULLY_MASKED_HEADERS.has(normalizedName)) {
       return MASK;
     }
 
-    if (!PARTIALLY_MASKED_HEADERS.includes(normalizedName)) {
+    if (!PARTIALLY_MASKED_HEADERS.has(normalizedName)) {
       return value;
     }
 
     const [, scheme, credentials] = SCHEME_SEPARATOR.exec(value) ?? [];
-    const hasKnownScheme = scheme && KNOWN_SCHEMES.includes(scheme.toLowerCase());
+    const hasKnownScheme = scheme && KNOWN_SCHEMES.has(scheme.toLowerCase());
 
     const prefix = hasKnownScheme ? `${scheme} ` : '';
     const secret = hasKnownScheme ? credentials : value;
 
-    const isDecodable = hasKnownScheme ? DECODABLE_SCHEMES.includes(scheme.toLowerCase()) : PADDED_BASE64.test(secret);
+    const isDecodable = hasKnownScheme ? DECODABLE_SCHEMES.has(scheme.toLowerCase()) : PADDED_BASE64.test(secret);
     const suffix = !isDecodable && secret.length > MIN_LENGTH_FOR_SUFFIX ? secret.slice(-SUFFIX_LENGTH) : '';
 
     return `${prefix}${MASK}${suffix}`;

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/mask-sensitive-header.pipe.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/mask-sensitive-header.pipe.ts
@@ -61,12 +61,13 @@ export class MaskSensitiveHeaderPipe implements PipeTransform {
     }
 
     const [, scheme, credentials] = SCHEME_SEPARATOR.exec(value) ?? [];
-    const hasKnownScheme = scheme && KNOWN_SCHEMES.has(scheme.toLowerCase());
+    const normalizedScheme = scheme?.toLowerCase();
+    const hasKnownScheme = !!normalizedScheme && KNOWN_SCHEMES.has(normalizedScheme);
 
     const prefix = hasKnownScheme ? `${scheme} ` : '';
     const secret = hasKnownScheme ? credentials : value;
 
-    const isDecodable = hasKnownScheme ? DECODABLE_SCHEMES.has(scheme.toLowerCase()) : PADDED_BASE64.test(secret);
+    const isDecodable = hasKnownScheme ? DECODABLE_SCHEMES.has(normalizedScheme) : PADDED_BASE64.test(secret);
     const suffix = !isDecodable && secret.length > MIN_LENGTH_FOR_SUFFIX ? secret.slice(-SUFFIX_LENGTH) : '';
 
     return `${prefix}${MASK}${suffix}`;

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/mask-sensitive-header.pipe.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-check-details-dialog/mask-sensitive-header.pipe.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Pipe, PipeTransform } from '@angular/core';
+
+/** Headers whose value is masked but whose authentication scheme and trailing characters stay readable. */
+const PARTIALLY_MASKED_HEADERS = ['authorization', 'proxy-authorization', 'x-api-key', 'x-gravitee-api-key'];
+
+/** Headers masked entirely: they hold several name=value pairs, a partial reveal would be both unreadable and leaky. */
+const FULLY_MASKED_HEADERS = ['cookie', 'set-cookie'];
+
+/** Schemes are not secret and are valuable when diagnosing a 401 (a Basic sent where a Bearer is expected). */
+const KNOWN_SCHEMES = ['bearer', 'basic', 'digest', 'apikey', 'negotiate'];
+
+/** Fixed width: a mask sized on the real value would disclose the secret length. */
+const MASK = '••••••••';
+
+/** At or below this length, revealing the last characters would expose too large a share of the secret. */
+const MIN_LENGTH_FOR_SUFFIX = 20;
+const SUFFIX_LENGTH = 4;
+
+const SCHEME_SEPARATOR = /^(\S+)\s+(\S.*)$/;
+
+/**
+ * Basic encodes `user:password` in base64, so any revealed character decodes to plaintext. This holds
+ * whatever the encoding looks like: a credential whose byte length is a multiple of three carries no
+ * padding at all, and its trailing characters then decode to the exact tail of the password.
+ */
+const DECODABLE_SCHEMES = ['basic'];
+
+/** Same reasoning for a value carrying no scheme: base64 padding is the only hint that it is decodable. */
+const PADDED_BASE64 = /^[A-Za-z0-9+/]+={1,2}$/;
+
+@Pipe({ name: 'maskSensitiveHeader' })
+export class MaskSensitiveHeaderPipe implements PipeTransform {
+  transform(value: string | null | undefined, headerName: string): string | null | undefined {
+    if (!value) {
+      return value;
+    }
+
+    const normalizedName = headerName?.toLowerCase();
+
+    if (FULLY_MASKED_HEADERS.includes(normalizedName)) {
+      return MASK;
+    }
+
+    if (!PARTIALLY_MASKED_HEADERS.includes(normalizedName)) {
+      return value;
+    }
+
+    const [, scheme, credentials] = SCHEME_SEPARATOR.exec(value) ?? [];
+    const hasKnownScheme = scheme && KNOWN_SCHEMES.includes(scheme.toLowerCase());
+
+    const prefix = hasKnownScheme ? `${scheme} ` : '';
+    const secret = hasKnownScheme ? credentials : value;
+
+    const isDecodable = hasKnownScheme ? DECODABLE_SCHEMES.includes(scheme.toLowerCase()) : PADDED_BASE64.test(secret);
+    const suffix = !isDecodable && secret.length > MIN_LENGTH_FOR_SUFFIX ? secret.slice(-SUFFIX_LENGTH) : '';
+
+    return `${prefix}${MASK}${suffix}`;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-checks.component.html
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-checks.component.html
@@ -49,6 +49,27 @@
               <th mat-header-cell *matHeaderCellDef id="gateway">Gateway</th>
               <td mat-cell *matCellDef="let record">{{ record.gatewayId }}</td>
             </ng-container>
+            <ng-container matColumnDef="responseTime">
+              <th mat-header-cell *matHeaderCellDef id="responseTime">Response Time</th>
+              <td mat-cell *matCellDef="let record">{{ record.responseTime }}ms</td>
+            </ng-container>
+            <ng-container matColumnDef="actions">
+              <th mat-header-cell *matHeaderCellDef id="actions" class="card__table__actions"></th>
+              <td mat-cell *matCellDef="let record" class="card__table__actions">
+                <button
+                  mat-icon-button
+                  type="button"
+                  data-testid="view-details-button"
+                  aria-label="View failure details"
+                  [disabled]="!record.steps?.length"
+                  disabledInteractive
+                  [matTooltip]="record.steps?.length ? 'View failure details' : 'No details available for this probe'"
+                  (click)="openStepDetails(record)"
+                >
+                  <mat-icon svgIcon="gio:eye-empty"></mat-icon>
+                </button>
+              </td>
+            </ng-container>
 
             <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
             <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-checks.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-checks.component.scss
@@ -9,6 +9,11 @@
 
   &__table {
     padding: 0;
+
+    &__actions {
+      width: 56px;
+      text-align: right;
+    }
   }
 
   &__no-data {

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-checks.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-checks.component.spec.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader, parallel } from '@angular/cdk/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+
+import { FailedHealthChecksComponent } from './failed-health-checks.component';
+import { FailedHealthChecksHarness } from './failed-health-checks.harness';
+import { FailedHealthCheckDetailsDialogHarness } from './failed-health-check-details-dialog/failed-health-check-details-dialog.harness';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../shared/testing';
+import { fakeApiHealthCheckLogs, fakeHealthCheckStep } from '../../../../../entities/management-api-v2/api/v4/healthCheck.fixture';
+import { HealthCheckLogsResponse } from '../../../../../entities/management-api-v2/api/v4/healthCheck';
+
+describe('FailedHealthChecksComponent', () => {
+  const API_ID = 'api-id';
+
+  let fixture: ComponentFixture<FailedHealthChecksComponent>;
+  let componentHarness: FailedHealthChecksHarness;
+  let httpTestingController: HttpTestingController;
+  let rootLoader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FailedHealthChecksComponent, NoopAnimationsModule, GioTestingModule, MatIconTestingModule],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { params: { apiId: API_ID } } },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FailedHealthChecksComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, FailedHealthChecksHarness);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    fixture.autoDetectChanges(true);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  function expectGetApiHealthCheckLogs(response: HealthCheckLogsResponse = fakeApiHealthCheckLogs()) {
+    const url = `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/health/logs`;
+    httpTestingController.expectOne(request => request.method === 'GET' && request.url.startsWith(url)).flush(response);
+  }
+
+  describe('table columns', () => {
+    it('should_display_response_time_and_actions_columns', async () => {
+      expectGetApiHealthCheckLogs();
+
+      const table = await componentHarness.tableHarness();
+      const headerRows = await table.getHeaderRows();
+      const headerCells = await parallel(() => headerRows.map(row => row.getCellTextByColumnName()));
+
+      expect(headerCells).toEqual([
+        {
+          timestamp: 'Timestamp',
+          endpoint: 'Endpoint',
+          gateway: 'Gateway',
+          responseTime: 'Response Time',
+          actions: '',
+        },
+      ]);
+    });
+
+    it('should_display_response_time_in_milliseconds', async () => {
+      expectGetApiHealthCheckLogs();
+
+      const table = await componentHarness.tableHarness();
+      const rows = await table.getRows();
+      const rowCells = await parallel(() => rows.map(row => row.getCellTextByColumnName()));
+
+      expect(rowCells[0].responseTime).toEqual('150ms');
+    });
+  });
+
+  describe('view details button', () => {
+    it('should_enable_view_details_button_when_log_has_steps', async () => {
+      expectGetApiHealthCheckLogs();
+
+      expect(await componentHarness.getViewDetailsButtonCount()).toEqual(1);
+      expect(await componentHarness.isViewDetailsButtonDisabled(0)).toBe(false);
+    });
+
+    it('should_disable_view_details_button_when_steps_are_empty', async () => {
+      const logs = fakeApiHealthCheckLogs();
+      expectGetApiHealthCheckLogs({ ...logs, data: [{ ...logs.data[0], steps: [] }] });
+
+      expect(await componentHarness.getViewDetailsButtonCount()).toEqual(1);
+      expect(await componentHarness.isViewDetailsButtonDisabled(0)).toBe(true);
+    });
+
+    it('should_disable_view_details_button_when_steps_are_undefined', async () => {
+      const logs = fakeApiHealthCheckLogs();
+      expectGetApiHealthCheckLogs({ ...logs, data: [{ ...logs.data[0], steps: undefined }] });
+
+      expect(await componentHarness.isViewDetailsButtonDisabled(0)).toBe(true);
+    });
+
+    it('should_explain_through_tooltip_why_disabled_button_cannot_be_used', async () => {
+      const logs = fakeApiHealthCheckLogs();
+      expectGetApiHealthCheckLogs({ ...logs, data: [{ ...logs.data[0], steps: [] }] });
+
+      expect(await componentHarness.getViewDetailsTooltip(0)).toEqual('No details available for this probe');
+    });
+
+    it('should_keep_disabled_button_hoverable_so_its_tooltip_stays_reachable', async () => {
+      const logs = fakeApiHealthCheckLogs();
+      expectGetApiHealthCheckLogs({ ...logs, data: [{ ...logs.data[0], steps: [] }] });
+
+      // A native `disabled` attribute would suppress pointer events in a real browser and kill the tooltip.
+      expect(await componentHarness.getViewDetailsDisabledAttributes(0)).toEqual({
+        nativeDisabled: null,
+        ariaDisabled: 'true',
+      });
+    });
+
+    it('should_not_open_dialog_when_disabled_button_is_clicked', async () => {
+      const logs = fakeApiHealthCheckLogs();
+      expectGetApiHealthCheckLogs({ ...logs, data: [{ ...logs.data[0], steps: [] }] });
+
+      await componentHarness.clickViewDetails(0);
+
+      expect(await rootLoader.getAllHarnesses(FailedHealthCheckDetailsDialogHarness)).toHaveLength(0);
+    });
+  });
+
+  describe('details dialog', () => {
+    it('should_open_details_dialog_with_log_data_when_clicking_view_details', async () => {
+      const logs = fakeApiHealthCheckLogs();
+      expectGetApiHealthCheckLogs({
+        ...logs,
+        data: [{ ...logs.data[0], steps: [fakeHealthCheckStep({ name: 'probe-step' })] }],
+      });
+
+      await componentHarness.clickViewDetails(0);
+
+      const dialog = await rootLoader.getHarness(FailedHealthCheckDetailsDialogHarness);
+      expect(await dialog.getStepNames()).toEqual(['probe-step']);
+      expect(await dialog.getSummaryValue('endpoint')).toEqual('sample-endpoint-name');
+
+      await dialog.close();
+    });
+
+    it('should_not_trigger_additional_http_call_when_opening_details_dialog', async () => {
+      expectGetApiHealthCheckLogs();
+
+      await componentHarness.clickViewDetails(0);
+
+      const dialog = await rootLoader.getHarness(FailedHealthCheckDetailsDialogHarness);
+      httpTestingController.verify();
+      await dialog.close();
+    });
+  });
+
+  describe('empty state', () => {
+    it('should_display_no_logs_row_when_response_is_empty', async () => {
+      expectGetApiHealthCheckLogs(
+        fakeApiHealthCheckLogs({
+          data: [],
+          pagination: { totalCount: 0, page: 1, pageCount: 0, pageItemsCount: 0, perPage: 10 },
+        }),
+      );
+
+      const table = await componentHarness.tableHarness();
+      expect(await table.getRows()).toHaveLength(0);
+      expect(await componentHarness.getViewDetailsButtonCount()).toEqual(0);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-checks.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-checks.component.ts
@@ -14,31 +14,52 @@
  * limitations under the License.
  */
 
-import { Component, DestroyRef, OnInit, signal } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
-import { GioLoaderModule } from '@gravitee/ui-particles-angular';
+import { GioIconsModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
 import { ActivatedRoute } from '@angular/router';
 import { MatSort } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { AsyncPipe } from '@angular/common';
 import { catchError, distinctUntilChanged, tap } from 'rxjs/operators';
 import { BehaviorSubject, combineLatestWith, EMPTY, Observable, switchMap } from 'rxjs';
 import { isEqual } from 'lodash';
+
+import {
+  FailedHealthCheckDetailsDialogComponent,
+  FailedHealthCheckDetailsDialogData,
+} from './failed-health-check-details-dialog/failed-health-check-details-dialog.component';
 
 import { GioChartLineModule } from '../../../../../shared/components/gio-chart-line/gio-chart-line.module';
 import { ApiHealthV2Service } from '../../../../../services-ngx/api-health-v2.service';
 import { GioTableWrapperModule } from '../../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { GioTableWrapperFilters } from '../../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
-import { HealthCheckLogsResponse } from '../../../../../entities/management-api-v2/api/v4/healthCheck';
+import { HealthCheckLog, HealthCheckLogsResponse } from '../../../../../entities/management-api-v2/api/v4/healthCheck';
 
 @Component({
-  imports: [MatCardModule, GioLoaderModule, GioChartLineModule, AsyncPipe, GioTableWrapperModule, MatSort, MatTableModule],
+  imports: [
+    MatCardModule,
+    GioLoaderModule,
+    GioIconsModule,
+    GioChartLineModule,
+    AsyncPipe,
+    GioTableWrapperModule,
+    MatSort,
+    MatTableModule,
+    MatButtonModule,
+    MatTooltipModule,
+  ],
   selector: 'failed-health-checks',
   styleUrl: './failed-health-checks.component.scss',
   templateUrl: './failed-health-checks.component.html',
 })
 export class FailedHealthChecksComponent implements OnInit {
+  private readonly matDialog = inject(MatDialog);
+
   isLoading = signal(true);
 
   defaultFilters: GioTableWrapperFilters = {
@@ -51,7 +72,7 @@ export class FailedHealthChecksComponent implements OnInit {
   private apiId = this.activatedRoute.snapshot.params.apiId;
   private showSuccessLogs = false;
 
-  protected displayedColumns: string[] = ['timestamp', 'endpoint', 'gateway'];
+  protected displayedColumns: string[] = ['timestamp', 'endpoint', 'gateway', 'responseTime', 'actions'];
 
   protected logs$: Observable<HealthCheckLogsResponse>;
 
@@ -90,5 +111,21 @@ export class FailedHealthChecksComponent implements OnInit {
 
   onFiltersChanged(filters: GioTableWrapperFilters) {
     this.filters$.next({ ...this.filters$.value, ...filters });
+  }
+
+  openStepDetails(log: HealthCheckLog) {
+    // The button is `disabledInteractive` so its tooltip stays reachable, which means it still emits click events.
+    if (!log.steps?.length) {
+      return;
+    }
+
+    this.matDialog.open<FailedHealthCheckDetailsDialogComponent, FailedHealthCheckDetailsDialogData, void>(
+      FailedHealthCheckDetailsDialogComponent,
+      {
+        data: log,
+        width: '800px',
+        autoFocus: false,
+      },
+    );
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-checks.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-checks.harness.ts
@@ -20,9 +20,9 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatTooltipHarness } from '@angular/material/tooltip/testing';
 
 export class FailedHealthChecksHarness extends ComponentHarness {
-  static hostSelector = 'failed-health-checks';
+  static readonly hostSelector = 'failed-health-checks';
 
-  private viewDetailsButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[data-testid="view-details-button"]' }));
+  private readonly viewDetailsButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[data-testid="view-details-button"]' }));
 
   async getTitle(): Promise<string> {
     const el = await this.locatorFor(MatCardHarness)();
@@ -34,7 +34,7 @@ export class FailedHealthChecksHarness extends ComponentHarness {
     return el.getSubtitleText();
   }
 
-  public tableHarness = this.locatorForOptional(MatTableHarness);
+  public readonly tableHarness = this.locatorForOptional(MatTableHarness);
 
   async getViewDetailsButtonCount(): Promise<number> {
     return (await this.viewDetailsButtons()).length;

--- a/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-checks.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check-dashboard-v4/components/failed-health-checks/failed-health-checks.harness.ts
@@ -16,9 +16,13 @@
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
 import { MatCardHarness } from '@angular/material/card/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatTooltipHarness } from '@angular/material/tooltip/testing';
 
 export class FailedHealthChecksHarness extends ComponentHarness {
   static hostSelector = 'failed-health-checks';
+
+  private viewDetailsButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[data-testid="view-details-button"]' }));
 
   async getTitle(): Promise<string> {
     const el = await this.locatorFor(MatCardHarness)();
@@ -31,4 +35,38 @@ export class FailedHealthChecksHarness extends ComponentHarness {
   }
 
   public tableHarness = this.locatorForOptional(MatTableHarness);
+
+  async getViewDetailsButtonCount(): Promise<number> {
+    return (await this.viewDetailsButtons()).length;
+  }
+
+  async isViewDetailsButtonDisabled(rowIndex: number): Promise<boolean> {
+    const buttons = await this.viewDetailsButtons();
+    return buttons[rowIndex].isDisabled();
+  }
+
+  async clickViewDetails(rowIndex: number): Promise<void> {
+    const buttons = await this.viewDetailsButtons();
+    return buttons[rowIndex].click();
+  }
+
+  /** Scoped by selector: the paginator buttons carry tooltips too, so a bare lookup would not be row-aligned. */
+  async getViewDetailsTooltip(rowIndex: number): Promise<string> {
+    const tooltips = await this.locatorForAll(MatTooltipHarness.with({ selector: '[data-testid="view-details-button"]' }))();
+    await tooltips[rowIndex].show();
+
+    return tooltips[rowIndex].getTooltipText();
+  }
+
+  /**
+   * A natively disabled button suppresses pointer events in a real browser, which would silently kill its
+   * tooltip. jsdom does not reproduce that, so the guarantee is asserted structurally instead.
+   */
+  async getViewDetailsDisabledAttributes(rowIndex: number): Promise<{ nativeDisabled: string | null; ariaDisabled: string | null }> {
+    const host = await (await this.viewDetailsButtons())[rowIndex].host();
+    return {
+      nativeDisabled: await host.getAttribute('disabled'),
+      ariaDisabled: await host.getAttribute('aria-disabled'),
+    };
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-76

## Description

Aligns the V4 Health Check dashboard with V2: adds a **Response Time** column and an eye button on the **Failed Health Checks** widget, opening a dialog with the probe's request, response, status and assertion message. Sensitive headers (Authorization, API keys, cookies) are masked. Also fixes `HealthCheckStep.success` typing (string → boolean).

The management API already returned these details in `steps[]`; the console just didn't render them.

## Additional context

<img width="1495" height="856" alt="Capture d’écran 2026-07-22 à 14 37 48" src="https://github.com/user-attachments/assets/63c81dc8-518d-4f79-8313-f83176b3a8e0" />