### PR TITLE
fix(rest-api): emit audit log on parameter deletion (APIM-14773)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ParameterServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ParameterServiceImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.impl;
 
 import static io.gravitee.repository.management.model.Audit.AuditProperties.PARAMETER;
 import static io.gravitee.repository.management.model.Parameter.AuditEvent.PARAMETER_CREATED;
+import static io.gravitee.repository.management.model.Parameter.AuditEvent.PARAMETER_DELETED;
 import static io.gravitee.repository.management.model.Parameter.AuditEvent.PARAMETER_UPDATED;
 import static io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT;
 import static io.gravitee.rest.api.model.parameters.ParameterReferenceType.ORGANIZATION;
@@ -473,6 +474,7 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
                         key.key(),
                         refIdToUse,
                         ParameterReferenceType.valueOf(referenceType.name()),
+                        optionalParameter.get(),
                         executionContext
                     );
                     return null;
@@ -740,10 +742,11 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
         String refIdToUse = getEffectiveReferenceId(executionContext, referenceId, referenceType);
         ParameterReferenceType repositoryReferenceType = ParameterReferenceType.valueOf(referenceType.name());
         try {
-            if (parameterRepository.findById(key.key(), refIdToUse, repositoryReferenceType).isEmpty()) {
+            Parameter deletedParameter = parameterRepository.findById(key.key(), refIdToUse, repositoryReferenceType).orElse(null);
+            if (deletedParameter == null) {
                 return;
             }
-            deleteParameterAndInvalidateCache(key.key(), refIdToUse, repositoryReferenceType, executionContext);
+            deleteParameterAndInvalidateCache(key.key(), refIdToUse, repositoryReferenceType, deletedParameter, executionContext);
         } catch (TechnicalException ex) {
             throw new TechnicalManagementException(
                 "An error occurs while trying to delete parameter with key: " +
@@ -758,17 +761,30 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
     }
 
     /**
-     * Deletes a parameter and invalidates its cache locally and across the cluster. Shared by the value-less
-     * {@code save(...)} path and {@link #delete(ExecutionContext, Key, String, io.gravitee.rest.api.model.parameters.ParameterReferenceType)}
-     * so the delete + invalidation sequence stays in one place.
+     * Deletes a parameter, invalidates its cache locally and across the cluster, and audits the removal. Shared by the
+     * value-less {@code save(...)} path and {@link #delete(ExecutionContext, Key, String, io.gravitee.rest.api.model.parameters.ParameterReferenceType)}
+     * so the delete + invalidation + audit sequence stays in one place.
+     *
+     * @param deletedParameter the parameter as stored before removal, recorded as the audit log's old value
      */
     private void deleteParameterAndInvalidateCache(
         String key,
         String referenceId,
         ParameterReferenceType referenceType,
+        Parameter deletedParameter,
         ExecutionContext executionContext
     ) throws TechnicalException {
         parameterRepository.delete(key, referenceId, referenceType);
+        // Audited as soon as the removal is persisted: the audit records the durable fact, while the cache
+        // invalidation below is best-effort housekeeping that must not sit between the two.
+        auditService.createAuditLog(
+            executionContext,
+            AuditService.AuditLogData.builder()
+                .properties(singletonMap(PARAMETER, key))
+                .event(PARAMETER_DELETED)
+                .oldValue(deletedParameter)
+                .build()
+        );
         cache.invalidate(computeCacheKey(key, referenceId, referenceType));
         sendInvalidateParameterCacheCommand(key, referenceId, referenceType, executionContext);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ParameterServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ParameterServiceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.impl;
 
 import static io.gravitee.repository.management.model.Audit.AuditProperties.PARAMETER;
 import static io.gravitee.repository.management.model.Parameter.AuditEvent.PARAMETER_CREATED;
+import static io.gravitee.repository.management.model.Parameter.AuditEvent.PARAMETER_DELETED;
 import static io.gravitee.repository.management.model.Parameter.AuditEvent.PARAMETER_UPDATED;
 import static io.gravitee.rest.api.model.parameters.Key.*;
 import static java.util.Arrays.asList;
@@ -53,6 +54,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -1202,6 +1204,200 @@ public class ParameterServiceTest {
         );
 
         verify(parameterRepository).delete(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT);
+    }
+
+    /**
+     * Matches the audit log expected for the deletion of {@code expected}.
+     * <p>
+     * Both {@code equals} and {@code getValue} are asserted on purpose: {@link Parameter#equals(Object)} compares only
+     * key, referenceId and referenceType — {@code value} is deliberately excluded — so neither check alone would catch
+     * a regression that recorded a partially populated parameter.
+     */
+    private static boolean isDeletionAuditOf(AuditService.AuditLogData auditLogData, Parameter expected) {
+        // instanceof keeps the matcher null-safe: a null oldValue must fail the match, not throw inside argThat.
+        return (
+            auditLogData.getOldValue() instanceof Parameter oldValue &&
+            auditLogData.getProperties().equals(singletonMap(PARAMETER, expected.getKey())) &&
+            auditLogData.getEvent().equals(PARAMETER_DELETED) &&
+            oldValue.equals(expected) &&
+            Objects.equals(oldValue.getValue(), expected.getValue()) &&
+            auditLogData.getNewValue() == null
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = io.gravitee.rest.api.model.parameters.ParameterReferenceType.class, names = { "ENVIRONMENT", "ORGANIZATION" })
+    public void should_emit_audit_log_when_deleting_parameter_on_scope(
+        io.gravitee.rest.api.model.parameters.ParameterReferenceType referenceType
+    ) throws TechnicalException {
+        final ParameterReferenceType repositoryReferenceType = ParameterReferenceType.valueOf(referenceType.name());
+        final String previousValue = """
+            [{"domains":["airtel.com"],"from":"noreply@airtel.com","subject":"[Airtel] %s"}]""";
+        final Parameter existing = new Parameter();
+        existing.setKey(EMAIL_BRANDED_SENDERS.key());
+        existing.setReferenceId("DEFAULT");
+        existing.setReferenceType(repositoryReferenceType);
+        existing.setValue(previousValue);
+
+        when(parameterRepository.findById(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", repositoryReferenceType)).thenReturn(of(existing));
+
+        parameterService.delete(GraviteeContext.getExecutionContext(), EMAIL_BRANDED_SENDERS, "DEFAULT", referenceType);
+
+        verify(parameterRepository).delete(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", repositoryReferenceType);
+
+        // Note: the audit entry's own reference scope is derived by AuditServiceImpl from the ExecutionContext, not
+        // from the parameter's ParameterReferenceType — same as the create and update paths.
+        verify(auditService).createAuditLog(
+            eq(GraviteeContext.getExecutionContext()),
+            argThat(auditLogData -> isDeletionAuditOf(auditLogData, existing))
+        );
+    }
+
+    @Test
+    public void should_not_emit_audit_log_when_deleting_absent_parameter_on_scope() throws TechnicalException {
+        when(parameterRepository.findById(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(empty());
+
+        parameterService.delete(
+            GraviteeContext.getExecutionContext(),
+            EMAIL_BRANDED_SENDERS,
+            "DEFAULT",
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        verifyNoInteractions(auditService);
+    }
+
+    @Test
+    public void should_not_emit_audit_log_when_the_parameter_deletion_fails() throws TechnicalException {
+        final Parameter existing = new Parameter();
+        existing.setKey(EMAIL_BRANDED_SENDERS.key());
+        existing.setReferenceId("DEFAULT");
+        existing.setReferenceType(ParameterReferenceType.ENVIRONMENT);
+        existing.setValue("[]");
+
+        when(parameterRepository.findById(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(
+            of(existing)
+        );
+        doThrow(new TechnicalException("boom"))
+            .when(parameterRepository)
+            .delete(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT);
+
+        assertThrows(TechnicalManagementException.class, () ->
+            parameterService.delete(
+                GraviteeContext.getExecutionContext(),
+                EMAIL_BRANDED_SENDERS,
+                "DEFAULT",
+                io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+            )
+        );
+
+        // The audit log must never record a deletion that did not happen: it is emitted only after the
+        // repository delete succeeds.
+        verifyNoInteractions(auditService);
+    }
+
+    @Test
+    public void should_emit_audit_log_when_saving_a_null_value_deletes_the_parameter() throws TechnicalException {
+        final Parameter existing = new Parameter();
+        existing.setKey(PORTAL_TOP_APIS.key());
+        existing.setReferenceId("DEFAULT");
+        existing.setReferenceType(ParameterReferenceType.ENVIRONMENT);
+        existing.setValue("api1");
+
+        when(parameterRepository.findById(PORTAL_TOP_APIS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(of(existing));
+
+        parameterService.save(
+            GraviteeContext.getExecutionContext(),
+            PORTAL_TOP_APIS,
+            (String) null,
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        verify(auditService).createAuditLog(
+            eq(GraviteeContext.getExecutionContext()),
+            argThat(auditLogData -> isDeletionAuditOf(auditLogData, existing))
+        );
+    }
+
+    @Test
+    public void should_emit_audit_log_when_an_empty_list_collapses_to_a_deletion() throws TechnicalException {
+        final Parameter existing = new Parameter();
+        existing.setKey(PORTAL_TOP_APIS.key());
+        existing.setReferenceId("DEFAULT");
+        existing.setReferenceType(ParameterReferenceType.ENVIRONMENT);
+        existing.setValue("api1");
+
+        when(parameterRepository.findById(PORTAL_TOP_APIS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(of(existing));
+
+        // An empty list collapses to a null value, which flips the update branch to the delete branch — this is how
+        // TopApiServiceImpl.delete() removes the last remaining top API.
+        parameterService.save(
+            GraviteeContext.getExecutionContext(),
+            PORTAL_TOP_APIS,
+            List.of(),
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        verify(parameterRepository).delete(PORTAL_TOP_APIS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT);
+        verify(auditService).createAuditLog(
+            eq(GraviteeContext.getExecutionContext()),
+            argThat(auditLogData -> isDeletionAuditOf(auditLogData, existing))
+        );
+    }
+
+    @Test
+    public void should_not_delete_or_audit_when_a_null_value_is_saved_for_a_key_overridden_by_configuration() throws TechnicalException {
+        final Parameter existing = new Parameter();
+        existing.setKey(EMAIL_FROM.key());
+        existing.setReferenceId("DEFAULT");
+        existing.setReferenceType(ParameterReferenceType.ENVIRONMENT);
+        existing.setValue("stored@example.com");
+
+        when(parameterRepository.findById(EMAIL_FROM.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(of(existing));
+        when(environment.containsProperty(EMAIL_FROM.key())).thenReturn(true);
+        when(environment.getProperty(EMAIL_FROM.key())).thenReturn("yaml@example.com");
+
+        // The system-override guard runs before the delete branch, so a null value must not wipe the stored fallback
+        // behind a configuration-locked key.
+        parameterService.save(
+            GraviteeContext.getExecutionContext(),
+            EMAIL_FROM,
+            (String) null,
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        verify(parameterRepository, never()).delete(anyString(), anyString(), any());
+        verifyNoInteractions(auditService);
+    }
+
+    @Test
+    public void should_not_delete_or_audit_when_a_null_value_is_saved_for_branded_senders_configured_in_yaml() throws TechnicalException {
+        final Parameter existing = new Parameter();
+        existing.setKey(EMAIL_BRANDED_SENDERS.key());
+        existing.setReferenceId("DEFAULT");
+        existing.setReferenceType(ParameterReferenceType.ENVIRONMENT);
+        existing.setValue("[]");
+
+        when(parameterRepository.findById(EMAIL_BRANDED_SENDERS.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(
+            of(existing)
+        );
+        // containsProperty is false for a native yaml list, so the reader is the only guard for this key.
+        when(brandedSendersEnvironmentReader.read()).thenReturn(
+            Optional.of(
+                """
+                [{"domains":["airtel.com"],"from":"noreply@airtel.com","subject":"[Airtel] %s"}]"""
+            )
+        );
+
+        parameterService.save(
+            GraviteeContext.getExecutionContext(),
+            EMAIL_BRANDED_SENDERS,
+            (String) null,
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        verify(parameterRepository, never()).delete(anyString(), anyString(), any());
+        verifyNoInteractions(auditService);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14773

## Description

Parameter deletion emitted no audit entry. `ParameterServiceImpl` audited its create and update branches but not its delete branch, so removing a parameter left no trace.

Adds a `PARAMETER_DELETED` audit log to the shared delete helper, recording the stored parameter as the old value and `null` as the new value.

## Additional context

<img width="1264" height="607" alt="Screenshot 2026-07-22 at 10 42 35 PM" src="https://github.com/user-attachments/assets/0db47c4a-1772-4bd7-ba0d-db888f0d77c4" />

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

