### PR TITLE
feat(apim-gamma): added list entrypoint ui

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -32,6 +32,7 @@ import { ApplicationDetailSubscriptionPage } from '../pages/ApplicationDetailSub
 import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { DictionariesPage } from '../pages/DictionariesPage';
 import { DictionaryDetailPage } from '../pages/DictionaryDetailPage';
+import { EntrypointsAndShardingTagsPage } from '../pages/EntrypointsAndShardingTagsPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
 import { UsersPage } from '../pages/UsersPage';
@@ -79,6 +80,7 @@ function isNavItemVisible(
     canReadMetadata: boolean,
     canReadDictionaries: boolean,
     canAccessUsers: boolean,
+    canReadEntrypoints: boolean,
 ): boolean {
     if (itemKey === 'users') {
         return !permissionsReady || canAccessUsers;
@@ -89,7 +91,18 @@ function isNavItemVisible(
     if (itemKey === 'dictionaries') {
         return !permissionsReady || canReadDictionaries;
     }
+    if (itemKey === 'entrypoints-and-sharding-tags') {
+        return !permissionsReady || canReadEntrypoints;
+    }
     return true;
+}
+
+function EntrypointsGuard() {
+    const permissionsReady = useEnvironmentPermissionsReady();
+    const canRead = useHasPermission({ anyOf: ['environment-entrypoint-r', 'organization-entrypoint-r'] });
+    if (!permissionsReady) return null;
+    if (!canRead) return <Navigate to="applications" replace />;
+    return <EntrypointsAndShardingTagsPage />;
 }
 
 function ModuleLayout() {
@@ -99,6 +112,7 @@ function ModuleLayout() {
     const canReadMetadata = useHasPermission({ anyOf: ['environment-metadata-r'] });
     const canReadDictionaries = useHasPermission({ anyOf: ['environment-dictionary-r'] });
     const canAccessUsers = useHasPermission({ anyOf: [...ORGANIZATION_USER_ACCESS_PERMISSIONS] });
+    const canReadEntrypoints = useHasPermission({ anyOf: ['environment-entrypoint-r', 'organization-entrypoint-r'] });
 
     const navigate = useNavigate();
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
@@ -108,10 +122,10 @@ function ModuleLayout() {
             NAV_GROUPS.map(group => ({
                 ...group,
                 items: group.items.filter(item =>
-                    isNavItemVisible(item.key, permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers),
+                    isNavItemVisible(item.key, permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers, canReadEntrypoints),
                 ),
             })).filter(group => group.items.length > 0),
-        [permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers],
+        [permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers, canReadEntrypoints],
     );
 
     const breadcrumbs = useMemo(
@@ -186,6 +200,7 @@ export function AppRoutes() {
                                 }
                             />
                         </Route>
+                        <Route path="entrypoints-and-sharding-tags" element={<EntrypointsGuard />} />
                         <Route path="security-plan-types" element={<SecurityPlanTypesPage />} />
                     </Route>
                 </Routes>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import type { NavGroup } from '@gravitee/graphene-core';
-import { AppWindowIcon, BookOpenIcon, DatabaseIcon, KeyIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
+import { AppWindowIcon, BookOpenIcon, DatabaseIcon, KeyIcon, RadioIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
 
 import { ROUTES } from './routes';
 
@@ -32,6 +32,16 @@ export const NAV_GROUPS: NavGroup[] = [
         items: [
             { key: 'metadata', title: ROUTES.metadata.label, icon: DatabaseIcon },
             { key: 'dictionaries', title: ROUTES.dictionaries.label, icon: BookOpenIcon },
+        ],
+    },
+    {
+        label: 'Gateways & Infrastructure',
+        items: [
+            {
+                key: 'entrypoints-and-sharding-tags',
+                title: ROUTES['entrypoints-and-sharding-tags'].label,
+                icon: RadioIcon,
+            },
         ],
     },
     {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -22,6 +22,7 @@ export const ROUTE_KEYS: readonly string[] = [
     'metadata',
     'dictionaries',
     'security-plan-types',
+    'entrypoints-and-sharding-tags',
 ];
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
@@ -34,6 +35,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     'security-plan-types': { path: 'security-plan-types', label: 'Security Plan Types' },
     metadata: { path: 'metadata', label: 'Metadata' },
     dictionaries: { path: 'dictionaries', label: 'Dictionaries' },
+    'entrypoints-and-sharding-tags': { path: 'entrypoints-and-sharding-tags', label: 'Entrypoints & Sharding Tags' },
 };
 
 export const PLATFORM_ROUTE_CONFIG: ModuleRouteConfig<RouteKey> = {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointConfigurationSection.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointConfigurationSection.spec.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { EntrypointConfigurationSection } from './EntrypointConfigurationSection';
+import type { EnvironmentEntrypointConfig } from '../types/entrypoint';
+
+jest.mock('../../../shared/copyToClipboard', () => ({
+    copyTextToClipboardWithNotifyHandler: jest.fn(),
+}));
+
+const CONFIGS: EnvironmentEntrypointConfig[] = [
+    {
+        environment: { id: 'env-1', name: 'Production' },
+        portalSettings: {
+            portal: {
+                entrypoint: 'https://api.company.com',
+                tcpPort: 4082,
+                kafkaDomain: '{apiHost}.company.org',
+                kafkaPort: 9092,
+            },
+        },
+    },
+    {
+        environment: { id: 'env-2', name: 'Development' },
+        portalSettings: {
+            portal: {
+                entrypoint: 'https://dev.company.com',
+                tcpPort: 4082,
+                kafkaDomain: '{apiHost}',
+                kafkaPort: 9092,
+            },
+        },
+    },
+];
+
+describe('EntrypointConfigurationSection', () => {
+    it('renders one card block per environment', () => {
+        render(<EntrypointConfigurationSection configs={CONFIGS} failedEnvironmentNames={[]} isLoading={false} isError={false} />);
+        expect(screen.getByText('Production')).not.toBeNull();
+        expect(screen.getByText('Development')).not.toBeNull();
+        expect(screen.getByDisplayValue('https://api.company.com')).not.toBeNull();
+        expect(screen.getByDisplayValue('https://dev.company.com')).not.toBeNull();
+    });
+
+    it('shows a partial-failure banner when some environments fail to load', () => {
+        render(
+            <EntrypointConfigurationSection
+                configs={[CONFIGS[0]!]}
+                failedEnvironmentNames={['Staging']}
+                isLoading={false}
+                isError={false}
+            />,
+        );
+        expect(screen.getByText(/Could not load entrypoint defaults for: Staging/)).not.toBeNull();
+    });
+
+    it('shows an error when environment list fails', () => {
+        render(<EntrypointConfigurationSection configs={[]} failedEnvironmentNames={[]} isLoading={false} isError />);
+        expect(screen.getByText(/Failed to load environments/)).not.toBeNull();
+    });
+
+    it('invokes copy helper when copy button is clicked', () => {
+        const { copyTextToClipboardWithNotifyHandler } = jest.requireMock('../../../shared/copyToClipboard') as {
+            copyTextToClipboardWithNotifyHandler: jest.Mock;
+        };
+        render(<EntrypointConfigurationSection configs={CONFIGS} failedEnvironmentNames={[]} isLoading={false} isError={false} />);
+        fireEvent.click(screen.getAllByRole('button', { name: 'Copy Default HTTP entrypoint' })[0]!);
+        expect(copyTextToClipboardWithNotifyHandler).toHaveBeenCalledWith('https://api.company.com', 'Copied to clipboard');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointConfigurationSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointConfigurationSection.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Alert,
+    AlertDescription,
+    Badge,
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Input,
+    Label,
+    Skeleton,
+} from '@gravitee/graphene-core';
+import { CopyIcon, InfoIcon } from '@gravitee/graphene-core/icons';
+
+import { copyTextToClipboardWithNotifyHandler } from '../../../shared/copyToClipboard';
+import type { EnvironmentEntrypointConfig } from '../types/entrypoint';
+
+function CopyableField({
+    id,
+    label,
+    value,
+    hint,
+}: Readonly<{
+    id: string;
+    label: string;
+    value: string;
+    hint?: string;
+}>) {
+    return (
+        <div className="space-y-2">
+            <Label htmlFor={id}>{label}</Label>
+            <div className="flex w-full gap-2">
+                <Input id={id} value={value} readOnly className="min-w-0 flex-1 bg-muted/40" />
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="shrink-0"
+                    onClick={() => copyTextToClipboardWithNotifyHandler(value, 'Copied to clipboard')}
+                    disabled={!value}
+                    aria-label={`Copy ${label}`}
+                >
+                    <CopyIcon className="size-4" aria-hidden />
+                </Button>
+            </div>
+            {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+        </div>
+    );
+}
+
+function EnvironmentConfigCard({ config }: Readonly<{ config: EnvironmentEntrypointConfig }>) {
+    const portal = config.portalSettings.portal ?? {};
+    const httpEntrypoint = portal.entrypoint ?? '';
+    const tcpPort = portal.tcpPort !== undefined && portal.tcpPort !== null ? String(portal.tcpPort) : '';
+    const kafkaDomain = portal.kafkaDomain ?? '';
+    const kafkaPort = portal.kafkaPort !== undefined && portal.kafkaPort !== null ? String(portal.kafkaPort) : '';
+    const envId = config.environment.id;
+
+    return (
+        <div className="space-y-4 border-t pt-4 first:border-t-0 first:pt-0">
+            <h4 className="flex flex-wrap items-center gap-2 text-sm font-medium">
+                Default values for environment:
+                <Badge variant="secondary">{config.environment.name || config.environment.id}</Badge>
+            </h4>
+            <div className="space-y-4">
+                <CopyableField id={`http-entrypoint-${envId}`} label="Default HTTP entrypoint" value={httpEntrypoint} />
+                <CopyableField id={`tcp-port-${envId}`} label="Default TCP port" value={tcpPort} />
+                <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_12rem]">
+                    <CopyableField
+                        id={`kafka-domain-${envId}`}
+                        label="Default Kafka Bootstrap Domain Pattern"
+                        value={kafkaDomain}
+                        hint="To be configured according to the gateway configuration. e.g: {apiHost}.mycompany.org"
+                    />
+                    <CopyableField id={`kafka-port-${envId}`} label="Default Kafka port" value={kafkaPort} />
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export function EntrypointConfigurationSection({
+    configs,
+    failedEnvironmentNames,
+    isLoading,
+    isError,
+}: Readonly<{
+    configs: EnvironmentEntrypointConfig[];
+    failedEnvironmentNames: string[];
+    isLoading: boolean;
+    isError: boolean;
+}>) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Entrypoint Configuration</CardTitle>
+                <CardDescription>Default entrypoint values to be shown in the Developer Portal</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {isLoading ? (
+                    <div className="space-y-3">
+                        {Array.from({ length: 3 }).map((_, i) => (
+                            <Skeleton key={i} className="h-24 w-full rounded-md" />
+                        ))}
+                    </div>
+                ) : isError ? (
+                    <Alert variant="destructive">
+                        <AlertDescription>Failed to load environments. Please refresh and try again.</AlertDescription>
+                    </Alert>
+                ) : (
+                    <>
+                        {failedEnvironmentNames.length > 0 ? (
+                            <Alert>
+                                <InfoIcon className="size-4" aria-hidden />
+                                <AlertDescription>
+                                    Could not load entrypoint defaults for: {failedEnvironmentNames.join(', ')}.
+                                </AlertDescription>
+                            </Alert>
+                        ) : null}
+                        {configs.length === 0 ? (
+                            <p className="text-sm text-muted-foreground">No environments found.</p>
+                        ) : (
+                            configs.map(config => <EnvironmentConfigCard key={config.environment.id} config={config} />)
+                        )}
+                    </>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointDetailSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointDetailSheet.spec.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { EntrypointDetailSheet } from './EntrypointDetailSheet';
+import type { EntrypointMappingRow } from '../types/entrypoint';
+
+const ROW: EntrypointMappingRow = {
+    id: 'ep-1',
+    value: 'https://api.example.com',
+    target: 'HTTP',
+    targetLabel: 'HTTP',
+    tags: ['prod'],
+    tagsName: ['Production'],
+    environmentIds: ['env-1'],
+    environmentNames: ['Default Environment'],
+};
+
+describe('EntrypointDetailSheet', () => {
+    it('renders read-only fields when an entrypoint is selected', () => {
+        render(<EntrypointDetailSheet entrypoint={ROW} onClose={jest.fn()} />);
+        expect(screen.getByText('Entrypoint details')).not.toBeNull();
+        expect(screen.getByText('https://api.example.com')).not.toBeNull();
+        expect(screen.getByText('HTTP')).not.toBeNull();
+        expect(screen.getByText('Production')).not.toBeNull();
+        expect(screen.getByText('Default Environment')).not.toBeNull();
+        expect(screen.queryByRole('button', { name: /save|edit|delete/i })).toBeNull();
+    });
+
+    it('calls onClose when Close is clicked', () => {
+        const onClose = jest.fn();
+        render(<EntrypointDetailSheet entrypoint={ROW} onClose={onClose} />);
+        const closeButtons = screen.getAllByRole('button', { name: 'Close' });
+        fireEvent.click(closeButtons[closeButtons.length - 1]!);
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointDetailSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointDetailSheet.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Badge, Button, Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from '@gravitee/graphene-core';
+import { XIcon } from '@gravitee/graphene-core/icons';
+import { useCallback } from 'react';
+
+import { ShardingTagsCell } from './ShardingTagsCell';
+import type { EntrypointMappingRow } from '../types/entrypoint';
+
+export function EntrypointDetailSheet({
+    entrypoint,
+    onClose,
+}: Readonly<{
+    entrypoint: EntrypointMappingRow | null;
+    onClose: () => void;
+}>) {
+    const handleOpenChange = useCallback(
+        (open: boolean) => {
+            if (!open) onClose();
+        },
+        [onClose],
+    );
+
+    return (
+        <Sheet open={entrypoint !== null} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" showCloseButton={false} className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader className="flex-row items-start justify-between gap-3 space-y-0">
+                    <div className="space-y-1.5 text-left">
+                        <SheetTitle>Entrypoint details</SheetTitle>
+                        <SheetDescription>Read-only view of this entrypoint mapping.</SheetDescription>
+                    </div>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-8 shrink-0"
+                        aria-label="Close"
+                        onClick={() => handleOpenChange(false)}
+                    >
+                        <XIcon className="size-4" aria-hidden />
+                    </Button>
+                </SheetHeader>
+                {entrypoint ? (
+                    <dl className="space-y-4 px-4 py-2 text-sm">
+                        <div className="space-y-1">
+                            <dt className="text-muted-foreground">Entrypoint</dt>
+                            <dd className="font-medium break-all">{entrypoint.value || '—'}</dd>
+                        </div>
+                        <div className="space-y-1">
+                            <dt className="text-muted-foreground">Type</dt>
+                            <dd>
+                                <Badge variant="secondary">{entrypoint.targetLabel}</Badge>
+                            </dd>
+                        </div>
+                        <div className="space-y-1">
+                            <dt className="text-muted-foreground">Sharding Tags</dt>
+                            <dd>
+                                <ShardingTagsCell tags={entrypoint.tagsName} />
+                            </dd>
+                        </div>
+                        <div className="space-y-1">
+                            <dt className="text-muted-foreground">Environments</dt>
+                            <dd>{entrypoint.environmentNames.length > 0 ? entrypoint.environmentNames.join(', ') : 'All'}</dd>
+                        </div>
+                    </dl>
+                ) : null}
+                <SheetFooter className="flex-row justify-end border-t">
+                    <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+                        Close
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointMappingsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointMappingsTable.spec.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { EntrypointMappingsTable } from './EntrypointMappingsTable';
+import type { EntrypointMappingRow } from '../types/entrypoint';
+
+const ROWS: EntrypointMappingRow[] = [
+    {
+        id: 'ep-1',
+        value: 'https://api.example.com',
+        target: 'HTTP',
+        targetLabel: 'HTTP',
+        tags: ['prod'],
+        tagsName: ['Production'],
+        environmentIds: [],
+        environmentNames: [],
+    },
+    {
+        id: 'ep-2',
+        value: '4082',
+        target: 'TCP',
+        targetLabel: 'TCP',
+        tags: [],
+        tagsName: [],
+        environmentIds: ['env-1'],
+        environmentNames: ['Production'],
+    },
+];
+
+describe('EntrypointMappingsTable', () => {
+    it('renders entrypoint rows and opens detail on value click', () => {
+        const onOpenDetail = jest.fn();
+        render(<EntrypointMappingsTable rows={ROWS} canCreate={false} onOpenDetail={onOpenDetail} />);
+        expect(screen.getByText('https://api.example.com')).not.toBeNull();
+        expect(screen.getByText('4082')).not.toBeNull();
+        fireEvent.click(screen.getByRole('button', { name: 'https://api.example.com' }));
+        expect(onOpenDetail).toHaveBeenCalledWith(ROWS[0]);
+    });
+
+    it('filters rows by entrypoint value', () => {
+        render(<EntrypointMappingsTable rows={ROWS} canCreate={false} onOpenDetail={jest.fn()} />);
+        fireEvent.change(screen.getByLabelText('Search entrypoints'), { target: { value: '4082' } });
+        expect(screen.queryByText('https://api.example.com')).toBeNull();
+        expect(screen.getByText('4082')).not.toBeNull();
+    });
+
+    it('shows create CTA in empty state when canCreate is true', () => {
+        const onCreate = jest.fn();
+        render(<EntrypointMappingsTable rows={[]} canCreate onOpenDetail={jest.fn()} onCreate={onCreate} />);
+        fireEvent.click(screen.getByRole('button', { name: /Add a mapping/i }));
+        expect(onCreate).toHaveBeenCalled();
+    });
+
+    it('hides create CTA in empty state when canCreate is false', () => {
+        render(<EntrypointMappingsTable rows={[]} canCreate={false} onOpenDetail={jest.fn()} />);
+        expect(screen.queryByRole('button', { name: /Add a mapping/i })).toBeNull();
+        expect(screen.getByText('No entrypoints')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointMappingsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointMappingsTable.tsx
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    DataTable,
+    DataTableColumnHeader,
+    DataTableEmptyState,
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { PlusIcon, RadioIcon, SearchIcon } from '@gravitee/graphene-core/icons';
+import { useMemo, useState } from 'react';
+
+import { ShardingTagsCell } from './ShardingTagsCell';
+import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+import type { TableSortingState } from '../../applications/utils/tableSort';
+import type { EntrypointMappingRow } from '../types/entrypoint';
+
+const DEFAULT_PAGE_SIZE = 10;
+const SORTABLE_IDS = new Set(['value', 'target', 'tags', 'environments']);
+
+function sortRows(items: EntrypointMappingRow[], sorting: TableSortingState): EntrypointMappingRow[] {
+    const active = sorting[0];
+    if (!active?.id || !SORTABLE_IDS.has(active.id)) return items;
+    const direction = active.desc ? -1 : 1;
+    return [...items].sort((a, b) => {
+        let av = '';
+        let bv = '';
+        if (active.id === 'value') {
+            av = a.value;
+            bv = b.value;
+        } else if (active.id === 'target') {
+            av = a.targetLabel;
+            bv = b.targetLabel;
+        } else if (active.id === 'tags') {
+            av = a.tagsName.join(', ');
+            bv = b.tagsName.join(', ');
+        } else {
+            av = a.environmentNames.join(', ');
+            bv = b.environmentNames.join(', ');
+        }
+        return av.localeCompare(bv) * direction;
+    });
+}
+
+function buildColumns(onOpenDetail: (row: EntrypointMappingRow) => void): DataTableProps<EntrypointMappingRow>['columns'] {
+    return [
+        {
+            id: 'value',
+            accessorKey: 'value',
+            header: ({ column }: ColHeader<EntrypointMappingRow>) => <DataTableColumnHeader column={column} title="Entrypoint" />,
+            cell: ({ row }: ColCell<EntrypointMappingRow>) => (
+                <button type="button" className="text-sm font-medium text-left hover:underline" onClick={() => onOpenDetail(row.original)}>
+                    {row.original.value || '-'}
+                </button>
+            ),
+        },
+        {
+            id: 'target',
+            accessorKey: 'targetLabel',
+            header: ({ column }: ColHeader<EntrypointMappingRow>) => <DataTableColumnHeader column={column} title="Type" />,
+            cell: ({ row }: ColCell<EntrypointMappingRow>) => <span className="text-sm">{row.original.targetLabel}</span>,
+        },
+        {
+            id: 'tags',
+            accessorFn: (row: EntrypointMappingRow) => row.tagsName.join(', '),
+            header: ({ column }: ColHeader<EntrypointMappingRow>) => <DataTableColumnHeader column={column} title="Sharding Tags" />,
+            cell: ({ row }: ColCell<EntrypointMappingRow>) => <ShardingTagsCell tags={row.original.tagsName} />,
+        },
+        {
+            id: 'environments',
+            accessorFn: (row: EntrypointMappingRow) => row.environmentNames.join(', '),
+            header: ({ column }: ColHeader<EntrypointMappingRow>) => <DataTableColumnHeader column={column} title="Environments" />,
+            cell: ({ row }: ColCell<EntrypointMappingRow>) => (
+                <span className="text-sm">
+                    {row.original.environmentNames.length > 0 ? row.original.environmentNames.join(', ') : 'All'}
+                </span>
+            ),
+        },
+    ];
+}
+
+export function EntrypointMappingsTable({
+    rows,
+    canCreate,
+    onOpenDetail,
+    onCreate,
+}: Readonly<{
+    rows: EntrypointMappingRow[];
+    canCreate: boolean;
+    onOpenDetail: (row: EntrypointMappingRow) => void;
+    onCreate?: () => void;
+}>) {
+    const [search, setSearch] = useState('');
+    const [sorting, setSorting] = useState<TableSortingState>([]);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+
+    const filtered = useMemo(() => {
+        const query = search.trim().toLowerCase();
+        if (!query) return rows;
+        return rows.filter(row => row.value.toLowerCase().includes(query));
+    }, [rows, search]);
+
+    const sorted = useMemo(() => sortRows(filtered, sorting), [filtered, sorting]);
+    const totalCount = sorted.length;
+    const paginatedData = useMemo(() => sorted.slice((page - 1) * pageSize, page * pageSize), [sorted, page, pageSize]);
+    const columns = useMemo(() => buildColumns(onOpenDetail), [onOpenDetail]);
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function handleSortingChange(updater: TableSortingState | ((prev: TableSortingState) => TableSortingState)) {
+        setSorting(prev => (typeof updater === 'function' ? updater(prev) : updater));
+        setPage(1);
+    }
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    if (rows.length === 0 && !search.trim()) {
+        return (
+            <DataTableEmptyState
+                variant="first-use"
+                icon={<RadioIcon />}
+                title="No entrypoints"
+                description="Entrypoint mappings connect gateway listeners to sharding tags for the Developer Portal."
+                primaryAction={
+                    canCreate && onCreate ? (
+                        <Button onClick={onCreate}>
+                            <PlusIcon className="size-4" aria-hidden />
+                            Add a mapping
+                        </Button>
+                    ) : undefined
+                }
+            />
+        );
+    }
+
+    return (
+        <div className="space-y-3">
+            <div className="max-w-sm">
+                <InputGroup>
+                    <InputGroupAddon align="inline-start">
+                        <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                    </InputGroupAddon>
+                    <InputGroupInput
+                        placeholder="Search by entrypoint..."
+                        value={search}
+                        onChange={e => handleSearchChange(e.target.value)}
+                        aria-label="Search entrypoints"
+                    />
+                </InputGroup>
+            </div>
+            <div data-testid="entrypoint-mappings-table-body">
+                <DataTable
+                    aria-label="Entrypoint mappings"
+                    columns={columns}
+                    data={paginatedData}
+                    sorting={sorting}
+                    onSortingChange={handleSortingChange}
+                    serverSide
+                    pagination={{
+                        page,
+                        pageSize,
+                        totalCount,
+                        pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                        onPageChange: setPage,
+                        onPageSizeChange: handlePageSizeChange,
+                    }}
+                    emptyMessage={
+                        <DataTableEmptyState
+                            variant="no-results"
+                            icon={<SearchIcon />}
+                            title="No entrypoints found"
+                            description="Try adjusting your search."
+                        />
+                    }
+                />
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/ShardingTagsCell.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/ShardingTagsCell.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Badge, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@gravitee/graphene-core';
+
+interface ShardingTagsCellProps {
+    tags?: string[];
+}
+
+export function ShardingTagsCell({ tags }: Readonly<ShardingTagsCellProps>) {
+    if (!tags || tags.length === 0) {
+        return <span className="text-muted-foreground text-xs">—</span>;
+    }
+    const sorted = [...tags].sort((a, b) => a.localeCompare(b));
+    const moreCount = sorted.length - 1;
+    return (
+        <div className="flex items-center gap-1">
+            <span className="text-sm">{sorted[0]}</span>
+            {moreCount > 0 ? (
+                <TooltipProvider delayDuration={0}>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Badge variant="secondary" className="text-xs tabular-nums cursor-default">
+                                {moreCount} more
+                            </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent>{sorted.join(', ')}</TooltipContent>
+                    </Tooltip>
+                </TooltipProvider>
+            ) : null}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/hooks/useEntrypointConfigurations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/hooks/useEntrypointConfigurations.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { listOrgEnvironments } from '../services/environments';
+import { getPortalSettingsByEnvironmentId } from '../services/portalSettings';
+import type { EnvironmentEntrypointConfig } from '../types/entrypoint';
+import { orgEnvironmentKeys, portalSettingsKeys } from '../utils/queryKeys';
+
+export interface EntrypointConfigurationsResult {
+    configs: EnvironmentEntrypointConfig[];
+    failedEnvironmentNames: string[];
+}
+
+export function useEntrypointConfigurations() {
+    return useQuery({
+        queryKey: [...orgEnvironmentKeys.list(), ...portalSettingsKeys.all, 'entrypoint-configurations'],
+        queryFn: async (): Promise<EntrypointConfigurationsResult> => {
+            const environments = await listOrgEnvironments();
+            const settled = await Promise.allSettled(
+                environments.map(async environment => {
+                    const portalSettings = await getPortalSettingsByEnvironmentId(environment.id);
+                    return { environment, portalSettings } satisfies EnvironmentEntrypointConfig;
+                }),
+            );
+
+            const configs: EnvironmentEntrypointConfig[] = [];
+            const failedEnvironmentNames: string[] = [];
+
+            settled.forEach((result, index) => {
+                const environment = environments[index]!;
+                if (result.status === 'fulfilled') {
+                    configs.push(result.value);
+                } else {
+                    failedEnvironmentNames.push(environment.name || environment.id);
+                }
+            });
+
+            return { configs, failedEnvironmentNames };
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/hooks/useEntrypointMappings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/hooks/useEntrypointMappings.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { listEntrypoints } from '../services/entrypoints';
+import { listOrgEnvironments } from '../services/environments';
+import { listOrgTags } from '../services/tags';
+import { toEntrypointMappingRows } from '../utils/entrypointMappings';
+import { entrypointKeys, orgEnvironmentKeys, orgTagKeys } from '../utils/queryKeys';
+
+export function useEntrypointMappings() {
+    const entrypointsQuery = useQuery({
+        queryKey: entrypointKeys.list(),
+        queryFn: listEntrypoints,
+    });
+
+    const environmentsQuery = useQuery({
+        queryKey: orgEnvironmentKeys.list(),
+        queryFn: listOrgEnvironments,
+    });
+
+    const tagsQuery = useQuery({
+        queryKey: orgTagKeys.list(),
+        queryFn: listOrgTags,
+    });
+
+    const rows = useMemo(() => {
+        if (!entrypointsQuery.data) return [];
+        return toEntrypointMappingRows(entrypointsQuery.data, environmentsQuery.data ?? [], tagsQuery.data ?? []);
+    }, [entrypointsQuery.data, environmentsQuery.data, tagsQuery.data]);
+
+    return {
+        rows,
+        isLoading: entrypointsQuery.isLoading || environmentsQuery.isLoading || tagsQuery.isLoading,
+        isError: entrypointsQuery.isError,
+        isNameResolutionError: environmentsQuery.isError || tagsQuery.isError,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/entrypoints.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/entrypoints.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { listEntrypoints } from './entrypoints';
+import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonOrg: jest.fn(),
+}));
+
+const mockApimFetchJsonOrg = jest.mocked(apimFetchJsonOrg);
+
+describe('entrypoints service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonOrg.mockResolvedValue([]);
+    });
+
+    it('calls GET on the organization configuration/entrypoints resource', async () => {
+        await listEntrypoints();
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/entrypoints');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/entrypoints.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/entrypoints.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
+import type { Entrypoint } from '../types/entrypoint';
+
+export async function listEntrypoints(): Promise<Entrypoint[]> {
+    return apimFetchJsonOrg<Entrypoint[]>('/configuration/entrypoints');
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/environments.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/environments.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
+import type { OrgEnvironment } from '../types/entrypoint';
+
+export async function listOrgEnvironments(): Promise<OrgEnvironment[]> {
+    return apimFetchJsonOrg<OrgEnvironment[]>('/environments');
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/portalSettings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/portalSettings.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
+import type { EntrypointPortalSettings } from '../types/entrypoint';
+
+export async function getPortalSettingsByEnvironmentId(environmentId: string): Promise<EntrypointPortalSettings> {
+    return apimFetchJsonOrg<EntrypointPortalSettings>(`/environments/${encodeURIComponent(environmentId)}/settings`);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/supportingServices.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/supportingServices.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { listOrgEnvironments } from './environments';
+import { getPortalSettingsByEnvironmentId } from './portalSettings';
+import { listOrgTags } from './tags';
+import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonOrg: jest.fn(),
+}));
+
+const mockApimFetchJsonOrg = jest.mocked(apimFetchJsonOrg);
+
+describe('entrypoint supporting services', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonOrg.mockResolvedValue([]);
+    });
+
+    it('listOrgEnvironments calls GET /environments', async () => {
+        await listOrgEnvironments();
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/environments');
+    });
+
+    it('getPortalSettingsByEnvironmentId calls GET /environments/:id/settings', async () => {
+        await getPortalSettingsByEnvironmentId('env-1');
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/environments/env-1/settings');
+    });
+
+    it('URL-encodes the environment id in portal settings path', async () => {
+        await getPortalSettingsByEnvironmentId('env with spaces');
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/environments/env%20with%20spaces/settings');
+    });
+
+    it('listOrgTags calls GET /configuration/tags', async () => {
+        await listOrgTags();
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/tags');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/tags.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/tags.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
+import type { OrgTag } from '../types/entrypoint';
+
+export async function listOrgTags(): Promise<OrgTag[]> {
+    return apimFetchJsonOrg<OrgTag[]>('/configuration/tags');
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/types/entrypoint.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/types/entrypoint.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type EntrypointTarget = 'HTTP' | 'TCP' | 'KAFKA';
+
+export interface Entrypoint {
+    id: string;
+    value?: string;
+    tags?: string[];
+    environmentIds?: string[];
+    target?: EntrypointTarget;
+}
+
+export interface OrgEnvironment {
+    id: string;
+    name: string;
+    hrids?: string[];
+}
+
+export interface EntrypointPortalSettings {
+    portal?: {
+        entrypoint?: string;
+        tcpPort?: number;
+        kafkaDomain?: string;
+        kafkaPort?: number;
+    };
+    metadata?: {
+        readonly?: string[];
+    };
+}
+
+export interface OrgTag {
+    id: string;
+    key: string;
+    name: string;
+    description?: string;
+}
+
+export interface EnvironmentEntrypointConfig {
+    environment: OrgEnvironment;
+    portalSettings: EntrypointPortalSettings;
+}
+
+export interface EntrypointMappingRow {
+    id: string;
+    value: string;
+    target: EntrypointTarget;
+    targetLabel: string;
+    tags: string[];
+    tagsName: string[];
+    environmentIds: string[];
+    environmentNames: string[];
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointMappings.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointMappings.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { entrypointTargetLabel, toEntrypointMappingRows } from './entrypointMappings';
+import type { Entrypoint, OrgEnvironment, OrgTag } from '../types/entrypoint';
+
+describe('entrypointMappings utils', () => {
+    const environments: OrgEnvironment[] = [
+        { id: 'env-1', name: 'Production' },
+        { id: 'env-2', name: 'Development' },
+    ];
+    const tags: OrgTag[] = [
+        { id: 't1', key: 'prod', name: 'Production tag' },
+        { id: 't2', key: 'edge', name: 'Edge' },
+    ];
+
+    it('maps target labels including Kafka display name', () => {
+        expect(entrypointTargetLabel('HTTP')).toBe('HTTP');
+        expect(entrypointTargetLabel('TCP')).toBe('TCP');
+        expect(entrypointTargetLabel('KAFKA')).toBe('Kafka');
+        expect(entrypointTargetLabel(undefined)).toBe('—');
+    });
+
+    it('joins tag and environment names for display rows', () => {
+        const entrypoints: Entrypoint[] = [
+            {
+                id: 'ep-1',
+                value: 'https://api.example.com',
+                target: 'HTTP',
+                tags: ['prod', 'missing'],
+                environmentIds: ['env-1'],
+            },
+        ];
+
+        const rows = toEntrypointMappingRows(entrypoints, environments, tags);
+        expect(rows).toEqual([
+            {
+                id: 'ep-1',
+                value: 'https://api.example.com',
+                target: 'HTTP',
+                targetLabel: 'HTTP',
+                tags: ['prod', 'missing'],
+                tagsName: ['Production tag', 'missing'],
+                environmentIds: ['env-1'],
+                environmentNames: ['Production'],
+            },
+        ]);
+    });
+
+    it('uses empty arrays when tags and environments are omitted', () => {
+        const rows = toEntrypointMappingRows([{ id: 'ep-2', value: '4082', target: 'TCP' }], environments, tags);
+        expect(rows[0]?.tagsName).toEqual([]);
+        expect(rows[0]?.environmentNames).toEqual([]);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointMappings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointMappings.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Entrypoint, EntrypointMappingRow, EntrypointTarget, OrgEnvironment, OrgTag } from '../types/entrypoint';
+
+const TARGET_LABELS: Record<EntrypointTarget, string> = {
+    HTTP: 'HTTP',
+    TCP: 'TCP',
+    KAFKA: 'Kafka',
+};
+
+export function entrypointTargetLabel(target: EntrypointTarget | undefined): string {
+    if (!target) return '—';
+    return TARGET_LABELS[target] ?? target;
+}
+
+export function toEntrypointMappingRows(entrypoints: Entrypoint[], environments: OrgEnvironment[], tags: OrgTag[]): EntrypointMappingRow[] {
+    const envNameById = new Map(environments.map(env => [env.id, env.name || env.id]));
+    const tagNameByKey = new Map(tags.map(tag => [tag.key, tag.name || tag.key]));
+
+    return entrypoints.map(entrypoint => {
+        const tagKeys = entrypoint.tags ?? [];
+        const environmentIds = entrypoint.environmentIds ?? [];
+        const target = entrypoint.target ?? 'HTTP';
+        return {
+            id: entrypoint.id,
+            value: entrypoint.value ?? '',
+            target,
+            targetLabel: entrypointTargetLabel(target),
+            tags: tagKeys,
+            tagsName: tagKeys.map(key => tagNameByKey.get(key) ?? key),
+            environmentIds,
+            environmentNames: environmentIds.map(id => envNameById.get(id) ?? id),
+        };
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/queryKeys.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const entrypointKeys = {
+    all: ['entrypoints'] as const,
+    list: () => [...entrypointKeys.all, 'list'] as const,
+} as const;
+
+export const orgEnvironmentKeys = {
+    all: ['org-environments'] as const,
+    list: () => [...orgEnvironmentKeys.all, 'list'] as const,
+} as const;
+
+export const portalSettingsKeys = {
+    all: ['portal-settings'] as const,
+    byEnvironment: (envId: string) => [...portalSettingsKeys.all, envId] as const,
+} as const;
+
+export const orgTagKeys = {
+    all: ['org-tags'] as const,
+    list: () => [...orgTagKeys.all, 'list'] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EntrypointsAndShardingTagsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EntrypointsAndShardingTagsPage.spec.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { EntrypointsAndShardingTagsPage } from './EntrypointsAndShardingTagsPage';
+import { useEntrypointConfigurations } from '../features/entrypoints/hooks/useEntrypointConfigurations';
+import { useEntrypointMappings } from '../features/entrypoints/hooks/useEntrypointMappings';
+import type { EntrypointMappingRow } from '../features/entrypoints/types/entrypoint';
+
+jest.mock('../features/entrypoints/hooks/useEntrypointConfigurations');
+jest.mock('../features/entrypoints/hooks/useEntrypointMappings');
+
+jest.mock('../features/entrypoints/components/EntrypointConfigurationSection', () => ({
+    EntrypointConfigurationSection: () => <div data-testid="entrypoint-configuration-section" />,
+}));
+
+jest.mock('../features/entrypoints/components/EntrypointMappingsTable', () => ({
+    EntrypointMappingsTable: ({
+        rows,
+        canCreate,
+        onOpenDetail,
+    }: {
+        rows: EntrypointMappingRow[];
+        canCreate: boolean;
+        onOpenDetail: (row: EntrypointMappingRow) => void;
+        onCreate?: () => void;
+    }) => (
+        <div>
+            <div data-testid="mappings-can-create">{String(canCreate)}</div>
+            {rows.map(row => (
+                <button key={row.id} type="button" onClick={() => onOpenDetail(row)}>
+                    Open {row.value}
+                </button>
+            ))}
+            {rows.length === 0 ? <div>No entrypoints</div> : null}
+        </div>
+    ),
+}));
+
+jest.mock('../features/entrypoints/components/EntrypointDetailSheet', () => ({
+    EntrypointDetailSheet: ({ entrypoint, onClose }: { entrypoint: EntrypointMappingRow | null; onClose: () => void }) =>
+        entrypoint ? (
+            <div>
+                <div>Detail {entrypoint.value}</div>
+                <button type="button" onClick={onClose}>
+                    Close detail
+                </button>
+            </div>
+        ) : null,
+}));
+
+const mockUseEntrypointConfigurations = jest.mocked(useEntrypointConfigurations);
+const mockUseEntrypointMappings = jest.mocked(useEntrypointMappings);
+
+const STUB_ROWS: EntrypointMappingRow[] = [
+    {
+        id: 'ep-1',
+        value: 'https://api.example.com',
+        target: 'HTTP',
+        targetLabel: 'HTTP',
+        tags: [],
+        tagsName: [],
+        environmentIds: [],
+        environmentNames: [],
+    },
+];
+
+describe('EntrypointsAndShardingTagsPage', () => {
+    beforeEach(() => {
+        mockUseEntrypointConfigurations.mockReturnValue({
+            data: { configs: [], failedEnvironmentNames: [] },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useEntrypointConfigurations>);
+        mockUseEntrypointMappings.mockReturnValue({
+            rows: STUB_ROWS,
+            isLoading: false,
+            isError: false,
+            isNameResolutionError: false,
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders the page title and both sections', () => {
+        render(<EntrypointsAndShardingTagsPage />);
+        expect(screen.getByRole('heading', { name: 'Entrypoints & Sharding Tags' })).not.toBeNull();
+        expect(screen.getByTestId('entrypoint-configuration-section')).not.toBeNull();
+        expect(screen.getByText('Entrypoint Mappings')).not.toBeNull();
+    });
+
+    it('uses read-only page copy without create CTA', () => {
+        render(<EntrypointsAndShardingTagsPage />);
+        expect(
+            screen.getByText(/View entrypoint configuration and mappings used by the Developer Portal based on API sharding tags/),
+        ).not.toBeNull();
+        expect(screen.queryByRole('button', { name: /Add a mapping/i })).toBeNull();
+        expect(screen.getByTestId('mappings-can-create').textContent).toBe('false');
+    });
+
+    it('opens detail sheet when a mapping row is selected', () => {
+        render(<EntrypointsAndShardingTagsPage />);
+        fireEvent.click(screen.getByRole('button', { name: 'Open https://api.example.com' }));
+        expect(screen.getByText('Detail https://api.example.com')).not.toBeNull();
+        fireEvent.click(screen.getByRole('button', { name: 'Close detail' }));
+        expect(screen.queryByText('Detail https://api.example.com')).toBeNull();
+    });
+
+    it('shows inline error when mappings fail to load', () => {
+        mockUseEntrypointMappings.mockReturnValue({
+            rows: [],
+            isLoading: false,
+            isError: true,
+            isNameResolutionError: false,
+        });
+        render(<EntrypointsAndShardingTagsPage />);
+        expect(screen.getByText(/Failed to load entrypoint mappings/)).not.toBeNull();
+    });
+
+    it('warns when environment or tag name resolution fails', () => {
+        mockUseEntrypointMappings.mockReturnValue({
+            rows: STUB_ROWS,
+            isLoading: false,
+            isError: false,
+            isNameResolutionError: true,
+        });
+        render(<EntrypointsAndShardingTagsPage />);
+        expect(screen.getByText(/Some environment or sharding tag names could not be loaded/)).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EntrypointsAndShardingTagsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EntrypointsAndShardingTagsPage.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Alert, AlertDescription, Card, CardContent, CardDescription, CardHeader, CardTitle, Skeleton } from '@gravitee/graphene-core';
+import { InfoIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+
+import { EntrypointConfigurationSection } from '../features/entrypoints/components/EntrypointConfigurationSection';
+import { EntrypointDetailSheet } from '../features/entrypoints/components/EntrypointDetailSheet';
+import { EntrypointMappingsTable } from '../features/entrypoints/components/EntrypointMappingsTable';
+import { useEntrypointConfigurations } from '../features/entrypoints/hooks/useEntrypointConfigurations';
+import { useEntrypointMappings } from '../features/entrypoints/hooks/useEntrypointMappings';
+import type { EntrypointMappingRow } from '../features/entrypoints/types/entrypoint';
+
+export function EntrypointsAndShardingTagsPage() {
+    const { data: configurationData, isLoading: isConfigurationLoading, isError: isConfigurationError } = useEntrypointConfigurations();
+    const { rows, isLoading: isMappingsLoading, isError: isMappingsError, isNameResolutionError } = useEntrypointMappings();
+
+    const [selected, setSelected] = useState<EntrypointMappingRow | null>(null);
+
+    return (
+        <div className="space-y-6">
+            <div className="space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">Entrypoints & Sharding Tags</h1>
+                <p className="text-sm text-muted-foreground">
+                    View entrypoint configuration and mappings used by the Developer Portal based on API sharding tags.
+                </p>
+            </div>
+
+            <Alert>
+                <InfoIcon className="size-4" aria-hidden />
+                <AlertDescription>
+                    Include entrypoint and sharding tag configuration according to the values already used by the deployed API Gateway(s).
+                </AlertDescription>
+            </Alert>
+
+            <EntrypointConfigurationSection
+                configs={configurationData?.configs ?? []}
+                failedEnvironmentNames={configurationData?.failedEnvironmentNames ?? []}
+                isLoading={isConfigurationLoading}
+                isError={isConfigurationError}
+            />
+
+            <Card>
+                <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+                    <div className="space-y-1.5">
+                        <CardTitle>Entrypoint Mappings</CardTitle>
+                        <CardDescription>Entrypoint to be displayed in the Developer Portal if an API has a given tag</CardDescription>
+                    </div>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                    {isNameResolutionError && !isMappingsLoading && !isMappingsError ? (
+                        <Alert>
+                            <InfoIcon className="size-4" aria-hidden />
+                            <AlertDescription>
+                                Some environment or sharding tag names could not be loaded. IDs may be shown instead of display names.
+                            </AlertDescription>
+                        </Alert>
+                    ) : null}
+                    {isMappingsLoading ? (
+                        <div className="space-y-2">
+                            {Array.from({ length: 4 }).map((_, i) => (
+                                <Skeleton key={i} className="h-12 w-full rounded-md" />
+                            ))}
+                        </div>
+                    ) : isMappingsError ? (
+                        <Alert variant="destructive">
+                            <AlertDescription>Failed to load entrypoint mappings. Please refresh and try again.</AlertDescription>
+                        </Alert>
+                    ) : (
+                        <EntrypointMappingsTable rows={rows} canCreate={false} onOpenDetail={setSelected} />
+                    )}
+                </CardContent>
+            </Card>
+
+            <EntrypointDetailSheet entrypoint={selected} onClose={() => setSelected(null)} />
+        </div>
+    );
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-36

## Description

Implements List Entrypoints in Gamma Platform as a single vertical slice.

Adds the Entrypoints & Sharding Tags page route/nav with a searchable mappings table (empty state, create CTA gated by permission, read-only detail on row click) plus the existing per-environment Entrypoint Configuration cards for classic parity. Permission checks follow backend environment|organization-entrypoint READ/CREATE. UI-only against existing APIs — create/edit and sharding-tags CRUD are out of scope.

## Additional context
[UI]

https://github.com/user-attachments/assets/00d3ed95-aba0-4e83-8e76-78ecb2602c26



