### PR TITLE
fix(gateway): skip API referencing an unauthorized environment during sync

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapper.java
@@ -24,6 +24,7 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.edge.EdgeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.gateway.services.sync.process.common.SyncErrors;
 import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.service.EnvironmentService;
 import io.gravitee.repository.management.model.Event;
@@ -106,9 +107,18 @@ public class ApiMapper {
 
                 return reactableApi;
             } catch (SyncException e) {
-                // Transient enrichment failure: fail the sync so this event is retried instead of
-                // being silently dropped (which would leave the API undeployed until a restart).
-                throw e;
+                if (SyncErrors.isTransient(e)) {
+                    // Transient enrichment failure (backing store momentarily unreachable): fail the sync so
+                    // this event is retried instead of being silently dropped (which would leave the API
+                    // undeployed until a restart). It self-heals once the store recovers.
+                    throw e;
+                }
+                // Permanent enrichment failure (e.g. the API references an environment this installation is
+                // not entitled to - the bridge server answers 403). Retrying can never succeed, so skip the
+                // offending API rather than failing (and crash-looping) the whole sync; every other API still
+                // deploys and the node becomes ready.
+                log.warn("Unable to enrich api definition from event [{}], skipping it.", apiEvent.getId(), e);
+                return null;
             } catch (Exception e) {
                 // Log the error and ignore this event.
                 log.warn("Unable to extract api definition from event [{}].", apiEvent.getId(), e);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapperTest.java
@@ -257,6 +257,19 @@ class ApiMapperTest {
     }
 
     @Test
+    void should_skip_api_when_environment_enrichment_fails_permanently() throws JsonProcessingException, TechnicalException {
+        // The bridge server rejects a foreign environment with a 403 ("Unauthorized environments"): a
+        // RuntimeException that is not a TechnicalException, i.e. a permanent failure. Retrying can never
+        // succeed, so the offending API must be skipped rather than failing (and crash-looping) the whole sync.
+        when(environmentRepository.findById(repoApiV4.getEnvironmentId())).thenThrow(
+            new RuntimeException("Bridge server return error with code [403] and message: Unauthorized environments")
+        );
+        Event event = new Event();
+        event.setPayload(objectMapper.writeValueAsString(repoApiV4));
+        cut.to(event).test().assertNoValues().assertComplete();
+    }
+
+    @Test
     void should_return_empty_with_mapping_error() throws JsonProcessingException {
         Event event = new Event();
         event.setPayload(objectMapper.writeValueAsString("wrong"));


### PR DESCRIPTION
## APIM-14787

https://gravitee.atlassian.net/browse/APIM-14787

## Problem

On a NextGen Cloud dataplane the gateway was stuck in a crash/restart loop (~every 5-6 min, exit 143). `ApiSynchronizer` repeatedly failed with a **403 "Unauthorized environments"** from the Bridge Server:

```
SyncException: An error occurred fetching the environment '5eaf98e9-...'.
Caused by: BridgeServerUnexpectedResponseException: Bridge server return error with code [403] and message: Unauthorized environments
```

One deployed API references an environment (`5eaf98e9-…`) that this installation's cloud token (`d1c30816-…`) is **not entitled to**. When enrichment resolves that foreign environment via the Bridge Server, the server correctly rejects it with a permanent 403.

## Root cause

`EnvironmentService.loadEnvironment` wraps the 403 in a `SyncException`, and `ApiMapper.to` re-threw **every** `SyncException` as if it were transient. On the initial sync that failed the whole sync → the sync-process probe never passed → the `startupProbe` budget (~5 min) was exhausted → Kubernetes killed the pod → crash loop. A permanent 403 can never succeed on retry, so failing-and-retrying is fatal over a single misassigned API.

Regression introduced when enrichment failures started propagating (4.11.21).

## Fix

Extend the existing transient/permanent split (already used by `AbstractApiSynchronizer.resumeOnDeployError`) to the enrichment/mapping stage:

- **Transient** failure (`TechnicalException` in the cause chain — backing store momentarily unreachable) → propagate → fail sync → retry → self-heals.
- **Permanent** failure (Bridge 403 = `BridgeServerUnexpectedResponseException`, a `RuntimeException`, not a `TechnicalException`) → log + **skip** the offending API so every other API deploys and the node becomes ready.

Reuses `SyncErrors.isTransient` — no new abstraction, one production file touched.

## Tests

- Added `ApiMapperTest#should_skip_api_when_environment_enrichment_fails_permanently` (403 → skip).
- Existing `should_propagate_error_when_environment_enrichment_fails_transiently` still green (transient → propagate).
- Full sync-module suites pass (`ApiMapperTest`, `ApiSynchronizerTest`, `EnvironmentServiceTest`, `DefaultSyncManagerTest`).

## Note / possible follow-up

On a Bridge (cloud) deployment, a genuine *connection* outage during enrichment also surfaces as a non-`TechnicalException`, so `isTransient` would classify it as permanent too. That is a pre-existing limitation of the shared `SyncErrors` classifier (it already governs `resumeOnDeployError` identically), not introduced here — worth a separate follow-up if bridge-transport precision is needed.