### PR TITLE
feat(gamma): align the api deploy banner with the shared warning Alert

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/package.json
@@ -5,7 +5,7 @@
         "@gravitee/gamma-lib-observability": "1.36.0",
         "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/graphene-charts": "3.3.0",
-        "@gravitee/graphene-core": "3.3.0",
+        "@gravitee/graphene-core": "3.4.0",
         "@gravitee/graphene-policy-studio": "3.3.0",
         "@tanstack/react-query": "5.100.14",
         "react": "19.2.6",

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.spec.tsx
@@ -63,6 +63,14 @@ let mockBannerHost: HTMLDivElement | null = null;
 
 jest.mock('@gravitee/graphene-core', () => {
     return {
+        Alert: ({ children, ...props }: { children?: ReactNode; role?: string; 'aria-label'?: string }) => (
+            <div role={props.role} aria-label={props['aria-label']}>
+                {children}
+            </div>
+        ),
+        AlertTitle: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+        AlertDescription: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+        AlertAction: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
         Badge: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
         Button: ({ children, onClick, disabled }: { children?: ReactNode; onClick?: () => void; disabled?: boolean }) => (
             <button type="button" onClick={onClick} disabled={disabled}>
@@ -205,7 +213,7 @@ describe('DeployBanner', () => {
             isLoading: false,
         });
         renderLayout();
-        expect(screen.getByText(/undeployed changes/i)).toBeInTheDocument();
+        expect(screen.getByText(/out of sync/i)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /deploy api/i })).toBeInTheDocument();
     });
 
@@ -304,13 +312,13 @@ describe('DeployBanner', () => {
             isLoading: false,
         });
         renderLayout();
-        expect(screen.queryByText(/undeployed changes/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/out of sync/i)).not.toBeInTheDocument();
     });
 
     it('hides the banner when deploymentState is absent', () => {
         (useApiDetail as jest.Mock).mockReturnValue({ data: { id: 'abc-123', name: 'My API' }, isLoading: false });
         renderLayout();
-        expect(screen.queryByText(/undeployed changes/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/out of sync/i)).not.toBeInTheDocument();
     });
 
     it('hides the banner when user lacks api-definition-u permission', () => {
@@ -320,7 +328,7 @@ describe('DeployBanner', () => {
             isLoading: false,
         });
         renderLayout();
-        expect(screen.queryByText(/undeployed changes/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/out of sync/i)).not.toBeInTheDocument();
     });
 });
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
@@ -15,6 +15,10 @@
  */
 import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
 import {
+    Alert,
+    AlertAction,
+    AlertDescription,
+    AlertTitle,
     Badge,
     Button,
     ContextSidebar,
@@ -97,15 +101,17 @@ function ApiAvatar({ api }: { api: ApiDetailDto }) {
 
 function DeployBanner({ onDeploy, isPending }: { onDeploy: () => void; isPending: boolean }) {
     return (
-        <div role="status" aria-label="Deploy status" className="flex items-center justify-between border-b px-6 py-2 bg-warning/10">
-            <span className="flex items-center gap-1.5 text-sm text-foreground">
-                <TriangleAlertIcon className="size-3.5 shrink-0 text-warning" />
-                This API has undeployed changes.
-            </span>
-            <Button size="sm" variant="outline" onClick={onDeploy} disabled={isPending}>
-                {isPending ? 'Deploying…' : 'Deploy API'}
-            </Button>
-        </div>
+        // A persistent status banner, not an interruption — override Alert's assertive `role="alert"`.
+        <Alert variant="warning" role="region" aria-label="Deploy status" className="rounded-none border-0 border-b px-6">
+            <TriangleAlertIcon aria-hidden="true" />
+            <AlertTitle>This API is out of sync</AlertTitle>
+            <AlertDescription>Your latest changes are not live yet. Deploy to push them to the gateway.</AlertDescription>
+            <AlertAction align="center">
+                <Button size="sm" onClick={onDeploy} disabled={isPending}>
+                    {isPending ? 'Deploying…' : 'Deploy API'}
+                </Button>
+            </AlertAction>
+        </Alert>
     );
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-platform/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "dependencies": {
         "@gravitee/gamma-modules-sdk": "1.2.0",
-        "@gravitee/graphene-core": "3.3.0",
+        "@gravitee/graphene-core": "3.4.0",
         "@tanstack/react-query": "5.100.14",
         "react": "19.2.6",
         "react-dom": "19.2.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@fontsource/roboto": "5.2.5",
         "@gravitee/gamma-lib-observability": "1.36.0",
         "@gravitee/graphene-charts": "3.3.0",
-        "@gravitee/graphene-core": "3.3.0",
+        "@gravitee/graphene-core": "3.4.0",
         "@gravitee/graphene-policy-studio": "3.3.0",
         "@gravitee/ui-analytics": "17.8.0",
         "@gravitee/ui-components": "4.5.2",

--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
     <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>
 
     <!-- Gamma plugins -->
-    <gravitee-gamma-module-aim.version>2.7.0</gravitee-gamma-module-aim.version>
+    <gravitee-gamma-module-aim.version>2.8.0</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.10.1</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>1.1.0</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.0.0</gravitee-gamma-module-esm.version>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4628,9 +4628,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/graphene-core@npm:3.3.0":
-  version: 3.3.0
-  resolution: "@gravitee/graphene-core@npm:3.3.0"
+"@gravitee/graphene-core@npm:3.4.0":
+  version: 3.4.0
+  resolution: "@gravitee/graphene-core@npm:3.4.0"
   dependencies:
     "@base-ui/react": "npm:1.4.1"
     "@types/json-schema": "npm:7.0.15"
@@ -4697,7 +4697,7 @@ __metadata:
       optional: true
   bin:
     graphene-sync-ai-rules: scripts/sync-ai-rules.mjs
-  checksum: 10c0/0ba95ce9011f69775522fe8ee8a995a47123faf325f77b946bdd2339957fcaae37d70081b75f4755ac7a59cba3b555e1025901b0799698cda009cbbd6a35344a
+  checksum: 10c0/089f07770ba7c6b93a9f6809d94bce5587a68ee69affbacd5d188e9b2bf8dfc9d613c22073e4b9f17012617cba57e5cc2ba100b2091415667f054a08fe181d4b
   languageName: node
   linkType: hard
 
@@ -21541,7 +21541,7 @@ __metadata:
     "@gravitee/gamma-lib-observability": "npm:1.36.0"
     "@gravitee/gamma-modules-sdk": "npm:1.2.0"
     "@gravitee/graphene-charts": "npm:3.3.0"
-    "@gravitee/graphene-core": "npm:3.3.0"
+    "@gravitee/graphene-core": "npm:3.4.0"
     "@gravitee/graphene-policy-studio": "npm:3.3.0"
     "@gravitee/ui-analytics": "npm:17.8.0"
     "@gravitee/ui-components": "npm:4.5.2"


### PR DESCRIPTION
  ## Issue                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  https://gravitee.atlassian.net/browse/AIAM-143                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  ## Description                                                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  Aligns the Gamma API detail deploy banner with the shared Graphene `Alert` (`variant="warning"` + `AlertAction align="center"`), replacing the hand-rolled `div` strip. The banner gains the same title + description + primary centred Deploy button as the Agent Management out-of-sync banner, so both products present an identical deploy affordance. Keeps the full-width top-strip placement and the existing           
  deployment-label dialog wiring; the banner is exposed as `role="region"` ("Deploy status") instead of the previous `role="status"`.                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  ## Additional context                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  - Depends on the Graphene `Alert` additions: gravitee-io/gravitee-ui-graphene → `feat(core): add a warning Alert variant and centered AlertAction alignment` (this PR should merge after that releases and the `@gravitee/graphene-core` version is bumped — CI will be red until then).                                                                                                                                       
  - Counterpart change in Agent Management: gravitee-io/gravitee-gamma-module-aim#557.                                                                                                                                                                                                                                                                                                                                           
  - Module tests: 629 green (spec's graphene mock extended with the Alert primitives).