### PR TITLE
fix(gateway): skip API referencing an unauthorized environment during sync [APIM-14787]

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapper.java
@@ -23,6 +23,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.gateway.services.sync.process.common.SyncErrors;
 import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.service.EnvironmentService;
 import io.gravitee.repository.management.model.Event;
@@ -100,9 +101,18 @@ public class ApiMapper {
 
                 return reactableApi;
             } catch (SyncException e) {
-                // Transient enrichment failure: fail the sync so this event is retried instead of
-                // being silently dropped (which would leave the API undeployed until a restart).
-                throw e;
+                if (SyncErrors.isTransient(e)) {
+                    // Transient enrichment failure (backing store momentarily unreachable): fail the sync so
+                    // this event is retried instead of being silently dropped (which would leave the API
+                    // undeployed until a restart). It self-heals once the store recovers.
+                    throw e;
+                }
+                // Permanent enrichment failure (e.g. the API references an environment this installation is
+                // not entitled to - the bridge server answers 403). Retrying can never succeed, so skip the
+                // offending API rather than failing (and crash-looping) the whole sync; every other API still
+                // deploys and the node becomes ready.
+                log.warn("Unable to enrich api definition from event [{}], skipping it.", apiEvent.getId(), e);
+                return null;
             } catch (Exception e) {
                 // Log the error and ignore this event.
                 log.warn("Unable to extract api definition from event [{}].", apiEvent.getId(), e);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapperTest.java
@@ -233,6 +233,19 @@ class ApiMapperTest {
     }
 
     @Test
+    void should_skip_api_when_environment_enrichment_fails_permanently() throws JsonProcessingException, TechnicalException {
+        // The bridge server rejects a foreign environment with a 403 ("Unauthorized environments"): a
+        // RuntimeException that is not a TechnicalException, i.e. a permanent failure. Retrying can never
+        // succeed, so the offending API must be skipped rather than failing (and crash-looping) the whole sync.
+        when(environmentRepository.findById(repoApiV4.getEnvironmentId())).thenThrow(
+            new RuntimeException("Bridge server return error with code [403] and message: Unauthorized environments")
+        );
+        Event event = new Event();
+        event.setPayload(objectMapper.writeValueAsString(repoApiV4));
+        cut.to(event).test().assertNoValues().assertComplete();
+    }
+
+    @Test
     void should_return_empty_with_mapping_error() throws JsonProcessingException {
         Event event = new Event();
         event.setPayload(objectMapper.writeValueAsString("wrong"));


### PR DESCRIPTION
## Summary

Backport (cherry-pick) to `4.11.x` of the fix from `master` (#18714).

Commit cherry-picked:
- `fix(gateway): skip API referencing an unauthorized environment during sync`

## Jira

[APIM-14787](https://gravitee.atlassian.net/browse/APIM-14787)

## Problem

On a NextGen Cloud dataplane the gateway was stuck in a crash/restart loop (~every 5-6 min, exit 143). `ApiSynchronizer` repeatedly failed with a **403 "Unauthorized environments"** from the Bridge Server:

```
SyncException: An error occurred fetching the environment '5eaf98e9-...'.
Caused by: BridgeServerUnexpectedResponseException: Bridge server return error with code [403] and message: Unauthorized environments
```

A deployed API references an environment this installation's cloud token is **not entitled to**. `EnvironmentService` wraps the permanent 403 in a `SyncException`, and `ApiMapper.to` re-threw **every** `SyncException` as if transient → the whole initial sync failed → the sync-process probe never passed → the `startupProbe` budget (~5 min) was exhausted → the pod was killed and crash-looped.

## Fix

Extend the existing transient/permanent split (already used by `AbstractApiSynchronizer.resumeOnDeployError`) to the enrichment/mapping stage:

- **Transient** (`TechnicalException` in cause chain — store momentarily unreachable) → propagate → fail sync → retry → self-heals.
- **Permanent** (Bridge 403 = `BridgeServerUnexpectedResponseException`, a `RuntimeException`) → log + **skip** the offending API so every other API deploys and the node becomes ready.

Reuses `SyncErrors.isTransient` — one production file touched.

## Notes

- Cherry-pick applied cleanly (no conflicts); the target file/context on `4.11.x` is identical to `master`.
- Validated locally on `4.11.x`: `mvn -pl …-sync -am test -Dtest=ApiMapperTest` → BUILD SUCCESS, `ApiMapperTest` 11/11 green (incl. the new `should_skip_api_when_environment_enrichment_fails_permanently` and the existing transient-propagation test).

[APIM-14787]: https://gravitee.atlassian.net/browse/APIM-14787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ