### PR TITLE
feat(api-properties): Add property-level classification

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
@@ -108,7 +108,6 @@ export class ApiDynamicPropertiesV4Component implements OnInit, OnDestroy {
           const configControl = this.form.controls.configuration;
           const originalMarkAsDirty = configControl.markAsDirty.bind(configControl);
           configControl.markAsDirty = () => {};
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           ((window as any).__zone_symbol__setTimeout || setTimeout)(() => {
             configControl.markAsDirty = originalMarkAsDirty;
             this.initialFormValue = this.form.getRawValue();

--- a/gravitee-apim-console-webui/src/management/api/properties/properties/api-properties.component.html
+++ b/gravitee-apim-console-webui/src/management/api/properties/properties/api-properties.component.html
@@ -96,14 +96,14 @@
           <span *ngIf="element.encrypted" class="gio-badge-success">Encrypted</span>
           <span *ngIf="!element.encrypted && element.encryptable" class="gio-badge-accent">Encrypted on save</span>
           <span *ngIf="!element.encrypted && !element.encryptable" class="gio-badge-neutral">Unencrypted </span>
-          <span *ngIf="element.dynamic" class="gio-badge-neutral">Dynamic</span>
+          <span *ngIf="element.dynamic" data-testid="property-characteristic-dynamic" class="gio-badge-warning">Dynamic</span>
         </td>
       </ng-container>
 
       <ng-container matColumnDef="actions">
         <th mat-header-cell *matHeaderCellDef mat-sort-header></th>
         <td mat-cell *matCellDef="let element">
-          <ng-container *ngIf="!element.dynamic">
+          <ng-container>
             <button
               *ngIf="element.encrypted || element.encryptable"
               type="button"

--- a/gravitee-apim-console-webui/src/management/api/properties/properties/api-properties.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/properties/api-properties.component.spec.ts
@@ -25,6 +25,7 @@ import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
+import { SpanHarness } from '@gravitee/ui-particles-angular/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -124,6 +125,69 @@ describe('ApiPropertiesComponent', () => {
         characteristic: 'Unencrypted Dynamic',
       },
     ]);
+  });
+
+  it('should visually distinguish the Dynamic chip from Unencrypted', async () => {
+    expectGetApi(
+      fakeApiV4({
+        id: API_ID,
+        properties: [{ key: 'key3', value: 'value3', dynamic: true }],
+        services: {
+          dynamicProperty: {
+            enabled: true,
+          },
+        },
+      }),
+    );
+
+    const dynamicChip = await loader.getHarness(SpanHarness.with({ selector: '[data-testid="property-characteristic-dynamic"]' }));
+    expect(await dynamicChip.getText()).toEqual('Dynamic');
+
+    const dynamicChipHost = await dynamicChip.host();
+    expect(await dynamicChipHost.hasClass('gio-badge-neutral')).toEqual(false);
+  });
+
+  it('should disable the value input for encrypted and dynamic properties (AC-4)', async () => {
+    expectGetApi(
+      fakeApiV4({
+        id: API_ID,
+        properties: [
+          { key: 'encryptedKey', value: 'cipher', encrypted: true },
+          { key: 'dynamicKey', value: 'value', dynamic: true },
+        ],
+        services: {
+          dynamicProperty: {
+            enabled: true,
+          },
+        },
+      }),
+    );
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: '[aria-label="API Properties"]' }));
+    const rows = await table.getRows();
+
+    const encryptedValueInput = await (await rows[0].getCells())[1].getHarness(MatInputHarness);
+    expect(await encryptedValueInput.isDisabled()).toEqual(true);
+
+    const dynamicValueInput = await (await rows[1].getCells())[1].getHarness(MatInputHarness);
+    expect(await dynamicValueInput.isDisabled()).toEqual(true);
+  });
+
+  it('should allow encrypting a dynamic property row', async () => {
+    expectGetApi(
+      fakeApiV4({
+        id: API_ID,
+        properties: [{ key: 'dynamicKey', value: 'value', dynamic: true }],
+        services: {
+          dynamicProperty: {
+            enabled: true,
+          },
+        },
+      }),
+    );
+
+    const encryptValueButton = await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Encrypt value"]' }));
+    expect(await encryptValueButton.isDisabled()).toEqual(false);
   });
 
   it('should renew encrypted value', async () => {

--- a/gravitee-apim-console-webui/src/management/api/properties/properties/properties-add-dialog/properties-add-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/properties/properties/properties-add-dialog/properties-add-dialog.component.html
@@ -38,7 +38,8 @@
 
   <gio-form-slide-toggle class="field">
     <gio-form-label>Encrypt</gio-form-label>
-    The value will be encrypted on save, and cannot be retrieved later on.
+    The value will be encrypted on save, and cannot be retrieved later on. Once encrypted, a property stays encrypted — you can renew its
+    value but cannot make it plain again.
     <mat-slide-toggle
       gioFormSlideToggle
       formControlName="toEncrypt"

--- a/gravitee-apim-console-webui/src/management/api/properties/properties/properties-add-dialog/properties-add-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/properties/properties-add-dialog/properties-add-dialog.component.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { PropertiesAddDialogComponent, PropertiesAddDialogData } from './properties-add-dialog.component';
+import { PropertiesAddDialogModule } from './properties-add-dialog.module';
+import { PropertiesAddDialogHarness } from './properties-add-dialog.harness';
+
+import { GioTestingModule } from '../../../../../shared/testing';
+
+describe('PropertiesAddDialogComponent', () => {
+  const matDialogRefMock = {
+    close: jest.fn(),
+  };
+
+  let fixture: ComponentFixture<PropertiesAddDialogComponent>;
+  let componentHarness: PropertiesAddDialogHarness;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioTestingModule, MatDialogModule, PropertiesAddDialogModule],
+      providers: [{ provide: MatDialogRef, useValue: matDialogRefMock }],
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    matDialogRefMock.close.mockClear();
+  });
+
+  async function createComponent(dialogData: PropertiesAddDialogData): Promise<PropertiesAddDialogHarness> {
+    TestBed.overrideProvider(MAT_DIALOG_DATA, { useValue: dialogData });
+    fixture = TestBed.createComponent(PropertiesAddDialogComponent);
+    return TestbedHarnessEnvironment.harnessForFixture(fixture, PropertiesAddDialogHarness);
+  }
+
+  it('should default classification to Plain (AC-2)', async () => {
+    componentHarness = await createComponent({ properties: [] });
+
+    expect(await componentHarness.isEncryptToggleChecked()).toEqual(false);
+
+    await componentHarness.setPropertyValue({ key: 'newKey', value: 'newValue' });
+    await componentHarness.add();
+
+    expect(matDialogRefMock.close).toHaveBeenCalledWith({
+      key: 'newKey',
+      value: 'newValue',
+      encryptable: false,
+    });
+  });
+
+  it('should disable Add while key is empty or duplicated, and enable once a unique key is entered (AC-1/AC-5)', async () => {
+    componentHarness = await createComponent({ properties: [{ key: 'existing', value: 'v', encrypted: false }] });
+
+    expect(await componentHarness.isAddDisabled()).toEqual(true);
+
+    await componentHarness.setPropertyValue({ key: 'existing', value: 'v2' });
+    expect(await componentHarness.isAddDisabled()).toEqual(true);
+
+    await componentHarness.setPropertyValue({ key: 'newUniqueKey' });
+    expect(await componentHarness.isAddDisabled()).toEqual(false);
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/properties/properties/properties-add-dialog/properties-add-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/properties/properties-add-dialog/properties-add-dialog.harness.ts
@@ -42,4 +42,12 @@ export class PropertiesAddDialogHarness extends ComponentHarness {
   async add(): Promise<void> {
     await this.locatorFor(MatButtonHarness.with({ text: 'Add' }))().then(btn => btn.click());
   }
+
+  async isAddDisabled(): Promise<boolean> {
+    return this.locatorFor(MatButtonHarness.with({ text: 'Add' }))().then(btn => btn.isDisabled());
+  }
+
+  async isEncryptToggleChecked(): Promise<boolean> {
+    return this.getMatToggleHarness('toEncrypt').then(toggle => toggle.isChecked());
+  }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -458,6 +458,10 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                     });
             }
 
+            if (updateApiEntity.getProperties() != null) {
+                PropertyClassificationValidator.rejectEncryptedToPlain(existingApiEntity.getProperties(), updateApiEntity.getProperties());
+            }
+
             // encrypt API properties
             if (updateApiEntity.getProperties() != null) {
                 updateApiEntity.setProperties(this.propertiesService.encryptProperties(updateApiEntity.getProperties()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PropertyClassificationValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PropertyClassificationValidator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import io.gravitee.definition.model.v4.property.Property;
+import io.gravitee.rest.api.model.v4.api.properties.PropertyEntity;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * This class ensures that property classification is immutable once encrypted.
+ * The only allowed transitions for a key that is already stored as {@code encrypted=true} are:
+ * staying encrypted, or a renew ({@code encryptable=true}). A move back to plain
+ * ({@code encrypted=false && encryptable=false}) is rejected. The one-way {@code plain -> encrypted}
+ * exception is always allowed because the existing property is not yet encrypted.
+ */
+public final class PropertyClassificationValidator {
+
+    private PropertyClassificationValidator() {}
+
+    public static void rejectEncryptedToPlain(List<Property> existing, List<PropertyEntity> incoming) {
+        if (existing == null || incoming == null) {
+            return;
+        }
+        Map<String, Property> existingByKey = existing
+            .stream()
+            .collect(Collectors.toMap(Property::getKey, Function.identity(), (a, b) -> a));
+
+        for (PropertyEntity in : incoming) {
+            Property old = existingByKey.get(in.getKey());
+            boolean wasEncrypted = old != null && old.isEncrypted();
+            boolean nowPlain = !in.isEncrypted() && !in.isEncryptable();
+            if (wasEncrypted && nowPlain) {
+                throw new InvalidDataException("Property '" + in.getKey() + "' is encrypted and cannot be reclassified to plain.");
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -115,6 +115,7 @@ import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
+import io.gravitee.rest.api.model.v4.api.properties.PropertyEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.service.AlertService;
 import io.gravitee.rest.api.service.ApiMetadataService;
@@ -1015,6 +1016,25 @@ public class ApiServiceImplTest {
             ApiEntity apiEntity = apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity, true, USER_NAME);
             verify(apiNotificationService, times(1)).triggerUpdateNotification(eq(GraviteeContext.getExecutionContext()), eq(apiEntity));
         });
+    }
+
+    @Test
+    public void shouldNotUpdate_EncryptedPropertyBecomesPlain() throws TechnicalException, JsonProcessingException {
+        prepareUpdate();
+
+        io.gravitee.definition.model.v4.Api apiDefinition = new io.gravitee.definition.model.v4.Api();
+        apiDefinition.setId(API_ID);
+        apiDefinition.setName(API_NAME);
+        HttpListener httpListener = HttpListener.builder().paths(List.of(Path.builder().path("/context").build())).build();
+        apiDefinition.setListeners(singletonList(httpListener));
+        apiDefinition.setProperties(List.of(new Property("secret-key", "encrypted-value", true)));
+        api.setDefinition(objectMapper.writeValueAsString(apiDefinition));
+
+        updateApiEntity.setProperties(List.of(new PropertyEntity("secret-key", "plain-value", false, false)));
+
+        assertThrows(InvalidDataException.class, () ->
+            apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity, USER_NAME)
+        );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PropertyClassificationValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PropertyClassificationValidatorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.definition.model.v4.property.Property;
+import io.gravitee.rest.api.model.v4.api.properties.PropertyEntity;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PropertyClassificationValidatorTest {
+
+    @Test
+    void rejects_encrypted_to_plain() {
+        var existing = List.of(new Property("secret", "cipher", true, false)); // stored encrypted
+        var incoming = List.of(new PropertyEntity("secret", "cipher", false, false)); // encryptable=false, encrypted=false
+        assertThatThrownBy(() -> PropertyClassificationValidator.rejectEncryptedToPlain(existing, incoming))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("secret");
+    }
+
+    @Test
+    void allows_plain_to_encrypted() {
+        var existing = List.of(new Property("k", "v", false, false));
+        var incoming = List.of(new PropertyEntity("k", "v", true, false)); // encryptable=true (D10 exception)
+        assertThatCode(() -> PropertyClassificationValidator.rejectEncryptedToPlain(existing, incoming)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void allows_renew_of_encrypted() {
+        var existing = List.of(new Property("k", "cipher", true, false));
+        var incoming = List.of(new PropertyEntity("k", "", true, false)); // renew: encryptable=true, encrypted=false
+        assertThatCode(() -> PropertyClassificationValidator.rejectEncryptedToPlain(existing, incoming)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void allows_unchanged_encrypted() {
+        var existing = List.of(new Property("k", "cipher", true, false));
+        var incoming = List.of(new PropertyEntity("k", "cipher", false, true)); // stays encrypted=true
+        assertThatCode(() -> PropertyClassificationValidator.rejectEncryptedToPlain(existing, incoming)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void ignores_new_keys_and_nulls() {
+        var existing = List.of(new Property("k", "cipher", true, false));
+        var incoming = List.of(new PropertyEntity("brand-new", "v", false, false));
+        assertThatCode(() -> PropertyClassificationValidator.rejectEncryptedToPlain(existing, incoming)).doesNotThrowAnyException();
+        assertThatCode(() -> PropertyClassificationValidator.rejectEncryptedToPlain(null, incoming)).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-167

## Description

Added the encrypt button for dynamic properties. Updated the Dynamic indicator chip on the list according to Figma. Added a validator ensuring the plain -> encrypted change is one way for the properties.

## Additional context

Persiting of the dynamic properties encryption will come in the following tasks.

