### PR TITLE
chore(deps): bump authz plugins to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
     <gravitee-reactor-mcp-proxy.version>3.0.2</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>3.2.0</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.0.0</gravitee-reactor-a2a-proxy.version>
-    <gravitee-reactor-authz.version>1.0.0</gravitee-reactor-authz.version>
+    <gravitee-reactor-authz.version>1.1.0</gravitee-reactor-authz.version>
     <gravitee-reactor-edge.version>1.0.0</gravitee-reactor-edge.version>
     <gravitee-resource-ai-vector-store-redis.version>2.0.0</gravitee-resource-ai-vector-store-redis.version>
     <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>
@@ -348,14 +348,14 @@
 
     <!-- Gamma plugins -->
     <gravitee-gamma-module-aim.version>2.1.0</gravitee-gamma-module-aim.version>
-    <gravitee-gamma-module-authz.version>1.6.0</gravitee-gamma-module-authz.version>
+    <gravitee-gamma-module-authz.version>1.10.1</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>1.1.0</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.0.0</gravitee-gamma-module-esm.version>
 
     <!-- Authz plugins -->
     <gravitee-service-authz-pdp.version>1.0.1</gravitee-service-authz-pdp.version>
-    <gravitee-policy-authz-pep.version>1.1.0</gravitee-policy-authz-pep.version>
-    <gravitee-policy-authz-pdp-authzen.version>1.0.0</gravitee-policy-authz-pdp-authzen.version>
+    <gravitee-policy-authz-pep.version>1.2.0</gravitee-policy-authz-pep.version>
+    <gravitee-policy-authz-pdp-authzen.version>1.1.0</gravitee-policy-authz-pdp-authzen.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
## Issue

N/A — routine authz plugin version bump.

## Description

Updates the bundled authz plugins to their latest released versions:

| Plugin | From | To |
|---|---|---|
| gravitee-gamma-module-authz | 1.6.0 | 1.10.1 |
| gravitee-reactor-authz / gravitee-entrypoint-authz | 1.0.0 | 1.1.0 |
| gravitee-policy-authz-pep | 1.1.0 | 1.2.0 |
| gravitee-policy-authz-pdp-authzen | 1.0.0 | 1.1.0 |
