### PR TITLE
FOUND-2-Environment-Scoped-Dictionaries-cleanup-and-bug-fix

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -17,6 +17,9 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { AppRoutes } from './AppRoutes';
+import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
+import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
+import { ApimApiError } from '../shared/api/apimClient';
 
 jest.mock('./PlatformToaster', () => ({
     PlatformToaster: () => <div data-testid="platform-toaster" />,
@@ -30,11 +33,13 @@ jest.mock('@gravitee/gamma-modules-sdk/routing', () => ({
     }),
 }));
 
+const mockUseLayoutConfig = jest.fn();
+
 jest.mock('@gravitee/graphene-core', () => {
     const actual = jest.requireActual('@gravitee/graphene-core') as object;
     return {
         ...actual,
-        useLayoutConfig: jest.fn(),
+        useLayoutConfig: (config: unknown, deps: unknown) => mockUseLayoutConfig(config, deps),
         SidebarNavigation: () => null,
         buildLinearBreadcrumbs: () => [],
     };
@@ -48,6 +53,18 @@ jest.mock('../shared/hooks/useEnvironmentPermissions', () => ({
     useEnvironmentPermissions: jest.fn(),
     useEnvironmentPermissionsReady: jest.fn().mockReturnValue(true),
 }));
+
+const mockUseHasPermission = jest.fn().mockReturnValue(true);
+
+jest.mock('../shared/gamma-modules-sdk', () => ({
+    useHasPermission: (options: unknown) => mockUseHasPermission(options),
+}));
+
+jest.mock('../features/dictionaries/hooks/useEnvironmentDictionaries');
+jest.mock('../features/metadata/hooks/useEnvironmentMetadata');
+
+const mockUseEnvironmentDictionaries = jest.mocked(useEnvironmentDictionaries);
+const mockUseEnvironmentMetadata = jest.mocked(useEnvironmentMetadata);
 
 jest.mock('../pages/ApplicationsPage', () => ({
     ApplicationsPage: () => <div data-testid="applications-page" />,
@@ -70,13 +87,40 @@ jest.mock('../pages/ApplicationDetailSubscriptionPage', () => ({
     ApplicationDetailSubscriptionPage: () => null,
 }));
 
+function renderPlatform() {
+    render(
+        <MemoryRouter initialEntries={['/applications']}>
+            <AppRoutes />
+        </MemoryRouter>,
+    );
+}
+
+function visibleNavKeys(): string[] {
+    const config = mockUseLayoutConfig.mock.calls.at(-1)?.[0] as { navigation?: { props?: { groups?: unknown } } } | undefined;
+    const groups = (config?.navigation?.props?.groups ?? []) as { items: { key: string }[] }[];
+    return groups.flatMap(group => group.items.map(item => item.key));
+}
+
 describe('AppRoutes', () => {
+    beforeEach(() => {
+        mockUseLayoutConfig.mockClear();
+        mockUseHasPermission.mockReset().mockReturnValue(true);
+        mockUseEnvironmentDictionaries.mockReturnValue({
+            data: [],
+            isLoading: false,
+            isError: false,
+            error: null,
+        } as ReturnType<typeof useEnvironmentDictionaries>);
+        mockUseEnvironmentMetadata.mockReturnValue({
+            data: [],
+            isLoading: false,
+            isError: false,
+            error: null,
+        } as ReturnType<typeof useEnvironmentMetadata>);
+    });
+
     it('mounts PlatformToaster for module-wide toast feedback', () => {
-        render(
-            <MemoryRouter initialEntries={['/applications']}>
-                <AppRoutes />
-            </MemoryRouter>,
-        );
+        renderPlatform();
 
         expect(screen.getByTestId('platform-toaster')).not.toBeNull();
         expect(screen.getByTestId('applications-page')).not.toBeNull();
@@ -90,5 +134,61 @@ describe('AppRoutes', () => {
         );
 
         expect(screen.getByTestId('users-page')).not.toBeNull();
+    });
+
+    it('shows the Dictionaries nav item when the user has read permission', () => {
+        renderPlatform();
+
+        expect(visibleNavKeys()).toContain('dictionaries');
+    });
+
+    it('hides the Dictionaries nav item when the user lacks environment-dictionary-r', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-dictionary-r'));
+
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('dictionaries');
+    });
+
+    it('hides the Dictionaries nav item on a fresh load when the permissions map is wrong and the resource 403s', () => {
+        // The permissions map says the user CAN read dictionaries, but the actual list call always 403s
+        // (e.g. a stale backend permission cache) — the nav must not trust the map alone.
+        mockUseEnvironmentDictionaries.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            error: new ApimApiError(403, 'Forbidden'),
+        } as ReturnType<typeof useEnvironmentDictionaries>);
+
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('dictionaries');
+    });
+
+    it('shows the Metadata nav item when the user has read permission', () => {
+        renderPlatform();
+
+        expect(visibleNavKeys()).toContain('metadata');
+    });
+
+    it('hides the Metadata nav item when the user lacks environment-metadata-r', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-metadata-r'));
+
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('metadata');
+    });
+
+    it('hides the Metadata nav item on a fresh load when the permissions map is wrong and the resource 403s', () => {
+        mockUseEnvironmentMetadata.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            error: new ApimApiError(403, 'Forbidden'),
+        } as ReturnType<typeof useEnvironmentMetadata>);
+
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('metadata');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -25,6 +25,8 @@ import { applicationDetailTabElement } from '../config/applicationDetailPages';
 import { NAV_GROUPS } from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
+import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
+import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
 import { SecurityPlanTypesPage } from '../features/security-plan-types/SecurityPlanTypesPage';
 import { ORGANIZATION_USER_ACCESS_PERMISSIONS } from '../features/users/utils/userPermissions';
 import { AccessManagementPage } from '../pages/AccessManagementPage';
@@ -40,6 +42,7 @@ import { retryTransientRequest } from '../shared/api/queryRetry';
 import { ConsoleSettingsProvider } from '../shared/console-settings';
 import { useHasPermission } from '../shared/gamma-modules-sdk';
 import { useEnvironmentPermissions, useEnvironmentPermissionsReady } from '../shared/hooks/useEnvironmentPermissions';
+import { isForbiddenApiError } from '../shared/utils/apiErrors';
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -109,8 +112,18 @@ function ModuleLayout() {
     useEnvironmentPermissions();
 
     const permissionsReady = useEnvironmentPermissionsReady();
-    const canReadMetadata = useHasPermission({ anyOf: ['environment-metadata-r'] });
-    const canReadDictionaries = useHasPermission({ anyOf: ['environment-dictionary-r'] });
+
+    // Only probe the resource once the permission map already says "yes" — that's the only case where a
+    // 403 here would disagree with it. Probing unconditionally would hit both list APIs on every platform
+    // page for every user, including those who already correctly lack access.
+    const canReadMetadataPermission = useHasPermission({ anyOf: ['environment-metadata-r'] });
+    const metadataQuery = useEnvironmentMetadata({ enabled: canReadMetadataPermission });
+    const canReadMetadata = canReadMetadataPermission && !isForbiddenApiError(metadataQuery.isError, metadataQuery.error);
+
+    const canReadDictionariesPermission = useHasPermission({ anyOf: ['environment-dictionary-r'] });
+    const dictionariesQuery = useEnvironmentDictionaries({ enabled: canReadDictionariesPermission });
+    const canReadDictionaries = canReadDictionariesPermission && !isForbiddenApiError(dictionariesQuery.isError, dictionariesQuery.error);
+
     const canAccessUsers = useHasPermission({ anyOf: [...ORGANIZATION_USER_ACCESS_PERMISSIONS] });
     const canReadEntrypoints = useHasPermission({ anyOf: ['environment-entrypoint-r', 'organization-entrypoint-r'] });
 
@@ -194,7 +207,15 @@ export function AppRoutes() {
                             <Route
                                 path=":dictionaryId"
                                 element={
-                                    <PermissionPageGuard permission="environment-dictionary-r" unauthorizedTo="../../applications">
+                                    <PermissionPageGuard
+                                        anyOf={[
+                                            'environment-dictionary-c',
+                                            'environment-dictionary-r',
+                                            'environment-dictionary-u',
+                                            'environment-dictionary-d',
+                                        ]}
+                                        unauthorizedTo="../../applications"
+                                    >
                                         <DictionaryDetailPage />
                                     </PermissionPageGuard>
                                 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesEmptyState.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesEmptyState.spec.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { DictionariesEmptyState } from './DictionariesEmptyState';
+
+describe('DictionariesEmptyState', () => {
+    it('renders the why/how-it-works/benefits content', () => {
+        render(<DictionariesEmptyState />);
+
+        expect(screen.getByText('Why configure dictionaries?')).not.toBeNull();
+        expect(screen.getByText('How it works')).not.toBeNull();
+        expect(screen.getByText('Dictionary')).not.toBeNull();
+        expect(screen.getByText('Referenced by policies')).not.toBeNull();
+        expect(screen.getByText('Reference shared lookup data from any API policy in this environment')).not.toBeNull();
+        expect(screen.getByText(/Dynamic dictionaries poll an HTTP provider/)).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesEmptyState.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesEmptyState.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent } from '@gravitee/graphene-core';
+import { ArrowRightIcon, BookOpenIcon, CircleCheckIcon, GlobeIcon, KeyIcon, RefreshCwIcon } from '@gravitee/graphene-core/icons';
+import type { ComponentType } from 'react';
+
+function FlowNode({
+    icon: Icon,
+    label,
+    active = false,
+}: Readonly<{ icon: ComponentType<{ className?: string }>; label: string; active?: boolean }>) {
+    return (
+        <div
+            className="flex flex-col items-center gap-1.5"
+            style={active ? { border: '1px solid var(--color-border)', borderRadius: '0.5rem', padding: '0.5rem 0.75rem' } : undefined}
+        >
+            <div
+                className="rounded-lg p-2"
+                style={{ backgroundColor: active ? 'color-mix(in oklab, var(--color-primary) 10%, transparent)' : 'var(--color-muted)' }}
+            >
+                <Icon className={active ? 'size-4 text-primary' : 'size-4 text-muted-foreground'} />
+            </div>
+            <p className={active ? 'text-xs font-semibold text-center' : 'text-xs text-muted-foreground text-center'}>{label}</p>
+        </div>
+    );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+const BENEFITS = [
+    'Reference shared lookup data from any API policy in this environment',
+    'Keep values manual, or sync them dynamically from an HTTP endpoint on a schedule',
+    'Update values in one place instead of duplicating them across APIs',
+] as const;
+
+export function DictionariesEmptyState() {
+    return (
+        <Card>
+            <CardContent className="p-6 space-y-6">
+                <div className="space-y-1">
+                    <p className="text-sm font-semibold">Why configure dictionaries?</p>
+                    <p className="text-sm text-muted-foreground">
+                        Dictionaries store environment-level lookup data — key/value pairs — that API policies can reference at runtime,
+                        without hardcoding values into each API.
+                    </p>
+                </div>
+
+                {/* How it works flow */}
+                <div
+                    className="rounded-xl p-5 space-y-3"
+                    style={{
+                        border: '2px solid color-mix(in oklab, var(--color-primary) 20%, transparent)',
+                        backgroundColor: 'color-mix(in oklab, var(--color-primary) 4%, transparent)',
+                    }}
+                >
+                    <p className="text-xs font-semibold text-primary">How it works</p>
+                    <div className="flex items-center justify-center gap-3">
+                        <FlowNode icon={GlobeIcon} label="Manual or HTTP source" />
+                        <ArrowRightIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                        <FlowNode icon={BookOpenIcon} label="Dictionary" active />
+                        <ArrowRightIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                        <FlowNode icon={KeyIcon} label="Referenced by policies" />
+                    </div>
+                </div>
+
+                {/* Benefits list */}
+                <ul className="space-y-2">
+                    {BENEFITS.map(b => (
+                        <li key={b} className="flex items-start gap-2">
+                            <CircleCheckIcon className="size-3.5 shrink-0 mt-0.5 text-success" aria-hidden="true" />
+                            <span className="text-xs text-muted-foreground">{b}</span>
+                        </li>
+                    ))}
+                </ul>
+
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <RefreshCwIcon className="size-3.5 shrink-0" aria-hidden="true" />
+                    <span>Dynamic dictionaries poll an HTTP provider on a configurable interval to stay up to date.</span>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.spec.tsx
@@ -72,10 +72,12 @@ describe('DictionariesTable', () => {
             expect(screen.queryByText('Status Map')).not.toBeNull();
         });
 
-        it('shows description under name, or an em dash when missing', () => {
+        it('shows description under name, or nothing when missing', () => {
             renderTable();
             expect(screen.queryByText('ISO country lookup')).not.toBeNull();
-            expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+
+            const nameButton = screen.getByText('Remote Codes').closest('button');
+            expect(nameButton?.textContent).toBe('Remote Codes');
         });
 
         it('truncates long descriptions with an ellipsis on one line', () => {
@@ -108,6 +110,24 @@ describe('DictionariesTable', () => {
         it('shows the empty message when there are no dictionaries', () => {
             renderTable({ dictionaries: [] });
             expect(screen.queryByText('No dictionaries defined for this environment.')).not.toBeNull();
+        });
+
+        it('shows — for Last Deployed on DYNAMIC dictionaries, even when deployed_at is set', () => {
+            renderTable({
+                dictionaries: [
+                    {
+                        id: '2',
+                        name: 'Remote Codes',
+                        type: 'DYNAMIC',
+                        state: 'STARTED',
+                        properties: 3,
+                        updated_at: '2026-01-02T00:00:00.000Z',
+                        deployed_at: '2026-01-05T00:00:00.000Z',
+                    },
+                ],
+            });
+            expect(screen.queryByText('—')).not.toBeNull();
+            expect(screen.queryByText(/Jan 5, 2026/)).toBeNull();
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionariesTable.tsx
@@ -169,17 +169,18 @@ function buildColumns({
             header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Name" />,
             cell: ({ row }: ColCell<DictionaryListItem>) => {
                 const fullDescription = row.original.description?.trim() || '';
-                const description = fullDescription ? truncateLabel(fullDescription, DESCRIPTION_MAX_LENGTH) : '—';
                 return (
                     <button
                         type="button"
-                        className="min-w-0 space-y-0.5 text-left hover:underline focus-visible:outline-none focus-visible:underline"
+                        className="flex min-w-0 h-full flex-col justify-center space-y-0.5 text-left hover:underline focus-visible:outline-none focus-visible:underline"
                         onClick={() => onOpen(row.original)}
                     >
                         <div className="truncate text-sm font-medium text-foreground">{row.original.name}</div>
-                        <div className="whitespace-nowrap text-xs text-muted-foreground" title={fullDescription || undefined}>
-                            {description}
-                        </div>
+                        {fullDescription && (
+                            <div className="whitespace-nowrap text-xs text-muted-foreground" title={fullDescription}>
+                                {truncateLabel(fullDescription, DESCRIPTION_MAX_LENGTH)}
+                            </div>
+                        )}
                     </button>
                 );
             },
@@ -211,7 +212,9 @@ function buildColumns({
             accessorKey: 'deployed_at',
             header: ({ column }: ColHeader<DictionaryListItem>) => <DataTableColumnHeader column={column} title="Last Deployed" />,
             cell: ({ row }: ColCell<DictionaryListItem>) => (
-                <span className="whitespace-nowrap text-sm text-muted-foreground">{formatDictionaryDate(row.original.deployed_at)}</span>
+                <span className="whitespace-nowrap text-sm text-muted-foreground">
+                    {row.original.type === 'DYNAMIC' ? '—' : formatDictionaryDate(row.original.deployed_at)}
+                </span>
             ),
         },
     ];

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryPropertiesTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryPropertiesTable.spec.tsx
@@ -15,6 +15,7 @@
  */
 
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { DictionaryPropertiesTable } from './DictionaryPropertiesTable';
 
@@ -22,6 +23,10 @@ const PROPERTIES = [
     { key: 'MUC', value: 'Munich' },
     { key: 'FRA', value: 'Frankfurt' },
 ];
+
+function manyProperties(count: number) {
+    return Array.from({ length: count }, (_, i) => ({ key: `KEY_${i}`, value: `value-${i}` }));
+}
 
 describe('DictionaryPropertiesTable', () => {
     it('renders property rows', () => {
@@ -59,6 +64,77 @@ describe('DictionaryPropertiesTable', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Delete property FRA' }));
         expect(onDelete).toHaveBeenCalledWith('FRA');
+    });
+
+    it('paginates properties, showing only the first page by default', () => {
+        render(
+            <DictionaryPropertiesTable
+                properties={manyProperties(12)}
+                canEdit={false}
+                isMutating={false}
+                onEdit={jest.fn()}
+                onDelete={jest.fn()}
+                emptyMessage="No properties yet."
+            />,
+        );
+
+        expect(screen.getByText('KEY_0')).not.toBeNull();
+        expect(screen.getByText('KEY_9')).not.toBeNull();
+        expect(screen.queryByText('KEY_10')).toBeNull();
+    });
+
+    it('shows the next page of properties after paging forward', async () => {
+        const user = userEvent.setup();
+        render(
+            <DictionaryPropertiesTable
+                properties={manyProperties(12)}
+                canEdit={false}
+                isMutating={false}
+                onEdit={jest.fn()}
+                onDelete={jest.fn()}
+                emptyMessage="No properties yet."
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /next page/i }));
+
+        expect(screen.getByText('KEY_10')).not.toBeNull();
+        expect(screen.getByText('KEY_11')).not.toBeNull();
+        expect(screen.queryByText('KEY_0')).toBeNull();
+    });
+
+    it('clamps back to the last valid page when properties shrink out from under the current page', async () => {
+        const user = userEvent.setup();
+        const onEdit = jest.fn();
+        const onDelete = jest.fn();
+        const { rerender } = render(
+            <DictionaryPropertiesTable
+                properties={manyProperties(15)}
+                canEdit={false}
+                isMutating={false}
+                onEdit={onEdit}
+                onDelete={onDelete}
+                emptyMessage="No properties yet."
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /next page/i }));
+        expect(screen.getByText('KEY_10')).not.toBeNull();
+
+        // Simulate deleting properties down to a single page — page 2 no longer exists.
+        rerender(
+            <DictionaryPropertiesTable
+                properties={manyProperties(5)}
+                canEdit={false}
+                isMutating={false}
+                onEdit={onEdit}
+                onDelete={onDelete}
+                emptyMessage="No properties yet."
+            />,
+        );
+
+        expect(await screen.findByText('KEY_0')).not.toBeNull();
+        expect(screen.queryByText('No properties yet.')).toBeNull();
     });
 
     it('shows empty message when there are no properties', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryPropertiesTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/components/DictionaryPropertiesTable.tsx
@@ -16,13 +16,21 @@
 
 import { Button, DataTable, type DataTableProps } from '@gravitee/graphene-core';
 import { PencilIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import type { ColCell } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+
+const DEFAULT_PAGE_SIZE = 10;
 
 export interface DictionaryPropertyRow {
     key: string;
     value: string;
+}
+
+function paginateProperties(rows: DictionaryPropertyRow[], page: number, pageSize: number): DictionaryPropertyRow[] {
+    const start = (page - 1) * pageSize;
+    return rows.slice(start, start + pageSize);
 }
 
 function buildColumns({
@@ -110,7 +118,41 @@ export function DictionaryPropertiesTable({
     onDelete: (propertyKey: string) => void;
     emptyMessage: string;
 }>) {
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+
+    const totalCount = properties.length;
+    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+    const paginatedData = useMemo(() => paginateProperties(properties, page, pageSize), [properties, page, pageSize]);
+
     const columns = useMemo(() => buildColumns({ canEdit, isMutating, onEdit, onDelete }), [canEdit, isMutating, onEdit, onDelete]);
 
-    return <DataTable aria-label="Dictionary properties" columns={columns} data={properties} emptyMessage={emptyMessage} />;
+    useEffect(() => {
+        if (page > totalPages) {
+            setPage(totalPages);
+        }
+    }, [page, totalPages]);
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    return (
+        <DataTable
+            aria-label="Dictionary properties"
+            columns={columns}
+            data={paginatedData}
+            serverSide
+            pagination={{
+                page,
+                pageSize,
+                totalCount,
+                pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                onPageChange: setPage,
+                onPageSizeChange: handlePageSizeChange,
+            }}
+            emptyMessage={emptyMessage}
+        />
+    );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useDictionaryMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/hooks/useDictionaryMutations.ts
@@ -23,7 +23,6 @@ import {
     deployEnvironmentDictionary,
     startEnvironmentDictionary,
     stopEnvironmentDictionary,
-    undeployEnvironmentDictionary,
     updateEnvironmentDictionary,
 } from '../services/dictionaries';
 import type { Dictionary, DictionaryListItem, NewDictionaryPayload, UpdateDictionaryPayload } from '../types/dictionary';
@@ -122,10 +121,6 @@ export function useDeleteDictionary() {
 
 export function useDeployDictionary() {
     return useDictionaryMutation<string>(deployEnvironmentDictionary);
-}
-
-export function useUndeployDictionary() {
-    return useDictionaryMutation<string>(undeployEnvironmentDictionary);
 }
 
 export function useStartDictionary() {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/services/dictionaries.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/services/dictionaries.spec.ts
@@ -21,7 +21,6 @@ import {
     listEnvironmentDictionaries,
     startEnvironmentDictionary,
     stopEnvironmentDictionary,
-    undeployEnvironmentDictionary,
     updateEnvironmentDictionary,
 } from './dictionaries';
 import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
@@ -127,16 +126,6 @@ describe('dictionaries service', () => {
         it('calls POST on the _deploy sub-resource', async () => {
             await deployEnvironmentDictionary('env-1', 'dict-1');
             expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries/dict-1/_deploy', {
-                method: 'POST',
-                body: JSON.stringify({}),
-            });
-        });
-    });
-
-    describe('undeployEnvironmentDictionary', () => {
-        it('calls POST on the _undeploy sub-resource', async () => {
-            await undeployEnvironmentDictionary('env-1', 'dict-1');
-            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/configuration/dictionaries/dict-1/_undeploy', {
                 method: 'POST',
                 body: JSON.stringify({}),
             });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/services/dictionaries.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/dictionaries/services/dictionaries.ts
@@ -62,13 +62,6 @@ export async function deployEnvironmentDictionary(environmentId: string, diction
     });
 }
 
-export async function undeployEnvironmentDictionary(environmentId: string, dictionaryId: string): Promise<Dictionary> {
-    return apimFetchJsonV1Env<Dictionary>(environmentId, `/configuration/dictionaries/${encodeURIComponent(dictionaryId)}/_undeploy`, {
-        method: 'POST',
-        body: JSON.stringify({}),
-    });
-}
-
 export async function startEnvironmentDictionary(environmentId: string, dictionaryId: string): Promise<Dictionary> {
     return changeDictionaryLifecycle(environmentId, dictionaryId, 'START');
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/hooks/useEnvironmentMetadata.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/metadata/hooks/useEnvironmentMetadata.ts
@@ -20,12 +20,12 @@ import { useQuery } from '@tanstack/react-query';
 import { listEnvironmentMetadata } from '../services/metadata';
 import { metadataKeys } from '../utils/queryKeys';
 
-export function useEnvironmentMetadata() {
+export function useEnvironmentMetadata(options?: { enabled?: boolean }) {
     const env = useEnvironment();
 
     return useQuery({
         queryKey: metadataKeys.list(env?.id ?? ''),
         queryFn: () => listEnvironmentMetadata(env!.id),
-        enabled: Boolean(env),
+        enabled: Boolean(env) && (options?.enabled ?? true),
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.spec.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { DictionariesPage } from './DictionariesPage';
+import { useCreateDictionary, useDeleteDictionary, useUpdateDictionary } from '../features/dictionaries/hooks/useDictionaryMutations';
+import { useDictionaryPermissions } from '../features/dictionaries/hooks/useDictionaryPermissions';
+import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
+import { useEnvironmentDictionary } from '../features/dictionaries/hooks/useEnvironmentDictionary';
+import { ApimApiError } from '../shared/api/apimClient';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(),
+}));
+
+jest.mock('../features/dictionaries/hooks/useDictionaryPermissions');
+jest.mock('../features/dictionaries/hooks/useEnvironmentDictionaries');
+jest.mock('../features/dictionaries/hooks/useEnvironmentDictionary');
+jest.mock('../features/dictionaries/hooks/useDictionaryMutations');
+
+jest.mock('../features/dictionaries/components/DictionariesTable', () => ({
+    DictionariesTable: () => <div data-testid="dictionaries-table" />,
+}));
+jest.mock('../features/dictionaries/components/DictionariesEmptyState', () => ({
+    DictionariesEmptyState: () => <div data-testid="dictionaries-empty-state" />,
+}));
+jest.mock('../features/dictionaries/components/CreateDictionarySheet', () => ({
+    CreateDictionarySheet: () => null,
+}));
+jest.mock('../features/dictionaries/components/EditDictionarySheet', () => ({
+    EditDictionarySheet: () => null,
+}));
+jest.mock('../features/dictionaries/components/DictionaryDeleteSheet', () => ({
+    DictionaryDeleteSheet: () => null,
+}));
+
+const mockUseEnvironment = jest.mocked(useEnvironment);
+const mockUseDictionaryPermissions = jest.mocked(useDictionaryPermissions);
+const mockUseEnvironmentDictionaries = jest.mocked(useEnvironmentDictionaries);
+const mockUseEnvironmentDictionary = jest.mocked(useEnvironmentDictionary);
+const mockUseCreateDictionary = jest.mocked(useCreateDictionary);
+const mockUseUpdateDictionary = jest.mocked(useUpdateDictionary);
+const mockUseDeleteDictionary = jest.mocked(useDeleteDictionary);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeMutation(): any {
+    return { mutateAsync: jest.fn(), isPending: false };
+}
+
+function renderPage(seedPermissions: string[] = []) {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['environment-permissions', 'env-1'], seedPermissions);
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={['/dictionaries']}>
+                <DictionariesPage />
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+    return { invalidateSpy, queryClient };
+}
+
+describe('DictionariesPage', () => {
+    beforeEach(() => {
+        mockNavigate.mockClear();
+        mockUseEnvironment.mockReturnValue({ id: 'env-1' } as ReturnType<typeof useEnvironment>);
+        mockUseDictionaryPermissions.mockReturnValue({ canRead: true, canCreate: true, canUpdate: true, canDelete: true });
+        mockUseEnvironmentDictionary.mockReturnValue({ data: undefined, isLoading: false } as ReturnType<typeof useEnvironmentDictionary>);
+        mockUseCreateDictionary.mockReturnValue(makeMutation());
+        mockUseUpdateDictionary.mockReturnValue(makeMutation());
+        mockUseDeleteDictionary.mockReturnValue(makeMutation());
+    });
+
+    it('renders the table when dictionaries load successfully', () => {
+        mockUseEnvironmentDictionaries.mockReturnValue({
+            data: [{ id: '1', name: 'Countries', type: 'MANUAL' }],
+            isLoading: false,
+            isError: false,
+            error: null,
+        } as ReturnType<typeof useEnvironmentDictionaries>);
+
+        renderPage();
+
+        expect(screen.getByTestId('dictionaries-table')).not.toBeNull();
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('shows the empty state, not the table, when the dictionaries list is empty', () => {
+        mockUseEnvironmentDictionaries.mockReturnValue({
+            data: [],
+            isLoading: false,
+            isError: false,
+            error: null,
+        } as ReturnType<typeof useEnvironmentDictionaries>);
+
+        renderPage();
+
+        expect(screen.getByTestId('dictionaries-empty-state')).not.toBeNull();
+        expect(screen.queryByTestId('dictionaries-table')).toBeNull();
+    });
+
+    it('shows a generic error message on a non-403 failure, without navigating away', () => {
+        mockUseEnvironmentDictionaries.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            error: new ApimApiError(500, 'Internal Server Error'),
+        } as ReturnType<typeof useEnvironmentDictionaries>);
+
+        renderPage();
+
+        expect(screen.getByText('Failed to load dictionaries. Please refresh and try again.')).not.toBeNull();
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('redirects away and strips dictionary permissions from the cache on a 403, even if the backend still grants them', async () => {
+        mockUseEnvironmentDictionaries.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            error: new ApimApiError(403, 'Forbidden'),
+        } as ReturnType<typeof useEnvironmentDictionaries>);
+
+        // Simulate the exact bug reported: the permissions map still says the user can read/write
+        // dictionaries (e.g. a stale backend-side cache), even though the live resource call 403s.
+        const { invalidateSpy, queryClient } = renderPage([
+            'environment-metadata-r',
+            'environment-dictionary-r',
+            'environment-dictionary-c',
+            'environment-dictionary-u',
+            'environment-dictionary-d',
+        ]);
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('../applications', { replace: true }));
+
+        // The cache is patched directly — hiding the nav item doesn't depend on the backend's next answer.
+        expect(queryClient.getQueryData(['environment-permissions', 'env-1'])).toEqual(['environment-metadata-r']);
+        // Deliberately not invalidated: refetching could just restore the same stale grant that caused the 403.
+        expect(invalidateSpy).not.toHaveBeenCalled();
+        expect(screen.queryByText('Failed to load dictionaries. Please refresh and try again.')).toBeNull();
+        expect(screen.queryByTestId('dictionaries-table')).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.tsx
@@ -20,6 +20,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { CreateDictionarySheet } from '../features/dictionaries/components/CreateDictionarySheet';
+import { DictionariesEmptyState } from '../features/dictionaries/components/DictionariesEmptyState';
 import { DictionariesTable } from '../features/dictionaries/components/DictionariesTable';
 import { DictionaryDeleteSheet } from '../features/dictionaries/components/DictionaryDeleteSheet';
 import { EditDictionarySheet } from '../features/dictionaries/components/EditDictionarySheet';
@@ -28,7 +29,9 @@ import { useDictionaryPermissions } from '../features/dictionaries/hooks/useDict
 import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
 import { useEnvironmentDictionary } from '../features/dictionaries/hooks/useEnvironmentDictionary';
 import type { DictionaryListItem, NewDictionaryPayload, UpdateDictionaryPayload } from '../features/dictionaries/types/dictionary';
+import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
 import { notify } from '../shared/notify';
+import { isForbiddenApiError } from '../shared/utils/apiErrors';
 
 type SheetState =
     | { type: 'closed' }
@@ -39,10 +42,13 @@ type SheetState =
 export function DictionariesPage() {
     const navigate = useNavigate();
     const { canCreate, canUpdate, canDelete } = useDictionaryPermissions();
-    const { data: dictionaries = [], isLoading, isError } = useEnvironmentDictionaries();
+    const { data: dictionaries = [], isLoading, isError, error } = useEnvironmentDictionaries();
     const createMutation = useCreateDictionary();
     const updateMutation = useUpdateDictionary();
     const deleteMutation = useDeleteDictionary();
+
+    const isForbidden = isForbiddenApiError(isError, error);
+    useForbiddenResourceRedirect({ isForbidden, permissionPrefix: 'environment-dictionary-', redirectTo: '../applications' });
 
     const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
     const editDictionaryId = sheet.type === 'edit' ? sheet.dictionaryId : undefined;
@@ -81,6 +87,46 @@ export function DictionariesPage() {
         }
     }
 
+    function renderContent() {
+        if (isLoading) {
+            return (
+                <div className="space-y-2">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                        <Skeleton key={i} className="h-12 w-full rounded-md" />
+                    ))}
+                </div>
+            );
+        }
+
+        if (isForbidden) {
+            // Redirecting away in the effect above — render nothing rather than flash an error.
+            return null;
+        }
+
+        if (isError) {
+            return (
+                <div className="flex items-center justify-center p-8">
+                    <p className="text-sm text-muted-foreground">Failed to load dictionaries. Please refresh and try again.</p>
+                </div>
+            );
+        }
+
+        if (dictionaries.length === 0) {
+            return <DictionariesEmptyState />;
+        }
+
+        return (
+            <DictionariesTable
+                dictionaries={dictionaries}
+                canEdit={canUpdate}
+                canDelete={canDelete}
+                onOpen={handleOpen}
+                onEdit={d => setSheet({ type: 'edit', dictionaryId: d.id })}
+                onDelete={d => setSheet({ type: 'delete', dictionary: d })}
+            />
+        );
+    }
+
     return (
         <div className="space-y-6">
             <div className="flex items-start justify-between">
@@ -98,26 +144,7 @@ export function DictionariesPage() {
                 )}
             </div>
 
-            {isLoading ? (
-                <div className="space-y-2">
-                    {Array.from({ length: 4 }).map((_, i) => (
-                        <Skeleton key={i} className="h-12 w-full rounded-md" />
-                    ))}
-                </div>
-            ) : isError ? (
-                <div className="flex items-center justify-center p-8">
-                    <p className="text-sm text-muted-foreground">Failed to load dictionaries. Please refresh and try again.</p>
-                </div>
-            ) : (
-                <DictionariesTable
-                    dictionaries={dictionaries}
-                    canEdit={canUpdate}
-                    canDelete={canDelete}
-                    onOpen={handleOpen}
-                    onEdit={d => setSheet({ type: 'edit', dictionaryId: d.id })}
-                    onDelete={d => setSheet({ type: 'delete', dictionary: d })}
-                />
-            )}
+            {renderContent()}
 
             <CreateDictionarySheet
                 open={sheet.type === 'create'}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionaryDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionaryDetailPage.tsx
@@ -234,13 +234,15 @@ export function DictionaryDetailPage() {
                                         {formatDictionaryDate(dictionary.updated_at)}
                                     </span>
                                 </div>
-                                <div className="inline-flex shrink-0 flex-col gap-1">
-                                    <span className="text-xs text-muted-foreground">Last Deployed</span>
-                                    <span className="inline-flex items-center gap-1.5 text-sm text-foreground">
-                                        <CalendarIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
-                                        {formatDictionaryDate(dictionary.deployed_at)}
-                                    </span>
-                                </div>
+                                {isDynamic ? null : (
+                                    <div className="inline-flex shrink-0 flex-col gap-1">
+                                        <span className="text-xs text-muted-foreground">Last Deployed</span>
+                                        <span className="inline-flex items-center gap-1.5 text-sm text-foreground">
+                                            <CalendarIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                                            {formatDictionaryDate(dictionary.deployed_at)}
+                                        </span>
+                                    </div>
+                                )}
                             </div>
                         </div>
                     </div>
@@ -377,6 +379,7 @@ export function DictionaryDetailPage() {
                 </div>
 
                 <DictionaryPropertiesTable
+                    key={dictionary.id}
                     properties={propertyRows}
                     canEdit={canEditManualProperties}
                     isMutating={updateMutation.isPending}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.spec.tsx
@@ -14,16 +14,27 @@
  * limitations under the License.
  */
 import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { MetadataPage } from './MetadataPage';
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
 import { useCreateMetadata, useDeleteMetadata, useUpdateMetadata } from '../features/metadata/hooks/useMetadataMutations';
 import type { Metadata } from '../features/metadata/types/metadata';
+import { ApimApiError } from '../shared/api/apimClient';
 import { notify } from '../shared/notify';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasPermission: jest.fn(),
+    useEnvironment: () => ({ id: 'env-1' }),
 }));
 jest.mock('../features/metadata/hooks/useEnvironmentMetadata');
 jest.mock('../features/metadata/hooks/useMetadataMutations');
@@ -92,12 +103,23 @@ function makeMutation(mutateAsync = jest.fn()): any {
     return { mutateAsync, isPending: false };
 }
 
-function renderPage() {
-    return render(<MetadataPage />);
+function renderPage(seedPermissions: string[] = []) {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['environment-permissions', 'env-1'], seedPermissions);
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const result = render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={['/metadata']}>
+                <MetadataPage />
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+    return { ...result, queryClient, invalidateSpy };
 }
 
 describe('MetadataPage', () => {
     beforeEach(() => {
+        mockNavigate.mockClear();
         mockUseHasPermission.mockReturnValue(true);
         mockUseEnvironmentMetadata.mockReturnValue(makeQueryResult());
         mockUseCreateMetadata.mockReturnValue(makeMutation());
@@ -140,6 +162,25 @@ describe('MetadataPage', () => {
             mockUseEnvironmentMetadata.mockReturnValue(makeQueryResult({ data: undefined, isError: true }));
             renderPage();
             expect(screen.queryByText('Failed to load metadata. Please refresh and try again.')).not.toBeNull();
+        });
+
+        it('redirects away and strips metadata permissions from the cache on a 403, without showing the generic error', async () => {
+            mockUseEnvironmentMetadata.mockReturnValue(
+                makeQueryResult({ data: undefined, isError: true, error: new ApimApiError(403, 'Forbidden') }),
+            );
+
+            const { queryClient, invalidateSpy } = renderPage([
+                'environment-metadata-r',
+                'environment-metadata-c',
+                'environment-metadata-u',
+                'environment-metadata-d',
+            ]);
+
+            await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('../applications', { replace: true }));
+            expect(queryClient.getQueryData(['environment-permissions', 'env-1'])).toEqual([]);
+            // Deliberately not invalidated: refetching could just restore the same stale grant that caused the 403.
+            expect(invalidateSpy).not.toHaveBeenCalled();
+            expect(screen.queryByText('Failed to load metadata. Please refresh and try again.')).toBeNull();
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.tsx
@@ -25,7 +25,9 @@ import { MetadataTable } from '../features/metadata/components/MetadataTable';
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
 import { useCreateMetadata, useDeleteMetadata, useUpdateMetadata } from '../features/metadata/hooks/useMetadataMutations';
 import type { Metadata, NewMetadataPayload, UpdateMetadataPayload } from '../features/metadata/types/metadata';
+import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
 import { notify } from '../shared/notify';
+import { isForbiddenApiError } from '../shared/utils/apiErrors';
 
 type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'edit'; metadata: Metadata } | { type: 'delete'; metadata: Metadata };
 
@@ -34,10 +36,13 @@ export function MetadataPage() {
     const canEdit = useHasPermission({ anyOf: ['environment-metadata-u'] });
     const canDelete = useHasPermission({ anyOf: ['environment-metadata-d'] });
 
-    const { data: metadata = [], isLoading, isError } = useEnvironmentMetadata();
+    const { data: metadata = [], isLoading, isError, error } = useEnvironmentMetadata();
     const createMutation = useCreateMetadata();
     const updateMutation = useUpdateMetadata();
     const deleteMutation = useDeleteMetadata();
+
+    const isForbidden = isForbiddenApiError(isError, error);
+    useForbiddenResourceRedirect({ isForbidden, permissionPrefix: 'environment-metadata-', redirectTo: '../applications' });
 
     const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
 
@@ -76,6 +81,41 @@ export function MetadataPage() {
         }
     }
 
+    function renderContent() {
+        if (isLoading) {
+            return (
+                <div className="space-y-2">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                        <Skeleton key={i} className="h-12 w-full rounded-md" />
+                    ))}
+                </div>
+            );
+        }
+
+        if (isForbidden) {
+            // Redirecting away in the effect above — render nothing rather than flash an error.
+            return null;
+        }
+
+        if (isError) {
+            return (
+                <div className="flex items-center justify-center p-8">
+                    <p className="text-sm text-muted-foreground">Failed to load metadata. Please refresh and try again.</p>
+                </div>
+            );
+        }
+
+        return (
+            <MetadataTable
+                metadata={metadata}
+                canEdit={canEdit}
+                canDelete={canDelete}
+                onEdit={m => setSheet({ type: 'edit', metadata: m })}
+                onDelete={m => setSheet({ type: 'delete', metadata: m })}
+            />
+        );
+    }
+
     return (
         <div className="space-y-6">
             <div className="flex items-start justify-between">
@@ -93,25 +133,7 @@ export function MetadataPage() {
                 )}
             </div>
 
-            {isLoading ? (
-                <div className="space-y-2">
-                    {Array.from({ length: 4 }).map((_, i) => (
-                        <Skeleton key={i} className="h-12 w-full rounded-md" />
-                    ))}
-                </div>
-            ) : isError ? (
-                <div className="flex items-center justify-center p-8">
-                    <p className="text-sm text-muted-foreground">Failed to load metadata. Please refresh and try again.</p>
-                </div>
-            ) : (
-                <MetadataTable
-                    metadata={metadata}
-                    canEdit={canEdit}
-                    canDelete={canDelete}
-                    onEdit={m => setSheet({ type: 'edit', metadata: m })}
-                    onDelete={m => setSheet({ type: 'delete', metadata: m })}
-                />
-            )}
+            {renderContent()}
 
             <MetadataSheet
                 open={sheet.type === 'create' || sheet.type === 'edit'}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.spec.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { useForbiddenResourceRedirect } from './useForbiddenResourceRedirect';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(),
+}));
+
+const mockUseEnvironment = jest.mocked(useEnvironment);
+
+function renderWithClient(isForbidden: boolean, seedPermissions: string[]) {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['environment-permissions', 'env-1'], seedPermissions);
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>{children}</MemoryRouter>
+        </QueryClientProvider>
+    );
+
+    renderHook(
+        () =>
+            useForbiddenResourceRedirect({
+                isForbidden,
+                permissionPrefix: 'environment-dictionary-',
+                redirectTo: '../applications',
+            }),
+        { wrapper },
+    );
+
+    return { queryClient, invalidateSpy };
+}
+
+describe('useForbiddenResourceRedirect', () => {
+    beforeEach(() => {
+        mockNavigate.mockClear();
+        mockUseEnvironment.mockReturnValue({ id: 'env-1' } as ReturnType<typeof useEnvironment>);
+    });
+
+    it('does nothing when not forbidden', () => {
+        const { queryClient } = renderWithClient(false, ['environment-dictionary-r']);
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(queryClient.getQueryData(['environment-permissions', 'env-1'])).toEqual(['environment-dictionary-r']);
+    });
+
+    it('strips only the matching permission prefix and navigates away when forbidden', async () => {
+        const { queryClient } = renderWithClient(true, ['environment-metadata-r', 'environment-dictionary-r', 'environment-dictionary-c']);
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('../applications', { replace: true }));
+        expect(queryClient.getQueryData(['environment-permissions', 'env-1'])).toEqual(['environment-metadata-r']);
+    });
+
+    it('does not invalidate the permissions query, so a stale backend grant cannot silently restore access', async () => {
+        const { invalidateSpy } = renderWithClient(true, ['environment-dictionary-r']);
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+        expect(invalidateSpy).not.toHaveBeenCalled();
+    });
+
+    it('still navigates away when the environment id is unavailable', async () => {
+        mockUseEnvironment.mockReturnValue(undefined as unknown as ReturnType<typeof useEnvironment>);
+
+        renderWithClient(true, []);
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('../applications', { replace: true }));
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { environmentPermissionKeys } from '../utils/queryKeys';
+
+// A live 403 overrides the cached environment-permissions map, which can otherwise still say access is granted.
+// Deliberately don't invalidate/refetch the permissions map here: if the backend is still serving the same
+// stale grant that caused this 403, a refetch would just restore it, flipping the nav back to "allowed" and
+// re-arming the same allow -> 403 -> redirect loop on the next visit.
+export function useForbiddenResourceRedirect({
+    isForbidden,
+    permissionPrefix,
+    redirectTo,
+}: {
+    isForbidden: boolean;
+    permissionPrefix: string;
+    redirectTo: string;
+}): void {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if (!isForbidden) return;
+        if (env?.id) {
+            const permissionsKey = environmentPermissionKeys.detail(env.id);
+            queryClient.setQueryData<string[]>(permissionsKey, previous =>
+                (previous ?? []).filter(permission => !permission.startsWith(permissionPrefix)),
+            );
+        }
+        navigate(redirectTo, { replace: true });
+    }, [isForbidden, permissionPrefix, redirectTo, env?.id, queryClient, navigate]);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/apiErrors.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/apiErrors.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isForbiddenApiError } from './apiErrors';
+import { ApimApiError } from '../api/apimClient';
+
+describe('isForbiddenApiError', () => {
+    it('is true for a 403 ApimApiError while isError is true', () => {
+        expect(isForbiddenApiError(true, new ApimApiError(403, 'Forbidden'))).toBe(true);
+    });
+
+    it('is false for a non-403 ApimApiError', () => {
+        expect(isForbiddenApiError(true, new ApimApiError(500, 'Internal Server Error'))).toBe(false);
+        expect(isForbiddenApiError(true, new ApimApiError(404, 'Not Found'))).toBe(false);
+    });
+
+    it('is false when isError is false, even if the error looks like a 403', () => {
+        expect(isForbiddenApiError(false, new ApimApiError(403, 'Forbidden'))).toBe(false);
+    });
+
+    it('is false for a plain Error with a status-shaped property, since it is not an ApimApiError', () => {
+        const fakeError = Object.assign(new Error('nope'), { status: 403 });
+        expect(isForbiddenApiError(true, fakeError)).toBe(false);
+    });
+
+    it('is false when there is no error', () => {
+        expect(isForbiddenApiError(true, undefined)).toBe(false);
+        expect(isForbiddenApiError(true, null)).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/apiErrors.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/apiErrors.ts
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 
-import { useEnvironment } from '@gravitee/gamma-modules-sdk';
-import { useQuery } from '@tanstack/react-query';
+import { ApimApiError } from '../api/apimClient';
 
-import { listEnvironmentDictionaries } from '../services/dictionaries';
-import { dictionaryKeys } from '../utils/queryKeys';
-
-export function useEnvironmentDictionaries(options?: { enabled?: boolean }) {
-    const env = useEnvironment();
-
-    return useQuery({
-        queryKey: dictionaryKeys.list(env?.id ?? ''),
-        queryFn: () => listEnvironmentDictionaries(env!.id),
-        enabled: Boolean(env) && (options?.enabled ?? true),
-    });
+export function isForbiddenApiError(isError: boolean, error: unknown): boolean {
+    return isError && error instanceof ApimApiError && error.status === 403;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-2

## Description

- **Empty state for dictionaries list** — the dictionaries list at /shell/dictionaries previously fell back to a bare "No dictionaries defined for this environment." table message when an environment had zero dictionaries. Added DictionariesEmptyState, a proper zero-state card (why to configure dictionaries, a "how it works" flow diagram, and key benefits) shown in place of the table when the list is empty, consistent with the empty-state pattern already used elsewhere (e.g. API notifications).
- **Dictionary description placeholder** — the name column showed a literal "—" under the dictionary name whenever no description was set, which read as a broken/missing value. Removed the placeholder; when there's no description, only the name renders, vertically centered in the cell instead of being pinned to the top with dead space below it.
- **Removed unused undeploy dictionary code** — undeployEnvironmentDictionary (service function), useUndeployDictionary (mutation hook), and its associated spec were dead code with no callers anywhere in the dictionaries feature; removed them along with their imports.
- **Dictionary detail page permission parity with classic Console** — `dictionaries/:dictionaryId` was gated on `environment-dictionary-r` only, so a user with only create/update/delete access (no read) was redirected away, whereas classic Console gates that page with `anyOf(-c, -r, -u, -d)`. Widened `PermissionPageGuard` to accept an array of permissions and aligned the route guard with classic; verified all other dictionary action buttons (Deploy, Start/Stop, Add/Edit/Delete Property, list row Edit/Delete) already matched classic's permission gating.
<img width="567" height="230" alt="Screenshot 2026-07-28 at 11 47 34 PM" src="https://github.com/user-attachments/assets/c8f5560e-c7f9-47c3-be7b-f5f2454ddc95" />

- **Extracted the 403-handling into a shared `useForbiddenResourceRedirect` hook + `isForbiddenApiError` helper** so it isn't duplicated per resource — both `DictionariesPage` and `MetadataPage` use it now, and any future environment-scoped resource can adopt it with one line.
- **"Last Deployed" no longer shown for DYNAMIC dictionaries** — Deploy is a MANUAL-only concept (dynamic dictionaries poll/refresh automatically instead), but the list table and detail page both rendered a "Last Deployed" value/timestamp for DYNAMIC rows too. The list table's "Last Deployed" column now always shows "—" for DYNAMIC dictionaries regardless of the raw `deployed_at` value, and the detail page no longer renders the "Last Deployed" stat at all for DYNAMIC type — matching that Deploy is only ever a MANUAL-type action.
- **Pagination for dictionary properties** — the properties table on the dictionary detail page rendered every key/value entry at once with no pagination, for both MANUAL and DYNAMIC dictionaries. Added client-side pagination (page/page-size controls, same page-size options used elsewhere) to `DictionaryPropertiesTable`, so large property sets no longer render as one long unpaginated list.


