### PR TITLE
feat(gamma-platform): add users and show user list

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.spec.ts
@@ -216,7 +216,7 @@ describe('toTaskView', () => {
         expect(view.toModuleId).toBe('apim');
     });
 
-    it('builds a user registration task labelled Users with no redirect yet', () => {
+    it('builds a user registration task without a deep link until approval UI exists', () => {
         const entity: TaskEntity = {
             type: 'USER_REGISTRATION_APPROVAL',
             created_at: 1,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -53,6 +53,10 @@ jest.mock('../pages/ApplicationsPage', () => ({
     ApplicationsPage: () => <div data-testid="applications-page" />,
 }));
 
+jest.mock('../pages/UsersPage', () => ({
+    UsersPage: () => <div data-testid="users-page" />,
+}));
+
 jest.mock('../pages/RegisterApplicationPage', () => ({
     RegisterApplicationPage: () => <div data-testid="register-application-page" />,
 }));
@@ -76,5 +80,15 @@ describe('AppRoutes', () => {
 
         expect(screen.getByTestId('platform-toaster')).not.toBeNull();
         expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('routes to the Users page under the platform module', () => {
+        render(
+            <MemoryRouter initialEntries={['/users']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('users-page')).not.toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -26,6 +26,7 @@ import { NAV_GROUPS } from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
 import { SecurityPlanTypesPage } from '../features/security-plan-types/SecurityPlanTypesPage';
+import { ORGANIZATION_USER_ACCESS_PERMISSIONS } from '../features/users/utils/userPermissions';
 import { AccessManagementPage } from '../pages/AccessManagementPage';
 import { ApplicationDetailSubscriptionPage } from '../pages/ApplicationDetailSubscriptionPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
@@ -33,6 +34,7 @@ import { DictionariesPage } from '../pages/DictionariesPage';
 import { DictionaryDetailPage } from '../pages/DictionaryDetailPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
+import { UsersPage } from '../pages/UsersPage';
 import { retryTransientRequest } from '../shared/api/queryRetry';
 import { ConsoleSettingsProvider } from '../shared/console-settings';
 import { useHasPermission } from '../shared/gamma-modules-sdk';
@@ -47,19 +49,40 @@ const queryClient = new QueryClient({
 
 const APPLICATION_DETAIL_TABS = flattenApplicationDetailNavItems(APPLICATION_NAV_GROUPS);
 
+function resolveRequiredPermissions(permission?: string, anyOf?: readonly string[]): readonly string[] {
+    if (anyOf) {
+        return anyOf;
+    }
+    if (permission) {
+        return [permission];
+    }
+    return [];
+}
+
 function PermissionPageGuard({
     permission,
+    anyOf,
     unauthorizedTo = 'applications',
     children,
-}: Readonly<{ permission: string; unauthorizedTo?: string; children: ReactElement }>) {
+}: Readonly<{ permission?: string; anyOf?: readonly string[]; unauthorizedTo?: string; children: ReactElement }>) {
+    const required = resolveRequiredPermissions(permission, anyOf);
     const permissionsReady = useEnvironmentPermissionsReady();
-    const canRead = useHasPermission({ anyOf: [permission] });
+    const canAccess = useHasPermission({ anyOf: [...required] });
     if (!permissionsReady) return null;
-    if (!canRead) return <Navigate to={unauthorizedTo} replace />;
+    if (!canAccess) return <Navigate to={unauthorizedTo} replace />;
     return children;
 }
 
-function isNavItemVisible(itemKey: string, permissionsReady: boolean, canReadMetadata: boolean, canReadDictionaries: boolean): boolean {
+function isNavItemVisible(
+    itemKey: string,
+    permissionsReady: boolean,
+    canReadMetadata: boolean,
+    canReadDictionaries: boolean,
+    canAccessUsers: boolean,
+): boolean {
+    if (itemKey === 'users') {
+        return !permissionsReady || canAccessUsers;
+    }
     if (itemKey === 'metadata') {
         return !permissionsReady || canReadMetadata;
     }
@@ -75,6 +98,7 @@ function ModuleLayout() {
     const permissionsReady = useEnvironmentPermissionsReady();
     const canReadMetadata = useHasPermission({ anyOf: ['environment-metadata-r'] });
     const canReadDictionaries = useHasPermission({ anyOf: ['environment-dictionary-r'] });
+    const canAccessUsers = useHasPermission({ anyOf: [...ORGANIZATION_USER_ACCESS_PERMISSIONS] });
 
     const navigate = useNavigate();
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
@@ -83,9 +107,11 @@ function ModuleLayout() {
         () =>
             NAV_GROUPS.map(group => ({
                 ...group,
-                items: group.items.filter(item => isNavItemVisible(item.key, permissionsReady, canReadMetadata, canReadDictionaries)),
+                items: group.items.filter(item =>
+                    isNavItemVisible(item.key, permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers),
+                ),
             })).filter(group => group.items.length > 0),
-        [permissionsReady, canReadMetadata, canReadDictionaries],
+        [permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers],
     );
 
     const breadcrumbs = useMemo(
@@ -126,6 +152,14 @@ export function AppRoutes() {
                             </Route>
                         </Route>
                         <Route path="access-management" element={<AccessManagementPage />} />
+                        <Route
+                            path="users"
+                            element={
+                                <PermissionPageGuard anyOf={ORGANIZATION_USER_ACCESS_PERMISSIONS}>
+                                    <UsersPage />
+                                </PermissionPageGuard>
+                            }
+                        />
                         <Route
                             path="metadata"
                             element={

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NAV_GROUPS } from './navigation';
+import { PLATFORM_ROUTE_CONFIG, ROUTES } from './routes';
+
+describe('platform navigation config', () => {
+    it('registers Users under Identity & Access', () => {
+        const identityGroup = NAV_GROUPS.find(group => group.label === 'Identity & Access');
+        expect(identityGroup).toBeDefined();
+        expect(identityGroup?.items.map(item => item.key)).toEqual(['users']);
+        expect(identityGroup?.items[0]?.title).toBe('Users');
+        expect(identityGroup?.items[0]?.icon).toBeUndefined();
+    });
+
+    it('declares the users route in platform routing config', () => {
+        expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('users');
+        expect(ROUTES.users).toEqual({ path: 'users', label: 'Users' });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -24,6 +24,10 @@ export const NAV_GROUPS: NavGroup[] = [
         items: [{ key: 'applications', title: ROUTES.applications.label, icon: AppWindowIcon }],
     },
     {
+        label: 'Identity & Access',
+        items: [{ key: 'users', title: ROUTES.users.label }],
+    },
+    {
         label: 'APIs & Assets',
         items: [
             { key: 'metadata', title: ROUTES.metadata.label, icon: DatabaseIcon },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -15,13 +15,21 @@
  */
 import type { ModuleRouteConfig } from '@gravitee/gamma-modules-sdk/routing';
 
-export const ROUTE_KEYS: readonly string[] = ['applications', 'access-management', 'metadata', 'dictionaries', 'security-plan-types'];
+export const ROUTE_KEYS: readonly string[] = [
+    'applications',
+    'users',
+    'access-management',
+    'metadata',
+    'dictionaries',
+    'security-plan-types',
+];
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
 const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
 
 export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: string }> = {
     applications: { path: 'applications', label: 'Applications' },
+    users: { path: 'users', label: 'Users' },
     'access-management': { path: 'access-management', label: 'Access Management' },
     'security-plan-types': { path: 'security-plan-types', label: 'Security Plan Types' },
     metadata: { path: 'metadata', label: 'Metadata' },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/AddUserSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/AddUserSheet.spec.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { buttonHarness, inputHarness, renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AddUserSheet } from './AddUserSheet';
+import { STANDARD_SHEET_WIDTH } from '../../applications/components/sheetLayout';
+import { useIdentityProviders } from '../hooks/useOrganizationUsers';
+import { GRAVITEE_IDP } from '../types/user';
+
+jest.mock('../hooks/useOrganizationUsers', () => ({
+    useIdentityProviders: jest.fn(),
+}));
+
+const mockUseIdentityProviders = jest.mocked(useIdentityProviders);
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as typeof ResizeObserver;
+    Element.prototype.scrollIntoView = jest.fn();
+});
+
+describe('AddUserSheet', () => {
+    beforeEach(() => {
+        mockUseIdentityProviders.mockReturnValue({
+            data: [GRAVITEE_IDP],
+            isLoading: false,
+        } as ReturnType<typeof useIdentityProviders>);
+    });
+
+    it('renders at the standard sheet width instead of the narrower graphene default', () => {
+        renderWithGraphene(<AddUserSheet open onClose={jest.fn()} onSubmit={jest.fn()} isPending={false} />);
+
+        const content = document.querySelector('[data-slot="sheet-content"]') as HTMLElement | null;
+        expect(content).not.toBeNull();
+        expect(content?.style.maxWidth).toBe(STANDARD_SHEET_WIDTH);
+    });
+
+    it('submits a service account payload with firstname null', async () => {
+        const user = userEvent.setup();
+        const onSubmit = jest.fn();
+        renderWithGraphene(<AddUserSheet open onClose={jest.fn()} onSubmit={onSubmit} isPending={false} />);
+
+        await user.click(screen.getByRole('radio', { name: 'Service Account' }));
+        await inputHarness({ name: /Service Name/i }).type('DevOps Bot');
+        await inputHarness({ name: /^Email/i }).type('bot@company.com');
+        await buttonHarness({ name: /^Add User$/ }).click();
+
+        await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+        expect(onSubmit.mock.calls[0]?.[0]).toEqual({
+            firstname: null,
+            lastname: 'DevOps Bot',
+            email: 'bot@company.com',
+            source: 'gravitee',
+            sourceId: '',
+            service: true,
+        });
+    });
+
+    it('shows identity provider fields when multiple providers are configured', async () => {
+        mockUseIdentityProviders.mockReturnValue({
+            data: [GRAVITEE_IDP, { id: 'ldap', name: 'LDAP' }],
+            isLoading: false,
+        } as ReturnType<typeof useIdentityProviders>);
+
+        renderWithGraphene(<AddUserSheet open onClose={jest.fn()} onSubmit={jest.fn()} isPending={false} />);
+
+        expect(await screen.findByLabelText('Identity Provider')).toBeTruthy();
+    });
+
+    it('requires an identifier for non-gravitee identity providers', async () => {
+        mockUseIdentityProviders.mockReturnValue({
+            data: [GRAVITEE_IDP, { id: 'ldap', name: 'LDAP' }],
+            isLoading: false,
+        } as ReturnType<typeof useIdentityProviders>);
+
+        renderWithGraphene(<AddUserSheet open onClose={jest.fn()} onSubmit={jest.fn()} isPending={false} />);
+
+        fireEvent.click(screen.getByLabelText('Identity Provider'));
+        fireEvent.click(screen.getByRole('option', { name: 'LDAP' }));
+
+        expect(await screen.findByLabelText(/Identifier/i)).toBeTruthy();
+
+        await inputHarness({ name: /First Name/i }).type('Jane');
+        await inputHarness({ name: /Last Name/i }).type('Doe');
+        await inputHarness({ name: /^Email/i }).type('jane@company.com');
+
+        const addUserButton = screen.getByRole('button', { name: /^Add User$/ }) as HTMLButtonElement;
+        expect(addUserButton.disabled).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/AddUserSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/AddUserSheet.tsx
@@ -1,0 +1,323 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Field,
+    FieldLabel,
+    Input,
+    ScrollArea,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+    ToggleGroup,
+    ToggleGroupItem,
+} from '@gravitee/graphene-core';
+import { BotIcon, UserIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+
+import { STANDARD_SHEET_WIDTH } from '../../applications/components/sheetLayout';
+import { useIdentityProviders } from '../hooks/useOrganizationUsers';
+import type { NewPreRegisterUserPayload, UserType } from '../types/user';
+import { GRAVITEE_IDP } from '../types/user';
+import { sanitizeTextInput } from '../utils/userDisplay';
+import { applyUserTypeChange, isAddUserFormValid, resolvePreRegisterUserSource } from '../utils/userFormValidation';
+
+interface UserFormState {
+    type: UserType;
+    firstName: string;
+    lastName: string;
+    email: string;
+    source: string;
+    sourceId: string;
+}
+
+const EMPTY_FORM: UserFormState = {
+    type: 'EXTERNAL_USER',
+    firstName: '',
+    lastName: '',
+    email: '',
+    source: GRAVITEE_IDP.id,
+    sourceId: '',
+};
+
+interface AddUserSheetProps {
+    readonly open: boolean;
+    readonly onClose: () => void;
+    readonly onSubmit: (payload: NewPreRegisterUserPayload) => void;
+    readonly isPending: boolean;
+    readonly serverEmailError?: string | null;
+}
+
+export function AddUserSheet({ open, onClose, onSubmit, isPending, serverEmailError = null }: AddUserSheetProps) {
+    const { data: identityProviders = [GRAVITEE_IDP], isLoading: idpLoading } = useIdentityProviders();
+    const [form, setForm] = useState<UserFormState>(EMPTY_FORM);
+    const [emailError, setEmailError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!open) return;
+        setForm(EMPTY_FORM);
+        setEmailError(null);
+    }, [open]);
+
+    useEffect(() => {
+        if (serverEmailError) {
+            setEmailError(serverEmailError);
+        }
+    }, [serverEmailError]);
+
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    function setField<K extends keyof UserFormState>(key: K, value: UserFormState[K]) {
+        setForm(prev => ({ ...prev, [key]: value }));
+        if (key === 'email' && emailError) {
+            setEmailError(null);
+        }
+    }
+
+    const showIdentityProviderFields = identityProviders.length > 1;
+    const isServiceAccount = form.type === 'SERVICE_ACCOUNT';
+    const identityProvidersReady = !idpLoading;
+
+    const isValid = isAddUserFormValid(form, { showIdentityProviderFields, identityProvidersReady });
+
+    function buildPayload(): NewPreRegisterUserPayload {
+        const email = form.email.trim();
+        const source = resolvePreRegisterUserSource(isServiceAccount, showIdentityProviderFields, form.source);
+        return {
+            firstname: isServiceAccount ? null : sanitizeTextInput(form.firstName),
+            lastname: sanitizeTextInput(form.lastName),
+            email: email || undefined,
+            source,
+            sourceId: !isServiceAccount && form.source !== GRAVITEE_IDP.id ? form.sourceId.trim() : '',
+            service: isServiceAccount,
+        };
+    }
+
+    function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        if (!isValid || isPending) return;
+        onSubmit(buildPayload());
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: STANDARD_SHEET_WIDTH }}>
+                <SheetHeader>
+                    <SheetTitle>Add User</SheetTitle>
+                    <SheetDescription>
+                        Pre-register a new user or service account. They will receive an email to set their password.
+                    </SheetDescription>
+                </SheetHeader>
+
+                <ScrollArea className="flex-1 min-h-0">
+                    <form id="add-user-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-1 py-4">
+                        <Field orientation="vertical" className="gap-2">
+                            <FieldLabel>User type</FieldLabel>
+                            <ToggleGroup
+                                type="single"
+                                value={form.type}
+                                onValueChange={value => {
+                                    if (value) setForm(prev => applyUserTypeChange(prev, value as UserType));
+                                }}
+                                className="grid grid-cols-2 gap-2"
+                                disabled={isPending}
+                            >
+                                <ToggleGroupItem
+                                    value="EXTERNAL_USER"
+                                    className="h-auto flex-col gap-2 py-4 data-[state=on]:border-primary"
+                                >
+                                    <UserIcon className="size-5" aria-hidden />
+                                    <span>External User</span>
+                                </ToggleGroupItem>
+                                <ToggleGroupItem
+                                    value="SERVICE_ACCOUNT"
+                                    className="h-auto flex-col gap-2 py-4 data-[state=on]:border-primary"
+                                >
+                                    <BotIcon className="size-5" aria-hidden />
+                                    <span>Service Account</span>
+                                </ToggleGroupItem>
+                            </ToggleGroup>
+                        </Field>
+
+                        {!isServiceAccount ? (
+                            <>
+                                <Field orientation="vertical" className="gap-1.5">
+                                    <FieldLabel htmlFor="user-first-name">
+                                        First Name{' '}
+                                        <span className="text-destructive" aria-hidden>
+                                            *
+                                        </span>
+                                    </FieldLabel>
+                                    <Input
+                                        id="user-first-name"
+                                        value={form.firstName}
+                                        onChange={e => setField('firstName', e.target.value)}
+                                        placeholder="Jane"
+                                        disabled={isPending}
+                                        required
+                                    />
+                                </Field>
+
+                                <Field orientation="vertical" className="gap-1.5">
+                                    <FieldLabel htmlFor="user-last-name">
+                                        Last Name{' '}
+                                        <span className="text-destructive" aria-hidden>
+                                            *
+                                        </span>
+                                    </FieldLabel>
+                                    <Input
+                                        id="user-last-name"
+                                        value={form.lastName}
+                                        onChange={e => setField('lastName', e.target.value)}
+                                        placeholder="Doe"
+                                        disabled={isPending}
+                                        required
+                                    />
+                                </Field>
+
+                                <Field orientation="vertical" className="gap-1.5">
+                                    <FieldLabel htmlFor="user-email">
+                                        Email{' '}
+                                        <span className="text-destructive" aria-hidden>
+                                            *
+                                        </span>
+                                    </FieldLabel>
+                                    <Input
+                                        id="user-email"
+                                        type="email"
+                                        value={form.email}
+                                        onChange={e => setField('email', e.target.value)}
+                                        placeholder="jane@company.com"
+                                        disabled={isPending}
+                                        required
+                                        aria-invalid={emailError !== null}
+                                        aria-describedby={emailError ? 'user-email-error' : undefined}
+                                    />
+                                    {emailError ? (
+                                        <p id="user-email-error" className="text-sm text-destructive" role="alert">
+                                            {emailError}
+                                        </p>
+                                    ) : null}
+                                </Field>
+                            </>
+                        ) : (
+                            <>
+                                <Field orientation="vertical" className="gap-1.5">
+                                    <FieldLabel htmlFor="service-name">
+                                        Service Name{' '}
+                                        <span className="text-destructive" aria-hidden>
+                                            *
+                                        </span>
+                                    </FieldLabel>
+                                    <Input
+                                        id="service-name"
+                                        value={form.lastName}
+                                        onChange={e => setField('lastName', e.target.value)}
+                                        disabled={isPending}
+                                        required
+                                    />
+                                    <p className="text-xs text-muted-foreground">Choose a meaningful name for your service account.</p>
+                                </Field>
+
+                                <Field orientation="vertical" className="gap-1.5">
+                                    <FieldLabel htmlFor="service-email">Email</FieldLabel>
+                                    <Input
+                                        id="service-email"
+                                        type="email"
+                                        value={form.email}
+                                        onChange={e => setField('email', e.target.value)}
+                                        disabled={isPending}
+                                        aria-invalid={emailError !== null}
+                                        aria-describedby={emailError ? 'service-email-error' : undefined}
+                                    />
+                                    {emailError ? (
+                                        <p id="service-email-error" className="text-sm text-destructive" role="alert">
+                                            {emailError}
+                                        </p>
+                                    ) : null}
+                                </Field>
+                            </>
+                        )}
+
+                        {showIdentityProviderFields && !isServiceAccount ? (
+                            <>
+                                <Field orientation="vertical" className="gap-1.5">
+                                    <FieldLabel htmlFor="user-source">Identity Provider</FieldLabel>
+                                    <Select
+                                        value={form.source}
+                                        onValueChange={value => setField('source', value)}
+                                        disabled={isPending || idpLoading}
+                                    >
+                                        <SelectTrigger id="user-source">
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {identityProviders.map(idp => (
+                                                <SelectItem key={idp.id} value={idp.id}>
+                                                    {idp.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </Field>
+
+                                {form.source !== GRAVITEE_IDP.id ? (
+                                    <Field orientation="vertical" className="gap-1.5">
+                                        <FieldLabel htmlFor="user-source-id">
+                                            Identifier{' '}
+                                            <span className="text-destructive" aria-hidden>
+                                                *
+                                            </span>
+                                        </FieldLabel>
+                                        <Input
+                                            id="user-source-id"
+                                            value={form.sourceId}
+                                            onChange={e => setField('sourceId', e.target.value)}
+                                            disabled={isPending}
+                                            required
+                                        />
+                                    </Field>
+                                ) : null}
+                            </>
+                        ) : null}
+                    </form>
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-row justify-end gap-2 border-t pt-4">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>
+                        Cancel
+                    </Button>
+                    <Button type="submit" form="add-user-form" disabled={!isValid || isPending}>
+                        {isPending ? 'Adding…' : 'Add User'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserAvatar.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserAvatar.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Avatar, AvatarFallback } from '@gravitee/graphene-core';
+
+export function UserAvatar({ name }: Readonly<{ name: string }>) {
+    const initials = name
+        .split(' ')
+        .map(part => part[0] ?? '')
+        .join('')
+        .toUpperCase()
+        .slice(0, 2);
+
+    return (
+        <Avatar size="sm" className="shrink-0">
+            <AvatarFallback className="bg-primary/10 text-primary text-xs font-semibold">{initials || '?'}</AvatarFallback>
+        </Avatar>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UsersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UsersTable.tsx
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge, Button, DataTable, DataTableEmptyState, DateCell, Input } from '@gravitee/graphene-core';
+import { SearchIcon } from '@gravitee/graphene-core/icons';
+import { useId, useMemo } from 'react';
+
+import { UserAvatar } from './UserAvatar';
+import { NON_SORTABLE_COLUMN } from '../../applications/utils/dataTableHeaders';
+import type { ColCell } from '../../applications/utils/dataTableTypes';
+import type { OrganizationUser } from '../types/user';
+import { USER_LIST_PAGE_SIZE_OPTIONS } from '../utils/paginationConstants';
+import { formatRoleSummary, formatSourceLabel, formatUserStatus, statusBadgeVariant } from '../utils/userDisplay';
+
+function buildColumns() {
+    return [
+        {
+            id: 'user',
+            accessorFn: (user: OrganizationUser) => user.displayName ?? user.email ?? user.id,
+            header: 'User',
+            ...NON_SORTABLE_COLUMN,
+            cell: ({ row }: ColCell<OrganizationUser>) => {
+                const user = row.original;
+                const displayName = user.displayName ?? user.email ?? user.id;
+                return (
+                    <div className="flex items-center gap-3 min-w-0">
+                        <UserAvatar name={displayName} />
+                        <div className="min-w-0">
+                            <div className="flex flex-wrap items-center gap-2">
+                                <span className="font-medium truncate">{displayName}</span>
+                                {user.primary_owner ? (
+                                    <Badge variant="outline" className="text-xs uppercase">
+                                        Owner
+                                    </Badge>
+                                ) : null}
+                                {(user.number_of_active_tokens ?? 0) > 0 ? (
+                                    <Badge variant="warning" className="text-xs">
+                                        Active Token{user.number_of_active_tokens === 1 ? '' : 's'}
+                                    </Badge>
+                                ) : null}
+                            </div>
+                            {user.email ? <p className="text-sm text-muted-foreground truncate">{user.email}</p> : null}
+                        </div>
+                    </div>
+                );
+            },
+        },
+        {
+            id: 'status',
+            accessorFn: (user: OrganizationUser) => user.status ?? '',
+            header: 'Status',
+            ...NON_SORTABLE_COLUMN,
+            cell: ({ row }: ColCell<OrganizationUser>) => (
+                <Badge variant={statusBadgeVariant(row.original.status)}>{formatUserStatus(row.original.status)}</Badge>
+            ),
+        },
+        {
+            id: 'source',
+            accessorFn: (user: OrganizationUser) => user.source ?? '',
+            header: 'Source',
+            ...NON_SORTABLE_COLUMN,
+            cell: ({ row }: ColCell<OrganizationUser>) => (
+                <Badge variant="outline" className="font-normal">
+                    {formatSourceLabel(row.original.source)}
+                </Badge>
+            ),
+        },
+        {
+            id: 'roles',
+            accessorFn: (user: OrganizationUser) => formatRoleSummary(user.roles),
+            header: 'Roles',
+            ...NON_SORTABLE_COLUMN,
+            cell: ({ row }: ColCell<OrganizationUser>) => (
+                <span className="text-sm text-muted-foreground">{formatRoleSummary(row.original.roles)}</span>
+            ),
+        },
+        {
+            id: 'lastActivity',
+            accessorFn: (user: OrganizationUser) => user.lastConnectionAt ?? 0,
+            header: 'Last Login',
+            ...NON_SORTABLE_COLUMN,
+            cell: ({ row }: ColCell<OrganizationUser>) => {
+                const lastConnectionAt = row.original.lastConnectionAt;
+                if (!lastConnectionAt) {
+                    return <span className="text-sm text-muted-foreground">Never</span>;
+                }
+                return <DateCell value={new Date(lastConnectionAt)} />;
+            },
+        },
+    ];
+}
+
+interface UsersTableProps {
+    readonly users: OrganizationUser[];
+    readonly totalCount: number;
+    readonly loading: boolean;
+    readonly isFirstUse: boolean;
+    readonly search: string;
+    readonly page: number;
+    readonly pageSize: number;
+    readonly onSearchChange: (value: string) => void;
+    readonly onPageChange: (page: number) => void;
+    readonly onPageSizeChange: (size: number) => void;
+    readonly onAddUser?: () => void;
+}
+
+export function UsersTable({
+    users,
+    totalCount,
+    loading,
+    isFirstUse,
+    search,
+    page,
+    pageSize,
+    onSearchChange,
+    onPageChange,
+    onPageSizeChange,
+    onAddUser,
+}: UsersTableProps) {
+    const searchInputId = useId();
+    const columns = useMemo(() => buildColumns(), []);
+
+    if (isFirstUse) {
+        return (
+            <div className="rounded-lg border">
+                <DataTableEmptyState
+                    variant="first-use"
+                    icon={<SearchIcon className="size-8" aria-hidden />}
+                    title="No users yet"
+                    description="Get started by inviting your first team member."
+                    primaryAction={onAddUser ? <Button onClick={onAddUser}>Add User</Button> : undefined}
+                />
+            </div>
+        );
+    }
+
+    return (
+        <DataTable
+            columns={columns}
+            data={users}
+            loading={loading}
+            skeletonCount={pageSize}
+            serverSide
+            pagination={{
+                page,
+                pageSize,
+                totalCount,
+                pageSizeOptions: [...USER_LIST_PAGE_SIZE_OPTIONS],
+                onPageChange,
+                onPageSizeChange: size => {
+                    onPageSizeChange(size);
+                    onPageChange(1);
+                },
+            }}
+            emptyMessage={
+                <DataTableEmptyState
+                    variant="no-results"
+                    icon={<SearchIcon className="size-8" aria-hidden />}
+                    title="No users match your search"
+                    description="Try adjusting your search terms."
+                    action={
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => {
+                                onSearchChange('');
+                                onPageChange(1);
+                            }}
+                        >
+                            Clear search
+                        </Button>
+                    }
+                />
+            }
+            toolbar={
+                <div className="relative w-64">
+                    <SearchIcon
+                        className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none"
+                        aria-hidden
+                    />
+                    <label htmlFor={searchInputId} className="sr-only">
+                        Search users
+                    </label>
+                    <Input
+                        id={searchInputId}
+                        placeholder="Search by name, email, or ID..."
+                        value={search}
+                        onChange={e => onSearchChange(e.target.value)}
+                        className="h-8 w-64 pl-9"
+                    />
+                </div>
+            }
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useOrganizationUsers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useOrganizationUsers.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { listIdentityProviders, listOrganizationUsers } from '../services/organizationUsers';
+import { GRAVITEE_IDP } from '../types/user';
+import { organizationUserKeys } from '../utils/queryKeys';
+
+export function useOrganizationUsers({ query, page, size }: { query: string; page: number; size: number }) {
+    return useQuery({
+        queryKey: organizationUserKeys.list(query, page, size),
+        queryFn: () => listOrganizationUsers({ query, page, size }),
+        staleTime: 30_000,
+        placeholderData: keepPreviousData,
+    });
+}
+
+export function useIdentityProviders() {
+    return useQuery({
+        queryKey: organizationUserKeys.identityProviders(),
+        queryFn: async () => {
+            const providers = await listIdentityProviders();
+            return [GRAVITEE_IDP, ...providers];
+        },
+        staleTime: 60_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useUserMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useUserMutations.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { createOrganizationUser } from '../services/organizationUsers';
+import type { NewPreRegisterUserPayload } from '../types/user';
+import { organizationUserKeys } from '../utils/queryKeys';
+
+export function useCreateOrganizationUser() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (payload: NewPreRegisterUserPayload) => createOrganizationUser(payload),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: organizationUserKeys.all });
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createOrganizationUser, listIdentityProviders, listOrganizationUsers } from './organizationUsers';
+import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonOrg: jest.fn(),
+}));
+
+const mockApimFetchJsonOrg = jest.mocked(apimFetchJsonOrg);
+
+describe('organizationUsers service', () => {
+    beforeEach(() => {
+        mockApimFetchJsonOrg.mockReset();
+    });
+
+    it('lists organization users with pagination and the search query sent verbatim', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue({ data: [], page: { total_elements: 0 } });
+
+        await listOrganizationUsers({ query: 'jane@company.com', page: 2, size: 50 });
+
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users?page=2&size=50&q=jane%40company.com');
+    });
+
+    it('omits the query parameter when the search term is blank', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue({ data: [], page: { total_elements: 0 } });
+
+        await listOrganizationUsers({ query: '   ', page: 1, size: 10 });
+
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users?page=1&size=10');
+    });
+
+    it('creates an organization user via POST', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue({ id: 'user-1' });
+
+        await createOrganizationUser({
+            firstname: 'Jane',
+            lastname: 'Doe',
+            email: 'jane@company.com',
+            source: 'gravitee',
+            sourceId: '',
+            service: false,
+        });
+
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users', {
+            method: 'POST',
+            body: JSON.stringify({
+                firstname: 'Jane',
+                lastname: 'Doe',
+                email: 'jane@company.com',
+                source: 'gravitee',
+                sourceId: '',
+                service: false,
+            }),
+        });
+    });
+
+    it('loads identity providers from organization configuration', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue([{ id: 'ldap', name: 'LDAP' }]);
+
+        await expect(listIdentityProviders()).resolves.toEqual([{ id: 'ldap', name: 'LDAP' }]);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/identities');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
+import type { IdentityProviderListItem, NewPreRegisterUserPayload, OrganizationUser, OrganizationUserListResponse } from '../types/user';
+
+export async function listOrganizationUsers(params: { query: string; page: number; size: number }): Promise<OrganizationUserListResponse> {
+    const searchParams = new URLSearchParams();
+    searchParams.set('page', String(params.page));
+    searchParams.set('size', String(params.size));
+    // Sent verbatim: the backend truncates at the first '@' so full email addresses still match.
+    const q = params.query.trim();
+    if (q) {
+        searchParams.set('q', q);
+    }
+    return apimFetchJsonOrg<OrganizationUserListResponse>(`/users?${searchParams.toString()}`);
+}
+
+export async function createOrganizationUser(payload: NewPreRegisterUserPayload): Promise<OrganizationUser> {
+    return apimFetchJsonOrg<OrganizationUser>('/users', { method: 'POST', body: JSON.stringify(payload) });
+}
+
+export async function listIdentityProviders(): Promise<IdentityProviderListItem[]> {
+    return apimFetchJsonOrg<IdentityProviderListItem[]>('/configuration/identities');
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/types/user.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/types/user.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export type UserStatus = 'ACTIVE' | 'PENDING' | 'REJECTED' | 'ARCHIVED';
+
+export interface UserRole {
+    id?: string;
+    name?: string;
+    scope?: 'API' | 'APPLICATION' | 'GROUP' | 'ENVIRONMENT' | 'ORGANIZATION' | 'PLATFORM';
+    permissions?: Record<string, string[]>;
+}
+
+export interface OrganizationUser {
+    id: string;
+    firstname?: string;
+    lastname?: string;
+    displayName?: string;
+    email?: string;
+    roles?: UserRole[];
+    source?: string;
+    sourceId?: string;
+    lastConnectionAt?: number;
+    status?: UserStatus | string;
+    primary_owner?: boolean;
+    number_of_active_tokens?: number;
+    isServiceAccount?: boolean;
+}
+
+export interface UserPageMeta {
+    current: number;
+    size: number;
+    per_page: number;
+    total_pages: number;
+    total_elements: number;
+}
+
+export interface OrganizationUserListResponse {
+    data: OrganizationUser[];
+    metadata?: Record<string, Record<string, unknown>>;
+    page: UserPageMeta;
+}
+
+export interface NewPreRegisterUserPayload {
+    firstname?: string | null;
+    lastname?: string;
+    email?: string;
+    source?: string;
+    sourceId?: string;
+    service?: boolean;
+}
+
+export interface IdentityProviderListItem {
+    id: string;
+    name: string;
+}
+
+export type UserType = 'EXTERNAL_USER' | 'SERVICE_ACCOUNT';
+
+export const GRAVITEE_IDP: IdentityProviderListItem = { id: 'gravitee', name: 'Gravitee' };

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/paginationConstants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/paginationConstants.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const DEFAULT_USER_LIST_PAGE_SIZE = 10;
+
+export const USER_LIST_PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
+
+export const USER_SEARCH_DEBOUNCE_MS = 300;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/queryKeys.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const organizationUserKeys = {
+    all: ['organization-users'] as const,
+    list: (query: string, page: number, size: number) => [...organizationUserKeys.all, 'list', query, page, size] as const,
+    identityProviders: () => [...organizationUserKeys.all, 'identity-providers'] as const,
+};

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    formatSourceLabel,
+    formatUserStatus,
+    isDuplicateUserError,
+    isValidEmail,
+    sanitizeTextInput,
+    statusBadgeVariant,
+} from './userDisplay';
+
+describe('userDisplay utilities', () => {
+    it('sanitizes HTML from text inputs', () => {
+        expect(sanitizeTextInput('<b>Jane</b>')).toBe('Jane');
+    });
+
+    it('accepts well-formed emails and rejects malformed ones', () => {
+        expect(isValidEmail('jane@company.com')).toBe(true);
+        expect(isValidEmail('jane@company')).toBe(false);
+    });
+
+    it('labels the archived status as deletion in progress', () => {
+        expect(formatUserStatus('ARCHIVED')).toBe('Deletion In Progress');
+        expect(formatUserStatus('ACTIVE')).toBe('Active');
+        expect(formatUserStatus(undefined)).toBe('Unknown');
+    });
+
+    it('maps user status to a badge variant', () => {
+        expect(statusBadgeVariant('ACTIVE')).toBe('success');
+        expect(statusBadgeVariant('PENDING')).toBe('warning');
+        expect(statusBadgeVariant('REJECTED')).toBe('destructive');
+        expect(statusBadgeVariant('SOMETHING_ELSE')).toBe('secondary');
+    });
+
+    it('formats the identity provider source label', () => {
+        expect(formatSourceLabel('gravitee')).toBe('Gravitee');
+        expect(formatSourceLabel('ldap')).toBe('LDAP');
+        expect(formatSourceLabel('openid-provider')).toBe('OpenID Provider');
+        expect(formatSourceLabel(undefined)).toBe('—');
+    });
+
+    it('detects duplicate-user API errors without matching unrelated messages', () => {
+        expect(isDuplicateUserError('User cannot be created.')).toBe(true);
+        expect(isDuplicateUserError('A user [jane@company.com] already exists for organization DEFAULT.')).toBe(true);
+        expect(isDuplicateUserError('A dictionary with name [Airport IATA Codes] already exists in this environment.')).toBe(false);
+        expect(isDuplicateUserError('Member already exists')).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** Strips HTML tags from user-provided name fields before submit. */
+export function sanitizeTextInput(value: string): string {
+    return value.replace(/<[^>]*>/g, '').trim();
+}
+
+const EMAIL_REGEX =
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+export function isValidEmail(value: string): boolean {
+    return EMAIL_REGEX.test(value.trim());
+}
+
+export function formatRoleSummary(roles: { name?: string; scope?: string }[] | undefined): string {
+    if (!roles?.length) {
+        return '—';
+    }
+    const names = roles.map(role => role.name).filter((name): name is string => Boolean(name));
+    return names.length > 0 ? names.join(', ') : '—';
+}
+
+export function formatUserStatus(status: string | undefined): string {
+    if (!status) {
+        return 'Unknown';
+    }
+    const normalized = status.toUpperCase();
+    if (normalized === 'ARCHIVED') {
+        return 'Deletion In Progress';
+    }
+    return normalized.charAt(0) + normalized.slice(1).toLowerCase();
+}
+
+export type StatusBadgeVariant = 'success' | 'warning' | 'destructive' | 'secondary';
+
+export function statusBadgeVariant(status: string | undefined): StatusBadgeVariant {
+    switch (status?.toUpperCase()) {
+        case 'ACTIVE':
+            return 'success';
+        case 'PENDING':
+        case 'ARCHIVED':
+            return 'warning';
+        case 'REJECTED':
+            return 'destructive';
+        default:
+            return 'secondary';
+    }
+}
+
+const KNOWN_IDP_LABELS: Record<string, string> = {
+    gravitee: 'Gravitee',
+    memory: 'Memory',
+    ldap: 'LDAP',
+    oidc: 'OIDC',
+    'openid-provider': 'OpenID Provider',
+};
+
+export function formatSourceLabel(source: string | undefined): string {
+    if (!source) {
+        return '—';
+    }
+    const known = KNOWN_IDP_LABELS[source.toLowerCase()];
+    if (known) {
+        return known;
+    }
+    if (source.includes('-')) {
+        return source
+            .split('-')
+            .map(part => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+            .join(' ');
+    }
+    return source.charAt(0).toUpperCase() + source.slice(1);
+}
+
+export function isDuplicateUserError(message: string): boolean {
+    const lower = message.toLowerCase();
+    return lower.includes('user cannot be created') || lower.includes('already exists for organization');
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userFormValidation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userFormValidation.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { applyUserTypeChange, isAddUserFormValid, resolvePreRegisterUserSource } from './userFormValidation';
+import { GRAVITEE_IDP } from '../types/user';
+
+const baseForm = {
+    type: 'EXTERNAL_USER' as const,
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane@company.com',
+    source: GRAVITEE_IDP.id,
+    sourceId: '',
+};
+
+describe('isAddUserFormValid', () => {
+    it('accepts a valid external user', () => {
+        expect(isAddUserFormValid(baseForm, { showIdentityProviderFields: false, identityProvidersReady: true })).toBe(true);
+    });
+
+    it('accepts a service account with email', () => {
+        expect(
+            isAddUserFormValid(
+                { ...baseForm, type: 'SERVICE_ACCOUNT', firstName: '', lastName: 'Bat-AI', email: 'bot@company.com' },
+                { showIdentityProviderFields: true, identityProvidersReady: true },
+            ),
+        ).toBe(true);
+    });
+
+    it('accepts a service account without email', () => {
+        expect(
+            isAddUserFormValid(
+                { ...baseForm, type: 'SERVICE_ACCOUNT', firstName: '', lastName: 'Bat-AI', email: '' },
+                { showIdentityProviderFields: true, identityProvidersReady: true },
+            ),
+        ).toBe(true);
+    });
+
+    it('does not require identity provider fields for service accounts', () => {
+        expect(
+            isAddUserFormValid(
+                {
+                    ...baseForm,
+                    type: 'SERVICE_ACCOUNT',
+                    firstName: '',
+                    lastName: 'service11',
+                    email: 'service11@gmail.com',
+                    source: 'ldap',
+                    sourceId: '',
+                },
+                { showIdentityProviderFields: true, identityProvidersReady: true },
+            ),
+        ).toBe(true);
+    });
+
+    it('requires identifier for external users with a non-gravitee provider', () => {
+        expect(
+            isAddUserFormValid(
+                { ...baseForm, source: 'ldap', sourceId: '' },
+                { showIdentityProviderFields: true, identityProvidersReady: true },
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('applyUserTypeChange', () => {
+    it('clears identity provider state when switching to service account', () => {
+        expect(applyUserTypeChange({ ...baseForm, source: 'ldap', sourceId: 'ldap-user-1' }, 'SERVICE_ACCOUNT')).toEqual({
+            ...baseForm,
+            type: 'SERVICE_ACCOUNT',
+            firstName: '',
+            source: GRAVITEE_IDP.id,
+            sourceId: '',
+        });
+    });
+});
+
+describe('resolvePreRegisterUserSource', () => {
+    it('uses gravitee for service accounts', () => {
+        expect(resolvePreRegisterUserSource(true, true, 'ldap')).toBe(GRAVITEE_IDP.id);
+    });
+
+    it('uses the selected source when multiple identity providers are shown', () => {
+        expect(resolvePreRegisterUserSource(false, true, 'ldap')).toBe('ldap');
+    });
+
+    it('uses gravitee when identity provider fields are hidden', () => {
+        expect(resolvePreRegisterUserSource(false, false, 'ldap')).toBe(GRAVITEE_IDP.id);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userFormValidation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userFormValidation.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isValidEmail } from './userDisplay';
+import type { UserType } from '../types/user';
+import { GRAVITEE_IDP } from '../types/user';
+
+export interface AddUserFormValues {
+    type: UserType;
+    firstName: string;
+    lastName: string;
+    email: string;
+    source: string;
+    sourceId: string;
+}
+
+export function isAddUserFormValid(
+    form: AddUserFormValues,
+    options: { showIdentityProviderFields: boolean; identityProvidersReady: boolean },
+): boolean {
+    const isServiceAccount = form.type === 'SERVICE_ACCOUNT';
+    const lastNameValid = form.lastName.trim().length > 0;
+
+    if (isServiceAccount) {
+        const emailValue = form.email.trim();
+        const emailValid = emailValue === '' || isValidEmail(emailValue);
+        return lastNameValid && emailValid;
+    }
+
+    const firstNameValid = form.firstName.trim().length > 0;
+    const emailValue = form.email.trim();
+    const emailValid = emailValue.length > 0 && isValidEmail(emailValue);
+    const sourceIdValid =
+        !options.showIdentityProviderFields ||
+        !options.identityProvidersReady ||
+        form.source === GRAVITEE_IDP.id ||
+        form.sourceId.trim().length > 0;
+
+    return lastNameValid && firstNameValid && emailValid && sourceIdValid;
+}
+
+export function resolvePreRegisterUserSource(
+    isServiceAccount: boolean,
+    showIdentityProviderFields: boolean,
+    selectedSource: string,
+): string {
+    if (isServiceAccount || !showIdentityProviderFields) {
+        return GRAVITEE_IDP.id;
+    }
+    return selectedSource;
+}
+
+/** Resets identity-provider fields when switching to service account (classic console parity). */
+export function applyUserTypeChange(form: AddUserFormValues, nextType: UserType): AddUserFormValues {
+    if (nextType === form.type) {
+        return form;
+    }
+    if (nextType === 'SERVICE_ACCOUNT') {
+        return {
+            ...form,
+            type: nextType,
+            firstName: '',
+            source: GRAVITEE_IDP.id,
+            sourceId: '',
+        };
+    }
+    return { ...form, type: nextType };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userPermissions.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userPermissions.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    ORGANIZATION_USER_ACCESS_PERMISSIONS,
+    ORGANIZATION_USER_CREATE_PERMISSION,
+    ORGANIZATION_USER_DELETE_PERMISSION,
+    ORGANIZATION_USER_UPDATE_PERMISSION,
+} from './userPermissions';
+
+describe('userPermissions', () => {
+    it('matches classic list and navigation access permissions', () => {
+        expect(ORGANIZATION_USER_ACCESS_PERMISSIONS).toEqual([
+            'organization-user-c',
+            'organization-user-r',
+            'organization-user-u',
+            'organization-user-d',
+        ]);
+    });
+
+    it('matches classic create, update, and delete permission keys', () => {
+        expect(ORGANIZATION_USER_CREATE_PERMISSION).toBe('organization-user-c');
+        expect(ORGANIZATION_USER_UPDATE_PERMISSION).toBe('organization-user-u');
+        expect(ORGANIZATION_USER_DELETE_PERMISSION).toBe('organization-user-d');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userPermissions.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Mirrors org-settings-users route + organization-navigation Users menu in classic console. */
+export const ORGANIZATION_USER_ACCESS_PERMISSIONS = [
+    'organization-user-c',
+    'organization-user-r',
+    'organization-user-u',
+    'organization-user-d',
+] as const;
+
+export const ORGANIZATION_USER_CREATE_PERMISSION = 'organization-user-c' as const;
+
+export const ORGANIZATION_USER_DELETE_PERMISSION = 'organization-user-d' as const;
+
+export const ORGANIZATION_USER_UPDATE_PERMISSION = 'organization-user-u' as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UsersPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UsersPage.spec.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { buttonHarness, inputHarness, renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+
+import { UsersPage } from './UsersPage';
+import { useOrganizationUsers } from '../features/users/hooks/useOrganizationUsers';
+import { useCreateOrganizationUser } from '../features/users/hooks/useUserMutations';
+import type { OrganizationUser } from '../features/users/types/user';
+import { notify } from '../shared/notify';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+
+jest.mock('../features/users/hooks/useOrganizationUsers', () => ({
+    useOrganizationUsers: jest.fn(),
+    useIdentityProviders: jest.fn().mockReturnValue({ data: [{ id: 'gravitee', name: 'Gravitee' }], isLoading: false }),
+}));
+
+jest.mock('../features/users/hooks/useUserMutations', () => ({
+    useCreateOrganizationUser: jest.fn(),
+}));
+
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseOrganizationUsers = jest.mocked(useOrganizationUsers);
+const mockUseCreateOrganizationUser = jest.mocked(useCreateOrganizationUser);
+
+const SAMPLE_USERS: OrganizationUser[] = [
+    {
+        id: 'user-1',
+        displayName: 'Jane Doe',
+        email: 'jane@company.com',
+        status: 'ACTIVE',
+        source: 'gravitee',
+        roles: [{ name: 'User', scope: 'ORGANIZATION' }],
+        lastConnectionAt: Date.now() - 5 * 60 * 1000,
+        primary_owner: false,
+        number_of_active_tokens: 0,
+    },
+    {
+        id: 'user-2',
+        displayName: 'John Doe',
+        email: 'john@company.com',
+        status: 'PENDING',
+        source: 'ldap',
+        roles: [{ name: 'Admin', scope: 'ORGANIZATION' }],
+        primary_owner: true,
+        number_of_active_tokens: 1,
+    },
+];
+
+function renderUsersPage() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return renderWithGraphene(
+        <QueryClientProvider client={queryClient}>
+            <UsersPage />
+        </QueryClientProvider>,
+    );
+}
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as typeof ResizeObserver;
+});
+
+describe('UsersPage', () => {
+    beforeEach(() => {
+        mockUseHasPermission.mockImplementation(({ anyOf }) => anyOf?.includes('organization-user-c') ?? false);
+        mockUseOrganizationUsers.mockReturnValue({
+            data: {
+                data: SAMPLE_USERS,
+                page: { current: 1, size: 10, per_page: 10, total_pages: 1, total_elements: 2 },
+            },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUsers>);
+        mockUseCreateOrganizationUser.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as unknown as ReturnType<typeof useCreateOrganizationUser>);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders users from the API with source and role columns', async () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderUsersPage();
+
+        expect(await screen.findByText('Jane Doe')).toBeTruthy();
+        expect(screen.getByText('john@company.com')).toBeTruthy();
+        expect(screen.getByText('Gravitee')).toBeTruthy();
+        expect(screen.getByText('Admin')).toBeTruthy();
+    });
+
+    it('hides Add User when the user lacks create permission', async () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderUsersPage();
+
+        await screen.findByText('Jane Doe');
+        expect(screen.queryByRole('button', { name: /Add User/i })).toBeNull();
+    });
+
+    it('hides the header Add User button during first-use and keeps the empty-state CTA', async () => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUsers.mockReturnValue({
+            data: {
+                data: [],
+                page: { current: 1, size: 10, per_page: 10, total_pages: 0, total_elements: 0 },
+            },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUsers>);
+
+        renderUsersPage();
+
+        expect(await screen.findByText('No users yet')).toBeTruthy();
+        expect(screen.getAllByRole('button', { name: /Add User/i })).toHaveLength(1);
+    });
+
+    it('shows Add User and submits create payload for admins', async () => {
+        mockUseHasPermission.mockReturnValue(true);
+        const mutate = jest.fn((_payload, options?: { onSuccess?: () => void }) => options?.onSuccess?.());
+        mockUseCreateOrganizationUser.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useCreateOrganizationUser>);
+
+        renderUsersPage();
+        await screen.findByText('Jane Doe');
+
+        await buttonHarness({ name: /Add User/i }).click();
+        await inputHarness({ name: /First Name/i }).type('New');
+        await inputHarness({ name: /Last Name/i }).type('Person');
+        await inputHarness({ name: /^Email/i }).type('new@company.com');
+        await buttonHarness({ name: /^Add User$/ }).click();
+
+        await waitFor(() => expect(mutate).toHaveBeenCalled());
+        expect(mutate.mock.calls[0]?.[0]).toEqual({
+            firstname: 'New',
+            lastname: 'Person',
+            email: 'new@company.com',
+            source: 'gravitee',
+            sourceId: '',
+            service: false,
+        });
+        expect(notify.success).toHaveBeenCalledWith('New user successfully registered!');
+    });
+
+    it('shows a load error message when the users query fails', async () => {
+        mockUseHasPermission.mockReturnValue(false);
+        mockUseOrganizationUsers.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+        } as ReturnType<typeof useOrganizationUsers>);
+
+        renderUsersPage();
+
+        expect(await screen.findByText('Failed to load users. Please refresh and try again.')).toBeTruthy();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UsersPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UsersPage.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Button } from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useState } from 'react';
+
+import { AddUserSheet } from '../features/users/components/AddUserSheet';
+import { UsersTable } from '../features/users/components/UsersTable';
+import { useOrganizationUsers } from '../features/users/hooks/useOrganizationUsers';
+import { useCreateOrganizationUser } from '../features/users/hooks/useUserMutations';
+import type { NewPreRegisterUserPayload } from '../features/users/types/user';
+import { DEFAULT_USER_LIST_PAGE_SIZE, USER_SEARCH_DEBOUNCE_MS } from '../features/users/utils/paginationConstants';
+import { isDuplicateUserError } from '../features/users/utils/userDisplay';
+import { ORGANIZATION_USER_CREATE_PERMISSION } from '../features/users/utils/userPermissions';
+import { notify } from '../shared/notify';
+
+export function UsersPage() {
+    const canCreate = useHasPermission({ anyOf: [ORGANIZATION_USER_CREATE_PERMISSION] });
+
+    const [search, setSearch] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DEFAULT_USER_LIST_PAGE_SIZE);
+    const [sheetOpen, setSheetOpen] = useState(false);
+    const [submitEmailError, setSubmitEmailError] = useState<string | null>(null);
+
+    const createMutation = useCreateOrganizationUser();
+
+    useEffect(() => {
+        const timer = setTimeout(() => setDebouncedSearch(search), USER_SEARCH_DEBOUNCE_MS);
+        return () => clearTimeout(timer);
+    }, [search]);
+
+    const { data, isLoading, isError } = useOrganizationUsers({
+        query: debouncedSearch,
+        page,
+        size: pageSize,
+    });
+
+    const users = data?.data ?? [];
+    const totalCount = data?.page.total_elements ?? 0;
+    // `keepPreviousData` keeps the previous page mounted across refetches, so only the very first
+    // load shows skeletons — reacting to `isFetching` here would flash them on every page change.
+    const isFirstUse = !isLoading && totalCount === 0 && !search.trim() && !debouncedSearch.trim();
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function openCreateSheet() {
+        setSubmitEmailError(null);
+        setSheetOpen(true);
+    }
+
+    function handleCreate(payload: NewPreRegisterUserPayload) {
+        setSubmitEmailError(null);
+        createMutation.mutate(payload, {
+            onSuccess: () => {
+                notify.success('New user successfully registered!');
+                setSheetOpen(false);
+            },
+            onError: error => {
+                const message = error instanceof Error ? error.message : '';
+                if (isDuplicateUserError(message)) {
+                    setSubmitEmailError(message);
+                    return;
+                }
+                notify.error(error, 'Failed to register user.');
+            },
+        });
+    }
+
+    if (isError) {
+        return (
+            <div className="flex items-center justify-center p-8">
+                <p className="text-sm text-muted-foreground">Failed to load users. Please refresh and try again.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Users</h1>
+                    <p className="text-sm text-muted-foreground">Manage users and service accounts across your organization.</p>
+                </div>
+                {canCreate && !isFirstUse ? (
+                    <Button className="shrink-0" size="sm" onClick={openCreateSheet}>
+                        <PlusIcon className="size-4" aria-hidden />
+                        Add User
+                    </Button>
+                ) : null}
+            </div>
+
+            <UsersTable
+                users={users}
+                totalCount={totalCount}
+                loading={isLoading}
+                isFirstUse={isFirstUse}
+                search={search}
+                page={page}
+                pageSize={pageSize}
+                onSearchChange={handleSearchChange}
+                onPageChange={setPage}
+                onPageSizeChange={setPageSize}
+                onAddUser={canCreate ? openCreateSheet : undefined}
+            />
+
+            <AddUserSheet
+                open={sheetOpen}
+                onClose={() => setSheetOpen(false)}
+                onSubmit={handleCreate}
+                isPending={createMutation.isPending}
+                serverEmailError={submitEmailError}
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-81
https://gravitee.atlassian.net/browse/FOUND-82

## Description

### Users list
- Server-side search, pagination, and page-size controls
- Table columns: User, Status, Source, Roles, Last Login
- Non-Sortable column headers (current page only — org users API has no `order` param)
- Nav and route gated on `organization-user-{c,r,u,d}`
- First-use empty state with **Add User** CTA when the user has create permission

### Add User
- Side sheet to pre-register an **External User** or **Service Account**
- Source + Identifier when multiple IDPs are configured
- Form validation, duplicate-email inline errors, 403 via toast
- Gravitee external users: UI sends sourceId: ''; backend sets sourceId to email.

### Tasks (control plane)
- **`USER_REGISTRATION_APPROVAL` deep link intentionally deferred** — task `to` / `toModuleId` remain `null` until a follow-up adds platform user detail with registration approve/reject (`POST …/users/{id}/_process`). Action label stays **Validate user**; admins use classic console or navigate to Users manually for now.


https://github.com/user-attachments/assets/9390fb34-7873-4c3f-9ad7-2e3edae205f3
