### PR TITLE
chore(deps): bump gravitee-resource-cache-redis to 5.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
     <gravitee-resource-auth-provider-http.version>2.0.0</gravitee-resource-auth-provider-http.version>
     <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>
     <gravitee-resource-auth-provider-ldap.version>2.0.1</gravitee-resource-auth-provider-ldap.version>
-    <gravitee-resource-cache-redis.version>5.0.0</gravitee-resource-cache-redis.version>
+    <gravitee-resource-cache-redis.version>5.0.1</gravitee-resource-cache-redis.version>
     <gravitee-resource-oauth2-provider-keycloak.version>4.0.0</gravitee-resource-oauth2-provider-keycloak.version>
     <gravitee-resource-ai-model-text-classification.version>2.2.1</gravitee-resource-ai-model-text-classification.version>
     <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14791

## Description

Add backward-compatible handling for legacy boolean "ssl" on Redis cache resource config.

Base PR : https://github.com/gravitee-io/gravitee-resource-cache-redis/pull/91





