### PR TITLE
feat: resolve API Product navigation context for Add API flow

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -144,7 +144,7 @@
         Add Page
       </button>
 
-      @if (node.type === 'FOLDER') {
+      @if (node.type === 'FOLDER' || node.type === 'API_PRODUCT') {
         <button mat-menu-item (click)="onCreate(node, 'API')">
           <mat-icon [svgIcon]="'API' | portalNavigationItemIcon"></mat-icon>
           Add API

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -892,7 +892,7 @@ describe('FlatTreeComponent', () => {
       expect(await harness.getMenuItemByText('Add Page')).toBeTruthy();
       expect(await harness.getMenuItemByText('Add Folder')).toBeTruthy();
       expect(await harness.getMenuItemByText('Add Link')).toBeTruthy();
-      expect(await harness.getMenuItemByText('Add API')).toBeNull();
+      expect(await harness.getMenuItemByText('Add API')).toBeTruthy();
       expect(await harness.getMenuItemByTestId('add-api-product-button')).toBeNull();
     });
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.ts
@@ -38,10 +38,16 @@ import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wra
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { getPublicVisibilityDisabledTooltip, isPublicVisibilityDisabled } from '../visibility-toggle.util';
 
+export interface ApiProductNavigationContext {
+  navigationItemId: string;
+  apiProductId: string;
+}
+
 export interface ApiSectionEditorDialogData {
   mode: 'create';
   parentItem?: PortalNavigationItem;
   existingApiIds?: string[];
+  apiProductContext?: ApiProductNavigationContext;
 }
 
 export interface ApiSectionEditorDialogResult {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -3350,6 +3350,117 @@ describe('PortalNavigationItemsComponent', () => {
     });
   });
 
+  describe('API Product context passed to API section dialog', () => {
+    async function openApiSectionDialog(parentItem: PortalNavigationItem): Promise<SpyInstance> {
+      const openSpy = jest.spyOn(TestBed.inject(MatDialog), 'open');
+      const parentNode: SectionNode = {
+        id: parentItem.id,
+        label: parentItem.title,
+        type: parentItem.type,
+        data: parentItem,
+      };
+
+      component.onNodeMenuAction({ action: 'create', itemType: 'API', node: parentNode });
+      fixture.detectChanges();
+      flushPendingLinkedApiProductRequests();
+      await fixture.whenStable();
+      expectApiSearchResponse([]);
+
+      return openSpy;
+    }
+
+    it('should pass API Product context when adding an API directly below the product', async () => {
+      const rootFolder = fakePortalNavigationFolder({ id: 'root-folder', title: 'Root folder' });
+      const apiProduct = fakePortalNavigationApiProduct({
+        id: 'product-navigation-item',
+        apiProductId: 'api-product-id',
+        title: 'API Product',
+        parentId: rootFolder.id,
+      });
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct] }));
+
+      const openSpy = await openApiSectionDialog(apiProduct);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            apiProductContext: {
+              navigationItemId: apiProduct.id,
+              apiProductId: apiProduct.apiProductId,
+            },
+          }),
+        }),
+      );
+    });
+
+    it('should pass the nearest API Product context when adding an API below nested folders', async () => {
+      const rootFolder = fakePortalNavigationFolder({ id: 'root-folder', title: 'Root folder' });
+      const apiProduct = fakePortalNavigationApiProduct({
+        id: 'product-navigation-item',
+        apiProductId: 'api-product-id',
+        title: 'API Product',
+        parentId: rootFolder.id,
+      });
+      const firstNestedFolder = fakePortalNavigationFolder({
+        id: 'first-nested-folder',
+        title: 'First nested folder',
+        parentId: apiProduct.id,
+      });
+      const secondNestedFolder = fakePortalNavigationFolder({
+        id: 'second-nested-folder',
+        title: 'Second nested folder',
+        parentId: firstNestedFolder.id,
+      });
+      await expectGetNavigationItems(
+        fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct, firstNestedFolder, secondNestedFolder] }),
+      );
+
+      const openSpy = await openApiSectionDialog(secondNestedFolder);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            apiProductContext: {
+              navigationItemId: apiProduct.id,
+              apiProductId: apiProduct.apiProductId,
+            },
+          }),
+        }),
+      );
+    });
+
+    it.each([
+      {
+        description: 'a standalone folder',
+        items: [fakePortalNavigationFolder({ id: 'standalone-folder', title: 'Standalone folder' })],
+      },
+      {
+        description: 'a folder whose parent is missing',
+        items: [fakePortalNavigationFolder({ id: 'orphan-folder', title: 'Orphan folder', parentId: 'missing-parent' })],
+      },
+      {
+        description: 'a folder in a cyclic hierarchy',
+        items: [
+          fakePortalNavigationFolder({ id: 'cycle-folder-1', title: 'Cycle folder 1', parentId: 'cycle-folder-2' }),
+          fakePortalNavigationFolder({ id: 'cycle-folder-2', title: 'Cycle folder 2', parentId: 'cycle-folder-1' }),
+        ],
+      },
+    ])('should not pass API Product context for $description', async ({ items }) => {
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items }));
+
+      const openSpy = await openApiSectionDialog(items[0]);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({ apiProductContext: undefined }),
+        }),
+      );
+    });
+  });
+
   describe('calling onAddSection with API type', () => {
     it('should not open any dialog when onAddSection is called with API type', async () => {
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [] }));

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -46,6 +46,7 @@ import {
   SectionEditorDialogMode,
 } from './section-editor-dialog/section-editor-dialog.component';
 import {
+  ApiProductNavigationContext,
   ApiSectionEditorDialogComponent,
   ApiSectionEditorDialogData,
 } from './api-section-editor-dialog/api-section-editor-dialog.component';
@@ -346,6 +347,8 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   }
 
   private createApiSection(existingItem?: PortalNavigationItem): void {
+    const apiProductContext = existingItem ? this.findApiProductNavigationContext(existingItem) : undefined;
+
     this.matDialog
       .open<ApiSectionEditorDialogComponent, ApiSectionEditorDialogData>(ApiSectionEditorDialogComponent, {
         width: GIO_DIALOG_WIDTH.LARGE,
@@ -353,6 +356,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
           mode: 'create',
           existingApiIds: this.extractApiIdsFromNavigationItems(),
           parentItem: existingItem,
+          apiProductContext,
         },
       })
       .afterClosed()
@@ -997,6 +1001,25 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     return this.menuLinks()
       .filter((item): item is PortalNavigationApiProduct => item.type === 'API_PRODUCT')
       .map(item => item.apiProductId);
+  }
+
+  private findApiProductNavigationContext(item: PortalNavigationItem): ApiProductNavigationContext | undefined {
+    const itemsById = new Map(this.menuLinks().map(menuItem => [menuItem.id, menuItem]));
+    const visitedItemIds = new Set<string>();
+    let currentItem: PortalNavigationItem | undefined = item;
+
+    while (currentItem && !visitedItemIds.has(currentItem.id)) {
+      visitedItemIds.add(currentItem.id);
+      if (currentItem.type === 'API_PRODUCT') {
+        return {
+          navigationItemId: currentItem.id,
+          apiProductId: currentItem.apiProductId,
+        };
+      }
+      currentItem = currentItem.parentId ? itemsById.get(currentItem.parentId) : undefined;
+    }
+
+    return undefined;
   }
 
   private isInsideApiProductSubtree(item: PortalNavigationItem): boolean {


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/PORTAL-78

## Description

Adds API Product navigation context resolution to the existing Add API flow.

## Changes

- Enables the **Add API** action for API Product navigation items.
- Resolves the nearest owning API Product for direct and nested navigation items.
- Passes the API Product navigation item ID and API Product ID to the Add APIs dialog.
- Preserves the existing standalone Add API behavior.
- Safely handles missing parents and cyclic navigation hierarchies.
- Adds regression tests for product, nested folder, standalone, orphaned, and cyclic contexts.


## Dependencies

This is a stacked PR based on `PORTAL-75-frontend-integrate-api-product-documentation-tree`.
