### PR TITLE
feat: grant AI Workspace access independently of API Product, and audit it

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/member/role.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/member/role.ts
@@ -19,5 +19,15 @@ export interface Role {
    * Role's name.
    */
   name?: string;
-  scope?: 'API' | 'APPLICATION' | 'GROUP' | 'ENVIRONMENT' | 'ORGANIZATION' | 'PLATFORM' | 'INTEGRATION' | 'CLUSTER' | 'API_PRODUCT';
+  scope?:
+    | 'API'
+    | 'APPLICATION'
+    | 'GROUP'
+    | 'ENVIRONMENT'
+    | 'ORGANIZATION'
+    | 'PLATFORM'
+    | 'INTEGRATION'
+    | 'CLUSTER'
+    | 'API_PRODUCT'
+    | 'AI_WORKSPACE';
 }

--- a/gravitee-apim-console-webui/src/entities/role/permission.fixtures.ts
+++ b/gravitee-apim-console-webui/src/entities/role/permission.fixtures.ts
@@ -36,6 +36,7 @@ export function fakePermissionsByScopes(attributes?: Partial<PermissionsByScopes
     ENVIRONMENT: [
       'AGENT_IDENTITY',
       'AI_CATALOG',
+      'AI_WORKSPACE',
       'ALERT',
       'AM_CONFIGURATION',
       'API',

--- a/gravitee-apim-console-webui/src/entities/role/role.ts
+++ b/gravitee-apim-console-webui/src/entities/role/role.ts
@@ -22,7 +22,8 @@ export type RoleScope =
   | 'PLATFORM'
   | 'INTEGRATION'
   | 'CLUSTER'
-  | 'API_PRODUCT';
+  | 'API_PRODUCT'
+  | 'AI_WORKSPACE';
 
 export interface Role {
   id: string;

--- a/gravitee-apim-console-webui/src/organization/configuration/roles/org-settings-roles.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/roles/org-settings-roles.component.spec.ts
@@ -122,6 +122,14 @@ describe('OrgSettingsRolesComponent', () => {
           scope: 'API_PRODUCT',
         }),
       ],
+      [
+        fakeRole({
+          id: 'role-9',
+          name: 'Role 9',
+          description: 'Role 9 description',
+          scope: 'AI_WORKSPACE',
+        }),
+      ],
     );
 
     expect(component.rolesByScope).toStrictEqual([
@@ -247,6 +255,22 @@ describe('OrgSettingsRolesComponent', () => {
           },
         ],
       },
+      {
+        scope: 'AI Workspace',
+        scopeId: 'AI_WORKSPACE',
+        roles: [
+          {
+            canBeDeleted: false,
+            description: 'Role 9 description',
+            hasUserRoleManagement: false,
+            icon: 'smart_toy',
+            isDefault: true,
+            isReadOnly: false,
+            isSystem: false,
+            name: 'Role 9',
+          },
+        ],
+      },
     ]);
   });
 
@@ -274,6 +298,7 @@ describe('OrgSettingsRolesComponent', () => {
         [],
         [],
         [],
+        [],
       );
 
       fixture.detectChanges();
@@ -291,7 +316,7 @@ describe('OrgSettingsRolesComponent', () => {
         })
         .flush(null);
 
-      respondToGetRolesRequests([], [], [], [], [], [], []);
+      respondToGetRolesRequests([], [], [], [], [], [], [], []);
     });
   });
 
@@ -307,6 +332,7 @@ describe('OrgSettingsRolesComponent', () => {
     integrationRoles: Role[],
     clusterRoles: Role[],
     apiProductRoles: Role[],
+    aiWorkspaceRoles: Role[],
   ) {
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/ORGANIZATION/roles`).flush(orgRoles);
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/ENVIRONMENT/roles`).flush(envRoles);
@@ -315,5 +341,6 @@ describe('OrgSettingsRolesComponent', () => {
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/INTEGRATION/roles`).flush(integrationRoles);
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/CLUSTER/roles`).flush(clusterRoles);
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/API_PRODUCT/roles`).flush(apiProductRoles);
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/AI_WORKSPACE/roles`).flush(aiWorkspaceRoles);
   }
 });

--- a/gravitee-apim-console-webui/src/organization/configuration/roles/org-settings-roles.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/roles/org-settings-roles.component.ts
@@ -69,9 +69,10 @@ export class OrgSettingsRolesComponent implements OnInit, OnDestroy {
       this.roleService.list('INTEGRATION'),
       this.roleService.list('CLUSTER'),
       this.roleService.list('API_PRODUCT'),
+      this.roleService.list('AI_WORKSPACE'),
     ])
       .pipe(
-        tap(([orgRoles, envRoles, apiRoles, appRoles, integrationRoles, clusterRoles, apiProductRoles]) => {
+        tap(([orgRoles, envRoles, apiRoles, appRoles, integrationRoles, clusterRoles, apiProductRoles, aiWorkspaceRoles]) => {
           this.rolesByScope = [
             { scope: 'Organization', scopeId: 'ORGANIZATION', roles: this.convertToRoleVMs(orgRoles) },
             { scope: 'Environment', scopeId: 'ENVIRONMENT', roles: this.convertToRoleVMs(envRoles) },
@@ -80,6 +81,7 @@ export class OrgSettingsRolesComponent implements OnInit, OnDestroy {
             { scope: 'Integration', scopeId: 'INTEGRATION', roles: this.convertToRoleVMs(integrationRoles) },
             { scope: 'Cluster', scopeId: 'CLUSTER', roles: this.convertToRoleVMs(clusterRoles) },
             { scope: 'API Product', scopeId: 'API_PRODUCT', roles: this.convertToRoleVMs(apiProductRoles) },
+            { scope: 'AI Workspace', scopeId: 'AI_WORKSPACE', roles: this.convertToRoleVMs(aiWorkspaceRoles) },
           ];
           this.loading = false;
         }),
@@ -157,6 +159,8 @@ export class OrgSettingsRolesComponent implements OnInit, OnDestroy {
         return 'list';
       case 'API_PRODUCT':
         return 'folder';
+      case 'AI_WORKSPACE':
+        return 'smart_toy';
       default:
         return '';
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/RoleScope.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/RoleScope.java
@@ -31,4 +31,5 @@ public enum RoleScope {
     API_PRODUCT,
     AI_CATALOG,
     EXPLORER,
+    AI_WORKSPACE,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1986,6 +1986,7 @@ components:
         - API_PRODUCT
         - AI_CATALOG
         - EXPLORER
+        - AI_WORKSPACE
     Member:
       type: object
       properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResource.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.model.RoleScope;
 import io.gravitee.rest.api.management.rest.model.wrapper.RoleScopesLinkedHashMap;
 import io.gravitee.rest.api.management.rest.resource.AbstractResource;
 import io.gravitee.rest.api.model.permissions.AiCatalogPermission;
+import io.gravitee.rest.api.model.permissions.AiWorkspacePermission;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
@@ -92,6 +93,10 @@ public class RoleScopesResource extends AbstractResource {
         roles.put(
             RoleScope.EXPLORER.name(),
             stream(ExplorerPermission.values()).map(ExplorerPermission::getName).sorted().collect(toList())
+        );
+        roles.put(
+            RoleScope.AI_WORKSPACE.name(),
+            stream(AiWorkspacePermission.values()).map(AiWorkspacePermission::getName).sorted().collect(toList())
         );
         return roles;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
@@ -51,6 +51,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
         List.of(
             "AGENT_IDENTITY",
             "AI_CATALOG",
+            "AI_WORKSPACE",
             "ALERT",
             "AM_CONFIGURATION",
             "API",
@@ -124,7 +125,9 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
         "AI_CATALOG",
         List.of("DEFINITION", "MEMBER"),
         "EXPLORER",
-        List.of("CONFIGURATION", "MEMBER")
+        List.of("CONFIGURATION", "MEMBER"),
+        "AI_WORKSPACE",
+        List.of("DEFINITION", "MEMBER", "PLAN", "USER")
     );
 
     @Override
@@ -140,7 +143,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
 
         assertAll(
             () -> assertEquals(HttpStatusCode.OK_200, response.getStatus()),
-            () -> assertThat(resultRoleScopes.size()).isEqualTo(9),
+            () -> assertThat(resultRoleScopes.size()).isEqualTo(10),
             () ->
                 assertThat(resultRoleScopes.keySet()).containsExactlyInAnyOrder(
                     "ORGANIZATION",
@@ -151,7 +154,8 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
                     "CLUSTER",
                     "API_PRODUCT",
                     "AI_CATALOG",
-                    "EXPLORER"
+                    "EXPLORER",
+                    "AI_WORKSPACE"
                 ),
             () -> assertThat(resultRoleScopes.get("ORGANIZATION")).isEqualTo(EXPECTED_ROLE_SCOPES.get("ORGANIZATION")),
             () -> assertThat(resultRoleScopes.get("ENVIRONMENT")).isEqualTo(EXPECTED_ROLE_SCOPES.get("ENVIRONMENT")),
@@ -160,7 +164,8 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
             () -> assertThat(resultRoleScopes.get("INTEGRATION")).isEqualTo(EXPECTED_ROLE_SCOPES.get("INTEGRATION")),
             () -> assertThat(resultRoleScopes.get("CLUSTER")).isEqualTo(EXPECTED_ROLE_SCOPES.get("CLUSTER")),
             () -> assertThat(resultRoleScopes.get("AI_CATALOG")).isEqualTo(EXPECTED_ROLE_SCOPES.get("AI_CATALOG")),
-            () -> assertThat(resultRoleScopes.get("EXPLORER")).isEqualTo(EXPECTED_ROLE_SCOPES.get("EXPLORER"))
+            () -> assertThat(resultRoleScopes.get("EXPLORER")).isEqualTo(EXPECTED_ROLE_SCOPES.get("EXPLORER")),
+            () -> assertThat(resultRoleScopes.get("AI_WORKSPACE")).isEqualTo(EXPECTED_ROLE_SCOPES.get("AI_WORKSPACE"))
         );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MembershipReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/MembershipReferenceType.java
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 public enum MembershipReferenceType {
     APPLICATION(EnumSet.of(RoleScope.APPLICATION)),
     API(EnumSet.of(RoleScope.API)),
-    API_PRODUCT(EnumSet.of(RoleScope.API_PRODUCT)),
+    API_PRODUCT(EnumSet.of(RoleScope.API_PRODUCT, RoleScope.AI_WORKSPACE)),
     GROUP(
         EnumSet.of(
             RoleScope.GROUP,
@@ -39,7 +39,8 @@ public enum MembershipReferenceType {
             RoleScope.INTEGRATION,
             RoleScope.CLUSTER,
             RoleScope.AI_CATALOG,
-            RoleScope.EXPLORER
+            RoleScope.EXPLORER,
+            RoleScope.AI_WORKSPACE
         )
     ),
     ENVIRONMENT(EnumSet.allOf(RoleScope.class)),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/AiWorkspacePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/AiWorkspacePermission.java
@@ -18,21 +18,32 @@ package io.gravitee.rest.api.model.permissions;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
- * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
- * @author GraviteeSource Team
+ * An AI Workspace is stored as an API Product, but is granted independently: holding an API Product
+ * permission must not imply access to a workspace. {@code PLAN} keeps the platform-wide name even
+ * though the workspace UI calls it a tier, so a role matrix reads consistently across scopes.
  */
 @Schema(enumAsRef = true)
-public enum RoleScope {
-    API,
-    APPLICATION,
-    GROUP,
-    ENVIRONMENT,
-    ORGANIZATION,
-    PLATFORM,
-    INTEGRATION,
-    CLUSTER,
-    API_PRODUCT,
-    AI_CATALOG,
-    EXPLORER,
-    AI_WORKSPACE,
+public enum AiWorkspacePermission implements Permission {
+    DEFINITION("DEFINITION", 1000),
+    PLAN("PLAN", 1100),
+    USER("USER", 1200),
+    MEMBER("MEMBER", 1300);
+
+    final String name;
+    final int mask;
+
+    AiWorkspacePermission(String name, int mask) {
+        this.name = name;
+        this.mask = mask;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int getMask() {
+        return mask;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
@@ -61,7 +61,8 @@ public enum EnvironmentPermission implements Permission {
     AUTHZ_PDP("AUTHZ_PDP", 4900),
     AUTHZ_SCHEMA("AUTHZ_SCHEMA", 5000),
     AI_CATALOG("AI_CATALOG", 5100),
-    EXPLORER("EXPLORER", 5200);
+    EXPLORER("EXPLORER", 5200),
+    AI_WORKSPACE("AI_WORKSPACE", 5300);
 
     String name;
     int mask;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/Permission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/Permission.java
@@ -50,6 +50,8 @@ public interface Permission {
                 return AiCatalogPermission.values();
             case EXPLORER:
                 return ExplorerPermission.values();
+            case AI_WORKSPACE:
+                return AiWorkspacePermission.values();
             default:
                 throw new IllegalArgumentException("[" + scope + "] are not a RolePermission");
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -102,6 +102,7 @@ public enum RolePermission {
     ENVIRONMENT_AUTHZ_SCHEMA(RoleScope.ENVIRONMENT, EnvironmentPermission.AUTHZ_SCHEMA),
     ENVIRONMENT_AI_CATALOG(RoleScope.ENVIRONMENT, EnvironmentPermission.AI_CATALOG),
     ENVIRONMENT_EXPLORER(RoleScope.ENVIRONMENT, EnvironmentPermission.EXPLORER),
+    ENVIRONMENT_AI_WORKSPACE(RoleScope.ENVIRONMENT, EnvironmentPermission.AI_WORKSPACE),
 
     ORGANIZATION_USERS(RoleScope.ORGANIZATION, OrganizationPermission.USER),
     ORGANIZATION_USERS_TOKEN(RoleScope.ORGANIZATION, OrganizationPermission.USER_TOKEN),
@@ -138,7 +139,12 @@ public enum RolePermission {
     AI_CATALOG_MEMBER(RoleScope.AI_CATALOG, AiCatalogPermission.MEMBER),
 
     EXPLORER_CONFIGURATION(RoleScope.EXPLORER, ExplorerPermission.CONFIGURATION),
-    EXPLORER_MEMBER(RoleScope.EXPLORER, ExplorerPermission.MEMBER);
+    EXPLORER_MEMBER(RoleScope.EXPLORER, ExplorerPermission.MEMBER),
+
+    AI_WORKSPACE_DEFINITION(RoleScope.AI_WORKSPACE, AiWorkspacePermission.DEFINITION),
+    AI_WORKSPACE_PLAN(RoleScope.AI_WORKSPACE, AiWorkspacePermission.PLAN),
+    AI_WORKSPACE_USER(RoleScope.AI_WORKSPACE, AiWorkspacePermission.USER),
+    AI_WORKSPACE_MEMBER(RoleScope.AI_WORKSPACE, AiWorkspacePermission.MEMBER);
 
     final RoleScope scope;
     final Permission permission;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-rest/src/main/java/io/gravitee/rest/api/rest/filter/PermissionsFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-rest/src/main/java/io/gravitee/rest/api/rest/filter/PermissionsFilter.java
@@ -92,6 +92,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
             case CLUSTER -> hasPermission(executionContext, permission, getId(CLUSTER_ID_PARAM, requestContext));
             case API_PRODUCT -> hasPermission(executionContext, permission, getId(API_PRODUCT_ID_PARAM, requestContext));
             case AI_CATALOG -> hasPermission(executionContext, permission, getId(CATALOG_ID_PARAM, requestContext));
+            case AI_WORKSPACE -> hasPermission(executionContext, permission, getId(API_PRODUCT_ID_PARAM, requestContext));
             case EXPLORER -> hasPermission(executionContext, permission, getId(EXPLORER_CONNECTION_ID_PARAM, requestContext));
             case PLATFORM -> false;
         };

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductAuditQueryFilters.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductAuditQueryFilters.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.model;
+
+import java.util.Optional;
+import java.util.Set;
+
+public record ApiProductAuditQueryFilters(
+    String apiProductId,
+    String organizationId,
+    String environmentId,
+    Optional<Long> from,
+    Optional<Long> to,
+    Set<String> events
+) {
+    public ApiProductAuditQueryFilters {
+        if (apiProductId == null) {
+            throw new IllegalArgumentException("apiProductId must not be null");
+        }
+        if (organizationId == null) {
+            throw new IllegalArgumentException("organizationId must not be null");
+        }
+        if (environmentId == null) {
+            throw new IllegalArgumentException("environmentId must not be null");
+        }
+        if (events == null) {
+            events = Set.of();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/GetApiProductMembersUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/GetApiProductMembersUseCase.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.member.model.Member;
 import io.gravitee.apim.core.member.model.MembershipReferenceType;
 import io.gravitee.apim.core.member.query_service.MemberQueryService;
 import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.permissions.RoleScope;
 import java.util.Comparator;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -39,8 +40,25 @@ public class GetApiProductMembersUseCase {
             .getMembersByReference(MembershipReferenceType.API_PRODUCT, input.apiProductId)
             .stream()
             .filter(member -> member.getType() == MembershipMemberType.USER)
+            .map(GetApiProductMembersUseCase::withApiProductRolesOnly)
             .sorted(Comparator.comparing(Member::getId, Comparator.nullsLast(String::compareTo)))
             .toList();
         return new Output(members);
+    }
+
+    /**
+     * The API_PRODUCT reference also backs AI Workspaces, so a membership on it may carry a role of
+     * either scope. Narrowing to API Product roles keeps the two admin surfaces showing their own
+     * members, and stops a caller that reads the first role from picking one out of the other scope.
+     */
+    private static Member withApiProductRolesOnly(Member member) {
+        var roles = member.getRoles() == null
+            ? List.<Member.Role>of()
+            : member
+                .getRoles()
+                .stream()
+                .filter(role -> role.getScope() == RoleScope.API_PRODUCT)
+                .toList();
+        return member.toBuilder().roles(roles).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/domain_service/SearchAuditDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/domain_service/SearchAuditDomainService.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.audit.domain_service;
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.api.model.ApiAuditQueryFilters;
+import io.gravitee.apim.core.api_product.model.ApiProductAuditQueryFilters;
 import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.query_service.AuditMetadataQueryService;
 import io.gravitee.apim.core.audit.query_service.AuditQueryService;
@@ -52,6 +53,17 @@ public class SearchAuditDomainService {
         );
     }
 
+    public MetadataPage<AuditEntity> searchApiProductAudit(ApiProductAuditQueryFilters query, Pageable pageable) {
+        var response = auditQueryService.searchApiProductAudit(query, pageable);
+        return new MetadataPage<>(
+            response.audits(),
+            pageable.getPageNumber(),
+            pageable.getPageSize(),
+            response.total(),
+            buildMetadata(response.audits())
+        );
+    }
+
     private Map<String, String> buildMetadata(List<AuditEntity> audits) {
         Map<String, String> metadata = new HashMap<>();
         for (var audit : audits) {
@@ -60,9 +72,9 @@ public class SearchAuditDomainService {
                 metadata.put(userMetadataKey, auditMetadataQueryService.fetchUserNameMetadata(audit.getUser()));
             }
 
-            var apiMetadataKey = nameMetadataKey("API", audit.getReferenceId());
-            if (!metadata.containsKey(apiMetadataKey)) {
-                metadata.put(apiMetadataKey, auditMetadataQueryService.fetchApiNameMetadata(audit.getReferenceId()));
+            var referenceMetadataKey = nameMetadataKey(audit.getReferenceType().name(), audit.getReferenceId());
+            if (!metadata.containsKey(referenceMetadataKey)) {
+                metadata.put(referenceMetadataKey, fetchReferenceName(audit));
             }
 
             if (audit.getProperties() != null) {
@@ -79,6 +91,17 @@ public class SearchAuditDomainService {
         }
 
         return metadata;
+    }
+
+    /**
+     * Consumers look the reference name up under the audit's own reference type, so the key has to be
+     * built from it rather than assumed to be an API. Anything else keeps its id as the display value:
+     * resolving it would mean a lookup against the wrong repository, which returns the id anyway.
+     */
+    private String fetchReferenceName(AuditEntity audit) {
+        return audit.getReferenceType() == AuditEntity.AuditReferenceType.API
+            ? auditMetadataQueryService.fetchApiNameMetadata(audit.getReferenceId())
+            : audit.getReferenceId();
     }
 
     public static String nameMetadataKey(String type, String value) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/AiWorkspaceAuditEvent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/AiWorkspaceAuditEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.audit.model.event;
+
+/**
+ * Recorded against the workspace itself, which is stored as an API Product.
+ *
+ * <p>Creating, updating and deleting a workspace already produce {@link ApiProductAuditEvent}s, and
+ * its tiers produce {@link PlanAuditEvent}s, so those are deliberately absent here. The events below
+ * are the ones that otherwise write a different entity — models and components mutate the underlying
+ * LLM proxy, and users mutate a subscription — leaving no trace on the workspace being administered.
+ */
+public enum AiWorkspaceAuditEvent implements AuditEvent {
+    AI_WORKSPACE_MODEL_ADDED,
+    AI_WORKSPACE_MODEL_REMOVED,
+    AI_WORKSPACE_COMPONENT_ADDED,
+    AI_WORKSPACE_COMPONENT_REMOVED,
+    AI_WORKSPACE_USER_ADDED,
+    AI_WORKSPACE_USER_REMOVED,
+    AI_WORKSPACE_USER_TIER_CHANGED,
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/query_service/AuditQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/query_service/AuditQueryService.java
@@ -16,12 +16,15 @@
 package io.gravitee.apim.core.audit.query_service;
 
 import io.gravitee.apim.core.api.model.ApiAuditQueryFilters;
+import io.gravitee.apim.core.api_product.model.ApiProductAuditQueryFilters;
 import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.rest.api.model.common.Pageable;
 import java.util.List;
 
 public interface AuditQueryService {
     SearchResponse searchApiAudit(ApiAuditQueryFilters query, Pageable pageable);
+
+    SearchResponse searchApiProductAudit(ApiProductAuditQueryFilters query, Pageable pageable);
 
     record SearchResponse(long total, List<AuditEntity> audits) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/use_case/SearchApiProductAuditUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/use_case/SearchApiProductAuditUseCase.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.audit.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.model.ApiProductAuditQueryFilters;
+import io.gravitee.apim.core.audit.domain_service.SearchAuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditEntity;
+import io.gravitee.common.data.domain.MetadataPage;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@UseCase
+public class SearchApiProductAuditUseCase {
+
+    private final SearchAuditDomainService searchAuditDomainService;
+
+    public SearchApiProductAuditUseCase(SearchAuditDomainService searchAuditDomainService) {
+        this.searchAuditDomainService = searchAuditDomainService;
+    }
+
+    public Output execute(Input input) {
+        var query = input.query;
+        var pageable = input.pageable.orElse(new PageableImpl(1, 10));
+
+        MetadataPage<AuditEntity> result = searchAuditDomainService.searchApiProductAudit(query, pageable);
+
+        return new Output(result.getContent(), result.getMetadata(), result.getTotalElements());
+    }
+
+    public record Input(ApiProductAuditQueryFilters query, Optional<Pageable> pageable) {
+        public Input(ApiProductAuditQueryFilters query) {
+            this(query, Optional.empty());
+        }
+
+        public Input(ApiProductAuditQueryFilters query, Pageable pageable) {
+            this(query, Optional.of(pageable));
+        }
+    }
+
+    public record Output(List<AuditEntity> data, Map<String, String> metadata, long total) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/Member.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/Member.java
@@ -31,7 +31,7 @@ import lombok.NoArgsConstructor;
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @Data

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/MembershipReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/MembershipReferenceType.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 public enum MembershipReferenceType {
     APPLICATION(EnumSet.of(RoleScope.APPLICATION)),
     API(EnumSet.of(RoleScope.API)),
-    API_PRODUCT(EnumSet.of(RoleScope.API_PRODUCT)),
+    API_PRODUCT(EnumSet.of(RoleScope.API_PRODUCT, RoleScope.AI_WORKSPACE)),
     GROUP(EnumSet.of(RoleScope.GROUP, RoleScope.API, RoleScope.APPLICATION, RoleScope.INTEGRATION)),
     ENVIRONMENT(EnumSet.allOf(RoleScope.class)),
     ORGANIZATION(EnumSet.allOf(RoleScope.class)),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/RoleScope.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/model/RoleScope.java
@@ -31,4 +31,5 @@ public enum RoleScope {
     API_PRODUCT,
     AI_CATALOG,
     EXPLORER,
+    AI_WORKSPACE,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Role.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Role.java
@@ -52,5 +52,6 @@ public class Role {
         API_PRODUCT,
         AI_CATALOG,
         EXPLORER,
+        AI_WORKSPACE,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/audit/AuditQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/audit/AuditQueryServiceImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.infra.query_service.audit;
 
 import io.gravitee.apim.core.api.model.ApiAuditQueryFilters;
+import io.gravitee.apim.core.api_product.model.ApiProductAuditQueryFilters;
 import io.gravitee.apim.core.audit.query_service.AuditQueryService;
 import io.gravitee.apim.infra.adapter.AuditAdapter;
 import io.gravitee.common.data.domain.Page;
@@ -39,6 +40,19 @@ public class AuditQueryServiceImpl implements AuditQueryService {
     }
 
     @Override
+    public SearchResponse searchApiProductAudit(ApiProductAuditQueryFilters query, Pageable pageable) {
+        AuditCriteria.Builder criteria = new AuditCriteria.Builder()
+            .organizationId(query.organizationId())
+            .environmentIds(List.of(query.environmentId()))
+            .references(Audit.AuditReferenceType.API_PRODUCT, List.of(query.apiProductId()))
+            .events(query.events() != null ? new ArrayList<>(query.events()) : null);
+        query.from().ifPresent(criteria::from);
+        query.to().ifPresent(criteria::to);
+
+        return search(criteria, pageable);
+    }
+
+    @Override
     public SearchResponse searchApiAudit(ApiAuditQueryFilters query, Pageable pageable) {
         AuditCriteria.Builder criteria = new AuditCriteria.Builder()
             .organizationId(query.organizationId())
@@ -49,6 +63,10 @@ public class AuditQueryServiceImpl implements AuditQueryService {
         query.from().ifPresent(criteria::from);
         query.to().ifPresent(criteria::to);
 
+        return search(criteria, pageable);
+    }
+
+    private SearchResponse search(AuditCriteria.Builder criteria, Pageable pageable) {
         Page<Audit> result = auditRepository.search(
             criteria.build(),
             new PageableBuilder().pageNumber(pageable.getPageNumber() - 1).pageSize(pageable.getPageSize()).build()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MembershipService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MembershipService.java
@@ -239,6 +239,13 @@ public interface MembershipService {
         String source
     );
 
+    /**
+     * Resolves the role scope from the reference type name, so it can only grant a role of the scope
+     * that shares its name. A reference type carrying more than one scope — API_PRODUCT, which backs
+     * both API Products and AI Workspaces — cannot be disambiguated this way: use
+     * {@link #createNewMembership(ExecutionContext, MembershipReferenceType, String, String, String, String, RoleScope)}
+     * and name the scope, otherwise the grant silently lands in the wrong one.
+     */
     MemberEntity createNewMembership(
         ExecutionContext executionContext,
         MembershipReferenceType referenceType,
@@ -246,6 +253,17 @@ public interface MembershipService {
         String userId,
         String externalReference,
         String roleName
+    );
+
+    /** Grants {@code roleName} in {@code roleScope}, for reference types that back more than one scope. */
+    MemberEntity createNewMembership(
+        ExecutionContext executionContext,
+        MembershipReferenceType referenceType,
+        String referenceId,
+        String userId,
+        String externalReference,
+        String roleName,
+        RoleScope roleScope
     );
 
     MemberEntity updateMembershipForApi(ExecutionContext executionContext, String apiId, String memberId, String roleName);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
@@ -22,6 +22,7 @@ import static java.util.stream.Collectors.toMap;
 import io.gravitee.common.util.Maps;
 import io.gravitee.rest.api.model.NewRoleEntity;
 import io.gravitee.rest.api.model.permissions.AiCatalogPermission;
+import io.gravitee.rest.api.model.permissions.AiWorkspacePermission;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
@@ -311,6 +312,32 @@ public interface DefaultRoleEntityDefinition {
             .put(ApiProductPermission.SUBSCRIPTION.getName(), new char[] { READ.getId() })
             .put(ApiProductPermission.NOTIFICATION.getName(), new char[] { READ.getId() })
             .put(ApiProductPermission.MEMBER.getName(), new char[] { READ.getId() })
+            .build()
+    );
+
+    NewRoleEntity ROLE_AI_WORKSPACE_OWNER = new NewRoleEntity(
+        "OWNER",
+        "AI Workspace Role. Created by Gravitee.io.",
+        AI_WORKSPACE,
+        false,
+        Maps.<String, char[]>builder()
+            .put(AiWorkspacePermission.DEFINITION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .put(AiWorkspacePermission.PLAN.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .put(AiWorkspacePermission.USER.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .put(AiWorkspacePermission.MEMBER.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .build()
+    );
+
+    NewRoleEntity ROLE_AI_WORKSPACE_USER = new NewRoleEntity(
+        "USER",
+        "Default AI Workspace Role. Created by Gravitee.io.",
+        AI_WORKSPACE,
+        true,
+        Maps.<String, char[]>builder()
+            .put(AiWorkspacePermission.DEFINITION.getName(), new char[] { READ.getId() })
+            .put(AiWorkspacePermission.PLAN.getName(), new char[] { READ.getId() })
+            .put(AiWorkspacePermission.USER.getName(), new char[] { READ.getId() })
+            .put(AiWorkspacePermission.MEMBER.getName(), new char[] { READ.getId() })
             .build()
     );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -2193,13 +2193,34 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         String externalReference,
         String roleName
     ) {
+        return createNewMembership(
+            executionContext,
+            referenceType,
+            referenceId,
+            userId,
+            externalReference,
+            roleName,
+            referenceType.findScope()
+        );
+    }
+
+    @Override
+    public MemberEntity createNewMembership(
+        ExecutionContext executionContext,
+        MembershipReferenceType referenceType,
+        String referenceId,
+        String userId,
+        String externalReference,
+        String roleName,
+        RoleScope roleScope
+    ) {
         MembershipService.MembershipReference reference = new MembershipService.MembershipReference(referenceType, referenceId);
         MembershipService.MembershipMember member = new MembershipService.MembershipMember(
             userId,
             externalReference,
             MembershipMemberType.USER
         );
-        MembershipService.MembershipRole role = new MembershipService.MembershipRole(RoleScope.valueOf(referenceType.name()), roleName);
+        MembershipService.MembershipRole role = new MembershipService.MembershipRole(roleScope, roleName);
 
         if (member.getMemberId() != null) {
             MemberEntity userMember = getUserMember(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
@@ -53,7 +53,8 @@ public class PermissionServiceImpl extends AbstractService implements Permission
         Pair.of(RoleScope.INTEGRATION, MembershipReferenceType.INTEGRATION),
         Pair.of(RoleScope.CLUSTER, MembershipReferenceType.CLUSTER),
         Pair.of(RoleScope.AI_CATALOG, MembershipReferenceType.AI_CATALOG),
-        Pair.of(RoleScope.EXPLORER, MembershipReferenceType.EXPLORER)
+        Pair.of(RoleScope.EXPLORER, MembershipReferenceType.EXPLORER),
+        Pair.of(RoleScope.AI_WORKSPACE, MembershipReferenceType.API_PRODUCT)
     );
 
     @Autowired

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -59,6 +59,7 @@ import io.gravitee.rest.api.model.NewRoleEntity;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.UpdateRoleEntity;
 import io.gravitee.rest.api.model.permissions.AiCatalogPermission;
+import io.gravitee.rest.api.model.permissions.AiWorkspacePermission;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.ApiProductPermission;
 import io.gravitee.rest.api.model.permissions.ApplicationPermission;
@@ -627,6 +628,14 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 SystemRole.PRIMARY_OWNER,
                 RoleScope.AI_CATALOG,
                 AiCatalogPermission.values(),
+                organizationId
+            );
+            // AI_WORKSPACE - PRIMARY_OWNER
+            createOrUpdateSystemRole(
+                executionContext,
+                SystemRole.PRIMARY_OWNER,
+                RoleScope.AI_WORKSPACE,
+                AiWorkspacePermission.values(),
                 organizationId
             );
             // EXPLORER - PRIMARY_OWNER

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AiWorkspaceRolesUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AiWorkspaceRolesUpgrader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.model.permissions.RoleScope.AI_WORKSPACE;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_AI_WORKSPACE_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_AI_WORKSPACE_USER;
+
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+@CustomLog
+public class AiWorkspaceRolesUpgrader implements Upgrader {
+
+    private final RoleService roleService;
+
+    private final OrganizationRepository organizationRepository;
+
+    @Autowired
+    public AiWorkspaceRolesUpgrader(RoleService roleService, @Lazy OrganizationRepository organizationRepository) {
+        this.roleService = roleService;
+        this.organizationRepository = organizationRepository;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
+            organizationRepository
+                .findAll()
+                .forEach(organization -> {
+                    ExecutionContext executionContext = new ExecutionContext(organization);
+                    initializeAiWorkspaceRoles(executionContext);
+                    roleService.createOrUpdateSystemRoles(executionContext, executionContext.getOrganizationId());
+                });
+            return true;
+        });
+    }
+
+    private void initializeAiWorkspaceRoles(ExecutionContext executionContext) {
+        if (shouldCreateRole(executionContext, ROLE_AI_WORKSPACE_OWNER.getName())) {
+            log.info("     - <AI_WORKSPACE> OWNER");
+            roleService.create(executionContext, ROLE_AI_WORKSPACE_OWNER);
+        }
+        if (shouldCreateRole(executionContext, ROLE_AI_WORKSPACE_USER.getName())) {
+            log.info("     - <AI_WORKSPACE> USER");
+            roleService.create(executionContext, ROLE_AI_WORKSPACE_USER);
+        }
+    }
+
+    private boolean shouldCreateRole(final ExecutionContext executionContext, String roleName) {
+        return roleService.findByScopeAndName(AI_WORKSPACE, roleName, executionContext.getOrganizationId()).isEmpty();
+    }
+
+    @Override
+    public int getOrder() {
+        return UpgraderOrder.AI_WORKSPACE_ROLES_UPGRADER;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -83,4 +83,5 @@ public class UpgraderOrder {
     public static final int AI_CATALOG_ROLES_UPGRADER = 958;
     public static final int KAFKA_EXPLORER_PERMISSION_UPGRADER = 959;
     public static final int EXPLORER_ROLES_UPGRADER = 960;
+    public static final int AI_WORKSPACE_ROLES_UPGRADER = 961;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/AuditFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/AuditFixtures.java
@@ -38,6 +38,14 @@ public class AuditFixtures {
                 [{ "op": "add", "path": "/hello", "value": ["world"] }]"""
             );
 
+    public static AuditEntity anApiProductAudit() {
+        return BASE.get()
+            .referenceType(AuditEntity.AuditReferenceType.API_PRODUCT)
+            .referenceId("api-product-id")
+            .properties(Map.of())
+            .build();
+    }
+
     public static AuditEntity anApiAudit() {
         return BASE.get().referenceType(AuditEntity.AuditReferenceType.API).referenceId("api-id").properties(Map.of()).build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/AuditQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/AuditQueryServiceInMemory.java
@@ -16,6 +16,7 @@
 package inmemory;
 
 import io.gravitee.apim.core.api.model.ApiAuditQueryFilters;
+import io.gravitee.apim.core.api_product.model.ApiProductAuditQueryFilters;
 import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.query_service.AuditQueryService;
 import io.gravitee.rest.api.model.common.Pageable;
@@ -39,33 +40,48 @@ public class AuditQueryServiceInMemory implements AuditQueryService, InMemoryAlt
 
     @Override
     public SearchResponse searchApiAudit(ApiAuditQueryFilters query, Pageable pageable) {
+        return search(query.apiId(), query.environmentId(), query.organizationId(), query.events(), query.from(), query.to(), pageable);
+    }
+
+    private SearchResponse search(
+        String referenceId,
+        String environmentId,
+        String organizationId,
+        java.util.Set<String> events,
+        java.util.Optional<Long> from,
+        java.util.Optional<Long> to,
+        Pageable pageable
+    ) {
         var pageNumber = pageable.getPageNumber();
         var pageSize = pageable.getPageSize();
 
         var matches = storage
             .stream()
-            .filter(audit -> audit.getReferenceId().equals(query.apiId()))
-            .filter(audit -> audit.getEnvironmentId().equals(query.environmentId()))
-            .filter(audit -> audit.getOrganizationId().equals(query.organizationId()))
-            .filter(audit -> query.events().isEmpty() || query.events().contains(audit.getEvent()))
-            .filter(audit ->
-                query
-                    .from()
-                    .map(from -> audit.getCreatedAt().toInstant().isAfter(new Date(from).toInstant()))
-                    .orElse(true)
-            )
-            .filter(audit ->
-                query
-                    .to()
-                    .map(to -> audit.getCreatedAt().toInstant().isBefore(new Date(to).toInstant()))
-                    .orElse(true)
-            )
+            .filter(audit -> audit.getReferenceId().equals(referenceId))
+            .filter(audit -> audit.getEnvironmentId().equals(environmentId))
+            .filter(audit -> audit.getOrganizationId().equals(organizationId))
+            .filter(audit -> events.isEmpty() || events.contains(audit.getEvent()))
+            .filter(audit -> from.map(f -> audit.getCreatedAt().toInstant().isAfter(new Date(f).toInstant())).orElse(true))
+            .filter(audit -> to.map(t -> audit.getCreatedAt().toInstant().isBefore(new Date(t).toInstant())).orElse(true))
             .sorted(Comparator.comparing(AuditEntity::getCreatedAt).reversed())
             .toList();
 
         var page = matches.size() <= pageSize ? matches : matches.subList((pageNumber - 1) * pageSize, pageNumber * pageSize);
 
         return new SearchResponse(matches.size(), page);
+    }
+
+    @Override
+    public SearchResponse searchApiProductAudit(ApiProductAuditQueryFilters query, Pageable pageable) {
+        return search(
+            query.apiProductId(),
+            query.environmentId(),
+            query.organizationId(),
+            query.events(),
+            query.from(),
+            query.to(),
+            pageable
+        );
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/GetApiProductMembersUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/GetApiProductMembersUseCaseTest.java
@@ -21,6 +21,7 @@ import inmemory.MemberQueryServiceInMemory;
 import io.gravitee.apim.core.member.model.Member;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.permissions.RoleScope;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,52 @@ class GetApiProductMembersUseCaseTest {
         var result = getApiProductMembersUseCase.execute(new GetApiProductMembersUseCase.Input("ap-1"));
 
         assertThat(result.members()).map(Member::getId).containsExactly("member-1", "member-2", "member-5", null);
+    }
+
+    @Test
+    void should_hide_roles_belonging_to_another_scope_sharing_the_reference() {
+        memberQueryService.initWith(
+            List.of(
+                Member.builder()
+                    .id("member-9")
+                    .referenceType(MembershipReferenceType.API_PRODUCT)
+                    .referenceId("ap-1")
+                    .type(MembershipMemberType.USER)
+                    .roles(
+                        List.of(
+                            Member.Role.builder().name("OWNER").scope(RoleScope.API_PRODUCT).build(),
+                            Member.Role.builder().name("OWNER").scope(RoleScope.AI_WORKSPACE).build()
+                        )
+                    )
+                    .build()
+            )
+        );
+
+        var result = getApiProductMembersUseCase.execute(new GetApiProductMembersUseCase.Input("ap-1"));
+
+        assertThat(result.members())
+            .filteredOn(member -> "member-9".equals(member.getId()))
+            .singleElement()
+            .satisfies(member -> assertThat(member.getRoles()).extracting(Member.Role::getScope).containsExactly(RoleScope.API_PRODUCT));
+    }
+
+    @Test
+    void should_keep_a_member_that_only_holds_a_role_of_another_scope() {
+        memberQueryService.initWith(
+            List.of(
+                Member.builder()
+                    .id("member-10")
+                    .referenceType(MembershipReferenceType.API_PRODUCT)
+                    .referenceId("ap-1")
+                    .type(MembershipMemberType.USER)
+                    .roles(List.of(Member.Role.builder().name("OWNER").scope(RoleScope.AI_WORKSPACE).build()))
+                    .build()
+            )
+        );
+
+        var result = getApiProductMembersUseCase.execute(new GetApiProductMembersUseCase.Input("ap-1"));
+
+        assertThat(result.members()).map(Member::getId).contains("member-10");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/audit/use_case/SearchApiProductAuditUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/audit/use_case/SearchApiProductAuditUseCaseTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.audit.use_case;
+
+import fixtures.core.model.AuditFixtures;
+import inmemory.AuditMetadataQueryServiceInMemory;
+import inmemory.AuditQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProductAuditQueryFilters;
+import io.gravitee.apim.core.audit.domain_service.SearchAuditDomainService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SearchApiProductAuditUseCaseTest {
+
+    private static final String API_PRODUCT_ID = "api-product-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+
+    AuditQueryServiceInMemory auditQueryService = new AuditQueryServiceInMemory();
+    AuditMetadataQueryServiceInMemory auditMetadataQueryService = new AuditMetadataQueryServiceInMemory();
+    SearchAuditDomainService searchAuditDomainService = new SearchAuditDomainService(auditQueryService, auditMetadataQueryService);
+
+    SearchApiProductAuditUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new SearchApiProductAuditUseCase(searchAuditDomainService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        auditQueryService.reset();
+    }
+
+    @Test
+    void should_return_only_the_audits_of_the_requested_api_product() {
+        var expected = AuditFixtures.anApiProductAudit();
+        auditQueryService.initWith(
+            List.of(
+                expected,
+                AuditFixtures.anApiProductAudit().toBuilder().id("audit2").referenceId("other-product").build(),
+                AuditFixtures.anApiProductAudit().toBuilder().id("audit3").environmentId("env2").build()
+            )
+        );
+
+        var result = useCase.execute(new SearchApiProductAuditUseCase.Input(filters()));
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.total()).isOne();
+            soft.assertThat(result.data()).containsExactly(expected);
+        });
+    }
+
+    @Test
+    void should_key_the_reference_metadata_by_its_own_type_not_as_an_api() {
+        auditQueryService.initWith(List.of(AuditFixtures.anApiProductAudit()));
+
+        var result = useCase.execute(new SearchApiProductAuditUseCase.Input(filters()));
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.metadata()).containsKey("API_PRODUCT:" + API_PRODUCT_ID + ":name");
+            soft.assertThat(result.metadata()).doesNotContainKey("API:" + API_PRODUCT_ID + ":name");
+        });
+    }
+
+    private ApiProductAuditQueryFilters filters() {
+        return new ApiProductAuditQueryFilters(
+            API_PRODUCT_ID,
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            Optional.of(0L),
+            Optional.of(Instant.now().toEpochMilli()),
+            Set.of()
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_CreateOrUpdateSystemRolesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_CreateOrUpdateSystemRolesTest.java
@@ -75,14 +75,14 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
 
         roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
 
-        verify(mockRoleRepository, times(10)).findByScopeAndNameAndReferenceIdAndReferenceType(
+        verify(mockRoleRepository, times(11)).findByScopeAndNameAndReferenceIdAndReferenceType(
             any(),
             anyString(),
             eq(REFERENCE_ID),
             eq(REFERENCE_TYPE)
         );
         verify(mockRoleRepository, never()).update(any());
-        verify(mockRoleRepository, times(10)).create(any());
+        verify(mockRoleRepository, times(11)).create(any());
     }
 
     @Test
@@ -127,7 +127,7 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
 
         roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
 
-        verify(mockRoleRepository, times(10)).findByScopeAndNameAndReferenceIdAndReferenceType(
+        verify(mockRoleRepository, times(11)).findByScopeAndNameAndReferenceIdAndReferenceType(
             any(),
             anyString(),
             eq(REFERENCE_ID),
@@ -189,7 +189,7 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
 
         roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
 
-        verify(mockRoleRepository, times(10)).findByScopeAndNameAndReferenceIdAndReferenceType(
+        verify(mockRoleRepository, times(11)).findByScopeAndNameAndReferenceIdAndReferenceType(
             any(),
             anyString(),
             eq(REFERENCE_ID),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AiWorkspaceRolesUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AiWorkspaceRolesUpgraderTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.model.permissions.RoleScope.AI_WORKSPACE;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_AI_WORKSPACE_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_AI_WORKSPACE_USER;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Organization;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
+public class AiWorkspaceRolesUpgraderTest {
+
+    @InjectMocks
+    AiWorkspaceRolesUpgrader upgrader;
+
+    @Mock
+    RoleService roleService;
+
+    @Mock
+    OrganizationRepository organizationRepository;
+
+    @Test
+    public void upgrade_should_fail_because_of_exception() throws TechnicalException {
+        assertThrows(UpgraderException.class, () -> {
+            when(organizationRepository.findAll()).thenThrow(new RuntimeException());
+            upgrader.upgrade();
+        });
+    }
+
+    @Test
+    public void shouldCreateAiWorkspaceRolesWhenNotPresent() throws UpgraderException, TechnicalException {
+        String organizationId = GraviteeContext.getDefaultOrganization();
+        Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(organizationId);
+        when(organizationRepository.findAll()).thenReturn(Set.of(organization));
+
+        ExecutionContext expectedExecutionContext = new ExecutionContext(organization);
+        when(roleService.findByScopeAndName(eq(AI_WORKSPACE), eq(ROLE_AI_WORKSPACE_OWNER.getName()), eq(organizationId))).thenReturn(
+            Optional.empty()
+        );
+        when(roleService.findByScopeAndName(eq(AI_WORKSPACE), eq(ROLE_AI_WORKSPACE_USER.getName()), eq(organizationId))).thenReturn(
+            Optional.empty()
+        );
+
+        upgrader.upgrade();
+
+        verify(roleService).create(expectedExecutionContext, ROLE_AI_WORKSPACE_OWNER);
+        verify(roleService).create(expectedExecutionContext, ROLE_AI_WORKSPACE_USER);
+        verify(roleService).createOrUpdateSystemRoles(expectedExecutionContext, organizationId);
+    }
+
+    @Test
+    public void shouldNotCreateAiWorkspaceRolesWhenAlreadyPresent() throws UpgraderException, TechnicalException {
+        String organizationId = GraviteeContext.getDefaultOrganization();
+        Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(organizationId);
+        when(organizationRepository.findAll()).thenReturn(Set.of(organization));
+
+        when(roleService.findByScopeAndName(eq(AI_WORKSPACE), eq(ROLE_AI_WORKSPACE_OWNER.getName()), eq(organizationId))).thenReturn(
+            Optional.of(new RoleEntity())
+        );
+        when(roleService.findByScopeAndName(eq(AI_WORKSPACE), eq(ROLE_AI_WORKSPACE_USER.getName()), eq(organizationId))).thenReturn(
+            Optional.of(new RoleEntity())
+        );
+
+        upgrader.upgrade();
+
+        verify(roleService, never()).create(any(), eq(ROLE_AI_WORKSPACE_OWNER));
+        verify(roleService, never()).create(any(), eq(ROLE_AI_WORKSPACE_USER));
+        verify(roleService).createOrUpdateSystemRoles(any(), eq(organizationId));
+    }
+
+    @Test
+    public void test_order() {
+        Assertions.assertEquals(UpgraderOrder.AI_WORKSPACE_ROLES_UPGRADER, upgrader.getOrder());
+    }
+}


### PR DESCRIPTION

https://gravitee.atlassian.net/browse/AIAM-195

## Problem

An AI Workspace is stored as an API Product, so it was also *governed* by API Product permissions:

- Granting someone API Product access silently gave them every AI Workspace
- AI Workspace access could not be granted **without** granting API Product access

And there was no audit trail for the workspace actions that write a *different* entity — adding a model mutates the underlying LLM proxy, adding a user mutates a subscription — so neither left a trace on the workspace being administered.

## Decoupling the grant from the storage

`RoleScope.AI_WORKSPACE` maps to the **existing** `API_PRODUCT` membership reference type:

```java
Pair.of(RoleScope.AI_WORKSPACE, MembershipReferenceType.API_PRODUCT)
```

That one line is what keeps this cheap. Memberships stay where they are, so `ApiProductAccessibleIdsDomainService` keeps resolving them and `GetApiProductsUseCase` keeps filtering the listing by membership with the admin bypass. **No migration, no new accessible-ids service, no change to how workspaces are listed** — only who may be granted what.

`PLAN` keeps the platform-wide name even though the workspace UI calls it a tier, so a role matrix reads consistently across scopes.

### Roles

| Role | Source |
|---|---|
| `PRIMARY_OWNER` | system role, per-scope block in `RoleServiceImpl` |
| `OWNER` | `ROLE_AI_WORKSPACE_OWNER` — full CRUD |
| `USER` | `ROLE_AI_WORKSPACE_USER` — read-only, default |

`ADMIN` is deliberately absent: it is an environment/organization-scope role here, not a resource-scope one (`API_PRODUCT` and `CLUSTER` both have exactly the three above). An environment admin already sees every workspace through the `isAdmin` bypass.

## Audit — write and read

**Write.** `AiWorkspaceAuditEvent` covers only the actions that would otherwise leave no trace. Creating, updating and deleting a workspace already emit `ApiProductAuditEvent`s and tier changes emit `PlanAuditEvent`s — deliberately **not** duplicated.

**Read.** The audit chain could only be searched for an API, so workspace entries were written and then unreachable. `AuditRepository` already accepts any reference type through `AuditCriteria`, so this is the same query with a different reference — the two search methods now share one implementation instead of duplicating the criteria and paging. No repository-level work was needed.

> **No management-v2 REST resource on purpose.** An `ApiProductAuditsResource` would be guarded by `API_PRODUCT_DEFINITION` — exactly the permission an AI Workspace role does not carry — so the endpoint belongs in AIM against the `AI_WORKSPACE` scope. That, and the Audit Logs page, land in the AIM PR.

> The two `AI_WORKSPACE_COMPONENT_*` constants have no emitter yet: components do not exist in AIM core on `main`. Happy to drop them until they do.

## Commits

Split for review; they ship together:

- `e549e73e35` — backend: scope, roles, upgrader, audit events
- `e9f18e8672` — console: the roles page enumerates its scopes explicitly, so a new scope stays invisible until listed there too
- `fb366c28ce` — audit read path: filters, query service, domain service, use case

## Verification

| Suite | Result |
|---|---|
| `rest-api-model` (full) | 227/227 |
| `rest-api-rest` (full, incl. `PermissionsFilter`) | 44/44 |
| role / permission / membership in `rest-api-service` | 282/282 |
| audit in `rest-api-service` | 64/64 |
| enum-enumerating tests (`DefaultOrganizationAdminRoleInitializer`, `MembershipService_*`, cluster permissions) | 85/85 |
| console role specs | 27/27, tsc + eslint + prettier clean |

Three existing tests needed updating, all assertions on exact platform inventories: `RoleScopesResourceTest` (scope count 9→10 and the ENVIRONMENT permission list) and `RoleService_CreateOrUpdateSystemRolesTest` (system role count 10→11).

**No Liquibase change.** `role_scope` is a plain varchar and `AI_CATALOG` was added the same way with none.

## Worth a reviewer's eye

- **`AiWorkspaceRolesUpgrader` against an existing organization**, not just a fresh install. That is where role upgraders usually fail and no unit test can prove it.
- Because both scopes hang off `MembershipReferenceType.API_PRODUCT`, an API Product membership on a workspace still surfaces it in the listing. The decoupling is one-way by design — a workspace *is* an API Product — but it should be a stated decision rather than a surprise.

