### PR TITLE
chore(deps): bump @gravitee/gamma-lib-observability to 1.36.0

### DIFF
--- a/.circleci/ci/src/jobs/frontend/job-webui-lint-test.ts
+++ b/.circleci/ci/src/jobs/frontend/job-webui-lint-test.ts
@@ -164,7 +164,8 @@ export class WebuiLintTestJob {
       }),
       new commands.Run({
         name: 'Test APIM Libs (affected)',
-        command: 'NODE_OPTIONS=--max-old-space-size=4096 yarn nx affected -t test --exclude=console,portal-next --coverage --maxWorkers=2',
+        command:
+          'NODE_OPTIONS=--max-old-space-size=4096 yarn nx affected -t test --exclude=console,portal-next --coverage --maxWorkers=2 --parallel=1',
       }),
       new reusable.ReusedCommand(notifyOnFailureCommand),
       // Ensure coverage files exist so persist/store steps don't fail when libs are not affected

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -570,7 +570,7 @@ jobs:
           command: yarn nx affected -t lint --exclude=console,portal-next
       - run:
           name: Test APIM Libs (affected)
-          command: NODE_OPTIONS=--max-old-space-size=4096 yarn nx affected -t test --exclude=console,portal-next --coverage --maxWorkers=2
+          command: NODE_OPTIONS=--max-old-space-size=4096 yarn nx affected -t test --exclude=console,portal-next --coverage --maxWorkers=2 --parallel=1
       - cmd-notify-on-failure
       - run:
           name: Ensure coverage files exist

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -528,7 +528,7 @@ jobs:
           command: yarn nx affected -t lint --exclude=console,portal-next
       - run:
           name: Test APIM Libs (affected)
-          command: NODE_OPTIONS=--max-old-space-size=4096 yarn nx affected -t test --exclude=console,portal-next --coverage --maxWorkers=2
+          command: NODE_OPTIONS=--max-old-space-size=4096 yarn nx affected -t test --exclude=console,portal-next --coverage --maxWorkers=2 --parallel=1
       - cmd-notify-on-failure
       - run:
           name: Ensure coverage files exist

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -570,7 +570,7 @@ jobs:
           command: yarn nx affected -t lint --exclude=console,portal-next
       - run:
           name: Test APIM Libs (affected)
-          command: NODE_OPTIONS=--max-old-space-size=4096 yarn nx affected -t test --exclude=console,portal-next --coverage --maxWorkers=2
+          command: NODE_OPTIONS=--max-old-space-size=4096 yarn nx affected -t test --exclude=console,portal-next --coverage --maxWorkers=2 --parallel=1
       - cmd-notify-on-failure
       - run:
           name: Ensure coverage files exist

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -528,7 +528,7 @@ jobs:
           command: yarn nx affected -t lint --exclude=console,portal-next
       - run:
           name: Test APIM Libs (affected)
-          command: NODE_OPTIONS=--max-old-space-size=4096 yarn nx affected -t test --exclude=console,portal-next --coverage --maxWorkers=2
+          command: NODE_OPTIONS=--max-old-space-size=4096 yarn nx affected -t test --exclude=console,portal-next --coverage --maxWorkers=2 --parallel=1
       - cmd-notify-on-failure
       - run:
           name: Ensure coverage files exist

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -553,7 +553,7 @@ jobs:
           command: yarn nx affected -t lint --exclude=console,portal-next
       - run:
           name: Test APIM Libs (affected)
-          command: NODE_OPTIONS=--max-old-space-size=4096 yarn nx affected -t test --exclude=console,portal-next --coverage --maxWorkers=2
+          command: NODE_OPTIONS=--max-old-space-size=4096 yarn nx affected -t test --exclude=console,portal-next --coverage --maxWorkers=2 --parallel=1
       - cmd-notify-on-failure
       - run:
           name: Ensure coverage files exist

--- a/gravitee-gamma/gravitee-gamma-module-apim/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/package.json
@@ -2,7 +2,7 @@
     "name": "gravitee-gamma-module-apim",
     "private": true,
     "dependencies": {
-        "@gravitee/gamma-lib-observability": "1.35.2",
+        "@gravitee/gamma-lib-observability": "1.36.0",
         "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/graphene-charts": "3.3.0",
         "@gravitee/graphene-core": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@fontsource/material-icons-two-tone": "5.2.5",
         "@fontsource/montserrat": "5.2.5",
         "@fontsource/roboto": "5.2.5",
-        "@gravitee/gamma-lib-observability": "1.35.2",
+        "@gravitee/gamma-lib-observability": "1.36.0",
         "@gravitee/graphene-charts": "3.3.0",
         "@gravitee/graphene-core": "3.3.0",
         "@gravitee/graphene-policy-studio": "3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4567,9 +4567,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/gamma-lib-observability@npm:1.35.2":
-  version: 1.35.2
-  resolution: "@gravitee/gamma-lib-observability@npm:1.35.2"
+"@gravitee/gamma-lib-observability@npm:1.36.0":
+  version: 1.36.0
+  resolution: "@gravitee/gamma-lib-observability@npm:1.36.0"
   peerDependencies:
     "@gravitee/graphene-charts": ^2.57.0
     "@gravitee/graphene-core": ^2.57.0
@@ -4585,7 +4585,7 @@ __metadata:
       optional: true
     tailwindcss:
       optional: true
-  checksum: 10c0/d3fa9962b0981883255435ac656737993c60e58313d45c673a7fbe7a37629124de7a8270d68cd019ed4404bd67c9fc9a79f6df37cad3290bf6c51b5209eae8f3
+  checksum: 10c0/347cdecbbe14418d6505f205d494fdef9caebb90f2abc22c8d0e50308cb2099a140e8cf234cd3abec91511fbd02f3d0d28a27e756ac48f60f93617de564aed6c
   languageName: node
   linkType: hard
 
@@ -21538,7 +21538,7 @@ __metadata:
     "@fontsource/material-icons-two-tone": "npm:5.2.5"
     "@fontsource/montserrat": "npm:5.2.5"
     "@fontsource/roboto": "npm:5.2.5"
-    "@gravitee/gamma-lib-observability": "npm:1.35.2"
+    "@gravitee/gamma-lib-observability": "npm:1.36.0"
     "@gravitee/gamma-modules-sdk": "npm:1.2.0"
     "@gravitee/graphene-charts": "npm:3.3.0"
     "@gravitee/graphene-core": "npm:3.3.0"


### PR DESCRIPTION
## What

Bumps `@gravitee/gamma-lib-observability` from `1.35.2` to the released **1.36.0** in both consumers of the lib in this repo:

- root `gravitee-apim-workspace` `package.json` (+ `yarn.lock`)
- `gravitee-gamma/gravitee-gamma-module-apim/package.json`
