### PR TITLE
fix(console): surface required errors on newly added branded-sender card (APIM-14777)

### DIFF
--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.html
@@ -76,6 +76,7 @@
         <mat-label>Recipient domains</mat-label>
         <gio-form-tags-input
           formControlName="domains"
+          [required]="true"
           [addOnBlur]="true"
           [placeholder]="group.controls.domains.value.length === 0 ? 'example.com, eu.example.com' : ''"
         ></gio-form-tags-input>

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.spec.ts
@@ -35,18 +35,21 @@ import { GioTestingModule } from '../../testing';
   imports: [ReactiveFormsModule, BrandedSendersComponent],
   template: `
     <form [formGroup]="form">
-      <branded-senders
-        formControlName="brandedSenders"
-        [defaultFrom]="defaultFrom"
-        [defaultSubject]="defaultSubject"
-        [inheritedFromOrg]="inheritedFromOrg"
-        [canReset]="canReset"
-        (reset)="resetEmitted = resetEmitted + 1"
-      />
+      @if (show) {
+        <branded-senders
+          formControlName="brandedSenders"
+          [defaultFrom]="defaultFrom"
+          [defaultSubject]="defaultSubject"
+          [inheritedFromOrg]="inheritedFromOrg"
+          [canReset]="canReset"
+          (reset)="resetEmitted = resetEmitted + 1"
+        />
+      }
     </form>
   `,
 })
 class TestHostComponent {
+  show = true;
   defaultFrom = '';
   defaultSubject = '';
   inheritedFromOrg = false;
@@ -336,6 +339,87 @@ describe('BrandedSendersComponent', () => {
 
       expect(control().invalid).toBe(true);
       expect(fixture.nativeElement.querySelector('.branded-senders__error')?.textContent).toContain('example.com');
+    });
+  });
+
+  describe('validator lifecycle on the host control', () => {
+    it('should remove its validator from the long-lived host control when destroyed (no stale validator pinning it invalid)', () => {
+      control().setValue([{ domains: [], from: '', subject: '' }]); // invalid configuration
+      fixture.detectChanges();
+      expect(control().invalid).toBe(true);
+
+      // Tear the (potentially license-gated) component down while the host control persists.
+      component.show = false;
+      fixture.detectChanges();
+      expect(control().valid).toBe(true);
+
+      // Re-mounting registers exactly one validator again — the invalid value is rejected, not double-counted.
+      component.show = true;
+      fixture.detectChanges();
+      expect(control().invalid).toBe(true);
+    });
+  });
+
+  describe('required markers', () => {
+    // Scope to the configuration card so "From" doesn't match the read-only "Default From" field above it.
+    const requiredMarker = (fieldLabel: string): boolean => {
+      const field = [...fixture.nativeElement.querySelectorAll('.branded-senders__card mat-form-field')].find(
+        el => el.querySelector('mat-label')?.textContent?.trim() === fieldLabel,
+      );
+      return !!field?.querySelector('.mat-mdc-form-field-required-marker');
+    };
+
+    it('should mark both required fields (Recipient domains and From) with an asterisk and leave the optional Subject prefix without one', async () => {
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      await addButton.click();
+      fixture.detectChanges();
+
+      expect(requiredMarker('Recipient domains')).toBe(true);
+      expect(requiredMarker('From')).toBe(true);
+      expect(requiredMarker('Subject prefix')).toBe(false);
+    });
+  });
+
+  describe('surfacing required errors on save', () => {
+    it('should not show required errors on a freshly added configuration (card starts clean)', async () => {
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      await addButton.click();
+
+      const fromField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'From' }));
+      const domainsField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Recipient domains' }));
+      expect(await fromField.getTextErrors()).toEqual([]);
+      expect(await domainsField.getTextErrors()).toEqual([]);
+    });
+
+    it('should surface the per-card required errors when the host form is marked touched (i.e. on Save)', async () => {
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      await addButton.click();
+
+      // The save bar marks the whole form touched on an invalid submit; simulate that here.
+      component.form.markAllAsTouched();
+      fixture.detectChanges();
+
+      const fromField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'From' }));
+      const domainsField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Recipient domains' }));
+      expect(await fromField.getTextErrors()).toEqual(['From is required.']);
+      expect(await domainsField.getTextErrors()).toEqual(['At least one domain is required.']);
+    });
+
+    it('should immediately surface errors on a card added after a prior invalid save (host already touched)', async () => {
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      await addButton.click();
+
+      // First invalid save leaves the host control permanently touched (no further TouchedChangeEvent afterwards).
+      component.form.markAllAsTouched();
+      fixture.detectChanges();
+
+      // A second card added in this already-touched state must show its errors at once, not stay silently invalid.
+      await addButton.click();
+      fixture.detectChanges();
+
+      const fromFields = await loader.getAllHarnesses(MatFormFieldHarness.with({ floatingLabelText: 'From' }));
+      expect(fromFields.length).toBe(2);
+      expect(await fromFields[1].getTextErrors()).toEqual(['From is required.']);
     });
   });
 

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.ts
@@ -19,10 +19,12 @@ import {
   Component,
   DestroyRef,
   ErrorHandler,
-  forwardRef,
   inject,
   input,
+  OnInit,
+  Optional,
   output,
+  Self,
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -32,14 +34,15 @@ import {
   FormArray,
   FormControl,
   FormGroup,
-  NG_VALIDATORS,
-  NG_VALUE_ACCESSOR,
+  NgControl,
   ReactiveFormsModule,
+  TouchedChangeEvent,
   ValidationErrors,
   Validator,
   ValidatorFn,
   Validators,
 } from '@angular/forms';
+import { filter } from 'rxjs/operators';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -137,15 +140,20 @@ const duplicateDomainsValidator: ValidatorFn = (control: AbstractControl): Valid
   templateUrl: './branded-senders.component.html',
   styleUrl: './branded-senders.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [
-    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => BrandedSendersComponent), multi: true },
-    { provide: NG_VALIDATORS, useExisting: forwardRef(() => BrandedSendersComponent), multi: true },
-  ],
 })
-export class BrandedSendersComponent implements ControlValueAccessor, Validator {
+export class BrandedSendersComponent implements ControlValueAccessor, Validator, OnInit {
   private readonly destroyRef = inject(DestroyRef);
   private readonly changeDetector = inject(ChangeDetectorRef);
   private readonly errorHandler = inject(ErrorHandler);
+
+  // Injecting the host NgControl (instead of registering via NG_VALUE_ACCESSOR / NG_VALIDATORS) lets this nested
+  // sub-form react to its parent control being touched — see ngOnInit. The value accessor is assigned in the
+  // constructor rather than provided, to avoid the circular dependency the forwardRef provider would create.
+  constructor(@Self() @Optional() private readonly ngControl?: NgControl) {
+    if (this.ngControl) {
+      this.ngControl.valueAccessor = this;
+    }
+  }
 
   /** The default sender/subject shown read-only for context (the `EMAIL_FROM` / `EMAIL_SUBJECT` fallback). */
   readonly defaultFrom = input('');
@@ -174,6 +182,8 @@ export class BrandedSendersComponent implements ControlValueAccessor, Validator 
   protected readonly hasUserEdited = signal(false);
 
   private _onChange: (value: BrandedSender[]) => void = () => undefined;
+  // Registered via registerOnTouched to satisfy the CVA contract, but intentionally never invoked: touched is driven
+  // by the save bar (host control -> ngOnInit cascade), not by add/remove/blur here. Kept so the interface stays whole.
   private _onTouched: () => void = () => undefined;
 
   // A CVA propagates its value on every form change; this subscription is the bridge to _onChange. A throw in the
@@ -189,6 +199,36 @@ export class BrandedSendersComponent implements ControlValueAccessor, Validator 
       this.errorHandler.handleError(error);
     }
   });
+
+  // Bound once so the exact same reference can be added in ngOnInit and removed on destroy.
+  private readonly hostValidator: ValidatorFn = () => this.validate();
+
+  ngOnInit(): void {
+    const control = this.ngControl?.control;
+    if (!control) {
+      return;
+    }
+    // Register this sub-form's validity on the host control (replaces the NG_VALIDATORS provider). Unlike that
+    // provider, a manually added validator is not auto-cleaned by Angular's cleanUpControl, so remove it on destroy:
+    // this component can be license-gated (@if) while the host control lives on a long-lived form, and without cleanup
+    // a teardown/rebuild would stack duplicate validators and leave a stale closure pinning the host control invalid.
+    control.addValidators(this.hostValidator);
+    control.updateValueAndValidity({ emitEvent: false });
+    this.destroyRef.onDestroy(() => {
+      control.removeValidators(this.hostValidator);
+      control.updateValueAndValidity({ emitEvent: false });
+    });
+
+    // Surface the per-card "required" errors only once the user tries to save: gio-save-bar marks the whole form
+    // touched on an invalid submit, which touches this host control; mirror that into the inner FormArray so the
+    // errors appear on Save rather than the instant a card is added (which would make a brand-new card look invalid).
+    control.events
+      .pipe(
+        filter((event): event is TouchedChangeEvent => event instanceof TouchedChangeEvent && event.touched),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => this.configurations.markAllAsTouched());
+  }
 
   // --- ControlValueAccessor ---
 
@@ -232,13 +272,19 @@ export class BrandedSendersComponent implements ControlValueAccessor, Validator 
   // --- Template actions ---
 
   protected addConfiguration(): void {
-    this.configurations.push(this.newConfiguration());
-    this._onTouched();
+    const card = this.newConfiguration();
+    this.configurations.push(card);
+    // Before the first save attempt the host control is untouched, so a freshly added card starts clean; its required
+    // errors surface only when the user tries to save (the save bar touches the host control -> see the ngOnInit
+    // cascade). After that first save the host stays permanently touched and emits no further TouchedChangeEvent, so
+    // the cascade won't re-fire: mark a card added in that already-touched state so it too shows its errors at once.
+    if (this.ngControl?.control?.touched) {
+      card.markAllAsTouched();
+    }
   }
 
   protected removeConfiguration(index: number): void {
     this.configurations.removeAt(index);
-    this._onTouched();
   }
 
   private newConfiguration(brandedSender?: BrandedSender): BrandedSenderForm {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14777

## Description

1. Surface card errors on Save, not on Add
- Rewired BrandedSendersComponent from the NG_VALUE_ACCESSOR/NG_VALIDATORS forwardRef providers to the established nested-CVA pattern used by ApiPlanFormComponent (and the design-system's GioFormJsonSchemaComponent): inject the host NgControl, self-assign ngControl.valueAccessor = this, register validation via addValidators.
- In ngOnInit, listen for the host control becoming touched and cascade markAllAsTouched() into the inner card form. Since gio-save-bar already calls form.markAllAsTouched() on an invalid submit, the per-card errors now appear on Save, while a freshly added card stays clean.
- Used Angular 20's control.events + TouchedChangeEvent for the trigger (markAllAsTouched() doesn't emit on statusChanges).

2. Consistent required asterisk
- Passed [required]="true" to the domains gio-form-tags-input so its label shows the asterisk, matching From.

## Additional context
<img width="957" height="521" alt="Screenshot 2026-07-23 at 9 37 55 AM" src="https://github.com/user-attachments/assets/07942a06-bb39-483f-93ef-222ed2cff515" />

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

