### PR TITLE
fix: show only v4 http proxy apis in API Product

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -21,6 +21,7 @@ import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDoc
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_API_TYPE;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CATEGORIES;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ID;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PORTAL_STATUS;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_STATUS;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS;
@@ -41,6 +42,8 @@ import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.VerifyApiHostsUseCase;
 import io.gravitee.apim.core.api.use_case.VerifyApiPathsUseCase;
 import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
+import io.gravitee.apim.core.api_product.model.ApiProductKind;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.common.data.domain.Page;
@@ -168,6 +171,9 @@ public class ApisResource extends AbstractResource {
 
     @Inject
     private RemoteApiDefinitionParser remoteApiDefinitionParser;
+
+    @Inject
+    private ApiProductQueryService apiProductQueryService;
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
@@ -397,6 +403,21 @@ public class ApisResource extends AbstractResource {
 
         if (apiSearchQuery.getAllowedInApiProducts() != null) {
             apiQueryBuilder.addFilter(FIELD_ALLOW_IN_API_PRODUCTS, apiSearchQuery.getAllowedInApiProducts());
+        }
+
+        // An AI Workspace default proxy is an ordinary API that carries the "allowed in api products" flag, but it belongs
+        // to an AI_WORKSPACE product and must never be addable to another product. When the caller is the product "Add API"
+        // picker (allowedInApiProducts=true), exclude every API that is a member of an AI_WORKSPACE product in this environment.
+        if (Boolean.TRUE.equals(apiSearchQuery.getAllowedInApiProducts())) {
+            Set<String> aiWorkspaceApiIds = apiProductQueryService
+                .findByEnvironmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
+                .stream()
+                .filter(apiProduct -> apiProduct.getKind() == ApiProductKind.AI_WORKSPACE)
+                .flatMap(apiProduct -> apiProduct.getApiIds() == null ? Stream.empty() : apiProduct.getApiIds().stream())
+                .collect(Collectors.toSet());
+            if (!aiWorkspaceApiIds.isEmpty()) {
+                apiQueryBuilder.addExcludedFilter(FIELD_ID, aiWorkspaceApiIds);
+            }
         }
 
         var selectedDefinitions = Stream.concat(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_SearchApisTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_SearchApisTest.java
@@ -18,10 +18,14 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 import static assertions.MAPIAssertions.assertThat;
 import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ID;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.ApiProductKind;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.model.DefinitionVersion;
@@ -57,6 +61,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @ExtendWith(MockitoExtension.class)
 public class ApisResource_SearchApisTest extends AbstractResourceTest {
@@ -65,6 +70,9 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
 
     @Captor
     ArgumentCaptor<QueryBuilder<ApiEntity>> apiQueryBuilderCaptor;
+
+    @Autowired
+    private ApiProductQueryService apiProductQueryService;
 
     @Override
     protected String contextPath() {
@@ -616,5 +624,45 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 assertThat(list).hasSize(1);
                 assertThat(list.getFirst().getApiV4().getId()).isEqualTo("api-id");
             });
+    }
+
+    @Test
+    public void should_exclude_ai_workspace_member_apis_when_searching_apis_allowed_in_api_products() {
+        var apiSearchQuery = new ApiSearchQuery();
+        apiSearchQuery.setAllowedInApiProducts(true);
+
+        var workspaceProduct = ApiProduct.builder()
+            .id("ws-1")
+            .kind(ApiProductKind.AI_WORKSPACE)
+            .apiIds(Set.of("workspace-proxy-a", "workspace-proxy-b"))
+            .build();
+        // a classic api product carries no AI_WORKSPACE kind; its member apis must remain addable
+        var classicProduct = ApiProduct.builder().id("p-1").apiIds(Set.of("regular-api")).build();
+        when(apiProductQueryService.findByEnvironmentId(ENVIRONMENT)).thenReturn(Set.of(workspaceProduct, classicProduct));
+
+        when(
+            apiSearchServiceV4.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("UnitTests"),
+                eq(true),
+                apiQueryBuilderCaptor.capture(),
+                eq(new PageableImpl(1, 10)),
+                eq(false),
+                eq(true),
+                isNull(),
+                isNull()
+            )
+        ).thenReturn(new Page<>(List.of(), 0, 0, 0));
+
+        final Response response = rootTarget().request().post(Entity.json(apiSearchQuery));
+        assertThat(response).hasStatus(OK_200);
+
+        var apiQuery = apiQueryBuilderCaptor.getValue().build();
+        SoftAssertions.assertSoftly(soft -> {
+            soft
+                .assertThat(apiQuery.getExcludedFilters().get(FIELD_ID))
+                .containsExactlyInAnyOrder("workspace-proxy-a", "workspace-proxy-b");
+            soft.assertThat(apiQuery.getExcludedFilters().get(FIELD_ID)).doesNotContain("regular-api");
+        });
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
     <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>
 
     <!-- Gamma plugins -->
-    <gravitee-gamma-module-aim.version>2.1.0</gravitee-gamma-module-aim.version>
+    <gravitee-gamma-module-aim.version>2.1.1</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.10.1</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>1.1.0</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.0.0</gravitee-gamma-module-esm.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-166

## Description

chore(deps): bump aim version
fix: allow only v4 http proxy APIs in API list of API Product

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

