### PR TITLE
fix: evaluate V4 flow conditions after previous flow completion

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -205,7 +205,8 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
     @SuppressWarnings("java:S1845")
     protected FlowResolverFactory flowResolverFactory() {
         return new FlowResolverFactory(
-            new CompositeConditionFilter(new HttpSelectorConditionFilter(), new ConditionSelectorConditionFilter()),
+            new CompositeConditionFilter(new HttpSelectorConditionFilter()),
+            new ConditionSelectorConditionFilter(),
             new BestMatchFlowSelector()
         );
     }
@@ -288,7 +289,11 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         );
 
         final io.gravitee.gateway.reactive.handlers.api.v4.flow.FlowChainFactory v4FlowChainFactory =
-            new io.gravitee.gateway.reactive.handlers.api.v4.flow.FlowChainFactory(v4PolicyChainFactory, v4FlowResolverFactory);
+            new io.gravitee.gateway.reactive.handlers.api.v4.flow.FlowChainFactory(
+                v4PolicyChainFactory,
+                v4FlowResolverFactory,
+                new ConditionSelectorConditionFilter()
+            );
 
         DefaultEndpointManager endpointManager = (DefaultEndpointManager) componentProvider.getComponent(EndpointManager.class);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChain.java
@@ -21,10 +21,11 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
-import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.hook.ChainHook;
 import io.gravitee.gateway.reactive.api.hook.Hookable;
+import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
 import io.gravitee.gateway.reactive.core.hook.HookHelper;
 import io.gravitee.gateway.reactive.policy.HttpPolicyChain;
 import io.gravitee.gateway.reactive.v4.flow.FlowResolver;
@@ -32,6 +33,7 @@ import io.gravitee.gateway.reactive.v4.policy.PolicyChainFactory;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.CustomLog;
@@ -51,21 +53,39 @@ public class FlowChain implements Hookable<ChainHook> {
     protected static final String INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED = "flowExecution.flowsMatched";
     private static final String EXECUTION_FAILURE_KEY_FAILURE = "FLOW_EXECUTION_FLOW_MATCHED_FAILURE";
     private final String id;
-    private final FlowResolver flowResolver;
+    private final FlowResolver<? super HttpExecutionContext> flowResolver;
     private final String resolvedFlowAttribute;
     private final PolicyChainFactory<HttpPolicyChain, Flow> policyChainFactory;
+    private final ConditionFilter<BaseExecutionContext, Flow> conditionFilter;
+    private final boolean evaluateConditionLazily;
     private final boolean validateFlowMatching;
     private final boolean interruptIfNoMatch;
     private List<ChainHook> hooks;
 
-    public FlowChain(final String id, final FlowResolver flowResolver, final PolicyChainFactory<HttpPolicyChain, Flow> policyChainFactory) {
+    public FlowChain(
+        final String id,
+        final FlowResolver<? super HttpExecutionContext> flowResolver,
+        final PolicyChainFactory<HttpPolicyChain, Flow> policyChainFactory
+    ) {
         this(id, flowResolver, policyChainFactory, false, false);
     }
 
     public FlowChain(
         final String id,
-        final FlowResolver flowResolver,
+        final FlowResolver<? super HttpExecutionContext> flowResolver,
         final PolicyChainFactory<HttpPolicyChain, Flow> policyChainFactory,
+        final boolean validateFlowMatching,
+        final boolean interruptIfNoMatch
+    ) {
+        this(id, flowResolver, policyChainFactory, (ctx, flow) -> Maybe.just(flow), false, validateFlowMatching, interruptIfNoMatch);
+    }
+
+    public FlowChain(
+        final String id,
+        final FlowResolver<? super HttpExecutionContext> flowResolver,
+        final PolicyChainFactory<HttpPolicyChain, Flow> policyChainFactory,
+        final ConditionFilter<BaseExecutionContext, Flow> conditionFilter,
+        final boolean evaluateConditionLazily,
         final boolean validateFlowMatching,
         final boolean interruptIfNoMatch
     ) {
@@ -73,6 +93,8 @@ public class FlowChain implements Hookable<ChainHook> {
         this.flowResolver = flowResolver;
         this.resolvedFlowAttribute = "flow." + id;
         this.policyChainFactory = policyChainFactory;
+        this.conditionFilter = conditionFilter;
+        this.evaluateConditionLazily = evaluateConditionLazily;
         this.validateFlowMatching = validateFlowMatching;
         this.interruptIfNoMatch = interruptIfNoMatch;
     }
@@ -97,69 +119,58 @@ public class FlowChain implements Hookable<ChainHook> {
      * The {@link Completable} may complete in error in case of any error occurred during the execution.
      */
     public Completable execute(HttpExecutionContext ctx, ExecutionPhase phase) {
-        Flowable<Flow> flowable = callResolveFlows(ctx, phase);
+        return Completable.defer(() -> {
+            final List<Flow> resolvedFlows = ctx.getInternalAttribute(resolvedFlowAttribute);
 
-        return flowable
-            .doOnNext(flow -> {
-                ctx.withLogger(log).debug("Executing flow {} ({} level, {} phase)", flow.getName(), id, phase.name());
-                ctx.putInternalAttribute(ATTR_INTERNAL_FLOW_STAGE, id);
-
-                // Only deal with flow matching if required
-                if (validateFlowMatching && phase == ExecutionPhase.REQUEST) {
-                    ctx.setInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED, true);
-                }
-            })
-            .concatMapCompletable(flow -> executeFlow(ctx, flow, phase))
-            .doOnComplete(() -> ctx.removeInternalAttribute(ATTR_INTERNAL_FLOW_STAGE));
-    }
-
-    private Flowable<Flow> callResolveFlows(HttpExecutionContext ctx, ExecutionPhase phase) {
-        if (validateFlowMatching && ExecutionPhase.REQUEST == phase) {
-            // Only deal with execution flow matching if required
-            return resolveFlows(ctx).switchIfEmpty(
-                Flowable.defer(() -> {
-                    boolean flowsMatch = false;
-                    // Retrieve previous flow chain resolution value
-                    Boolean previousChainFlowsMatch = ctx.getInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED);
-                    if (previousChainFlowsMatch == null) {
-                        ctx.setInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED, false);
-                    } else {
-                        flowsMatch = previousChainFlowsMatch;
-                    }
-                    if (interruptIfNoMatch && !flowsMatch) {
-                        ctx.withLogger(log).debug("No flow matched for chain [{}], interrupting with 404", id);
-                        return ctx
-                            .interruptWith(new ExecutionFailure(HttpStatusCode.NOT_FOUND_404).key(EXECUTION_FAILURE_KEY_FAILURE))
-                            .toFlowable();
-                    }
-                    return Flowable.empty();
-                })
-            );
-        } else {
-            return resolveFlows(ctx);
-        }
-    }
-
-    /**
-     * Resolves the flows to execute once and stores the resolved flows into an internal attribute of the context for later reuse.
-     * This allows to make sure the flow resolved during the execution phase (usually, {@link ExecutionPhase#REQUEST}) will be the same to be executed during the other phases.
-     * If flows have already been resolved, they will be returned without triggering a new resolution.
-     *
-     * @param ctx the context used to temporary store the resolved flows.
-     * @return the resolved flows.
-     */
-    private Flowable<Flow> resolveFlows(HttpPlainExecutionContext ctx) {
-        return Flowable.defer(() -> {
-            Flowable<Flow> flows = ctx.getInternalAttribute(resolvedFlowAttribute);
-
-            if (flows == null) {
-                // Resolves the flows once. Subsequent resolutions will return the same flows.
-                flows = flowResolver.resolve(ctx).cache();
-                ctx.setInternalAttribute(resolvedFlowAttribute, flows);
+            if (resolvedFlows != null) {
+                return Flowable.fromIterable(resolvedFlows)
+                    .concatMapCompletable(flow -> executeFlow(ctx, flow, phase))
+                    .andThen(Completable.defer(() -> handleNoFlowMatched(ctx, phase, resolvedFlows.isEmpty())));
             }
 
-            return flows;
+            final List<Flow> matchedFlows = new ArrayList<>();
+            ctx.setInternalAttribute(resolvedFlowAttribute, matchedFlows);
+
+            return flowResolver
+                .resolve(ctx)
+                .concatMapCompletable(flow -> resolveAndExecuteFlow(ctx, flow, phase, matchedFlows))
+                .andThen(Completable.defer(() -> handleNoFlowMatched(ctx, phase, matchedFlows.isEmpty())));
+        }).doOnComplete(() -> ctx.removeInternalAttribute(ATTR_INTERNAL_FLOW_STAGE));
+    }
+
+    private Completable resolveAndExecuteFlow(
+        final HttpExecutionContext ctx,
+        final Flow flow,
+        final ExecutionPhase phase,
+        final List<Flow> matchedFlows
+    ) {
+        final Maybe<Flow> matchingFlow = evaluateConditionLazily ? conditionFilter.filter(ctx, flow) : Maybe.just(flow);
+
+        return matchingFlow.flatMapCompletable(resolvedFlow -> {
+            matchedFlows.add(resolvedFlow);
+            return executeFlow(ctx, resolvedFlow, phase);
         });
+    }
+
+    private Completable handleNoFlowMatched(final HttpExecutionContext ctx, final ExecutionPhase phase, final boolean noFlowMatched) {
+        if (!noFlowMatched || !(validateFlowMatching && ExecutionPhase.REQUEST == phase)) {
+            return Completable.complete();
+        }
+
+        boolean flowsMatch = false;
+        final Boolean previousChainFlowsMatch = ctx.getInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED);
+        if (previousChainFlowsMatch == null) {
+            ctx.setInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED, false);
+        } else {
+            flowsMatch = previousChainFlowsMatch;
+        }
+
+        if (interruptIfNoMatch && !flowsMatch) {
+            ctx.withLogger(log).debug("No flow matched for chain [{}], interrupting with 404", id);
+            return ctx.interruptWith(new ExecutionFailure(HttpStatusCode.NOT_FOUND_404).key(EXECUTION_FAILURE_KEY_FAILURE));
+        }
+
+        return Completable.complete();
     }
 
     /**
@@ -173,6 +184,13 @@ public class FlowChain implements Hookable<ChainHook> {
      * @return a {@link Completable} that completes when the flow policy chain completes.
      */
     private Completable executeFlow(final HttpExecutionContext ctx, final Flow flow, final ExecutionPhase phase) {
+        ctx.withLogger(log).debug("Executing flow {} ({} level, {} phase)", flow.getName(), id, phase.name());
+        ctx.putInternalAttribute(ATTR_INTERNAL_FLOW_STAGE, id);
+
+        if (validateFlowMatching && phase == ExecutionPhase.REQUEST) {
+            ctx.setInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED, true);
+        }
+
         if (phase == ExecutionPhase.RESPONSE) {
             // Before executing response phase, execute eventual response actions registered during request phase.
             final HttpPolicyChain policyChain = policyChainFactory.create(id, flow, ExecutionPhase.REQUEST);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChainFactory.java
@@ -15,10 +15,14 @@
  */
 package io.gravitee.gateway.reactive.handlers.api.v4.flow;
 
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.opentelemetry.TracingContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.hook.ChainHook;
+import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
 import io.gravitee.gateway.reactive.core.tracing.TracingHook;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
 import io.gravitee.gateway.reactive.handlers.api.v4.flow.resolver.FlowResolverFactory;
@@ -34,16 +38,30 @@ public class FlowChainFactory {
 
     private final PolicyChainFactory policyChainFactory;
     private final FlowResolverFactory flowResolverFactory;
+    private final ConditionFilter<BaseExecutionContext, Flow> conditionFilter;
     private TracingHook tracingHook;
 
-    public FlowChainFactory(final PolicyChainFactory policyChainFactory, final FlowResolverFactory flowResolverFactory) {
+    public FlowChainFactory(
+        final PolicyChainFactory policyChainFactory,
+        final FlowResolverFactory flowResolverFactory,
+        final ConditionFilter<BaseExecutionContext, Flow> conditionFilter
+    ) {
         this.policyChainFactory = policyChainFactory;
         this.flowResolverFactory = flowResolverFactory;
+        this.conditionFilter = conditionFilter;
         this.tracingHook = new TracingHook("flow");
     }
 
     public FlowChain createPlanFlow(final Api api, final TracingContext tracingContext) {
-        FlowChain flowPlanChain = new FlowChain("plan", flowResolverFactory.forApiPlan(api), policyChainFactory, true, false);
+        FlowChain flowPlanChain = new FlowChain(
+            "plan",
+            flowResolverFactory.forApiPlan(api),
+            policyChainFactory,
+            conditionFilter,
+            shouldEvaluateConditionLazily(api),
+            true,
+            false
+        );
         flowPlanChain.addHooks(flowHooks(tracingContext));
         return flowPlanChain;
     }
@@ -59,6 +77,8 @@ public class FlowChainFactory {
             "product-plan",
             flowResolverFactory.forApiProductPlan(api, environmentId, apiProductRegistry),
             productPlanPolicyChainFactory,
+            conditionFilter,
+            shouldEvaluateConditionLazily(api),
             true,
             false
         );
@@ -72,11 +92,18 @@ public class FlowChainFactory {
             "api",
             flowResolverFactory.forApi(api),
             policyChainFactory,
+            conditionFilter,
+            shouldEvaluateConditionLazily(api),
             true,
             flowExecution != null && flowExecution.isMatchRequired()
         );
         flowApiChain.addHooks(flowHooks(tracingContext));
         return flowApiChain;
+    }
+
+    private static boolean shouldEvaluateConditionLazily(final Api api) {
+        final FlowExecution flowExecution = api.getDefinition().getFlowExecution();
+        return flowExecution == null || flowExecution.getMode() != FlowMode.BEST_MATCH;
     }
 
     private List<ChainHook> flowHooks(final TracingContext tracingContext) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/FlowResolverFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/FlowResolverFactory.java
@@ -20,6 +20,8 @@ import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.gravitee.gateway.reactive.core.condition.CompositeConditionFilter;
 import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
 import io.gravitee.gateway.reactive.v4.flow.AbstractBestMatchFlowSelector;
@@ -35,44 +37,67 @@ import io.gravitee.gateway.reactive.v4.flow.FlowResolver;
 @SuppressWarnings("common-java:DuplicatedBlocks") // Needed for v4 definition. Will replace the other one at the end.
 public class FlowResolverFactory {
 
-    private final ConditionFilter<BaseExecutionContext, Flow> apiFlowFilter;
+    private final ConditionFilter<BaseExecutionContext, Flow> flowFilter;
+    private final ConditionFilter<BaseExecutionContext, Flow> bestMatchFlowFilter;
     private final AbstractBestMatchFlowSelector<Flow> bestMatchFlowSelector;
 
     public FlowResolverFactory(
         final ConditionFilter<BaseExecutionContext, Flow> apiFlowFilter,
         final AbstractBestMatchFlowSelector<Flow> bestMatchFlowSelector
     ) {
-        this.apiFlowFilter = apiFlowFilter;
+        this.flowFilter = apiFlowFilter;
+        this.bestMatchFlowFilter = apiFlowFilter;
         this.bestMatchFlowSelector = bestMatchFlowSelector;
     }
 
-    public FlowResolver<? extends BaseExecutionContext> forApi(Api api) {
-        ApiFlowResolver apiFlowResolver = new ApiFlowResolver(api.getDefinition(), apiFlowFilter);
+    public FlowResolverFactory(
+        final ConditionFilter<BaseExecutionContext, Flow> flowFilter,
+        final ConditionFilter<BaseExecutionContext, Flow> conditionFilter,
+        final AbstractBestMatchFlowSelector<Flow> bestMatchFlowSelector
+    ) {
+        this.flowFilter = flowFilter;
+        this.bestMatchFlowFilter = new CompositeConditionFilter<>(flowFilter, conditionFilter);
+        this.bestMatchFlowSelector = bestMatchFlowSelector;
+    }
+
+    public FlowResolver<? super HttpExecutionContext> forApi(Api api) {
+        ApiFlowResolver apiFlowResolver = new ApiFlowResolver(api.getDefinition(), flowFilter(api.getDefinition().getFlowExecution()));
         if (isBestMatchFlowMode(api.getDefinition().getFlowExecution())) {
             return new BestMatchFlowResolver(apiFlowResolver, bestMatchFlowSelector);
         }
         return apiFlowResolver;
     }
 
-    public FlowResolver forApiPlan(Api api) {
-        ApiPlanFlowResolver apiPlanFlowResolver = new ApiPlanFlowResolver(api.getDefinition(), apiFlowFilter);
+    public FlowResolver<? super HttpExecutionContext> forApiPlan(Api api) {
+        ApiPlanFlowResolver apiPlanFlowResolver = new ApiPlanFlowResolver(
+            api.getDefinition(),
+            flowFilter(api.getDefinition().getFlowExecution())
+        );
         if (isBestMatchFlowMode(api.getDefinition().getFlowExecution())) {
             return new BestMatchFlowResolver(apiPlanFlowResolver, bestMatchFlowSelector);
         }
         return apiPlanFlowResolver;
     }
 
-    public FlowResolver forApiProductPlan(Api api, String environmentId, ApiProductRegistry apiProductRegistry) {
+    public FlowResolver<? super HttpExecutionContext> forApiProductPlan(
+        Api api,
+        String environmentId,
+        ApiProductRegistry apiProductRegistry
+    ) {
         ApiProductPlanFlowResolver apiProductPlanFlowResolver = new ApiProductPlanFlowResolver(
             api.getDefinition(),
             environmentId,
             apiProductRegistry,
-            apiFlowFilter
+            flowFilter(api.getDefinition().getFlowExecution())
         );
         if (isBestMatchFlowMode(api.getDefinition().getFlowExecution())) {
             return new BestMatchFlowResolver(apiProductPlanFlowResolver, bestMatchFlowSelector);
         }
         return apiProductPlanFlowResolver;
+    }
+
+    private ConditionFilter<BaseExecutionContext, Flow> flowFilter(final FlowExecution flowExecution) {
+        return isBestMatchFlowMode(flowExecution) ? bestMatchFlowFilter : flowFilter;
     }
 
     private static boolean isBestMatchFlowMode(final FlowExecution flowExecution) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChainTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChainTest.java
@@ -30,9 +30,11 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpMessageExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
+import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
 import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
 import io.gravitee.gateway.reactive.core.context.MutableRequest;
 import io.gravitee.gateway.reactive.core.context.MutableResponse;
@@ -44,9 +46,12 @@ import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.subjects.CompletableSubject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -154,7 +159,7 @@ class FlowChainTest {
         buildPolicyChain("pc-flow2", flow2, REQUEST, policy2);
 
         // Force the resolved flows to be already present in the context.
-        ctx.setInternalAttribute("flow." + FLOW_CHAIN_ID, Flowable.just(flow1, flow2));
+        ctx.setInternalAttribute("flow." + FLOW_CHAIN_ID, List.of(flow1, flow2));
 
         final TestObserver<Void> obs = cut.execute(ctx, REQUEST).test();
 
@@ -252,6 +257,68 @@ class FlowChainTest {
             "policy5-onResponse",
             "policy6-onResponse"
         );
+    }
+
+    @Test
+    void should_evaluate_next_flow_condition_after_previous_async_flow_completes() {
+        final CompletableSubject asyncCompletion = CompletableSubject.create();
+        final AtomicInteger flow2ConditionEvaluations = new AtomicInteger();
+        final ConditionFilter<BaseExecutionContext, Flow> fooIsNull = (context, flow) -> {
+            if (flow != flow2) {
+                return Maybe.just(flow);
+            }
+            flow2ConditionEvaluations.incrementAndGet();
+            return context.getAttribute("foo") == null ? Maybe.just(flow) : Maybe.empty();
+        };
+        cut = new FlowChain(FLOW_CHAIN_ID, flowResolver, policyChainFactory, fooIsNull, true, false, false);
+
+        final HttpPolicy asyncPolicy = mock(HttpPolicy.class);
+        when(asyncPolicy.id()).thenReturn("async-policy");
+        when(asyncPolicy.onRequest(ctx)).thenReturn(asyncCompletion.doOnComplete(() -> ctx.setAttribute("foo", "bar")));
+        buildPolicyChain("pc-flow1", flow1, REQUEST, asyncPolicy);
+        buildPolicyChain("pc-flow2", flow2, REQUEST, policy2);
+
+        final TestObserver<Void> obs = cut.execute(ctx, REQUEST).test();
+
+        obs.assertNotComplete();
+        assertThat(flow2ConditionEvaluations).hasValue(0);
+
+        asyncCompletion.onComplete();
+
+        obs.assertResult();
+        assertThat(flow2ConditionEvaluations).hasValue(1);
+        assertThat(ctx.<String>getAttribute("foo")).isEqualTo("bar");
+        verify(policyChainFactory, times(0)).create(FLOW_CHAIN_ID, flow2, REQUEST);
+    }
+
+    @Test
+    void should_reuse_matched_flows_without_reevaluating_condition_on_response() {
+        final AtomicInteger conditionEvaluations = new AtomicInteger();
+        final ConditionFilter<BaseExecutionContext, Flow> conditionFilter = (context, flow) -> {
+            conditionEvaluations.incrementAndGet();
+            return flow == flow1 ? Maybe.just(flow) : Maybe.empty();
+        };
+        cut = new FlowChain(FLOW_CHAIN_ID, flowResolver, policyChainFactory, conditionFilter, true, false, false);
+
+        buildPolicyChain("pc-flow1-request", flow1, REQUEST, policy1);
+        buildPolicyChain("pc-flow1-response", flow1, RESPONSE, policy2);
+
+        cut.execute(ctx, REQUEST).andThen(cut.execute(ctx, RESPONSE)).test().assertResult();
+
+        assertThat(conditionEvaluations).hasValue(2);
+        assertThat(executionOrder).containsExactly("policy1-onRequest", "policy1-actionActionOnResponse", "policy2-onResponse");
+        verify(policyChainFactory, times(0)).create(FLOW_CHAIN_ID, flow2, RESPONSE);
+    }
+
+    @Test
+    void should_interrupt_when_static_selector_matches_but_lazy_condition_does_not() {
+        final ConditionFilter<BaseExecutionContext, Flow> noMatch = (context, flow) -> Maybe.empty();
+        cut = new FlowChain(FLOW_CHAIN_ID, flowResolver, policyChainFactory, noMatch, true, true, true);
+
+        cut.execute(ctx, REQUEST).test().assertError(InterruptionFailureException.class);
+
+        assertThat(ctx.<Boolean>getInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED)).isFalse();
+        verifyNoInteractions(policyChainFactory);
     }
 
     private static @NonNull DefaultExecutionContext buildExecutionContext() {

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowPhaseExecutionV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowPhaseExecutionV4IntegrationTest.java
@@ -15,10 +15,16 @@
  */
 package io.gravitee.apim.integration.tests.http.flows;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.integration.tests.fake.LatencyPolicy;
 import io.gravitee.definition.model.flow.Operator;
 import io.gravitee.definition.model.v4.Api;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
@@ -28,11 +34,18 @@ import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
 import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.assignattributes.AssignAttributesPolicy;
+import io.gravitee.policy.assignattributes.configuration.AssignAttributesPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -109,10 +122,24 @@ class FlowPhaseExecutionV4IntegrationTest extends FlowPhaseExecutionV4EmulationI
     @Nested
     @GatewayTest
     @DeployApi(
-        { "/apis/v4/http/flows/api-conditional-flows.json", "/apis/v4/http/flows/api-conditional-flows-double-evaluation-case.json" }
+        {
+            "/apis/v4/http/flows/api-conditional-flows.json",
+            "/apis/v4/http/flows/api-conditional-flows-double-evaluation-case.json",
+            "/apis/v4/http/flows/api-condition-after-async-policy.json",
+        }
     )
-    @DisplayName("Flows without condition and mixed operators")
+    @DisplayName("Flows with condition")
     class ConditionalFlows extends FlowPhaseExecutionV4EmulationIntegrationTest.ConditionalFlows {
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            super.configurePolicies(policies);
+            policies.put("latency", PolicyBuilder.build("latency", LatencyPolicy.class, LatencyPolicy.LatencyConfiguration.class));
+            policies.put(
+                "assign-attributes",
+                PolicyBuilder.build("assign-attributes", AssignAttributesPolicy.class, AssignAttributesPolicyConfiguration.class)
+            );
+        }
 
         @Override
         public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
@@ -122,6 +149,27 @@ class FlowPhaseExecutionV4IntegrationTest extends FlowPhaseExecutionV4EmulationI
         @Override
         public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
             endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        @Test
+        void should_skip_downstream_flow_after_previous_async_flow_assigns_attribute(HttpClient client) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok(RESPONSE_FROM_BACKEND)));
+
+            client
+                .rxRequest(HttpMethod.GET, "/test-condition-after-async")
+                .flatMap(request -> request.rxSend())
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    assertThat(response.getHeader("X-Flow2-Executed")).isNull();
+                    return response.body();
+                })
+                .test()
+                .awaitDone(5, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(body -> {
+                    assertThat(body).hasToString(RESPONSE_FROM_BACKEND);
+                    return true;
+                });
         }
     }
 }

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/flows/api-condition-after-async-policy.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/flows/api-condition-after-async-policy.json
@@ -1,0 +1,117 @@
+{
+  "id": "api-v4-condition-after-async-policy",
+  "name": "api-v4-condition-after-async-policy",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test-condition-after-async"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Flow with asynchronous policy then attribute assignment",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "request": [
+        {
+          "name": "Latency",
+          "enabled": true,
+          "policy": "latency",
+          "configuration": {
+            "delay": 100
+          }
+        },
+        {
+          "name": "Assign foo",
+          "enabled": true,
+          "policy": "assign-attributes",
+          "configuration": {
+            "scope": "REQUEST",
+            "attributes": [
+              {
+                "name": "foo",
+                "value": "bar"
+              }
+            ]
+          }
+        }
+      ],
+      "response": [],
+      "subscribe": [],
+      "publish": []
+    },
+    {
+      "name": "Flow selected only while foo is absent",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": []
+        },
+        {
+          "type": "condition",
+          "condition": "{#context.attributes['foo'] == null}"
+        }
+      ],
+      "request": [],
+      "response": [
+        {
+          "name": "Mark flow 2 as executed",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Flow2-Executed",
+                "value": "true"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-83

## Description

Fixes V4 flow condition evaluation when a previous flow contains an asynchronous policy.

In the default execution mode, flow conditions are now evaluated immediately before each flow executes, after the previous flow has fully completed. Matched flows are stored and reused during the response phase without reevaluating their conditions.

`BEST_MATCH` behavior remains unchanged, with conditions evaluated during resolver-side selection.

## Validation

- Added unit coverage for asynchronous execution, response reuse, and `matchRequired`.
- Added a V4 integration test using Latency and Assign Attributes policies.
- Verified the existing `BEST_MATCH` integration suite.

## How to test 

see: https://github.com/gravitee-io/gravitee-api-management/pull/18780#issuecomment-5117157602

Tests manual  tests done locally on master and development branch shows that fix was effective
 

