### PR TITLE
fix(gateway): deliver wildcard authz documents to tagged PDP engines

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHostedScopes.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHostedScopes.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
 
 import io.gravitee.common.util.EnvironmentUtils;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,7 +39,7 @@ import java.util.stream.Collectors;
  * an untagged gateway is a catch-all that serves every scope, a tagged gateway serves a scope whose tag
  * it carries (and is not excluded via {@code !tag}). A tag-scoped default ({@code default@<tag>}) needs no
  * provisioning — the default engine is always present — so it is served from this node's static sharding
- * tags, not from the provisioned {@link #hosted} set.
+ * tags, not from the provisioned {@link #hostedByBase} index.
  */
 public class AuthzHostedScopes {
 
@@ -46,7 +47,9 @@ public class AuthzHostedScopes {
     static final String WILDCARD = "*";
     static final String SCOPE_TAG_SEPARATOR = "@";
 
-    private final Set<String> hosted = ConcurrentHashMap.newKeySet();
+    // Keyed by "environmentId:base" so serves() stays an O(1) lookup; values are the full routing
+    // scopes (possibly "@tag"-suffixed) the wildcard expansion routes to.
+    private final Map<String, Set<String>> hostedByBase = new ConcurrentHashMap<>();
     private final Set<String> nodeTags;
 
     public AuthzHostedScopes() {
@@ -61,27 +64,33 @@ public class AuthzHostedScopes {
         return environmentId + ":" + targetPdpId;
     }
 
-    public void markHosted(String environmentId, String targetPdpId) {
-        hosted.add(key(environmentId, targetPdpId));
+    /** Record a provisioned scope. Pass the full routing scope ("targetPdpId@tag" when tagged) so the
+     *  wildcard expansion can reach tagged engines — "*" means every gateway, tagged and untagged. */
+    public void markHosted(String environmentId, String routingScope) {
+        hostedByBase.computeIfAbsent(key(environmentId, baseOf(routingScope)), k -> ConcurrentHashMap.newKeySet()).add(routingScope);
     }
 
-    public void unmarkHosted(String environmentId, String targetPdpId) {
-        hosted.remove(key(environmentId, targetPdpId));
+    public void unmarkHosted(String environmentId, String routingScope) {
+        hostedByBase.computeIfPresent(key(environmentId, baseOf(routingScope)), (k, scopes) -> {
+            scopes.remove(routingScope);
+            return scopes.isEmpty() ? null : scopes;
+        });
     }
 
     public boolean isHosted(String environmentId, String targetPdpId) {
-        return hosted.contains(key(environmentId, targetPdpId));
+        return hostedByBase.containsKey(key(environmentId, baseOf(targetPdpId)));
     }
 
-    /** The named scopes (targetPdpIds) whose engine is provisioned on this node for the given environment.
+    /** The routing scopes whose engine is provisioned on this node for the given environment.
      *  A wildcard ("*") document expands to these (plus the always-on default) so it is routed per-scope to
      *  exactly the engines this node hosts, rather than via a fire-and-forget broadcast. */
     public Set<String> hostedFor(String environmentId) {
         String prefix = environmentId + ":";
-        return hosted
+        return hostedByBase
+            .entrySet()
             .stream()
-            .filter(k -> k.startsWith(prefix))
-            .map(k -> k.substring(prefix.length()))
+            .filter(e -> e.getKey().startsWith(prefix))
+            .flatMap(e -> e.getValue().stream())
             .collect(Collectors.toSet());
     }
 
@@ -102,11 +111,18 @@ public class AuthzHostedScopes {
         if (DEFAULT_SCOPE.equals(base) && tag == null) {
             return true;
         }
-        // The default engine is always present; a named engine must be provisioned here.
-        boolean baseHosted = DEFAULT_SCOPE.equals(base) || hosted.contains(key(environmentId, base));
+        // The default engine is always present; a named engine must be provisioned here. The index is
+        // keyed by the bare targetPdpId part — the engine identity is the base, the tag only gates
+        // placement.
+        boolean baseHosted = DEFAULT_SCOPE.equals(base) || hostedByBase.containsKey(key(environmentId, base));
         // Tag gating mirrors API sharding (EnvironmentUtils#hasMatchingTags): an untagged node is a
         // catch-all, a tagged node serves a scope whose tag it carries (and is not excluded via "!tag").
         Set<String> scopeTags = tag == null ? Set.of() : Set.of(tag);
         return baseHosted && EnvironmentUtils.hasMatchingTags(Optional.of(List.copyOf(nodeTags)), scopeTags);
+    }
+
+    private static String baseOf(String scope) {
+        int at = scope.indexOf(SCOPE_TAG_SEPARATOR);
+        return at >= 0 ? scope.substring(0, at) : scope;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizer.java
@@ -311,7 +311,7 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
                     pendingProvisions.remove(rk);
                     pendingProvisionAttempts.remove(rk);
                     pendingEvicts.remove(rk);
-                    hostedScopes.markHosted(deployable.environmentId(), deployable.targetPdpId());
+                    hostedScopes.markHosted(deployable.environmentId(), routingScope(deployable.targetPdpId(), deployable.tag()));
                     if (!wasHosted) {
                         provisionedScopes.add(deployable);
                     }
@@ -323,7 +323,7 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
                     pendingHydrations.remove(rk);
                     pendingHydrationAttempts.remove(rk);
                     pendingEvicts.remove(rk);
-                    hostedScopes.unmarkHosted(deployable.environmentId(), deployable.targetPdpId());
+                    hostedScopes.unmarkHosted(deployable.environmentId(), routingScope(deployable.targetPdpId(), deployable.tag()));
                     // Drop the bare id AND every tag-variant bucket: revisions are keyed by routing scope
                     // (targetPdpId@tag), and on a catch-all node several tag variants alias to this one engine.
                     revisions.forgetEngine(deployable.environmentId(), deployable.targetPdpId());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHostedScopesTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHostedScopesTest.java
@@ -64,6 +64,19 @@ class AuthzHostedScopesTest {
     }
 
     @Test
+    void a_scope_marked_with_its_routing_scope_serves_and_is_listed_for_wildcard_expansion() {
+        // Provision records the full routing scope ("orders@eu") so the wildcard expansion can reach
+        // tagged engines: "*" means every gateway, tagged and untagged.
+        AuthzHostedScopes euNode = new AuthzHostedScopes(Set.of("eu"));
+        euNode.markHosted("env-1", "orders@eu");
+        assertThat(euNode.serves("env-1", "orders@eu")).isTrue();
+        assertThat(euNode.hostedFor("env-1")).containsExactly("orders@eu");
+        euNode.unmarkHosted("env-1", "orders@eu");
+        assertThat(euNode.serves("env-1", "orders@eu")).isFalse();
+        assertThat(euNode.hostedFor("env-1")).isEmpty();
+    }
+
+    @Test
     void a_named_tagged_scope_requires_both_the_provisioned_engine_and_the_node_tag() {
         // "orders@us" (a regional replica) is served only when this node hosts the "orders" engine AND
         // carries the "us" tag — the placement gate is the conjunction of both, not either alone.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePortScopeTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePortScopeTest.java
@@ -101,6 +101,32 @@ class EventBusAuthzEnginePortScopeTest {
     }
 
     @Test
+    void wildcard_policy_reaches_a_tagged_scope_hosted_on_a_tag_matching_node() {
+        // "*" means every gateway, tagged and untagged: a tagged node hosting "orders@eu" must deliver a
+        // wildcard document to that engine (address derives from the bare targetPdpId part).
+        AuthzHostedScopes hosted = new AuthzHostedScopes(Set.of("eu"));
+        hosted.markHosted("env-1", "orders@eu");
+        EventBusAuthzEnginePort scopedPort = new EventBusAuthzEnginePort(vertx, hosted, new AuthzAppliedRevisions());
+        recordAndReplyOn("service:authz-pdp:sync");
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:orders");
+        scopedPort.addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("*"), 1L).blockingAwait();
+        assertThat(hits).containsExactlyInAnyOrder("service:authz-pdp:sync", "service:authz-pdp:sync:scope:env-1:orders");
+    }
+
+    @Test
+    void wildcard_unpublish_reaches_a_tagged_scope_hosted_on_a_tag_matching_node() {
+        // The eviction side of the same rule — a wildcard UNPUBLISH must evict from tagged engines too,
+        // otherwise a delete after retargeting to "*" leaves an orphan on the tagged node.
+        AuthzHostedScopes hosted = new AuthzHostedScopes(Set.of("eu"));
+        hosted.markHosted("env-1", "orders@eu");
+        EventBusAuthzEnginePort scopedPort = new EventBusAuthzEnginePort(vertx, hosted, new AuthzAppliedRevisions());
+        recordAndReplyOn("service:authz-pdp:sync");
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:orders");
+        scopedPort.removePolicy("env-1", "p1", Set.of("*")).blockingAwait();
+        assertThat(hits).containsExactlyInAnyOrder("service:authz-pdp:sync", "service:authz-pdp:sync:scope:env-1:orders");
+    }
+
+    @Test
     void wildcard_policy_does_not_route_to_scopes_hosted_in_another_environment() {
         // The wildcard expands only to THIS environment's hosted scopes; a scope hosted for env-2 must not
         // receive an env-1 wildcard document. env-1 hosts nothing extra, so only the default engine is hit.


### PR DESCRIPTION
## Problem

A policy (or entity) targeted at a **tagged** PDP scope (e.g. `orders@eu`), then retargeted to `*` and deleted, keeps evaluating **forever** on the tagged node — the deleted policy still returns PERMIT (customer-reported; reproduced live on a 3-gateway stack: untagged catch-all + `eu` + `us`).

Root cause: the three wildcard code paths in the authz sync disagreed about what `*` means:

| Path | Behavior before |
|---|---|
| Incremental delivery (`expandWildcard` + `serves()`) | `*` skips tagged engines |
| Hydration (`groupDocs` on provision/restart) | `*` includes tagged engines |
| Eviction delta (`dropped.clear()`) | `*` assumed to cover everything |

Consequences (both live-verified):
- **Orphans**: wildcard publish/unpublish never reached tagged engines, so a scoped copy left behind by a retarget to `*` had no eviction path — deleted documents stayed live on tagged nodes (policies *and* entities, the latter meaning deprovisioned users kept group-based access).
- **Restart nondeterminism**: the same `{*}` policy was absent from a tagged engine when deployed incrementally, but present after a gateway restart or PDP provision (hydration) — a node restart alone flipped evaluation decisions from DENY to PERMIT.

## Fix

`*` now means **every gateway, tagged and untagged** (empty targets still mean the default engines only). Provisioning records the full routing scope (`targetPdpId@tag`) in `AuthzHostedScopes`, so the wildcard expansion delivers publish **and** unpublish to tagged engines; `serves()` matches hosted engines by their bare `targetPdpId` part (the tag only gates placement). Hydration and the eviction delta are untouched — they were already consistent with this semantics.

## Verification

- Sync module: 643 tests green, including new pins for wildcard publish/unpublish reaching a tagged scope; no pre-existing wildcard/hydration/placement pins changed.
- Live on a 3-gateway stack (untagged + `eu` + `us`):
  - customer repro (`{orders@eu}` → retarget `{*}` → delete) leaves **no orphan** — all engines evicted;
  - a deployed `{*}` policy is present on **all** engines deterministically (no restart needed);
  - narrowing `{*}` → `{named}` evicts everywhere including tagged; tag isolation (`orders@eu` vs `orders@us`) and empty-target (default engines only) behavior unchanged.

## Release note

Wildcard-targeted authz policies/entities now appear on tagged gateways immediately. Previously they reached tagged nodes inconsistently — only after a gateway restart or PDP re-provision — so this makes existing wildcard deployments deterministic rather than changing their eventual state. This also matches what the console already promises ("* — all gateways").
