### PR TITLE
feat(gamma): create dynamic dictionaries with HTTP provider and trigger

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/CreateDictionarySheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/CreateDictionarySheet.spec.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
-import { CreateDictionarySheet } from './CreateDictionarySheet';
 import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
+import { CreateDictionarySheet } from './CreateDictionarySheet';
 
 function renderSheet({
     open = true,
@@ -33,22 +33,41 @@ function renderSheet({
     return { onClose, onSubmit };
 }
 
+function selectType(typeLabel: 'Manual' | 'Dynamic') {
+    fireEvent.click(screen.getByLabelText(/^Type/));
+    fireEvent.click(screen.getByRole('option', { name: typeLabel }));
+}
+
 describe('CreateDictionarySheet', () => {
+    beforeEach(() => {
+        let id = 0;
+        Object.defineProperty(globalThis, 'crypto', {
+            configurable: true,
+            value: { randomUUID: () => `row-${++id}` },
+        });
+        Element.prototype.scrollIntoView = jest.fn();
+        global.ResizeObserver = class ResizeObserver {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as typeof ResizeObserver;
+    });
+
     it('does not show sheet content when closed', () => {
         renderSheet({ open: false });
         expect(querySheetHeading('Create Dictionary')).toBeNull();
     });
 
-    it('shows create title and no Key field', () => {
+    it('shows create title and type selector', () => {
         renderSheet();
         expect(screen.getByRole('heading', { name: 'Create Dictionary' })).not.toBeNull();
-        expect(screen.queryByText('Define a new manual dictionary with a name and description.')).not.toBeNull();
-        expect(screen.queryByLabelText(/^Key/)).toBeNull();
-        expect(screen.getByText('Type')).not.toBeNull();
-        expect(screen.getByText('Manual')).not.toBeNull();
+        expect(
+            screen.queryByText('Define a new dictionary. For dynamic dictionaries, configure the trigger and HTTP provider.'),
+        ).not.toBeNull();
+        expect(screen.getByLabelText(/^Type/)).not.toBeNull();
     });
 
-    it('keeps Create disabled until name is valid', () => {
+    it('keeps Create disabled until name is valid for MANUAL', () => {
         renderSheet();
         const createBtn = screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement;
         expect(createBtn.disabled).toBe(true);
@@ -61,7 +80,7 @@ describe('CreateDictionarySheet', () => {
         expect((screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement).disabled).toBe(false);
     });
 
-    it('submits a MANUAL payload without key or properties', async () => {
+    it('submits a MANUAL payload without provider or trigger', async () => {
         const { onSubmit } = renderSheet();
         fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'Airport IATA Codes' } });
         fireEvent.change(screen.getByLabelText(/^Description/), {
@@ -74,6 +93,91 @@ describe('CreateDictionarySheet', () => {
                 name: 'Airport IATA Codes',
                 description: 'IATA codes for airports',
                 type: 'MANUAL',
+            });
+        });
+    });
+
+    it('shows dynamic fields when type is Dynamic and keeps Create disabled until required fields are valid', () => {
+        renderSheet();
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'gamma-dict-dynamix' } });
+        selectType('Dynamic');
+
+        expect(screen.queryByText('Trigger')).not.toBeNull();
+        expect(screen.queryByText('HTTP Provider')).not.toBeNull();
+        expect((screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement).disabled).toBe(true);
+
+        fireEvent.change(screen.getByLabelText(/HTTP Service URL/), {
+            target: { value: 'not-a-url' },
+        });
+        expect(screen.queryByText('Enter a valid URL')).not.toBeNull();
+
+        fireEvent.change(screen.getByLabelText(/HTTP Service URL/), {
+            target: { value: 'https://service.internal/dictionary' },
+        });
+        expect((screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('rejects trigger rate of 0 for DYNAMIC', () => {
+        renderSheet();
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'gamma-dict-dynamix' } });
+        selectType('Dynamic');
+        fireEvent.change(screen.getByLabelText(/HTTP Service URL/), {
+            target: { value: 'https://service.internal/dictionary' },
+        });
+        fireEvent.change(screen.getByLabelText(/^Interval/), { target: { value: '0' } });
+
+        expect(screen.queryByText('Interval must be greater than 0')).not.toBeNull();
+        expect((screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('submits a DYNAMIC payload with HTTP provider and trigger', async () => {
+        const { onSubmit } = renderSheet();
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'gamma-dict-dynamix' } });
+        fireEvent.change(screen.getByLabelText(/^Description/), { target: { value: 'Dynamic lookup' } });
+        selectType('Dynamic');
+
+        fireEvent.change(screen.getByLabelText(/^Interval/), { target: { value: '5' } });
+        fireEvent.click(screen.getByLabelText(/^Time Unit/));
+        fireEvent.click(screen.getByRole('option', { name: 'Hours' }));
+
+        fireEvent.change(screen.getByLabelText(/HTTP Service URL/), {
+            target: { value: 'https://service.internal/dictionary' },
+        });
+        fireEvent.click(screen.getByLabelText(/^HTTP Method/));
+        fireEvent.click(screen.getByRole('option', { name: 'POST' }));
+        fireEvent.click(screen.getByLabelText(/Use system proxy/));
+        fireEvent.change(screen.getByLabelText(/^Request body/), { target: { value: '{"ok":true}' } });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+        const headerNameInputs = screen.getAllByLabelText('Header name');
+        const headerValueInputs = screen.getAllByLabelText('Header value');
+        fireEvent.change(headerNameInputs[0], { target: { value: 'X-Api-Key' } });
+        fireEvent.change(headerValueInputs[0], { target: { value: 'secret' } });
+
+        const specification = screen.getByLabelText(/JOLT Specification/);
+        fireEvent.change(specification, {
+            target: { value: '[{"operation":"shift","spec":{"*":"&"}}]' },
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith({
+                name: 'gamma-dict-dynamix',
+                description: 'Dynamic lookup',
+                type: 'DYNAMIC',
+                trigger: { rate: 5, unit: 'HOURS' },
+                provider: {
+                    type: 'HTTP',
+                    configuration: {
+                        url: 'https://service.internal/dictionary',
+                        method: 'POST',
+                        body: '{"ok":true}',
+                        headers: [{ name: 'X-Api-Key', value: 'secret' }],
+                        specification: '[{"operation":"shift","spec":{"*":"&"}}]',
+                        useSystemProxy: true,
+                    },
+                },
             });
         });
     });
@@ -94,5 +198,6 @@ describe('CreateDictionarySheet', () => {
     it('shows Creating… while saving', () => {
         renderSheet({ isSaving: true });
         expect(screen.queryByRole('button', { name: 'Creating…' })).not.toBeNull();
+        expect(within(screen.getByRole('button', { name: 'Creating…' })).getByText('Creating…')).not.toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/CreateDictionarySheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/CreateDictionarySheet.tsx
@@ -20,38 +20,59 @@ import {
     FieldLabel,
     Input,
     ScrollArea,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
     Sheet,
     SheetContent,
     SheetDescription,
     SheetFooter,
     SheetHeader,
     SheetTitle,
+    Textarea,
 } from '@gravitee/graphene-core';
 import { useCallback, useEffect, useState, type FormEvent } from 'react';
 
 import { extractErrorMessage } from '../../../shared/notify/extractErrorMessage';
-import type { NewDictionaryPayload } from '../types/dictionary';
-
-const NAME_MIN = 3;
-const NAME_MAX = 50;
+import type { DictionaryType, NewDictionaryPayload } from '../types/dictionary';
+import {
+    DEFAULT_JOLT_SPECIFICATION,
+    DICTIONARY_NAME_MAX,
+    getDictionaryNameError,
+    isDictionaryNameValid,
+} from '../utils/dictionaryFormValidation';
+import {
+    DictionaryHttpProviderFields,
+    isHttpProviderFormValid,
+    toProviderHeaders,
+    type DictionaryHttpProviderFormValue,
+} from './DictionaryHttpProviderFields';
+import { DictionaryTriggerFields, isTriggerFormValid, type DictionaryTriggerFormValue } from './DictionaryTriggerFields';
 
 interface CreateDictionaryForm {
     name: string;
     description: string;
+    type: DictionaryType;
+    trigger: DictionaryTriggerFormValue;
+    provider: DictionaryHttpProviderFormValue;
 }
 
 const EMPTY_FORM: CreateDictionaryForm = {
     name: '',
     description: '',
+    type: 'MANUAL',
+    trigger: { rate: '1', unit: 'MINUTES' },
+    provider: {
+        url: '',
+        method: 'GET',
+        body: '',
+        headers: [],
+        specification: DEFAULT_JOLT_SPECIFICATION,
+        useSystemProxy: false,
+    },
 };
-
-function getNameError(name: string): string | null {
-    const trimmed = name.trim();
-    if (!trimmed) return null;
-    if (trimmed.length < NAME_MIN) return `Name must be at least ${NAME_MIN} characters`;
-    if (trimmed.length > NAME_MAX) return `Name must be at most ${NAME_MAX} characters`;
-    return null;
-}
 
 export function CreateDictionarySheet({
     open,
@@ -80,19 +101,42 @@ export function CreateDictionarySheet({
         [onClose],
     );
 
-    const nameError = getNameError(form.name);
-    const isNameValid = form.name.trim().length >= NAME_MIN && form.name.trim().length <= NAME_MAX;
-    const isValid = isNameValid && nameError === null;
+    const nameError = getDictionaryNameError(form.name);
+    const isNameValid = isDictionaryNameValid(form.name);
+    const isDynamicValid = form.type === 'MANUAL' || (isTriggerFormValid(form.trigger) && isHttpProviderFormValid(form.provider));
+    const isValid = isNameValid && nameError === null && isDynamicValid;
 
     async function handleSubmit(e: FormEvent) {
         e.preventDefault();
         if (!isValid || isSaving) return;
 
-        const payload: NewDictionaryPayload = {
-            name: form.name.trim(),
-            description: form.description.trim() || undefined,
-            type: 'MANUAL',
-        };
+        const payload: NewDictionaryPayload =
+            form.type === 'MANUAL'
+                ? {
+                      name: form.name.trim(),
+                      description: form.description.trim() || undefined,
+                      type: 'MANUAL',
+                  }
+                : {
+                      name: form.name.trim(),
+                      description: form.description.trim() || undefined,
+                      type: 'DYNAMIC',
+                      trigger: {
+                          rate: Number(form.trigger.rate),
+                          unit: form.trigger.unit,
+                      },
+                      provider: {
+                          type: 'HTTP',
+                          configuration: {
+                              url: form.provider.url.trim(),
+                              method: form.provider.method,
+                              body: form.provider.body.trim() || undefined,
+                              headers: toProviderHeaders(form.provider.headers),
+                              specification: form.provider.specification.trim(),
+                              useSystemProxy: form.provider.useSystemProxy,
+                          },
+                      },
+                  };
 
         try {
             setSubmitError(null);
@@ -107,7 +151,9 @@ export function CreateDictionarySheet({
             <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '560px' }}>
                 <SheetHeader>
                     <SheetTitle>Create Dictionary</SheetTitle>
-                    <SheetDescription>Define a new manual dictionary with a name and description.</SheetDescription>
+                    <SheetDescription>
+                        Define a new dictionary. For dynamic dictionaries, configure the trigger and HTTP provider.
+                    </SheetDescription>
                 </SheetHeader>
 
                 <ScrollArea className="min-h-0 flex-1">
@@ -126,8 +172,8 @@ export function CreateDictionarySheet({
                                 placeholder="e.g. Airport IATA Codes"
                                 disabled={isSaving}
                                 required
-                                minLength={NAME_MIN}
-                                maxLength={NAME_MAX}
+                                minLength={3}
+                                maxLength={DICTIONARY_NAME_MAX}
                                 aria-invalid={nameError !== null}
                                 aria-describedby={nameError !== null ? 'dictionary-name-error' : 'dictionary-name-hint'}
                             />
@@ -137,29 +183,59 @@ export function CreateDictionarySheet({
                                 </p>
                             ) : (
                                 <p id="dictionary-name-hint" className="text-xs text-muted-foreground">
-                                    Max {NAME_MAX} characters.
+                                    Max {DICTIONARY_NAME_MAX} characters.
                                 </p>
                             )}
                         </Field>
 
                         <Field orientation="vertical" className="gap-1.5">
                             <FieldLabel htmlFor="dictionary-description">Description</FieldLabel>
-                            <Input
+                            <Textarea
                                 id="dictionary-description"
                                 value={form.description}
                                 onChange={e => setForm(prev => ({ ...prev, description: e.target.value }))}
                                 placeholder="Provide a description of the dictionary"
                                 disabled={isSaving}
+                                rows={3}
                             />
                         </Field>
 
                         <Field orientation="vertical" className="gap-1.5">
-                            <FieldLabel>Type</FieldLabel>
-                            <p id="dictionary-type" className="text-sm text-foreground">
-                                Manual
-                            </p>
-                            <p className="text-xs text-muted-foreground">Dynamic dictionaries will be available in a later story.</p>
+                            <FieldLabel htmlFor="dictionary-type">
+                                Type{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            <Select
+                                value={form.type}
+                                onValueChange={type => setForm(prev => ({ ...prev, type: type as DictionaryType }))}
+                                disabled={isSaving}
+                            >
+                                <SelectTrigger id="dictionary-type">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="MANUAL">Manual</SelectItem>
+                                    <SelectItem value="DYNAMIC">Dynamic</SelectItem>
+                                </SelectContent>
+                            </Select>
                         </Field>
+
+                        {form.type === 'DYNAMIC' ? (
+                            <>
+                                <DictionaryTriggerFields
+                                    value={form.trigger}
+                                    onChange={trigger => setForm(prev => ({ ...prev, trigger }))}
+                                    disabled={isSaving}
+                                />
+                                <DictionaryHttpProviderFields
+                                    value={form.provider}
+                                    onChange={provider => setForm(prev => ({ ...prev, provider }))}
+                                    disabled={isSaving}
+                                />
+                            </>
+                        ) : null}
 
                         {submitError ? (
                             <p className="text-sm text-destructive" role="alert">

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.tsx
@@ -22,7 +22,9 @@ import {
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuTrigger,
-    Input,
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
     type DataTableProps,
 } from '@gravitee/graphene-core';
 import { MoreHorizontalIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
@@ -249,14 +251,17 @@ export function DictionariesTable({
 
     return (
         <div className="space-y-3">
-            <div className="relative max-w-sm">
-                <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
-                <Input
-                    className="pl-10"
-                    placeholder="Search by key, name, or description…"
-                    value={search}
-                    onChange={e => handleSearchChange(e.target.value)}
-                />
+            <div className="max-w-sm">
+                <InputGroup>
+                    <InputGroupAddon align="inline-start">
+                        <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                    </InputGroupAddon>
+                    <InputGroupInput
+                        placeholder="Search by key, name, or description…"
+                        value={search}
+                        onChange={e => handleSearchChange(e.target.value)}
+                    />
+                </InputGroup>
             </div>
 
             <DataTable

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryHttpProviderFields.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryHttpProviderFields.tsx
@@ -1,0 +1,248 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Checkbox,
+    Field,
+    FieldLabel,
+    Input,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Textarea,
+} from '@gravitee/graphene-core';
+import { PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+
+import { getHttpUrlError, isHttpUrlValid } from '../utils/dictionaryFormValidation';
+
+export const HTTP_METHOD_OPTIONS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const;
+
+export type DictionaryHttpMethod = (typeof HTTP_METHOD_OPTIONS)[number];
+
+export interface DictionaryHttpHeaderFormValue {
+    id: string;
+    name: string;
+    value: string;
+}
+
+export interface DictionaryHttpProviderFormValue {
+    url: string;
+    method: DictionaryHttpMethod;
+    body: string;
+    headers: DictionaryHttpHeaderFormValue[];
+    specification: string;
+    useSystemProxy: boolean;
+}
+
+function newHeaderRow(): DictionaryHttpHeaderFormValue {
+    return { id: crypto.randomUUID(), name: '', value: '' };
+}
+
+export function DictionaryHttpProviderFields({
+    value,
+    onChange,
+    disabled,
+}: Readonly<{
+    value: DictionaryHttpProviderFormValue;
+    onChange: (next: DictionaryHttpProviderFormValue) => void;
+    disabled?: boolean;
+}>) {
+    const urlError = getHttpUrlError(value.url);
+    const specificationMissing = value.specification.trim().length === 0;
+
+    function updateHeader(id: string, patch: Partial<Pick<DictionaryHttpHeaderFormValue, 'name' | 'value'>>) {
+        onChange({
+            ...value,
+            headers: value.headers.map(header => (header.id === id ? { ...header, ...patch } : header)),
+        });
+    }
+
+    function removeHeader(id: string) {
+        onChange({
+            ...value,
+            headers: value.headers.filter(header => header.id !== id),
+        });
+    }
+
+    return (
+        <section className="space-y-4 rounded-lg border p-4">
+            <div className="space-y-1">
+                <h3 className="text-sm font-semibold">HTTP Provider</h3>
+            </div>
+
+            <Field orientation="vertical" className="gap-1.5">
+                <FieldLabel htmlFor="dictionary-provider-url">
+                    HTTP Service URL{' '}
+                    <span className="text-destructive" aria-hidden>
+                        *
+                    </span>
+                </FieldLabel>
+                <Input
+                    id="dictionary-provider-url"
+                    value={value.url}
+                    onChange={e => onChange({ ...value, url: e.target.value })}
+                    placeholder="https://service.internal/dictionary"
+                    disabled={disabled}
+                    required
+                    aria-invalid={urlError !== null}
+                    aria-describedby={urlError !== null ? 'dictionary-provider-url-error' : undefined}
+                />
+                {urlError ? (
+                    <p id="dictionary-provider-url-error" className="text-sm text-destructive" role="alert">
+                        {urlError}
+                    </p>
+                ) : null}
+            </Field>
+
+            <div className="grid gap-4 sm:grid-cols-[1fr_auto] sm:items-end">
+                <Field orientation="vertical" className="gap-1.5">
+                    <FieldLabel htmlFor="dictionary-provider-method">HTTP Method</FieldLabel>
+                    <Select
+                        value={value.method}
+                        onValueChange={method => onChange({ ...value, method: method as DictionaryHttpMethod })}
+                        disabled={disabled}
+                    >
+                        <SelectTrigger id="dictionary-provider-method">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {HTTP_METHOD_OPTIONS.map(method => (
+                                <SelectItem key={method} value={method}>
+                                    {method}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </Field>
+
+                <label
+                    htmlFor="dictionary-provider-system-proxy"
+                    className="mb-0.5 flex cursor-pointer items-center gap-2 rounded-md px-1 py-2 text-sm"
+                >
+                    <Checkbox
+                        id="dictionary-provider-system-proxy"
+                        checked={value.useSystemProxy}
+                        onCheckedChange={checked => onChange({ ...value, useSystemProxy: checked === true })}
+                        disabled={disabled}
+                    />
+                    Use system proxy
+                </label>
+            </div>
+
+            <Field orientation="vertical" className="gap-1.5">
+                <FieldLabel htmlFor="dictionary-provider-body">Request body</FieldLabel>
+                <Textarea
+                    id="dictionary-provider-body"
+                    value={value.body}
+                    onChange={e => onChange({ ...value, body: e.target.value })}
+                    placeholder="Optional request body"
+                    disabled={disabled}
+                    rows={3}
+                />
+            </Field>
+
+            <div className="space-y-3">
+                <div className="flex items-center justify-between gap-2">
+                    <FieldLabel className="mb-0">Headers</FieldLabel>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="gap-1"
+                        disabled={disabled}
+                        onClick={() => onChange({ ...value, headers: [...value.headers, newHeaderRow()] })}
+                    >
+                        <PlusIcon className="size-4" aria-hidden />
+                        Add
+                    </Button>
+                </div>
+
+                {value.headers.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">No headers. Click Add to include request headers.</p>
+                ) : (
+                    <div className="space-y-2">
+                        {value.headers.map(header => (
+                            <div key={header.id} className="grid grid-cols-[1fr_1fr_auto] gap-2">
+                                <Input
+                                    value={header.name}
+                                    onChange={e => updateHeader(header.id, { name: e.target.value })}
+                                    placeholder="Header name"
+                                    disabled={disabled}
+                                    aria-label="Header name"
+                                />
+                                <Input
+                                    value={header.value}
+                                    onChange={e => updateHeader(header.id, { value: e.target.value })}
+                                    placeholder="Header value"
+                                    disabled={disabled}
+                                    aria-label="Header value"
+                                />
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    disabled={disabled}
+                                    onClick={() => removeHeader(header.id)}
+                                    aria-label="Remove header"
+                                >
+                                    <Trash2Icon className="size-4" aria-hidden />
+                                </Button>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            <Field orientation="vertical" className="gap-1.5">
+                <FieldLabel htmlFor="dictionary-provider-specification">
+                    JOLT Specification{' '}
+                    <span className="text-destructive" aria-hidden>
+                        *
+                    </span>
+                </FieldLabel>
+                <Textarea
+                    id="dictionary-provider-specification"
+                    value={value.specification}
+                    onChange={e => onChange({ ...value, specification: e.target.value })}
+                    disabled={disabled}
+                    required
+                    rows={8}
+                    className="font-mono text-xs"
+                    aria-invalid={specificationMissing}
+                    aria-describedby={specificationMissing ? 'dictionary-provider-specification-error' : undefined}
+                />
+                {specificationMissing ? (
+                    <p id="dictionary-provider-specification-error" className="text-sm text-destructive" role="alert">
+                        JOLT specification is required
+                    </p>
+                ) : (
+                    <p className="text-xs text-muted-foreground">Transforms the HTTP response into dictionary key/value properties.</p>
+                )}
+            </Field>
+        </section>
+    );
+}
+
+export function isHttpProviderFormValid(value: DictionaryHttpProviderFormValue): boolean {
+    return isHttpUrlValid(value.url) && value.specification.trim().length > 0;
+}
+
+export function toProviderHeaders(headers: DictionaryHttpHeaderFormValue[]): Array<{ name: string; value: string }> {
+    return headers.map(header => ({ name: header.name.trim(), value: header.value })).filter(header => header.name.length > 0);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryStateBadge.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryStateBadge.tsx
@@ -19,7 +19,7 @@ import { Badge, cn } from '@gravitee/graphene-core';
 import type { DictionaryLifecycleState } from '../types/dictionary';
 
 const STATE_CONFIG: Record<DictionaryLifecycleState, { label: string; className: string }> = {
-    STARTED: { label: 'Started', className: 'bg-green-100 text-green-700 border-transparent' },
+    STARTED: { label: 'Started', className: 'bg-success/10 text-success border-transparent' },
     STOPPED: { label: 'Stopped', className: 'bg-muted text-muted-foreground border-transparent' },
 };
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryTriggerFields.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryTriggerFields.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Field, FieldLabel, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
+
+import type { DictionaryTriggerUnit } from '../types/dictionary';
+
+export const TRIGGER_UNIT_OPTIONS: Array<{ value: DictionaryTriggerUnit; label: string }> = [
+    { value: 'SECONDS', label: 'Seconds' },
+    { value: 'MINUTES', label: 'Minutes' },
+    { value: 'HOURS', label: 'Hours' },
+];
+
+export interface DictionaryTriggerFormValue {
+    rate: string;
+    unit: DictionaryTriggerUnit;
+}
+
+function isValidTriggerRate(rate: string): boolean {
+    const rateNumber = Number(rate);
+    return rate.trim() !== '' && Number.isFinite(rateNumber) && Number.isInteger(rateNumber) && rateNumber > 0;
+}
+
+export function DictionaryTriggerFields({
+    value,
+    onChange,
+    disabled,
+}: Readonly<{
+    value: DictionaryTriggerFormValue;
+    onChange: (next: DictionaryTriggerFormValue) => void;
+    disabled?: boolean;
+}>) {
+    const rateInvalid = value.rate.trim() !== '' && !isValidTriggerRate(value.rate);
+
+    return (
+        <section className="space-y-4 rounded-lg border p-4">
+            <div className="space-y-1">
+                <h3 className="text-sm font-semibold">Trigger</h3>
+                <p className="text-xs text-muted-foreground">How often the provider is polled to refresh properties.</p>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+                <Field orientation="vertical" className="gap-1.5">
+                    <FieldLabel htmlFor="dictionary-trigger-rate">
+                        Interval{' '}
+                        <span className="text-destructive" aria-hidden>
+                            *
+                        </span>
+                    </FieldLabel>
+                    <Input
+                        id="dictionary-trigger-rate"
+                        type="number"
+                        min={1}
+                        step={1}
+                        value={value.rate}
+                        onChange={e => onChange({ ...value, rate: e.target.value })}
+                        disabled={disabled}
+                        required
+                        aria-invalid={rateInvalid}
+                        aria-describedby={rateInvalid ? 'dictionary-trigger-rate-error' : undefined}
+                    />
+                    {rateInvalid ? (
+                        <p id="dictionary-trigger-rate-error" className="text-sm text-destructive" role="alert">
+                            Interval must be a whole number greater than 0
+                        </p>
+                    ) : null}
+                </Field>
+
+                <Field orientation="vertical" className="gap-1.5">
+                    <FieldLabel htmlFor="dictionary-trigger-unit">
+                        Time Unit{' '}
+                        <span className="text-destructive" aria-hidden>
+                            *
+                        </span>
+                    </FieldLabel>
+                    <Select
+                        value={value.unit}
+                        onValueChange={unit => onChange({ ...value, unit: unit as DictionaryTriggerUnit })}
+                        disabled={disabled}
+                    >
+                        <SelectTrigger id="dictionary-trigger-unit">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {TRIGGER_UNIT_OPTIONS.map(option => (
+                                <SelectItem key={option.value} value={option.value}>
+                                    {option.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </Field>
+            </div>
+        </section>
+    );
+}
+
+export function isTriggerFormValid(value: DictionaryTriggerFormValue): boolean {
+    return isValidTriggerRate(value.rate);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryTypeBadge.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryTypeBadge.tsx
@@ -18,12 +18,18 @@ import { Badge, cn } from '@gravitee/graphene-core';
 
 import type { DictionaryType } from '../types/dictionary';
 
-const TYPE_CONFIG: Record<DictionaryType, { label: string; className: string }> = {
-    MANUAL: { label: 'Manual', className: 'bg-blue-100 text-blue-700 border-transparent' },
-    DYNAMIC: { label: 'Dynamic', className: 'bg-purple-100 text-purple-700 border-transparent' },
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline';
+
+const TYPE_CONFIG: Record<DictionaryType, { label: string; variant: BadgeVariant; className?: string }> = {
+    MANUAL: { label: 'Manual', variant: 'outline', className: 'text-muted-foreground' },
+    DYNAMIC: { label: 'Dynamic', variant: 'outline', className: 'border-primary/30 text-primary' },
 };
 
 export function DictionaryTypeBadge({ type }: Readonly<{ type: DictionaryType }>) {
-    const config = TYPE_CONFIG[type] ?? { label: type, className: '' };
-    return <Badge className={cn('font-normal text-xs', config.className)}>{config.label}</Badge>;
+    const config = TYPE_CONFIG[type] ?? { label: type, variant: 'outline' as BadgeVariant };
+    return (
+        <Badge variant={config.variant} className={cn('font-normal text-xs', config.className)}>
+            {config.label}
+        </Badge>
+    );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryTypeLabel.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryTypeLabel.tsx
@@ -33,7 +33,8 @@ export function DictionaryTypeLabel({
     }
 
     const stateLabel = state ? (STATE_LABEL[state] ?? state) : undefined;
-    const stateClassName = state === 'STARTED' ? 'text-green-600' : 'text-muted-foreground';
+    const stateClassName = state === 'STARTED' ? 'text-success' : 'text-muted-foreground';
+    const separatorClassName = state === 'STARTED' ? 'text-success' : 'text-muted-foreground';
 
     return (
         <span className="text-sm text-muted-foreground">
@@ -41,7 +42,10 @@ export function DictionaryTypeLabel({
             {stateLabel ? (
                 <>
                     {' '}
-                    <span aria-hidden>·</span> <span className={stateClassName}>{stateLabel}</span>
+                    <span className={separatorClassName} aria-hidden>
+                        ·
+                    </span>{' '}
+                    <span className={stateClassName}>{stateLabel}</span>
                 </>
             ) : null}
         </span>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useDictionaryMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useDictionaryMutations.ts
@@ -29,14 +29,15 @@ import {
 import type { Dictionary, NewDictionaryPayload, UpdateDictionaryPayload } from '../types/dictionary';
 import { dictionaryKeys } from '../utils/queryKeys';
 
-function useDictionaryMutation<TData, TResult>(mutationFn: (envId: string, data: TData) => Promise<TResult>) {
+function useDictionaryMutation<TVariables, TResult = Dictionary>(mutationFn: (envId: string, data: TVariables) => Promise<TResult>) {
     const env = useEnvironment();
     const queryClient = useQueryClient();
 
     return useMutation({
-        mutationFn: (data: TData) => mutationFn(env!.id, data),
-        onSuccess: () => {
-            void queryClient.invalidateQueries({ queryKey: dictionaryKeys.all });
+        mutationFn: (data: TVariables) => mutationFn(env!.id, data),
+        onSuccess: async () => {
+            // Prefix key invalidates both list and detail caches for all consumers.
+            await queryClient.invalidateQueries({ queryKey: dictionaryKeys.all });
         },
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/utils/dictionaryFormValidation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/utils/dictionaryFormValidation.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getDictionaryNameError, getHttpUrlError, isDictionaryNameValid, isHttpUrlValid } from './dictionaryFormValidation';
+
+describe('dictionaryFormValidation', () => {
+    describe('name', () => {
+        it('accepts names between 3 and 50 characters', () => {
+            expect(isDictionaryNameValid('abc')).toBe(true);
+            expect(getDictionaryNameError('ab')).toBe('Name must be at least 3 characters');
+            expect(isDictionaryNameValid('ab')).toBe(false);
+        });
+    });
+
+    describe('http url', () => {
+        it('requires a valid http(s) URL', () => {
+            expect(getHttpUrlError('')).toBeNull();
+            expect(getHttpUrlError('not-a-url')).toBe('Enter a valid URL');
+            expect(getHttpUrlError('ftp://example.com')).toBe('URL must start with http:// or https://');
+            expect(getHttpUrlError('https://service.internal/dictionary')).toBeNull();
+            expect(isHttpUrlValid('https://service.internal/dictionary')).toBe(true);
+            expect(isHttpUrlValid('')).toBe(false);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/utils/dictionaryFormValidation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/utils/dictionaryFormValidation.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const DICTIONARY_NAME_MIN = 3;
+export const DICTIONARY_NAME_MAX = 50;
+
+export const DEFAULT_JOLT_SPECIFICATION = `[
+  {
+    "operation": "shift",
+    "spec": {
+      "*": "&"
+    }
+  }
+]`;
+
+export function getDictionaryNameError(name: string): string | null {
+    const trimmed = name.trim();
+    if (!trimmed) return null;
+    if (trimmed.length < DICTIONARY_NAME_MIN) return `Name must be at least ${DICTIONARY_NAME_MIN} characters`;
+    if (trimmed.length > DICTIONARY_NAME_MAX) return `Name must be at most ${DICTIONARY_NAME_MAX} characters`;
+    return null;
+}
+
+export function isDictionaryNameValid(name: string): boolean {
+    const trimmed = name.trim();
+    return trimmed.length >= DICTIONARY_NAME_MIN && trimmed.length <= DICTIONARY_NAME_MAX && getDictionaryNameError(name) === null;
+}
+
+/** Returns an error message for invalid URLs; null when empty or valid http(s). */
+export function getHttpUrlError(url: string): string | null {
+    const trimmed = url.trim();
+    if (!trimmed) return null;
+    try {
+        const parsed = new URL(trimmed);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            return 'URL must start with http:// or https://';
+        }
+        return null;
+    } catch {
+        return 'Enter a valid URL';
+    }
+}
+
+export function isHttpUrlValid(url: string): boolean {
+    return url.trim().length > 0 && getHttpUrlError(url) === null;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionaryDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionaryDetailPage.tsx
@@ -15,17 +15,46 @@
  */
 
 import { Button, Skeleton } from '@gravitee/graphene-core';
-import { ArrowLeftIcon, BookOpenIcon, CalendarIcon, ClockIcon, CloudUploadIcon, PlusIcon } from '@gravitee/graphene-core/icons';
+import {
+    ArrowLeftIcon,
+    BookOpenIcon,
+    CalendarIcon,
+    CircleStopIcon,
+    ClockIcon,
+    CloudUploadIcon,
+    PlayIcon,
+    PlusIcon,
+} from '@gravitee/graphene-core/icons';
 import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { AddDictionaryPropertySheet } from '../features/dictionaries/components/AddDictionaryPropertySheet';
+import { DictionaryStateBadge } from '../features/dictionaries/components/DictionaryStateBadge';
 import { DictionaryTypeBadge } from '../features/dictionaries/components/DictionaryTypeBadge';
-import { useDeployDictionary, useUpdateDictionary } from '../features/dictionaries/hooks/useDictionaryMutations';
+import { TRIGGER_UNIT_OPTIONS } from '../features/dictionaries/components/DictionaryTriggerFields';
+import {
+    useDeployDictionary,
+    useStartDictionary,
+    useStopDictionary,
+    useUpdateDictionary,
+} from '../features/dictionaries/hooks/useDictionaryMutations';
 import { useDictionaryPermissions } from '../features/dictionaries/hooks/useDictionaryPermissions';
 import { useEnvironmentDictionary } from '../features/dictionaries/hooks/useEnvironmentDictionary';
+import type { DictionaryHttpProviderConfiguration } from '../features/dictionaries/types/dictionary';
 import { formatDictionaryDate } from '../features/dictionaries/utils/formatDictionaryDate';
 import { notify } from '../shared/notify';
+
+function triggerUnitLabel(unit: string | undefined): string {
+    if (!unit) return '';
+    return TRIGGER_UNIT_OPTIONS.find(option => option.value === unit)?.label.toLowerCase() ?? unit.toLowerCase();
+}
+
+function asHttpProviderConfig(configuration: unknown): DictionaryHttpProviderConfiguration {
+    if (configuration && typeof configuration === 'object') {
+        return configuration as DictionaryHttpProviderConfiguration;
+    }
+    return {};
+}
 
 export function DictionaryDetailPage() {
     const { dictionaryId } = useParams<{ dictionaryId: string }>();
@@ -34,12 +63,21 @@ export function DictionaryDetailPage() {
     const { data: dictionary, isLoading, isError } = useEnvironmentDictionary(dictionaryId);
     const updateMutation = useUpdateDictionary();
     const deployMutation = useDeployDictionary();
+    const startMutation = useStartDictionary();
+    const stopMutation = useStopDictionary();
     const [addPropertyOpen, setAddPropertyOpen] = useState(false);
 
     const properties = dictionary?.properties ?? {};
     const propertyEntries = Object.entries(properties);
     const propertyCount = propertyEntries.length;
-    const canEditManualProperties = canUpdate && dictionary?.type === 'MANUAL';
+    const isDynamic = dictionary?.type === 'DYNAMIC';
+    const canEditManualProperties = canUpdate && !isDynamic;
+    const isStarted = dictionary?.state === 'STARTED';
+    const lifecyclePending = startMutation.isPending || stopMutation.isPending;
+    const providerConfig = asHttpProviderConfig(dictionary?.provider?.configuration);
+    const providerHeaders = (providerConfig.headers ?? []).filter(header => header.name?.trim() || header.value?.trim());
+    const providerBody = providerConfig.body?.trim() ?? '';
+    const providerSpecification = providerConfig.specification?.trim() ?? '';
 
     async function handleAddProperty(property: { key: string; value: string }) {
         if (!dictionary || dictionary.type !== 'MANUAL') return;
@@ -70,6 +108,26 @@ export function DictionaryDetailPage() {
             notify.success('Dictionary deployed successfully');
         } catch (error) {
             notify.error(error, 'Failed to deploy dictionary');
+        }
+    }
+
+    async function handleStart() {
+        if (!dictionary) return;
+        try {
+            await startMutation.mutateAsync(dictionary.id);
+            notify.success('Dictionary started successfully');
+        } catch (error) {
+            notify.error(error, 'Failed to start dictionary');
+        }
+    }
+
+    async function handleStop() {
+        if (!dictionary) return;
+        try {
+            await stopMutation.mutateAsync(dictionary.id);
+            notify.success('Dictionary stopped successfully');
+        } catch (error) {
+            notify.error(error, 'Failed to stop dictionary');
         }
     }
 
@@ -115,6 +173,7 @@ export function DictionaryDetailPage() {
                                 <div className="flex flex-wrap items-center gap-2">
                                     <h1 className="text-xl font-semibold tracking-tight">{dictionary.name}</h1>
                                     <DictionaryTypeBadge type={dictionary.type} />
+                                    {isDynamic ? <DictionaryStateBadge state={dictionary.state} /> : null}
                                 </div>
                                 {dictionary.description?.trim() ? (
                                     <p className="text-sm text-muted-foreground">{dictionary.description}</p>
@@ -150,28 +209,127 @@ export function DictionaryDetailPage() {
                             </div>
                         </div>
                     </div>
-                    {canEditManualProperties ? (
-                        <Button
-                            type="button"
-                            variant="outline"
-                            className="shrink-0 gap-1.5"
-                            onClick={handleDeploy}
-                            disabled={deployMutation.isPending}
-                        >
-                            <CloudUploadIcon className="size-4" aria-hidden />
-                            {deployMutation.isPending ? 'Deploying…' : 'Deploy'}
-                        </Button>
+                    {canUpdate ? (
+                        <div className="flex shrink-0 items-center gap-2">
+                            {isDynamic ? (
+                                isStarted ? (
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        className="gap-1.5"
+                                        onClick={handleStop}
+                                        disabled={lifecyclePending}
+                                    >
+                                        <CircleStopIcon className="size-4" aria-hidden />
+                                        {stopMutation.isPending ? 'Stopping…' : 'Stop'}
+                                    </Button>
+                                ) : (
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        className="gap-1.5"
+                                        onClick={handleStart}
+                                        disabled={lifecyclePending}
+                                    >
+                                        <PlayIcon className="size-4" aria-hidden />
+                                        {startMutation.isPending ? 'Starting…' : 'Start'}
+                                    </Button>
+                                )
+                            ) : (
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    className="gap-1.5"
+                                    onClick={handleDeploy}
+                                    disabled={deployMutation.isPending}
+                                >
+                                    <CloudUploadIcon className="size-4" aria-hidden />
+                                    {deployMutation.isPending ? 'Deploying…' : 'Deploy'}
+                                </Button>
+                            )}
+                        </div>
                     ) : null}
                 </div>
             </section>
+
+            {isDynamic ? (
+                <section className="space-y-4 rounded-xl border bg-card p-5">
+                    <div>
+                        <h2 className="text-base font-semibold">Trigger & Provider</h2>
+                        <p className="text-sm text-muted-foreground">Polling schedule and HTTP source used to refresh properties.</p>
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="space-y-1">
+                            <div className="text-xs text-muted-foreground">Polling Interval</div>
+                            <div className="text-sm font-medium">
+                                {dictionary.trigger ? `Every ${dictionary.trigger.rate} ${triggerUnitLabel(dictionary.trigger.unit)}` : '—'}
+                            </div>
+                        </div>
+                        <div className="space-y-1">
+                            <div className="text-xs text-muted-foreground">Provider Type</div>
+                            <div className="text-sm font-medium">
+                                {dictionary.provider?.type ? `Custom (${dictionary.provider.type})` : '—'}
+                            </div>
+                        </div>
+                        <div className="space-y-1 sm:col-span-2">
+                            <div className="text-xs text-muted-foreground">HTTP Service URL</div>
+                            <div className="flex items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-xs">
+                                {providerConfig.method ? (
+                                    <span className="shrink-0 font-semibold text-foreground">{providerConfig.method}</span>
+                                ) : null}
+                                <span className="truncate">{providerConfig.url?.trim() || '—'}</span>
+                            </div>
+                        </div>
+                        <div className="space-y-1">
+                            <div className="text-xs text-muted-foreground">Use system proxy</div>
+                            <div className="text-sm font-medium">{providerConfig.useSystemProxy ? 'Yes' : 'No'}</div>
+                        </div>
+                        <div className="space-y-1">
+                            <div className="text-xs text-muted-foreground">Headers</div>
+                            {providerHeaders.length > 0 ? (
+                                <ul className="space-y-1 text-sm">
+                                    {providerHeaders.map((header, index) => (
+                                        <li key={`${header.name ?? ''}-${index}`} className="font-mono text-xs">
+                                            <span className="font-semibold text-foreground">{header.name?.trim() || '—'}</span>
+                                            <span className="text-muted-foreground">: {header.value?.trim() || '—'}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            ) : (
+                                <div className="text-sm text-muted-foreground">None</div>
+                            )}
+                        </div>
+                        <div className="space-y-1 sm:col-span-2">
+                            <div className="text-xs text-muted-foreground">Request body</div>
+                            {providerBody ? (
+                                <pre className="max-h-40 overflow-auto whitespace-pre-wrap rounded-md bg-muted px-3 py-2 font-mono text-xs">
+                                    {providerBody}
+                                </pre>
+                            ) : (
+                                <div className="text-sm text-muted-foreground">None</div>
+                            )}
+                        </div>
+                        <div className="space-y-1 sm:col-span-2">
+                            <div className="text-xs text-muted-foreground">JOLT specification</div>
+                            {providerSpecification ? (
+                                <pre className="max-h-48 overflow-auto whitespace-pre-wrap rounded-md bg-muted px-3 py-2 font-mono text-xs">
+                                    {providerSpecification}
+                                </pre>
+                            ) : (
+                                <div className="text-sm text-muted-foreground">—</div>
+                            )}
+                        </div>
+                    </div>
+                </section>
+            ) : null}
 
             <section className="space-y-4 rounded-xl border bg-card p-5">
                 <div className="flex items-start justify-between gap-4">
                     <div>
                         <h2 className="text-base font-semibold">Properties</h2>
                         <p className="text-sm text-muted-foreground">
-                            {dictionary.type === 'DYNAMIC'
-                                ? 'Values managed by the dictionary provider.'
+                            {isDynamic
+                                ? 'Properties are populated automatically by the provider.'
                                 : 'Key/value entries that make up this dictionary.'}
                         </p>
                     </div>
@@ -187,8 +345,8 @@ export function DictionaryDetailPage() {
                     <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed px-6 py-16 text-center">
                         <BookOpenIcon className="size-10 text-muted-foreground/40" aria-hidden />
                         <p className="text-sm text-muted-foreground">
-                            {dictionary.type === 'DYNAMIC'
-                                ? 'No properties yet. Values will appear when the provider syncs this dictionary.'
+                            {isDynamic
+                                ? 'Properties will be populated once the dictionary is started.'
                                 : 'No properties yet. Add key/value entries to this dictionary.'}
                         </p>
                     </div>
@@ -214,15 +372,13 @@ export function DictionaryDetailPage() {
                 )}
             </section>
 
-            {canEditManualProperties ? (
-                <AddDictionaryPropertySheet
-                    open={addPropertyOpen}
-                    onClose={() => setAddPropertyOpen(false)}
-                    onSubmit={handleAddProperty}
-                    isSaving={updateMutation.isPending}
-                    existingKeys={Object.keys(properties)}
-                />
-            ) : null}
+            <AddDictionaryPropertySheet
+                open={addPropertyOpen}
+                onClose={() => setAddPropertyOpen(false)}
+                onSubmit={handleAddProperty}
+                isSaving={updateMutation.isPending}
+                existingKeys={Object.keys(properties)}
+            />
         </div>
     );
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-8

Part of https://gravitee.atlassian.net/browse/FOUND-2 (Environment-Scoped Dictionaries)

## Description

Adds **create Dynamic dictionary** support in Gamma Platform Management (builds on FOUND-6 list + FOUND-7 manual create).

### Create flow
- `CreateDictionarySheet` type selector: **Manual** | **Dynamic**
- Dynamic create collects:
  - **Trigger** — polling interval + unit (`SECONDS` / `MINUTES` / `HOURS`) via `DictionaryTriggerFields`
  - **HTTP provider** — URL, method, system proxy, body, headers, JOLT specification via `DictionaryHttpProviderFields`
- Payload creates `type: DYNAMIC` with `provider.type: HTTP`
- Shared validation helpers for name / HTTP URL (`dictionaryFormValidation`)
- Unit tests updated/added for create sheet + validation

### Detail page (dynamic)
- Shows **Dynamic** + lifecycle state badge (**Started** / **Stopped**)
- **Trigger & Provider** read-only section (interval, provider type, HTTP URL/method)
- Lifecycle actions: **Start** / **Stop** for dynamic dictionaries
- **Deploy** remains **Manual-only** (dynamic dictionaries are not manually deployed)

## Additional context
- Stacked on FOUND-6 / FOUND-7 (both already on `master`); this PR is the FOUND-8 commit only.

https://github.com/user-attachments/assets/0984eaf1-b959-4855-9a17-1f5d06d9f094


