### PR TITLE
fix(console,portal): trim leading/trailing whitespace from client_id before saving

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/creation/application-creation.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/application-creation.component.ts
@@ -127,7 +127,7 @@ export class ApplicationCreationComponent implements OnInit {
           ...(applicationPayload.type === 'SIMPLE'
             ? {
                 app: {
-                  client_id: applicationPayload.appClientId,
+                  client_id: applicationPayload.appClientId?.trim() || undefined,
                   type: applicationPayload.appType,
                 },
               }

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.spec.ts
@@ -161,6 +161,26 @@ describe('ApplicationGeneralInfoComponent', () => {
         },
       });
     });
+
+    it('should trim leading and trailing whitespace from client_id', async () => {
+      const applicationDetails = fakeApplication({ type: 'SIMPLE' });
+      const applicationType = fakeApplicationType();
+      expectListApplicationRequest(applicationDetails);
+      expectApplicationTypeRequest(applicationType);
+      expectListCertificatesRequest([]);
+      fixture.detectChanges();
+      await waitImageCheck();
+
+      const clientIdInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="client_id"]' }));
+      await clientIdInput.setValue('  my-client-id  ');
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/applications/${applicationDetails.id}`);
+      expect(req.request.method).toEqual('PUT');
+      expect(req.request.body.settings.app.client_id).toEqual('my-client-id');
+    });
   });
 
   describe('Application General details when OpenID Connect integration enabled', () => {

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.ts
@@ -175,6 +175,7 @@ export class ApplicationGeneralComponent implements OnInit {
           ? {
               app: {
                 ...this.applicationForm.getRawValue().OAuth2Form,
+                client_id: this.applicationForm.getRawValue().OAuth2Form.client_id?.trim() || undefined,
               },
             }
           : {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.ts
@@ -243,7 +243,7 @@ export class ApplicationTabSettingsEditComponent implements OnInit {
     };
     if (appToUpdate.settings.app) {
       appToUpdate.settings.app.type = appVM.appType;
-      appToUpdate.settings.app.client_id = appVM.appClientId;
+      appToUpdate.settings.app.client_id = appVM.appClientId?.trim() || undefined;
     } else if (appToUpdate.settings.oauth) {
       if (appVM.oauthGrantTypes) {
         appToUpdate.settings.oauth.grant_types = appVM.oauthGrantTypes;

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation.component.ts
@@ -77,6 +77,9 @@ function mapToApplicationInput(rawValue): ApplicationInput {
       return acc;
     }, {});
   }
+  if (result.settings.app) {
+    result.settings.app.client_id = result.settings.app.client_id?.trim() || undefined;
+  }
   return result;
 }
 

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.ts
@@ -253,8 +253,12 @@ export class ApplicationGeneralComponent implements OnInit, OnDestroy {
 
   submit() {
     this.isSaving = true;
+    const applicationPayload = this.applicationForm.getRawValue();
+    if ('app' in applicationPayload.settings && applicationPayload.settings.app) {
+      applicationPayload.settings.app.client_id = applicationPayload.settings.app.client_id?.trim() || undefined;
+    }
     this.applicationService
-      .updateApplicationByApplicationId({ applicationId: this.application.id, application: this.applicationForm.getRawValue() })
+      .updateApplicationByApplicationId({ applicationId: this.application.id, application: applicationPayload })
       .toPromise()
       .then(application => {
         this.application = application;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14763

## Description

Trim whitespace from client_id in the UI                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  A Client ID pasted with leading/trailing whitespace was saved as-is, causing gateway auth/subscription lookup failures with misleading "no subscription found" errors.                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  The value is now trimmed on save in every editable client_id field - console (edit + create), classic portal (edit + create), and new portal (edit) — using the same ?.trim() || undefined pattern the new-portal create flow already had. Whitespace-only input saves as unset. Regression test added on the console General page.

## Additional context

https://github.com/user-attachments/assets/42012493-7aa0-4a9a-a453-c00dfb080ad6


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

