### PR TITLE
feat(repository): persist Gamma dashboards in a dedicated store

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/GammaDashboardRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/GammaDashboardRepository.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.GammaDashboard;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * <h2>Required fields</h2>
+ *
+ * {@code id}, {@code environmentId}, {@code title}, {@code createdBy}, {@code createdAt} and {@code updatedAt} are
+ * required and must be supplied by the caller. The two backends do <strong>not</strong> agree on what happens
+ * otherwise: JDBC declares them {@code NOT NULL} and fails the write, while Mongo accepts the document as-is. Callers
+ * must therefore validate before writing rather than rely on the store to reject — the same input can succeed on one
+ * deployment and fail on another.
+ *
+ * @author GraviteeSource Team
+ */
+public interface GammaDashboardRepository extends CrudRepository<GammaDashboard, String> {
+    /**
+     * Ordered by creation date, then id. The order is part of the contract: without it Mongo would return natural
+     * order, which shifts when an update grows a document, so editing one dashboard could reshuffle the whole list.
+     */
+    List<GammaDashboard> findByEnvironmentId(String environmentId) throws TechnicalException;
+
+    /**
+     * Environment-scoped lookup. Prefer this over {@link #findById(Object)} for anything reachable from a request:
+     * it makes cross-environment isolation a property of the query rather than of a caller-side check somebody has to
+     * remember to write.
+     */
+    Optional<GammaDashboard> findByIdAndEnvironmentId(String id, String environmentId) throws TechnicalException;
+
+    void deleteByEnvironmentId(String environmentId) throws TechnicalException;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/GammaDashboard.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/GammaDashboard.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import java.util.Date;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * Dashboard owned by the Gamma observability module.
+ *
+ * <p>Distinct from {@link Dashboard} (legacy analytics dashboard) and from {@link CustomDashboard}, whose collection is
+ * read unfiltered by the APIM Console and the Developer Portal.
+ *
+ * <p>{@code widgets} is deliberately stored as opaque JSON: the widget shape belongs to the frontend and would
+ * otherwise force a backend release per new widget option. It also sidesteps Mongo's rejection of dotted map keys,
+ * which widget colour maps use (they are keyed by host and API names).
+ *
+ * @author GraviteeSource Team
+ */
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@EqualsAndHashCode(of = "id")
+public class GammaDashboard {
+
+    private String id;
+    private String environmentId;
+    private String title;
+    private String description;
+    private List<Filter> filters;
+    private TimeRange timeRange;
+
+    /** Raw, opaque widget JSON. Never parsed by the backend. */
+    private String widgets;
+
+    private String createdBy;
+    private Date createdAt;
+    private Date updatedAt;
+
+    /**
+     * Optimistic concurrency counter. This layer only persists it verbatim — it never initialises, increments or
+     * checks it. Bumping it belongs to the update use case, and rejecting a stale value is a separate concern.
+     */
+    private Integer version;
+
+    /**
+     * Dashboard-definition filter, applied to every widget of the dashboard.
+     *
+     * <p>Field names and casing deliberately mirror the frontend's {@code FilterCondition}, which is the only producer
+     * and consumer of these values — the same type also travels verbatim inside the opaque {@code widgets} payload, so
+     * any divergence here would mean storing one type in two shapes and maintaining a mapping table between them.
+     */
+    @Builder(toBuilder = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Data
+    public static class Filter {
+
+        private String field;
+
+        /**
+         * Display name of the field, e.g. {@code API Type}. Persisted because nothing derives it: the frontend's
+         * resolve hook rehydrates {@code valueLabels} from the API, never {@code label}.
+         */
+        private String label;
+
+        /** Lowercase wire operator, matching the frontend vocabulary — {@code eq}, {@code in}, {@code not_in}. */
+        private String operator;
+
+        /** An empty list is the "all values" placeholder and carries no query constraint. */
+        private List<String> value;
+
+        /**
+         * {@code true} when the viewer may change the value; {@code false} locks it. The one deliberate addition to
+         * the frontend shape: it replaces the optional {@code locked} tri-state with a required positive boolean.
+         */
+        private boolean editable;
+    }
+
+    /**
+     * Time window a dashboard opens on. {@code period} is set for {@code relative}, {@code from} / {@code to} (epoch
+     * millis) for {@code absolute}.
+     */
+    @Builder(toBuilder = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Data
+    public static class TimeRange {
+
+        /** {@code relative} or {@code absolute}, lowercase to match the frontend's discriminated union. */
+        private String type;
+
+        /** Relative period token owned by the frontend, e.g. {@code 7d}, {@code 1h}, {@code currentMonth}. */
+        private String period;
+
+        private Long from;
+        private Long to;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcGammaDashboardRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcGammaDashboardRepository.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import io.gravitee.repository.management.api.GammaDashboardRepository;
+import io.gravitee.repository.management.model.GammaDashboard;
+import java.sql.Types;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Repository
+public class JdbcGammaDashboardRepository extends JdbcAbstractCrudRepository<GammaDashboard, String> implements GammaDashboardRepository {
+
+    /**
+     * Unknown properties are ignored on purpose, but this only picks the lesser of two silent failures — it does not
+     * make the store forward-compatible.
+     *
+     * <p>{@link io.gravitee.repository.jdbc.orm.JdbcObjectMapper#setFromResultSet} catches per column and only logs, so
+     * a deserialization failure never fails the query: the row still maps and the field is left {@code null}. With the
+     * feature enabled, a row written by a newer node would therefore come back with {@code filters} entirely
+     * {@code null}, and the next {@code update()} would write that null back. Ignoring the unknown field instead loses
+     * only that field.
+     *
+     * <p>Both paths lose data silently on a rollback or a rolling upgrade. Closing the hole properly means either
+     * storing these columns opaquely, like {@code widgets}, or enforcing {@code version} before the first write
+     * endpoint ships.
+     */
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    JdbcGammaDashboardRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
+        super(tablePrefix, "gamma_dashboards");
+    }
+
+    /**
+     * {@code filters} is declared last on purpose: its element type cannot be expressed as a {@code Class} literal, so
+     * {@code List.class} makes that call an unchecked invocation, which would erase the generics of every builder call
+     * chained after it.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    protected JdbcObjectMapper<GammaDashboard> buildOrm() {
+        return JdbcObjectMapper.builder(GammaDashboard.class, this.tableName, "id")
+            .addColumn("id", Types.NVARCHAR, String.class)
+            .addColumn("environment_id", Types.NVARCHAR, String.class)
+            .addColumn("title", Types.NVARCHAR, String.class)
+            .addColumn("description", Types.NVARCHAR, String.class)
+            .addColumn("created_by", Types.NVARCHAR, String.class)
+            .addColumn("created_at", Types.TIMESTAMP, Date.class)
+            .addColumn("updated_at", Types.TIMESTAMP, Date.class)
+            .addColumn("version", Types.INTEGER, Integer.class)
+            .addColumn(
+                "time_range",
+                Types.NCLOB,
+                GammaDashboard.TimeRange.class,
+                JdbcGammaDashboardRepository::serializeTimeRange,
+                JdbcGammaDashboardRepository::deserializeTimeRange
+            )
+            // Already an opaque JSON String on the model, so it needs no conversion.
+            .addColumn("widgets", Types.NCLOB, String.class)
+            .addColumn(
+                "filters",
+                Types.NCLOB,
+                List.class,
+                JdbcGammaDashboardRepository::serializeFilters,
+                JdbcGammaDashboardRepository::deserializeFilters
+            )
+            .build();
+    }
+
+    @Override
+    protected String getId(GammaDashboard item) {
+        return item.getId();
+    }
+
+    @Override
+    public List<GammaDashboard> findByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("JdbcGammaDashboardRepository.findByEnvironmentId({})", environmentId);
+        try {
+            return jdbcTemplate.query(
+                getOrm().getSelectAllSql() + " where environment_id = ? order by created_at, id",
+                getRowMapper(),
+                environmentId
+            );
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to find gamma dashboards by environment id: " + environmentId, ex);
+        }
+    }
+
+    @Override
+    public Optional<GammaDashboard> findByIdAndEnvironmentId(String id, String environmentId) throws TechnicalException {
+        log.debug("JdbcGammaDashboardRepository.findByIdAndEnvironmentId({}, {})", id, environmentId);
+        try {
+            return jdbcTemplate
+                .query(getOrm().getSelectAllSql() + " where id = ? and environment_id = ?", getRowMapper(), id, environmentId)
+                .stream()
+                .findFirst();
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to find gamma dashboard by id: " + id + " and environment id: " + environmentId, ex);
+        }
+    }
+
+    @Override
+    public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("JdbcGammaDashboardRepository.deleteByEnvironmentId({})", environmentId);
+        try {
+            jdbcTemplate.update("delete from " + this.tableName + " where environment_id = ?", environmentId);
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to delete gamma dashboards by environment id: " + environmentId, ex);
+        }
+    }
+
+    private static String serializeFilters(List<?> filters) {
+        return serialize(filters);
+    }
+
+    private static List<GammaDashboard.Filter> deserializeFilters(String json) {
+        return deserialize(json, new TypeReference<>() {});
+    }
+
+    private static String serializeTimeRange(GammaDashboard.TimeRange timeRange) {
+        return serialize(timeRange);
+    }
+
+    private static GammaDashboard.TimeRange deserializeTimeRange(String json) {
+        return deserialize(json, new TypeReference<>() {});
+    }
+
+    private static String serialize(Object value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return JSON_MAPPER.writeValueAsString(value);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to serialize gamma dashboard JSON column", e);
+        }
+    }
+
+    private static <T> T deserialize(String json, TypeReference<T> typeRef) {
+        if (json == null || json.isEmpty()) {
+            return null;
+        }
+        try {
+            return JSON_MAPPER.readValue(json, typeRef);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to deserialize gamma dashboard JSON column", e);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/09_create_gamma_dashboards_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/09_create_gamma_dashboards_table.yml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_09_create_gamma_dashboards_table
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      changes:
+        - createTable:
+            tableName: ${gravitee_prefix}gamma_dashboards
+            columns:
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}gamma_dashboards" } }
+              - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: title, type: nvarchar(512), constraints: { nullable: false } }
+              - column: { name: description, type: nvarchar(1024) }
+              - column: { name: created_by, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: created_at, type: timestamp(6), constraints: { nullable: false } }
+              - column: { name: updated_at, type: timestamp(6), constraints: { nullable: false } }
+              - column: { name: version, type: int }
+              - column: { name: filters, type: nclob }
+              - column: { name: time_range, type: nclob }
+              - column: { name: widgets, type: nclob }
+        - createIndex:
+            tableName: ${gravitee_prefix}gamma_dashboards
+            indexName: idx_${gravitee_prefix}gamma_dashboards_environment_id
+            columns:
+              - column:
+                  name: environment_id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -403,3 +403,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_13_0/07_add_api_product_id_to_portal_navigation_items.yml
     - include:
         - file: liquibase/changelogs/v4_13_0/08_backfill_cluster_lifecycle_state.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/09_create_gamma_dashboards_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -74,6 +74,7 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
         "dictionary_property",
         "environments",
         "environment_hrids",
+        "gamma_dashboards",
         "events",
         "event_properties",
         "event_environments",

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoGammaDashboardRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoGammaDashboardRepository.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.GammaDashboardRepository;
+import io.gravitee.repository.management.model.GammaDashboard;
+import io.gravitee.repository.mongodb.management.internal.GammaDashboardMongoRepository;
+import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.FindAndReplaceOptions;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Component
+@RequiredArgsConstructor
+public class MongoGammaDashboardRepository implements GammaDashboardRepository {
+
+    private final GammaDashboardMongoRepository internalGammaDashboardRepo;
+    private final GraviteeMapper mapper;
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public Set<GammaDashboard> findAll() throws TechnicalException {
+        log.debug("Find all gamma dashboards");
+        var dashboards = internalGammaDashboardRepo.findAll();
+        var res = mapper.mapGammaDashboards(dashboards);
+        log.debug("Find all gamma dashboards - Done");
+        return res;
+    }
+
+    @Override
+    public Optional<GammaDashboard> findById(String id) throws TechnicalException {
+        log.debug("Find gamma dashboard by ID [{}]", id);
+        var dashboard = internalGammaDashboardRepo.findById(id).map(mapper::map);
+        log.debug("Find gamma dashboard by ID [{}] - Done", id);
+        return dashboard;
+    }
+
+    @Override
+    public GammaDashboard create(GammaDashboard gammaDashboard) throws TechnicalException {
+        log.debug("Create gamma dashboard [{}]", gammaDashboard.getTitle());
+        var dashboardMongo = mapper.map(gammaDashboard);
+        var createdDashboardMongo = internalGammaDashboardRepo.insert(dashboardMongo);
+        var res = mapper.map(createdDashboardMongo);
+        log.debug("Create gamma dashboard [{}] - Done", gammaDashboard.getTitle());
+        return res;
+    }
+
+    /**
+     * A single conditional replace rather than a read followed by {@code save()}.
+     *
+     * <p>{@code save()} is an upsert, so with a read-then-write pair a dashboard deleted between the two calls would be
+     * silently re-inserted — while the JDBC implementation, guarded by its affected-row count, raises. Matching on
+     * {@code _id} folds the existence check into the same round trip and keeps the two backends behaving alike.
+     *
+     * <p>When {@code version} is eventually enforced, the guard is one more criterion on this same query rather than a
+     * new round trip.
+     */
+    @Override
+    public GammaDashboard update(GammaDashboard gammaDashboard) throws TechnicalException {
+        if (gammaDashboard == null) {
+            throw new IllegalStateException("Unable to update a null gamma dashboard");
+        }
+
+        try {
+            var replaced = mongoTemplate.findAndReplace(
+                Query.query(Criteria.where("_id").is(gammaDashboard.getId())),
+                mapper.map(gammaDashboard),
+                FindAndReplaceOptions.options().returnNew()
+            );
+
+            if (replaced == null) {
+                throw new IllegalStateException(String.format("No gamma dashboard found with id [%s]", gammaDashboard.getId()));
+            }
+            return mapper.map(replaced);
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new TechnicalException("An error occurred when updating gamma dashboard " + gammaDashboard.getId(), e);
+        }
+    }
+
+    @Override
+    public void delete(String id) throws TechnicalException {
+        try {
+            internalGammaDashboardRepo.deleteById(id);
+        } catch (Exception e) {
+            throw new TechnicalException("An error occurred when deleting gamma dashboard " + id, e);
+        }
+    }
+
+    @Override
+    public List<GammaDashboard> findByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("Find gamma dashboards by environment ID [{}]", environmentId);
+        var dashboards = internalGammaDashboardRepo.findByEnvironmentIdOrderByCreatedAtAscIdAsc(environmentId);
+        log.debug("Find gamma dashboards by environment ID [{}] - Done", environmentId);
+        return dashboards.stream().map(mapper::map).toList();
+    }
+
+    @Override
+    public Optional<GammaDashboard> findByIdAndEnvironmentId(String id, String environmentId) throws TechnicalException {
+        log.debug("Find gamma dashboard by ID [{}] and environment ID [{}]", id, environmentId);
+        var dashboard = internalGammaDashboardRepo.findByIdAndEnvironmentId(id, environmentId).map(mapper::map);
+        log.debug("Find gamma dashboard by ID [{}] and environment ID [{}] - Done", id, environmentId);
+        return dashboard;
+    }
+
+    @Override
+    public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("Delete gamma dashboards by environment ID [{}]", environmentId);
+        try {
+            internalGammaDashboardRepo.deleteByEnvironmentId(environmentId);
+            log.debug("Delete gamma dashboards by environment ID [{}] - Done", environmentId);
+        } catch (Exception e) {
+            throw new TechnicalException("An error occurred when deleting gamma dashboards by environment id " + environmentId, e);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/GammaDashboardMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/GammaDashboardMongoRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal;
+
+import io.gravitee.repository.mongodb.management.internal.model.GammaDashboardMongo;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Repository
+public interface GammaDashboardMongoRepository extends MongoRepository<GammaDashboardMongo, String> {
+    /**
+     * Ordered explicitly: Mongo natural order is not stable — a document can move when an update grows it — so an
+     * unordered list would let a user reshuffle their own dashboards just by editing one.
+     */
+    List<GammaDashboardMongo> findByEnvironmentIdOrderByCreatedAtAscIdAsc(String environmentId);
+
+    Optional<GammaDashboardMongo> findByIdAndEnvironmentId(String id, String environmentId);
+
+    void deleteByEnvironmentId(String environmentId);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/GammaDashboardMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/GammaDashboardMongo.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.model;
+
+import java.util.Date;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Document(collection = "#{@environment.getProperty('management.mongodb.prefix')}gamma_dashboards")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+public class GammaDashboardMongo {
+
+    @Id
+    private String id;
+
+    private String environmentId;
+    private String title;
+    private String description;
+    private List<Filter> filters;
+    private TimeRange timeRange;
+
+    /** Raw, opaque widget JSON. Stored as a String so dotted map keys survive Mongo. */
+    private String widgets;
+
+    private String createdBy;
+    private Date createdAt;
+    private Date updatedAt;
+
+    /** Deliberately not annotated {@code @Version}: this layer stores the counter, it does not manage it. */
+    private Integer version;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Filter {
+
+        private String field;
+        private String label;
+        private String operator;
+        private List<String> value;
+        private boolean editable;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TimeRange {
+
+        private String type;
+        private String period;
+        private Long from;
+        private Long to;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
@@ -148,6 +148,21 @@ public interface GraviteeMapper {
 
     CustomDashboardWidgetMongo map(CustomDashboardWidget toMap);
 
+    // GammaDashboard mapping
+    GammaDashboard map(GammaDashboardMongo toMap);
+
+    GammaDashboardMongo map(GammaDashboard toMap);
+
+    Set<GammaDashboard> mapGammaDashboards(Collection<GammaDashboardMongo> toMap);
+
+    GammaDashboard.Filter map(GammaDashboardMongo.Filter toMap);
+
+    GammaDashboardMongo.Filter map(GammaDashboard.Filter toMap);
+
+    GammaDashboard.TimeRange map(GammaDashboardMongo.TimeRange toMap);
+
+    GammaDashboardMongo.TimeRange map(GammaDashboard.TimeRange toMap);
+
     // PortalCategory mapping
     PortalCategory map(PortalCategoryMongo toMap);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/gammadashboards/EnvironmentIdIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/gammadashboards/EnvironmentIdIndexUpgrader.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.gammadashboards;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("GammaDashboardsEnvironmentIdIndexUpgrader")
+public class EnvironmentIdIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("gamma_dashboards")
+            .name("ei1")
+            .key("environmentId", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/gammadashboards/EnvironmentIdIndexUpgraderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/gammadashboards/EnvironmentIdIndexUpgraderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.gammadashboards;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+class EnvironmentIdIndexUpgraderTest {
+
+    @Test
+    void buildIndex_definesIndexOnGammaDashboardsWithExpectedNameAndKey() {
+        Index index = new EnvironmentIdIndexUpgrader().buildIndex();
+
+        assertThat(index.getCollection()).isEqualTo("gamma_dashboards");
+        assertThat(index.options().getName()).isEqualTo("ei1");
+
+        Document keys = index.toIndexDefinition().getIndexKeys();
+        assertThat(keys).hasSize(1);
+        assertThat(keys.get("environmentId")).isEqualTo(1);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
@@ -255,6 +255,9 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
     protected CustomDashboardRepository customDashboardRepository;
 
     @Inject
+    protected GammaDashboardRepository gammaDashboardRepository;
+
+    @Inject
     protected PortalCategoryRepository portalCategoryRepository;
 
     @Inject
@@ -312,6 +315,7 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
             case ScoringRuleset scoringRuleset -> scoringRulesetRepository.create(scoringRuleset);
             case ScoringFunction scoringFunction -> scoringFunctionRepository.create(scoringFunction);
             case CustomDashboard customDashboard -> customDashboardRepository.create(customDashboard);
+            case GammaDashboard gammaDashboard -> gammaDashboardRepository.create(gammaDashboard);
             case PortalCategory portalCategory -> portalCategoryRepository.create(portalCategory);
             case Dashboard apiQualityRule -> dashboardRepository.create(apiQualityRule);
             case AlertEvent alertEvent -> alertEventRepository.create(alertEvent);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/GammaDashboardRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/GammaDashboardRepositoryTest.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management;
+
+import static io.gravitee.repository.utils.DateUtils.compareDate;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.gravitee.repository.management.model.GammaDashboard;
+import java.util.*;
+import org.junit.jupiter.api.Test;
+
+public class GammaDashboardRepositoryTest extends AbstractManagementRepositoryTest {
+
+    /** Widget payload with a dotted map key — Mongo rejects those as document keys, hence the opaque String column. */
+    private static final String DOTTED_KEY_WIDGETS =
+        "{\"widgets\":[{\"id\":\"w-1\",\"type\":\"line\",\"colorByGroup\":{\"api.example.com\":\"#fff\",\"other.host\":\"#000\"}}]}";
+
+    @Override
+    protected String getTestCasesPath() {
+        return "/data/gamma-dashboard-tests/";
+    }
+
+    @Test
+    public void shouldFindByEnvironmentId() throws Exception {
+        var dashboards = gammaDashboardRepository.findByEnvironmentId("DEFAULT");
+        assertThat(dashboards).hasSize(3);
+    }
+
+    @Test
+    public void shouldFindByEnvironmentId_otherEnv() throws Exception {
+        var dashboards = gammaDashboardRepository.findByEnvironmentId("OTHER_ENV");
+        assertThat(dashboards).hasSize(1);
+        assertThat(dashboards.get(0).getTitle()).isEqualTo("Other Env Dashboard");
+    }
+
+    /**
+     * The three DEFAULT fixtures share a {@code createdAt}, so this also pins the id tie-break — without it the order
+     * would still be backend-dependent.
+     */
+    @Test
+    public void shouldReturnEnvironmentDashboardsInStableOrder() throws Exception {
+        assertThat(gammaDashboardRepository.findByEnvironmentId("DEFAULT"))
+            .extracting(GammaDashboard::getId)
+            .containsExactly("gd-1", "gd-2", "gd-3");
+    }
+
+    @Test
+    public void shouldReturnEmptyListForUnknownEnvironmentId() throws Exception {
+        var dashboards = gammaDashboardRepository.findByEnvironmentId("UNKNOWN");
+        assertThat(dashboards).isEmpty();
+    }
+
+    @Test
+    public void shouldFindById() throws Exception {
+        var dashboard = gammaDashboardRepository.findById("gd-1");
+        assertThat(dashboard).hasValueSatisfying(result -> {
+            assertThat(result.getTitle()).isEqualTo("Performance Overview");
+            assertThat(result.getDescription()).isEqualTo("Latency and throughput");
+            assertThat(result.getEnvironmentId()).isEqualTo("DEFAULT");
+            assertThat(result.getCreatedBy()).isEqualTo("user-1");
+            assertThat(compareDate(result.getCreatedAt(), new Date(1000000000000L))).isTrue();
+            assertThat(compareDate(result.getUpdatedAt(), new Date(1111111111111L))).isTrue();
+            assertThat(result.getVersion()).isEqualTo(3);
+        });
+    }
+
+    @Test
+    public void shouldRoundTripAbsentVersionAsNull() throws Exception {
+        var dashboard = gammaDashboardRepository.findById("gd-3");
+        assertThat(dashboard).hasValueSatisfying(result -> assertThat(result.getVersion()).isNull());
+    }
+
+    @Test
+    public void shouldReturnEmptyForUnknownId() throws Exception {
+        var dashboard = gammaDashboardRepository.findById("unknown");
+        assertThat(dashboard).isEmpty();
+    }
+
+    @Test
+    public void shouldFindByIdAndEnvironmentId() throws Exception {
+        var dashboard = gammaDashboardRepository.findByIdAndEnvironmentId("gd-1", "DEFAULT");
+        assertThat(dashboard).hasValueSatisfying(result -> assertThat(result.getTitle()).isEqualTo("Performance Overview"));
+    }
+
+    /** Cross-environment isolation is a property of the query, not of a caller-side check. */
+    @Test
+    public void shouldNotFindByIdWhenEnvironmentDoesNotMatch() throws Exception {
+        assertThat(gammaDashboardRepository.findById("gd-4")).isPresent();
+        assertThat(gammaDashboardRepository.findByIdAndEnvironmentId("gd-4", "DEFAULT")).isEmpty();
+        assertThat(gammaDashboardRepository.findByIdAndEnvironmentId("gd-1", "OTHER_ENV")).isEmpty();
+    }
+
+    @Test
+    public void shouldNotFindByIdAndEnvironmentIdForUnknownId() throws Exception {
+        assertThat(gammaDashboardRepository.findByIdAndEnvironmentId("unknown", "DEFAULT")).isEmpty();
+    }
+
+    /**
+     * The payload mirrors what the frontend actually emits — see the in-repo literal in
+     * {@code gravitee-gamma-module-apim/.../templates/shared.ts}: {@code field}, {@code label}, a lowercase operator
+     * and {@code value}. Asserting on an invented shape would prove serialization, not compatibility.
+     */
+    @Test
+    public void shouldRoundTripFilters() throws Exception {
+        var dashboard = gammaDashboardRepository.findById("gd-1");
+        assertThat(dashboard).hasValueSatisfying(result -> {
+            assertThat(result.getFilters()).hasSize(2);
+
+            var editable = result
+                .getFilters()
+                .stream()
+                .filter(f -> "API_TYPE".equals(f.getField()))
+                .findFirst()
+                .orElseThrow();
+            assertThat(editable.getLabel()).isEqualTo("API Type");
+            assertThat(editable.getOperator()).isEqualTo("in");
+            assertThat(editable.getValue()).containsExactly("MCP", "A2A");
+            assertThat(editable.isEditable()).isTrue();
+
+            // The "all values" placeholder: locked filter carrying an empty value list.
+            var locked = result
+                .getFilters()
+                .stream()
+                .filter(f -> "HTTP_STATUS".equals(f.getField()))
+                .findFirst()
+                .orElseThrow();
+            assertThat(locked.getLabel()).isEqualTo("Status");
+            assertThat(locked.getOperator()).isEqualTo("eq");
+            assertThat(locked.getValue()).isEmpty();
+            assertThat(locked.isEditable()).isFalse();
+        });
+    }
+
+    @Test
+    public void shouldRoundTripRelativeTimeRange() throws Exception {
+        var dashboard = gammaDashboardRepository.findById("gd-1");
+        assertThat(dashboard).hasValueSatisfying(result -> {
+            assertThat(result.getTimeRange()).isNotNull();
+            assertThat(result.getTimeRange().getType()).isEqualTo("relative");
+            assertThat(result.getTimeRange().getPeriod()).isEqualTo("7d");
+            assertThat(result.getTimeRange().getFrom()).isNull();
+            assertThat(result.getTimeRange().getTo()).isNull();
+        });
+    }
+
+    @Test
+    public void shouldRoundTripAbsoluteTimeRange() throws Exception {
+        var dashboard = gammaDashboardRepository.findById("gd-2");
+        assertThat(dashboard).hasValueSatisfying(result -> {
+            assertThat(result.getTimeRange()).isNotNull();
+            assertThat(result.getTimeRange().getType()).isEqualTo("absolute");
+            assertThat(result.getTimeRange().getPeriod()).isNull();
+            assertThat(result.getTimeRange().getFrom()).isEqualTo(1735689600000L);
+            assertThat(result.getTimeRange().getTo()).isEqualTo(1738368000000L);
+        });
+    }
+
+    @Test
+    public void shouldRoundTripWidgetsWithDottedMapKey() throws Exception {
+        var dashboard = gammaDashboardRepository.findById("gd-1");
+        assertThat(dashboard).hasValueSatisfying(result -> assertThat(result.getWidgets()).isEqualTo(DOTTED_KEY_WIDGETS));
+    }
+
+    @Test
+    public void shouldCreate() throws Exception {
+        var dashboard = GammaDashboard.builder()
+            .id("new-gd")
+            .environmentId("DEFAULT")
+            .title("New Dashboard")
+            .description("Created by the TCK")
+            .createdBy("user-new")
+            .createdAt(new Date(1000000000000L))
+            .updatedAt(new Date(1111111111111L))
+            .version(1)
+            .filters(
+                List.of(
+                    GammaDashboard.Filter.builder()
+                        .field("API_TYPE")
+                        .label("API Type")
+                        .operator("eq")
+                        .value(List.of("MCP"))
+                        .editable(true)
+                        .build()
+                )
+            )
+            .timeRange(GammaDashboard.TimeRange.builder().type("relative").period("1h").build())
+            .widgets(DOTTED_KEY_WIDGETS)
+            .build();
+
+        var nbBefore = gammaDashboardRepository.findByEnvironmentId("DEFAULT").size();
+        gammaDashboardRepository.create(dashboard);
+        var nbAfter = gammaDashboardRepository.findByEnvironmentId("DEFAULT").size();
+
+        assertThat(nbAfter).isEqualTo(nbBefore + 1);
+
+        var saved = gammaDashboardRepository.findById("new-gd");
+        assertThat(saved).hasValueSatisfying(result -> {
+            assertThat(result.getId()).isEqualTo("new-gd");
+            assertThat(result.getEnvironmentId()).isEqualTo("DEFAULT");
+            assertThat(result.getTitle()).isEqualTo("New Dashboard");
+            assertThat(result.getDescription()).isEqualTo("Created by the TCK");
+            assertThat(result.getCreatedBy()).isEqualTo("user-new");
+            assertThat(compareDate(result.getCreatedAt(), new Date(1000000000000L))).isTrue();
+            assertThat(compareDate(result.getUpdatedAt(), new Date(1111111111111L))).isTrue();
+            assertThat(result.getFilters()).hasSize(1);
+            assertThat(result.getFilters().get(0).getField()).isEqualTo("API_TYPE");
+            assertThat(result.getFilters().get(0).isEditable()).isTrue();
+            assertThat(result.getTimeRange().getPeriod()).isEqualTo("1h");
+            assertThat(result.getWidgets()).isEqualTo(DOTTED_KEY_WIDGETS);
+            assertThat(result.getVersion()).isEqualTo(1);
+        });
+    }
+
+    /**
+     * The version counter is carried, never managed here: this layer must not initialise or bump it. Bumping belongs
+     * to the update use case, so an update that leaves it alone must store it unchanged, and one that sets it must
+     * store exactly what it was given.
+     */
+    @Test
+    public void shouldPersistVersionVerbatimOnUpdate() throws Exception {
+        var untouched = gammaDashboardRepository.findById("gd-2").orElseThrow();
+        assertThat(untouched.getVersion()).isEqualTo(7);
+
+        untouched.setTitle("Same version");
+        gammaDashboardRepository.update(untouched);
+        assertThat(gammaDashboardRepository.findById("gd-2")).hasValueSatisfying(result -> assertThat(result.getVersion()).isEqualTo(7));
+
+        var bumped = gammaDashboardRepository.findById("gd-2").orElseThrow();
+        bumped.setVersion(8);
+        gammaDashboardRepository.update(bumped);
+        assertThat(gammaDashboardRepository.findById("gd-2")).hasValueSatisfying(result -> assertThat(result.getVersion()).isEqualTo(8));
+    }
+
+    @Test
+    public void shouldUpdate() throws Exception {
+        var optional = gammaDashboardRepository.findById("gd-2");
+        assertThat(optional).as("Gamma dashboard to update not found").isPresent();
+        assertThat(optional.get().getTitle()).isEqualTo("API Metrics");
+
+        var dashboard = optional.get();
+        dashboard.setTitle("Updated Dashboard");
+        dashboard.setDescription("Updated description");
+        dashboard.setFilters(
+            List.of(GammaDashboard.Filter.builder().field("PLAN").label("Plan").operator("in").value(List.of()).editable(true).build())
+        );
+        dashboard.setTimeRange(GammaDashboard.TimeRange.builder().type("relative").period("30d").build());
+        dashboard.setWidgets(DOTTED_KEY_WIDGETS);
+        dashboard.setUpdatedAt(new Date(1222222222222L));
+
+        gammaDashboardRepository.update(dashboard);
+
+        var updated = gammaDashboardRepository.findById("gd-2");
+        assertThat(updated).hasValueSatisfying(result -> {
+            assertThat(result.getId()).isEqualTo("gd-2");
+            assertThat(result.getEnvironmentId()).isEqualTo("DEFAULT");
+            assertThat(result.getTitle()).isEqualTo("Updated Dashboard");
+            assertThat(result.getDescription()).isEqualTo("Updated description");
+            assertThat(result.getCreatedBy()).isEqualTo("user-2");
+            assertThat(compareDate(result.getCreatedAt(), new Date(1000000000000L))).isTrue();
+            assertThat(compareDate(result.getUpdatedAt(), new Date(1222222222222L))).isTrue();
+            assertThat(result.getFilters()).hasSize(1);
+            assertThat(result.getFilters().get(0).getValue()).isEmpty();
+            assertThat(result.getFilters().get(0).isEditable()).isTrue();
+            assertThat(result.getTimeRange().getType()).isEqualTo("relative");
+            assertThat(result.getTimeRange().getPeriod()).isEqualTo("30d");
+            assertThat(result.getTimeRange().getFrom()).isNull();
+            assertThat(result.getWidgets()).isEqualTo(DOTTED_KEY_WIDGETS);
+            assertThat(result.getVersion()).isEqualTo(7);
+        });
+    }
+
+    @Test
+    public void shouldDelete() throws Exception {
+        var nbBefore = gammaDashboardRepository.findByEnvironmentId("DEFAULT").size();
+        gammaDashboardRepository.delete("gd-3");
+        var nbAfter = gammaDashboardRepository.findByEnvironmentId("DEFAULT").size();
+
+        assertThat(nbAfter).isEqualTo(nbBefore - 1);
+        assertThat(gammaDashboardRepository.findById("gd-3")).isEmpty();
+    }
+
+    @Test
+    public void shouldDeleteByEnvironmentId() throws Exception {
+        assertThat(gammaDashboardRepository.findByEnvironmentId("OTHER_ENV")).hasSize(1);
+        assertThat(gammaDashboardRepository.findByEnvironmentId("DEFAULT")).hasSize(3);
+
+        gammaDashboardRepository.deleteByEnvironmentId("OTHER_ENV");
+
+        assertThat(gammaDashboardRepository.findByEnvironmentId("OTHER_ENV")).isEmpty();
+        assertThat(gammaDashboardRepository.findByEnvironmentId("DEFAULT")).hasSize(3);
+        assertThat(gammaDashboardRepository.findById("gd-4")).isEmpty();
+    }
+
+    @Test
+    public void shouldNotUpdateUnknownDashboard() throws Exception {
+        assertThrows(IllegalStateException.class, () -> {
+            var unknown = GammaDashboard.builder().id("unknown").title("Unknown").build();
+            gammaDashboardRepository.update(unknown);
+            fail("An unknown gamma dashboard should not be updated");
+        });
+    }
+
+    /**
+     * Mongo's {@code save()} is an upsert, so a read-then-write update would silently re-insert a dashboard deleted in
+     * between — while JDBC, guarded by its affected-row count, raises. This pins the two backends to the same
+     * behaviour: the delete wins, and nothing comes back.
+     */
+    @Test
+    public void shouldNotResurrectADashboardDeletedBeforeTheUpdate() throws Exception {
+        var dashboard = gammaDashboardRepository.findById("gd-3").orElseThrow();
+        gammaDashboardRepository.delete("gd-3");
+
+        dashboard.setTitle("Resurrected");
+        assertThrows(IllegalStateException.class, () -> gammaDashboardRepository.update(dashboard));
+
+        assertThat(gammaDashboardRepository.findById("gd-3")).isEmpty();
+    }
+
+    @Test
+    public void shouldNotUpdateNull() throws Exception {
+        assertThrows(IllegalStateException.class, () -> {
+            gammaDashboardRepository.update(null);
+            fail("A null gamma dashboard should not be updated");
+        });
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/RepositoryTestSuite.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/RepositoryTestSuite.java
@@ -46,6 +46,7 @@ import org.junit.platform.suite.api.Suite;
         CustomUserFieldsRepositoryTest.class,
         CustomDashboardRepositoryTest.class,
         DashboardRepositoryTest.class,
+        GammaDashboardRepositoryTest.class,
         DictionaryRepositoryTest.class,
         EntrypointRepositoryTest.class,
         EnvironmentRepositoryTest.class,

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/gamma-dashboard-tests/gammaDashboards.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/gamma-dashboard-tests/gammaDashboards.json
@@ -1,0 +1,75 @@
+[
+  {
+    "id": "gd-1",
+    "environmentId": "DEFAULT",
+    "title": "Performance Overview",
+    "description": "Latency and throughput",
+    "createdBy": "user-1",
+    "createdAt": 1000000000000,
+    "updatedAt": 1111111111111,
+    "version": 3,
+    "filters": [
+      {
+        "field": "API_TYPE",
+        "label": "API Type",
+        "operator": "in",
+        "value": ["MCP", "A2A"],
+        "editable": true
+      },
+      {
+        "field": "HTTP_STATUS",
+        "label": "Status",
+        "operator": "eq",
+        "value": [],
+        "editable": false
+      }
+    ],
+    "timeRange": {
+      "type": "relative",
+      "period": "7d"
+    },
+    "widgets": "{\"widgets\":[{\"id\":\"w-1\",\"type\":\"line\",\"colorByGroup\":{\"api.example.com\":\"#fff\",\"other.host\":\"#000\"}}]}"
+  },
+  {
+    "id": "gd-2",
+    "environmentId": "DEFAULT",
+    "title": "API Metrics",
+    "createdBy": "user-2",
+    "createdAt": 1000000000000,
+    "updatedAt": 1111111111111,
+    "version": 7,
+    "filters": [
+      {
+        "field": "PLAN",
+        "label": "Plan",
+        "operator": "not_in",
+        "value": ["plan-1"],
+        "editable": false
+      }
+    ],
+    "timeRange": {
+      "type": "absolute",
+      "from": 1735689600000,
+      "to": 1738368000000
+    },
+    "widgets": "{\"widgets\":[]}"
+  },
+  {
+    "id": "gd-3",
+    "environmentId": "DEFAULT",
+    "title": "Dashboard To Delete",
+    "createdBy": "user-1",
+    "createdAt": 1000000000000,
+    "updatedAt": 1111111111111,
+    "widgets": "{\"widgets\":[]}"
+  },
+  {
+    "id": "gd-4",
+    "environmentId": "OTHER_ENV",
+    "title": "Other Env Dashboard",
+    "createdBy": "user-3",
+    "createdAt": 1000000000000,
+    "updatedAt": 1111111111111,
+    "widgets": "{\"widgets\":[]}"
+  }
+]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
@@ -46,6 +46,7 @@ import io.gravitee.repository.management.api.CustomUserFieldsRepository;
 import io.gravitee.repository.management.api.DashboardRepository;
 import io.gravitee.repository.management.api.DictionaryRepository;
 import io.gravitee.repository.management.api.FlowRepository;
+import io.gravitee.repository.management.api.GammaDashboardRepository;
 import io.gravitee.repository.management.api.GenericNotificationConfigRepository;
 import io.gravitee.repository.management.api.GroupRepository;
 import io.gravitee.repository.management.api.IdentityProviderActivationRepository;
@@ -153,6 +154,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
     private final DictionaryService dictionaryService;
     private final EnvironmentService environmentService;
     private final FlowRepository flowRepository;
+    private final GammaDashboardRepository gammaDashboardRepository;
     private final GenericNotificationConfigRepository genericNotificationConfigRepository;
     private final GroupRepository groupRepository;
     private final IdentityProviderActivationRepository identityProviderActivationRepository;
@@ -217,6 +219,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         @Lazy DashboardRepository dashboardRepository,
         @Lazy DictionaryRepository dictionaryRepository,
         @Lazy FlowRepository flowRepository,
+        @Lazy GammaDashboardRepository gammaDashboardRepository,
         @Lazy GenericNotificationConfigRepository genericNotificationConfigRepository,
         @Lazy GroupRepository groupRepository,
         @Lazy IdentityProviderActivationRepository identityProviderActivationRepository,
@@ -290,6 +293,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         this.dictionaryService = dictionaryService;
         this.environmentService = environmentService;
         this.flowRepository = flowRepository;
+        this.gammaDashboardRepository = gammaDashboardRepository;
         this.genericNotificationConfigRepository = genericNotificationConfigRepository;
         this.groupRepository = groupRepository;
         this.identityProviderActivationRepository = identityProviderActivationRepository;
@@ -440,6 +444,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         categoryRepository.deleteByEnvironmentId(environment.getId());
         dashboardRepository.deleteByReferenceIdAndReferenceType(environment.getId(), DashboardReferenceType.ENVIRONMENT);
         customDashboardRepository.deleteByEnvironmentId(environment.getId());
+        gammaDashboardRepository.deleteByEnvironmentId(environment.getId());
         dictionaryRepository.deleteByEnvironmentId(environment.getId());
         scoringRulesetRepository.deleteByReferenceId(environment.getId(), ScoringRuleset.ReferenceType.ENVIRONMENT.name());
         scoringFunctionRepository.deleteByReferenceId(environment.getId(), ScoringRuleset.ReferenceType.ENVIRONMENT.name());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
@@ -50,6 +50,7 @@ import io.gravitee.repository.management.api.CustomUserFieldsRepository;
 import io.gravitee.repository.management.api.DashboardRepository;
 import io.gravitee.repository.management.api.DictionaryRepository;
 import io.gravitee.repository.management.api.FlowRepository;
+import io.gravitee.repository.management.api.GammaDashboardRepository;
 import io.gravitee.repository.management.api.GenericNotificationConfigRepository;
 import io.gravitee.repository.management.api.GroupRepository;
 import io.gravitee.repository.management.api.IdentityProviderActivationRepository;
@@ -254,6 +255,9 @@ public class DeleteEnvironmentCommandHandlerTest {
 
     @Mock
     private CustomDashboardRepository customDashboardRepository;
+
+    @Mock
+    private GammaDashboardRepository gammaDashboardRepository;
 
     @Mock
     private DashboardRepository dashboardRepository;
@@ -471,6 +475,7 @@ public class DeleteEnvironmentCommandHandlerTest {
             dashboardRepository,
             dictionaryRepository,
             flowRepository,
+            gammaDashboardRepository,
             genericNotificationConfigRepository,
             groupRepository,
             identityProviderActivationRepository,
@@ -587,6 +592,7 @@ public class DeleteEnvironmentCommandHandlerTest {
         verify(categoryRepository).deleteByEnvironmentId(ENV_ID);
         verify(dashboardRepository).deleteByReferenceIdAndReferenceType(ENV_ID, DashboardReferenceType.ENVIRONMENT);
         verify(customDashboardRepository).deleteByEnvironmentId(ENV_ID);
+        verify(gammaDashboardRepository).deleteByEnvironmentId(ENV_ID);
         verify(dictionaryRepository).deleteByEnvironmentId(ENV_ID);
         verify(portalNotificationConfigRepository).deleteByReferenceIdAndReferenceType(ENV_ID, NotificationReferenceType.ENVIRONMENT);
         verify(genericNotificationConfigRepository).deleteByReferenceIdAndReferenceType(ENV_ID, NotificationReferenceType.ENVIRONMENT);


### PR DESCRIPTION
## Summary

Gamma has **no custom dashboards today**. The observability library ships read-only *template* dashboards — `DashboardListPage` on `gamma-lib-observability` `main` takes `templates: readonly DashboardTemplate[]` and renders nothing else — so a user cannot create, edit or save a dashboard of their own. What exists on `main` is the seam: a `DashboardPersistence` port and its provider, with no implementation behind them.

This PR adds the store that will back that port, so the feature can ship with server-side persistence from the start: a `GammaDashboardRepository` SPI with Mongo and JDBC implementations, validated by the shared repository TCK.

Building the backend first is what keeps this cheap. There is no existing user data, so there is nothing to migrate and no interim client-side format to be compatible with — the alternative would be to ship the UI against browser storage, then pay for a migration and a coexistence window later. It also means the "dashboard identity filters" work can land with a persistence model instead of without one.

**No API is exposed by this PR.** It is the first of three increments under [OBS-13](https://gravitee.atlassian.net/browse/OBS-13); the endpoints follow in [OBS-15](https://gravitee.atlassian.net/browse/OBS-15) (read) and [OBS-16](https://gravitee.atlassian.net/browse/OBS-16) (write).

Jira: [OBS-14](https://gravitee.atlassian.net/browse/OBS-14)

## Changes

- **SPI** — `GammaDashboardRepository extends CrudRepository<GammaDashboard, String>` plus `findByEnvironmentId`, `findByIdAndEnvironmentId` and `deleteByEnvironmentId`, and the `GammaDashboard` model with its nested `Filter` and `TimeRange` statics.
- **Mongo** — `GammaDashboardMongo` document on a new `gamma_dashboards` collection (honouring the configured prefix), internal Spring Data repository, `MongoGammaDashboardRepository` facade, `GraviteeMapper` MapStruct methods both ways, and an `EnvironmentIdIndexUpgrader` creating index `ei1` on `environmentId` (+ its unit test).
- **JDBC** — `JdbcGammaDashboardRepository` declares `filters` and `time_range` as converted `NCLOB` columns through `JdbcObjectMapper`'s serializer/deserializer `addColumn` overload (the idiom `JdbcPortalPageContentRepository` already uses), and `widgets` as a plain `String` column since it is opaque JSON on the model. That leaves the ORM to build the insert/update SQL and the row mapper, so there is no hand-rolled SQL, no custom `PreparedStatementCreator` and no `findById` override — unlike `JdbcCustomDashboardRepository`, which predates that overload and hand-rolls all of it. Liquibase changeset `v4_13_0/09_create_gamma_dashboards_table.yml` with an index on `environment_id`, `master.yml` include, and `gamma_dashboards` added to the test truncate list.
- **Environment deletion cascade** — `DeleteEnvironmentCommandHandler` now calls `gammaDashboardRepository.deleteByEnvironmentId(...)` alongside the existing `customDashboardRepository` call, with the matching assertion in `DeleteEnvironmentCommandHandlerTest`. Without it, deleting an environment would leave its dashboards orphaned in the collection.
- **TCK** — `GammaDashboardRepositoryTest` and its fixture, wired into `AbstractManagementRepositoryTest` and `RepositoryTestSuite`.

### Design decisions worth knowing

- **A new collection, not `custom_dashboards`.** That collection is already read *unfiltered* by two products — APIM Console v2 (`DashboardsResource`) and the Developer Portal (`PortalAnalyticsDashboardsResource`), both via `ListDashboardsUseCase.execute(new Input(environmentId))`. Adding a discriminator would make leaking the default behaviour. `CoreRulesTest` also forbids the Gamma core from importing `io.gravitee.apim.core.dashboard.model.Dashboard`, so Gamma needs its own model regardless.
- **`widgets` is stored as opaque JSON.** Typing 6 widget variants × ~40 optional fields in Java would go stale on every frontend release and force a backend release per new widget option. It also neutralises the dotted-map-key hazard: `colorByGroup` is keyed by hostnames and API names, and no `MappingMongoConverter#setMapKeyDotReplacement` is configured in this repo. `filters` and `timeRange` stay structured.
- **`filters` and `timeRange` stay structured, but their shape mirrors the frontend's `FilterCondition` exactly** — `{ field, label, operator, value }` with lowercase operators, and `timeRange.type` lowercase. The same type also travels verbatim inside the opaque `widgets` payload, so any divergence would mean storing one type in two shapes and maintaining a mapping table between them. `label` is persisted because nothing derives it: the resolve hook rehydrates `valueLabels` from the API, never `label`. The one deliberate difference is `editable`, which replaces the frontend's optional `locked` tri-state with a required positive boolean.
- **Why structured rather than opaque like `widgets`.** What justifies opacity for widgets is an *open* schema — 6 variants × ~40 optional fields, changing every release, with a dotted-map-key hazard. `FilterCondition` is a closed 5-field shape and `TimeRange` a closed 4-field one, neither with dotted keys. Structuring does not validate values, but it does guarantee shape integrity: a caller has to build `Filter` instances to write, so the column cannot hold arbitrary text.
- **`updated_at`, not `last_modified`** — matches the frontend field and the majority convention here; `custom_dashboards` is the outlier.
- **`findByEnvironmentId` orders by `created_at`, then `id`.** Mongo natural order is not stable — a document can move when an update grows it — so an unordered list would let a user reshuffle their own dashboards just by editing one. The id tie-break matters: the fixtures deliberately share a `createdAt`.
- **Mongo `update()` is a single conditional `findAndReplace` matched on `_id`.** `save()` is an upsert, so a read-then-write pair would silently re-insert a dashboard deleted in between, while JDBC raises on 0 affected rows. Matching on `_id` folds the existence check into the same round trip and keeps the backends aligned; enforcing `version` later is one more criterion on that query.
- **A `version` column is included up front, but nothing manages it yet.** Once dashboards are stored server-side they become a shared artifact that two people can edit at once, so they will need optimistic concurrency control. Adding the column before the table ships costs three lines; adding it afterwards costs a migration changeset, a backfill and coordination with deployed instances. This layer therefore persists the counter **verbatim** — it never initialises, increments or checks it (deliberately no Spring Data `@Version`; the shape follows the existing `Cluster.version`). Incrementing belongs to the update use case in OBS-16, and rejecting a stale value (409) is a separate ticket. `GammaDashboardRepositoryTest#shouldPersistVersionVerbatimOnUpdate` pins that contract so the behaviour cannot drift silently.
- **Model named `GammaDashboard`** because `io.gravitee.repository.management.model.Dashboard` already exists (legacy analytics dashboard).

## Test plan

- [ ] `mvn -f gravitee-apim-repository/pom.xml install -DskipTests -pl gravitee-apim-repository-api,gravitee-apim-repository-test -am` (the TCK ships as a test-jar; without the install, the Mongo/JDBC modules unpack a stale one).
- [ ] Mongo: `mvn -f gravitee-apim-repository/pom.xml test -pl gravitee-apim-repository-mongodb -Dtest=GammaDashboardRepositoryTest -DfailIfNoSpecifiedTests=false` — 22 tests, runs both with and without encryption.
- [ ] Every JDBC dialect: same command on `gravitee-apim-repository-jdbc`, repeated with `-Ddefault-database.jdbcType=` `postgresql` (default), `mariadb`, `mysql`, `sqlserver`.
- [ ] Index upgrader: `-Dtest=EnvironmentIdIndexUpgraderTest` on the mongodb module.
- [ ] Regression on the neighbouring stores: `-Dtest='CustomDashboardRepositoryTest,DashboardRepositoryTest'` on both mongodb and jdbc — the Liquibase changeset and the truncate list are shared.
- [ ] Environment cascade: `mvn -f gravitee-apim-rest-api/pom.xml test -pl gravitee-apim-rest-api-service -Dtest=DeleteEnvironmentCommandHandlerTest`.

Edge cases covered by the TCK: find by environment / other environment / unknown environment, `findById` hit and miss, create, update, update of an unknown id, update of `null`, delete, `deleteByEnvironmentId`; filters round-tripping with `editable` and with the empty `value` "all values" placeholder; `timeRange` in both `relative` and `absolute` form; `version` round-tripping when set, staying `null` when absent, and being stored verbatim across an update (neither auto-initialised nor auto-incremented); a stable list order pinned including the id tie-break; an update of a dashboard deleted beforehand raising rather than resurrecting it; and a widget payload carrying a **dotted map key** (`colorByGroup: {"api.example.com": "#fff"}`) asserted to round-trip byte-for-byte.

The fixtures use payloads the product actually emits — `field` / `label` / lowercase operator / `value`, and real `RelativePeriod` tokens such as `7d` — modelled on the in-repo literal in `gravitee-gamma-module-apim/.../templates/shared.ts`. An earlier revision asserted on an invented shape, which proved serialization rather than compatibility.

`findByIdAndEnvironmentId` is covered both ways: it returns the dashboard for its own environment, and returns empty for an id that exists under a different one (`gd-4` is findable by `findById` and invisible through the scoped lookup).

All of the above was run locally and is green (22/22 on each of the five backends, plus `DeleteEnvironmentCommandHandlerTest`).

## Reviewer notes

- **`liquibase/master.yml`** — the include is appended at the tail, which is order-sensitive and a known conflict point: this branch has already been renumbered once, from `08_` to `09_`, after `08_backfill_cluster_lifecycle_state.yml` landed on master. If another changeset reaches `v4_13_0` before this merges, the ordinal and the tail position both need re-checking.
- **`MongoGammaDashboardRepository.update` reads then saves**, so the existence check and the write are two round trips, whereas the JDBC side is a single statement guarded by the affected-row count. Harmless while `version` is only carried, but there is a comment on the method recording that enforcement must turn this into a single conditional `findAndModify` matching on the expected version — otherwise the gap reopens the very lost-update window the locking is meant to close.
- **The Mongo index upgrader is mandatory, not cosmetic.** The TCK container runs with `notablescan=true` and `MongoTestRepositoryInitializer` executes every `IndexMongoUpgrader` bean, so without it `findByEnvironmentId` fails with a confusing error. Note the explicit bean name `@Component("GammaDashboardsEnvironmentIdIndexUpgrader")`: about thirty sibling classes are also called `EnvironmentIdIndexUpgrader`, and the Spring default bean name would collide.
- **No `NoOpGammaDashboardRepository`.** `NoOpCustomDashboardRepository` exists but is not registered in `NoOpManagementRepositoryConfiguration` — dead code, deliberately not replicated.
- **`findByIdAndEnvironmentId` is on the SPI from the start**, and is what the read endpoints should use rather than `findById` plus a caller-side ownership check. It makes cross-environment isolation a property of the query instead of something each call site has to remember, which is the difference between a 404 that is structural and one that depends on review catching a missing check.
- **The JDBC JSON mapper ignores unknown properties.** `filters` and `time_range` are stored as JSON, so a row written by a newer version must stay readable by an older one; otherwise a rollback or a rolling upgrade turns one unreadable row into a failure of the entire environment listing, since `findByEnvironmentId` maps every row through it.
- **Required-field behaviour differs between the two backends** and is documented on the SPI: JDBC declares `title` / `created_by` / `created_at` / `updated_at` `NOT NULL` and rejects the write, Mongo accepts the document. Callers must validate rather than rely on the store, or the same input succeeds on one deployment and fails on another.
- **No write-time validation of filter names** against the `StaticFilters` catalogue: a dashboard is declarative config, the analytics query path already validates and 400s at read time, and coupling writes to the `FilterRegistry` would make dashboards non-importable across environments.

---

<details>
<summary><b>Verification report</b> — expected / observed / status for all 20 checks run locally (click to expand)</summary>


Everything below was executed locally against real engines — no mocks, no stubs at the persistence boundary. The shared TCK runs on Testcontainers-backed MongoDB and on four JDBC engines; the runtime checks run against the local Docker stack with the Management API image rebuilt from this branch.

### Automated — shared repository TCK

The TCK is an integration suite, not a unit suite: each run starts a real database container, applies the real Liquibase changelog or the real Mongo index upgraders, and exercises the SPI through the actual driver.

| # | Check | Expected | Observed | Status |
|---|-------|----------|----------|--------|
| 1 | `GammaDashboardRepositoryTest` on MongoDB 6.0.26 (replica set, `notablescan=true`) | 22 tests pass, both with and without field-level encryption | 22/22 pass in both surefire executions | PASS |
| 2 | Same suite on PostgreSQL | 22 tests pass | 22/22 pass | PASS |
| 3 | Same suite on MariaDB | 22 tests pass | 22/22 pass | PASS |
| 4 | Same suite on MySQL | 22 tests pass | 22/22 pass | PASS |
| 5 | Same suite on SQL Server | 22 tests pass | 22/22 pass | PASS |
| 6 | `filters` round-trip, including `editable` and the empty-`values` "all values" placeholder | Structured filters survive the round trip on every backend | Asserted field by field; no loss | PASS |
| 7 | `timeRange` round-trip in both forms | `RELATIVE` keeps `period` with null `from`/`to`; `ABSOLUTE` keeps epoch-millis `from`/`to` with null `period` | Both asserted explicitly | PASS |
| 8 | Widget payload with a **dotted map key** (`colorByGroup: {"api.example.com": "#fff"}`) | Stored and returned byte-for-byte; Mongo must not reject the dotted key | Exact string equality asserted; no rejection — the opaque `String` column is what makes this safe | PASS |
| 9 | `version` is persisted verbatim | Round-trips when set, stays `null` when absent, and an update that does not touch it leaves it unchanged | `shouldPersistVersionVerbatimOnUpdate` confirms no auto-initialisation and no auto-increment leak into this layer | PASS |
| 9b | Stable list order | `findByEnvironmentId` returns a deterministic sequence on every backend, including when `created_at` ties | `shouldReturnEnvironmentDashboardsInStableOrder` pins `gd-1, gd-2, gd-3`; the three fixtures share a `createdAt`, so the id tie-break is exercised | PASS |
| 9c | An update must not resurrect a deleted dashboard | Raises on both backends; the row stays deleted | `shouldNotResurrectADashboardDeletedBeforeTheUpdate` green on Mongo and all four dialects. Would have passed on JDBC and failed on Mongo before the `findAndReplace` change | PASS |
| 10 | Cross-environment isolation via `findByIdAndEnvironmentId` | A dashboard belonging to another environment is invisible through the scoped lookup even though `findById` still finds it | `gd-4` found by `findById`, empty via `findByIdAndEnvironmentId("gd-4", "DEFAULT")` | PASS |
| 11 | `EnvironmentIdIndexUpgraderTest` | `buildIndex()` targets `gamma_dashboards`, index name `ei1`, single ascending key on `environmentId` | Matches | PASS |
| 12 | `DeleteEnvironmentCommandHandlerTest` | Deleting an environment cascades to Gamma dashboards | 9/9 pass, including `verify(gammaDashboardRepository).deleteByEnvironmentId(ENV_ID)` | PASS |
| 13 | No regression on the neighbouring stores sharing the changelog and the truncate list | `CustomDashboardRepositoryTest` and `DashboardRepositoryTest` stay green on Mongo and JDBC | 23/23 pass on each | PASS |

### Runtime — local Docker stack, Management API rebuilt from this branch

The distribution was rebuilt from this branch, the `local/apim-management-api:local` image regenerated, and the container force-recreated against the existing MongoDB volume. This is the only check that exercises the **production** upgrader wiring: the TCK deliberately excludes `MongoUpgraderConfiguration` and runs upgraders through test-only wiring, so bean discovery in the real application is otherwise unproven.

| # | Check | Expected | Observed | Status |
|---|-------|----------|----------|--------|
| 14 | Baseline before deploy | `gamma_dashboards` does not exist | Collections matching `/dashboard/i`: `['dashboards', 'custom_dashboards']`; `getIndexes()` returns `ns does not exist` | PASS |
| 15 | Management API boots with the new repository code | Clean startup | `started in 6242 ms`, JVM 21.0.11, version 4.13.0-SNAPSHOT | PASS |
| 16 | Collection created on first boot | `gamma_dashboards` present | `['dashboards', 'gamma_dashboards', 'custom_dashboards']` | PASS |
| 17 | **Mongo index created by the production upgrader path** | `ei1` on `environmentId` | `[{ v: 2, key: { _id: 1 }, name: '_id_' }, { v: 2, key: { environmentId: 1 }, name: 'ei1' }]` | PASS |
| 18 | No bean-name collision from the index upgrader | No `ConflictingBeanDefinition` / `BeanDefinitionOverrideException` | None. Confirms the explicit `@Component("GammaDashboardsEnvironmentIdIndexUpgrader")` is doing its job — production registers upgraders **by bean name** via `context.getBeansOfType(Upgrader.class)`, and ~30 sibling classes share the simple name `EnvironmentIdIndexUpgrader` | PASS |
| 19 | Gamma still loads | Gamma endpoints reachable | `GET /gamma/ui/bootstrap` → `200` | PASS |
| 20 | No Gamma-related error in the startup logs | No exception mentioning the new types | None found | PASS |

### Not covered, and why

| Area | Why it is not covered here | Where it lands |
|------|---------------------------|----------------|
| HTTP-level CRUD (create, read, update, delete over the wire) | Structural: this increment exposes no API. There is nothing to call. | OBS-15 and OBS-16 — their DoD is curl CRUD, 404 across environments, 400 at 51 widgets |
| Liquibase applied to an **already-migrated** JDBC database | The TCK rebuilds the schema from scratch on every run, and the local Docker stack is MongoDB-backed, so Liquibase is not exercised at runtime here. Risk is low by construction: the change adds a new changelog at the tail of `master.yml` and modifies no released changeset, so the usual failure mode — an invalidated checksum on an existing changeset — cannot occur. | CI runs the JDBC suites on all four dialects |
| Concurrent-edit behaviour of `version` | Deliberate: this layer only carries the counter. Enforcement does not exist yet, so there is nothing to test. | OBS-16 for the increment, a dedicated ticket for 409 on a stale version |

One unrelated error appears in the startup logs and is worth naming so it is not mistaken for a regression: `BeanCreationException` on `indexWriter` from `SearchEngineConfiguration`, caused by a stale Lucene `write.lock` in the persisted `data/` volume after the container was force-recreated. It is environmental, touches the search index rather than persistence, and is independent of this change — the API still served requests and the Mongo upgraders still ran.

</details>


[OBS-13]: https://gravitee.atlassian.net/browse/OBS-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ