### PR TITLE
feat(gamma): edit dictionary configuration

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/CreateDictionarySheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/CreateDictionarySheet.spec.tsx
@@ -16,8 +16,8 @@
 
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
-import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
 import { CreateDictionarySheet } from './CreateDictionarySheet';
+import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
 
 function renderSheet({
     open = true,
@@ -126,7 +126,7 @@ describe('CreateDictionarySheet', () => {
         });
         fireEvent.change(screen.getByLabelText(/^Interval/), { target: { value: '0' } });
 
-        expect(screen.queryByText('Interval must be greater than 0')).not.toBeNull();
+        expect(screen.queryByText('Interval must be a whole number greater than 0')).not.toBeNull();
         expect((screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement).disabled).toBe(true);
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/CreateDictionarySheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/CreateDictionarySheet.tsx
@@ -35,6 +35,13 @@ import {
 } from '@gravitee/graphene-core';
 import { useCallback, useEffect, useState, type FormEvent } from 'react';
 
+import {
+    DictionaryHttpProviderFields,
+    isHttpProviderFormValid,
+    toProviderHeaders,
+    type DictionaryHttpProviderFormValue,
+} from './DictionaryHttpProviderFields';
+import { DictionaryTriggerFields, isTriggerFormValid, type DictionaryTriggerFormValue } from './DictionaryTriggerFields';
 import { extractErrorMessage } from '../../../shared/notify/extractErrorMessage';
 import type { DictionaryType, NewDictionaryPayload } from '../types/dictionary';
 import {
@@ -43,13 +50,6 @@ import {
     getDictionaryNameError,
     isDictionaryNameValid,
 } from '../utils/dictionaryFormValidation';
-import {
-    DictionaryHttpProviderFields,
-    isHttpProviderFormValid,
-    toProviderHeaders,
-    type DictionaryHttpProviderFormValue,
-} from './DictionaryHttpProviderFields';
-import { DictionaryTriggerFields, isTriggerFormValid, type DictionaryTriggerFormValue } from './DictionaryTriggerFields';
 
 interface CreateDictionaryForm {
     name: string;
@@ -157,7 +157,7 @@ export function CreateDictionarySheet({
                 </SheetHeader>
 
                 <ScrollArea className="min-h-0 flex-1">
-                    <form id="create-dictionary-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-1 py-4">
+                    <form id="create-dictionary-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-4 py-4">
                         <Field orientation="vertical" className="gap-1.5">
                             <FieldLabel htmlFor="dictionary-name">
                                 Name{' '}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DeleteDictionaryPropertySheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DeleteDictionaryPropertySheet.spec.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { DeleteDictionaryPropertySheet } from './DeleteDictionaryPropertySheet';
+
+function renderSheet(open: boolean, propertyKey: string | undefined = 'SCHEDULED') {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    render(
+        <DeleteDictionaryPropertySheet open={open} propertyKey={propertyKey} onClose={onClose} onConfirm={onConfirm} isDeleting={false} />,
+    );
+    return { onClose, onConfirm };
+}
+
+describe('DeleteDictionaryPropertySheet', () => {
+    it('does not show dialog content when closed', () => {
+        renderSheet(false);
+        expect(screen.queryByRole('heading', { name: 'Delete Property' })).toBeNull();
+    });
+
+    it('shows the property key in the confirmation message', () => {
+        renderSheet(true);
+        expect(screen.getByRole('heading', { name: 'Delete Property' })).not.toBeNull();
+        expect(screen.getByText('SCHEDULED')).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Delete' })).not.toBeNull();
+    });
+
+    it('invokes onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet(true);
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes onConfirm when Delete is clicked', () => {
+        const { onConfirm } = renderSheet(true);
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables Delete when propertyKey is missing', () => {
+        render(<DeleteDictionaryPropertySheet open propertyKey={undefined} onClose={jest.fn()} onConfirm={jest.fn()} isDeleting={false} />);
+        expect((screen.getByRole('button', { name: 'Delete' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('shows deleting label while the mutation is in progress', () => {
+        render(<DeleteDictionaryPropertySheet open propertyKey="SCHEDULED" onClose={jest.fn()} onConfirm={jest.fn()} isDeleting />);
+
+        expect(screen.getByRole('button', { name: 'Deleting…' })).not.toBeNull();
+        expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();
+        expect((screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement).disabled).toBe(true);
+        expect((screen.getByRole('button', { name: 'Deleting…' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DeleteDictionaryPropertySheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DeleteDictionaryPropertySheet.tsx
@@ -26,17 +26,15 @@ import {
 } from '@gravitee/graphene-core';
 import { TriangleAlertIcon } from '@gravitee/graphene-core/icons';
 
-import type { DictionaryListItem } from '../types/dictionary';
-
-export function DictionaryDeleteSheet({
+export function DeleteDictionaryPropertySheet({
     open,
-    dictionary,
+    propertyKey,
     onClose,
     onConfirm,
     isDeleting,
 }: Readonly<{
     open: boolean;
-    dictionary: DictionaryListItem | undefined;
+    propertyKey: string | undefined;
     onClose: () => void;
     onConfirm: () => void;
     isDeleting: boolean;
@@ -47,11 +45,11 @@ export function DictionaryDeleteSheet({
                 <DialogHeader>
                     <DialogTitle className="flex items-center gap-2">
                         <TriangleAlertIcon className="size-5 shrink-0 text-destructive" aria-hidden />
-                        Delete Dictionary
+                        Delete Property
                     </DialogTitle>
                     <DialogDescription>
-                        Are you sure you want to delete <strong>{dictionary?.name}</strong>? This will permanently remove all of its
-                        properties. This action cannot be undone.
+                        Are you sure you want to delete property <strong className="font-mono text-xs">{propertyKey}</strong>? Policies that
+                        reference this key will no longer resolve its value. This action cannot be undone.
                     </DialogDescription>
                 </DialogHeader>
                 <DialogFooter className="sm:justify-end gap-2">
@@ -60,8 +58,8 @@ export function DictionaryDeleteSheet({
                             Cancel
                         </Button>
                     </DialogClose>
-                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || !dictionary}>
-                        {isDeleting ? 'Deleting…' : 'Delete Dictionary'}
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || !propertyKey}>
+                        {isDeleting ? 'Deleting…' : 'Delete'}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.spec.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { DictionariesTable } from './DictionariesTable';
 import type { DictionaryListItem } from '../types/dictionary';
@@ -21,7 +22,6 @@ import type { DictionaryListItem } from '../types/dictionary';
 const DICTIONARIES: DictionaryListItem[] = [
     {
         id: '1',
-        key: 'countries',
         name: 'Countries',
         description: 'ISO country lookup',
         type: 'MANUAL',
@@ -31,7 +31,6 @@ const DICTIONARIES: DictionaryListItem[] = [
     },
     {
         id: '2',
-        key: 'remote-codes',
         name: 'Remote Codes',
         type: 'DYNAMIC',
         state: 'STARTED',
@@ -39,8 +38,7 @@ const DICTIONARIES: DictionaryListItem[] = [
         updated_at: '2026-01-02T00:00:00.000Z',
     },
     {
-        id: '3',
-        key: 'status-map',
+        id: 'status-map',
         name: 'Status Map',
         type: 'MANUAL',
         state: 'STOPPED',
@@ -48,18 +46,21 @@ const DICTIONARIES: DictionaryListItem[] = [
     },
 ];
 
-function renderTable(overrides: Partial<{ canDelete: boolean; dictionaries: DictionaryListItem[] }> = {}) {
+function renderTable(overrides: Partial<{ canEdit: boolean; canDelete: boolean; dictionaries: DictionaryListItem[] }> = {}) {
     const onOpen = jest.fn();
+    const onEdit = jest.fn();
     const onDelete = jest.fn();
     render(
         <DictionariesTable
             dictionaries={overrides.dictionaries ?? DICTIONARIES}
+            canEdit={overrides.canEdit ?? true}
             canDelete={overrides.canDelete ?? true}
             onOpen={onOpen}
+            onEdit={onEdit}
             onDelete={onDelete}
         />,
     );
-    return { onOpen, onDelete };
+    return { onOpen, onEdit, onDelete };
 }
 
 describe('DictionariesTable', () => {
@@ -118,17 +119,27 @@ describe('DictionariesTable', () => {
         });
     });
 
+    describe('row actions', () => {
+        it('calls onEdit when Edit is selected from the actions menu', async () => {
+            const user = userEvent.setup();
+            const { onEdit } = renderTable();
+            await user.click(screen.getAllByRole('button', { name: 'Dictionary actions' })[0]);
+            await user.click(await screen.findByRole('menuitem', { name: /^Edit$/ }));
+            expect(onEdit).toHaveBeenCalledWith(expect.objectContaining({ id: '1', name: 'Countries' }));
+        });
+    });
+
     describe('search filtering', () => {
         it('filters rows by name', () => {
             renderTable();
-            fireEvent.change(screen.getByPlaceholderText('Search by key, name, or description…'), { target: { value: 'remote' } });
+            fireEvent.change(screen.getByPlaceholderText('Search by name, id, or description…'), { target: { value: 'remote' } });
             expect(screen.queryByText('Remote Codes')).not.toBeNull();
             expect(screen.queryByText('Countries')).toBeNull();
         });
 
-        it('filters rows by key', () => {
+        it('filters rows by id', () => {
             renderTable();
-            fireEvent.change(screen.getByPlaceholderText('Search by key, name, or description…'), { target: { value: 'status-map' } });
+            fireEvent.change(screen.getByPlaceholderText('Search by name, id, or description…'), { target: { value: 'status-map' } });
             expect(screen.queryByText('Status Map')).not.toBeNull();
             expect(screen.queryByText('Countries')).toBeNull();
         });
@@ -140,32 +151,37 @@ describe('DictionariesTable', () => {
                     { id: '2', name: 'Remote Codes', description: 'Partner status codes', type: 'DYNAMIC', state: 'STARTED' },
                 ],
             });
-            fireEvent.change(screen.getByPlaceholderText('Search by key, name, or description…'), { target: { value: 'partner' } });
+            fireEvent.change(screen.getByPlaceholderText('Search by name, id, or description…'), { target: { value: 'partner' } });
             expect(screen.queryByText('Remote Codes')).not.toBeNull();
             expect(screen.queryByText('Countries')).toBeNull();
         });
 
         it('shows the no-match message when search has no results', () => {
             renderTable();
-            fireEvent.change(screen.getByPlaceholderText('Search by key, name, or description…'), { target: { value: 'zzznomatch' } });
+            fireEvent.change(screen.getByPlaceholderText('Search by name, id, or description…'), { target: { value: 'zzznomatch' } });
             expect(screen.queryByText('No dictionaries match your search.')).not.toBeNull();
         });
 
         it('is case-insensitive', () => {
             renderTable();
-            fireEvent.change(screen.getByPlaceholderText('Search by key, name, or description…'), { target: { value: 'COUNTRIES' } });
+            fireEvent.change(screen.getByPlaceholderText('Search by name, id, or description…'), { target: { value: 'COUNTRIES' } });
             expect(screen.queryByText('Countries')).not.toBeNull();
         });
     });
 
     describe('permissions', () => {
-        it('hides the actions column when canDelete is false', () => {
-            renderTable({ canDelete: false });
-            expect(screen.queryByRole('button', { name: 'Dictionary actions' })).toBeNull();
+        it('always shows the actions menu so View Details remains available', () => {
+            renderTable({ canEdit: false, canDelete: false });
+            expect(screen.getAllByRole('button', { name: 'Dictionary actions' }).length).toBe(DICTIONARIES.length);
+        });
+
+        it('shows one action button per row when canEdit is true', () => {
+            renderTable({ canEdit: true, canDelete: false });
+            expect(screen.getAllByRole('button', { name: 'Dictionary actions' }).length).toBe(DICTIONARIES.length);
         });
 
         it('shows one action button per row when canDelete is true', () => {
-            renderTable({ canDelete: true });
+            renderTable({ canEdit: false, canDelete: true });
             expect(screen.getAllByRole('button', { name: 'Dictionary actions' }).length).toBe(DICTIONARIES.length);
         });
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.tsx
@@ -27,7 +27,7 @@ import {
     InputGroupInput,
     type DataTableProps,
 } from '@gravitee/graphene-core';
-import { MoreHorizontalIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { BookOpenIcon, MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
 import { useMemo, useState } from 'react';
 
 import { DictionaryTypeLabel } from './DictionaryTypeLabel';
@@ -93,7 +93,7 @@ function filterDictionaries(dictionaries: DictionaryListItem[], search: string):
     return dictionaries.filter(
         d =>
             d.name.toLowerCase().includes(query) ||
-            (d.key ?? '').toLowerCase().includes(query) ||
+            d.id.toLowerCase().includes(query) ||
             (d.description ?? '').toLowerCase().includes(query),
     );
 }
@@ -105,9 +105,17 @@ function paginateDictionaries(items: DictionaryListItem[], page: number, pageSiz
 
 function DictionaryActionsCell({
     dictionary,
+    canEdit,
+    canDelete,
+    onOpen,
+    onEdit,
     onDelete,
 }: Readonly<{
     dictionary: DictionaryListItem;
+    canEdit: boolean;
+    canDelete: boolean;
+    onOpen: (dictionary: DictionaryListItem) => void;
+    onEdit: (dictionary: DictionaryListItem) => void;
     onDelete: (dictionary: DictionaryListItem) => void;
 }>) {
     return (
@@ -118,11 +126,23 @@ function DictionaryActionsCell({
                         <MoreHorizontalIcon className="size-4" aria-hidden />
                     </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                    <DropdownMenuItem variant="destructive" onSelect={() => onDelete(dictionary)}>
-                        <Trash2Icon className="size-4 mr-2" aria-hidden />
-                        Delete
+                <DropdownMenuContent align="end" className="min-w-48">
+                    <DropdownMenuItem className="whitespace-nowrap" onSelect={() => onOpen(dictionary)}>
+                        <BookOpenIcon className="size-4 mr-2 shrink-0" aria-hidden />
+                        View Details
                     </DropdownMenuItem>
+                    {canEdit ? (
+                        <DropdownMenuItem className="whitespace-nowrap" onSelect={() => onEdit(dictionary)}>
+                            <PencilIcon className="size-4 mr-2 shrink-0" aria-hidden />
+                            Edit
+                        </DropdownMenuItem>
+                    ) : null}
+                    {canDelete ? (
+                        <DropdownMenuItem className="whitespace-nowrap" variant="destructive" onSelect={() => onDelete(dictionary)}>
+                            <Trash2Icon className="size-4 mr-2 shrink-0" aria-hidden />
+                            Delete
+                        </DropdownMenuItem>
+                    ) : null}
                 </DropdownMenuContent>
             </DropdownMenu>
         </div>
@@ -130,12 +150,16 @@ function DictionaryActionsCell({
 }
 
 function buildColumns({
+    canEdit,
     canDelete,
     onOpen,
+    onEdit,
     onDelete,
 }: {
+    canEdit: boolean;
     canDelete: boolean;
     onOpen: (dictionary: DictionaryListItem) => void;
+    onEdit: (dictionary: DictionaryListItem) => void;
     onDelete: (dictionary: DictionaryListItem) => void;
 }): DataTableProps<DictionaryListItem>['columns'] {
     const columns: DataTableProps<DictionaryListItem>['columns'] = [
@@ -192,29 +216,40 @@ function buildColumns({
         },
     ];
 
-    if (canDelete) {
-        columns.push({
-            id: 'actions',
-            header: () => <span className="sr-only">Actions</span>,
-            size: 56,
-            enableSorting: false,
-            enableHiding: false,
-            cell: ({ row }: ColCell<DictionaryListItem>) => <DictionaryActionsCell dictionary={row.original} onDelete={onDelete} />,
-        });
-    }
+    columns.push({
+        id: 'actions',
+        header: () => <span className="sr-only">Actions</span>,
+        size: 56,
+        enableSorting: false,
+        enableHiding: false,
+        cell: ({ row }: ColCell<DictionaryListItem>) => (
+            <DictionaryActionsCell
+                dictionary={row.original}
+                canEdit={canEdit}
+                canDelete={canDelete}
+                onOpen={onOpen}
+                onEdit={onEdit}
+                onDelete={onDelete}
+            />
+        ),
+    });
 
     return columns;
 }
 
 export function DictionariesTable({
     dictionaries,
+    canEdit,
     canDelete,
     onOpen,
+    onEdit,
     onDelete,
 }: Readonly<{
     dictionaries: DictionaryListItem[];
+    canEdit: boolean;
     canDelete: boolean;
     onOpen: (dictionary: DictionaryListItem) => void;
+    onEdit: (dictionary: DictionaryListItem) => void;
     onDelete: (dictionary: DictionaryListItem) => void;
 }>) {
     const [search, setSearch] = useState('');
@@ -227,7 +262,10 @@ export function DictionariesTable({
     const totalCount = sorted.length;
     const paginatedData = useMemo(() => paginateDictionaries(sorted, page, pageSize), [sorted, page, pageSize]);
 
-    const columns = useMemo(() => buildColumns({ canDelete, onOpen, onDelete }), [canDelete, onOpen, onDelete]);
+    const columns = useMemo(
+        () => buildColumns({ canEdit, canDelete, onOpen, onEdit, onDelete }),
+        [canEdit, canDelete, onOpen, onEdit, onDelete],
+    );
 
     function handleSearchChange(value: string) {
         setSearch(value);
@@ -257,7 +295,7 @@ export function DictionariesTable({
                         <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
                     </InputGroupAddon>
                     <InputGroupInput
-                        placeholder="Search by key, name, or description…"
+                        placeholder="Search by name, id, or description…"
                         value={search}
                         onChange={e => handleSearchChange(e.target.value)}
                     />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryPropertiesTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryPropertiesTable.spec.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { DictionaryPropertiesTable } from './DictionaryPropertiesTable';
+
+const PROPERTIES = [
+    { key: 'MUC', value: 'Munich' },
+    { key: 'FRA', value: 'Frankfurt' },
+];
+
+describe('DictionaryPropertiesTable', () => {
+    it('renders property rows', () => {
+        render(
+            <DictionaryPropertiesTable
+                properties={PROPERTIES}
+                canEdit={false}
+                isMutating={false}
+                onEdit={jest.fn()}
+                onDelete={jest.fn()}
+                emptyMessage="No properties yet."
+            />,
+        );
+        expect(screen.getByText('MUC')).not.toBeNull();
+        expect(screen.getByText('Munich')).not.toBeNull();
+        expect(screen.queryByRole('button', { name: /Edit property/ })).toBeNull();
+    });
+
+    it('calls edit and delete handlers when permitted', () => {
+        const onEdit = jest.fn();
+        const onDelete = jest.fn();
+        render(
+            <DictionaryPropertiesTable
+                properties={PROPERTIES}
+                canEdit
+                isMutating={false}
+                onEdit={onEdit}
+                onDelete={onDelete}
+                emptyMessage="No properties yet."
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Edit property MUC' }));
+        expect(onEdit).toHaveBeenCalledWith({ key: 'MUC', value: 'Munich' });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Delete property FRA' }));
+        expect(onDelete).toHaveBeenCalledWith('FRA');
+    });
+
+    it('shows empty message when there are no properties', () => {
+        render(
+            <DictionaryPropertiesTable
+                properties={[]}
+                canEdit
+                isMutating={false}
+                onEdit={jest.fn()}
+                onDelete={jest.fn()}
+                emptyMessage="No properties yet."
+            />,
+        );
+        expect(screen.getByText('No properties yet.')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryPropertiesTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryPropertiesTable.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, DataTable, type DataTableProps } from '@gravitee/graphene-core';
+import { PencilIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useMemo } from 'react';
+
+import type { ColCell } from '../../applications/utils/dataTableTypes';
+
+export interface DictionaryPropertyRow {
+    key: string;
+    value: string;
+}
+
+function buildColumns({
+    canEdit,
+    isMutating,
+    onEdit,
+    onDelete,
+}: {
+    canEdit: boolean;
+    isMutating: boolean;
+    onEdit: (property: DictionaryPropertyRow) => void;
+    onDelete: (propertyKey: string) => void;
+}): DataTableProps<DictionaryPropertyRow>['columns'] {
+    const columns: DataTableProps<DictionaryPropertyRow>['columns'] = [
+        {
+            id: 'key',
+            accessorKey: 'key',
+            header: 'Key',
+            cell: ({ row }: ColCell<DictionaryPropertyRow>) => <span className="font-mono text-xs">{row.original.key}</span>,
+            enableSorting: false,
+        },
+        {
+            id: 'value',
+            accessorKey: 'value',
+            header: 'Value',
+            cell: ({ row }: ColCell<DictionaryPropertyRow>) => <span className="text-sm">{row.original.value}</span>,
+            enableSorting: false,
+        },
+    ];
+
+    if (canEdit) {
+        columns.push({
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            size: 88,
+            enableSorting: false,
+            enableHiding: false,
+            cell: ({ row }: ColCell<DictionaryPropertyRow>) => {
+                const property = row.original;
+                return (
+                    <div className="flex items-center justify-end gap-1">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="size-8"
+                            aria-label={`Edit property ${property.key}`}
+                            disabled={isMutating}
+                            onClick={() => onEdit(property)}
+                        >
+                            <PencilIcon className="size-4 text-muted-foreground" aria-hidden />
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="size-8 text-destructive hover:text-destructive"
+                            aria-label={`Delete property ${property.key}`}
+                            disabled={isMutating}
+                            onClick={() => onDelete(property.key)}
+                        >
+                            <Trash2Icon className="size-4" aria-hidden />
+                        </Button>
+                    </div>
+                );
+            },
+        });
+    }
+
+    return columns;
+}
+
+export function DictionaryPropertiesTable({
+    properties,
+    canEdit,
+    isMutating,
+    onEdit,
+    onDelete,
+    emptyMessage,
+}: Readonly<{
+    properties: DictionaryPropertyRow[];
+    canEdit: boolean;
+    isMutating: boolean;
+    onEdit: (property: DictionaryPropertyRow) => void;
+    onDelete: (propertyKey: string) => void;
+    emptyMessage: string;
+}>) {
+    const columns = useMemo(() => buildColumns({ canEdit, isMutating, onEdit, onDelete }), [canEdit, isMutating, onEdit, onDelete]);
+
+    return <DataTable aria-label="Dictionary properties" columns={columns} data={properties} emptyMessage={emptyMessage} />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/EditDictionaryPropertySheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/EditDictionaryPropertySheet.spec.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { EditDictionaryPropertySheet } from './EditDictionaryPropertySheet';
+import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
+
+jest.mock('../../../shared/notify', () => ({
+    notify: { error: jest.fn(), success: jest.fn() },
+}));
+
+function renderSheet(
+    overrides: Partial<{
+        open: boolean;
+        property: { key: string; value: string } | undefined;
+        isSaving: boolean;
+        existingKeys: string[];
+        onSubmit: jest.Mock;
+    }> = {},
+) {
+    const onClose = jest.fn();
+    const onSubmit = overrides.onSubmit ?? jest.fn().mockResolvedValue(undefined);
+    render(
+        <EditDictionaryPropertySheet
+            open={overrides.open ?? true}
+            property={overrides.property ?? { key: 'MUC', value: 'Munich' }}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={overrides.isSaving ?? false}
+            existingKeys={overrides.existingKeys ?? ['MUC', 'FRA']}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('EditDictionaryPropertySheet', () => {
+    it('does not show sheet when closed', () => {
+        renderSheet({ open: false });
+        expect(querySheetHeading('Edit Property')).toBeNull();
+    });
+
+    it('prefills key and value', () => {
+        renderSheet();
+        expect(screen.getByRole('heading', { name: 'Edit Property' })).not.toBeNull();
+        expect((screen.getByLabelText(/^Key/) as HTMLInputElement).value).toBe('MUC');
+        expect((screen.getByLabelText(/^Value/) as HTMLInputElement).value).toBe('Munich');
+    });
+
+    it('submits updated value with original key', async () => {
+        const { onSubmit } = renderSheet();
+        fireEvent.change(screen.getByLabelText(/^Value/), { target: { value: 'Munich Airport' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith({
+                originalKey: 'MUC',
+                key: 'MUC',
+                value: 'Munich Airport',
+            });
+        });
+    });
+
+    it('blocks rename to an existing key', async () => {
+        const { notify } = jest.requireMock('../../../shared/notify') as { notify: { error: jest.Mock } };
+        const { onSubmit } = renderSheet();
+        fireEvent.change(screen.getByLabelText(/^Key/), { target: { value: 'FRA' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+
+        await waitFor(() => {
+            expect(notify.error).toHaveBeenCalledWith('Property key "FRA" already exists');
+        });
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/EditDictionaryPropertySheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/EditDictionaryPropertySheet.tsx
@@ -30,16 +30,18 @@ import { useCallback, useEffect, useState, type FormEvent } from 'react';
 
 import { notify } from '../../../shared/notify';
 
-export function AddDictionaryPropertySheet({
+export function EditDictionaryPropertySheet({
     open,
+    property,
     onClose,
     onSubmit,
     isSaving,
     existingKeys,
 }: Readonly<{
     open: boolean;
+    property: { key: string; value: string } | undefined;
     onClose: () => void;
-    onSubmit: (property: { key: string; value: string }) => Promise<void>;
+    onSubmit: (next: { originalKey: string; key: string; value: string }) => Promise<void>;
     isSaving: boolean;
     existingKeys: string[];
 }>) {
@@ -47,10 +49,10 @@ export function AddDictionaryPropertySheet({
     const [value, setValue] = useState('');
 
     useEffect(() => {
-        if (!open) return;
-        setKey('');
-        setValue('');
-    }, [open]);
+        if (!open || !property) return;
+        setKey(property.key);
+        setValue(property.value);
+    }, [open, property]);
 
     const handleOpenChange = useCallback(
         (isOpen: boolean) => {
@@ -59,34 +61,35 @@ export function AddDictionaryPropertySheet({
         [onClose],
     );
 
+    const originalKey = property?.key ?? '';
     const trimmedKey = key.trim();
-    const canSubmit = trimmedKey.length > 0 && !isSaving;
+    const canSubmit = Boolean(property) && trimmedKey.length > 0 && !isSaving;
 
     async function handleSubmit(e: FormEvent) {
         e.preventDefault();
-        if (!canSubmit) return;
-        if (existingKeys.includes(trimmedKey)) {
+        if (!property || !canSubmit) return;
+        if (trimmedKey !== originalKey && existingKeys.includes(trimmedKey)) {
             notify.error(`Property key "${trimmedKey}" already exists`);
             return;
         }
-        await onSubmit({ key: trimmedKey, value });
+        await onSubmit({ originalKey, key: trimmedKey, value });
     }
 
     return (
         <Sheet open={open} onOpenChange={handleOpenChange}>
             <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
                 <SheetHeader>
-                    <SheetTitle>Add Property</SheetTitle>
+                    <SheetTitle>Edit Property</SheetTitle>
                     <SheetDescription>Property keys must be unique within a dictionary.</SheetDescription>
                 </SheetHeader>
 
-                <form id="add-dictionary-property-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-4 py-4">
+                <form id="edit-dictionary-property-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-4 py-4">
                     <Field orientation="vertical" className="gap-1.5">
-                        <FieldLabel htmlFor="property-key">
+                        <FieldLabel htmlFor="edit-property-key">
                             Key <span className="text-destructive">*</span>
                         </FieldLabel>
                         <Input
-                            id="property-key"
+                            id="edit-property-key"
                             value={key}
                             onChange={e => setKey(e.target.value)}
                             placeholder="e.g. MUC"
@@ -96,9 +99,9 @@ export function AddDictionaryPropertySheet({
                         />
                     </Field>
                     <Field orientation="vertical" className="gap-1.5">
-                        <FieldLabel htmlFor="property-value">Value</FieldLabel>
+                        <FieldLabel htmlFor="edit-property-value">Value</FieldLabel>
                         <Input
-                            id="property-value"
+                            id="edit-property-value"
                             value={value}
                             onChange={e => setValue(e.target.value)}
                             placeholder="e.g. Munich"
@@ -111,8 +114,8 @@ export function AddDictionaryPropertySheet({
                     <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
                         Cancel
                     </Button>
-                    <Button type="submit" form="add-dictionary-property-form" disabled={!canSubmit}>
-                        {isSaving ? 'Adding…' : 'Add'}
+                    <Button type="submit" form="edit-dictionary-property-form" disabled={!canSubmit}>
+                        {isSaving ? 'Updating…' : 'Update'}
                     </Button>
                 </SheetFooter>
             </SheetContent>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/EditDictionarySheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/EditDictionarySheet.spec.tsx
@@ -1,0 +1,233 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { EditDictionarySheet } from './EditDictionarySheet';
+import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
+import type { Dictionary } from '../types/dictionary';
+
+const MANUAL_DICTIONARY: Dictionary = {
+    id: 'dict-1',
+    name: 'Airport IATA Codes',
+    description: 'IATA codes for airports',
+    type: 'MANUAL',
+    properties: { CDG: 'Paris Charles de Gaulle', LHR: 'London Heathrow' },
+};
+
+const DYNAMIC_DICTIONARY: Dictionary = {
+    id: 'dict-2',
+    name: 'Remote Codes',
+    description: 'Pulled from HTTP',
+    type: 'DYNAMIC',
+    properties: { a: '1' },
+    trigger: { rate: 5, unit: 'MINUTES' },
+    provider: {
+        type: 'HTTP',
+        configuration: {
+            url: 'https://example.com/codes',
+            method: 'GET',
+            body: '{"include":"all"}',
+            specification: '[{"operation":"shift","spec":{"*":"&"}}]',
+            useSystemProxy: false,
+            headers: [{ name: 'Accept', value: 'application/json' }],
+        },
+    },
+};
+
+function renderSheet({
+    open = true,
+    dictionary = MANUAL_DICTIONARY,
+    isLoading = false,
+    isSaving = false,
+    onSubmit = jest.fn().mockResolvedValue(undefined),
+}: {
+    open?: boolean;
+    dictionary?: Dictionary | undefined;
+    isLoading?: boolean;
+    isSaving?: boolean;
+    onSubmit?: jest.Mock;
+} = {}) {
+    const onClose = jest.fn();
+    render(
+        <EditDictionarySheet
+            open={open}
+            dictionary={dictionary}
+            isLoading={isLoading}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={isSaving}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('EditDictionarySheet', () => {
+    beforeEach(() => {
+        let id = 0;
+        Object.defineProperty(globalThis, 'crypto', {
+            configurable: true,
+            value: { randomUUID: () => `row-${++id}` },
+        });
+        Element.prototype.scrollIntoView = jest.fn();
+        global.ResizeObserver = class ResizeObserver {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as typeof ResizeObserver;
+    });
+
+    it('does not show sheet content when closed', () => {
+        renderSheet({ open: false });
+        expect(querySheetHeading('Edit Dictionary')).toBeNull();
+    });
+
+    it('prefills name and description for MANUAL without key or properties', () => {
+        renderSheet();
+        expect(screen.getByRole('heading', { name: 'Edit Dictionary' })).not.toBeNull();
+        expect((screen.getByLabelText(/^Name/) as HTMLInputElement).value).toBe('Airport IATA Codes');
+        expect((screen.getByLabelText(/^Description/) as HTMLTextAreaElement).value).toBe('IATA codes for airports');
+        expect(screen.queryByLabelText(/^Key/)).toBeNull();
+        expect(screen.queryByText('Key cannot be changed after creation.')).toBeNull();
+        expect(screen.queryByText('Type cannot be changed after creation.')).not.toBeNull();
+        expect(screen.queryByDisplayValue('CDG')).toBeNull();
+        expect(screen.queryByText('Properties')).toBeNull();
+        expect(screen.queryByLabelText(/HTTP Service URL/)).toBeNull();
+    });
+
+    it('prefills when dictionary arrives after the sheet opens', () => {
+        const { rerender } = render(
+            <EditDictionarySheet
+                open
+                dictionary={undefined}
+                isLoading
+                onClose={jest.fn()}
+                onSubmit={jest.fn().mockResolvedValue(undefined)}
+                isSaving={false}
+            />,
+        );
+
+        expect(screen.queryByLabelText(/^Name/)).toBeNull();
+
+        rerender(
+            <EditDictionarySheet
+                open
+                dictionary={MANUAL_DICTIONARY}
+                isLoading={false}
+                onClose={jest.fn()}
+                onSubmit={jest.fn().mockResolvedValue(undefined)}
+                isSaving={false}
+            />,
+        );
+
+        expect((screen.getByLabelText(/^Name/) as HTMLInputElement).value).toBe('Airport IATA Codes');
+        expect((screen.getByLabelText(/^Description/) as HTMLTextAreaElement).value).toBe('IATA codes for airports');
+    });
+
+    it('keeps Save Changes disabled when name becomes invalid', () => {
+        renderSheet();
+        const saveBtn = screen.getByRole('button', { name: 'Save Changes' }) as HTMLButtonElement;
+        expect(saveBtn.disabled).toBe(false);
+
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'ab' } });
+        expect((screen.getByRole('button', { name: 'Save Changes' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('submits MANUAL update with existing properties preserved', async () => {
+        const { onSubmit } = renderSheet();
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'Airport Codes Updated' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith({
+                name: 'Airport Codes Updated',
+                description: 'IATA codes for airports',
+                type: 'MANUAL',
+                properties: { CDG: 'Paris Charles de Gaulle', LHR: 'London Heathrow' },
+            });
+        });
+    });
+
+    it('submits empty string when description is cleared', async () => {
+        const { onSubmit } = renderSheet();
+        fireEvent.change(screen.getByLabelText(/^Description/), { target: { value: '   ' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    description: '',
+                }),
+            );
+        });
+    });
+
+    it('prefills DYNAMIC trigger and provider without key field', async () => {
+        const { onSubmit } = renderSheet({ dictionary: DYNAMIC_DICTIONARY });
+        expect(screen.queryByLabelText(/^Key/)).toBeNull();
+        expect((screen.getByLabelText(/HTTP Service URL/) as HTMLInputElement).value).toBe('https://example.com/codes');
+        expect((screen.getByLabelText(/^Interval/) as HTMLInputElement).value).toBe('5');
+
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'Remote Codes Updated' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    name: 'Remote Codes Updated',
+                    type: 'DYNAMIC',
+                    properties: { a: '1' },
+                    trigger: { rate: 5, unit: 'MINUTES' },
+                    provider: expect.objectContaining({
+                        type: 'HTTP',
+                        configuration: expect.objectContaining({
+                            url: 'https://example.com/codes',
+                            method: 'GET',
+                            body: '{"include":"all"}',
+                        }),
+                    }),
+                }),
+            );
+        });
+    });
+
+    it('submits empty properties object when DYNAMIC dictionary has no properties', async () => {
+        const { onSubmit } = renderSheet({
+            dictionary: { ...DYNAMIC_DICTIONARY, properties: undefined },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ properties: {} }));
+        });
+    });
+
+    it('submits empty string when HTTP body is cleared', async () => {
+        const { onSubmit } = renderSheet({ dictionary: DYNAMIC_DICTIONARY });
+        fireEvent.change(screen.getByLabelText(/Request body/), { target: { value: '   ' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    provider: expect.objectContaining({
+                        configuration: expect.objectContaining({ body: '' }),
+                    }),
+                }),
+            );
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/EditDictionarySheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/EditDictionarySheet.tsx
@@ -1,0 +1,341 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Field,
+    FieldLabel,
+    Input,
+    ScrollArea,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+    Skeleton,
+    Textarea,
+} from '@gravitee/graphene-core';
+import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react';
+
+import {
+    DictionaryHttpProviderFields,
+    HTTP_METHOD_OPTIONS,
+    isHttpProviderFormValid,
+    toProviderHeaders,
+    type DictionaryHttpMethod,
+    type DictionaryHttpProviderFormValue,
+} from './DictionaryHttpProviderFields';
+import { DictionaryTriggerFields, isTriggerFormValid, type DictionaryTriggerFormValue } from './DictionaryTriggerFields';
+import { extractErrorMessage } from '../../../shared/notify/extractErrorMessage';
+import type { Dictionary, DictionaryType, UpdateDictionaryPayload } from '../types/dictionary';
+import {
+    DEFAULT_JOLT_SPECIFICATION,
+    DICTIONARY_NAME_MAX,
+    getDictionaryNameError,
+    isDictionaryNameValid,
+} from '../utils/dictionaryFormValidation';
+
+interface EditDictionaryForm {
+    name: string;
+    description: string;
+    type: DictionaryType;
+    trigger: DictionaryTriggerFormValue;
+    provider: DictionaryHttpProviderFormValue;
+}
+
+function asHttpProviderConfig(configuration: unknown): Record<string, unknown> {
+    if (configuration && typeof configuration === 'object') {
+        return configuration as Record<string, unknown>;
+    }
+    return {};
+}
+
+function toHttpMethod(method: unknown): DictionaryHttpMethod {
+    const value = typeof method === 'string' ? method.toUpperCase() : 'GET';
+    return (HTTP_METHOD_OPTIONS as readonly string[]).includes(value) ? (value as DictionaryHttpMethod) : 'GET';
+}
+
+function dictionaryToForm(dictionary: Dictionary): EditDictionaryForm {
+    const config = asHttpProviderConfig(dictionary.provider?.configuration);
+    const headers = Array.isArray(config.headers) ? config.headers : [];
+
+    return {
+        name: dictionary.name ?? '',
+        description: dictionary.description ?? '',
+        type: dictionary.type,
+        trigger: {
+            rate: String(dictionary.trigger?.rate ?? 1),
+            unit: dictionary.trigger?.unit ?? 'MINUTES',
+        },
+        provider: {
+            url: typeof config.url === 'string' ? config.url : '',
+            method: toHttpMethod(config.method),
+            body: typeof config.body === 'string' ? config.body : '',
+            headers: headers.map(header => {
+                const row = header && typeof header === 'object' ? (header as { name?: string; value?: string }) : {};
+                return {
+                    id: crypto.randomUUID(),
+                    name: row.name ?? '',
+                    value: row.value ?? '',
+                };
+            }),
+            specification:
+                typeof config.specification === 'string' && config.specification.trim() ? config.specification : DEFAULT_JOLT_SPECIFICATION,
+            useSystemProxy: Boolean(config.useSystemProxy),
+        },
+    };
+}
+
+const EMPTY_FORM: EditDictionaryForm = {
+    name: '',
+    description: '',
+    type: 'MANUAL',
+    trigger: { rate: '1', unit: 'MINUTES' },
+    provider: {
+        url: '',
+        method: 'GET',
+        body: '',
+        headers: [],
+        specification: DEFAULT_JOLT_SPECIFICATION,
+        useSystemProxy: false,
+    },
+};
+
+export function EditDictionarySheet({
+    open,
+    dictionary,
+    isLoading = false,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    dictionary: Dictionary | undefined;
+    isLoading?: boolean;
+    onClose: () => void;
+    onSubmit: (data: UpdateDictionaryPayload) => Promise<void>;
+    isSaving: boolean;
+}>) {
+    const [form, setForm] = useState<EditDictionaryForm>(EMPTY_FORM);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+    const dictionaryId = dictionary?.id;
+    /** Seed once per open session when detail data first arrives (list may open before cache is warm). */
+    const seededDictionaryIdRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!open) {
+            seededDictionaryIdRef.current = null;
+            return;
+        }
+        if (!dictionary || !dictionaryId) {
+            if (seededDictionaryIdRef.current === null) {
+                setForm(EMPTY_FORM);
+                setSubmitError(null);
+            }
+            return;
+        }
+        if (seededDictionaryIdRef.current === dictionaryId) {
+            return;
+        }
+        seededDictionaryIdRef.current = dictionaryId;
+        setForm(dictionaryToForm(dictionary));
+        setSubmitError(null);
+    }, [open, dictionaryId, dictionary]);
+
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    const nameError = getDictionaryNameError(form.name);
+    const isNameValid = isDictionaryNameValid(form.name);
+    const isDynamicValid = form.type === 'MANUAL' || (isTriggerFormValid(form.trigger) && isHttpProviderFormValid(form.provider));
+    const isValid = Boolean(dictionary) && isNameValid && nameError === null && isDynamicValid;
+
+    async function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        if (!dictionary || !isValid || isSaving) return;
+
+        // Send "" so clearing description is persisted (JSON.stringify drops undefined).
+        const description = form.description.trim();
+        const payload: UpdateDictionaryPayload =
+            form.type === 'MANUAL'
+                ? {
+                      name: form.name.trim(),
+                      description,
+                      type: 'MANUAL',
+                      // Properties are managed on the detail page; preserve existing values.
+                      properties: dictionary.properties ?? {},
+                  }
+                : {
+                      name: form.name.trim(),
+                      description,
+                      type: 'DYNAMIC',
+                      // Preserve existing properties; ?? {} so they are never omitted from the PUT.
+                      properties: dictionary.properties ?? {},
+                      trigger: {
+                          rate: Number(form.trigger.rate),
+                          unit: form.trigger.unit,
+                      },
+                      provider: {
+                          type: dictionary.provider?.type || 'HTTP',
+                          configuration: {
+                              url: form.provider.url.trim(),
+                              method: form.provider.method,
+                              // Send "" so clearing body is persisted (JSON.stringify drops undefined).
+                              body: form.provider.body.trim(),
+                              headers: toProviderHeaders(form.provider.headers),
+                              specification: form.provider.specification.trim(),
+                              useSystemProxy: form.provider.useSystemProxy,
+                          },
+                      },
+                  };
+
+        try {
+            setSubmitError(null);
+            await onSubmit(payload);
+        } catch (error) {
+            setSubmitError(extractErrorMessage(error, 'Failed to update dictionary'));
+        }
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '560px' }}>
+                <SheetHeader>
+                    <SheetTitle>Edit Dictionary</SheetTitle>
+                    <SheetDescription>Update dictionary details and configuration.</SheetDescription>
+                </SheetHeader>
+
+                <ScrollArea className="min-h-0 flex-1">
+                    {isLoading || !dictionary ? (
+                        <div className="flex flex-col gap-4 px-4 py-4">
+                            <Skeleton className="h-10 w-full" />
+                            <Skeleton className="h-20 w-full" />
+                            <Skeleton className="h-10 w-full" />
+                        </div>
+                    ) : (
+                        <form id="edit-dictionary-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-4 py-4">
+                            <Field orientation="vertical" className="gap-1.5">
+                                <FieldLabel htmlFor="edit-dictionary-name">
+                                    Name{' '}
+                                    <span className="text-destructive" aria-hidden>
+                                        *
+                                    </span>
+                                </FieldLabel>
+                                <Input
+                                    id="edit-dictionary-name"
+                                    value={form.name}
+                                    onChange={e => setForm(prev => ({ ...prev, name: e.target.value }))}
+                                    placeholder="e.g. Airport IATA Codes"
+                                    disabled={isSaving}
+                                    required
+                                    minLength={3}
+                                    maxLength={DICTIONARY_NAME_MAX}
+                                    aria-invalid={nameError !== null}
+                                    aria-describedby={nameError !== null ? 'edit-dictionary-name-error' : 'edit-dictionary-name-hint'}
+                                />
+                                {nameError ? (
+                                    <p id="edit-dictionary-name-error" className="text-sm text-destructive" role="alert">
+                                        {nameError}
+                                    </p>
+                                ) : (
+                                    <p id="edit-dictionary-name-hint" className="text-xs text-muted-foreground">
+                                        Max {DICTIONARY_NAME_MAX} characters.
+                                    </p>
+                                )}
+                            </Field>
+
+                            <Field orientation="vertical" className="gap-1.5">
+                                <FieldLabel htmlFor="edit-dictionary-description">Description</FieldLabel>
+                                <Textarea
+                                    id="edit-dictionary-description"
+                                    value={form.description}
+                                    onChange={e => setForm(prev => ({ ...prev, description: e.target.value }))}
+                                    placeholder="Provide a description of the dictionary"
+                                    disabled={isSaving}
+                                    rows={3}
+                                />
+                            </Field>
+
+                            <Field orientation="vertical" className="gap-1.5">
+                                <FieldLabel htmlFor="edit-dictionary-type">
+                                    Type{' '}
+                                    <span className="text-destructive" aria-hidden>
+                                        *
+                                    </span>
+                                </FieldLabel>
+                                <Select value={form.type} disabled>
+                                    <SelectTrigger id="edit-dictionary-type" aria-readonly="true">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="MANUAL">Manual</SelectItem>
+                                        <SelectItem value="DYNAMIC">Dynamic</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                                <p className="text-xs text-muted-foreground">Type cannot be changed after creation.</p>
+                            </Field>
+
+                            {form.type === 'DYNAMIC' ? (
+                                <>
+                                    <DictionaryTriggerFields
+                                        value={form.trigger}
+                                        onChange={trigger => setForm(prev => ({ ...prev, trigger }))}
+                                        disabled={isSaving}
+                                    />
+                                    <DictionaryHttpProviderFields
+                                        value={form.provider}
+                                        onChange={provider => setForm(prev => ({ ...prev, provider }))}
+                                        disabled={isSaving}
+                                    />
+                                </>
+                            ) : null}
+
+                            {submitError ? (
+                                <p className="text-sm text-destructive" role="alert">
+                                    {submitError}
+                                </p>
+                            ) : null}
+                        </form>
+                    )}
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-col gap-2 border-t pt-4 sm:flex-col">
+                    <Button type="button" variant="outline" className="w-full" onClick={onClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button
+                        type="submit"
+                        form="edit-dictionary-form"
+                        className="w-full"
+                        disabled={!isValid || isSaving || isLoading || !dictionary}
+                    >
+                        {isSaving ? 'Saving…' : 'Save Changes'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useDictionaryMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useDictionaryMutations.ts
@@ -15,7 +15,7 @@
  */
 
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query';
 
 import {
     createEnvironmentDictionary,
@@ -26,48 +26,112 @@ import {
     undeployEnvironmentDictionary,
     updateEnvironmentDictionary,
 } from '../services/dictionaries';
-import type { Dictionary, NewDictionaryPayload, UpdateDictionaryPayload } from '../types/dictionary';
+import type { Dictionary, DictionaryListItem, NewDictionaryPayload, UpdateDictionaryPayload } from '../types/dictionary';
 import { dictionaryKeys } from '../utils/queryKeys';
 
-function useDictionaryMutation<TVariables, TResult = Dictionary>(mutationFn: (envId: string, data: TVariables) => Promise<TResult>) {
+function toListItemFromDictionary(dictionary: Dictionary): DictionaryListItem {
+    const providerType =
+        dictionary.provider && typeof dictionary.provider === 'object' ? dictionary.provider.type : (dictionary.provider ?? undefined);
+
+    return {
+        id: dictionary.id,
+        key: dictionary.key,
+        name: dictionary.name,
+        description: dictionary.description,
+        type: dictionary.type,
+        state: dictionary.state,
+        provider: providerType,
+        properties: dictionary.properties ? Object.keys(dictionary.properties).length : 0,
+        created_at: dictionary.created_at,
+        updated_at: dictionary.updated_at,
+        deployed_at: dictionary.deployed_at,
+    };
+}
+
+function updateDictionaryListCache(previous: DictionaryListItem[] | undefined, dictionary: Dictionary): DictionaryListItem[] | undefined {
+    if (!previous) return previous;
+    const nextItem = toListItemFromDictionary(dictionary);
+    const index = previous.findIndex(item => item.id === dictionary.id);
+    if (index === -1) {
+        return [nextItem, ...previous];
+    }
+    return previous.map(item => {
+        if (item.id === dictionary.id) {
+            return { ...item, ...nextItem };
+        }
+        return item;
+    });
+}
+
+/** Apply mutation response to detail + list caches so timestamps/state refresh immediately. */
+function syncDictionaryCaches(queryClient: QueryClient, envId: string, dictionary: Dictionary) {
+    queryClient.setQueryData(dictionaryKeys.detail(envId, dictionary.id), dictionary);
+    queryClient.setQueryData<DictionaryListItem[]>(dictionaryKeys.list(envId), previous => updateDictionaryListCache(previous, dictionary));
+}
+
+function removeDictionaryFromCaches(queryClient: QueryClient, envId: string, dictionaryId: string) {
+    queryClient.removeQueries({ queryKey: dictionaryKeys.detail(envId, dictionaryId) });
+    queryClient.setQueryData<DictionaryListItem[]>(dictionaryKeys.list(envId), previous =>
+        previous ? previous.filter(item => item.id !== dictionaryId) : previous,
+    );
+}
+
+async function invalidateDictionaryCaches(queryClient: QueryClient) {
+    await queryClient.invalidateQueries({ queryKey: dictionaryKeys.all });
+}
+
+function useDictionaryMutation<TVariables>(mutationFn: (envId: string, data: TVariables) => Promise<Dictionary>) {
     const env = useEnvironment();
     const queryClient = useQueryClient();
 
     return useMutation({
         mutationFn: (data: TVariables) => mutationFn(env!.id, data),
-        onSuccess: async () => {
-            // Prefix key invalidates both list and detail caches for all consumers.
-            await queryClient.invalidateQueries({ queryKey: dictionaryKeys.all });
+        onSuccess: async (dictionary: Dictionary) => {
+            if (env?.id) {
+                syncDictionaryCaches(queryClient, env.id, dictionary);
+            }
+            await invalidateDictionaryCaches(queryClient);
         },
     });
 }
 
 export function useCreateDictionary() {
-    return useDictionaryMutation<NewDictionaryPayload, Dictionary>(createEnvironmentDictionary);
+    return useDictionaryMutation<NewDictionaryPayload>(createEnvironmentDictionary);
 }
 
 export function useUpdateDictionary() {
-    return useDictionaryMutation<{ dictionaryId: string; data: UpdateDictionaryPayload }, Dictionary>((envId, { dictionaryId, data }) =>
+    return useDictionaryMutation<{ dictionaryId: string; data: UpdateDictionaryPayload }>((envId, { dictionaryId, data }) =>
         updateEnvironmentDictionary(envId, dictionaryId, data),
     );
 }
 
 export function useDeleteDictionary() {
-    return useDictionaryMutation<string, void>(deleteEnvironmentDictionary);
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (dictionaryId: string) => deleteEnvironmentDictionary(env!.id, dictionaryId),
+        onSuccess: async (_result, dictionaryId) => {
+            if (env?.id) {
+                removeDictionaryFromCaches(queryClient, env.id, dictionaryId);
+            }
+            await invalidateDictionaryCaches(queryClient);
+        },
+    });
 }
 
 export function useDeployDictionary() {
-    return useDictionaryMutation<string, Dictionary>(deployEnvironmentDictionary);
+    return useDictionaryMutation<string>(deployEnvironmentDictionary);
 }
 
 export function useUndeployDictionary() {
-    return useDictionaryMutation<string, Dictionary>(undeployEnvironmentDictionary);
+    return useDictionaryMutation<string>(undeployEnvironmentDictionary);
 }
 
 export function useStartDictionary() {
-    return useDictionaryMutation<string, Dictionary>(startEnvironmentDictionary);
+    return useDictionaryMutation<string>(startEnvironmentDictionary);
 }
 
 export function useStopDictionary() {
-    return useDictionaryMutation<string, Dictionary>(stopEnvironmentDictionary);
+    return useDictionaryMutation<string>(stopEnvironmentDictionary);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/types/dictionary.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/types/dictionary.ts
@@ -46,6 +46,7 @@ export interface DictionaryProvider {
  */
 export interface DictionaryListItem {
     id: string;
+    /** Optional API field used by classic Console list as ID display (`key || id`). Not a create/edit form field. */
     key?: string;
     name: string;
     description?: string;
@@ -60,10 +61,12 @@ export interface DictionaryListItem {
 
 /**
  * Detail entity from GET/POST/PUT /configuration/dictionaries/{id}.
- * Note: `properties` is the key→value map; `provider` is the full object.
+ * Note: `properties` is the property key→value map; `provider` is the full object.
+ * Create/update forms match classic Console: name, description, type (+ properties/provider/trigger) — no dictionary `key`.
  */
 export interface Dictionary {
     id: string;
+    /** Optional API field; not part of create/update UI (classic Console does not expose it). */
     key?: string;
     name: string;
     description?: string;
@@ -78,7 +81,6 @@ export interface Dictionary {
 }
 
 export interface NewDictionaryPayload {
-    key?: string;
     name: string;
     description?: string;
     type: DictionaryType;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataDeleteSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataDeleteSheet.spec.tsx
@@ -15,41 +15,45 @@
  */
 import { fireEvent, render, screen } from '@testing-library/react';
 
-import { MetadataDeleteDialog } from './MetadataDeleteDialog';
+import { MetadataDeleteSheet } from './MetadataDeleteSheet';
 import type { Metadata } from '../types/metadata';
 
 const METADATA: Metadata = { key: 'support-email', name: 'Support Email', format: 'MAIL', value: 'help@example.com' };
 
-describe('MetadataDeleteDialog', () => {
-    it('does not show dialog content when metadata is null', () => {
-        render(<MetadataDeleteDialog metadata={null} isDeleting={false} onCancel={jest.fn()} onConfirm={jest.fn()} />);
+function renderSheet(open: boolean, metadata: Metadata | undefined = METADATA) {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    render(<MetadataDeleteSheet open={open} metadata={metadata} onClose={onClose} onConfirm={onConfirm} isDeleting={false} />);
+    return { onClose, onConfirm };
+}
+
+describe('MetadataDeleteSheet', () => {
+    it('does not show dialog content when closed', () => {
+        renderSheet(false);
         expect(screen.queryByRole('heading', { name: 'Delete Metadata' })).toBeNull();
     });
 
     it('shows the metadata name and key in the confirmation message', () => {
-        render(<MetadataDeleteDialog metadata={METADATA} isDeleting={false} onCancel={jest.fn()} onConfirm={jest.fn()} />);
-
+        renderSheet(true);
         expect(screen.getByText(/Support Email/)).not.toBeNull();
         expect(screen.getByText('support-email')).not.toBeNull();
         expect(screen.getByRole('button', { name: 'Delete' })).not.toBeNull();
     });
 
-    it('invokes onCancel when Cancel is clicked', () => {
-        const onCancel = jest.fn();
-        render(<MetadataDeleteDialog metadata={METADATA} isDeleting={false} onCancel={onCancel} onConfirm={jest.fn()} />);
+    it('invokes onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet(true);
         fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-        expect(onCancel).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
     });
 
     it('invokes onConfirm when Delete is clicked', () => {
-        const onConfirm = jest.fn();
-        render(<MetadataDeleteDialog metadata={METADATA} isDeleting={false} onCancel={jest.fn()} onConfirm={onConfirm} />);
+        const { onConfirm } = renderSheet(true);
         fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
         expect(onConfirm).toHaveBeenCalledTimes(1);
     });
 
     it('shows deleting label while the mutation is in progress', () => {
-        render(<MetadataDeleteDialog metadata={METADATA} isDeleting onCancel={jest.fn()} onConfirm={jest.fn()} />);
+        render(<MetadataDeleteSheet open metadata={METADATA} onClose={jest.fn()} onConfirm={jest.fn()} isDeleting />);
 
         expect(screen.getByRole('button', { name: 'Deleting…' })).not.toBeNull();
         expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataDeleteSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/components/MetadataDeleteSheet.tsx
@@ -13,23 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
 
 import type { Metadata } from '../types/metadata';
 
-export function MetadataDeleteDialog({
+export function MetadataDeleteSheet({
+    open,
     metadata,
-    isDeleting,
-    onCancel,
+    onClose,
     onConfirm,
+    isDeleting,
 }: Readonly<{
-    metadata: Metadata | null;
-    isDeleting: boolean;
-    onCancel: () => void;
+    open: boolean;
+    metadata: Metadata | undefined;
+    onClose: () => void;
     onConfirm: () => void;
+    isDeleting: boolean;
 }>) {
     return (
-        <Dialog open={metadata !== null} onOpenChange={open => !open && onCancel()}>
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
             <DialogContent className="max-w-sm">
                 <DialogHeader>
                     <DialogTitle>Delete Metadata</DialogTitle>
@@ -45,10 +48,10 @@ export function MetadataDeleteDialog({
                     </DialogDescription>
                 </DialogHeader>
                 <DialogFooter className="border-t px-6 py-4 gap-2">
-                    <Button type="button" variant="outline" onClick={onCancel} disabled={isDeleting}>
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
                         Cancel
                     </Button>
-                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || metadata === null}>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || !metadata}>
                         {isDeleting ? 'Deleting…' : 'Delete'}
                     </Button>
                 </DialogFooter>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.tsx
@@ -22,22 +22,31 @@ import { useNavigate } from 'react-router-dom';
 import { CreateDictionarySheet } from '../features/dictionaries/components/CreateDictionarySheet';
 import { DictionariesTable } from '../features/dictionaries/components/DictionariesTable';
 import { DictionaryDeleteSheet } from '../features/dictionaries/components/DictionaryDeleteSheet';
-import { useCreateDictionary, useDeleteDictionary } from '../features/dictionaries/hooks/useDictionaryMutations';
+import { EditDictionarySheet } from '../features/dictionaries/components/EditDictionarySheet';
+import { useCreateDictionary, useDeleteDictionary, useUpdateDictionary } from '../features/dictionaries/hooks/useDictionaryMutations';
 import { useDictionaryPermissions } from '../features/dictionaries/hooks/useDictionaryPermissions';
 import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
-import type { DictionaryListItem, NewDictionaryPayload } from '../features/dictionaries/types/dictionary';
+import { useEnvironmentDictionary } from '../features/dictionaries/hooks/useEnvironmentDictionary';
+import type { DictionaryListItem, NewDictionaryPayload, UpdateDictionaryPayload } from '../features/dictionaries/types/dictionary';
 import { notify } from '../shared/notify';
 
-type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'delete'; dictionary: DictionaryListItem };
+type SheetState =
+    | { type: 'closed' }
+    | { type: 'create' }
+    | { type: 'edit'; dictionaryId: string }
+    | { type: 'delete'; dictionary: DictionaryListItem };
 
 export function DictionariesPage() {
     const navigate = useNavigate();
-    const { canCreate, canDelete } = useDictionaryPermissions();
+    const { canCreate, canUpdate, canDelete } = useDictionaryPermissions();
     const { data: dictionaries = [], isLoading, isError } = useEnvironmentDictionaries();
     const createMutation = useCreateDictionary();
+    const updateMutation = useUpdateDictionary();
     const deleteMutation = useDeleteDictionary();
 
     const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
+    const editDictionaryId = sheet.type === 'edit' ? sheet.dictionaryId : undefined;
+    const { data: editDictionary, isLoading: editLoading } = useEnvironmentDictionary(editDictionaryId);
 
     function closeSheet() {
         setSheet({ type: 'closed' });
@@ -52,6 +61,13 @@ export function DictionariesPage() {
 
     function handleOpen(dictionary: DictionaryListItem) {
         navigate(dictionary.id);
+    }
+
+    async function handleEdit(data: UpdateDictionaryPayload) {
+        if (sheet.type !== 'edit') return;
+        await updateMutation.mutateAsync({ dictionaryId: sheet.dictionaryId, data });
+        notify.success('Dictionary updated successfully');
+        closeSheet();
     }
 
     async function handleDelete() {
@@ -95,8 +111,10 @@ export function DictionariesPage() {
             ) : (
                 <DictionariesTable
                     dictionaries={dictionaries}
+                    canEdit={canUpdate}
                     canDelete={canDelete}
                     onOpen={handleOpen}
+                    onEdit={d => setSheet({ type: 'edit', dictionaryId: d.id })}
                     onDelete={d => setSheet({ type: 'delete', dictionary: d })}
                 />
             )}
@@ -106,6 +124,15 @@ export function DictionariesPage() {
                 onClose={closeSheet}
                 onSubmit={handleCreate}
                 isSaving={createMutation.isPending}
+            />
+
+            <EditDictionarySheet
+                open={sheet.type === 'edit'}
+                dictionary={editDictionary}
+                isLoading={editLoading}
+                onClose={closeSheet}
+                onSubmit={handleEdit}
+                isSaving={updateMutation.isPending}
             />
 
             <DictionaryDeleteSheet

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionaryDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionaryDetailPage.tsx
@@ -25,13 +25,16 @@ import {
     PlayIcon,
     PlusIcon,
 } from '@gravitee/graphene-core/icons';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { AddDictionaryPropertySheet } from '../features/dictionaries/components/AddDictionaryPropertySheet';
+import { DeleteDictionaryPropertySheet } from '../features/dictionaries/components/DeleteDictionaryPropertySheet';
+import { DictionaryPropertiesTable } from '../features/dictionaries/components/DictionaryPropertiesTable';
 import { DictionaryStateBadge } from '../features/dictionaries/components/DictionaryStateBadge';
-import { DictionaryTypeBadge } from '../features/dictionaries/components/DictionaryTypeBadge';
 import { TRIGGER_UNIT_OPTIONS } from '../features/dictionaries/components/DictionaryTriggerFields';
+import { DictionaryTypeBadge } from '../features/dictionaries/components/DictionaryTypeBadge';
+import { EditDictionaryPropertySheet } from '../features/dictionaries/components/EditDictionaryPropertySheet';
 import {
     useDeployDictionary,
     useStartDictionary,
@@ -40,7 +43,7 @@ import {
 } from '../features/dictionaries/hooks/useDictionaryMutations';
 import { useDictionaryPermissions } from '../features/dictionaries/hooks/useDictionaryPermissions';
 import { useEnvironmentDictionary } from '../features/dictionaries/hooks/useEnvironmentDictionary';
-import type { DictionaryHttpProviderConfiguration } from '../features/dictionaries/types/dictionary';
+import type { Dictionary, DictionaryHttpProviderConfiguration, UpdateDictionaryPayload } from '../features/dictionaries/types/dictionary';
 import { formatDictionaryDate } from '../features/dictionaries/utils/formatDictionaryDate';
 import { notify } from '../shared/notify';
 
@@ -56,6 +59,17 @@ function asHttpProviderConfig(configuration: unknown): DictionaryHttpProviderCon
     return {};
 }
 
+function toUpdatePayload(dictionary: Dictionary, nextProperties: Record<string, string>): UpdateDictionaryPayload {
+    return {
+        name: dictionary.name,
+        description: dictionary.description,
+        type: dictionary.type,
+        properties: nextProperties,
+        provider: dictionary.provider ?? undefined,
+        trigger: dictionary.trigger ?? undefined,
+    };
+}
+
 export function DictionaryDetailPage() {
     const { dictionaryId } = useParams<{ dictionaryId: string }>();
     const navigate = useNavigate();
@@ -66,11 +80,14 @@ export function DictionaryDetailPage() {
     const startMutation = useStartDictionary();
     const stopMutation = useStopDictionary();
     const [addPropertyOpen, setAddPropertyOpen] = useState(false);
+    const [propertyToEdit, setPropertyToEdit] = useState<{ key: string; value: string } | undefined>();
+    const [propertyToDelete, setPropertyToDelete] = useState<string | undefined>();
 
-    const properties = dictionary?.properties ?? {};
-    const propertyEntries = Object.entries(properties);
-    const propertyCount = propertyEntries.length;
+    const properties = dictionary?.properties;
+    const propertyRows = useMemo(() => Object.entries(properties ?? {}).map(([key, value]) => ({ key, value })), [properties]);
+    const propertyCount = propertyRows.length;
     const isDynamic = dictionary?.type === 'DYNAMIC';
+    // Classic Console gates property add/edit/delete with environment-dictionary-u.
     const canEditManualProperties = canUpdate && !isDynamic;
     const isStarted = dictionary?.state === 'STARTED';
     const lifecyclePending = startMutation.isPending || stopMutation.isPending;
@@ -79,25 +96,49 @@ export function DictionaryDetailPage() {
     const providerBody = providerConfig.body?.trim() ?? '';
     const providerSpecification = providerConfig.specification?.trim() ?? '';
 
-    async function handleAddProperty(property: { key: string; value: string }) {
+    async function saveProperties(nextProperties: Record<string, string>, successMessage: string) {
         if (!dictionary || dictionary.type !== 'MANUAL') return;
+        await updateMutation.mutateAsync({
+            dictionaryId: dictionary.id,
+            data: toUpdatePayload(dictionary, nextProperties),
+        });
+        notify.success(successMessage);
+    }
+
+    async function handleAddProperty(property: { key: string; value: string }) {
         try {
-            await updateMutation.mutateAsync({
-                dictionaryId: dictionary.id,
-                data: {
-                    name: dictionary.name,
-                    description: dictionary.description,
-                    type: dictionary.type,
-                    properties: { ...properties, [property.key]: property.value },
-                    provider: dictionary.provider ?? undefined,
-                    trigger: dictionary.trigger ?? undefined,
-                },
-            });
-            notify.success('Property added successfully');
+            await saveProperties({ ...(properties ?? {}), [property.key]: property.value }, 'Property added successfully');
             setAddPropertyOpen(false);
         } catch (error) {
             notify.error(error, 'Failed to add property');
             throw error;
+        }
+    }
+
+    async function handleEditProperty(next: { originalKey: string; key: string; value: string }) {
+        const updated = { ...(properties ?? {}) };
+        if (next.key !== next.originalKey) {
+            delete updated[next.originalKey];
+        }
+        updated[next.key] = next.value;
+        try {
+            await saveProperties(updated, 'Property updated successfully');
+            setPropertyToEdit(undefined);
+        } catch (error) {
+            notify.error(error, 'Failed to update property');
+            throw error;
+        }
+    }
+
+    async function handleDeleteProperty() {
+        if (!propertyToDelete) return;
+        const updated = { ...(properties ?? {}) };
+        delete updated[propertyToDelete];
+        try {
+            await saveProperties(updated, 'Property deleted successfully');
+            setPropertyToDelete(undefined);
+        } catch (error) {
+            notify.error(error, 'Failed to delete property');
         }
     }
 
@@ -179,31 +220,25 @@ export function DictionaryDetailPage() {
                                     <p className="text-sm text-muted-foreground">{dictionary.description}</p>
                                 ) : null}
                             </div>
-                            <div className="grid gap-4 sm:grid-cols-2">
-                                <div className="space-y-1">
-                                    <div className="text-xs text-muted-foreground">Dictionary Key</div>
-                                    <div className="inline-flex rounded-md bg-muted px-2 py-1 font-mono text-xs">
-                                        {dictionary.key || dictionary.id}
-                                    </div>
-                                </div>
-                                <div className="space-y-1">
-                                    <div className="text-xs text-muted-foreground">Properties</div>
-                                    <div className="text-sm font-medium">
+                            <div className="inline-flex items-start gap-6">
+                                <div className="inline-flex shrink-0 flex-col gap-1">
+                                    <span className="text-xs text-muted-foreground">Properties</span>
+                                    <span className="text-sm font-medium text-foreground">
                                         {propertyCount} {propertyCount === 1 ? 'entry' : 'entries'}
-                                    </div>
-                                </div>
-                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                    <ClockIcon className="size-4 shrink-0" aria-hidden />
-                                    <span>
-                                        <span className="text-xs">Last Updated</span>
-                                        <div className="text-foreground">{formatDictionaryDate(dictionary.updated_at)}</div>
                                     </span>
                                 </div>
-                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                    <CalendarIcon className="size-4 shrink-0" aria-hidden />
-                                    <span>
-                                        <span className="text-xs">Last Deployed</span>
-                                        <div className="text-foreground">{formatDictionaryDate(dictionary.deployed_at)}</div>
+                                <div className="inline-flex shrink-0 flex-col gap-1">
+                                    <span className="text-xs text-muted-foreground">Last Updated</span>
+                                    <span className="inline-flex items-center gap-1.5 text-sm text-foreground">
+                                        <ClockIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                                        {formatDictionaryDate(dictionary.updated_at)}
+                                    </span>
+                                </div>
+                                <div className="inline-flex shrink-0 flex-col gap-1">
+                                    <span className="text-xs text-muted-foreground">Last Deployed</span>
+                                    <span className="inline-flex items-center gap-1.5 text-sm text-foreground">
+                                        <CalendarIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                                        {formatDictionaryDate(dictionary.deployed_at)}
                                     </span>
                                 </div>
                             </div>
@@ -341,35 +376,18 @@ export function DictionaryDetailPage() {
                     ) : null}
                 </div>
 
-                {propertyCount === 0 ? (
-                    <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed px-6 py-16 text-center">
-                        <BookOpenIcon className="size-10 text-muted-foreground/40" aria-hidden />
-                        <p className="text-sm text-muted-foreground">
-                            {isDynamic
-                                ? 'Properties will be populated once the dictionary is started.'
-                                : 'No properties yet. Add key/value entries to this dictionary.'}
-                        </p>
-                    </div>
-                ) : (
-                    <div className="overflow-hidden rounded-lg border">
-                        <table className="w-full text-sm">
-                            <thead className="bg-muted/50 text-left text-muted-foreground">
-                                <tr>
-                                    <th className="px-4 py-2 font-medium">Key</th>
-                                    <th className="px-4 py-2 font-medium">Value</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {propertyEntries.map(([key, value]) => (
-                                    <tr key={key} className="border-t">
-                                        <td className="px-4 py-2 font-mono text-xs">{key}</td>
-                                        <td className="px-4 py-2">{value}</td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
-                )}
+                <DictionaryPropertiesTable
+                    properties={propertyRows}
+                    canEdit={canEditManualProperties}
+                    isMutating={updateMutation.isPending}
+                    onEdit={setPropertyToEdit}
+                    onDelete={setPropertyToDelete}
+                    emptyMessage={
+                        isDynamic
+                            ? 'Properties will be populated once the dictionary is started.'
+                            : 'No properties yet. Add key/value entries to this dictionary.'
+                    }
+                />
             </section>
 
             <AddDictionaryPropertySheet
@@ -377,7 +395,24 @@ export function DictionaryDetailPage() {
                 onClose={() => setAddPropertyOpen(false)}
                 onSubmit={handleAddProperty}
                 isSaving={updateMutation.isPending}
-                existingKeys={Object.keys(properties)}
+                existingKeys={Object.keys(properties ?? {})}
+            />
+
+            <EditDictionaryPropertySheet
+                open={propertyToEdit !== undefined}
+                property={propertyToEdit}
+                onClose={() => setPropertyToEdit(undefined)}
+                onSubmit={handleEditProperty}
+                isSaving={updateMutation.isPending}
+                existingKeys={Object.keys(properties ?? {})}
+            />
+
+            <DeleteDictionaryPropertySheet
+                open={propertyToDelete !== undefined}
+                propertyKey={propertyToDelete}
+                onClose={() => setPropertyToDelete(undefined)}
+                onConfirm={() => void handleDeleteProperty()}
+                isDeleting={updateMutation.isPending}
             />
         </div>
     );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.tsx
@@ -19,7 +19,7 @@ import { Button, Skeleton } from '@gravitee/graphene-core';
 import { PlusIcon } from '@gravitee/graphene-core/icons';
 import { useState } from 'react';
 
-import { MetadataDeleteDialog } from '../features/metadata/components/MetadataDeleteDialog';
+import { MetadataDeleteSheet } from '../features/metadata/components/MetadataDeleteSheet';
 import { MetadataSheet } from '../features/metadata/components/MetadataSheet';
 import { MetadataTable } from '../features/metadata/components/MetadataTable';
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
@@ -27,7 +27,7 @@ import { useCreateMetadata, useDeleteMetadata, useUpdateMetadata } from '../feat
 import type { Metadata, NewMetadataPayload, UpdateMetadataPayload } from '../features/metadata/types/metadata';
 import { notify } from '../shared/notify';
 
-type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'edit'; metadata: Metadata };
+type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'edit'; metadata: Metadata } | { type: 'delete'; metadata: Metadata };
 
 export function MetadataPage() {
     const canCreate = useHasPermission({ anyOf: ['environment-metadata-c'] });
@@ -40,7 +40,6 @@ export function MetadataPage() {
     const deleteMutation = useDeleteMetadata();
 
     const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
-    const [metadataToDelete, setMetadataToDelete] = useState<Metadata | null>(null);
 
     function closeSheet() {
         setSheet({ type: 'closed' });
@@ -67,11 +66,11 @@ export function MetadataPage() {
     }
 
     async function handleDelete() {
-        if (!metadataToDelete) return;
+        if (sheet.type !== 'delete') return;
         try {
-            await deleteMutation.mutateAsync(metadataToDelete.key);
+            await deleteMutation.mutateAsync(sheet.metadata.key);
             notify.success('Metadata deleted successfully');
-            setMetadataToDelete(null);
+            closeSheet();
         } catch (error) {
             notify.error(error, 'Failed to delete metadata');
         }
@@ -110,7 +109,7 @@ export function MetadataPage() {
                     canEdit={canEdit}
                     canDelete={canDelete}
                     onEdit={m => setSheet({ type: 'edit', metadata: m })}
-                    onDelete={setMetadataToDelete}
+                    onDelete={m => setSheet({ type: 'delete', metadata: m })}
                 />
             )}
 
@@ -123,11 +122,12 @@ export function MetadataPage() {
                 isSaving={createMutation.isPending || updateMutation.isPending}
             />
 
-            <MetadataDeleteDialog
-                metadata={metadataToDelete}
-                isDeleting={deleteMutation.isPending}
-                onCancel={() => setMetadataToDelete(null)}
+            <MetadataDeleteSheet
+                open={sheet.type === 'delete'}
+                metadata={sheet.type === 'delete' ? sheet.metadata : undefined}
+                onClose={closeSheet}
                 onConfirm={handleDelete}
+                isDeleting={deleteMutation.isPending}
             />
         </div>
     );


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-9

## Description

Add **Edit Dictionary** in Gamma Platform UI (right sheet) for environment-scoped dictionaries.

- Prefill name, description, type, and for DYNAMIC: trigger + HTTP provider
- No dictionary `key` field in create/edit (aligned with classic Console); type is immutable after creation
- Properties are managed on the detail page (add / edit / delete with confirm), not in the edit sheet
- Save via `PUT /configuration/dictionaries/{id}` with success toast
- Gated by `ENVIRONMENT_DICTIONARY` UPDATE (`environment-dictionary-u`)
- List row actions: View Details / Edit / Delete — config edit is from the list only (not the detail page)
- UI polish: View Details stays on one line; sheet form padding matches header/footer; dictionary delete uses a center dialog

**Base:** `master` (FOUND-8 create dynamic dictionary already merged)