### PR TITLE
fix(ci): log warning when remote branch deletion fails [skip ci]

### DIFF
--- a/release/ci-steps/generate-changelog.mjs
+++ b/release/ci-steps/generate-changelog.mjs
@@ -77,6 +77,12 @@ try {
 } catch (e) {
   // Best effort to have no open PR before creating a new one
 }
+try {
+  await $`git push origin --delete ${gitBranch}`;
+} catch (e) {
+  // Best effort: remote branch may not exist
+  echo(chalk.yellow(`# Could not delete remote branch ${gitBranch} (may not exist), continuing`));
+}
 await $`git checkout -b ${gitBranch}`;
 await $`git add ./${docApimChangelogFile}`;
 await $`git commit -m "chore: add changelog for ${releasingVersion}"`;


### PR DESCRIPTION
Summary

When the release pipeline retries, the remote branch release-apim-X.Y.Z may already exist from the previous run.
gh pr close --delete-branch only deletes the branch when an open PR exists; if the PR was already closed/merged, the branch is left behind.

A subsequent git push then fails with "rejected (fetch first)" because the remote has commits the shallow clone does not.

Fix: add an explicit git push origin --delete attempt (wrapped in try/catch) after the gh pr close step to clean up any stale remote branch before creating a fresh one.

Test plan

Re-run job 1933782 (or a subsequent release pipeline for 4.12.10) and confirm the push succeeds.
Confirm a PR is opened against gravitee-platform-docs as expected.

https://app.circleci.com/agents/gh/gravitee-io/chat/f1a0b71e-b9ba-4279-a844-d5d8d7a08b21

