### PR TITLE
feat: expose API Product navigation items in Portal API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -194,6 +194,7 @@ import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudServi
 import io.gravitee.apim.core.portal_page.domain_service.GraviteePortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiPortalPageContentValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
@@ -1453,9 +1454,18 @@ public class ResourceContextConfiguration {
     @Bean
     public ListPortalNavigationItemsUseCase listPortalNavigationItemsUseCase(
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
-        PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService
+        PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService,
+        PortalNavigationApiProductVisibilityDomainService portalNavigationApiProductVisibilityDomainService
     ) {
-        return new ListPortalNavigationItemsUseCase(portalNavigationItemsQueryService, portalNavigationApiVisibilityDomainService);
+        return new ListPortalNavigationItemsUseCase(
+            portalNavigationItemsQueryService,
+            List.of(portalNavigationApiVisibilityDomainService, portalNavigationApiProductVisibilityDomainService)
+        );
+    }
+
+    @Bean
+    public PortalNavigationApiProductVisibilityDomainService portalNavigationApiProductVisibilityDomainService() {
+        return mock(PortalNavigationApiProductVisibilityDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.rest.api.portal.rest.mapper;
 
-import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.OpenApiConfiguration;
@@ -59,9 +58,7 @@ public interface PortalNavigationItemMapper {
             case PortalNavigationLink link -> map(link);
             case PortalNavigationPage page -> map(page);
             case PortalNavigationApi api -> map(api);
-            case PortalNavigationApiProduct ignored -> throw new TechnicalDomainException(
-                "API Product navigation items are not yet supported by the Portal API"
-            );
+            case PortalNavigationApiProduct apiProduct -> map(apiProduct);
         };
         var wrappedItem = new io.gravitee.rest.api.portal.rest.model.PortalNavigationItem();
         wrappedItem.setActualInstance(baseItem);
@@ -72,6 +69,7 @@ public interface PortalNavigationItemMapper {
     io.gravitee.rest.api.portal.rest.model.PortalNavigationLink map(PortalNavigationLink link);
     io.gravitee.rest.api.portal.rest.model.PortalNavigationPage map(PortalNavigationPage page);
     io.gravitee.rest.api.portal.rest.model.PortalNavigationApi map(PortalNavigationApi api);
+    io.gravitee.rest.api.portal.rest.model.PortalNavigationApiProduct map(PortalNavigationApiProduct apiProduct);
 
     @Mapping(source = "value", target = "content")
     default String extractContent(PortalPageContent<?> content) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/spring/RestPortalConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/spring/RestPortalConfiguration.java
@@ -16,8 +16,11 @@
 package io.gravitee.rest.api.portal.rest.spring;
 
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
@@ -94,7 +97,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @EnableAsync
 public class RestPortalConfiguration {
 
-    // NOTE: The @Bean definitions for ApiPortalMembershipDomainService and PortalNavigationApiVisibilityDomainService
+    // NOTE: The @Bean definitions for Portal visibility domain services
     // are required because @DomainService classes in io.gravitee.apim.core are not component-scanned in the portal
     // context (we don't Import CoreServiceSpringConfiguration or UsecaseSpringConfiguration here to keep this
     // context lean). When Stories 2/3 (dashboard + analytics endpoints) import UsecaseSpringConfiguration to pull
@@ -115,6 +118,25 @@ public class RestPortalConfiguration {
         ApiPortalMembershipDomainService apiPortalMembershipDomainService
     ) {
         return new PortalNavigationApiVisibilityDomainService(portalNavigationItemsQueryService, apiPortalMembershipDomainService);
+    }
+
+    @Bean
+    public ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService(
+        ApiProductQueryService apiProductQueryService,
+        MembershipQueryService membershipQueryService
+    ) {
+        return new ApiProductAccessibleIdsDomainService(apiProductQueryService, membershipQueryService);
+    }
+
+    @Bean
+    public PortalNavigationApiProductVisibilityDomainService portalNavigationApiProductVisibilityDomainService(
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService,
+        ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService
+    ) {
+        return new PortalNavigationApiProductVisibilityDomainService(
+            portalNavigationItemsQueryService,
+            apiProductAccessibleIdsDomainService
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -8163,6 +8163,7 @@ components:
                     FOLDER: "#/components/schemas/PortalNavigationFolder"
                     LINK: "#/components/schemas/PortalNavigationLink"
                     API: "#/components/schemas/PortalNavigationApi"
+                    API_PRODUCT: "#/components/schemas/PortalNavigationApiProduct"
         PortalNavigationPage:
             allOf:
                 - $ref: "#/components/schemas/BasePortalNavigationItem"
@@ -8190,12 +8191,22 @@ components:
                   type: string
                   description: The ApiId for the navigation item
               required: [ apiId ]
+        PortalNavigationApiProduct:
+          allOf:
+            - $ref: "#/components/schemas/BasePortalNavigationItem"
+            - properties:
+                apiProductId:
+                  type: string
+                  format: uuid
+                  description: The API Product ID for the navigation item
+              required: [ apiProductId ]
         PortalNavigationItem:
             oneOf:
                 - $ref: "#/components/schemas/PortalNavigationPage"
                 - $ref: "#/components/schemas/PortalNavigationFolder"
                 - $ref: "#/components/schemas/PortalNavigationLink"
                 - $ref: "#/components/schemas/PortalNavigationApi"
+                - $ref: "#/components/schemas/PortalNavigationApiProduct"
             discriminator:
                 propertyName: type
                 mapping:
@@ -8203,6 +8214,7 @@ components:
                     FOLDER: "#/components/schemas/PortalNavigationFolder"
                     LINK: "#/components/schemas/PortalNavigationLink"
                     API: "#/components/schemas/PortalNavigationApi"
+                    API_PRODUCT: "#/components/schemas/PortalNavigationApiProduct"
 
         PortalPageContent:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/fixture/PortalNavigationFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/fixture/PortalNavigationFixtures.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.portal.rest.fixture;
 
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -25,6 +26,7 @@ import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public final class PortalNavigationFixtures {
 
@@ -83,6 +85,21 @@ public final class PortalNavigationFixtures {
             .area(area)
             .order(1)
             .portalPageContentId(pageId)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    public static PortalNavigationApiProduct apiProduct(PortalNavigationItemId id, String title, PortalArea area, UUID apiProductId) {
+        return PortalNavigationApiProduct.builder()
+            .id(id)
+            .organizationId("org")
+            .environmentId("env")
+            .title(title)
+            .segment(PortalNavigationItem.slugify(title).value())
+            .area(area)
+            .order(1)
+            .apiProductId(apiProductId.toString())
             .published(true)
             .visibility(PortalVisibility.PUBLIC)
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapperTest.java
@@ -16,9 +16,7 @@
 package io.gravitee.rest.api.portal.rest.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
@@ -30,6 +28,7 @@ import io.gravitee.rest.api.portal.rest.model.PortalNavigationFolder;
 import io.gravitee.rest.api.portal.rest.model.PortalNavigationLink;
 import io.gravitee.rest.api.portal.rest.model.PortalNavigationPage;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -81,7 +80,8 @@ class PortalNavigationItemMapperTest {
     }
 
     @Test
-    void should_reject_api_product_not_yet_supported_by_portal_api() {
+    void should_map_api_product() {
+        var apiProductId = "00000000-0000-0000-0000-000000000019";
         var apiProduct = PortalNavigationApiProduct.builder()
             .id(PortalNavigationFixtures.randomNavigationId())
             .organizationId("org")
@@ -90,13 +90,16 @@ class PortalNavigationItemMapperTest {
             .segment("api-product")
             .area(PortalArea.TOP_NAVBAR)
             .order(1)
-            .apiProductId("api-product-id")
+            .apiProductId(apiProductId)
             .published(true)
             .visibility(PortalVisibility.PUBLIC)
             .build();
 
-        assertThatThrownBy(() -> PortalNavigationItemMapper.INSTANCE.getBasePortalNavigationItem(apiProduct))
-            .isInstanceOf(TechnicalDomainException.class)
-            .hasMessage("API Product navigation items are not yet supported by the Portal API");
+        var mapped = PortalNavigationItemMapper.INSTANCE.getBasePortalNavigationItem(apiProduct);
+
+        assertThat(mapped.getActualInstance()).isInstanceOf(io.gravitee.rest.api.portal.rest.model.PortalNavigationApiProduct.class);
+        var mappedApiProduct = (io.gravitee.rest.api.portal.rest.model.PortalNavigationApiProduct) mapped.getActualInstance();
+        assertThat(mappedApiProduct.getApiProductId()).isEqualTo(UUID.fromString(apiProductId));
+        assertThat(mappedApiProduct.getTitle()).isEqualTo("API Product");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
@@ -33,11 +33,13 @@ import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
 import io.gravitee.rest.api.portal.rest.model.PageConfiguration;
+import io.gravitee.rest.api.portal.rest.model.PortalNavigationApiProduct;
 import io.gravitee.rest.api.portal.rest.model.PortalPageContent;
 import io.gravitee.rest.api.portal.rest.model.PortalPageContentType;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -140,6 +142,22 @@ public class PortalNavigationItemResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_return_api_product_navigation_item() {
+            var itemId = PortalNavigationFixtures.randomNavigationId();
+            var apiProductId = UUID.randomUUID();
+            var apiProduct = PortalNavigationFixtures.apiProduct(itemId, "API Product", PortalArea.TOP_NAVBAR, apiProductId);
+            apiProduct.setEnvironmentId(ENV_ID);
+            portalNavigationItemsQueryService.initWith(List.of(apiProduct));
+
+            Response response = target(itemId.toString()).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            var result = response.readEntity(io.gravitee.rest.api.portal.rest.model.PortalNavigationItem.class);
+            assertThat(result.getActualInstance()).isInstanceOf(PortalNavigationApiProduct.class);
+            assertThat(result.getPortalNavigationApiProduct().getApiProductId()).isEqualTo(apiProductId);
+        }
+
+        @Test
         void should_return_404_when_item_not_found() {
             // Given
             var unknownId = PortalNavigationFixtures.randomNavigationId();
@@ -205,6 +223,37 @@ public class PortalNavigationItemResourceTest extends AbstractResourceTest {
             var content = response.readEntity(PortalPageContent.class);
             assertThat(content.getContent()).isEqualTo("Page content text");
             assertThat(content.getType()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
+        }
+
+        @Test
+        void should_return_404_when_page_is_under_inaccessible_private_api_product() {
+            var productId = PortalNavigationFixtures.randomNavigationId();
+            var apiProduct = PortalNavigationFixtures.apiProduct(
+                productId,
+                "Private API Product",
+                PortalArea.TOP_NAVBAR,
+                UUID.randomUUID()
+            );
+            apiProduct.setEnvironmentId(ENV_ID);
+            apiProduct.setVisibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
+
+            var pageId = PortalNavigationFixtures.randomNavigationId();
+            var contentId = PortalNavigationFixtures.randomPageId();
+            var page = PortalNavigationFixtures.page(pageId, "Product documentation", PortalArea.TOP_NAVBAR, contentId);
+            page.setEnvironmentId(ENV_ID);
+            page.updateParent(apiProduct);
+            var pageContent = PortalPageContentFixtures.aGraviteeMarkdownPageContent(
+                contentId,
+                ORGANIZATION_ID,
+                ENV_ID,
+                "Private product content"
+            );
+            portalNavigationItemsQueryService.initWith(List.of(apiProduct, page));
+            portalPageContentQueryService.initWith(List.of(pageContent));
+
+            Response response = target(pageId.toString()).path("content").request().get();
+
+            assertThat(response.getStatus()).isEqualTo(404);
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceTest.java
@@ -32,11 +32,13 @@ import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
+import io.gravitee.rest.api.portal.rest.model.PortalNavigationApiProduct;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -96,6 +98,32 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
             new jakarta.ws.rs.core.GenericType<List<io.gravitee.rest.api.portal.rest.model.PortalNavigationItem>>() {}
         );
         assertThat(result).hasSize(items.size());
+    }
+
+    @Test
+    void should_return_api_product_navigation_item() {
+        var itemId = PortalNavigationFixtures.randomNavigationId();
+        var apiProductId = UUID.randomUUID();
+        var apiProduct = PortalNavigationFixtures.apiProduct(itemId, "API Product", PortalArea.TOP_NAVBAR, apiProductId);
+        apiProduct.setEnvironmentId(ENV_ID);
+        portalNavigationItemsQueryService.initWith(List.of(apiProduct));
+
+        Response response = target()
+            .queryParam("area", io.gravitee.rest.api.portal.rest.model.PortalArea.TOP_NAVBAR)
+            .queryParam("loadChildren", true)
+            .request()
+            .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(
+            new jakarta.ws.rs.core.GenericType<List<io.gravitee.rest.api.portal.rest.model.PortalNavigationItem>>() {}
+        );
+        assertThat(result)
+            .singleElement()
+            .satisfies(item -> {
+                assertThat(item.getActualInstance()).isInstanceOf(PortalNavigationApiProduct.class);
+                assertThat(item.getPortalNavigationApiProduct().getApiProductId()).isEqualTo(apiProductId);
+            });
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -73,7 +73,9 @@ import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Fields;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductTagsValidationDomainService;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
@@ -148,6 +150,7 @@ import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomain
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.CheckTypoToleranceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
@@ -1281,9 +1284,13 @@ public class ResourceContextConfiguration {
     @Bean
     public ListPortalNavigationItemsUseCase listPortalNavigationItemsUseCase(
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
-        PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService
+        PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService,
+        PortalNavigationApiProductVisibilityDomainService portalNavigationApiProductVisibilityDomainService
     ) {
-        return new ListPortalNavigationItemsUseCase(portalNavigationItemsQueryService, portalNavigationApiVisibilityDomainService);
+        return new ListPortalNavigationItemsUseCase(
+            portalNavigationItemsQueryService,
+            List.of(portalNavigationApiVisibilityDomainService, portalNavigationApiProductVisibilityDomainService)
+        );
     }
 
     @Bean
@@ -1316,6 +1323,25 @@ public class ResourceContextConfiguration {
         ApiPortalMembershipDomainService apiPortalMembershipDomainService
     ) {
         return new PortalNavigationApiVisibilityDomainService(portalNavigationItemsQueryService, apiPortalMembershipDomainService);
+    }
+
+    @Bean
+    public ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService(
+        ApiProductQueryService apiProductQueryService,
+        MembershipQueryService membershipQueryService
+    ) {
+        return new ApiProductAccessibleIdsDomainService(apiProductQueryService, membershipQueryService);
+    }
+
+    @Bean
+    public PortalNavigationApiProductVisibilityDomainService portalNavigationApiProductVisibilityDomainService(
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService,
+        ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService
+    ) {
+        return new PortalNavigationApiProductVisibilityDomainService(
+            portalNavigationItemsQueryService,
+            apiProductAccessibleIdsDomainService
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiProductVisibilityDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiProductVisibilityDomainService.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class PortalNavigationApiProductVisibilityDomainService implements PortalNavigationItemVisibilityService {
+
+    private final PortalNavigationItemsQueryService queryService;
+    private final ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService;
+
+    @Override
+    public boolean appliesTo(PortalNavigationItem item) {
+        return item instanceof PortalNavigationApiProduct;
+    }
+
+    @Override
+    public Predicate<PortalNavigationItem> prepareVisibilityPredicate(
+        String environmentId,
+        PortalNavigationItemViewerContext viewerContext
+    ) {
+        Set<String> accessibleApiProductIds = resolveAccessibleApiProductIds(environmentId, viewerContext);
+        return item -> !isApiProductItemHidden((PortalNavigationApiProduct) item, viewerContext, accessibleApiProductIds);
+    }
+
+    public boolean isApiProductItemHidden(
+        String environmentId,
+        PortalNavigationApiProduct item,
+        PortalNavigationItemViewerContext viewerContext
+    ) {
+        if (!viewerContext.isPortalMode() || PortalVisibility.PUBLIC.equals(item.getVisibility())) {
+            return false;
+        }
+        if (!viewerContext.isAuthenticated()) {
+            return true;
+        }
+        return viewerContext
+            .userId()
+            .map(userId ->
+                !apiProductAccessibleIdsDomainService.findAccessibleApiProductIds(environmentId, userId).contains(item.getApiProductId())
+            )
+            .orElse(true);
+    }
+
+    public Set<String> resolveAccessibleApiProductIds(String environmentId, PortalNavigationItemViewerContext viewerContext) {
+        if (!viewerContext.isPortalMode()) {
+            return Set.of();
+        }
+        return viewerContext
+            .userId()
+            .map(userId -> apiProductAccessibleIdsDomainService.findAccessibleApiProductIds(environmentId, userId))
+            .orElse(Set.of());
+    }
+
+    public boolean isApiProductItemHidden(
+        PortalNavigationApiProduct item,
+        PortalNavigationItemViewerContext viewerContext,
+        Set<String> accessibleApiProductIds
+    ) {
+        if (!viewerContext.isPortalMode() || PortalVisibility.PUBLIC.equals(item.getVisibility())) {
+            return false;
+        }
+        return !viewerContext.isAuthenticated() || !accessibleApiProductIds.contains(item.getApiProductId());
+    }
+
+    public boolean hasHiddenApiProductAncestor(
+        String environmentId,
+        PortalNavigationItem item,
+        PortalNavigationItemViewerContext viewerContext
+    ) {
+        return hasHiddenApiProductAncestor(environmentId, item, viewerContext, apiProductAncestor ->
+            isApiProductItemHidden(environmentId, apiProductAncestor, viewerContext)
+        );
+    }
+
+    public boolean hasHiddenApiProductAncestor(
+        String environmentId,
+        PortalNavigationItem item,
+        PortalNavigationItemViewerContext viewerContext,
+        Set<String> accessibleApiProductIds
+    ) {
+        return hasHiddenApiProductAncestor(environmentId, item, viewerContext, apiProductAncestor ->
+            isApiProductItemHidden(apiProductAncestor, viewerContext, accessibleApiProductIds)
+        );
+    }
+
+    private boolean hasHiddenApiProductAncestor(
+        String environmentId,
+        PortalNavigationItem item,
+        PortalNavigationItemViewerContext viewerContext,
+        Predicate<PortalNavigationApiProduct> isHidden
+    ) {
+        if (!viewerContext.isPortalMode()) {
+            return false;
+        }
+
+        Set<PortalNavigationItemId> visited = new HashSet<>();
+        PortalNavigationItem current = item;
+        while (current != null && current.getParentId() != null && visited.add(current.getId())) {
+            current = queryService.findByIdAndEnvironmentId(environmentId, current.getParentId());
+            if (current instanceof PortalNavigationApiProduct apiProductAncestor && isHidden.test(apiProductAncestor)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
@@ -28,14 +28,28 @@ import jakarta.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
 @RequiredArgsConstructor
-public class PortalNavigationApiVisibilityDomainService {
+public class PortalNavigationApiVisibilityDomainService implements PortalNavigationItemVisibilityService {
 
     private final PortalNavigationItemsQueryService queryService;
     private final ApiPortalMembershipDomainService apiMembershipDomainService;
+
+    @Override
+    public boolean appliesTo(PortalNavigationItem item) {
+        return item instanceof PortalNavigationApi;
+    }
+
+    @Override
+    public Predicate<PortalNavigationItem> prepareVisibilityPredicate(
+        String environmentId,
+        PortalNavigationItemViewerContext viewerContext
+    ) {
+        return item -> !isApiItemHidden((PortalNavigationApi) item, viewerContext);
+    }
 
     /**
      * Resolves visible APIs for unauthenticated portal access where only public APIs should be exposed.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemVisibilityEvaluator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemVisibilityEvaluator.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+public class PortalNavigationItemVisibilityEvaluator {
+
+    private final String environmentId;
+    private final PortalNavigationItemsQueryService queryService;
+    private final List<PreparedVisibilityService> visibilityServices;
+
+    public PortalNavigationItemVisibilityEvaluator(
+        String environmentId,
+        PortalNavigationItemViewerContext viewerContext,
+        PortalNavigationItemsQueryService queryService,
+        List<PortalNavigationItemVisibilityService> visibilityServices
+    ) {
+        this.environmentId = environmentId;
+        this.queryService = queryService;
+        this.visibilityServices = visibilityServices
+            .stream()
+            .map(service -> new PreparedVisibilityService(service, service.prepareVisibilityPredicate(environmentId, viewerContext)))
+            .toList();
+    }
+
+    public boolean isVisible(PortalNavigationItem item) {
+        return visibilityServices
+            .stream()
+            .filter(service -> service.appliesTo(item))
+            .findFirst()
+            .map(service -> service.isVisible(item))
+            .orElse(true);
+    }
+
+    public boolean hasHiddenAncestor(PortalNavigationItem item) {
+        Set<PortalNavigationItemId> visited = new HashSet<>();
+        PortalNavigationItem current = item;
+        while (current != null && current.getParentId() != null && visited.add(current.getId())) {
+            current = queryService.findByIdAndEnvironmentId(environmentId, current.getParentId());
+            if (current != null && !isVisible(current)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private record PreparedVisibilityService(
+        PortalNavigationItemVisibilityService service,
+        Predicate<PortalNavigationItem> visibilityPredicate
+    ) {
+        private boolean appliesTo(PortalNavigationItem item) {
+            return service.appliesTo(item);
+        }
+
+        private boolean isVisible(PortalNavigationItem item) {
+            return visibilityPredicate.test(item);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemVisibilityService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemVisibilityService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import java.util.function.Predicate;
+
+public interface PortalNavigationItemVisibilityService {
+    boolean appliesTo(PortalNavigationItem item);
+
+    Predicate<PortalNavigationItem> prepareVisibilityPredicate(String environmentId, PortalNavigationItemViewerContext viewerContext);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCase.java
@@ -16,13 +16,14 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityEvaluator;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityService;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
@@ -31,7 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class GetPortalNavigationItemUseCase {
 
     private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
-    private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
+    private final List<PortalNavigationItemVisibilityService> visibilityServices;
 
     public Output execute(Input input) {
         final PortalNavigationItem foundItem = Optional.ofNullable(
@@ -40,11 +41,13 @@ public class GetPortalNavigationItemUseCase {
 
         input.viewerContext().validateAccess(foundItem);
 
-        if (foundItem instanceof PortalNavigationApi api && apiVisibilityDomainService.isApiItemHidden(api, input.viewerContext())) {
-            throw new PortalNavigationItemNotFoundException(foundItem.getId().json());
-        }
-
-        if (apiVisibilityDomainService.hasHiddenApiAncestor(input.environmentId(), foundItem, input.viewerContext())) {
+        var visibilityEvaluator = new PortalNavigationItemVisibilityEvaluator(
+            input.environmentId(),
+            input.viewerContext(),
+            portalNavigationItemsQueryService,
+            visibilityServices
+        );
+        if (!visibilityEvaluator.isVisible(foundItem) || visibilityEvaluator.hasHiddenAncestor(foundItem)) {
             throw new PortalNavigationItemNotFoundException(foundItem.getId().json());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
@@ -17,12 +17,12 @@ package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.portal_page.domain_service.ContentRenderer;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityEvaluator;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.RendererException;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
@@ -41,7 +41,7 @@ public class GetPortalPageContentByNavigationIdUseCase {
 
     private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
     private final PortalPageContentQueryService portalPageContentQueryService;
-    private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
+    private final List<PortalNavigationItemVisibilityService> visibilityServices;
     private final List<ContentRenderer> contentRenderers;
 
     public Output execute(Input input) {
@@ -54,14 +54,13 @@ public class GetPortalPageContentByNavigationIdUseCase {
 
         input.viewerContext().validateAccess(portalNavigationItem);
 
-        if (
-            portalNavigationItem instanceof PortalNavigationApi api &&
-            apiVisibilityDomainService.isApiItemHidden(api, input.viewerContext())
-        ) {
-            throw new PortalNavigationItemNotFoundException(portalNavigationItem.getId().json());
-        }
-
-        if (apiVisibilityDomainService.hasHiddenApiAncestor(input.environmentId(), portalNavigationItem, input.viewerContext())) {
+        var visibilityEvaluator = new PortalNavigationItemVisibilityEvaluator(
+            input.environmentId(),
+            input.viewerContext(),
+            portalNavigationItemsQueryService,
+            visibilityServices
+        );
+        if (!visibilityEvaluator.isVisible(portalNavigationItem) || visibilityEvaluator.hasHiddenAncestor(portalNavigationItem)) {
             throw new PortalNavigationItemNotFoundException(portalNavigationItem.getId().json());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCase.java
@@ -16,9 +16,9 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityEvaluator;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityService;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemComparator;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
@@ -39,31 +39,43 @@ import lombok.RequiredArgsConstructor;
 public class ListPortalNavigationItemsUseCase {
 
     private final PortalNavigationItemsQueryService queryService;
-    private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
+    private final List<PortalNavigationItemVisibilityService> visibilityServices;
     private static final Predicate<PortalNavigationItem> IS_CONTAINER_PREDICATE = i -> i instanceof PortalNavigationItemContainer;
 
     public Output execute(Input input) {
+        var visibilityEvaluator = new PortalNavigationItemVisibilityEvaluator(
+            input.environmentId(),
+            input.viewerContext(),
+            queryService,
+            visibilityServices
+        );
+
         PortalNavigationItem parentItem;
         if (input.parentId().isPresent()) {
-            parentItem = findAndValidateParent(input);
+            parentItem = findAndValidateParent(input, visibilityEvaluator);
             if (parentItem == null) {
                 return new Output(List.of());
             }
         }
 
-        List<PortalNavigationItem> rootItems = searchItems(input, input.parentId().orElse(null), input.parentId().isEmpty());
+        List<PortalNavigationItem> rootItems = searchItems(
+            input,
+            input.parentId().orElse(null),
+            input.parentId().isEmpty(),
+            visibilityEvaluator
+        );
 
         List<PortalNavigationItem> allItems = new ArrayList<>(rootItems);
 
         if (input.loadChildren()) {
-            List<PortalNavigationItem> descendants = loadDescendants(rootItems, input);
+            List<PortalNavigationItem> descendants = loadDescendants(rootItems, input, visibilityEvaluator);
             allItems.addAll(descendants);
         }
 
         return new Output(sortItems(allItems));
     }
 
-    private PortalNavigationItem findAndValidateParent(Input input) {
+    private PortalNavigationItem findAndValidateParent(Input input, PortalNavigationItemVisibilityEvaluator visibilityEvaluator) {
         var parent = queryService.findByIdAndEnvironmentId(input.environmentId(), input.parentId().get());
 
         if (parent == null) {
@@ -74,16 +86,7 @@ public class ListPortalNavigationItemsUseCase {
             return null;
         }
 
-        // The parent itself may be an API navigation item the viewer cannot see (private API,
-        // user is not a member/subscriber). In that case none of its descendants must be exposed.
-        if (parent instanceof PortalNavigationApi api && apiVisibilityDomainService.isApiItemHidden(api, input.viewerContext())) {
-            return null;
-        }
-
-        // The parent may also be a descendant of a hidden API navigation item. Walk up to make sure
-        // no ancestor API is hidden; otherwise descendants of an API the viewer cannot access would
-        // still be reachable by navigating to them directly.
-        if (apiVisibilityDomainService.hasHiddenApiAncestor(input.environmentId(), parent, input.viewerContext())) {
+        if (!visibilityEvaluator.isVisible(parent) || visibilityEvaluator.hasHiddenAncestor(parent)) {
             return null;
         }
 
@@ -94,7 +97,11 @@ public class ListPortalNavigationItemsUseCase {
      * Loads children recursively.
      * Prunes children by discarding if a child is found but deemed "not visible".
      */
-    private List<PortalNavigationItem> loadDescendants(List<PortalNavigationItem> initialItems, Input input) {
+    private List<PortalNavigationItem> loadDescendants(
+        List<PortalNavigationItem> initialItems,
+        Input input,
+        PortalNavigationItemVisibilityEvaluator visibilityEvaluator
+    ) {
         List<PortalNavigationItem> childrenAccumulator = new ArrayList<>();
         LinkedList<PortalNavigationItem> queue = new LinkedList<>();
 
@@ -103,7 +110,7 @@ public class ListPortalNavigationItemsUseCase {
         while (!queue.isEmpty()) {
             var currentFolder = queue.removeFirst();
 
-            var foundChildren = searchItems(input, currentFolder.getId(), false);
+            var foundChildren = searchItems(input, currentFolder.getId(), false, visibilityEvaluator);
 
             if (!foundChildren.isEmpty()) {
                 childrenAccumulator.addAll(foundChildren);
@@ -114,7 +121,12 @@ public class ListPortalNavigationItemsUseCase {
         return childrenAccumulator;
     }
 
-    private List<PortalNavigationItem> searchItems(Input input, PortalNavigationItemId parentId, boolean isRootSearch) {
+    private List<PortalNavigationItem> searchItems(
+        Input input,
+        PortalNavigationItemId parentId,
+        boolean isRootSearch,
+        PortalNavigationItemVisibilityEvaluator visibilityEvaluator
+    ) {
         var builder = PortalNavigationItemQueryCriteria.builder()
             .environmentId(input.environmentId())
             .area(input.portalArea())
@@ -130,22 +142,23 @@ public class ListPortalNavigationItemsUseCase {
         }
 
         List<PortalNavigationItem> items = queryService.search(builder.build());
-        return filterHiddenApis(items, input.viewerContext());
+        return filterHiddenItems(items, input.viewerContext(), visibilityEvaluator);
     }
 
     /**
-     * Drops {@link PortalNavigationApi} items the viewer must not see. When an API navigation
-     * item is dropped here it is also not enqueued by the BFS in {@link #loadDescendants},
-     * so its descendants are naturally excluded from the result.
+     * Drops API and API product navigation items the viewer must not see. When a container is
+     * dropped here it is also not enqueued by the BFS in {@link #loadDescendants}, so its
+     * descendants are naturally excluded from the result.
      */
-    private List<PortalNavigationItem> filterHiddenApis(List<PortalNavigationItem> items, PortalNavigationItemViewerContext viewerContext) {
+    private List<PortalNavigationItem> filterHiddenItems(
+        List<PortalNavigationItem> items,
+        PortalNavigationItemViewerContext viewerContext,
+        PortalNavigationItemVisibilityEvaluator visibilityEvaluator
+    ) {
         if (!viewerContext.isPortalMode()) {
             return items;
         }
-        return items
-            .stream()
-            .filter(i -> !(i instanceof PortalNavigationApi api) || !apiVisibilityDomainService.isApiItemHidden(api, viewerContext))
-            .toList();
+        return items.stream().filter(visibilityEvaluator::isVisible).toList();
     }
 
     private List<PortalNavigationItem> sortItems(List<PortalNavigationItem> items) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiProductVisibilityDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiProductVisibilityDomainServiceTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationApiProductVisibilityDomainServiceTest {
+
+    private static final String ENVIRONMENT_ID = PortalNavigationItemFixtures.ENV_ID;
+    private static final String USER_ID = "user-id";
+    private static final String API_PRODUCT_ID = "api-product-id";
+
+    private PortalNavigationApiProductVisibilityDomainService domainService;
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+    private ApiProductQueryServiceInMemory apiProductQueryService;
+    private MembershipQueryServiceInMemory membershipQueryService;
+
+    @BeforeEach
+    void set_up() {
+        navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
+        apiProductQueryService = new ApiProductQueryServiceInMemory();
+        membershipQueryService = new MembershipQueryServiceInMemory();
+        domainService = new PortalNavigationApiProductVisibilityDomainService(
+            navigationItemsQueryService,
+            new ApiProductAccessibleIdsDomainService(apiProductQueryService, membershipQueryService)
+        );
+    }
+
+    @Test
+    void should_show_public_api_product_to_anonymous_user() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            PortalNavigationItemFixtures.API_PRODUCT_ID,
+            "Public product",
+            null,
+            API_PRODUCT_ID
+        );
+
+        assertThat(
+            domainService.isApiProductItemHidden(ENVIRONMENT_ID, apiProduct, PortalNavigationItemViewerContext.forPortal(false))
+        ).isFalse();
+    }
+
+    @Test
+    void should_hide_private_api_product_from_anonymous_user() {
+        var apiProduct = privateApiProduct();
+
+        assertThat(
+            domainService.isApiProductItemHidden(ENVIRONMENT_ID, apiProduct, PortalNavigationItemViewerContext.forPortal(false))
+        ).isTrue();
+    }
+
+    @Test
+    void should_show_private_api_product_to_direct_member() {
+        var apiProduct = privateApiProduct();
+        membershipQueryService.initWith(List.of(apiProductMembership()));
+
+        assertThat(
+            domainService.isApiProductItemHidden(ENVIRONMENT_ID, apiProduct, PortalNavigationItemViewerContext.forPortal(USER_ID))
+        ).isFalse();
+    }
+
+    @Test
+    void should_show_private_api_product_to_group_member() {
+        var groupId = "group-id";
+        var apiProduct = privateApiProduct();
+        apiProductQueryService.initWith(
+            List.of(
+                ApiProduct.builder()
+                    .id(API_PRODUCT_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .name("Private product")
+                    .groups(Set.of(groupId))
+                    .build()
+            )
+        );
+        membershipQueryService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("membership-id")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.GROUP)
+                    .referenceId(groupId)
+                    .build()
+            )
+        );
+
+        assertThat(
+            domainService.isApiProductItemHidden(ENVIRONMENT_ID, apiProduct, PortalNavigationItemViewerContext.forPortal(USER_ID))
+        ).isFalse();
+    }
+
+    @Test
+    void should_hide_private_api_product_from_authenticated_non_member() {
+        var apiProduct = privateApiProduct();
+
+        assertThat(
+            domainService.isApiProductItemHidden(ENVIRONMENT_ID, apiProduct, PortalNavigationItemViewerContext.forPortal(USER_ID))
+        ).isTrue();
+    }
+
+    @Test
+    void should_not_apply_portal_access_filter_in_console() {
+        assertThat(
+            domainService.isApiProductItemHidden(ENVIRONMENT_ID, privateApiProduct(), PortalNavigationItemViewerContext.forConsole())
+        ).isFalse();
+    }
+
+    @Test
+    void should_detect_hidden_api_product_ancestor() {
+        var apiProduct = privateApiProduct();
+        var childFolder = PortalNavigationItemFixtures.aFolder("Product docs", apiProduct.getId());
+        childFolder.updateParent(apiProduct);
+        navigationItemsQueryService.initWith(List.of(apiProduct, childFolder));
+
+        assertThat(
+            domainService.hasHiddenApiProductAncestor(ENVIRONMENT_ID, childFolder, PortalNavigationItemViewerContext.forPortal(USER_ID))
+        ).isTrue();
+    }
+
+    @Test
+    void should_stop_ancestor_lookup_when_hierarchy_contains_cycle() {
+        var firstId = PortalNavigationItemId.of("00000000-0000-0000-0000-000000000093");
+        var secondId = PortalNavigationItemId.of("00000000-0000-0000-0000-000000000094");
+        var first = PortalNavigationItemFixtures.aFolder(firstId.json(), "First", secondId);
+        var second = PortalNavigationItemFixtures.aFolder(secondId.json(), "Second", firstId);
+        navigationItemsQueryService.initWith(List.of(first, second));
+
+        assertThat(
+            domainService.hasHiddenApiProductAncestor(ENVIRONMENT_ID, first, PortalNavigationItemViewerContext.forPortal(USER_ID))
+        ).isFalse();
+    }
+
+    private static io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct privateApiProduct() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            PortalNavigationItemFixtures.API_PRODUCT_ID,
+            "Private product",
+            null,
+            API_PRODUCT_ID
+        );
+        apiProduct.setVisibility(PortalVisibility.PRIVATE);
+        return apiProduct;
+    }
+
+    private static Membership apiProductMembership() {
+        return Membership.builder()
+            .id("membership-id")
+            .memberId(USER_ID)
+            .memberType(Membership.Type.USER)
+            .referenceType(Membership.ReferenceType.API_PRODUCT)
+            .referenceId(API_PRODUCT_ID)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemVisibilityEvaluatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemVisibilityEvaluatorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import java.util.List;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationItemVisibilityEvaluatorTest {
+
+    private PortalNavigationItemsQueryServiceInMemory queryService;
+
+    @BeforeEach
+    void set_up() {
+        queryService = new PortalNavigationItemsQueryServiceInMemory();
+    }
+
+    @Test
+    void should_use_matching_visibility_service() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            PortalNavigationItemFixtures.API_PRODUCT_ID,
+            "API Product",
+            null,
+            "api-product-id"
+        );
+        var evaluator = evaluatorWith(new HiddenApiProductVisibilityService());
+
+        assertThat(evaluator.isVisible(apiProduct)).isFalse();
+    }
+
+    @Test
+    void should_default_to_visible_when_no_service_applies() {
+        var page = PortalNavigationItemFixtures.aPage("Page", null);
+        var evaluator = evaluatorWith(new HiddenApiProductVisibilityService());
+
+        assertThat(evaluator.isVisible(page)).isTrue();
+    }
+
+    @Test
+    void should_detect_hidden_ancestor_using_matching_visibility_service() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            PortalNavigationItemFixtures.API_PRODUCT_ID,
+            "API Product",
+            null,
+            "api-product-id"
+        );
+        var page = PortalNavigationItemFixtures.aPage("Page", apiProduct.getId());
+        page.updateParent(apiProduct);
+        queryService.initWith(List.of(apiProduct, page));
+        var evaluator = evaluatorWith(new HiddenApiProductVisibilityService());
+
+        assertThat(evaluator.hasHiddenAncestor(page)).isTrue();
+    }
+
+    private PortalNavigationItemVisibilityEvaluator evaluatorWith(PortalNavigationItemVisibilityService visibilityService) {
+        return new PortalNavigationItemVisibilityEvaluator(
+            PortalNavigationItemFixtures.ENV_ID,
+            PortalNavigationItemViewerContext.forPortal("user-id"),
+            queryService,
+            List.of(visibilityService)
+        );
+    }
+
+    private static class HiddenApiProductVisibilityService implements PortalNavigationItemVisibilityService {
+
+        @Override
+        public boolean appliesTo(PortalNavigationItem item) {
+            return item instanceof PortalNavigationApiProduct;
+        }
+
+        @Override
+        public Predicate<PortalNavigationItem> prepareVisibilityPredicate(
+            String environmentId,
+            PortalNavigationItemViewerContext viewerContext
+        ) {
+            return item -> false;
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCaseTest.java
@@ -23,15 +23,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -43,19 +49,26 @@ class GetPortalNavigationItemUseCaseTest {
     private static final String ENVIRONMENT_ID = ENV_ID;
 
     private GetPortalNavigationItemUseCase useCase;
+    private PortalNavigationItemsQueryServiceInMemory queryService;
+    private MembershipQueryServiceInMemory membershipQueryService;
 
     @BeforeEach
     void setUp() {
-        PortalNavigationItemsQueryServiceInMemory queryService = new PortalNavigationItemsQueryServiceInMemory();
+        queryService = new PortalNavigationItemsQueryServiceInMemory();
+        membershipQueryService = new MembershipQueryServiceInMemory();
         var apiVisibilityDomainService = new PortalNavigationApiVisibilityDomainService(
             queryService,
             new ApiPortalMembershipDomainService(
-                new MembershipQueryServiceInMemory(),
+                membershipQueryService,
                 new SubscriptionQueryServiceInMemory(),
                 new ApiQueryServiceInMemory()
             )
         );
-        useCase = new GetPortalNavigationItemUseCase(queryService, apiVisibilityDomainService);
+        var apiProductVisibilityDomainService = new PortalNavigationApiProductVisibilityDomainService(
+            queryService,
+            new ApiProductAccessibleIdsDomainService(new ApiProductQueryServiceInMemory(), membershipQueryService)
+        );
+        useCase = new GetPortalNavigationItemUseCase(queryService, List.of(apiVisibilityDomainService, apiProductVisibilityDomainService));
 
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
     }
@@ -134,6 +147,85 @@ class GetPortalNavigationItemUseCaseTest {
         );
 
         // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PortalNavigationItemNotFoundException.class)
+            .hasMessage("Portal navigation item not found");
+    }
+
+    @Test
+    void should_throw_when_api_product_is_private_and_user_is_not_member() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            PortalNavigationItemId.random().toString(),
+            "Restricted product",
+            null,
+            "api-product-id"
+        );
+        apiProduct.setVisibility(PortalVisibility.PRIVATE);
+        queryService.initWith(List.of(apiProduct));
+
+        var input = new GetPortalNavigationItemUseCase.Input(
+            apiProduct.getId(),
+            ENVIRONMENT_ID,
+            PortalNavigationItemViewerContext.forPortal("user-without-access")
+        );
+
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PortalNavigationItemNotFoundException.class)
+            .hasMessage("Portal navigation item not found");
+    }
+
+    @Test
+    void should_return_private_api_product_to_member() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            PortalNavigationItemId.random().toString(),
+            "Restricted product",
+            null,
+            "api-product-id"
+        );
+        apiProduct.setVisibility(PortalVisibility.PRIVATE);
+        queryService.initWith(List.of(apiProduct));
+        membershipQueryService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("membership-id")
+                    .memberId("product-member")
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("api-product-id")
+                    .build()
+            )
+        );
+
+        var output = useCase.execute(
+            new GetPortalNavigationItemUseCase.Input(
+                apiProduct.getId(),
+                ENVIRONMENT_ID,
+                PortalNavigationItemViewerContext.forPortal("product-member")
+            )
+        );
+
+        assertThat(output.portalNavigationItem()).isEqualTo(apiProduct);
+    }
+
+    @Test
+    void should_throw_when_item_has_private_api_product_ancestor_and_user_is_not_member() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            PortalNavigationItemId.random().toString(),
+            "Restricted product",
+            null,
+            "api-product-id"
+        );
+        apiProduct.setVisibility(PortalVisibility.PRIVATE);
+        var childPage = PortalNavigationItemFixtures.aPage("Product overview", apiProduct.getId());
+        childPage.updateParent(apiProduct);
+        queryService.initWith(List.of(apiProduct, childPage));
+
+        var input = new GetPortalNavigationItemUseCase.Input(
+            childPage.getId(),
+            ENVIRONMENT_ID,
+            PortalNavigationItemViewerContext.forPortal("user-without-access")
+        );
+
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(PortalNavigationItemNotFoundException.class)
             .hasMessage("Portal navigation item not found");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
@@ -32,18 +32,21 @@ import fixtures.core.model.PortalNavigationItemFixtures;
 import fixtures.core.model.PortalPageContentFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiExposedEntrypointDomainServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
 import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.DefaultContentRenderer;
 import io.gravitee.apim.core.portal_page.domain_service.GraviteeMarkdownContentRenderer;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentRenderer;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
@@ -113,6 +116,10 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
                 new ApiQueryServiceInMemory()
             )
         );
+        var apiProductVisibilityDomainService = new PortalNavigationApiProductVisibilityDomainService(
+            navigationItemsQueryService,
+            new ApiProductAccessibleIdsDomainService(new ApiProductQueryServiceInMemory(), new MembershipQueryServiceInMemory())
+        );
         var enclosingApiDomainService = new PortalNavigationEnclosingApiDomainService(navigationItemsQueryService);
         when(portalNavigationTemplatingService.renderGraviteeMarkdown(any())).thenAnswer(invocation -> {
             var in = (PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput) invocation.getArgument(0);
@@ -128,7 +135,7 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
         useCase = new GetPortalPageContentByNavigationIdUseCase(
             navigationItemsQueryService,
             pageContentQueryService,
-            apiVisibilityDomainService,
+            List.of(apiVisibilityDomainService, apiProductVisibilityDomainService),
             List.of(
                 gmdRenderer,
                 new OpenApiContentRenderer(
@@ -434,6 +441,37 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
             ORGANIZATION_ID,
             ENVIRONMENT_ID,
             PortalNavigationItemViewerContext.forPortal(false)
+        );
+
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PortalNavigationItemNotFoundException.class)
+            .hasMessage("Portal navigation item not found");
+    }
+
+    @Test
+    void should_throw_when_page_is_a_descendant_of_private_api_product_inaccessible_to_viewer() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            "00000000-0000-0000-0000-000000000091",
+            "Private product",
+            null,
+            "00000000-0000-0000-0000-000000000092"
+        );
+        apiProduct.markAsRoot();
+        apiProduct.setVisibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
+        var page = PortalNavigationItemFixtures.aPage(
+            PAGE11_ID,
+            "Product documentation",
+            apiProduct.getId(),
+            PortalPageContentId.of(PAGE11_CONTENT_ID)
+        );
+        page.updateParent(apiProduct);
+        navigationItemsQueryService.initWith(List.of(apiProduct, page));
+
+        var input = new GetPortalPageContentByNavigationIdUseCase.Input(
+            PAGE11_ID,
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            PortalNavigationItemViewerContext.forPortal("non-member")
         );
 
         assertThatThrownBy(() -> useCase.execute(input))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
@@ -18,13 +18,19 @@ package io.gravitee.apim.core.portal_page.use_case;
 import static fixtures.core.model.PortalNavigationItemFixtures.APIS_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
@@ -47,6 +53,7 @@ class ListPortalNavigationItemsUseCaseTest {
     private MembershipQueryServiceInMemory membershipQueryService;
     private SubscriptionQueryServiceInMemory subscriptionQueryService;
     private ApiQueryServiceInMemory apiQueryService;
+    private ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService;
 
     @BeforeEach
     void setUp() {
@@ -60,7 +67,17 @@ class ListPortalNavigationItemsUseCaseTest {
             apiQueryService
         );
         var apiVisibilityDomainService = new PortalNavigationApiVisibilityDomainService(queryService, apiMembershipDomainService);
-        useCase = new ListPortalNavigationItemsUseCase(queryService, apiVisibilityDomainService);
+        apiProductAccessibleIdsDomainService = spy(
+            new ApiProductAccessibleIdsDomainService(new ApiProductQueryServiceInMemory(), membershipQueryService)
+        );
+        var apiProductVisibilityDomainService = new PortalNavigationApiProductVisibilityDomainService(
+            queryService,
+            apiProductAccessibleIdsDomainService
+        );
+        useCase = new ListPortalNavigationItemsUseCase(
+            queryService,
+            List.of(apiVisibilityDomainService, apiProductVisibilityDomainService)
+        );
 
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
     }
@@ -565,6 +582,146 @@ class ListPortalNavigationItemsUseCaseTest {
 
         // Then the ancestor check still prevents exposure.
         assertThat(result.items()).isEmpty();
+    }
+
+    @Test
+    void should_hide_private_api_product_and_its_descendants_from_authenticated_non_member() {
+        var rootFolder = PortalNavigationItemFixtures.aFolder("Products");
+        rootFolder.markAsRoot();
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            PortalNavigationItemId.random().toString(),
+            "Restricted product",
+            rootFolder.getId(),
+            "api-product-id"
+        );
+        apiProduct.setVisibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
+        apiProduct.updateParent(rootFolder);
+        var childPage = PortalNavigationItemFixtures.aPage("Product overview", apiProduct.getId());
+        childPage.updateParent(apiProduct);
+        queryService.initWith(List.of(rootFolder, apiProduct, childPage));
+
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forPortal("user-without-access")
+            )
+        );
+
+        assertThat(result.items()).extracting(PortalNavigationItem::getTitle).containsExactly("Products");
+    }
+
+    @Test
+    void should_resolve_accessible_api_products_once_when_filtering_multiple_products() {
+        var rootFolder = PortalNavigationItemFixtures.aFolder("Products");
+        rootFolder.markAsRoot();
+        var firstApiProduct = PortalNavigationItemFixtures.anApiProduct(
+            PortalNavigationItemId.random().toString(),
+            "First restricted product",
+            rootFolder.getId(),
+            "first-api-product-id"
+        );
+        firstApiProduct.setVisibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
+        firstApiProduct.updateParent(rootFolder);
+        var secondApiProduct = PortalNavigationItemFixtures.anApiProduct(
+            PortalNavigationItemId.random().toString(),
+            "Second restricted product",
+            rootFolder.getId(),
+            "second-api-product-id"
+        );
+        secondApiProduct.setVisibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
+        secondApiProduct.updateParent(rootFolder);
+        queryService.initWith(List.of(rootFolder, firstApiProduct, secondApiProduct));
+
+        useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forPortal("user-without-access")
+            )
+        );
+
+        verify(apiProductAccessibleIdsDomainService).findAccessibleApiProductIds(ENV_ID, "user-without-access");
+    }
+
+    @Test
+    void should_show_private_api_product_and_its_descendants_to_member() {
+        var rootFolder = PortalNavigationItemFixtures.aFolder("Products");
+        rootFolder.markAsRoot();
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            PortalNavigationItemId.random().toString(),
+            "Restricted product",
+            rootFolder.getId(),
+            "api-product-id"
+        );
+        apiProduct.setVisibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
+        apiProduct.updateParent(rootFolder);
+        var childPage = PortalNavigationItemFixtures.aPage("Product overview", apiProduct.getId());
+        childPage.updateParent(apiProduct);
+        queryService.initWith(List.of(rootFolder, apiProduct, childPage));
+        membershipQueryService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("membership-id")
+                    .memberId("product-member")
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("api-product-id")
+                    .build()
+            )
+        );
+
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forPortal("product-member")
+            )
+        );
+
+        assertThat(result.items())
+            .extracting(PortalNavigationItem::getTitle)
+            .containsExactlyInAnyOrder("Products", "Restricted product", "Product overview");
+    }
+
+    @Test
+    void should_keep_api_visibility_filter_inside_visible_api_product() {
+        var rootFolder = PortalNavigationItemFixtures.aFolder("Products");
+        rootFolder.markAsRoot();
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            PortalNavigationItemId.random().toString(),
+            "Public product",
+            rootFolder.getId(),
+            "api-product-id"
+        );
+        apiProduct.updateParent(rootFolder);
+        var privateApi = PortalNavigationItemFixtures.anApi(
+            PortalNavigationItemId.random().toString(),
+            "Restricted API",
+            apiProduct.getId(),
+            "api-id"
+        );
+        privateApi.setVisibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
+        privateApi.updateParent(apiProduct);
+        queryService.initWith(List.of(rootFolder, apiProduct, privateApi));
+
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forPortal("user-without-api-access")
+            )
+        );
+
+        assertThat(result.items()).extracting(PortalNavigationItem::getTitle).containsExactly("Products", "Public product");
     }
 
     @Test


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/PORTAL-79


## Description

Adds API Product navigation support to the Portal API.

This change:

- adds `API_PRODUCT` to the Portal navigation OpenAPI contract
- exposes `apiProductId` using the UUID format
- maps API Product navigation items in Portal API responses
- applies API Product visibility rules for public, private, direct-member, and group-member access
- filters descendants of inaccessible API Products
- protects navigation item and page content endpoints from direct-access bypasses
- preserves the existing independent visibility checks for APIs included in the navigation tree
- adds focused domain service, use-case, mapper, and REST resource tests
