### PR TITLE
fix: surface encryption cause when AM connection save/read fails

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImpl.java
@@ -115,7 +115,16 @@ public class AmConnectionServiceImpl implements AmConnectionService {
         try {
             return dataEncryptor.encrypt(plaintextToken);
         } catch (GeneralSecurityException e) {
-            throw new TechnicalManagementException("Failed to encrypt am service account access token", e);
+            log.warn(
+                "Failed to encrypt the AM service account token — check the length of api.properties.encryption.secret on the rest-api: {}",
+                e.getMessage(),
+                e
+            );
+            throw new TechnicalManagementException(
+                "Failed to encrypt the AM service account token — check the property-encryption secret (api.properties.encryption.secret) on the rest-api, it must be 16, 24 or 32 bytes. Cause: " +
+                    e.getMessage(),
+                e
+            );
         }
     }
 
@@ -140,7 +149,16 @@ public class AmConnectionServiceImpl implements AmConnectionService {
         try {
             return dataEncryptor.decrypt(ciphertext);
         } catch (GeneralSecurityException | IllegalArgumentException e) {
-            throw new TechnicalManagementException("Failed to decrypt am service account access token", e);
+            log.warn(
+                "Failed to decrypt the AM service account token — check the length of api.properties.encryption.secret on the rest-api: {}",
+                e.getMessage(),
+                e
+            );
+            throw new TechnicalManagementException(
+                "Failed to decrypt the AM service account token — check the property-encryption secret (api.properties.encryption.secret) on the rest-api, it must be 16, 24 or 32 bytes. Cause: " +
+                    e.getMessage(),
+                e
+            );
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImplTest.java
@@ -183,6 +183,23 @@ public class AmConnectionServiceImplTest {
     }
 
     @Test
+    public void save_encryption_failure_message_names_secret_property_and_carries_cause() throws Exception {
+        // 36-byte secret (a UUID with dashes) — AES accepts only 16/24/32, so encrypt() throws InvalidKeyException.
+        DataEncryptor invalidLengthEncryptor = new DataEncryptor(
+            new MockEnvironment(),
+            "test.secret",
+            "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+        );
+        AmConnectionServiceImpl serviceWithInvalidSecret = new AmConnectionServiceImpl(amConnectionRepository, invalidLengthEncryptor);
+        when(amConnectionRepository.findByOrganizationId("org-1")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> serviceWithInvalidSecret.save("org-1", entity("https://am.example.com", "my-token")))
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessageContaining("api.properties.encryption.secret")
+            .hasMessageContaining("Invalid AES key length");
+    }
+
+    @Test
     public void find_throws_when_decryption_fails() throws Exception {
         DataEncryptor brokenEncryptor = Mockito.mock(DataEncryptor.class);
         when(brokenEncryptor.decrypt(any())).thenThrow(new GeneralSecurityException("corrupted"));
@@ -196,6 +213,27 @@ public class AmConnectionServiceImplTest {
         assertThatThrownBy(() -> broken.findByOrganizationId("org-1"))
             .isInstanceOf(TechnicalManagementException.class)
             .hasMessageContaining("decrypt");
+    }
+
+    @Test
+    public void find_decryption_failure_message_names_secret_property_and_carries_cause() throws Exception {
+        String cipherFromValidSecret = dataEncryptor.encrypt("secret-token");
+        // Secret rotated to an invalid length (36-byte UUID) — decrypt then throws InvalidKeyException.
+        DataEncryptor rotatedToInvalidLength = new DataEncryptor(
+            new MockEnvironment(),
+            "test.secret",
+            "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+        );
+        AmConnectionServiceImpl serviceAfterBadRotation = new AmConnectionServiceImpl(amConnectionRepository, rotatedToInvalidLength);
+        AmConnection stored = new AmConnection();
+        stored.setOrganizationId("org-1");
+        stored.setServiceAccountAccessTokenEncrypted(cipherFromValidSecret);
+        when(amConnectionRepository.findByOrganizationId("org-1")).thenReturn(Optional.of(stored));
+
+        assertThatThrownBy(() -> serviceAfterBadRotation.findByOrganizationId("org-1"))
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessageContaining("api.properties.encryption.secret")
+            .hasMessageContaining("Invalid AES key length");
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AUTHZ-26

## Description

When `api.properties.encryption.secret` has an invalid AES key length (not 16, 24 or 32 bytes), saving or reading the AM connection failed with an opaque `500 "Failed to encrypt/decrypt am service account access token"` — nothing was logged, and the message blamed the token/AM instead of the misconfigured secret.

`AmConnectionServiceImpl.encryptOrPreserve` (save) and `decryptOrNull` (read) now:
- log the cause at `ERROR`, and
- include the cause **and** the offending property name in the message — which the AM config panel already renders verbatim, so the operator sees *why* the connection can't be saved.

No frontend change.

## Additional context

**Reproduce:** set `gravitee_api_properties_encryption_secret` to a 36-byte value (e.g. a UUID with dashes) and Save the AM connection.

- Before: `500 {"message":"Failed to encrypt am service account access token"}` and no log line.
- After:

  > Failed to encrypt the AM service account token — check the property-encryption secret (api.properties.encryption.secret) on the rest-api, it must be 16, 24 or 32 bytes. Cause: Invalid AES key length: 36 bytes

Covered by `AmConnectionServiceImplTest` — a real `DataEncryptor` with a 36-byte secret reproduces both the save-encrypt failure and the read-decrypt-after-rotation failure.

**Deliberately out of scope** (tracked separately): startup fail-fast length validation, `AES/ECB`→AEAD, a control-plane-only secret.
