### PR TITLE
fix(console): explain SYSTEM-locked branded senders with a padlock and tooltip

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -742,6 +742,7 @@
           [defaultSubject]="portalForm.get('email.subject')?.value ?? ''"
           [inheritedFromOrg]="settings.email?.brandedSendersInherited ?? false"
           [canReset]="canResetBrandedSenders"
+          [systemLocked]="isReadonly('email.branded_senders')"
           (reset)="resetBrandedSenders()"
         ></branded-senders>
       </mat-card-content>

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -20,7 +20,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MatIconHarness, MatIconTestingModule } from '@angular/material/icon/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import {
@@ -654,6 +654,20 @@ describe('PortalSettingsComponent', () => {
       await init();
     });
 
+    // Guards the property the padlock specs below silently depend on. They can only catch a mis-keyed
+    // [systemLocked] binding because the fixture's base readonly covers other email.* keys while omitting this one:
+    // a wrong key resolves to a read-only entry and lights the padlock where the negative specs expect none. Adding
+    // 'email.branded_senders' to the fixture would blunt them without failing anything, so fail here instead.
+    it('should keep email.branded_senders out of the fixture base readonly, but other email keys in it', () => {
+      // The component created in beforeEach issues a settings GET; flush it so afterEach's verify() stays clean.
+      expectPortalSettingsGetRequest(fakePortalSettings());
+
+      const readonly = fakePortalSettings().metadata.readonly;
+
+      expect(readonly).not.toContain('email.branded_senders');
+      expect(readonly).toEqual(expect.arrayContaining(['email.from', 'email.subject']));
+    });
+
     it('should render the branded senders control enabled when emailing is on and not read-only', async () => {
       const settings = fakePortalSettings();
       settings.email.enabled = true;
@@ -680,6 +694,40 @@ describe('PortalSettingsComponent', () => {
 
       const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
       expect(await addConfigurationButton.isDisabled()).toBe(true);
+    });
+
+    it('should explain the lock when email.branded_senders is read-only', async () => {
+      const settings = fakePortalSettings();
+      settings.email.enabled = true;
+      settings.metadata.readonly.push('email.branded_senders');
+      expectPortalSettingsGetRequest(settings);
+
+      // Disabling alone is indistinguishable from missing ENVIRONMENT_SETTINGS[U]; the reason has to be shown.
+      const lock = await loader.getHarnessOrNull(MatIconHarness.with({ selector: '[data-testid="branded-senders-system-lock"]' }));
+      expect(lock).not.toBeNull();
+    });
+
+    it('should not show the system lock when branded senders are merely disabled', async () => {
+      const settings = fakePortalSettings();
+      settings.email.enabled = false;
+      expectPortalSettingsGetRequest(settings);
+
+      const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      expect(await addConfigurationButton.isDisabled()).toBe(true);
+      expect(await loader.getHarnessOrNull(MatIconHarness.with({ selector: '[data-testid="branded-senders-system-lock"]' }))).toBeNull();
+    });
+
+    it('should still explain the lock when the setting is read-only and email is disabled', async () => {
+      // The host collapses both conditions into one `disabled` flag; the lock tracks only the read-only one, so
+      // their intersection must still be explained rather than falling back to a bare disabled section.
+      const settings = fakePortalSettings();
+      settings.email.enabled = false;
+      settings.metadata.readonly.push('email.branded_senders');
+      expectPortalSettingsGetRequest(settings);
+
+      expect(
+        await loader.getHarnessOrNull(MatIconHarness.with({ selector: '[data-testid="branded-senders-system-lock"]' })),
+      ).not.toBeNull();
     });
 
     it('should round-trip branded senders from a populated GET through save at env scope', async () => {
@@ -711,6 +759,10 @@ describe('PortalSettingsComponent', () => {
 
       const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
       expect(await addConfigurationButton.isDisabled()).toBe(true);
+
+      // This is the state the padlock exists to be told apart from. Showing it here would assert "the system
+      // configured this" to someone who is merely unprivileged — the original ambiguity, now confidently wrong.
+      expect(await loader.getHarnessOrNull(MatIconHarness.with({ selector: '[data-testid="branded-senders-system-lock"]' }))).toBeNull();
     });
   });
 

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
@@ -440,6 +440,7 @@
           formControlName="brandedSenders"
           [defaultFrom]="formSettings.get('email.from')?.value ?? ''"
           [defaultSubject]="formSettings.get('email.subject')?.value ?? ''"
+          [systemLocked]="isReadonlySetting('email.branded_senders')"
         ></branded-senders>
       </mat-card-content>
     </mat-card>

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
@@ -26,7 +26,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { GioFormTagsInputHarness, GioSaveBarHarness } from '@gravitee/ui-particles-angular';
-import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MatIconHarness, MatIconTestingModule } from '@angular/material/icon/testing';
 
 import { OrgSettingsGeneralComponent } from './org-settings-general.component';
 
@@ -542,6 +542,25 @@ describe('ConsoleSettingsComponent', () => {
       expect(await addConfigurationButton.isDisabled()).toEqual(true);
     });
 
+    it('should explain the lock when email.branded_senders is read-only', async () => {
+      expectConsoleSettingsGetRequest({
+        email: { enabled: true },
+        metadata: { readonly: ['email.branded_senders'] },
+      });
+
+      // Disabling alone is indistinguishable from missing ENVIRONMENT_SETTINGS[U]; the reason has to be shown.
+      const lock = await loader.getHarnessOrNull(MatIconHarness.with({ selector: '[data-testid="branded-senders-system-lock"]' }));
+      expect(lock).not.toBeNull();
+    });
+
+    it('should not show the system lock when branded senders are merely disabled', async () => {
+      expectConsoleSettingsGetRequest({ email: { enabled: false } });
+
+      const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      expect(await addConfigurationButton.isDisabled()).toEqual(true);
+      expect(await loader.getHarnessOrNull(MatIconHarness.with({ selector: '[data-testid="branded-senders-system-lock"]' }))).toBeNull();
+    });
+
     it('should disable branded senders on initial load when email is disabled', async () => {
       expectConsoleSettingsGetRequest({
         email: { enabled: false },
@@ -550,6 +569,19 @@ describe('ConsoleSettingsComponent', () => {
 
       const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
       expect(await addConfigurationButton.isDisabled()).toEqual(true);
+    });
+
+    it('should still explain the lock when the setting is read-only and email is disabled', async () => {
+      // The host collapses both conditions into one `disabled` flag; the lock tracks only the read-only one, so
+      // their intersection must still be explained rather than falling back to a bare disabled section.
+      expectConsoleSettingsGetRequest({
+        email: { enabled: false },
+        metadata: { readonly: ['email.branded_senders'] },
+      });
+
+      expect(
+        await loader.getHarnessOrNull(MatIconHarness.with({ selector: '[data-testid="branded-senders-system-lock"]' })),
+      ).not.toBeNull();
     });
 
     it('should round-trip branded senders from a populated GET through save', async () => {
@@ -626,6 +658,10 @@ describe('ConsoleSettingsComponent', () => {
 
       const addConfigurationButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
       expect(await addConfigurationButton.isDisabled()).toEqual(true);
+
+      // This is the state the padlock exists to be told apart from. Showing it here would assert "the system
+      // configured this" to someone who is merely unprivileged — the original ambiguity, now confidently wrong.
+      expect(await loader.getHarnessOrNull(MatIconHarness.with({ selector: '[data-testid="branded-senders-system-lock"]' }))).toBeNull();
     });
   });
 

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.html
@@ -45,8 +45,26 @@
     <mat-hint>%s is replaced with the email's subject.</mat-hint>
   </mat-form-field>
 
-  <!-- Branded notification email (editable rules) -->
-  <h3 class="branded-senders__title">Branded notification email</h3>
+  <!--
+    Branded notification email (editable rules).
+
+    The lock tooltip is hosted on the <h3> rather than on the icon, matching the console's container-tooltip pattern
+    and — because a heading is a semantic, AT-navigable node — giving MatTooltip's AriaDescriber somewhere the
+    description is actually announced. The glyph stays decorative (MatIcon defaults it to aria-hidden="true").
+    Note this only holds for the heading: the same placement on a <mat-form-field> lands the description on a
+    role-less div that never reaches the input, which is why the two preview locks above are left alone.
+  -->
+  <h3
+    class="branded-senders__title"
+    data-testid="branded-senders-branded-heading"
+    matTooltip="Configuration provided by the system"
+    [matTooltipDisabled]="!systemLocked()"
+  >
+    Branded notification email
+    @if (systemLocked()) {
+      <mat-icon class="branded-senders__lock" data-testid="branded-senders-system-lock">lock</mat-icon>
+    }
+  </h3>
   <p class="branded-senders__subtitle">
     Add one or more rules. When a recipient's domain matches a rule, that rule's <strong>From</strong> and <strong>Subject</strong> prefix
     are used instead of the defaults above.

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.scss
@@ -27,7 +27,21 @@ $warn: map.get(gio.$mat-theme, warn);
 
   &__title {
     @include mat.m2-typography-level($typography, subtitle-1);
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    // Keeps the heading from stretching across the card: the lock tooltip is hosted on this element, so a
+    // full-width h3 would arm it over empty space to the right and anchor the bubble away from the padlock.
+    width: fit-content;
     margin: 24px 0 4px;
+
+    // MatIcon defaults to 24px, which towers over the heading text; match the icon to the type size so it reads
+    // as part of the heading rather than as a separate control.
+    .branded-senders__lock {
+      width: 16px;
+      height: 16px;
+      font-size: 16px;
+    }
   }
 
   &__subtitle {

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.spec.ts
@@ -21,6 +21,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatFormFieldHarness } from '@angular/material/form-field/testing';
+import { MatIconHarness } from '@angular/material/icon/testing';
 import { MatTooltipHarness } from '@angular/material/tooltip/testing';
 import { GioFormTagsInputHarness } from '@gravitee/ui-particles-angular';
 import { SpanHarness } from '@gravitee/ui-particles-angular/testing';
@@ -41,6 +42,7 @@ import { GioTestingModule } from '../../testing';
         [defaultSubject]="defaultSubject"
         [inheritedFromOrg]="inheritedFromOrg"
         [canReset]="canReset"
+        [systemLocked]="systemLocked"
         (reset)="resetEmitted = resetEmitted + 1"
       />
     </form>
@@ -51,6 +53,7 @@ class TestHostComponent {
   defaultSubject = '';
   inheritedFromOrg = false;
   canReset = false;
+  systemLocked = false;
   resetEmitted = 0;
   form = new FormGroup({
     brandedSenders: new FormControl<BrandedSender[]>([], { nonNullable: true }),
@@ -107,6 +110,59 @@ describe('BrandedSendersComponent', () => {
 
       expect(messages).toContain('Read-only preview of the Default From configured in the Email settings above');
       expect(messages).toContain('Read-only preview of the Default subject prefix configured in the Email settings above');
+    });
+  });
+
+  describe('locked by system configuration', () => {
+    const systemLock = () => loader.getHarnessOrNull(MatIconHarness.with({ selector: '[data-testid="branded-senders-system-lock"]' }));
+    const headingTooltip = () => loader.getHarness(MatTooltipHarness.with({ selector: '[data-testid="branded-senders-branded-heading"]' }));
+    const describedText = () => {
+      const heading: HTMLElement = fixture.nativeElement.querySelector('[data-testid="branded-senders-branded-heading"]');
+      const describedBy = heading.getAttribute('aria-describedby');
+      return describedBy ? document.getElementById(describedBy)?.textContent?.trim() : null;
+    };
+
+    const lockSection = async () => {
+      // A host always disables the control alongside the lock — a locked-but-editable section is unreachable in
+      // production, so exercising that combination would test a state the app cannot produce.
+      component.systemLocked = true;
+      control().disable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+    };
+
+    it('should state that the branded section is locked by the system configuration', async () => {
+      await lockSection();
+
+      expect(await systemLock()).not.toBeNull();
+
+      const tooltip = await headingTooltip();
+      await tooltip.show();
+      expect(await tooltip.getTooltipText()).toBe('Configuration provided by the system');
+    });
+
+    it('should expose the lock reason to assistive technology', async () => {
+      await lockSection();
+
+      // The tooltip sits on the heading, so MatTooltip's AriaDescriber points aria-describedby at the message from an
+      // element that is genuinely in the accessibility tree. The glyph itself stays decorative — MatIcon defaults it
+      // to aria-hidden="true" — so the reason is announced once, with the heading, rather than as a stray icon label.
+      expect(describedText()).toBe('Configuration provided by the system');
+
+      const icon: HTMLElement = fixture.nativeElement.querySelector('[data-testid="branded-senders-system-lock"]');
+      expect(icon.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    // Without this the locked-by-configuration state is indistinguishable from the missing-permission state, which
+    // also arrives as a disabled control (setDisabledState carries no reason).
+    it('should not show the system lock when the section is merely disabled', async () => {
+      control().disable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(await systemLock()).toBeNull();
+      // The description must go too, or assistive tech still hears a lock reason on an unlocked section.
+      expect(describedText()).toBeNull();
     });
   });
 

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.stories.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.stories.ts
@@ -70,6 +70,20 @@ export const Disabled: StoryObj = {
   }),
 };
 
+/** Disabled *and* explained: locked by `gravitee.yml`, as opposed to `Disabled` above (missing permission). */
+export const SystemLocked: StoryObj = {
+  render: () => ({
+    template: `<branded-senders [formControl]="control" [defaultFrom]="defaultFrom" [defaultSubject]="defaultSubject" [systemLocked]="true" />`,
+    props: {
+      control: new FormControl<BrandedSender[]>({
+        value: [{ domains: ['example.com'], from: 'noreply@example.com', subject: '[Example] %s' }],
+        disabled: true,
+      }),
+      ...defaults,
+    },
+  }),
+};
+
 export const InheritedFromOrg: StoryObj = {
   render: () => ({
     template: `<branded-senders [formControl]="control" [defaultFrom]="defaultFrom" [defaultSubject]="defaultSubject" [inheritedFromOrg]="true" />`,

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.ts
@@ -152,6 +152,14 @@ export class BrandedSendersComponent implements ControlValueAccessor, Validator 
   readonly defaultSubject = input('');
 
   /**
+   * Whether the configurations are locked by the system configuration (`gravitee.yml` / `gravitee_email_branded_senders`)
+   * rather than by the user's permissions. Both reach this component as a plain disabled control — `setDisabledState`
+   * carries no reason — so the parent has to state it explicitly for the UI to be able to explain the lock. Without it
+   * the locked-by-configuration state is indistinguishable from "you lack `ENVIRONMENT_SETTINGS[U]`".
+   */
+  readonly systemLocked = input(false);
+
+  /**
    * Whether the shown configurations are inherited from the Organization scope (no Environment-level override).
    * Drives the per-configuration "Inherited from Org" badge; only meaningful at Environment scope. A true value does
    * not imply the Organization has a non-empty configuration, so the badge only renders for configurations actually


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14775

## Description

When branded senders are set in `gravitee.yml`, the section renders greyed out with no padlock and no tooltip — visually identical to the missing-`ENVIRONMENT_SETTINGS[U]` state. An operator sees a dead form with no stated reason and can't tell "locked by system configuration" from "you lack permission".

Adds a `systemLocked` input to the shared `branded-senders` component, rendering the same padlock + tooltip treatment already used by the sibling default fields. Both hosts pass their existing readonly check `isReadonlySetting('email.branded_senders')` in org settings, `isReadonly('email.branded_senders')` in portal settings.

## Additional context

<img width="1500" height="704" alt="Screenshot 2026-07-22 at 4 45 55 PM" src="https://github.com/user-attachments/assets/e14f8014-fcd9-4dd2-bae1-085364995a92" />



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

