### PR TITLE
fix(mongodb): add PageRevisionIndexUpgrader for optimized page revisions query performance

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/pagerevisions/PageRevisionIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/pagerevisions/PageRevisionIndexUpgrader.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.pagerevisions;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Compound index on {@code _id.pageId} (ascending) and {@code _id.revision} (descending) to
+ * cover the {@code findLastByPageId} query: filter on {@code _id.pageId} + sort by
+ * {@code _id.revision DESC} + limit 1.
+ *
+ * <p>Without this index MongoDB falls back to a COLLSCAN across the entire {@code page_revisions}
+ * collection for every call, which becomes a severe bottleneck when the endpoint that triggers
+ * these look-ups is called frequently (e.g. {@code GET /applications}).
+ *
+ * @author GraviteeSource Team
+ */
+@Component("PageRevisionsPageRevisionIndexUpgrader")
+public class PageRevisionIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("page_revisions")
+            .name("pi1r-1")
+            .key("_id.pageId", ascending())
+            .key("_id.revision", descending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/pagerevisions/PageRevisionIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/pagerevisions/PageRevisionIndexUpgrader.java
@@ -19,17 +19,6 @@ import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
 import org.springframework.stereotype.Component;
 
-/**
- * Compound index on {@code _id.pageId} (ascending) and {@code _id.revision} (descending) to
- * cover the {@code findLastByPageId} query: filter on {@code _id.pageId} + sort by
- * {@code _id.revision DESC} + limit 1.
- *
- * <p>Without this index MongoDB falls back to a COLLSCAN across the entire {@code page_revisions}
- * collection for every call, which becomes a severe bottleneck when the endpoint that triggers
- * these look-ups is called frequently (e.g. {@code GET /applications}).
- *
- * @author GraviteeSource Team
- */
 @Component("PageRevisionsPageRevisionIndexUpgrader")
 public class PageRevisionIndexUpgrader extends IndexUpgrader {
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/pagerevisions/PageRevisionIndexUpgraderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/pagerevisions/PageRevisionIndexUpgraderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.pagerevisions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+class PageRevisionIndexUpgraderTest {
+
+    @Test
+    void buildIndex_definesCompoundIndexOnPageRevisionsWithExpectedNameAndKeys() {
+        Index index = new PageRevisionIndexUpgrader().buildIndex();
+
+        assertThat(index.getCollection()).isEqualTo("page_revisions");
+        assertThat(index.options().getName()).isEqualTo("pi1r-1");
+
+        Document keys = index.toIndexDefinition().getIndexKeys();
+        assertThat(keys).hasSize(2);
+        assertThat(keys.get("_id.pageId")).isEqualTo(1);
+        assertThat(keys.get("_id.revision")).isEqualTo(-1);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14337

## Description

Adds a compound MongoDB index on `page_revisions` (`_id.pageId` ascending, `_id.revision` descending) to fix a response-time regression on `GET /management/organizations/{orgId}/environments/{envId}/applications`.

`PageRevisionMongoRepositoryImpl.findLastByPageId()` filters on `_id.pageId`, a sub-field of the composite `_id = {pageId, revision}`. MongoDB cannot use the default compound `_id` index to satisfy a filter on one sub-field, so
every call falls back to a full collection scan (COLLSCAN) across `page_revisions`. This index lets Mongo serve the filter and the sort directly instead of scanning the collection.

### Root cause

`page_revisions` documents use a composite `_id`, not a plain string:

[`PageRevisionPkMongo.java#L32-L33`](https://github.com/gravitee-io/gravitee-api-management/blob/4.11.x/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PageRevisionPkMongo.java#L32-L33)
```java
private String pageId;
private int revision;
```

[`PageRevisionMongo.java#L36-L37`](https://github.com/gravitee-io/gravitee-api-management/blob/4.11.x/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PageRevisionMongo.java#L36-L37)
```java
@Id
private PageRevisionPkMongo id;
```
`@Id` maps this straight to MongoDB's `_id`, so every document's `_id` is `{pageId, revision}` combined — not a single value.

The query that reads this collection filters on only one piece of that composite key:

[`PageRevisionMongoRepositoryImpl.java#L38-L47`](https://github.com/gravitee-io/gravitee-api-management/blob/4.11.x/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/revision/PageRevisionMongoRepositoryImpl.java#L38-L47)
```java
public Optional<PageRevisionMongo> findLastByPageId(String pageId) {
    Query query = new Query();
    query.limit(1);
    query.with(Sort.by(Sort.Direction.DESC, "_id.revision"));
    query.addCriteria(where("_id.pageId").is(pageId));

    PageRevisionMongo revision = mongoTemplate.findOne(query, PageRevisionMongo.class);
    return Optional.ofNullable(revision);
}
```
The filter (`addCriteria`) only references `_id.pageId`; `_id.revision` is used solely for sorting, never for filtering.

MongoDB's automatic index on `_id` is built to match on the *whole* `_id` value as a single unit — it doesn't decompose `_id` into independently searchable sub-fields. A filter on `_id.pageId` alone can't use that index, so MongoDB falls back to a full collection scan (COLLSCAN) on every call. 
### Before Fix: 
```gravitee> db.page_revisions.estimatedDocumentCount()
5
gravitee> const bulk = [];
| for (let i = 0; i < 20000; i++) {
|   const pageId = i < 200 ? "hot-page" : "page-" + (i % 2900);
|   const revision = i < 200 ? i + 1 : Math.floor(i / 2900) + 1;
|   bulk.push({
|     insertOne: {
|       document: {
|         _id: { pageId: pageId, revision: revision },
|         name: "rev",
|         content: "seed data " + i
|       }
|     }
|   });
| }
| db.page_revisions.bulkWrite(bulk, { ordered: false });
| db.page_revisions.estimatedDocumentCount()
20005
gravitee> db.page_revisions.dropIndex("pi1")
| 
| db.page_revisions.find({ "_id.pageId": "hot-page" })
|   .sort({ "_id.revision": -1 })
|   .limit(1)
|   .explain("executionStats")
{
  explainVersion: '1',
  queryPlanner: {
    namespace: 'gravitee.page_revisions',
    indexFilterSet: false,
    parsedQuery: { '_id.pageId': { '$eq': 'hot-page' } },
    queryHash: '3D3C4E15',
    planCacheKey: '3D3C4E15',
    maxIndexedOrSolutionsReached: false,
    maxIndexedAndSolutionsReached: false,
    maxScansToExplodeReached: false,
    winningPlan: {
      stage: 'SORT',
      sortPattern: { '_id.revision': -1 },
      memLimit: 104857600,
      limitAmount: 1,
      type: 'simple',
      inputStage: {
        stage: 'COLLSCAN',
        filter: { '_id.pageId': { '$eq': 'hot-page' } },
        direction: 'forward'
      }
    },
    rejectedPlans: []
  },
  executionStats: {
    executionSuccess: true,
    nReturned: 1,
    executionTimeMillis: 5,
    totalKeysExamined: 0,
    totalDocsExamined: 20005,
    executionStages: {
      stage: 'SORT',
      nReturned: 1,
      executionTimeMillisEstimate: 0,
      works: 20008,
      advanced: 1,
      needTime: 20006,
      needYield: 0,
      saveState: 20,
      restoreState: 20,
      isEOF: 1,
      sortPattern: { '_id.revision': -1 },
      memLimit: 104857600,
      limitAmount: 1,
      type: 'simple',
      totalDataSizeSorted: 0,
      usedDisk: false,
      spills: 0,
      inputStage: {
        stage: 'COLLSCAN',
        filter: { '_id.pageId': { '$eq': 'hot-page' } },
        nReturned: 200,
        executionTimeMillisEstimate: 0,
        works: 20006,
        advanced: 200,
        needTime: 19805,
        needYield: 0,
        saveState: 20,
        restoreState: 20,
        isEOF: 1,
        direction: 'forward',
        docsExamined: 20005
      }
    }
  },
  command: {
    find: 'page_revisions',
    filter: { '_id.pageId': 'hot-page' },
    sort: { '_id.revision': -1 },
    limit: 1,
    '$db': 'gravitee'
  },
  serverInfo: {
    host: 'b23430303480',
    port: 27017,
    version: '6.0.8',
    gitVersion: '3d84c0dd4e5d99be0d69003652313e7eaf4cdd74'
  },
  serverParameters: {
    internalQueryFacetBufferSizeBytes: 104857600,
    internalQueryFacetMaxOutputDocSizeBytes: 104857600,
    internalLookupStageIntermediateDocumentMaxSizeBytes: 104857600,
    internalDocumentSourceGroupMaxMemoryBytes: 104857600,
    internalQueryMaxBlockingSortMemoryUsageBytes: 104857600,
    internalQueryProhibitBlockingMergeOnMongoS: 0,
    internalQueryMaxAddToSetBytes: 104857600,
    internalDocumentSourceSetWindowFieldsMaxMemoryBytes: 104857600
  },
  ok: 1
}
```

This PR adds an index built explicitly on `_id.pageId` (+ `_id.revision` for the sort), so MongoDB can serve the filter directly instead of scanning the collection.

### Verification

Reproduced locally against a seeded `page_revisions` collection (20k docs,
one page with 200 revisions) to confirm the query plan change:

**Before** (index dropped to simulate no covering index): `SORT` → `COLLSCAN`,
20,005 docs examined to return 1.

**After** (`pi1r-1` created): `LIMIT` → `FETCH` → `IXSCAN` on `pi1r-1`,
1 doc examined, no blocking sort stage needed since the index already
returns results in the required order.
