### PR TITLE
fix(apim): show tool tip after selection for users

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-add-group-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-add-group-dialog.component.scss
@@ -17,7 +17,17 @@
     }
 
     .mat-mdc-select-value-text {
+      display: block;
       overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      .org-settings-user-detail__role-trigger {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
   }
 

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.scss
@@ -62,7 +62,17 @@ $border-color: mat.m2-get-color-from-palette($foreground, divider);
         }
 
         .mat-mdc-select-value-text {
+          display: block;
           overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+
+          .org-settings-user-detail__role-trigger {
+            display: block;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
         }
       }
     }

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.scss
@@ -98,6 +98,7 @@ org-settings-user-detail {
 
   &__role-trigger {
     display: block;
+    width: 100%;
     min-width: 0;
     overflow: hidden;
     white-space: nowrap;

--- a/gravitee-apim-console-webui/src/shared/components/gio-tooltip-on-ellipsis/gio-tooltip-on-ellipsis.directive.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-tooltip-on-ellipsis/gio-tooltip-on-ellipsis.directive.spec.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
+
+import { GioTooltipOnEllipsisDirective } from './gio-tooltip-on-ellipsis.directive';
+import { GioTooltipOnEllipsisModule } from './gio-tooltip-on-ellipsis.module';
+
+@Component({
+  standalone: false,
+  template: `
+    <span class="truncated" gioTooltipOnEllipsis>{{ truncatedText }}</span>
+    <span class="short" gioTooltipOnEllipsis>{{ shortText }}</span>
+    <span class="select-trigger" gioTooltipOnEllipsis>{{ matSelectTriggerText }}</span>
+    <div class="mat-mdc-select-value-text">
+      <span class="select-value" gioTooltipOnEllipsis>{{ selectValueText }}</span>
+    </div>
+    <div class="role-option" gioTooltipOnEllipsis>
+      <span class="mdc-list-item__primary-text">{{ optionRoleName }}</span>
+    </div>
+  `,
+})
+class TestHostComponent {
+  truncatedText = 'VERY_LONG_ROLE_NAME_THAT_SHOULD_TRUNCATE';
+  shortText = 'SHORT';
+  matSelectTriggerText = '';
+  selectValueText = 'SENIOR_REGIONAL_DEPUTY_VICE_PRESIDENT';
+  optionRoleName = 'SENIOR_REGIONAL_DEPUTY_VICE_PRESIDENT_OF_OPERATIONS';
+}
+
+describe('GioTooltipOnEllipsisDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestHostComponent],
+      imports: [NoopAnimationsModule, GioTooltipOnEllipsisModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
+  function setElementDimensions(element: HTMLElement, offsetWidth: number, scrollWidth: number): void {
+    Object.defineProperty(element, 'offsetWidth', { configurable: true, value: offsetWidth });
+    Object.defineProperty(element, 'scrollWidth', { configurable: true, value: scrollWidth });
+  }
+
+  function getDirective(selector: string): GioTooltipOnEllipsisDirective {
+    return fixture.debugElement.query(By.css(selector)).injector.get(GioTooltipOnEllipsisDirective);
+  }
+
+  function getHostElement(selector: string): HTMLElement {
+    return fixture.debugElement.query(By.css(selector)).nativeElement as HTMLElement;
+  }
+
+  it('should show tooltip on hover when content is truncated', () => {
+    const truncatedEl = getHostElement('.truncated');
+    setElementDimensions(truncatedEl, 40, 200);
+
+    const directive = getDirective('.truncated');
+    const showSpy = jest.spyOn(directive, 'show');
+
+    truncatedEl.dispatchEvent(new MouseEvent('mouseenter'));
+    fixture.detectChanges();
+
+    expect(directive.disabled).toBe(false);
+    expect(directive.message).toBe('VERY_LONG_ROLE_NAME_THAT_SHOULD_TRUNCATE');
+    expect(showSpy).toHaveBeenCalled();
+  });
+
+  it('should not show tooltip on hover when content fits', () => {
+    const shortEl = getHostElement('.short');
+    setElementDimensions(shortEl, 400, 400);
+
+    const directive = getDirective('.short');
+    const showSpy = jest.spyOn(directive, 'show');
+
+    shortEl.dispatchEvent(new MouseEvent('mouseenter'));
+    fixture.detectChanges();
+
+    expect(directive.disabled).toBe(true);
+    expect(directive.message).toBe('');
+    expect(showSpy).not.toHaveBeenCalled();
+  });
+
+  it('should show tooltip after trigger text changes following init', () => {
+    const triggerEl = getHostElement('.select-trigger');
+    const directive = getDirective('.select-trigger');
+    const showSpy = jest.spyOn(directive, 'show');
+
+    triggerEl.dispatchEvent(new MouseEvent('mouseenter'));
+    fixture.detectChanges();
+    expect(showSpy).not.toHaveBeenCalled();
+
+    fixture.componentInstance.matSelectTriggerText = 'SENIOR_REGIONAL_DEPUTY_VICE_PRESIDENT_OF_OPERATIONS';
+    fixture.detectChanges();
+    setElementDimensions(triggerEl, 80, 400);
+
+    triggerEl.dispatchEvent(new MouseEvent('mouseenter'));
+    fixture.detectChanges();
+
+    expect(directive.disabled).toBe(false);
+    expect(directive.message).toBe('SENIOR_REGIONAL_DEPUTY_VICE_PRESIDENT_OF_OPERATIONS');
+    expect(showSpy).toHaveBeenCalled();
+  });
+
+  it('should detect overflow on mat-select value text container', () => {
+    const selectValueEl = getHostElement('.select-value');
+    const selectValueTextEl = selectValueEl.closest('.mat-mdc-select-value-text') as HTMLElement;
+
+    setElementDimensions(selectValueEl, 160, 160);
+    setElementDimensions(selectValueTextEl, 80, 320);
+
+    const directive = getDirective('.select-value');
+    const showSpy = jest.spyOn(directive, 'show');
+
+    selectValueEl.dispatchEvent(new MouseEvent('mouseenter'));
+    fixture.detectChanges();
+
+    expect(directive.disabled).toBe(false);
+    expect(directive.message).toBe('SENIOR_REGIONAL_DEPUTY_VICE_PRESIDENT');
+    expect(showSpy).toHaveBeenCalled();
+  });
+
+  it('should detect overflow on mat-option primary text', () => {
+    const optionEl = getHostElement('.role-option');
+    const primaryTextEl = optionEl.querySelector('.mdc-list-item__primary-text') as HTMLElement;
+
+    setElementDimensions(optionEl, 280, 280);
+    setElementDimensions(primaryTextEl, 200, 400);
+
+    const directive = getDirective('.role-option');
+    const showSpy = jest.spyOn(directive, 'show');
+
+    optionEl.dispatchEvent(new MouseEvent('mouseenter'));
+    fixture.detectChanges();
+
+    expect(directive.disabled).toBe(false);
+    expect(directive.message).toBe('SENIOR_REGIONAL_DEPUTY_VICE_PRESIDENT_OF_OPERATIONS');
+    expect(showSpy).toHaveBeenCalled();
+  });
+});

--- a/gravitee-apim-console-webui/src/shared/components/gio-tooltip-on-ellipsis/gio-tooltip-on-ellipsis.directive.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-tooltip-on-ellipsis/gio-tooltip-on-ellipsis.directive.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AfterViewInit, Directive, ElementRef, HostListener, Inject, NgZone, Optional, ViewContainerRef, DOCUMENT } from '@angular/core';
+import { Directive, ElementRef, HostListener, Inject, NgZone, Optional, ViewContainerRef, DOCUMENT } from '@angular/core';
 import { MAT_TOOLTIP_DEFAULT_OPTIONS, MAT_TOOLTIP_SCROLL_STRATEGY, MatTooltip, MatTooltipDefaultOptions } from '@angular/material/tooltip';
 import { Overlay, ScrollDispatcher } from '@angular/cdk/overlay';
 import { Platform } from '@angular/cdk/platform';
@@ -21,38 +21,42 @@ import { AriaDescriber, FocusMonitor } from '@angular/cdk/a11y';
 import { Directionality } from '@angular/cdk/bidi';
 
 /**
- * This directive will enable and display tooltip if the element is formatted with ellipsis.
- * The tooltip will display the full original message.
+ * Enables and displays a tooltip with the element's full text when that text is truncated with an ellipsis.
  */
 @Directive({
   selector: '[gioTooltipOnEllipsis]',
   standalone: false,
 })
-export class GioTooltipOnEllipsisDirective extends MatTooltip implements AfterViewInit {
+export class GioTooltipOnEllipsisDirective extends MatTooltip {
   private nativeElement: HTMLElement;
-  private isEllipsis = false;
-
-  override get message(): string {
-    return this.nativeElement?.textContent?.trim() ?? '';
-  }
-
-  override get disabled(): boolean {
-    return !this.isEllipsis;
-  }
-
-  override ngAfterViewInit(): void {
-    super.ngAfterViewInit();
-    this.isEllipsis = this.hasVisibleOverflow(this.nativeElement);
-  }
 
   @HostListener('mouseenter')
   onMouseEnter(): void {
-    this.isEllipsis = this.hasVisibleOverflow(this.nativeElement);
+    this.syncFromElement();
+    if (!this.disabled && this.message) {
+      this.show();
+    }
+  }
+
+  private syncFromElement(): void {
+    const text = this.nativeElement?.textContent?.trim() ?? '';
+    const isEllipsis = !!text && this.hasVisibleOverflow(this.nativeElement);
+
+    this.message = isEllipsis ? text : '';
+    this.disabled = !isEllipsis;
   }
 
   private hasVisibleOverflow(element: HTMLElement): boolean {
-    if (element.offsetWidth < element.scrollWidth) {
-      return true;
+    const elementsToCheck = [
+      element,
+      element.closest<HTMLElement>('.mat-mdc-select-value-text'),
+      element.closest<HTMLElement>('.mat-mdc-select-trigger'),
+    ].filter((el, index, list): el is HTMLElement => !!el && list.indexOf(el) === index);
+
+    for (const el of elementsToCheck) {
+      if (el.offsetWidth < el.scrollWidth) {
+        return true;
+      }
     }
 
     const primaryText =


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-14453

## Description

- Fixes truncated role names on User detail role dropdowns.

- As Per product/UX team feedback: keep fixed-width dropdowns with ellipsis (not AM-style expanding panels), and show the full role name on hover when truncated, for both options and the selected value.

- Updates gioTooltipOnEllipsis so hover works after selection, plus small CSS so mat-select triggers truncate and detect overflow correctly.

## Additional context


https://github.com/user-attachments/assets/3ce0c2d1-d8b9-4892-9e7d-5ee284ac09de


