### PR TITLE
fix(console): base runtime-logs reporting banner on analytics enabled

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.spec.ts
@@ -170,13 +170,23 @@ describe('ApiRuntimeLogsComponent', () => {
     });
   });
 
-  describe('GIVEN logs are disabled', () => {
+  describe('GIVEN reporting is disabled', () => {
     beforeEach(async () => {
       await initComponentWithLogs({ hasLogs: false, areLogsEnabled: false });
     });
 
     it('should display the info banner', async () => {
       expect(await componentHarness.banner()).toBeTruthy();
+    });
+  });
+
+  describe('GIVEN reporting is enabled but no logging mode is set', () => {
+    beforeEach(async () => {
+      await initComponentWithLogs({ hasLogs: false, apiModifier: { analytics: { enabled: true, logging: {} } } });
+    });
+
+    it('should not display the reporting-disabled banner', async () => {
+      expect(await componentHarness.banner()).toBeFalsy();
     });
   });
 
@@ -870,7 +880,7 @@ describe('ApiRuntimeLogsComponent', () => {
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`,
         method: 'GET',
       })
-      .flush(fakeApiV4({ id: API_ID, analytics: { enabled: true, logging: {} } }));
+      .flush(fakeApiV4({ id: API_ID, analytics: { enabled: false, logging: {} } }));
   }
 
   function expectApiWithNoLog() {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.ts
@@ -50,9 +50,7 @@ export class ApiRuntimeLogsComponent implements OnInit {
   private apiService = inject(ApiV2Service);
   private api$ = this.apiService.get(this.activatedRoute.snapshot.params.apiId).pipe(shareReplay(1));
 
-  isReportingDisabled$ = this.api$.pipe(
-    map((api: ApiV4) => !api.analytics.enabled || (!api.analytics.logging?.mode?.endpoint && !api.analytics.logging?.mode?.entrypoint)),
-  );
+  isReportingDisabled$ = this.api$.pipe(map((api: ApiV4) => !(api.analytics?.enabled ?? true)));
   apiLogsSubject$ = new ReplaySubject<ApiLogsResponse>(1);
   apiPlans$ = this.planService
     .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED', 'CLOSED'], undefined, undefined, 1, 9999)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-82

## Description

Fixes the **Runtime Logs** _"Reporting is disabled"_ banner on v4 proxy/message APIs, which was wrongly shown whenever both logging modes (entrypoint/endpoint) were off even though reporting was enabled. The banner now reflects only `analytics.enabled`.

## Additional context

Now displayed only when reporter settings is disabled :

<img width="1495" height="683" alt="Capture d’écran 2026-07-24 à 16 02 08" src="https://github.com/user-attachments/assets/28596ecb-f93b-4ec2-8107-3bd23c04cc3d" />