### PR TITLE
fix(gateway): perform a full initial sync when the primary node cold starts

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManager.java
@@ -159,10 +159,18 @@ public class DefaultSyncManager extends AbstractService<SyncManager> implements 
         })
             .andThen(
                 Single.defer(() -> {
+                    // Only a secondary promoted to primary after completing at least one sync can
+                    // resume from the stored distributed sync state: its memory is already warm
+                    // from the distributed sync. A node with nothing deployed yet (cold-started
+                    // primary, or secondary promoted before its first sync) must ignore the state
+                    // and perform a full initial sync (nextFromTime stays at -1). The CAS runs
+                    // before the nextFromTime check so an early promotion consumes it and never
+                    // resumes from the state on a later cycle.
                     if (
                         distributedSyncService.isEnabled() &&
                         distributedSyncService.isPrimaryNode() &&
-                        (nextFromTime == -1 || isClusterPrimaryNode.compareAndSet(false, true))
+                        isClusterPrimaryNode.compareAndSet(false, true) &&
+                        nextFromTime != -1
                     ) {
                         return distributedSyncService
                             .state()

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManagerTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.gateway.services.sync.process.distributed.DistributedSynchronizer;
 import io.gravitee.gateway.services.sync.process.distributed.service.DistributedSyncService;
 import io.gravitee.gateway.services.sync.process.distributed.service.NoopDistributedSyncService;
 import io.gravitee.gateway.services.sync.process.repository.handler.SyncHandler;
@@ -89,12 +90,14 @@ class DefaultSyncManagerTest {
     }
 
     @Test
-    void should_report_sync_done_on_primary_node_when_restoring_existing_distributed_state() throws Exception {
+    void should_perform_full_initial_sync_on_primary_cold_start_even_with_existing_distributed_state() throws Exception {
         DistributedSyncService distributedSyncService = mock(DistributedSyncService.class);
         when(distributedSyncService.isEnabled()).thenReturn(true);
         when(distributedSyncService.isPrimaryNode()).thenReturn(true);
         when(distributedSyncService.ready()).thenReturn(Completable.complete());
-        when(distributedSyncService.state()).thenReturn(Maybe.just(DistributedSyncState.builder().from(1_000L).to(2_000L).build()));
+        lenient()
+            .when(distributedSyncService.state())
+            .thenReturn(Maybe.just(DistributedSyncState.builder().from(1_000L).to(2_000L).build()));
         when(distributedSyncService.storeState(anyLong(), anyLong())).thenReturn(Completable.complete());
 
         RepositorySynchronizer synchronizer = spy(new FakeSynchronizer(Completable.complete(), 1));
@@ -103,7 +106,81 @@ class DefaultSyncManagerTest {
         cut = new DefaultSyncManager(router, node, synchronizers, null, distributedSyncService, 5, TimeUnit.SECONDS, 1);
         cut.start();
 
-        verify(synchronizer).synchronize(eq(1_000L), any(), anySet());
+        // A cold-started primary has nothing deployed in memory: the distributed sync state stored
+        // by a previous run must not shrink the first sync window, otherwise no API gets deployed.
+        verify(synchronizer).synchronize(eq(-1L), any(), anySet());
+        verify(distributedSyncService, never()).state();
+        assertThat(cut.syncDone()).isTrue();
+    }
+
+    @Test
+    void should_resume_from_distributed_state_when_secondary_is_promoted_to_primary() throws Exception {
+        try {
+            final TestScheduler testScheduler = new TestScheduler();
+            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+            RxJavaPlugins.setIoSchedulerHandler(s -> testScheduler);
+
+            DistributedSyncService distributedSyncService = mock(DistributedSyncService.class);
+            when(distributedSyncService.isEnabled()).thenReturn(true);
+            // Node starts as secondary (doStart + first cycle), then gets promoted to primary.
+            when(distributedSyncService.isPrimaryNode()).thenReturn(false, false, false, true);
+            when(distributedSyncService.ready()).thenReturn(Completable.complete());
+            when(distributedSyncService.state()).thenReturn(Maybe.just(DistributedSyncState.builder().from(1_000L).to(2_000L).build()));
+            when(distributedSyncService.storeState(anyLong(), anyLong())).thenReturn(Completable.complete());
+
+            RepositorySynchronizer synchronizer = spy(new FakeSynchronizer(Completable.complete(), 1));
+            synchronizers.add(synchronizer);
+            DistributedSynchronizer distributedSynchronizer = mock(DistributedSynchronizer.class);
+            when(distributedSynchronizer.synchronize(any(), any())).thenReturn(Completable.complete());
+
+            cut = new DefaultSyncManager(
+                router,
+                node,
+                synchronizers,
+                new ArrayList<>(List.of(distributedSynchronizer)),
+                distributedSyncService,
+                5,
+                TimeUnit.SECONDS,
+                1
+            );
+            cut.start();
+
+            // As a secondary, the initial sync reads distributed events from scratch.
+            verify(distributedSynchronizer).synchronize(eq(-1L), any());
+
+            // Promotion happens on the next cycle: the node is already warm, so it resumes the
+            // repository sync from the window stored by the previous primary.
+            testScheduler.advanceTimeBy(5, TimeUnit.SECONDS);
+            testScheduler.triggerActions();
+
+            verify(distributedSyncService).state();
+            verify(synchronizer).synchronize(eq(1_000L), any(), anySet());
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    void should_perform_full_initial_sync_when_secondary_is_promoted_before_completing_any_sync() throws Exception {
+        DistributedSyncService distributedSyncService = mock(DistributedSyncService.class);
+        when(distributedSyncService.isEnabled()).thenReturn(true);
+        // Node starts as secondary but the primary dies before the first sync cycle runs.
+        when(distributedSyncService.isPrimaryNode()).thenReturn(false, true);
+        when(distributedSyncService.ready()).thenReturn(Completable.complete());
+        lenient()
+            .when(distributedSyncService.state())
+            .thenReturn(Maybe.just(DistributedSyncState.builder().from(1_000L).to(2_000L).build()));
+        when(distributedSyncService.storeState(anyLong(), anyLong())).thenReturn(Completable.complete());
+
+        RepositorySynchronizer synchronizer = spy(new FakeSynchronizer(Completable.complete(), 1));
+        synchronizers.add(synchronizer);
+
+        cut = new DefaultSyncManager(router, node, synchronizers, null, distributedSyncService, 5, TimeUnit.SECONDS, 1);
+        cut.start();
+
+        // Nothing is deployed yet, so the promotion must not resume from the stored state.
+        verify(synchronizer).synchronize(eq(-1L), any(), anySet());
+        verify(distributedSyncService, never()).state();
         assertThat(cut.syncDone()).isTrue();
     }
 


### PR DESCRIPTION
📋 [ESM-118](https://gravitee.atlassian.net/browse/ESM-118)
📋 [APIM-14755](https://gravitee.atlassian.net/browse/APIM-14755)

## Issue

When distributed sync is enabled, a **cold-started primary node deploys (almost) no API while reporting ready**, with no error anywhere.

`DefaultSyncManager.synchronize()` reads the `DistributedSyncState` persisted in the distributed sync repository on the first cycle and adopts `state.from` as the sync window start. Since the cluster id is the Hazelcast **cluster name** (stable across restarts) and the state is refreshed on every 5s cycle, a restarted primary — whose memory is empty — only asks the database for events of the last few seconds:

- almost no API gets deployed locally (`/_node/apis` returns `[]`);
- the gateway still reports ready (`sync-process` probe is green: empty incremental cycles complete successfully);
- no `"X apis synchronized"` INFO line (incremental cycles log at DEBUG), no error;
- every 5s cycle keeps the state fresh, so the situation never self-heals — only deleting the `distributed_sync_state:<cluster>` key in Redis (or disabling distributed sync) recovers the node.

Field report: single-gateway environment, distributed sync enabled, gateway starts immediately with 0 APIs and completely silent sync; works again when distributed sync is disabled.

## Fix

The stored state is only meaningful for a **secondary promoted to primary**: its memory is already warm from the distributed sync, and resuming the distribution window where the previous primary left off is exactly what the state was designed for.

A **cold-started primary** now ignores the stored state and performs a full initial sync (`from = -1`) from the database, then re-distributes all events (idempotent writes).

## Tests

- Unit: `should_perform_full_initial_sync_on_primary_cold_start_even_with_existing_distributed_state` (red before the fix: synchronizers were invoked with `from = state.from` instead of `-1`) and `should_resume_from_distributed_state_when_secondary_is_promoted_to_primary` guarding the legitimate promotion path. Full sync module suite: 410/410 green.
- E2E on `docker/quick-setup/distributed-sync` (redis-stack + mongo + EE cluster-hazelcast):
  - **before**: deploy + start an API, cold restart the primary → gateway READY, `/_node/apis` = `[]`, no sync log line (bug reproduced);
  - **after** (same Redis, state key untouched): cold restart → `1 apis synchronized in 1695ms`, API deployed; repeated restarts OK; with a second node, the promoted path and the secondary read path (`1 api(s) synchronized`) still work and a newly created API propagates to both gateways.


[ESM-118]: https://gravitee.atlassian.net/browse/ESM-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APIM-14755]: https://gravitee.atlassian.net/browse/APIM-14755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ