### PR TITLE
fix: align branded-sender From validation with the SMTP send-path parser (backend + console)

### DIFF
--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.spec.ts
@@ -361,6 +361,20 @@ describe('BrandedSendersComponent', () => {
 
       expect(await fromField.getTextErrors()).toEqual(['Enter a valid email address, optionally with a display name.']);
     });
+
+    it('should not reject a single-label host in the from address (the backend accepts it)', async () => {
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '.branded-senders__add' }));
+      await addButton.click();
+
+      const fromField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'From' }));
+      const fromInput = (await fromField.getControl(MatInputHarness))!;
+      await fromInput.setValue('noreply@localhost');
+      await fromInput.blur();
+
+      // The client check must stay more permissive than the backend: single-label hosts are valid senders,
+      // so the browser must not raise a false error the backend would never produce.
+      expect(await fromField.getTextErrors()).toEqual([]);
+    });
   });
 
   describe('inherited from org badge', () => {

--- a/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/branded-senders/branded-senders.component.ts
@@ -61,14 +61,20 @@ const SUBJECT_MAX_LENGTH = 255;
 // Mirror it here as an aggregate guard so many individually-valid configurations can't silently overflow it at save time.
 const MAX_SERIALIZED_LENGTH = 4000;
 
-// Client-side format checks so the admin gets a helpful inline error (RFC 1035 host name, and a bare address or a
-// "Name <addr>" sender). These are UX-only and intentionally lenient — the backend only rejects null entries and
-// CR/LF, so this is NOT a mirror of backend validation. The final label allows either an alphabetic TLD or an
-// ACE/punycode IDN TLD (e.g. `xn--p1ai`), which contains digits and hyphens. The `i` flag keeps hostnames
-// case-insensitive (RFC 4343) so e.g. an `XN--P1AI` TLD is accepted the same in a bare domain and in a sender address.
+// Client-side format checks so the admin gets a helpful inline error before saving. The backend
+// (SenderAddressValidator, parsing with the same jakarta.mail parser the SMTP send-path uses) is the
+// authority; these stay deliberately MORE permissive than it for the shapes that matter, so a single-label
+// host like `user@localhost` (the standard docker/k8s SMTP config) or an IDN sender is not locked out
+// client-side even though it saves fine. (A few exotic RFC forms — e.g. a quoted local part containing `@` —
+// are still rejected here though the backend accepts them; negligible for a sender address.)
+//
+// DOMAIN_PATTERN (recipient domains) still requires a real dot-separated host name: the final label allows an
+// alphabetic TLD or an ACE/punycode IDN TLD (e.g. `xn--p1ai`). The `i` flag keeps hostnames case-insensitive
+// (RFC 4343). EMAIL_PATTERN (sender address) only checks that a local and a domain part surround a single `@`
+// with no whitespace — enough to catch an obvious typo (a missing `@` or domain) without mirroring the backend.
 const TLD = '(?:[a-zA-Z]{2,}|xn--[a-zA-Z0-9-]{1,59})';
 const DOMAIN_PATTERN = new RegExp(String.raw`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+${TLD}$`, 'i');
-const EMAIL_PATTERN = new RegExp(String.raw`^[A-Za-z0-9._%+-]+@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+${TLD}$`, 'i');
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+$/;
 
 /** Rejects a `string[]` where any entry is not a valid, dot-separated host name (case-insensitive). */
 const domainsValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/pom.xml
@@ -68,6 +68,12 @@
 			<artifactId>jakarta.validation-api</artifactId>
 		</dependency>
 
+		<!-- InternetAddress parser for SenderAddressValidator (API artifact only — no mail transport here). -->
+		<dependency>
+			<groupId>jakarta.mail</groupId>
+			<artifactId>jakarta.mail-api</artifactId>
+		</dependency>
+
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/email/EmailAddresses.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/email/EmailAddresses.java
@@ -18,11 +18,11 @@ package io.gravitee.rest.api.model.email;
 import java.util.Optional;
 
 /**
- * Shared parsing of a single sender/recipient email address, so the save-time {@code SenderAddressValidator}
- * and the send-time branded-sender matching ({@code BrandedSenders}) agree on what counts as a single,
- * sendable address. Extracting this in one place keeps validation honest: a value the validator accepts is
- * one {@code new jakarta.mail.internet.InternetAddress(value)} can also send, rather than a multi-address
- * list the greedy display-name strip once let through.
+ * Shared parsing of a single sender/recipient email address for the send-time branded-sender matching
+ * ({@code BrandedSenders}): it unwraps a {@code Name <addr>} personal name and rejects multi-address lists,
+ * so matching never keys off a value delivery cannot send from. Save-time validation
+ * ({@code SenderAddressValidator}) enforces the same "single, sendable address" contract, but does so
+ * directly against the {@code jakarta.mail} parser the SMTP send-path uses rather than through this helper.
  *
  * @author GraviteeSource Team
  */

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/SenderAddressValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/SenderAddressValidator.java
@@ -15,37 +15,59 @@
  */
 package io.gravitee.rest.api.validator;
 
-import io.gravitee.rest.api.model.email.EmailAddresses;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import java.util.regex.Pattern;
 
 /**
  * @author GraviteeSource Team
  */
 public class SenderAddressValidator implements ConstraintValidator<ValidSenderAddress, String> {
 
-    /**
-     * Pragmatic {@code local@domain.tld} check for a branded sender address. The domain is matched as
-     * RFC 1035 labels (each starts and ends alphanumeric, no empty or leading-dot labels, no consecutive
-     * dots) with a bounded label length. The label group is matched with a possessive quantifier
-     * ({@code ++}) so the engine runs iteratively — it can't backtrack super-linearly or recurse into a
-     * stack overflow on a large input — and it rejects shapes like {@code a..b.com} / {@code .a.com}.
-     */
-    private static final Pattern EMAIL = Pattern.compile(
-        "^[A-Za-z0-9._%+-]+@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)++[A-Za-z]{2,}$"
-    );
+    static final String MULTI_ADDRESS_MESSAGE = "must be a single sender address";
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
         if (value == null || value.isBlank()) {
             return true;
         }
-        // Resolve the single address (unwrapping a "Name <addr>" personal name and rejecting multi-address
-        // lists) with the same helper the send-time branded-sender matching uses, so save never accepts a
-        // From that delivery cannot send. The format check then rejects a malformed single address.
-        return EmailAddresses.singleAddress(value)
-            .filter(address -> EMAIL.matcher(address).matches())
-            .isPresent();
+        // Validate the *whole* value with the same jakarta.mail parser the SMTP send-path uses
+        // (EmailServiceImpl -> new InternetAddress(from)), so a From accepted at save time is one delivery
+        // can actually send. Checking only an unwrapped inner address would let a broken display name
+        // through — an unquoted comma in "Acme, Inc <noreply@acme.com>" parses as two addresses at send
+        // time and fails, even though its inner address is valid on its own.
+        if (isSendable(value)) {
+            return true;
+        }
+        // A value carrying more than one '@' is an address list, not a single sender. Say so distinctly
+        // rather than with the generic message: each address may be valid on its own — the problem is that
+        // there is more than one.
+        if (hasMultipleAddresses(value)) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(MULTI_ADDRESS_MESSAGE).addConstraintViolation();
+        }
+        return false;
+    }
+
+    /**
+     * Strict-parses the whole value with {@link InternetAddress#validate()}, mirroring the SMTP send-path so
+     * a save-accepted {@code From} is one delivery can send. It is intentionally stricter than the send-path's
+     * lenient {@code new InternetAddress(value)} in a single respect: it also rejects a value with no real
+     * domain ({@code not-an-email}), which parses but could never be delivered. It therefore never rejects an
+     * address the send-path could actually send, so it cannot reintroduce a false-reject lockout.
+     */
+    private static boolean isSendable(String value) {
+        try {
+            new InternetAddress(value, true).validate();
+            return true;
+        } catch (AddressException e) {
+            return false;
+        }
+    }
+
+    private static boolean hasMultipleAddresses(String value) {
+        var trimmed = value.trim();
+        return trimmed.indexOf('@') != trimmed.lastIndexOf('@');
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/validator/SenderAddressValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/validator/SenderAddressValidatorTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SenderAddressValidatorTest {
+
+    private SenderAddressValidator cut;
+
+    @Mock
+    private ConstraintValidatorContext constraintValidatorContext;
+
+    @Mock
+    private ConstraintValidatorContext.ConstraintViolationBuilder constraintViolationBuilder;
+
+    @BeforeEach
+    void setUp() {
+        cut = new SenderAddressValidator();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "   " })
+    void should_accept_null_or_blank_and_defer_to_notblank(String value) {
+        // A required value is enforced by a separate @NotBlank — this constraint only checks shape.
+        assertThat(cut.isValid(value, constraintValidatorContext)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "noreply@localhost", // single-label host — old regex wrongly rejected
+            "noreply@mail.example.com", // dotted domain
+            "o'brien@acme.co", // apostrophe in local part — old regex wrongly rejected
+            "Acme Inc <noreply@acme.com>", // RFC 822 personal-name form
+            "\"Acme, Inc\" <noreply@acme.com>", // comma in a *quoted* display name is a single sendable address
+            "\"a@b\"@x.com", // quoted local part containing '@' is one valid address (send-path accepts it)
+        }
+    )
+    void should_accept_addresses_the_send_path_can_send(String value) {
+        assertThat(cut.isValid(value, constraintValidatorContext)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "not-an-email", // no domain
+            "a..b@x.com", // consecutive dots — old regex wrongly accepted
+            ".a@x.com", // leading dot in local part — old regex wrongly accepted
+            "Acme, Inc <noreply@acme.com>", // unquoted comma in display name — send path parses it as a list and fails
+            "Acme; Inc <a@localhost>", // unquoted semicolon in display name — likewise unsendable
+            "jane@work <Jane>", // the single '@' sits outside the brackets, leaving no address to send
+            "noreply@example.com\r\nSubject: hacked", // single-'@' CR/LF header injection — only validate() rejects the newline
+        }
+    )
+    void should_reject_an_unsendable_value_with_the_default_message(String value) {
+        assertThat(cut.isValid(value, constraintValidatorContext)).isFalse();
+        // A malformed single address keeps the annotation's default message; only the multi-address case
+        // overrides it (see below).
+        verify(constraintValidatorContext, never()).buildConstraintViolationWithTemplate(any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "alice@example.com, bob@example.com", // a plain address list — both valid, but there are two
+            "Alice <alice@example.com>, Bob <bob@example.com>", // comma-joined personal-name list
+            "noreply@localhost\nBcc: attacker@evil.com", // header-injection attempt reads as multiple addresses
+        }
+    )
+    void should_reject_a_multi_address_value_with_a_distinct_message(String value) {
+        var messageCaptor = ArgumentCaptor.forClass(String.class);
+        when(constraintValidatorContext.buildConstraintViolationWithTemplate(messageCaptor.capture())).thenReturn(
+            constraintViolationBuilder
+        );
+
+        assertThat(cut.isValid(value, constraintValidatorContext)).isFalse();
+
+        verify(constraintValidatorContext).disableDefaultConstraintViolation();
+        verify(constraintViolationBuilder).addConstraintViolation();
+        assertThat(messageCaptor.getValue()).isEqualTo("must be a single sender address");
+    }
+
+    // --- annotation wiring: the messages actually resolve through a real Validator, not just the mock ---
+
+    @Test
+    void should_surface_the_default_message_end_to_end_for_a_malformed_address() {
+        var violations = beanValidator().validate(new Holder("not-an-email"));
+        assertThat(violations)
+            .singleElement()
+            .extracting(ConstraintViolation::getMessage)
+            .isEqualTo("must be a valid email address, optionally with a display name (e.g. \"Name <user@example.com>\")");
+    }
+
+    @Test
+    void should_surface_the_multi_address_message_end_to_end() {
+        var violations = beanValidator().validate(new Holder("alice@example.com, bob@example.com"));
+        assertThat(violations).singleElement().extracting(ConstraintViolation::getMessage).isEqualTo("must be a single sender address");
+    }
+
+    private static Validator beanValidator() {
+        return Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    private static final class Holder {
+
+        @ValidSenderAddress
+        final String from;
+
+        Holder(String from) {
+            this.from = from;
+        }
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14778

## Description

`SenderAddressValidator` used a hand-rolled regex that disagreed with the `jakarta.mail` parser the SMTP send-path (`EmailServiceImpl → new InternetAddress(from)`) actually uses. It wrongly rejected single-label hosts (`noreply@localhost`, the standard docker/k8s SMTP shape), so an install with such a sender could no longer save settings — and the console's own client-side check had the same false-reject.

**Backend** — validate the whole `From` value with `new InternetAddress(value, true).validate()`, the same parser the send-path uses, so a `From` accepted at save is one delivery can actually send. Closes the gap in both directions:
- False rejects — single-label hosts and apostrophes in the local part now save.
- False accepts — `a..b@x.com` and a broken display name (`Acme, Inc <noreply@acme.com>`, whose unquoted comma parses as two addresses at send time) are now rejected at save instead of failing silently at send.

**Console** — relax the branded-sender `From` check so it stays more permissive than the backend, so single-label hosts are no longer falsely blocked in the browser.

## Changes (6 files)

- `SenderAddressValidator` — parses the whole value against the send-path parser; distinct violation message for the multi-address case (`a@x, b@x` — both valid, but there's more than one).
- `EmailAddresses` — javadoc corrected: the validator no longer routes through this helper (still used by send-time `BrandedSenders` matching).
- `pom.xml` — adds `jakarta.mail:jakarta.mail-api` (version-managed); the `InternetAddress` parser lives in the API artifact, no SMTP transport provider pulled into this module.
- `SenderAddressValidatorTest` (new) — 20 tests: accept/reject table, single-label hosts, broken display names, CR/LF rejection, and end-to-end message wiring through a real `Validator`.
- `branded-senders.component.ts` / `.spec.ts` — lenient client-side `From` check + test.

## Verification

Backend tests 20/20; existing `BrandedSenderValidationTest` (22) + `EmailAddressesTest` (13) still green — no regressions. Verified end-to-end in the console UI (see recording below).

## Additional context

https://github.com/user-attachments/assets/a437bf45-5c30-464e-ab96-3f1dd080c42e
