### PR TITLE
fix(gateway): keep deploying an API when an encrypted property value is malformed

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/deployer/ApiDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/deployer/ApiDeployer.java
@@ -80,7 +80,11 @@ public class ApiDeployer extends AbstractApiDeployer<Api> {
                     property.setValue(dataEncryptor.decrypt(property.getValue()));
                     property.setEncrypted(false);
                     properties.getValues().put(property.getKey(), property.getValue());
-                } catch (GeneralSecurityException e) {
+                } catch (GeneralSecurityException | RuntimeException e) {
+                    // Any failure to decrypt a single property (bad key/padding -> GeneralSecurityException,
+                    // or a malformed non-base64 value -> IllegalArgumentException) must stay confined to this
+                    // property. It is logged and the property is left as-is so a single corrupted value cannot
+                    // fail the whole API deployment and, on the initial sync, keep the node not-ready forever.
                     log.error("Error decrypting API property value for key {}", property.getKey(), e);
                 }
             }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/deployer/AbstractApiDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/deployer/AbstractApiDeployer.java
@@ -64,7 +64,11 @@ public abstract class AbstractApiDeployer<T extends ReactableApi<?>> implements 
                 try {
                     property.setValue(dataEncryptor.decrypt(property.getValue()));
                     property.setEncrypted(false);
-                } catch (GeneralSecurityException e) {
+                } catch (GeneralSecurityException | RuntimeException e) {
+                    // Any failure to decrypt a single property (bad key/padding -> GeneralSecurityException,
+                    // or a malformed non-base64 value -> IllegalArgumentException) must stay confined to this
+                    // property. It is logged and the property is left as-is so a single corrupted value cannot
+                    // fail the whole API deployment and, on the initial sync, keep the node not-ready forever.
                     log.error("Error decrypting API property value for key {}", property.getKey(), e);
                 }
             }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/deployer/ApiDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/deployer/ApiDeployerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.manager.deployer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.definition.model.Properties;
+import io.gravitee.definition.model.Property;
+import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.handlers.api.definition.Api;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class ApiDeployerTest {
+
+    @Mock
+    private DataEncryptor dataEncryptor;
+
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
+
+    private ApiDeployer cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new ApiDeployer(gatewayConfiguration, dataEncryptor);
+    }
+
+    @SneakyThrows
+    @Test
+    void should_decrypt_properties_on_initialize() {
+        final Api api = buildApiWithProperties(new Property("key1", "value1", true), new Property("key2", "value2", false));
+        when(dataEncryptor.decrypt("value1")).thenReturn("VALUE1");
+
+        cut.initialize(api);
+
+        assertThat(api.getDefinition().getProperties().getProperties()).containsExactly(
+            new Property("key1", "VALUE1", false),
+            new Property("key2", "value2", false)
+        );
+    }
+
+    @SneakyThrows
+    @Test
+    void should_not_fail_initialize_when_an_encrypted_property_value_is_malformed() {
+        // Reproduces a corrupted definition where an encrypted property holds a non-base64 value (e.g. a "***"
+        // display mask persisted with encrypted=true). DataEncryptor.decrypt base64-decodes before the AES step,
+        // so it throws an unchecked IllegalArgumentException rather than a GeneralSecurityException. This must not
+        // escape decryptProperties: otherwise the whole API deployment fails and, on the initial sync, the node
+        // stays not-ready forever (see fix #18650).
+        final Api api = buildApiWithProperties(new Property("bad", "***", true), new Property("good", "value2", true));
+        when(dataEncryptor.decrypt("***")).thenThrow(new IllegalArgumentException("Illegal base64 character 2a"));
+        when(dataEncryptor.decrypt("value2")).thenReturn("VALUE2");
+
+        // Must not throw.
+        cut.initialize(api);
+
+        assertThat(api.getDefinition().getProperties().getProperties()).containsExactly(
+            // Malformed property is left untouched (still encrypted) instead of breaking the deployment.
+            new Property("bad", "***", true),
+            // Other properties are still decrypted normally.
+            new Property("good", "VALUE2", false)
+        );
+    }
+
+    private Api buildApiWithProperties(final Property... properties) {
+        final io.gravitee.definition.model.Api definition = new io.gravitee.definition.model.Api();
+        definition.setProperties(new Properties(List.of(properties)));
+        return new Api(definition);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/deployer/NativeApiDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/deployer/NativeApiDeployerTest.java
@@ -95,4 +95,36 @@ class NativeApiDeployerTest {
             Property.builder().key("key3").value("value3").encrypted(false).build()
         );
     }
+
+    @SneakyThrows
+    @Test
+    void should_not_fail_initialize_when_an_encrypted_property_value_is_malformed() {
+        // Reproduces a corrupted definition where an encrypted property holds a non-base64 value (e.g. a "***"
+        // display mask persisted with encrypted=true). DataEncryptor.decrypt base64-decodes before the AES step,
+        // so it throws an unchecked IllegalArgumentException rather than a GeneralSecurityException. This must not
+        // escape decryptProperties: otherwise the whole API deployment fails and, on the initial sync, the node
+        // stays not-ready forever (see fix #18650).
+        final NativeApi nativeApi = new NativeApi(
+            io.gravitee.definition.model.v4.nativeapi.NativeApi.builder()
+                .properties(
+                    List.of(
+                        Property.builder().key("bad").value("***").encrypted(true).build(),
+                        Property.builder().key("good").value("value2").encrypted(true).build()
+                    )
+                )
+                .build()
+        );
+        when(dataEncryptor.decrypt("***")).thenThrow(new IllegalArgumentException("Illegal base64 character 2a"));
+        when(dataEncryptor.decrypt("value2")).thenReturn("VALUE2");
+
+        // Must not throw.
+        cut.initialize(nativeApi);
+
+        assertThat(nativeApi.getDefinition().getProperties()).containsExactly(
+            // Malformed property is left untouched (still encrypted) instead of breaking the deployment.
+            Property.builder().key("bad").value("***").encrypted(true).build(),
+            // Other properties are still decrypted normally.
+            Property.builder().key("good").value("VALUE2").encrypted(false).build()
+        );
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>guava</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Gravitee.io dependencies -->
         <dependency>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/SyncErrors.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/SyncErrors.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.common;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+/**
+ * Classification of synchronization failures shared by the repository and distributed sync paths.
+ *
+ * @author GraviteeSource Team
+ */
+public final class SyncErrors {
+
+    private SyncErrors() {}
+
+    /**
+     * A failure is transient (retryable) when a repository {@link TechnicalException} appears anywhere in its
+     * cause chain: the backing store was momentarily unreachable and a later attempt can succeed. Every other
+     * failure is deterministic and would fail identically on retry, so it is treated as permanent.
+     * <p>
+     * The whole chain is scanned (not only the most-specific cause): a {@link TechnicalException} usually
+     * wraps the underlying driver exception (Mongo/JDBC/...), so the innermost cause is not the one we test.
+     */
+    public static boolean isTransient(final Throwable throwable) {
+        return ExceptionUtils.throwableOfType(throwable, TechnicalException.class) != null;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/AbstractDistributedSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/AbstractDistributedSynchronizer.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.services.sync.process.distributed.synchronizer;
 
+import io.gravitee.gateway.services.sync.process.common.SyncErrors;
 import io.gravitee.gateway.services.sync.process.common.deployer.Deployer;
 import io.gravitee.gateway.services.sync.process.common.model.Deployable;
 import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
@@ -67,9 +68,9 @@ public abstract class AbstractDistributedSynchronizer<T extends Deployable, Y ex
                     .runOn(Schedulers.from(syncDeployerExecutor))
                     .flatMap(deployable -> {
                         if (deployable.syncAction() == SyncAction.DEPLOY) {
-                            return deploy(deployer, deployable);
+                            return deploy(deployer, deployable).onErrorResumeNext(throwable -> resumeOnError(initialSync, throwable));
                         } else if (deployable.syncAction() == SyncAction.UNDEPLOY) {
-                            return undeploy(deployer, deployable);
+                            return undeploy(deployer, deployable).onErrorResumeNext(throwable -> resumeOnError(initialSync, throwable));
                         } else {
                             return Flowable.empty();
                         }
@@ -110,5 +111,20 @@ public abstract class AbstractDistributedSynchronizer<T extends Deployable, Y ex
 
     private Flowable<T> undeploy(final Y apiDeployer, final T deployable) {
         return apiDeployer.undeploy(deployable).andThen(apiDeployer.doAfterUndeployment(deployable)).andThen(Flowable.just(deployable));
+    }
+
+    /**
+     * Mirrors the repository sync error handling (see {@code AbstractApiSynchronizer}) for the distributed
+     * path: a transient failure (a repository {@code TechnicalException} in the cause chain) on the initial
+     * sync fails the sync so the secondary node stays not-ready and retries, while a permanent failure (or any
+     * failure on an incremental sync) isolates the offending entity so a single poison event cannot block the
+     * whole distributed synchronization.
+     */
+    private Flowable<T> resumeOnError(final boolean initialSync, final Throwable throwable) {
+        if (initialSync && SyncErrors.isTransient(throwable)) {
+            return Flowable.error(throwable);
+        }
+        log.error("An error occurred while (un)deploying a distributed event during synchronization", throwable);
+        return Flowable.empty();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/AbstractApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/AbstractApiSynchronizer.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.services.sync.process.repository.synchronizer.api;
 
 import io.gravitee.gateway.handlers.api.manager.ActionOnApi;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
+import io.gravitee.gateway.services.sync.process.common.SyncErrors;
 import io.gravitee.gateway.services.sync.process.common.deployer.ApiDeployer;
 import io.gravitee.gateway.services.sync.process.common.deployer.ApiKeyDeployer;
 import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
@@ -182,17 +183,29 @@ public abstract class AbstractApiSynchronizer {
     }
 
     /**
-     * On the initial sync the gateway has no routing table yet: a failed (un)deployment must fail the
-     * whole sync so the node stays not-ready (sync-process probe) and retries, instead of being marked
-     * ready with a partial or empty deployment. On incremental syncs a single failing API is isolated
-     * (logged and skipped) so it does not tear down an already-serving node.
+     * Decides how a failed (un)deployment affects the synchronization, mirroring the transient-vs-permanent
+     * distinction the mapper/enrichment layer already applies (see {@code ApiMapper#to} and
+     * {@code EnvironmentService}):
+     * <ul>
+     *   <li><b>Transient failure</b> (a repository {@code TechnicalException} in the cause chain, i.e. the
+     *   backing store is momentarily unreachable): on the initial sync the gateway has no routing table yet,
+     *   so the sync must fail to keep the node not-ready (sync-process probe) and retry. It self-heals once
+     *   the store recovers.</li>
+     *   <li><b>Permanent failure</b> (malformed definition, invalid configuration, undecryptable property...):
+     *   retrying would fail identically, so the offending API is isolated (logged and skipped) even on the
+     *   initial sync. This lets every other API deploy and the node become ready instead of a single broken
+     *   API blocking the whole gateway startup forever.</li>
+     * </ul>
+     * On incremental syncs a single failing API is always isolated so it does not tear down an
+     * already-serving node.
      */
     private Flowable<ApiReactorDeployable> resumeOnDeployError(final boolean initialSync, final Throwable throwable) {
-        if (initialSync) {
+        if (initialSync && SyncErrors.isTransient(throwable)) {
             // Fail the sync; the error is logged once by the sync manager's error handler.
             return Flowable.error(throwable);
         }
-        // Incremental sync: isolate the failing API. Log here since the error is swallowed.
+        // Permanent failure on the initial sync, or any failure on an incremental sync: isolate the failing
+        // API. Log here since the error is swallowed.
         log.error("An error occurred while (un)deploying an API during synchronization", throwable);
         return Flowable.empty();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/api/DistributedApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/api/DistributedApiSynchronizerTest.java
@@ -32,6 +32,7 @@ import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.services.sync.process.common.deployer.ApiDeployer;
 import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
+import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.distributed.fetcher.DistributedEventFetcher;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiKeyMapper;
 import io.gravitee.gateway.services.sync.process.distributed.mapper.ApiMapper;
@@ -39,6 +40,7 @@ import io.gravitee.gateway.services.sync.process.distributed.mapper.Subscription
 import io.gravitee.repository.distributedsync.model.DistributedEvent;
 import io.gravitee.repository.distributedsync.model.DistributedEventType;
 import io.gravitee.repository.distributedsync.model.DistributedSyncAction;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import java.time.Instant;
@@ -240,6 +242,56 @@ class DistributedApiSynchronizerTest {
 
             verify(apiDeployer).undeploy(any());
             verify(apiDeployer).doAfterUndeployment(any());
+        }
+    }
+
+    @Nested
+    class DeployFailureTest {
+
+        private DistributedEvent publishEvent() throws JsonProcessingException {
+            io.gravitee.definition.model.v4.Api api = new io.gravitee.definition.model.v4.Api();
+            api.setId("api");
+            api.setDefinitionVersion(DefinitionVersion.V4);
+            api.setType(ApiType.PROXY);
+            io.gravitee.gateway.reactive.handlers.api.v4.Api reactableApi = new io.gravitee.gateway.reactive.handlers.api.v4.Api(api);
+            return DistributedEvent.builder()
+                .id("api")
+                .payload(objectMapper.writeValueAsString(reactableApi))
+                .type(DistributedEventType.API)
+                .syncAction(DistributedSyncAction.DEPLOY)
+                .updatedAt(new Date())
+                .build();
+        }
+
+        @Test
+        void should_isolate_permanently_failing_api_on_initial_sync() throws InterruptedException, JsonProcessingException {
+            // A deterministic per-entity failure must not block the whole distributed sync of a secondary node.
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.just(publishEvent()));
+            when(apiDeployer.deploy(any())).thenReturn(Completable.error(new RuntimeException("deploy boom")));
+
+            cut.synchronize(-1L, Instant.now().toEpochMilli()).test().await().assertComplete();
+
+            verify(apiDeployer).deploy(any());
+        }
+
+        @Test
+        void should_fail_initial_sync_when_api_deployment_fails_transiently() throws InterruptedException, JsonProcessingException {
+            // A transient failure (repository momentarily unreachable) must keep the secondary node not-ready.
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.just(publishEvent()));
+            when(apiDeployer.deploy(any())).thenReturn(
+                Completable.error(new SyncException("An error occurred when trying to deploy api", new TechnicalException("bridge 502")))
+            );
+
+            cut.synchronize(-1L, Instant.now().toEpochMilli()).test().await().assertError(SyncException.class);
+        }
+
+        @Test
+        void should_skip_failed_api_on_incremental_sync() throws InterruptedException, JsonProcessingException {
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.just(publishEvent()));
+            when(apiDeployer.deploy(any())).thenReturn(Completable.error(new RuntimeException("deploy boom")));
+
+            long now = Instant.now().toEpochMilli();
+            cut.synchronize(now, now).test().await().assertComplete();
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
@@ -399,12 +399,31 @@ class ApiSynchronizerTest {
         }
 
         @Test
-        void should_fail_initial_sync_when_api_deployment_fails() throws InterruptedException, JsonProcessingException {
+        void should_isolate_permanently_failing_api_on_initial_sync() throws InterruptedException, JsonProcessingException {
+            // A deterministic per-API failure (e.g. an undecryptable property, an invalid configuration) would
+            // fail identically on every retry: it must not block the whole initial sync. The offending API is
+            // isolated and the sync completes so the node can become ready and serve every other API.
             when(eventsFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(publishEvent())));
             when(apiManager.requiredActionFor(argThat(argument -> argument.getId().equals("api")))).thenReturn(ActionOnApi.DEPLOY);
             when(apiDeployer.deploy(any())).thenReturn(Completable.error(new RuntimeException("deploy boom")));
 
-            cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertError(RuntimeException.class);
+            // The sync completes (node becomes ready) instead of erroring: the broken API is isolated, not fatal.
+            cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
+
+            verify(apiDeployer).deploy(any());
+        }
+
+        @Test
+        void should_fail_initial_sync_when_api_deployment_fails_transiently() throws InterruptedException, JsonProcessingException {
+            // A transient failure (repository momentarily unreachable -> TechnicalException in the cause chain)
+            // can succeed later: the initial sync must fail so the node stays not-ready and retries.
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(publishEvent())));
+            when(apiManager.requiredActionFor(argThat(argument -> argument.getId().equals("api")))).thenReturn(ActionOnApi.DEPLOY);
+            when(apiDeployer.deploy(any())).thenReturn(
+                Completable.error(new SyncException("An error occurred when trying to deploy api", new TechnicalException("bridge 502")))
+            );
+
+            cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertError(SyncException.class);
         }
 
         @Test


### PR DESCRIPTION
## Problem

Since #18650 ("keep node not-ready when initial API sync fails"), a **single** un-deployable API bricks gateway startup: the initial sync fails, the node stays not-ready, and it retries forever without recovering.

Incident: a V4 API whose encrypted property value was persisted as a `***` display mask (`{"value":"***","encrypted":true}`). `DataEncryptor.decrypt()` base64-decodes before the AES step, so `***` throws an unchecked `IllegalArgumentException` ("Illegal base64 character 2a") — **not** a `GeneralSecurityException`:

```
SyncException: An error occurred when trying to deploy api ...
Caused by: java.lang.IllegalArgumentException: Illegal base64 character 2a
    at java.util.Base64$Decoder.decode
    at io.gravitee.common.util.DataEncryptor.decrypt(DataEncryptor.java:86)
    at ...AbstractApiDeployer.decryptProperties(AbstractApiDeployer.java:65)
```

Startup regressed between **4.11.20** (no #18650: error swallowed, API skipped, node came up) and **4.11.21** (#18650: any deploy error fails the whole initial sync).

## Fix — three commits

**1. `keep deploying an API when an encrypted property value is malformed`**
The per-property `try/catch` in both deployers (`AbstractApiDeployer` V4, `handlers/api/manager/deployer/ApiDeployer` V2) only caught `GeneralSecurityException`, so the unchecked base64 error escaped and failed the deployment. Widen the catch to also cover `RuntimeException`: a single undecryptable property is logged and left as-is, confined to that property (it was always meant to be confined — that is why the catch is inside the loop).

**2. `isolate a permanently-failing API on the initial sync instead of blocking the whole node`**
`AbstractApiSynchronizer.resumeOnDeployError` failed the initial sync on **any** error, without distinguishing transient from permanent — unlike the mapper/enrichment layer, where #18650 itself made `SyncException` = transient (retry) and everything else = permanent (skip). Align the deploy stage with that distinction, via a shared `SyncErrors.isTransient` classifier:

- **Transient** (a repository `TechnicalException` in the cause chain — store momentarily unreachable) → still fails the initial sync so the node stays not-ready and retries, self-healing once the store recovers. #18650's guarantee is preserved.
- **Permanent** (malformed definition, invalid config, undecryptable property...) → isolated (logged and skipped) even on the initial sync, so every deployable API comes up and the node becomes ready. A single broken API can no longer block the whole gateway.

> `isTransient` scans the whole cause chain (via `ExceptionUtils.throwableOfType`), not the most-specific cause: a `TechnicalException` usually wraps the driver exception (Mongo/JDBC), so `NestedExceptionUtils.getMostSpecificCause` would miss it and misclassify a transient failure as permanent.

**3. `isolate a permanently-failing entity on the distributed initial sync`**
The distributed sync path (`AbstractDistributedSynchronizer`, used by secondary nodes reading from the distributed store) had **no per-entity error isolation at all** — a single failing deployable aborted the whole distributed sync, on both initial and incremental. Since `DefaultSyncManager` gates readiness the same way, one poison event kept a secondary node not-ready forever. Apply the same `SyncErrors.isTransient` handling in the shared base class, so it covers **every** distributed entity type (api, api-key, subscription, dictionary, license, organization, ...).

> The corrupted value remains undecryptable at runtime (it resolves to its raw stored value). The data must be fixed management-side, and the write-path that persisted the `***` mask investigated separately.

## Tests

All validated both ways (fail on the previous behavior, pass with the fix):
- `NativeApiDeployerTest`, `ApiDeployerTest` (new) — a malformed encrypted value no longer fails `initialize()`.
- `ApiSynchronizerTest` — a **permanent** deploy failure now **completes** the initial sync (isolated); a **transient** `TechnicalException` still **fails** it (not-ready + retry). Existing bridge-502 and incremental-skip tests unchanged.
- `DistributedApiSynchronizerTest` — same permanent-isolated / transient-fails / incremental-skip coverage for the distributed path.

Full `gravitee-apim-gateway-services-sync` module green.
