### PR TITLE
feat: expose API Product details in Portal API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApiProductMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApiProductMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.api_product.model.ApiProductKind;
+import io.gravitee.apim.core.api_product.model.PortalApiProductDetails.ApiSummary;
+import io.gravitee.rest.api.portal.rest.model.PortalApiProductApi;
+import io.gravitee.rest.api.portal.rest.model.PortalApiProductDetails;
+import java.util.UUID;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ApiProductMapper {
+    ApiProductMapper INSTANCE = Mappers.getMapper(ApiProductMapper.class);
+
+    PortalApiProductDetails map(io.gravitee.apim.core.api_product.model.PortalApiProductDetails apiProduct);
+
+    PortalApiProductApi map(ApiSummary api);
+
+    default UUID map(String value) {
+        return value == null ? null : UUID.fromString(value);
+    }
+
+    default PortalApiProductDetails.KindEnum map(ApiProductKind kind) {
+        return kind == null ? null : PortalApiProductDetails.KindEnum.valueOf(kind.name());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiProductResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiProductResource.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static io.gravitee.rest.api.service.common.GraviteeContext.getExecutionContext;
+
+import io.gravitee.apim.core.api_product.use_case.GetPortalApiProductUseCase;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.portal.rest.mapper.ApiProductMapper;
+import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import java.util.UUID;
+
+public class ApiProductResource extends AbstractResource {
+
+    private static final ApiProductMapper apiProductMapper = ApiProductMapper.INSTANCE;
+
+    @Inject
+    private GetPortalApiProductUseCase getPortalApiProductUseCase;
+
+    @GET
+    @Path("{apiProductId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @RequirePortalAuth
+    public Response getApiProductByApiProductId(@PathParam("apiProductId") UUID apiProductId) {
+        var executionContext = getExecutionContext();
+        var output = getPortalApiProductUseCase.execute(
+            new GetPortalApiProductUseCase.Input(
+                executionContext.getEnvironmentId(),
+                apiProductId.toString(),
+                PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull())
+            )
+        );
+
+        return Response.ok(apiProductMapper.map(output.apiProduct())).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/EnvironmentsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/EnvironmentsResource.java
@@ -37,6 +37,11 @@ public class EnvironmentsResource extends AbstractResource {
         return resourceContext.getResource(ApisResource.class);
     }
 
+    @Path("api-products")
+    public ApiProductResource getApiProductResource() {
+        return resourceContext.getResource(ApiProductResource.class);
+    }
+
     @Path("applications")
     public ApplicationsResource getApplicationsResource() {
         return resourceContext.getResource(ApplicationsResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -23,6 +23,8 @@ tags:
       description: All about application analytics
     - name: Api
       description: All about APIs
+    - name: Api Product
+      description: All about API Products
     - name: Application
       description: All about applications
     - name: Group
@@ -235,6 +237,40 @@ paths:
                                 $ref: "#/components/schemas/Api"
                 404:
                     $ref: "#/components/responses/APINotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+    /api-products/{apiProductId}:
+        parameters:
+            - name: apiProductId
+              in: path
+              required: true
+              description: Unique identifier of an API Product.
+              schema:
+                  type: string
+                  format: uuid
+        get:
+            tags:
+                - Api Product
+            summary: Get API Product details
+            description: |
+                Get consumer-safe details of an API Product and its APIs accessible to the current user.
+
+                The API Product must be exposed by an accessible, published Portal navigation item,
+                otherwise a 404 is returned.
+            operationId: getApiProductByApiProductId
+            security:
+                - {}
+                - BasicAuth: []
+                - CookieAuth: []
+            responses:
+                200:
+                    description: API Product details
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/PortalApiProductDetails"
+                404:
+                    $ref: "#/components/responses/ApiProductNotFoundError"
                 500:
                     $ref: "#/components/responses/InternalServerError"
     /apis/{apiId}/informations:
@@ -5221,6 +5257,69 @@ components:
                     items:
                         $ref: "#/components/schemas/Plan"
 
+        PortalApiProductDetails:
+            type: object
+            description: Consumer-safe details of an API Product exposed in the Developer Portal.
+            required:
+                - id
+                - name
+                - version
+                - kind
+                - navigationItemId
+                - tags
+                - apis
+            properties:
+                id:
+                    type: string
+                    format: uuid
+                    description: Unique identifier of the API Product.
+                name:
+                    type: string
+                    description: Name of the API Product.
+                description:
+                    type: string
+                    description: Description of the API Product.
+                version:
+                    type: string
+                    description: Version of the API Product.
+                kind:
+                    type: string
+                    description: Kind of the API Product.
+                    enum:
+                        - AI_WORKSPACE
+                navigationItemId:
+                    type: string
+                    format: uuid
+                    description: Identifier of the Portal navigation item exposing the API Product.
+                tags:
+                    type: array
+                    description: Tags associated with the API Product.
+                    items:
+                        type: string
+                apis:
+                    type: array
+                    description: APIs included in the API Product and accessible to the current user.
+                    items:
+                        $ref: "#/components/schemas/PortalApiProductApi"
+
+        PortalApiProductApi:
+            type: object
+            description: Consumer-safe summary of an API included in an API Product.
+            required:
+                - id
+                - name
+                - version
+            properties:
+                id:
+                    type: string
+                    description: Unique identifier of the API.
+                name:
+                    type: string
+                    description: Name of the API.
+                version:
+                    type: string
+                    description: Version of the API.
+
         DefinitionVersion:
             type: string
             description: API's gravitee definition version.
@@ -8363,6 +8462,12 @@ components:
                         $ref: "#/components/schemas/ErrorResponse"
         APINotFoundError:
             description: API not found
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/ErrorResponse"
+        ApiProductNotFoundError:
+            description: API Product not found
             content:
                 application/json:
                     schema:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApiProductMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApiProductMapperTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.api_product.model.ApiProductKind;
+import io.gravitee.apim.core.api_product.model.PortalApiProductDetails;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ApiProductMapperTest {
+
+    private static final UUID API_PRODUCT_ID = UUID.fromString("00000000-0000-0000-0000-000000000101");
+    private static final UUID NAVIGATION_ITEM_ID = UUID.fromString("00000000-0000-0000-0000-000000000102");
+
+    @Test
+    void should_map_consumer_safe_api_product_details() {
+        var source = new PortalApiProductDetails(
+            API_PRODUCT_ID.toString(),
+            "AI Workspace",
+            "Description",
+            "1.0.0",
+            ApiProductKind.AI_WORKSPACE,
+            NAVIGATION_ITEM_ID.toString(),
+            List.of("ai"),
+            List.of(new PortalApiProductDetails.ApiSummary("api-id", "API", "2.0.0"))
+        );
+
+        var result = ApiProductMapper.INSTANCE.map(source);
+
+        assertThat(result.getId()).isEqualTo(API_PRODUCT_ID);
+        assertThat(result.getName()).isEqualTo("AI Workspace");
+        assertThat(result.getDescription()).isEqualTo("Description");
+        assertThat(result.getVersion()).isEqualTo("1.0.0");
+        assertThat(result.getKind()).isEqualTo(io.gravitee.rest.api.portal.rest.model.PortalApiProductDetails.KindEnum.AI_WORKSPACE);
+        assertThat(result.getNavigationItemId()).isEqualTo(NAVIGATION_ITEM_ID);
+        assertThat(result.getTags()).containsExactly("ai");
+        assertThat(result.getApis())
+            .singleElement()
+            .satisfies(api -> {
+                assertThat(api.getId()).isEqualTo("api-id");
+                assertThat(api.getName()).isEqualTo("API");
+                assertThat(api.getVersion()).isEqualTo("2.0.0");
+            });
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiProductResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiProductResourceTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.ApiProductKind;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.rest.api.portal.rest.model.PortalApiProductDetails;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiProductResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT_ID = "DEFAULT";
+    private static final UUID API_PRODUCT_ID = UUID.fromString("00000000-0000-0000-0000-000000000101");
+    private static final PortalNavigationItemId NAVIGATION_ITEM_ID = PortalNavigationItemId.of("00000000-0000-0000-0000-000000000102");
+
+    @Autowired
+    private ApiProductQueryServiceInMemory apiProductQueryService;
+
+    @Autowired
+    private ApiQueryServiceInMemory apiQueryService;
+
+    @Autowired
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+
+    @Override
+    protected String contextPath() {
+        return "api-products/";
+    }
+
+    @BeforeEach
+    void setUp() {
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+    }
+
+    @AfterEach
+    void tearDown() {
+        GraviteeContext.cleanContext();
+        apiProductQueryService.reset();
+        apiQueryService.reset();
+        navigationItemsQueryService.reset();
+    }
+
+    @Test
+    void should_return_api_product_details_and_accessible_apis() {
+        var api = Api.builder().id("api-id").environmentId(ENVIRONMENT_ID).name("Payments API").version("2.0.0").build();
+        apiProductQueryService.initWith(List.of(apiProduct(Set.of(api.getId()))));
+        apiQueryService.initWith(List.of(api));
+        navigationItemsQueryService.initWith(List.of(apiProductNavigationItem(), apiNavigationItem(api)));
+
+        Response response = target(API_PRODUCT_ID.toString()).request().get();
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        var result = response.readEntity(PortalApiProductDetails.class);
+        assertThat(result.getId()).isEqualTo(API_PRODUCT_ID);
+        assertThat(result.getName()).isEqualTo("AI Workspace");
+        assertThat(result.getDescription()).isEqualTo("Consumer description");
+        assertThat(result.getVersion()).isEqualTo("1.0.0");
+        assertThat(result.getKind()).isEqualTo(PortalApiProductDetails.KindEnum.AI_WORKSPACE);
+        assertThat(result.getNavigationItemId()).isEqualTo(NAVIGATION_ITEM_ID.id());
+        assertThat(result.getTags()).containsExactly("ai", "public");
+        assertThat(result.getApis())
+            .singleElement()
+            .satisfies(includedApi -> {
+                assertThat(includedApi.getId()).isEqualTo("api-id");
+                assertThat(includedApi.getName()).isEqualTo("Payments API");
+                assertThat(includedApi.getVersion()).isEqualTo("2.0.0");
+            });
+    }
+
+    @Test
+    void should_return_not_found_when_api_product_is_not_exposed_in_navigation() {
+        apiProductQueryService.initWith(List.of(apiProduct(Set.of())));
+
+        Response response = target(API_PRODUCT_ID.toString()).request().get();
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
+    }
+
+    private static ApiProduct apiProduct(Set<String> apiIds) {
+        return ApiProduct.builder()
+            .id(API_PRODUCT_ID.toString())
+            .environmentId(ENVIRONMENT_ID)
+            .name("AI Workspace")
+            .description("Consumer description")
+            .version("1.0.0")
+            .kind(ApiProductKind.AI_WORKSPACE)
+            .tags(Set.of("public", "ai"))
+            .apiIds(apiIds)
+            .build();
+    }
+
+    private static PortalNavigationApiProduct apiProductNavigationItem() {
+        return PortalNavigationApiProduct.builder()
+            .id(NAVIGATION_ITEM_ID)
+            .organizationId("organization-id")
+            .environmentId(ENVIRONMENT_ID)
+            .title("AI Workspace")
+            .segment("ai-workspace")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .apiProductId(API_PRODUCT_ID.toString())
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    private static PortalNavigationItem apiNavigationItem(Api api) {
+        return PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId("organization-id")
+            .environmentId(ENVIRONMENT_ID)
+            .title(api.getName())
+            .segment("payments-api")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .parentId(NAVIGATION_ITEM_ID)
+            .apiId(api.getId())
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/PortalApiProductDetails.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/PortalApiProductDetails.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.model;
+
+import java.util.List;
+
+public record PortalApiProductDetails(
+    String id,
+    String name,
+    String description,
+    String version,
+    ApiProductKind kind,
+    String navigationItemId,
+    List<String> tags,
+    List<ApiSummary> apis
+) {
+    public PortalApiProductDetails {
+        tags = tags == null ? List.of() : List.copyOf(tags);
+        apis = apis == null ? List.of() : List.copyOf(apis);
+    }
+
+    public record ApiSummary(String id, String name, String version) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetPortalApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetPortalApiProductUseCase.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiFieldFilter;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.PortalApiProductDetails;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetPortalApiProductUseCase {
+
+    private static final Comparator<String> NULL_SAFE_STRING_COMPARATOR = Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER);
+    private static final ApiFieldFilter API_FIELD_FILTER = ApiFieldFilter.builder().definitionExcluded(true).pictureExcluded(true).build();
+
+    private final ApiProductQueryService apiProductQueryService;
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalNavigationApiProductVisibilityDomainService apiProductVisibilityDomainService;
+    private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
+    private final ApiQueryService apiQueryService;
+
+    public Output execute(Input input) {
+        var apiProduct = apiProductQueryService
+            .findById(input.apiProductId())
+            .filter(product -> input.environmentId().equals(product.getEnvironmentId()))
+            .orElseThrow(() -> new ApiProductNotFoundException(input.apiProductId()));
+
+        var navigationItem = findAccessibleNavigationItem(input);
+        var apis = findAccessibleApis(apiProduct, input);
+        var tags = apiProduct.getTags() == null
+            ? List.<String>of()
+            : apiProduct.getTags().stream().sorted(NULL_SAFE_STRING_COMPARATOR).toList();
+
+        return new Output(
+            new PortalApiProductDetails(
+                apiProduct.getId(),
+                apiProduct.getName(),
+                apiProduct.getDescription(),
+                apiProduct.getVersion(),
+                apiProduct.getKind(),
+                navigationItem.getId().json(),
+                tags,
+                apis
+            )
+        );
+    }
+
+    private PortalNavigationApiProduct findAccessibleNavigationItem(Input input) {
+        Set<String> accessibleApiProductIds = apiProductVisibilityDomainService.resolveAccessibleApiProductIds(
+            input.environmentId(),
+            input.viewerContext()
+        );
+
+        return portalNavigationItemsQueryService
+            .search(
+                PortalNavigationItemQueryCriteria.builder()
+                    .environmentId(input.environmentId())
+                    .published(true)
+                    .type(PortalNavigationItemType.API_PRODUCT)
+                    .apiProductIds(Set.of(input.apiProductId()))
+                    .build()
+            )
+            .stream()
+            .filter(PortalNavigationApiProduct.class::isInstance)
+            .map(PortalNavigationApiProduct.class::cast)
+            .filter(item -> !input.viewerContext().shouldNotShow(item))
+            .filter(item -> !apiProductVisibilityDomainService.isApiProductItemHidden(item, input.viewerContext(), accessibleApiProductIds))
+            .filter(item ->
+                !apiProductVisibilityDomainService.hasHiddenApiProductAncestor(
+                    input.environmentId(),
+                    item,
+                    input.viewerContext(),
+                    accessibleApiProductIds
+                )
+            )
+            .filter(item -> !apiVisibilityDomainService.hasHiddenApiAncestor(input.environmentId(), item, input.viewerContext()))
+            .findFirst()
+            .orElseThrow(() -> new ApiProductNotFoundException(input.apiProductId()));
+    }
+
+    private List<PortalApiProductDetails.ApiSummary> findAccessibleApis(ApiProduct apiProduct, Input input) {
+        if (apiProduct.getApiIds() == null || apiProduct.getApiIds().isEmpty()) {
+            return List.of();
+        }
+
+        Set<String> visibleApiIds = input
+            .viewerContext()
+            .userId()
+            .map(userId -> apiVisibilityDomainService.resolveVisibleItems(input.environmentId(), userId))
+            .orElseGet(() -> apiVisibilityDomainService.resolveVisibleItems(input.environmentId()))
+            .stream()
+            .map(PortalNavigationApi::getApiId)
+            .filter(apiProduct.getApiIds()::contains)
+            .collect(Collectors.toSet());
+
+        if (visibleApiIds.isEmpty()) {
+            return List.of();
+        }
+
+        return apiQueryService
+            .search(
+                ApiSearchCriteria.builder().environmentId(input.environmentId()).ids(List.copyOf(visibleApiIds)).build(),
+                null,
+                API_FIELD_FILTER
+            )
+            .sorted(
+                Comparator.comparing(Api::getName, NULL_SAFE_STRING_COMPARATOR)
+                    .thenComparing(Api::getVersion, NULL_SAFE_STRING_COMPARATOR)
+                    .thenComparing(Api::getId, NULL_SAFE_STRING_COMPARATOR)
+            )
+            .map(api -> new PortalApiProductDetails.ApiSummary(api.getId(), api.getName(), api.getVersion()))
+            .toList();
+    }
+
+    public record Input(String environmentId, String apiProductId, PortalNavigationItemViewerContext viewerContext) {}
+
+    public record Output(PortalApiProductDetails apiProduct) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetPortalApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetPortalApiProductUseCaseTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.ApiProductKind;
+import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetPortalApiProductUseCaseTest {
+
+    private static final String ENVIRONMENT_ID = PortalNavigationItemFixtures.ENV_ID;
+    private static final String OTHER_ENVIRONMENT_ID = "other-environment-id";
+    private static final String API_PRODUCT_ID = "00000000-0000-0000-0000-000000000101";
+    private static final String NAVIGATION_ITEM_ID = "00000000-0000-0000-0000-000000000102";
+    private static final String USER_ID = "user-id";
+    private static final String GROUP_ID = "group-id";
+
+    private ApiProductQueryServiceInMemory apiProductQueryService;
+    private ApiQueryServiceInMemory apiQueryService;
+    private MembershipQueryServiceInMemory membershipQueryService;
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+    private GetPortalApiProductUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        apiProductQueryService = new ApiProductQueryServiceInMemory();
+        apiQueryService = new ApiQueryServiceInMemory();
+        membershipQueryService = new MembershipQueryServiceInMemory();
+        navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
+
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            new SubscriptionQueryServiceInMemory(),
+            apiQueryService
+        );
+        var apiVisibilityDomainService = new PortalNavigationApiVisibilityDomainService(
+            navigationItemsQueryService,
+            apiMembershipDomainService
+        );
+        var apiProductVisibilityDomainService = new PortalNavigationApiProductVisibilityDomainService(
+            navigationItemsQueryService,
+            new ApiProductAccessibleIdsDomainService(apiProductQueryService, membershipQueryService)
+        );
+        useCase = new GetPortalApiProductUseCase(
+            apiProductQueryService,
+            navigationItemsQueryService,
+            apiProductVisibilityDomainService,
+            apiVisibilityDomainService,
+            apiQueryService
+        );
+    }
+
+    @Test
+    void should_return_public_api_product_details_with_sorted_tags_and_apis() {
+        var secondApi = api("api-b", "Zebra API", "2.0");
+        var firstApi = api("api-a", "Alpha API", "1.0");
+        var product = apiProduct(Set.of(firstApi.getId(), secondApi.getId()));
+        var navigationItem = publicApiProductNavigationItem();
+        givenProductAndNavigation(product, navigationItem, publicApiNavigationItem(firstApi), publicApiNavigationItem(secondApi));
+        apiQueryService.initWith(List.of(secondApi, firstApi));
+
+        var result = useCase.execute(input(null)).apiProduct();
+
+        assertThat(result.id()).isEqualTo(API_PRODUCT_ID);
+        assertThat(result.name()).isEqualTo("AI Workspace");
+        assertThat(result.description()).isEqualTo("Consumer description");
+        assertThat(result.version()).isEqualTo("1.0.0");
+        assertThat(result.kind()).isEqualTo(ApiProductKind.AI_WORKSPACE);
+        assertThat(result.navigationItemId()).isEqualTo(NAVIGATION_ITEM_ID);
+        assertThat(result.tags()).containsExactly("ai", "public");
+        assertThat(result.apis())
+            .extracting(apiSummary -> apiSummary.id() + ":" + apiSummary.name() + ":" + apiSummary.version())
+            .containsExactly("api-a:Alpha API:1.0", "api-b:Zebra API:2.0");
+    }
+
+    @Test
+    void should_return_private_api_product_to_direct_member() {
+        var product = apiProduct(Set.of());
+        var navigationItem = publicApiProductNavigationItem();
+        navigationItem.setVisibility(PortalVisibility.PRIVATE);
+        givenProductAndNavigation(product, navigationItem);
+        membershipQueryService.initWith(List.of(apiProductMembership(USER_ID)));
+
+        var result = useCase.execute(input(USER_ID));
+
+        assertThat(result.apiProduct().id()).isEqualTo(API_PRODUCT_ID);
+    }
+
+    @Test
+    void should_return_private_api_product_to_group_member() {
+        var product = apiProduct(Set.of());
+        product.setGroups(new HashSet<>(Set.of(GROUP_ID)));
+        var navigationItem = publicApiProductNavigationItem();
+        navigationItem.setVisibility(PortalVisibility.PRIVATE);
+        givenProductAndNavigation(product, navigationItem);
+        membershipQueryService.initWith(List.of(groupMembership(USER_ID, GROUP_ID)));
+
+        var result = useCase.execute(input(USER_ID));
+
+        assertThat(result.apiProduct().id()).isEqualTo(API_PRODUCT_ID);
+    }
+
+    @Test
+    void should_return_not_found_for_private_api_product_without_access() {
+        var navigationItem = publicApiProductNavigationItem();
+        navigationItem.setVisibility(PortalVisibility.PRIVATE);
+        givenProductAndNavigation(apiProduct(Set.of()), navigationItem);
+
+        assertThatThrownBy(() -> useCase.execute(input(USER_ID))).isInstanceOf(ApiProductNotFoundException.class);
+    }
+
+    @Test
+    void should_return_not_found_when_api_product_does_not_exist() {
+        assertThatThrownBy(() -> useCase.execute(input(null))).isInstanceOf(ApiProductNotFoundException.class);
+    }
+
+    @Test
+    void should_return_not_found_when_api_product_belongs_to_another_environment() {
+        var product = apiProduct(Set.of());
+        product.setEnvironmentId(OTHER_ENVIRONMENT_ID);
+        givenProductAndNavigation(product, publicApiProductNavigationItem());
+
+        assertThatThrownBy(() -> useCase.execute(input(null))).isInstanceOf(ApiProductNotFoundException.class);
+    }
+
+    @Test
+    void should_return_not_found_when_api_product_navigation_item_is_unpublished() {
+        var navigationItem = publicApiProductNavigationItem();
+        navigationItem.setPublished(false);
+        givenProductAndNavigation(apiProduct(Set.of()), navigationItem);
+
+        assertThatThrownBy(() -> useCase.execute(input(null))).isInstanceOf(ApiProductNotFoundException.class);
+    }
+
+    @Test
+    void should_return_empty_api_list_when_api_product_has_no_apis() {
+        givenProductAndNavigation(apiProduct(Set.of()), publicApiProductNavigationItem());
+
+        var result = useCase.execute(input(null));
+
+        assertThat(result.apiProduct().apis()).isEmpty();
+    }
+
+    @Test
+    void should_only_return_included_apis_accessible_to_the_current_user() {
+        var publicApi = api("public-api", "Public API", "1.0");
+        var privateApi = api("private-api", "Private API", "1.0");
+        var publicApiNavigation = publicApiNavigationItem(publicApi);
+        var privateApiNavigation = publicApiNavigationItem(privateApi);
+        privateApiNavigation.setVisibility(PortalVisibility.PRIVATE);
+        givenProductAndNavigation(
+            apiProduct(Set.of(publicApi.getId(), privateApi.getId())),
+            publicApiProductNavigationItem(),
+            publicApiNavigation,
+            privateApiNavigation
+        );
+        apiQueryService.initWith(List.of(publicApi, privateApi));
+
+        var result = useCase.execute(input(USER_ID));
+
+        assertThat(result.apiProduct().apis())
+            .extracting(api -> api.id())
+            .containsExactly("public-api");
+    }
+
+    private void givenProductAndNavigation(
+        ApiProduct apiProduct,
+        PortalNavigationApiProduct apiProductNavigationItem,
+        PortalNavigationItem... otherItems
+    ) {
+        apiProductQueryService.initWith(List.of(apiProduct));
+        var navigationItems = new ArrayList<PortalNavigationItem>();
+        navigationItems.add(apiProductNavigationItem);
+        navigationItems.addAll(List.of(otherItems));
+        navigationItemsQueryService.initWith(navigationItems);
+    }
+
+    private static ApiProduct apiProduct(Set<String> apiIds) {
+        return ApiProduct.builder()
+            .id(API_PRODUCT_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .name("AI Workspace")
+            .description("Consumer description")
+            .version("1.0.0")
+            .kind(ApiProductKind.AI_WORKSPACE)
+            .tags(Set.of("public", "ai"))
+            .apiIds(new HashSet<>(apiIds))
+            .build();
+    }
+
+    private static PortalNavigationApiProduct publicApiProductNavigationItem() {
+        return PortalNavigationItemFixtures.anApiProduct(NAVIGATION_ITEM_ID, "AI Workspace", null, API_PRODUCT_ID);
+    }
+
+    private static Api api(String id, String name, String version) {
+        return Api.builder().id(id).environmentId(ENVIRONMENT_ID).name(name).version(version).build();
+    }
+
+    private static PortalNavigationApi publicApiNavigationItem(Api api) {
+        return PortalNavigationItemFixtures.anApi(
+            PortalNavigationItemId.random().toString(),
+            api.getName(),
+            PortalNavigationItemId.of(NAVIGATION_ITEM_ID),
+            api.getId()
+        );
+    }
+
+    private static Membership apiProductMembership(String userId) {
+        return Membership.builder()
+            .id("api-product-membership")
+            .memberId(userId)
+            .memberType(Membership.Type.USER)
+            .referenceType(Membership.ReferenceType.API_PRODUCT)
+            .referenceId(API_PRODUCT_ID)
+            .build();
+    }
+
+    private static Membership groupMembership(String userId, String groupId) {
+        return Membership.builder()
+            .id("group-membership")
+            .memberId(userId)
+            .memberType(Membership.Type.USER)
+            .referenceType(Membership.ReferenceType.GROUP)
+            .referenceId(groupId)
+            .build();
+    }
+
+    private static GetPortalApiProductUseCase.Input input(String userId) {
+        return new GetPortalApiProductUseCase.Input(ENVIRONMENT_ID, API_PRODUCT_ID, PortalNavigationItemViewerContext.forPortal(userId));
+    }
+}


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/PORTAL-80

## Description

Adds the Portal API endpoint for retrieving consumer-safe API Product details:

`GET /api-products/{apiProductId}`

The endpoint:

- returns API Product metadata, tags, navigation item ID, and included APIs;
- exposes only APIs accessible to the current Portal user;
- verifies that the API Product is exposed through an accessible, published navigation item;
- returns `404` when the product does not exist or is not visible in the current environment;
- supports both authenticated and anonymous Portal users.

The change includes the OpenAPI contract, REST resource and mapper, application use case, and focused unit/resource tests.

## Dependencies

This is a stacked PR based on `PORTAL-79-backend-expose-api-product-navigation-in-portal-api` and depends on the API Product navigation support introduced there.

