### PR TITLE
feat(gamma): gate API Products behind license with upgrade dialog

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/jest.config.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/jest.config.ts
@@ -34,6 +34,7 @@ export default {
         '^@gravitee/graphene-charts/(.*)$': '<rootDir>/../../node_modules/@gravitee/graphene-charts/dist/$1',
         '^@gravitee/gamma-lib-observability$': '<rootDir>/../../node_modules/@gravitee/gamma-lib-observability/dist/index.js',
         '^@gravitee/gamma-modules-sdk$': '<rootDir>/src/main/ui/shared/gamma-modules-sdk.ts',
+        '^@gravitee/gamma-modules-sdk/routing$': '<rootDir>/../../node_modules/@gravitee/gamma-modules-sdk/dist/routing.js',
         '^@gravitee/gamma-ui-shared/api$': '<rootDir>/../gamma-ui-shared/src/api/index.ts',
     },
     transform: {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -16,9 +16,9 @@
 import '@gravitee/gamma-lib-observability/styles';
 import '@gravitee/graphene-charts/lineage/styles.css';
 import { CapabilityProvider, type DashboardCapabilities } from '@gravitee/gamma-lib-observability';
-import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useEnvironment, useHasFeature } from '@gravitee/gamma-modules-sdk';
 import { buildModuleNavPath, resolveModulePath } from '@gravitee/gamma-modules-sdk/routing';
-import { buildLinearBreadcrumbs, SidebarNavigation, useLayoutConfig } from '@gravitee/graphene-core';
+import { buildLinearBreadcrumbs, SidebarNavigation, useLayoutConfig, type NavGroup } from '@gravitee/graphene-core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 import { Navigate, Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
@@ -74,6 +74,7 @@ import { PolicyStudioPage } from '../features/apis/pages/policy-studio/PolicyStu
 import { ScratchWizardPage } from '../features/apis/pages/ScratchWizardPage';
 import { TemplateWizardPage } from '../features/apis/pages/TemplateWizardPage';
 import { QuickStartPage } from '../features/dashboard/pages/QuickStartPage';
+import { ApimLicenseFeature, RequireFeatureLicense } from '../features/license';
 import { SettingsPage } from '../features/settings/pages/SettingsPage';
 import { createTracingApiPaginatedLoader } from '../lib/api/tracing-api-loader';
 import { useEnvironmentId } from '../lib/hooks/useEnvironmentId';
@@ -99,11 +100,27 @@ function buildObserveBreadcrumbItem(segment: { label: string; routeKey?: string 
     return { label: segment.label, to };
 }
 
+function useLicenseAwareNavGroups(): NavGroup[] {
+    const hasApiProducts = useHasFeature(ApimLicenseFeature.API_PRODUCTS);
+
+    return useMemo(
+        () =>
+            NAV_GROUPS.map(group => ({
+                ...group,
+                items: group.items.map(item =>
+                    item.key === 'api-products' && !hasApiProducts ? { ...item, access: 'locked' as const } : item,
+                ),
+            })),
+        [hasApiProducts],
+    );
+}
+
 function ModuleLayout() {
     const location = useLocation();
     const navigate = useNavigate();
     const { modulePrefix } = useMemo(() => resolveModulePath(location.pathname, APIM_ROUTE_CONFIG), [location.pathname]);
     const activeNavKey = useMemo(() => getActiveNavKey(location.pathname, modulePrefix), [location.pathname, modulePrefix]);
+    const navGroups = useLicenseAwareNavGroups();
 
     const handleNavSelect = useCallback(
         (key: string) => {
@@ -124,10 +141,10 @@ function ModuleLayout() {
 
     useLayoutConfig(
         {
-            navigation: <SidebarNavigation groups={NAV_GROUPS} activeItemKey={activeNavKey} onItemSelect={handleNavSelect} />,
+            navigation: <SidebarNavigation groups={navGroups} activeItemKey={activeNavKey} onItemSelect={handleNavSelect} />,
             breadcrumbs,
         },
-        [activeNavKey, breadcrumbs, handleNavSelect],
+        [activeNavKey, breadcrumbs, handleNavSelect, navGroups],
     );
 
     return <Outlet />;
@@ -247,7 +264,14 @@ export function AppRoutes() {
                                 <Route path="*" element={<ApiDetailIndexRedirect />} />
                             </Route>
                         </Route>
-                        <Route path="api-products">
+                        <Route
+                            path="api-products"
+                            element={
+                                <RequireFeatureLicense feature={ApimLicenseFeature.API_PRODUCTS}>
+                                    <Outlet />
+                                </RequireFeatureLicense>
+                            }
+                        >
                             <Route index element={<ApiProductsPage />} />
                             <Route path="new" element={<CreateApiProductPage />} />
                             <Route path=":productId" element={<ApiProductDetailLayout />}>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardGetStartedCards.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardGetStartedCards.tsx
@@ -17,6 +17,10 @@ import { Badge, Button, Card, CardContent } from '@gravitee/graphene-core';
 import { ArchiveIcon, ArrowRightIcon, RadioIcon } from '@gravitee/graphene-core/icons';
 import type { LucideIcon } from '@gravitee/graphene-core/icons';
 
+import { UpgradeToAccessButton } from '../../../shared/components/UpgradeToAccessButton';
+
+const NOOP = () => undefined;
+
 interface GetStartedCardProps {
     Icon: LucideIcon;
     title: string;
@@ -25,9 +29,10 @@ interface GetStartedCardProps {
     protocols: readonly string[];
     ctaLabel: string;
     onCta: () => void;
+    locked?: boolean;
 }
 
-function GetStartedCard({ Icon, title, description, features, protocols, ctaLabel, onCta }: GetStartedCardProps) {
+function GetStartedCard({ Icon, title, description, features, protocols, ctaLabel, onCta, locked }: GetStartedCardProps) {
     return (
         <Card className="flex flex-col">
             <CardContent className="pt-6 pb-6 flex flex-col gap-5 h-full">
@@ -60,10 +65,14 @@ function GetStartedCard({ Icon, title, description, features, protocols, ctaLabe
                     </div>
                 </div>
 
-                <Button onClick={onCta} className="w-full">
-                    {ctaLabel}
-                    <ArrowRightIcon className="size-4" aria-hidden />
-                </Button>
+                {locked ? (
+                    <UpgradeToAccessButton onClick={onCta} size="default" fullWidth />
+                ) : (
+                    <Button onClick={onCta} className="w-full">
+                        {ctaLabel}
+                        <ArrowRightIcon className="size-4" aria-hidden />
+                    </Button>
+                )}
             </CardContent>
         </Card>
     );
@@ -89,9 +98,19 @@ const API_PRODUCT_PROTOCOLS = ['HTTP', 'REST', 'GraphQL'] as const;
 interface DashboardGetStartedCardsProps {
     onCreateProxy: () => void;
     onCreateProduct: () => void;
+    apiProductsLocked?: boolean;
+    onUpgradeApiProducts?: () => void;
 }
 
-export function DashboardGetStartedCards({ onCreateProxy, onCreateProduct }: DashboardGetStartedCardsProps) {
+export function DashboardGetStartedCards({
+    onCreateProxy,
+    onCreateProduct,
+    apiProductsLocked = false,
+    onUpgradeApiProducts,
+}: DashboardGetStartedCardsProps) {
+    // When locked, never fall through to create/navigation — require the upgrade handler (or no-op).
+    const onProductCta = apiProductsLocked ? (onUpgradeApiProducts ?? NOOP) : onCreateProduct;
+
     return (
         <div className="grid grid-cols-2 gap-4">
             <GetStartedCard
@@ -110,7 +129,8 @@ export function DashboardGetStartedCards({ onCreateProxy, onCreateProduct }: Das
                 features={API_PRODUCT_FEATURES}
                 protocols={API_PRODUCT_PROTOCOLS}
                 ctaLabel="Create API Product"
-                onCta={onCreateProduct}
+                onCta={onProductCta}
+                locked={apiProductsLocked}
             />
         </div>
     );

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardQuickActions.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardQuickActions.spec.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DashboardQuickActions } from './DashboardQuickActions';
+
+describe('DashboardQuickActions', () => {
+    it('should call the upgrade handler when locked, not navigation', async () => {
+        const user = userEvent.setup();
+        const onGoToApiProducts = jest.fn();
+        const onUpgradeApiProducts = jest.fn();
+
+        render(
+            <DashboardQuickActions
+                onGoToApis={jest.fn()}
+                onGoToApiProducts={onGoToApiProducts}
+                apiProductsLocked
+                onUpgradeApiProducts={onUpgradeApiProducts}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /upgrade to access/i }));
+
+        expect(onUpgradeApiProducts).toHaveBeenCalled();
+        expect(onGoToApiProducts).not.toHaveBeenCalled();
+    });
+
+    it('should no-op when locked and the upgrade handler is omitted', async () => {
+        const user = userEvent.setup();
+        const onGoToApiProducts = jest.fn();
+
+        render(<DashboardQuickActions onGoToApis={jest.fn()} onGoToApiProducts={onGoToApiProducts} apiProductsLocked />);
+
+        await user.click(screen.getByText('API Products'));
+
+        expect(onGoToApiProducts).not.toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardQuickActions.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardQuickActions.tsx
@@ -16,6 +16,10 @@
 import { ArchiveIcon, RadioIcon } from '@gravitee/graphene-core/icons';
 import type { LucideIcon } from '@gravitee/graphene-core/icons';
 
+import { UpgradeToAccessButton } from '../../../shared/components/UpgradeToAccessButton';
+
+const NOOP = () => undefined;
+
 // ─── Single tile ──────────────────────────────────────────────────────────────
 
 interface ActionTileProps {
@@ -23,62 +27,54 @@ interface ActionTileProps {
     label: string;
     description: string;
     onClick: () => void;
+    locked?: boolean;
 }
 
-function ActionTile({ Icon, label, description, onClick }: ActionTileProps) {
+function ActionTile({ Icon, label, description, onClick, locked }: ActionTileProps) {
     return (
-        <button
-            type="button"
-            onClick={onClick}
-            className="flex flex-col items-start gap-2 rounded-xl border bg-card p-4 text-left transition-colors hover:bg-muted flex-1"
-        >
-            <div className="rounded-lg bg-primary/10 p-2">
-                <Icon className="size-4 text-primary" aria-hidden />
-            </div>
-            <div>
-                <p className="text-sm font-semibold">{label}</p>
-                <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
-            </div>
-        </button>
+        <div className="flex flex-1 flex-col items-start gap-2 rounded-xl border bg-card p-4 text-left transition-colors hover:bg-muted">
+            <button type="button" onClick={onClick} className="flex w-full flex-col items-start gap-2 text-left">
+                <div className="rounded-lg bg-primary/10 p-2">
+                    <Icon className="size-4 text-primary" aria-hidden />
+                </div>
+                <div>
+                    <p className="text-sm font-semibold">{label}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
+                </div>
+            </button>
+            {locked ? <UpgradeToAccessButton onClick={onClick} className="mt-auto" /> : null}
+        </div>
     );
 }
-
-// ─── Static tile definitions ──────────────────────────────────────────────────
-
-const TILES = [
-    {
-        key: 'apis' as const,
-        Icon: RadioIcon,
-        label: 'API Proxies',
-        description: 'Browse and manage your APIs',
-    },
-    {
-        key: 'api-products' as const,
-        Icon: ArchiveIcon,
-        label: 'API Products',
-        description: 'Manage product bundles',
-    },
-    // Analytics is out of scope for now; re-add this tile (and the `analytics` route) when the feature is ready.
-] as const;
 
 // ─── Public component ─────────────────────────────────────────────────────────
 
 interface DashboardQuickActionsProps {
     onGoToApis: () => void;
     onGoToApiProducts: () => void;
+    apiProductsLocked?: boolean;
+    onUpgradeApiProducts?: () => void;
 }
 
-export function DashboardQuickActions({ onGoToApis, onGoToApiProducts }: DashboardQuickActionsProps) {
-    const handlers: Record<(typeof TILES)[number]['key'], () => void> = {
-        apis: onGoToApis,
-        'api-products': onGoToApiProducts,
-    };
+export function DashboardQuickActions({
+    onGoToApis,
+    onGoToApiProducts,
+    apiProductsLocked = false,
+    onUpgradeApiProducts,
+}: DashboardQuickActionsProps) {
+    // When locked, never fall through to navigation — require the upgrade handler (or no-op).
+    const onApiProductsClick = apiProductsLocked ? (onUpgradeApiProducts ?? NOOP) : onGoToApiProducts;
 
     return (
         <div className="flex gap-3">
-            {TILES.map(({ key, Icon, label, description }) => (
-                <ActionTile key={key} Icon={Icon} label={label} description={description} onClick={handlers[key]} />
-            ))}
+            <ActionTile Icon={RadioIcon} label="API Proxies" description="Browse and manage your APIs" onClick={onGoToApis} />
+            <ActionTile
+                Icon={ArchiveIcon}
+                label="API Products"
+                description="Manage product bundles"
+                onClick={onApiProductsClick}
+                locked={apiProductsLocked}
+            />
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardView.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardView.spec.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DashboardView } from './DashboardView';
+import { APIM_FEATURE_UPGRADES, ApimLicenseFeature } from '../../license/apimFeatures';
+
+const CONTENT = APIM_FEATURE_UPGRADES[ApimLicenseFeature.API_PRODUCTS];
+
+const baseProps = {
+    totalApis: 3,
+    totalProducts: 0,
+    onCreateProxy: jest.fn(),
+    onCreateProduct: jest.fn(),
+    onGoToApis: jest.fn(),
+    onGoToApiProducts: jest.fn(),
+};
+
+describe('DashboardView', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should show Upgrade to access CTAs and open the upgrade dialog when API Products are locked', async () => {
+        const user = userEvent.setup();
+
+        render(<DashboardView {...baseProps} apiProductsLocked />);
+
+        const upgradeButtons = screen.getAllByRole('button', { name: /upgrade to access/i });
+        expect(upgradeButtons.length).toBeGreaterThanOrEqual(2);
+
+        await user.click(upgradeButtons[0]);
+
+        expect(screen.getByRole('heading', { name: CONTENT.title })).toBeTruthy();
+        expect(baseProps.onGoToApiProducts).not.toHaveBeenCalled();
+        expect(baseProps.onCreateProduct).not.toHaveBeenCalled();
+    });
+
+    it('should not show Upgrade to access CTAs when API Products are licensed', () => {
+        render(<DashboardView {...baseProps} apiProductsLocked={false} />);
+
+        expect(screen.queryByRole('button', { name: /upgrade to access/i })).toBeNull();
+        expect(screen.getByRole('button', { name: /create api product/i })).toBeTruthy();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardView.tsx
@@ -15,10 +15,13 @@
  */
 import { Button } from '@gravitee/graphene-core';
 import { SparklesIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
 
 import { DashboardGetStartedCards } from './DashboardGetStartedCards';
 import { DashboardQuickActions } from './DashboardQuickActions';
 import { DashboardSummaryCards } from './DashboardSummaryCards';
+import { FeatureUpgradeDialog } from '../../../shared/components';
+import { APIM_FEATURE_UPGRADES, ApimLicenseFeature } from '../../license/apimFeatures';
 
 interface DashboardViewProps {
     totalApis: number | null;
@@ -28,6 +31,7 @@ interface DashboardViewProps {
     onGoToApis: () => void;
     onGoToApiProducts: () => void;
     onStartTour?: () => void;
+    apiProductsLocked?: boolean;
 }
 
 export function DashboardView({
@@ -38,7 +42,10 @@ export function DashboardView({
     onGoToApis,
     onGoToApiProducts,
     onStartTour,
+    apiProductsLocked = false,
 }: DashboardViewProps) {
+    const [upgradeOpen, setUpgradeOpen] = useState(false);
+
     return (
         <div className="space-y-6">
             {/* Header */}
@@ -59,13 +66,31 @@ export function DashboardView({
             <DashboardSummaryCards totalApis={totalApis} totalProducts={totalProducts} />
 
             {/* Quick actions */}
-            <DashboardQuickActions onGoToApis={onGoToApis} onGoToApiProducts={onGoToApiProducts} />
+            <DashboardQuickActions
+                onGoToApis={onGoToApis}
+                onGoToApiProducts={onGoToApiProducts}
+                apiProductsLocked={apiProductsLocked}
+                onUpgradeApiProducts={() => setUpgradeOpen(true)}
+            />
 
             {/* Get Started */}
             <section>
                 <h2 className="text-base font-semibold mb-4">Get Started</h2>
-                <DashboardGetStartedCards onCreateProxy={onCreateProxy} onCreateProduct={onCreateProduct} />
+                <DashboardGetStartedCards
+                    onCreateProxy={onCreateProxy}
+                    onCreateProduct={onCreateProduct}
+                    apiProductsLocked={apiProductsLocked}
+                    onUpgradeApiProducts={() => setUpgradeOpen(true)}
+                />
             </section>
+
+            {apiProductsLocked ? (
+                <FeatureUpgradeDialog
+                    content={APIM_FEATURE_UPGRADES[ApimLicenseFeature.API_PRODUCTS]}
+                    open={upgradeOpen}
+                    onOpenChange={setUpgradeOpen}
+                />
+            ) : null}
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/hooks/useDashboardStats.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/hooks/useDashboardStats.spec.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment, useHasFeature } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useDashboardStats } from './useDashboardStats';
+import { searchApiProducts } from '../../api-products/services/apiProduct';
+import { searchApis } from '../../apis/services/apiList';
+import { ApimLicenseFeature } from '../../license/apimFeatures';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(),
+    useHasFeature: jest.fn(),
+}));
+
+jest.mock('../../api-products/services/apiProduct', () => ({
+    searchApiProducts: jest.fn(),
+}));
+
+jest.mock('../../apis/services/apiList', () => ({
+    searchApis: jest.fn(),
+}));
+
+const mockUseEnvironment = useEnvironment as jest.MockedFunction<typeof useEnvironment>;
+const mockUseHasFeature = useHasFeature as jest.MockedFunction<typeof useHasFeature>;
+const mockSearchApis = searchApis as jest.MockedFunction<typeof searchApis>;
+const mockSearchApiProducts = searchApiProducts as jest.MockedFunction<typeof searchApiProducts>;
+
+function createWrapper() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    };
+}
+
+describe('useDashboardStats', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseEnvironment.mockReturnValue({ id: 'DEFAULT' } as ReturnType<typeof useEnvironment>);
+        mockSearchApis.mockResolvedValue({ data: [], pagination: { totalCount: 2 } } as Awaited<ReturnType<typeof searchApis>>);
+        mockSearchApiProducts.mockResolvedValue({
+            data: [],
+            pagination: { totalCount: 5 },
+        } as Awaited<ReturnType<typeof searchApiProducts>>);
+    });
+
+    it('should fetch API and product counts when API Products are licensed', async () => {
+        mockUseHasFeature.mockReturnValue(true);
+
+        const { result } = renderHook(() => useDashboardStats(), { wrapper: createWrapper() });
+
+        await waitFor(() => expect(result.current.hasContent).not.toBeNull());
+
+        expect(mockSearchApis).toHaveBeenCalled();
+        expect(mockSearchApiProducts).toHaveBeenCalled();
+        expect(result.current.totalApis).toBe(2);
+        expect(result.current.totalProducts).toBe(5);
+        expect(result.current.hasContent).toBe(true);
+        expect(result.current.isError).toBe(false);
+    });
+
+    it('should skip the products query and report zero products when unlicensed', async () => {
+        mockUseHasFeature.mockImplementation(feature => feature !== ApimLicenseFeature.API_PRODUCTS);
+
+        const { result } = renderHook(() => useDashboardStats(), { wrapper: createWrapper() });
+
+        await waitFor(() => expect(result.current.hasContent).not.toBeNull());
+
+        expect(mockSearchApis).toHaveBeenCalled();
+        expect(mockSearchApiProducts).not.toHaveBeenCalled();
+        expect(result.current.totalApis).toBe(2);
+        expect(result.current.totalProducts).toBe(0);
+        expect(result.current.hasContent).toBe(true);
+        expect(result.current.isError).toBe(false);
+    });
+
+    it('should not mark the dashboard as errored when the skipped products query would have failed', async () => {
+        mockUseHasFeature.mockImplementation(feature => feature !== ApimLicenseFeature.API_PRODUCTS);
+        mockSearchApiProducts.mockRejectedValue(new Error('forbidden'));
+
+        const { result } = renderHook(() => useDashboardStats(), { wrapper: createWrapper() });
+
+        await waitFor(() => expect(result.current.hasContent).not.toBeNull());
+
+        expect(result.current.isError).toBe(false);
+        expect(result.current.totalProducts).toBe(0);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/hooks/useDashboardStats.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/hooks/useDashboardStats.ts
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useEnvironment, useHasFeature } from '@gravitee/gamma-modules-sdk';
 import { useQuery } from '@tanstack/react-query';
 
 import { searchApiProducts } from '../../api-products/services/apiProduct';
 import { apiProductKeys } from '../../api-products/utils/queryKeys';
 import { searchApis } from '../../apis/services/apiList';
 import { apiListKeys } from '../../apis/utils/queryKeys';
+import { ApimLicenseFeature } from '../../license/apimFeatures';
 
 const STATS_PAGE = 1;
 const STATS_PER_PAGE = 1;
@@ -36,6 +37,7 @@ export interface DashboardStats {
 export function useDashboardStats(): DashboardStats {
     const env = useEnvironment();
     const envId = env?.id ?? '';
+    const hasApiProducts = useHasFeature(ApimLicenseFeature.API_PRODUCTS);
     // Guard on envId too — env may be truthy but id not yet populated
     const enabled = Boolean(envId);
 
@@ -46,25 +48,25 @@ export function useDashboardStats(): DashboardStats {
         staleTime: 60_000,
     });
 
-    // Use apiProductKeys.count — not apiProductKeys.list — to avoid a cache-key
-    // collision with useApiProductList (which shares the list key with sortBy='name').
+    // Skip products search when unlicensed — the call can fail or flake and would
+    // otherwise mark the whole Quick Start page as an error. Show 0 products instead.
     const totalProductsQuery = useQuery({
         queryKey: apiProductKeys.count(envId, {}),
         queryFn: () => searchApiProducts(envId, {}, STATS_PAGE, STATS_PER_PAGE),
-        enabled,
+        enabled: enabled && hasApiProducts,
         staleTime: 60_000,
     });
 
     const totalApis = totalApisQuery.data?.pagination?.totalCount ?? null;
-    const totalProducts = totalProductsQuery.data?.pagination?.totalCount ?? null;
+    const totalProducts = hasApiProducts ? (totalProductsQuery.data?.pagination?.totalCount ?? null) : 0;
 
-    const hasContent = totalApis !== null && totalProducts !== null ? totalApis > 0 || totalProducts > 0 : null;
+    const hasContent = totalApis !== null && (!hasApiProducts || totalProducts !== null) ? totalApis > 0 || (totalProducts ?? 0) > 0 : null;
 
     return {
         totalApis,
         totalProducts,
         hasContent,
-        isLoading: totalApisQuery.isLoading || totalProductsQuery.isLoading,
-        isError: totalApisQuery.isError || totalProductsQuery.isError,
+        isLoading: totalApisQuery.isLoading || (hasApiProducts && totalProductsQuery.isLoading),
+        isError: totalApisQuery.isError || (hasApiProducts && totalProductsQuery.isError),
     };
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/pages/QuickStartPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/pages/QuickStartPage.tsx
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useHasFeature } from '@gravitee/gamma-modules-sdk';
 import { useModuleRouting } from '@gravitee/gamma-modules-sdk/routing';
 import { Alert, AlertDescription, Skeleton } from '@gravitee/graphene-core';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { APIM_OVERVIEW_TOUR_ID, useOnboarding } from '../../../app/onboarding';
 import { APIM_ROUTE_CONFIG } from '../../../config/routes';
+import { ApimLicenseFeature } from '../../license/apimFeatures';
 import { DashboardEmptyLanding, DashboardView } from '../components';
 import { useDashboardStats } from '../hooks/useDashboardStats';
 
@@ -53,6 +55,7 @@ export function QuickStartPage() {
     const { navigateToKey, modulePrefix } = useModuleRouting(APIM_ROUTE_CONFIG);
     const { openTour } = useOnboarding();
     const stats = useDashboardStats();
+    const hasApiProducts = useHasFeature(ApimLicenseFeature.API_PRODUCTS);
 
     // Mirror buildModuleNavPath from the SDK: /environments/{env}/{module}/{subPath}
     const goTo = (subPath: string) => {
@@ -89,6 +92,7 @@ export function QuickStartPage() {
                 onGoToApis={() => navigateToKey('apis')}
                 onGoToApiProducts={() => navigateToKey('api-products')}
                 onStartTour={() => openTour(APIM_OVERVIEW_TOUR_ID)}
+                apiProductsLocked={!hasApiProducts}
             />
         );
     }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/license/RequireFeatureLicense.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/license/RequireFeatureLicense.spec.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasFeature } from '@gravitee/gamma-modules-sdk';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { APIM_FEATURE_UPGRADES, ApimLicenseFeature } from './apimFeatures';
+import { RequireFeatureLicense } from './RequireFeatureLicense';
+
+const mockNavigateToKey = jest.fn();
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasFeature: jest.fn(),
+}));
+
+jest.mock('@gravitee/gamma-modules-sdk/routing', () => ({
+    useModuleRouting: () => ({ navigateToKey: mockNavigateToKey, modulePrefix: 'apim' }),
+}));
+
+const mockUseHasFeature = useHasFeature as jest.MockedFunction<typeof useHasFeature>;
+const FEATURE = ApimLicenseFeature.API_PRODUCTS;
+const CONTENT = APIM_FEATURE_UPGRADES[FEATURE];
+
+describe('RequireFeatureLicense', () => {
+    beforeEach(() => {
+        mockNavigateToKey.mockClear();
+    });
+
+    it('should render children when the feature is licensed', () => {
+        mockUseHasFeature.mockReturnValue(true);
+
+        render(
+            <RequireFeatureLicense feature={FEATURE}>
+                <div>Licensed content</div>
+            </RequireFeatureLicense>,
+        );
+
+        expect(screen.getByText('Licensed content')).toBeTruthy();
+        expect(screen.queryByRole('heading', { name: CONTENT.title })).toBeNull();
+    });
+
+    it('should show the upgrade dialog and block children when unlicensed', () => {
+        mockUseHasFeature.mockReturnValue(false);
+
+        render(
+            <RequireFeatureLicense feature={FEATURE}>
+                <div>Licensed content</div>
+            </RequireFeatureLicense>,
+        );
+
+        expect(screen.queryByText('Licensed content')).toBeNull();
+        expect(screen.getByRole('heading', { name: CONTENT.title })).toBeTruthy();
+    });
+
+    it('should navigate to quick-start by default when the upgrade dialog is closed', async () => {
+        mockUseHasFeature.mockReturnValue(false);
+        const user = userEvent.setup();
+
+        render(
+            <RequireFeatureLicense feature={FEATURE}>
+                <div>Licensed content</div>
+            </RequireFeatureLicense>,
+        );
+
+        await user.keyboard('{Escape}');
+
+        expect(mockNavigateToKey).toHaveBeenCalledWith('quick-start');
+        // Dialog stays open until navigation unmounts the gate (avoids empty outlet flash).
+        expect(screen.getByRole('heading', { name: CONTENT.title })).toBeTruthy();
+    });
+
+    it('should navigate to a custom fallback route when provided', async () => {
+        mockUseHasFeature.mockReturnValue(false);
+        const user = userEvent.setup();
+
+        render(
+            <RequireFeatureLicense feature={FEATURE} fallbackRouteKey="apis">
+                <div>Licensed content</div>
+            </RequireFeatureLicense>,
+        );
+
+        await user.keyboard('{Escape}');
+
+        expect(mockNavigateToKey).toHaveBeenCalledWith('apis');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/license/RequireFeatureLicense.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/license/RequireFeatureLicense.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasFeature } from '@gravitee/gamma-modules-sdk';
+import { useModuleRouting } from '@gravitee/gamma-modules-sdk/routing';
+import { useState, type ReactNode } from 'react';
+
+import { APIM_FEATURE_UPGRADES, type ApimLicenseFeatureId } from './apimFeatures';
+import { APIM_ROUTE_CONFIG, type RouteKey } from '../../config/routes';
+import { FeatureUpgradeDialog } from '../../shared/components/FeatureUpgradeDialog';
+
+/**
+ * Generic route gate for any APIM license feature registered in {@link APIM_FEATURE_UPGRADES}.
+ * When the feature is missing from the org license, blocks children and shows the upgrade dialog.
+ * Closing the dialog navigates to `fallbackRouteKey` (defaults to Quick Start).
+ *
+ * Keep the dialog open until navigation unmounts this gate — clearing `open` first would flash
+ * an empty outlet on the gated route.
+ */
+export function RequireFeatureLicense({
+    feature,
+    fallbackRouteKey = 'quick-start',
+    children,
+}: {
+    readonly feature: ApimLicenseFeatureId;
+    readonly fallbackRouteKey?: RouteKey;
+    readonly children: ReactNode;
+}) {
+    const hasFeature = useHasFeature(feature);
+    const { navigateToKey } = useModuleRouting(APIM_ROUTE_CONFIG);
+    const [upgradeOpen, setUpgradeOpen] = useState(true);
+
+    if (hasFeature) {
+        return children;
+    }
+
+    function handleUpgradeOpenChange(open: boolean) {
+        if (!open) {
+            navigateToKey(fallbackRouteKey);
+            return;
+        }
+        setUpgradeOpen(open);
+    }
+
+    return <FeatureUpgradeDialog content={APIM_FEATURE_UPGRADES[feature]} open={upgradeOpen} onOpenChange={handleUpgradeOpenChange} />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/license/apimFeatures.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/license/apimFeatures.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { LucideIcon } from '@gravitee/graphene-core/icons';
+import { ArchiveIcon } from '@gravitee/graphene-core/icons';
+
+/**
+ * License feature ids used by APIM Gamma UI.
+ * Values must match classic console `ApimFeature` / backend license feature strings.
+ */
+export const ApimLicenseFeature = {
+    API_PRODUCTS: 'apim-api-products',
+} as const;
+
+export type ApimLicenseFeatureId = (typeof ApimLicenseFeature)[keyof typeof ApimLicenseFeature];
+
+/**
+ * Destination of the "Request an enterprise license" CTA in upgrade dialogs.
+ * Aligned with classic console (`gio-license-data`) and Gamma home `UpgradeDialog`.
+ */
+export const REQUEST_ENTERPRISE_LICENSE_URL = 'https://gravitee.io/self-hosted-trial';
+
+export interface FeatureUpgradeContent {
+    readonly featureId: ApimLicenseFeatureId;
+    readonly title: string;
+    readonly description: string;
+    readonly Icon: LucideIcon;
+    readonly features: readonly string[];
+}
+
+/** Upsell content for license-gated APIM features. */
+export const APIM_FEATURE_UPGRADES: Record<ApimLicenseFeatureId, FeatureUpgradeContent> = {
+    [ApimLicenseFeature.API_PRODUCTS]: {
+        featureId: ApimLicenseFeature.API_PRODUCTS,
+        title: 'API Products',
+        description: 'Bundle multiple APIs into consumable products with unified plans, subscriptions, and access control.',
+        Icon: ArchiveIcon,
+        features: [
+            'Bundle multiple APIs into one product surface',
+            'Define plans and manage subscriptions in one place',
+            'Give developers unified access through the portal',
+        ],
+    },
+};

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/license/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/license/index.ts
@@ -13,13 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { FeatureTile } from './FeatureTile';
-export { FeatureUpgradeDialog } from './FeatureUpgradeDialog';
-export { UpgradeToAccessButton } from './UpgradeToAccessButton';
-export { CircularProgress } from './CircularProgress';
-export { ConfirmDialog } from './ConfirmDialog';
-export type { ConfirmDialogProps } from './ConfirmDialog';
-export { MultiSelectFilter } from './MultiSelectFilter';
-export type { MultiSelectFilterOption } from './MultiSelectFilter';
-export { OverviewChecklistCard } from './OverviewChecklistCard';
-export type { OverviewChecklistItem } from './OverviewChecklistCard';
+export {
+    APIM_FEATURE_UPGRADES,
+    ApimLicenseFeature,
+    REQUEST_ENTERPRISE_LICENSE_URL,
+    type ApimLicenseFeatureId,
+    type FeatureUpgradeContent,
+} from './apimFeatures';
+export { RequireFeatureLicense } from './RequireFeatureLicense';

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/components/FeatureUpgradeDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/components/FeatureUpgradeDialog.spec.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { FeatureUpgradeDialog } from './FeatureUpgradeDialog';
+import { APIM_FEATURE_UPGRADES, ApimLicenseFeature, REQUEST_ENTERPRISE_LICENSE_URL } from '../../features/license/apimFeatures';
+
+const API_PRODUCTS = APIM_FEATURE_UPGRADES[ApimLicenseFeature.API_PRODUCTS];
+
+describe('FeatureUpgradeDialog', () => {
+    it('should render the feature title, description and every bullet when open', () => {
+        render(<FeatureUpgradeDialog content={API_PRODUCTS} open onOpenChange={() => {}} />);
+
+        expect(screen.getByRole('heading', { name: API_PRODUCTS.title })).toBeTruthy();
+        expect(screen.getByText(API_PRODUCTS.description)).toBeTruthy();
+        API_PRODUCTS.features.forEach(feature => {
+            expect(screen.getByText(feature)).toBeTruthy();
+        });
+    });
+
+    it('should point the enterprise license CTA to the configured URL', () => {
+        render(<FeatureUpgradeDialog content={API_PRODUCTS} open onOpenChange={() => {}} />);
+
+        const cta = screen.getByRole('link', { name: /request an enterprise license/i });
+        expect(cta.getAttribute('href')).toBe(REQUEST_ENTERPRISE_LICENSE_URL);
+    });
+
+    it('should not render its content when closed', () => {
+        render(<FeatureUpgradeDialog content={API_PRODUCTS} open={false} onOpenChange={() => {}} />);
+
+        expect(screen.queryByText(API_PRODUCTS.features[0])).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/components/FeatureUpgradeDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/components/FeatureUpgradeDialog.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+import { CircleCheckIcon } from '@gravitee/graphene-core/icons';
+
+import { REQUEST_ENTERPRISE_LICENSE_URL, type FeatureUpgradeContent } from '../../features/license/apimFeatures';
+
+/**
+ * Upgrade dialog shown when a user interacts with an APIM feature that is not
+ * covered by the current organization license. Mirrors the Gamma home
+ * `UpgradeDialog` pattern (icon header, feature checklist, enterprise CTA).
+ */
+export function FeatureUpgradeDialog({
+    content,
+    open,
+    onOpenChange,
+}: {
+    readonly content: FeatureUpgradeContent;
+    readonly open: boolean;
+    readonly onOpenChange: (open: boolean) => void;
+}) {
+    const { Icon, title, description, features } = content;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="w-96 gap-0 overflow-hidden p-0">
+                <div className="flex flex-col items-center gap-3 bg-primary/10 px-6 pt-10 pb-8 text-center">
+                    <div className="flex size-12 items-center justify-center rounded-xl bg-background ring-1 ring-foreground/10">
+                        <Icon className="size-8" aria-hidden />
+                    </div>
+                    <DialogHeader className="gap-1.5">
+                        <DialogTitle className="text-center text-xl font-semibold">{title}</DialogTitle>
+                        <DialogDescription className="text-center">{description}</DialogDescription>
+                    </DialogHeader>
+                </div>
+
+                <ul className="flex flex-col gap-2.5 px-6 py-5">
+                    {features.map(feature => (
+                        <li key={feature} className="flex items-start gap-2.5 text-sm">
+                            <CircleCheckIcon className="mt-0.5 size-4 shrink-0 text-success" aria-hidden />
+                            <span>{feature}</span>
+                        </li>
+                    ))}
+                </ul>
+
+                <div className="px-6 pb-6">
+                    <Button asChild variant="outline" className="w-full rounded-full">
+                        <a href={REQUEST_ENTERPRISE_LICENSE_URL} target="_blank" rel="noreferrer">
+                            Request an enterprise license
+                        </a>
+                    </Button>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/components/UpgradeToAccessButton.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/components/UpgradeToAccessButton.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button } from '@gravitee/graphene-core';
+import { ZapIcon } from '@gravitee/graphene-core/icons';
+import type { ComponentProps } from 'react';
+
+type ButtonSize = ComponentProps<typeof Button>['size'];
+
+/**
+ * Pill CTA used on locked license surfaces (dashboard tiles, get-started cards).
+ * Opens a {@link FeatureUpgradeDialog} (or equivalent) via `onClick`.
+ */
+export function UpgradeToAccessButton({
+    onClick,
+    className,
+    size = 'sm',
+    fullWidth = false,
+}: {
+    readonly onClick: () => void;
+    readonly className?: string;
+    readonly size?: ButtonSize;
+    readonly fullWidth?: boolean;
+}) {
+    return (
+        <Button
+            variant="outline"
+            size={size}
+            onClick={onClick}
+            className={[
+                'rounded-full border-primary text-primary hover:bg-primary/10 hover:text-primary',
+                fullWidth ? 'w-full' : 'self-start px-4',
+                className,
+            ]
+                .filter(Boolean)
+                .join(' ')}
+        >
+            <ZapIcon aria-hidden />
+            Upgrade to access
+        </Button>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/gamma-modules-sdk.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/gamma-modules-sdk.ts
@@ -24,6 +24,25 @@
  */
 import type { ReactNode } from 'react';
 
+// ─── License ──────────────────────────────────────────────────────────────────
+
+/** Test stub — defaults to granted. Mock `useHasFeature` per-test for denied states. */
+export const useHasFeature = (_feature: string): boolean => true;
+
+export const useHasPack = (_pack: string): boolean => true;
+
+export const licenseService = {
+    setLicense: (_license: unknown): void => {},
+    getLicense: (): null => null,
+    hasFeature: (_feature: string): boolean => true,
+    hasPack: (_pack: string): boolean => true,
+    isExpired: (): boolean => false,
+    subscribe:
+        (_listener: () => void): (() => void) =>
+        () => {},
+    getSnapshot: (): null => null,
+};
+
 // ─── Permissions ──────────────────────────────────────────────────────────────
 
 export const useHasPermission = (): boolean => true;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14783

## Description
## Summary
- Gate API Products behind the `apim-api-products` license feature when the org license does not include it.
- Show graphene-core upgrade UX: sidebar **Upgrade** badge, **Upgrade to access** CTAs on Quick Start, and an upsell dialog with enterprise license CTA.
- Extract **reusable APIM license helpers** so the next gated feature does not need a one-off copy of this pattern.

## Reusable pieces (for other APIM license locks)
| Piece | Path | Use when |
| --- | --- | --- |
| Feature catalog | `features/license/apimFeatures.ts` | Add a new `ApimLicenseFeature` id + upsell copy/`Icon`/bullets to `APIM_FEATURE_UPGRADES` |
| Route gate | `features/license/RequireFeatureLicense` | Wrap a route (or section) that requires a feature |
| Dialog | `shared/components/FeatureUpgradeDialog` | Show the upsell modal for a catalog entry |
| CTA button | `shared/components/UpgradeToAccessButton` | Locked tiles/cards that open the dialog |

**Example for the next feature**
```tsx
<RequireFeatureLicense feature={ApimLicenseFeature.SOME_FEATURE}>
  <Outlet />
</RequireFeatureLicense>

<UpgradeToAccessButton onClick={() => setUpgradeOpen(true)} />
<FeatureUpgradeDialog
  content={APIM_FEATURE_UPGRADES[ApimLicenseFeature.SOME_FEATURE]}
  open={upgradeOpen}
  onOpenChange={setUpgradeOpen}
/>
```

Note: graphene-core does **not** export an `UpgradeDialog` (only `SidebarUpgradeFooter` for nav nudges). The dialog UI is composed from graphene `Dialog`/`Button` primitives in APIM.
