### PR TITLE
chore(deps): bump gravitee-policy-oas-validation to 1.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
         <gravitee-policy-mock.version>1.14.2</gravitee-policy-mock.version>
         <gravitee-policy-mtls.version>1.0.0</gravitee-policy-mtls.version>
         <gravitee-policy-oauth2.version>4.0.1</gravitee-policy-oauth2.version>
-        <gravitee-policy-oas-validation.version>1.2.3</gravitee-policy-oas-validation.version>
+        <gravitee-policy-oas-validation.version>1.2.4</gravitee-policy-oas-validation.version>
         <gravitee-policy-openid-connect-userinfo.version>1.7.0</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>2.2.1</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14801

## Description

bump gravitee-policy-oas-validation to 1.2.4

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

