### PR TITLE
feat(apim-gamma): create/edit/delete entrypoint mapping and edit entrypoint config

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointConfigurationSection.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointConfigurationSection.spec.tsx
@@ -13,14 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { EntrypointConfigurationSection } from './EntrypointConfigurationSection';
+import { useSaveEntrypointConfigurations } from '../hooks/useSaveEntrypointConfigurations';
 import type { EnvironmentEntrypointConfig } from '../types/entrypoint';
 
 jest.mock('../../../shared/copyToClipboard', () => ({
     copyTextToClipboardWithNotifyHandler: jest.fn(),
 }));
+
+jest.mock('../hooks/useSaveEntrypointConfigurations');
+
+const mockUseSaveEntrypointConfigurations = jest.mocked(useSaveEntrypointConfigurations);
+const mockMutateAsync = jest.fn();
 
 const CONFIGS: EnvironmentEntrypointConfig[] = [
     {
@@ -47,9 +53,39 @@ const CONFIGS: EnvironmentEntrypointConfig[] = [
     },
 ];
 
+function renderSection(
+    overrides: {
+        configs?: EnvironmentEntrypointConfig[];
+        failedEnvironmentNames?: string[];
+        isLoading?: boolean;
+        isError?: boolean;
+        canEdit?: boolean;
+    } = {},
+) {
+    return render(
+        <EntrypointConfigurationSection
+            configs={CONFIGS}
+            failedEnvironmentNames={[]}
+            isLoading={false}
+            isError={false}
+            canEdit={false}
+            {...overrides}
+        />,
+    );
+}
+
 describe('EntrypointConfigurationSection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockMutateAsync.mockResolvedValue({ succeededEnvironmentIds: ['env-1'], failed: [] });
+        mockUseSaveEntrypointConfigurations.mockReturnValue({
+            mutateAsync: mockMutateAsync,
+            isPending: false,
+        } as unknown as ReturnType<typeof useSaveEntrypointConfigurations>);
+    });
+
     it('renders one card block per environment', () => {
-        render(<EntrypointConfigurationSection configs={CONFIGS} failedEnvironmentNames={[]} isLoading={false} isError={false} />);
+        renderSection();
         expect(screen.getByText('Production')).not.toBeNull();
         expect(screen.getByText('Development')).not.toBeNull();
         expect(screen.getByDisplayValue('https://api.company.com')).not.toBeNull();
@@ -57,19 +93,15 @@ describe('EntrypointConfigurationSection', () => {
     });
 
     it('shows a partial-failure banner when some environments fail to load', () => {
-        render(
-            <EntrypointConfigurationSection
-                configs={[CONFIGS[0]!]}
-                failedEnvironmentNames={['Staging']}
-                isLoading={false}
-                isError={false}
-            />,
-        );
+        renderSection({
+            configs: [CONFIGS[0]!],
+            failedEnvironmentNames: ['Staging'],
+        });
         expect(screen.getByText(/Could not load entrypoint defaults for: Staging/)).not.toBeNull();
     });
 
     it('shows an error when environment list fails', () => {
-        render(<EntrypointConfigurationSection configs={[]} failedEnvironmentNames={[]} isLoading={false} isError />);
+        renderSection({ configs: [], isError: true });
         expect(screen.getByText(/Failed to load environments/)).not.toBeNull();
     });
 
@@ -77,8 +109,88 @@ describe('EntrypointConfigurationSection', () => {
         const { copyTextToClipboardWithNotifyHandler } = jest.requireMock('../../../shared/copyToClipboard') as {
             copyTextToClipboardWithNotifyHandler: jest.Mock;
         };
-        render(<EntrypointConfigurationSection configs={CONFIGS} failedEnvironmentNames={[]} isLoading={false} isError={false} />);
+        renderSection();
         fireEvent.click(screen.getAllByRole('button', { name: 'Copy Default HTTP entrypoint' })[0]!);
         expect(copyTextToClipboardWithNotifyHandler).toHaveBeenCalledWith('https://api.company.com', 'Copied to clipboard');
+    });
+
+    it('does not show Discard/Save when canEdit is false', () => {
+        renderSection({ canEdit: false });
+        const httpInput = screen.getByDisplayValue('https://api.company.com');
+        fireEvent.change(httpInput, { target: { value: 'https://changed.company.com' } });
+        expect(screen.queryByRole('button', { name: 'Discard' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+    });
+
+    it('shows Discard/Save when canEdit and values are dirty', () => {
+        renderSection({ canEdit: true });
+        expect(screen.queryByRole('button', { name: 'Discard' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+
+        fireEvent.change(screen.getByDisplayValue('https://api.company.com'), {
+            target: { value: 'https://changed.company.com' },
+        });
+
+        expect(screen.getByRole('button', { name: 'Discard' })).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Save' })).not.toBeNull();
+    });
+
+    it('reverts dirty values when Discard is clicked', () => {
+        renderSection({ canEdit: true });
+        const httpInput = screen.getByDisplayValue('https://api.company.com');
+        fireEvent.change(httpInput, { target: { value: 'https://changed.company.com' } });
+        expect(screen.getByDisplayValue('https://changed.company.com')).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+
+        expect(screen.getByDisplayValue('https://api.company.com')).not.toBeNull();
+        expect(screen.queryByRole('button', { name: 'Discard' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+    });
+
+    it('saves only dirty environments with merged payload', async () => {
+        renderSection({ canEdit: true });
+        const tcpInputs = screen.getAllByLabelText('Default TCP port');
+        fireEvent.change(tcpInputs[0]!, { target: { value: '8888' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+        const [inputs] = mockMutateAsync.mock.calls[0]!;
+        expect(inputs).toEqual([
+            {
+                environmentId: 'env-1',
+                settings: {
+                    portal: {
+                        entrypoint: 'https://api.company.com',
+                        tcpPort: 8888,
+                        kafkaDomain: '{apiHost}.company.org',
+                        kafkaPort: 9092,
+                    },
+                },
+            },
+        ]);
+
+        await waitFor(() => {
+            expect(screen.queryByRole('button', { name: 'Discard' })).toBeNull();
+            expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+        });
+    });
+
+    it('keeps a failed environment dirty when saving multiple environments partially fails', async () => {
+        mockMutateAsync.mockResolvedValue({
+            succeededEnvironmentIds: ['env-1'],
+            failed: [{ environmentId: 'env-2', error: new Error('boom') }],
+        });
+        renderSection({ canEdit: true });
+        const tcpInputs = screen.getAllByLabelText('Default TCP port');
+        fireEvent.change(tcpInputs[0]!, { target: { value: '8888' } });
+        fireEvent.change(tcpInputs[1]!, { target: { value: '9999' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            // env-1 succeeded and is no longer dirty, but env-2 failed and Save/Discard should still show.
+            expect(screen.getByRole('button', { name: 'Discard' })).not.toBeNull();
+            expect(screen.getByRole('button', { name: 'Save' })).not.toBeNull();
+        });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointConfigurationSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointConfigurationSection.tsx
@@ -22,33 +22,85 @@ import {
     Card,
     CardContent,
     CardDescription,
+    CardFooter,
     CardHeader,
     CardTitle,
     Input,
     Label,
     Skeleton,
 } from '@gravitee/graphene-core';
-import { CopyIcon, InfoIcon } from '@gravitee/graphene-core/icons';
+import { CheckIcon, CopyIcon, InfoIcon, LockIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useRef, useState } from 'react';
 
 import { copyTextToClipboardWithNotifyHandler } from '../../../shared/copyToClipboard';
+import { useSaveEntrypointConfigurations } from '../hooks/useSaveEntrypointConfigurations';
 import type { EnvironmentEntrypointConfig } from '../types/entrypoint';
+import {
+    buildEntrypointPortalSettingsPayload,
+    CONFIG_PORT_MAX,
+    CONFIG_PORT_MIN,
+    isEntrypointConfigFieldReadonly,
+    isEntrypointConfigFormDirty,
+    isEntrypointConfigFormValid,
+    isValidConfigPort,
+    KAFKA_DOMAIN_PLACEHOLDER,
+    toEntrypointConfigFormValues,
+    type EntrypointConfigFieldKey,
+    type EntrypointConfigFormValues,
+} from '../utils/entrypointConfigForm';
+import { isValidKafkaDomain } from '../utils/entrypointForm';
 
-function CopyableField({
+type FormStateByEnv = Record<string, EntrypointConfigFormValues>;
+
+function buildFormState(configs: EnvironmentEntrypointConfig[]): FormStateByEnv {
+    return Object.fromEntries(configs.map(config => [config.environment.id, toEntrypointConfigFormValues(config.portalSettings)]));
+}
+
+/** Fingerprint of env ids + their server-side settings, so a refetch with unchanged data is a no-op. */
+function configsFingerprint(configs: EnvironmentEntrypointConfig[]): string {
+    return JSON.stringify(configs.map(config => [config.environment.id, toEntrypointConfigFormValues(config.portalSettings)]));
+}
+
+function ConfigField({
     id,
     label,
     value,
+    onChange,
+    readOnly,
+    systemReadonly = false,
     hint,
+    error,
+    type = 'text',
 }: Readonly<{
     id: string;
     label: string;
     value: string;
+    onChange?: (value: string) => void;
+    readOnly: boolean;
+    systemReadonly?: boolean;
     hint?: string;
+    error?: string;
+    type?: 'text' | 'number';
 }>) {
     return (
         <div className="space-y-2">
-            <Label htmlFor={id}>{label}</Label>
+            <Label htmlFor={id} className="flex items-center gap-1.5">
+                {systemReadonly ? <LockIcon className="size-3.5 text-muted-foreground" aria-hidden /> : null}
+                {label}
+            </Label>
             <div className="flex w-full gap-2">
-                <Input id={id} value={value} readOnly className="min-w-0 flex-1 bg-muted/40" />
+                <Input
+                    id={id}
+                    type={type}
+                    value={value}
+                    onChange={event => onChange?.(event.target.value)}
+                    readOnly={readOnly}
+                    disabled={readOnly}
+                    className={readOnly ? 'min-w-0 flex-1 bg-muted/40' : 'min-w-0 flex-1'}
+                    aria-invalid={Boolean(error)}
+                    min={type === 'number' ? CONFIG_PORT_MIN : undefined}
+                    max={type === 'number' ? CONFIG_PORT_MAX : undefined}
+                />
                 <Button
                     type="button"
                     variant="outline"
@@ -61,18 +113,58 @@ function CopyableField({
                     <CopyIcon className="size-4" aria-hidden />
                 </Button>
             </div>
-            {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+            {error ? (
+                <p className="text-xs text-destructive" role="alert">
+                    {error}
+                </p>
+            ) : null}
+            {hint && !error ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
         </div>
     );
 }
 
-function EnvironmentConfigCard({ config }: Readonly<{ config: EnvironmentEntrypointConfig }>) {
-    const portal = config.portalSettings.portal ?? {};
-    const httpEntrypoint = portal.entrypoint ?? '';
-    const tcpPort = portal.tcpPort !== undefined && portal.tcpPort !== null ? String(portal.tcpPort) : '';
-    const kafkaDomain = portal.kafkaDomain ?? '';
-    const kafkaPort = portal.kafkaPort !== undefined && portal.kafkaPort !== null ? String(portal.kafkaPort) : '';
+function fieldError(field: EntrypointConfigFieldKey, form: EntrypointConfigFormValues, showValidation: boolean): string | undefined {
+    if (!showValidation) return undefined;
+    if (field === 'tcpPort' && !isValidConfigPort(form.tcpPort)) {
+        return `TCP port should be in range between ${CONFIG_PORT_MIN} and ${CONFIG_PORT_MAX}`;
+    }
+    if (field === 'kafkaPort' && !isValidConfigPort(form.kafkaPort)) {
+        return `Port should be in range between ${CONFIG_PORT_MIN} and ${CONFIG_PORT_MAX}`;
+    }
+    if (field === 'kafkaDomain') {
+        const domain = form.kafkaDomain.trim();
+        if (!domain) return 'Kafka Bootstrap Domain Pattern is required.';
+        if (!isValidKafkaDomain(form.kafkaDomain)) {
+            if (!domain.includes(KAFKA_DOMAIN_PLACEHOLDER)) {
+                return `Kafka Bootstrap Domain Pattern must contain ${KAFKA_DOMAIN_PLACEHOLDER}.`;
+            }
+            return 'Kafka Domain must be less than 201 characters.';
+        }
+    }
+    return undefined;
+}
+
+function EnvironmentConfigCard({
+    config,
+    form,
+    canEdit,
+    isSaving,
+    showValidation,
+    onFieldChange,
+}: Readonly<{
+    config: EnvironmentEntrypointConfig;
+    form: EntrypointConfigFormValues;
+    canEdit: boolean;
+    isSaving: boolean;
+    showValidation: boolean;
+    onFieldChange: (field: EntrypointConfigFieldKey, value: string) => void;
+}>) {
     const envId = config.environment.id;
+    const settings = config.portalSettings;
+
+    function isFieldReadonly(field: EntrypointConfigFieldKey): boolean {
+        return !canEdit || isSaving || isEntrypointConfigFieldReadonly(settings, field);
+    }
 
     return (
         <div className="space-y-4 border-t pt-4 first:border-t-0 first:pt-0">
@@ -81,16 +173,45 @@ function EnvironmentConfigCard({ config }: Readonly<{ config: EnvironmentEntrypo
                 <Badge variant="secondary">{config.environment.name || config.environment.id}</Badge>
             </h4>
             <div className="space-y-4">
-                <CopyableField id={`http-entrypoint-${envId}`} label="Default HTTP entrypoint" value={httpEntrypoint} />
-                <CopyableField id={`tcp-port-${envId}`} label="Default TCP port" value={tcpPort} />
+                <ConfigField
+                    id={`http-entrypoint-${envId}`}
+                    label="Default HTTP entrypoint"
+                    value={form.entrypoint}
+                    onChange={value => onFieldChange('entrypoint', value)}
+                    readOnly={isFieldReadonly('entrypoint')}
+                    systemReadonly={isEntrypointConfigFieldReadonly(settings, 'entrypoint')}
+                />
+                <ConfigField
+                    id={`tcp-port-${envId}`}
+                    label="Default TCP port"
+                    value={form.tcpPort}
+                    onChange={value => onFieldChange('tcpPort', value)}
+                    readOnly={isFieldReadonly('tcpPort')}
+                    systemReadonly={isEntrypointConfigFieldReadonly(settings, 'tcpPort')}
+                    type="number"
+                    error={fieldError('tcpPort', form, showValidation)}
+                />
                 <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_12rem]">
-                    <CopyableField
+                    <ConfigField
                         id={`kafka-domain-${envId}`}
                         label="Default Kafka Bootstrap Domain Pattern"
-                        value={kafkaDomain}
+                        value={form.kafkaDomain}
+                        onChange={value => onFieldChange('kafkaDomain', value)}
+                        readOnly={isFieldReadonly('kafkaDomain')}
+                        systemReadonly={isEntrypointConfigFieldReadonly(settings, 'kafkaDomain')}
                         hint="To be configured according to the gateway configuration. e.g: {apiHost}.mycompany.org"
+                        error={fieldError('kafkaDomain', form, showValidation)}
                     />
-                    <CopyableField id={`kafka-port-${envId}`} label="Default Kafka port" value={kafkaPort} />
+                    <ConfigField
+                        id={`kafka-port-${envId}`}
+                        label="Default Kafka port"
+                        value={form.kafkaPort}
+                        onChange={value => onFieldChange('kafkaPort', value)}
+                        readOnly={isFieldReadonly('kafkaPort')}
+                        systemReadonly={isEntrypointConfigFieldReadonly(settings, 'kafkaPort')}
+                        type="number"
+                        error={fieldError('kafkaPort', form, showValidation)}
+                    />
                 </div>
             </div>
         </div>
@@ -102,12 +223,90 @@ export function EntrypointConfigurationSection({
     failedEnvironmentNames,
     isLoading,
     isError,
+    canEdit,
 }: Readonly<{
     configs: EnvironmentEntrypointConfig[];
     failedEnvironmentNames: string[];
     isLoading: boolean;
     isError: boolean;
+    canEdit: boolean;
 }>) {
+    const [drafts, setDrafts] = useState<FormStateByEnv>(() => buildFormState(configs));
+    const [saved, setSaved] = useState<FormStateByEnv>(() => buildFormState(configs));
+    const saveMutation = useSaveEntrypointConfigurations();
+
+    const fingerprint = configsFingerprint(configs);
+    const lastFingerprintRef = useRef<string>(fingerprint);
+
+    const dirtyEnvIds = configs
+        .map(config => config.environment.id)
+        .filter(envId => {
+            const draft = drafts[envId];
+            const savedForm = saved[envId];
+            return Boolean(draft && savedForm && isEntrypointConfigFormDirty(draft, savedForm));
+        });
+
+    const isDirty = dirtyEnvIds.length > 0;
+    const dirtyFormsValid = dirtyEnvIds.every(envId => {
+        const draft = drafts[envId];
+        return draft ? isEntrypointConfigFormValid(draft) : false;
+    });
+    const showFooter = canEdit && isDirty;
+    const canSave = showFooter && dirtyFormsValid && !saveMutation.isPending;
+
+    useEffect(() => {
+        // Skip while the user has unsaved edits so a background refetch can't clobber them;
+        // once isDirty flips back to false (discard/save) this re-checks the latest fingerprint.
+        if (isDirty) return;
+        if (lastFingerprintRef.current === fingerprint) return;
+        lastFingerprintRef.current = fingerprint;
+        const next = buildFormState(configs);
+        setDrafts(next);
+        setSaved(next);
+    }, [fingerprint, isDirty, configs]);
+
+    function setField(envId: string, field: EntrypointConfigFieldKey, value: string) {
+        setDrafts(prev => {
+            const current = prev[envId];
+            if (!current) return prev;
+            return { ...prev, [envId]: { ...current, [field]: value } };
+        });
+    }
+
+    function handleDiscard() {
+        setDrafts(saved);
+    }
+
+    async function handleSave() {
+        if (!canSave) return;
+        const inputs = configs
+            .filter(config => dirtyEnvIds.includes(config.environment.id))
+            .map(config => {
+                const draft = drafts[config.environment.id]!;
+                return {
+                    environmentId: config.environment.id,
+                    settings: buildEntrypointPortalSettingsPayload(config.portalSettings, draft),
+                };
+            });
+
+        try {
+            const result = await saveMutation.mutateAsync(inputs);
+            if (result.succeededEnvironmentIds.length === 0) return;
+            // Only mark the environments that actually saved as clean; failed ones stay dirty
+            // so Discard/Save keep reflecting what really happened on the server.
+            setSaved(prev => {
+                const next = { ...prev };
+                for (const envId of result.succeededEnvironmentIds) {
+                    const draft = drafts[envId];
+                    if (draft) next[envId] = draft;
+                }
+                return next;
+            });
+        } catch {
+            // Failure toast is already shown by the mutation's onError handler.
+        }
+    }
+
     return (
         <Card>
             <CardHeader>
@@ -138,11 +337,36 @@ export function EntrypointConfigurationSection({
                         {configs.length === 0 ? (
                             <p className="text-sm text-muted-foreground">No environments found.</p>
                         ) : (
-                            configs.map(config => <EnvironmentConfigCard key={config.environment.id} config={config} />)
+                            configs.map(config => {
+                                const form = drafts[config.environment.id] ?? toEntrypointConfigFormValues(config.portalSettings);
+                                const envDirty = dirtyEnvIds.includes(config.environment.id);
+                                return (
+                                    <EnvironmentConfigCard
+                                        key={config.environment.id}
+                                        config={config}
+                                        form={form}
+                                        canEdit={canEdit}
+                                        isSaving={saveMutation.isPending}
+                                        showValidation={envDirty}
+                                        onFieldChange={(field, value) => setField(config.environment.id, field, value)}
+                                    />
+                                );
+                            })
                         )}
                     </>
                 )}
             </CardContent>
+            {showFooter ? (
+                <CardFooter className="justify-end gap-2 border-t">
+                    <Button type="button" variant="outline" size="sm" onClick={handleDiscard} disabled={saveMutation.isPending}>
+                        Discard
+                    </Button>
+                    <Button type="button" size="sm" onClick={handleSave} disabled={!canSave}>
+                        <CheckIcon className="size-4" aria-hidden />
+                        {saveMutation.isPending ? 'Saving…' : 'Save'}
+                    </Button>
+                </CardFooter>
+            ) : null}
         </Card>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointDeleteSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointDeleteSheet.spec.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { EntrypointDeleteSheet } from './EntrypointDeleteSheet';
+import type { EntrypointMappingRow } from '../types/entrypoint';
+
+const ENTRYPOINT: EntrypointMappingRow = {
+    id: 'ep-1',
+    value: 'https://api.example.com',
+    target: 'HTTP',
+    targetLabel: 'HTTP',
+    tags: ['prod'],
+    tagsName: ['Production'],
+    environmentIds: [],
+    environmentNames: [],
+};
+
+describe('EntrypointDeleteSheet', () => {
+    it('renders nothing meaningful when closed', () => {
+        render(<EntrypointDeleteSheet open={false} entrypoint={ENTRYPOINT} onClose={jest.fn()} onConfirm={jest.fn()} isDeleting={false} />);
+        expect(screen.queryByText('Delete Entrypoint Mapping')).toBeNull();
+    });
+
+    it('shows the target label and value when open', () => {
+        render(<EntrypointDeleteSheet open entrypoint={ENTRYPOINT} onClose={jest.fn()} onConfirm={jest.fn()} isDeleting={false} />);
+        expect(screen.getByText('Delete Entrypoint Mapping')).not.toBeNull();
+        expect(screen.getByText('HTTP')).not.toBeNull();
+        expect(screen.getByText('https://api.example.com')).not.toBeNull();
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const onClose = jest.fn();
+        render(<EntrypointDeleteSheet open entrypoint={ENTRYPOINT} onClose={onClose} onConfirm={jest.fn()} isDeleting={false} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onConfirm when Delete is clicked', () => {
+        const onConfirm = jest.fn();
+        render(<EntrypointDeleteSheet open entrypoint={ENTRYPOINT} onClose={jest.fn()} onConfirm={onConfirm} isDeleting={false} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+        expect(onConfirm).toHaveBeenCalled();
+    });
+
+    it('disables both buttons and shows Deleting… label while isDeleting is true', () => {
+        render(<EntrypointDeleteSheet open entrypoint={ENTRYPOINT} onClose={jest.fn()} onConfirm={jest.fn()} isDeleting />);
+        expect((screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement).disabled).toBe(true);
+        expect((screen.getByRole('button', { name: 'Deleting…' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('disables the Delete button when there is no entrypoint', () => {
+        render(<EntrypointDeleteSheet open entrypoint={undefined} onClose={jest.fn()} onConfirm={jest.fn()} isDeleting={false} />);
+        expect((screen.getByRole('button', { name: 'Delete' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointDeleteSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointDeleteSheet.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+
+import type { EntrypointMappingRow } from '../types/entrypoint';
+
+export function EntrypointDeleteSheet({
+    open,
+    entrypoint,
+    onClose,
+    onConfirm,
+    isDeleting,
+}: Readonly<{
+    open: boolean;
+    entrypoint: EntrypointMappingRow | undefined;
+    onClose: () => void;
+    onConfirm: () => void;
+    isDeleting: boolean;
+}>) {
+    return (
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Delete Entrypoint Mapping</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to delete the <span className="font-medium text-foreground">{entrypoint?.targetLabel}</span>{' '}
+                        mapping <span className="font-mono text-xs bg-muted px-1 py-0.5 rounded break-all">{entrypoint?.value}</span>? This
+                        action cannot be undone.
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || !entrypoint}>
+                        {isDeleting ? 'Deleting…' : 'Delete'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointDetailSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointDetailSheet.spec.tsx
@@ -37,7 +37,7 @@ describe('EntrypointDetailSheet', () => {
         expect(screen.getByText('HTTP')).not.toBeNull();
         expect(screen.getByText('Production')).not.toBeNull();
         expect(screen.getByText('Default Environment')).not.toBeNull();
-        expect(screen.queryByRole('button', { name: /save|edit|delete/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /^Edit$/i })).toBeNull();
     });
 
     it('calls onClose when Close is clicked', () => {
@@ -46,5 +46,12 @@ describe('EntrypointDetailSheet', () => {
         const closeButtons = screen.getAllByRole('button', { name: 'Close' });
         fireEvent.click(closeButtons[closeButtons.length - 1]!);
         expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onEdit when Edit is clicked', () => {
+        const onEdit = jest.fn();
+        render(<EntrypointDetailSheet entrypoint={ROW} canEdit onClose={jest.fn()} onEdit={onEdit} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+        expect(onEdit).toHaveBeenCalledWith(ROW);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointDetailSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointDetailSheet.tsx
@@ -23,10 +23,14 @@ import type { EntrypointMappingRow } from '../types/entrypoint';
 
 export function EntrypointDetailSheet({
     entrypoint,
+    canEdit,
     onClose,
+    onEdit,
 }: Readonly<{
     entrypoint: EntrypointMappingRow | null;
+    canEdit?: boolean;
     onClose: () => void;
+    onEdit?: (row: EntrypointMappingRow) => void;
 }>) {
     const handleOpenChange = useCallback(
         (open: boolean) => {
@@ -78,10 +82,20 @@ export function EntrypointDetailSheet({
                         </div>
                     </dl>
                 ) : null}
-                <SheetFooter className="flex-row justify-end border-t">
+                <SheetFooter className="flex-row justify-end gap-2 border-t">
                     <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
                         Close
                     </Button>
+                    {canEdit && entrypoint && onEdit ? (
+                        <Button
+                            type="button"
+                            onClick={() => {
+                                onEdit(entrypoint);
+                            }}
+                        >
+                            Edit
+                        </Button>
+                    ) : null}
                 </SheetFooter>
             </SheetContent>
         </Sheet>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointMappingsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointMappingsTable.spec.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { EntrypointMappingsTable } from './EntrypointMappingsTable';
 import type { EntrypointMappingRow } from '../types/entrypoint';
@@ -44,7 +45,7 @@ const ROWS: EntrypointMappingRow[] = [
 describe('EntrypointMappingsTable', () => {
     it('renders entrypoint rows and opens detail on value click', () => {
         const onOpenDetail = jest.fn();
-        render(<EntrypointMappingsTable rows={ROWS} canCreate={false} onOpenDetail={onOpenDetail} />);
+        render(<EntrypointMappingsTable rows={ROWS} canCreate={false} canEdit={false} canDelete={false} onOpenDetail={onOpenDetail} />);
         expect(screen.getByText('https://api.example.com')).not.toBeNull();
         expect(screen.getByText('4082')).not.toBeNull();
         fireEvent.click(screen.getByRole('button', { name: 'https://api.example.com' }));
@@ -52,21 +53,33 @@ describe('EntrypointMappingsTable', () => {
     });
 
     it('filters rows by entrypoint value', () => {
-        render(<EntrypointMappingsTable rows={ROWS} canCreate={false} onOpenDetail={jest.fn()} />);
+        render(<EntrypointMappingsTable rows={ROWS} canCreate={false} canEdit={false} canDelete={false} onOpenDetail={jest.fn()} />);
         fireEvent.change(screen.getByLabelText('Search entrypoints'), { target: { value: '4082' } });
         expect(screen.queryByText('https://api.example.com')).toBeNull();
         expect(screen.getByText('4082')).not.toBeNull();
     });
 
     it('shows create CTA in empty state when canCreate is true', () => {
+        render(
+            <EntrypointMappingsTable rows={[]} canCreate canEdit={false} canDelete={false} onOpenDetail={jest.fn()} onCreate={jest.fn()} />,
+        );
+        expect(screen.getByRole('button', { name: /Add a mapping/i })).not.toBeNull();
+    });
+
+    it('calls onCreate with the chosen target after opening the create dropdown', async () => {
+        const user = userEvent.setup();
         const onCreate = jest.fn();
-        render(<EntrypointMappingsTable rows={[]} canCreate onOpenDetail={jest.fn()} onCreate={onCreate} />);
-        fireEvent.click(screen.getByRole('button', { name: /Add a mapping/i }));
-        expect(onCreate).toHaveBeenCalled();
+        render(
+            <EntrypointMappingsTable rows={[]} canCreate canEdit={false} canDelete={false} onOpenDetail={jest.fn()} onCreate={onCreate} />,
+        );
+        // "Add a mapping" opens a target picker (HTTP / TCP / Kafka) rather than firing onCreate directly.
+        await user.click(screen.getByRole('button', { name: /Add a mapping/i }));
+        await user.click(await screen.findByRole('menuitem', { name: 'HTTP' }));
+        expect(onCreate).toHaveBeenCalledWith('HTTP');
     });
 
     it('hides create CTA in empty state when canCreate is false', () => {
-        render(<EntrypointMappingsTable rows={[]} canCreate={false} onOpenDetail={jest.fn()} />);
+        render(<EntrypointMappingsTable rows={[]} canCreate={false} canEdit={false} canDelete={false} onOpenDetail={jest.fn()} />);
         expect(screen.queryByRole('button', { name: /Add a mapping/i })).toBeNull();
         expect(screen.getByText('No entrypoints')).not.toBeNull();
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointMappingsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointMappingsTable.tsx
@@ -19,22 +19,28 @@ import {
     DataTable,
     DataTableColumnHeader,
     DataTableEmptyState,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
     InputGroup,
     InputGroupAddon,
     InputGroupInput,
     type DataTableProps,
 } from '@gravitee/graphene-core';
-import { PlusIcon, RadioIcon, SearchIcon } from '@gravitee/graphene-core/icons';
+import { MoreHorizontalIcon, PencilIcon, PlusIcon, RadioIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
 import { useMemo, useState } from 'react';
 
 import { ShardingTagsCell } from './ShardingTagsCell';
 import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
 import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
 import type { TableSortingState } from '../../applications/utils/tableSort';
-import type { EntrypointMappingRow } from '../types/entrypoint';
+import type { EntrypointMappingRow, EntrypointTarget } from '../types/entrypoint';
 
 const DEFAULT_PAGE_SIZE = 10;
 const SORTABLE_IDS = new Set(['value', 'target', 'tags', 'environments']);
+const CREATE_TARGETS: EntrypointTarget[] = ['HTTP', 'TCP', 'KAFKA'];
 
 function sortRows(items: EntrypointMappingRow[], sorting: TableSortingState): EntrypointMappingRow[] {
     const active = sorting[0];
@@ -60,8 +66,24 @@ function sortRows(items: EntrypointMappingRow[], sorting: TableSortingState): En
     });
 }
 
-function buildColumns(onOpenDetail: (row: EntrypointMappingRow) => void): DataTableProps<EntrypointMappingRow>['columns'] {
-    return [
+function targetMenuLabel(target: EntrypointTarget): string {
+    return target === 'KAFKA' ? 'Kafka' : target;
+}
+
+function buildColumns({
+    canEdit,
+    canDelete,
+    onOpenDetail,
+    onEdit,
+    onDelete,
+}: {
+    canEdit: boolean;
+    canDelete: boolean;
+    onOpenDetail: (row: EntrypointMappingRow) => void;
+    onEdit: (row: EntrypointMappingRow) => void;
+    onDelete: (row: EntrypointMappingRow) => void;
+}): DataTableProps<EntrypointMappingRow>['columns'] {
+    const columns: DataTableProps<EntrypointMappingRow>['columns'] = [
         {
             id: 'value',
             accessorKey: 'value',
@@ -95,18 +117,84 @@ function buildColumns(onOpenDetail: (row: EntrypointMappingRow) => void): DataTa
             ),
         },
     ];
+
+    if (canEdit || canDelete) {
+        columns.push({
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            size: 56,
+            enableSorting: false,
+            enableHiding: false,
+            cell: ({ row }: ColCell<EntrypointMappingRow>) => (
+                <div className="flex justify-end">
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" size="icon" className="size-8" aria-label="Entrypoint mapping actions">
+                                <MoreHorizontalIcon className="size-4" aria-hidden />
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            {canEdit && (
+                                <DropdownMenuItem onSelect={() => onEdit(row.original)}>
+                                    <PencilIcon className="size-4 mr-2" aria-hidden />
+                                    Edit
+                                </DropdownMenuItem>
+                            )}
+                            {canEdit && canDelete && <DropdownMenuSeparator />}
+                            {canDelete && (
+                                <DropdownMenuItem variant="destructive" onSelect={() => onDelete(row.original)}>
+                                    <Trash2Icon className="size-4 mr-2" aria-hidden />
+                                    Delete
+                                </DropdownMenuItem>
+                            )}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </div>
+            ),
+        });
+    }
+
+    return columns;
+}
+
+export function CreateMappingButton({ onCreate }: { onCreate: (target: EntrypointTarget) => void }) {
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button>
+                    <PlusIcon className="size-4" aria-hidden />
+                    Add a mapping
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+                {CREATE_TARGETS.map(target => (
+                    <DropdownMenuItem key={target} onSelect={() => onCreate(target)}>
+                        {targetMenuLabel(target)}
+                    </DropdownMenuItem>
+                ))}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
 }
 
 export function EntrypointMappingsTable({
     rows,
     canCreate,
+    canEdit,
+    canDelete,
     onOpenDetail,
     onCreate,
+    onEdit,
+    onDelete,
 }: Readonly<{
     rows: EntrypointMappingRow[];
     canCreate: boolean;
+    canEdit: boolean;
+    canDelete: boolean;
     onOpenDetail: (row: EntrypointMappingRow) => void;
-    onCreate?: () => void;
+    onCreate?: (target: EntrypointTarget) => void;
+    onEdit?: (row: EntrypointMappingRow) => void;
+    onDelete?: (row: EntrypointMappingRow) => void;
 }>) {
     const [search, setSearch] = useState('');
     const [sorting, setSorting] = useState<TableSortingState>([]);
@@ -122,7 +210,17 @@ export function EntrypointMappingsTable({
     const sorted = useMemo(() => sortRows(filtered, sorting), [filtered, sorting]);
     const totalCount = sorted.length;
     const paginatedData = useMemo(() => sorted.slice((page - 1) * pageSize, page * pageSize), [sorted, page, pageSize]);
-    const columns = useMemo(() => buildColumns(onOpenDetail), [onOpenDetail]);
+    const columns = useMemo(
+        () =>
+            buildColumns({
+                canEdit,
+                canDelete,
+                onOpenDetail,
+                onEdit: onEdit ?? (() => undefined),
+                onDelete: onDelete ?? (() => undefined),
+            }),
+        [canEdit, canDelete, onOpenDetail, onEdit, onDelete],
+    );
 
     function handleSearchChange(value: string) {
         setSearch(value);
@@ -146,14 +244,7 @@ export function EntrypointMappingsTable({
                 icon={<RadioIcon />}
                 title="No entrypoints"
                 description="Entrypoint mappings connect gateway listeners to sharding tags for the Developer Portal."
-                primaryAction={
-                    canCreate && onCreate ? (
-                        <Button onClick={onCreate}>
-                            <PlusIcon className="size-4" aria-hidden />
-                            Add a mapping
-                        </Button>
-                    ) : undefined
-                }
+                primaryAction={canCreate && onCreate ? <CreateMappingButton onCreate={onCreate} /> : undefined}
             />
         );
     }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointSheet.spec.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { EntrypointSheet } from './EntrypointSheet';
+import type { EntrypointMappingRow, OrgEnvironment, OrgTag } from '../types/entrypoint';
+
+const TAGS: OrgTag[] = [{ id: 'tag-1', key: 'prod', name: 'Production' }];
+const ENVIRONMENTS: OrgEnvironment[] = [{ id: 'env-1', name: 'Production' }];
+
+const EXISTING_ROW: EntrypointMappingRow = {
+    id: 'ep-1',
+    value: 'https://api.example.com',
+    target: 'HTTP',
+    targetLabel: 'HTTP',
+    tags: ['prod'],
+    tagsName: ['Production'],
+    environmentIds: [],
+    environmentNames: [],
+};
+
+const EDIT_ROW: EntrypointMappingRow = {
+    id: 'ep-2',
+    value: 'https://api.example.com',
+    target: 'HTTP',
+    targetLabel: 'HTTP',
+    tags: ['prod'],
+    tagsName: ['Production'],
+    environmentIds: [],
+    environmentNames: [],
+};
+
+function renderSheet(overrides: Partial<Parameters<typeof EntrypointSheet>[0]> = {}) {
+    const props: Parameters<typeof EntrypointSheet>[0] = {
+        open: true,
+        mode: 'create',
+        target: 'HTTP',
+        tags: TAGS,
+        environments: ENVIRONMENTS,
+        existingRows: [],
+        onClose: jest.fn(),
+        onSubmit: jest.fn(),
+        isSaving: false,
+        ...overrides,
+    };
+    render(<EntrypointSheet {...props} />);
+    return props;
+}
+
+describe('EntrypointSheet', () => {
+    it('does not render its content when closed', () => {
+        renderSheet({ open: false });
+        expect(screen.queryByText('Add HTTP Mapping')).toBeNull();
+    });
+
+    it('shows the create title for HTTP target', () => {
+        renderSheet({ mode: 'create', target: 'HTTP' });
+        expect(screen.getByText('Add HTTP Mapping')).not.toBeNull();
+    });
+
+    it('shows the edit title and prefills fields from the entrypoint', () => {
+        renderSheet({ mode: 'edit', target: 'HTTP', entrypoint: EDIT_ROW });
+        expect(screen.getByText('Edit HTTP Mapping')).not.toBeNull();
+        expect(screen.getByDisplayValue('https://api.example.com')).not.toBeNull();
+    });
+
+    it('shows a validation error for an invalid HTTP URL', () => {
+        renderSheet({ mode: 'create', target: 'HTTP' });
+        const input = screen.getByLabelText(/Entrypoint URL/);
+        fireEvent.change(input, { target: { value: 'not-a-url' } });
+        expect(screen.getByText('Enter a valid URL (http:// or https://).')).not.toBeNull();
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const props = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(props.onClose).toHaveBeenCalled();
+    });
+
+    it('keeps the submit button disabled when no sharding tags are selected', () => {
+        renderSheet({ mode: 'create', target: 'HTTP' });
+        const input = screen.getByLabelText(/Entrypoint URL/);
+        fireEvent.change(input, { target: { value: 'https://api.example.com' } });
+        expect((screen.getByRole('button', { name: 'Add Mapping' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('shows a duplicate warning and disables submit when editing into an existing overlapping mapping', () => {
+        renderSheet({ mode: 'edit', target: 'HTTP', entrypoint: EDIT_ROW, existingRows: [EXISTING_ROW, EDIT_ROW] });
+        expect(screen.getByText(/already exists for an overlapping environment/)).not.toBeNull();
+        expect((screen.getByRole('button', { name: 'Save Changes' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('disables all controls while isSaving is true', () => {
+        renderSheet({ mode: 'create', target: 'HTTP', isSaving: true });
+        expect((screen.getByLabelText(/Entrypoint URL/) as HTMLInputElement).disabled).toBe(true);
+        expect((screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement).disabled).toBe(true);
+        expect((screen.getByRole('button', { name: 'Saving...' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/EntrypointSheet.tsx
@@ -1,0 +1,355 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Combobox,
+    ComboboxChip,
+    ComboboxChips,
+    ComboboxChipsInput,
+    ComboboxContent,
+    ComboboxEmpty,
+    ComboboxItem,
+    ComboboxList,
+    Field,
+    FieldLabel,
+    Input,
+    ScrollArea,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+    useComboboxAnchor,
+} from '@gravitee/graphene-core';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import type {
+    EntrypointMappingRow,
+    EntrypointTarget,
+    NewEntrypointPayload,
+    OrgEnvironment,
+    OrgTag,
+    UpdateEntrypointPayload,
+} from '../types/entrypoint';
+import { buildSheetSelectOptions, submitEntrypointForm } from '../utils/buildEntrypointPayload';
+import {
+    composeEntrypointValue,
+    decomposeEntrypointValue,
+    EMPTY_ENTRYPOINT_FORM,
+    findDuplicateMapping,
+    isEntrypointFormDirty,
+    isEntrypointFormValid,
+    isValidEntrypointHttpUrl,
+    isValidKafkaDomain,
+    isValidPort,
+    KAFKA_DOMAIN_PLACEHOLDER,
+    type EntrypointFormValues,
+} from '../utils/entrypointForm';
+import { displayNameFor } from '../utils/targetDisplayNames';
+
+export type EntrypointSheetMode = 'create' | 'edit';
+
+interface MultiSelectFieldProps {
+    id: string;
+    label: string;
+    required?: boolean;
+    placeholder: string;
+    hint?: string;
+    options: { id: string; name: string }[];
+    selectedIds: string[];
+    onChange: (ids: string[]) => void;
+    disabled?: boolean;
+}
+
+function MultiSelectField({ id, label, required, placeholder, hint, options, selectedIds, onChange, disabled }: MultiSelectFieldProps) {
+    const anchorRef = useComboboxAnchor();
+    const sortedOptions = useMemo(() => [...options].sort((a, b) => a.name.localeCompare(b.name)), [options]);
+    const selectedOptions = useMemo(() => sortedOptions.filter(option => selectedIds.includes(option.id)), [sortedOptions, selectedIds]);
+
+    return (
+        <Field orientation="vertical" className="gap-1.5">
+            <FieldLabel htmlFor={id}>
+                {label}
+                {required && (
+                    <span className="text-destructive" aria-hidden>
+                        {' '}
+                        *
+                    </span>
+                )}
+            </FieldLabel>
+            <Combobox
+                multiple
+                value={selectedIds}
+                onValueChange={value => onChange(Array.isArray(value) ? value : [value])}
+                disabled={disabled}
+            >
+                <ComboboxChips ref={anchorRef}>
+                    {selectedOptions.map(option => (
+                        <ComboboxChip key={option.id} removeAriaLabel={`Remove ${option.name}`}>
+                            {option.name}
+                        </ComboboxChip>
+                    ))}
+                    <ComboboxChipsInput id={id} placeholder={selectedIds.length === 0 ? placeholder : ''} readOnly />
+                </ComboboxChips>
+                <ComboboxContent anchor={anchorRef} align="start">
+                    <ComboboxList>
+                        {sortedOptions.length === 0 ? <ComboboxEmpty>No options available</ComboboxEmpty> : null}
+                        {sortedOptions.map(option => (
+                            <ComboboxItem key={option.id} value={option.id}>
+                                {option.name}
+                            </ComboboxItem>
+                        ))}
+                    </ComboboxList>
+                </ComboboxContent>
+            </Combobox>
+            {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+        </Field>
+    );
+}
+
+interface EntrypointSheetProps {
+    open: boolean;
+    mode: EntrypointSheetMode;
+    target: EntrypointTarget;
+    entrypoint?: EntrypointMappingRow;
+    tags: OrgTag[];
+    environments: OrgEnvironment[];
+    defaultForm?: Partial<EntrypointFormValues>;
+    existingRows: EntrypointMappingRow[];
+    onClose: () => void;
+    onSubmit: (data: NewEntrypointPayload | UpdateEntrypointPayload) => void;
+    isSaving: boolean;
+}
+
+interface InitialSnapshot {
+    form: EntrypointFormValues;
+    tagKeys: string[];
+    environmentIds: string[];
+}
+
+export function EntrypointSheet(props: EntrypointSheetProps) {
+    const { open, mode, target, entrypoint, tags, environments, defaultForm, existingRows, onClose, onSubmit, isSaving } = props;
+    const [form, setForm] = useState<EntrypointFormValues>(EMPTY_ENTRYPOINT_FORM);
+    const [tagKeys, setTagKeys] = useState<string[]>([]);
+    const [environmentIds, setEnvironmentIds] = useState<string[]>([]);
+    const [initial, setInitial] = useState<InitialSnapshot | null>(null);
+
+    useEffect(() => {
+        if (!open) return;
+        if (mode === 'edit' && entrypoint) {
+            const initialForm = decomposeEntrypointValue(target, entrypoint.value);
+            setForm(initialForm);
+            setTagKeys(entrypoint.tags);
+            setEnvironmentIds(entrypoint.environmentIds);
+            setInitial({ form: initialForm, tagKeys: entrypoint.tags, environmentIds: entrypoint.environmentIds });
+        } else {
+            setForm({ ...EMPTY_ENTRYPOINT_FORM, ...defaultForm });
+            setTagKeys([]);
+            setEnvironmentIds([]);
+            setInitial(null);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open, mode, entrypoint, target]);
+
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    function setField<K extends keyof EntrypointFormValues>(key: K, value: EntrypointFormValues[K]) {
+        setForm(prev => ({ ...prev, [key]: value }));
+    }
+
+    const composedValue = useMemo(() => composeEntrypointValue(target, form), [target, form]);
+    const isValueValid = isEntrypointFormValid(target, form);
+    const tagsValid = tagKeys.length > 0;
+
+    const duplicate = useMemo(() => {
+        if (!isValueValid) return undefined;
+        return findDuplicateMapping(target, composedValue, environmentIds, existingRows, entrypoint?.id);
+    }, [isValueValid, target, composedValue, environmentIds, existingRows, entrypoint]);
+
+    const isValid = isValueValid && tagsValid && !duplicate;
+    const hasChanged = isEntrypointFormDirty(target, { form, tagKeys, environmentIds }, initial);
+    const canSubmit = isValid && hasChanged;
+    const targetLabel = displayNameFor(target);
+    const { tagOptions, environmentOptions } = useMemo(() => buildSheetSelectOptions(tags, environments), [tags, environments]);
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>
+                        {mode === 'create' ? 'Add' : 'Edit'} {targetLabel} Mapping
+                    </SheetTitle>
+                    <SheetDescription>
+                        Establish a mapping between an entrypoint and sharding tags. This mapping will be used on the portal to display
+                        different entrypoints based on API tags.
+                    </SheetDescription>
+                </SheetHeader>
+
+                <ScrollArea className="flex-1 min-h-0">
+                    <div className="flex flex-col gap-5 px-1 py-4">
+                        {target === 'HTTP' && (
+                            <Field orientation="vertical" className="gap-1.5">
+                                <FieldLabel htmlFor="entrypoint-http-value">
+                                    Entrypoint URL{' '}
+                                    <span className="text-destructive" aria-hidden>
+                                        *
+                                    </span>
+                                </FieldLabel>
+                                <Input
+                                    id="entrypoint-http-value"
+                                    type="url"
+                                    value={form.httpValue}
+                                    onChange={e => setField('httpValue', e.target.value)}
+                                    placeholder="https://api.example.com"
+                                    disabled={isSaving}
+                                    aria-invalid={form.httpValue.trim() !== '' && !isValidEntrypointHttpUrl(form.httpValue)}
+                                />
+                                {form.httpValue.trim() !== '' && !isValidEntrypointHttpUrl(form.httpValue) ? (
+                                    <p className="text-sm text-destructive" role="alert">
+                                        Enter a valid URL (http:// or https://).
+                                    </p>
+                                ) : null}
+                            </Field>
+                        )}
+
+                        {target === 'TCP' && (
+                            <Field orientation="vertical" className="gap-1.5">
+                                <FieldLabel htmlFor="entrypoint-tcp-port">
+                                    TCP Port{' '}
+                                    <span className="text-destructive" aria-hidden>
+                                        *
+                                    </span>
+                                </FieldLabel>
+                                <Input
+                                    id="entrypoint-tcp-port"
+                                    type="number"
+                                    min={1}
+                                    max={65535}
+                                    value={form.tcpPort}
+                                    onChange={e => setField('tcpPort', e.target.value)}
+                                    placeholder="4082"
+                                    disabled={isSaving}
+                                    aria-invalid={form.tcpPort.trim() !== '' && !isValidPort(form.tcpPort)}
+                                />
+                                {form.tcpPort.trim() !== '' && !isValidPort(form.tcpPort) ? (
+                                    <p className="text-sm text-destructive" role="alert">
+                                        Port must be a number between 1 and 65535.
+                                    </p>
+                                ) : null}
+                            </Field>
+                        )}
+
+                        {target === 'KAFKA' && (
+                            <>
+                                <Field orientation="vertical" className="gap-1.5">
+                                    <FieldLabel htmlFor="entrypoint-kafka-domain">
+                                        Kafka Bootstrap Domain Pattern{' '}
+                                        <span className="text-destructive" aria-hidden>
+                                            *
+                                        </span>
+                                    </FieldLabel>
+                                    <Input
+                                        id="entrypoint-kafka-domain"
+                                        value={form.kafkaDomain}
+                                        onChange={e => setField('kafkaDomain', e.target.value)}
+                                        placeholder={KAFKA_DOMAIN_PLACEHOLDER}
+                                        disabled={isSaving}
+                                        aria-invalid={form.kafkaDomain.trim() !== '' && !isValidKafkaDomain(form.kafkaDomain)}
+                                    />
+                                    <p className="text-xs text-muted-foreground">Must contain {KAFKA_DOMAIN_PLACEHOLDER} placeholder.</p>
+                                </Field>
+                                <Field orientation="vertical" className="gap-1.5">
+                                    <FieldLabel htmlFor="entrypoint-kafka-port">
+                                        Kafka Port{' '}
+                                        <span className="text-destructive" aria-hidden>
+                                            *
+                                        </span>
+                                    </FieldLabel>
+                                    <Input
+                                        id="entrypoint-kafka-port"
+                                        type="number"
+                                        min={1}
+                                        max={65535}
+                                        value={form.kafkaPort}
+                                        onChange={e => setField('kafkaPort', e.target.value)}
+                                        placeholder="9092"
+                                        disabled={isSaving}
+                                        aria-invalid={form.kafkaPort.trim() !== '' && !isValidPort(form.kafkaPort)}
+                                    />
+                                    {form.kafkaPort.trim() !== '' && !isValidPort(form.kafkaPort) ? (
+                                        <p className="text-sm text-destructive" role="alert">
+                                            Port must be a number between 1 and 65535.
+                                        </p>
+                                    ) : null}
+                                </Field>
+                            </>
+                        )}
+
+                        <MultiSelectField
+                            id="entrypoint-tags"
+                            label="Sharding Tags"
+                            required
+                            placeholder="Select sharding tags"
+                            options={tagOptions}
+                            selectedIds={tagKeys}
+                            onChange={setTagKeys}
+                            disabled={isSaving}
+                        />
+
+                        <MultiSelectField
+                            id="entrypoint-environments"
+                            label="Environments"
+                            placeholder="All environments"
+                            hint="Leave empty to apply to all environments."
+                            options={environmentOptions}
+                            selectedIds={environmentIds}
+                            onChange={setEnvironmentIds}
+                            disabled={isSaving}
+                        />
+
+                        {duplicate ? (
+                            <p className="text-sm text-destructive" role="alert">
+                                An entrypoint mapping with this value already exists for an overlapping environment.
+                            </p>
+                        ) : null}
+                    </div>
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-col gap-2 border-t pt-4 sm:flex-col">
+                    <Button type="button" variant="outline" className="w-full" onClick={onClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button
+                        type="button"
+                        className="w-full"
+                        onClick={() =>
+                            submitEntrypointForm(canSubmit, onSubmit, entrypoint?.id, target, composedValue, tagKeys, environmentIds)
+                        }
+                        disabled={!canSubmit || isSaving}
+                    >
+                        {isSaving ? 'Saving...' : mode === 'create' ? 'Add Mapping' : 'Save Changes'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/ShardingTagsCell.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/components/ShardingTagsCell.tsx
@@ -14,33 +14,25 @@
  * limitations under the License.
  */
 
-import { Badge, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@gravitee/graphene-core';
-
 interface ShardingTagsCellProps {
     tags?: string[];
 }
 
 export function ShardingTagsCell({ tags }: Readonly<ShardingTagsCellProps>) {
-    if (!tags || tags.length === 0) {
-        return <span className="text-muted-foreground text-xs">—</span>;
+    const sorted = [...(tags ?? [])]
+        .map(tag => tag.trim())
+        .filter(Boolean)
+        .sort((a, b) => a.localeCompare(b));
+    if (sorted.length === 0) {
+        return null;
     }
-    const sorted = [...tags].sort((a, b) => a.localeCompare(b));
-    const moreCount = sorted.length - 1;
     return (
-        <div className="flex items-center gap-1">
-            <span className="text-sm">{sorted[0]}</span>
-            {moreCount > 0 ? (
-                <TooltipProvider delayDuration={0}>
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <Badge variant="secondary" className="text-xs tabular-nums cursor-default">
-                                {moreCount} more
-                            </Badge>
-                        </TooltipTrigger>
-                        <TooltipContent>{sorted.join(', ')}</TooltipContent>
-                    </Tooltip>
-                </TooltipProvider>
-            ) : null}
+        <div className="flex flex-wrap items-center gap-1">
+            {sorted.map(tag => (
+                <span key={tag} className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-normal text-foreground">
+                    {tag}
+                </span>
+            ))}
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/hooks/useEntrypointMappings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/hooks/useEntrypointMappings.ts
@@ -46,6 +46,8 @@ export function useEntrypointMappings() {
 
     return {
         rows,
+        tags: tagsQuery.data ?? [],
+        environments: environmentsQuery.data ?? [],
         isLoading: entrypointsQuery.isLoading || environmentsQuery.isLoading || tagsQuery.isLoading,
         isError: entrypointsQuery.isError,
         isNameResolutionError: environmentsQuery.isError || tagsQuery.isError,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/hooks/useEntrypointMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/hooks/useEntrypointMutations.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { createEntrypoint, deleteEntrypoint, updateEntrypoint } from '../services/entrypoints';
+import type { NewEntrypointPayload, UpdateEntrypointPayload } from '../types/entrypoint';
+import { entrypointKeys } from '../utils/queryKeys';
+
+function useEntrypointMutation<TData>(mutationFn: (data: TData) => Promise<unknown>) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn,
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: entrypointKeys.list() });
+        },
+    });
+}
+
+export function useCreateEntrypoint() {
+    return useEntrypointMutation<NewEntrypointPayload>(createEntrypoint);
+}
+
+export function useUpdateEntrypoint() {
+    return useEntrypointMutation<UpdateEntrypointPayload>(updateEntrypoint);
+}
+
+export function useDeleteEntrypoint() {
+    return useEntrypointMutation<string>(deleteEntrypoint);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/hooks/useSaveEntrypointConfigurations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/hooks/useSaveEntrypointConfigurations.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { notify } from '../../../shared/notify';
+import { savePortalSettingsByEnvironmentId } from '../services/portalSettings';
+import type { EntrypointPortalSettings } from '../types/entrypoint';
+import { orgEnvironmentKeys, portalSettingsKeys } from '../utils/queryKeys';
+
+export interface SaveEntrypointConfigurationInput {
+    environmentId: string;
+    settings: EntrypointPortalSettings;
+}
+
+export interface SaveEntrypointConfigurationsResult {
+    succeededEnvironmentIds: string[];
+    failed: { environmentId: string; error: unknown }[];
+}
+
+export function useSaveEntrypointConfigurations() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (inputs: SaveEntrypointConfigurationInput[]): Promise<SaveEntrypointConfigurationsResult> => {
+            const settled = await Promise.allSettled(
+                inputs.map(({ environmentId, settings }) => savePortalSettingsByEnvironmentId(environmentId, settings)),
+            );
+
+            const succeededEnvironmentIds: string[] = [];
+            const failed: { environmentId: string; error: unknown }[] = [];
+            settled.forEach((outcome, index) => {
+                const { environmentId } = inputs[index];
+                if (outcome.status === 'fulfilled') {
+                    succeededEnvironmentIds.push(environmentId);
+                } else {
+                    failed.push({ environmentId, error: outcome.reason });
+                }
+            });
+
+            return { succeededEnvironmentIds, failed };
+        },
+        onSuccess: result => {
+            if (result.succeededEnvironmentIds.length > 0) {
+                // Two distinct query keys: environment list and portal settings must be invalidated separately.
+                void queryClient.invalidateQueries({ queryKey: orgEnvironmentKeys.list() });
+                void queryClient.invalidateQueries({ queryKey: portalSettingsKeys.all });
+            }
+
+            if (result.failed.length === 0) {
+                notify.success('Configuration saved!');
+            } else if (result.succeededEnvironmentIds.length > 0) {
+                notify.error(
+                    result.failed[0].error,
+                    `Saved ${result.succeededEnvironmentIds.length} environment(s), but ${result.failed.length} failed to save`,
+                );
+            } else {
+                notify.error(result.failed[0].error, 'Failed to save entrypoint configuration');
+            }
+        },
+        onError: error => notify.error(error, 'Failed to save entrypoint configuration'),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/entrypoints.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/entrypoints.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { listEntrypoints } from './entrypoints';
+import { createEntrypoint, deleteEntrypoint, listEntrypoints, updateEntrypoint } from './entrypoints';
 import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
 
 jest.mock('../../../shared/api/apimClient', () => ({
@@ -31,5 +31,30 @@ describe('entrypoints service', () => {
     it('calls GET on the organization configuration/entrypoints resource', async () => {
         await listEntrypoints();
         expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/entrypoints');
+    });
+
+    it('POSTs a new entrypoint mapping', async () => {
+        const body = { target: 'HTTP' as const, value: 'https://x', tags: ['prod'], environmentIds: [] };
+        await createEntrypoint(body);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/entrypoints', {
+            method: 'POST',
+            body: JSON.stringify(body),
+        });
+    });
+
+    it('PUTs an updated entrypoint mapping', async () => {
+        const body = { id: 'ep-1', target: 'HTTP' as const, value: 'https://x', tags: ['prod'], environmentIds: [] };
+        await updateEntrypoint(body);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/entrypoints', {
+            method: 'PUT',
+            body: JSON.stringify(body),
+        });
+    });
+
+    it('DELETEs an entrypoint mapping by id', async () => {
+        await deleteEntrypoint('ep-1');
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/entrypoints/ep-1', {
+            method: 'DELETE',
+        });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/entrypoints.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/entrypoints.ts
@@ -15,8 +15,28 @@
  */
 
 import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
-import type { Entrypoint } from '../types/entrypoint';
+import type { Entrypoint, NewEntrypointPayload, UpdateEntrypointPayload } from '../types/entrypoint';
 
 export async function listEntrypoints(): Promise<Entrypoint[]> {
     return apimFetchJsonOrg<Entrypoint[]>('/configuration/entrypoints');
+}
+
+export async function createEntrypoint(data: NewEntrypointPayload): Promise<Entrypoint> {
+    return apimFetchJsonOrg<Entrypoint>('/configuration/entrypoints', {
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+}
+
+export async function updateEntrypoint(data: UpdateEntrypointPayload): Promise<Entrypoint> {
+    return apimFetchJsonOrg<Entrypoint>('/configuration/entrypoints', {
+        method: 'PUT',
+        body: JSON.stringify(data),
+    });
+}
+
+export async function deleteEntrypoint(id: string): Promise<void> {
+    return apimFetchJsonOrg<void>(`/configuration/entrypoints/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+    });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/portalSettings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/portalSettings.ts
@@ -20,3 +20,13 @@ import type { EntrypointPortalSettings } from '../types/entrypoint';
 export async function getPortalSettingsByEnvironmentId(environmentId: string): Promise<EntrypointPortalSettings> {
     return apimFetchJsonOrg<EntrypointPortalSettings>(`/environments/${encodeURIComponent(environmentId)}/settings`);
 }
+
+export async function savePortalSettingsByEnvironmentId(
+    environmentId: string,
+    settings: EntrypointPortalSettings,
+): Promise<EntrypointPortalSettings> {
+    return apimFetchJsonOrg<EntrypointPortalSettings>(`/environments/${encodeURIComponent(environmentId)}/settings`, {
+        method: 'POST',
+        body: JSON.stringify(settings),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/supportingServices.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/services/supportingServices.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { listOrgEnvironments } from './environments';
-import { getPortalSettingsByEnvironmentId } from './portalSettings';
+import { getPortalSettingsByEnvironmentId, savePortalSettingsByEnvironmentId } from './portalSettings';
 import { listOrgTags } from './tags';
 import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
 
@@ -43,6 +43,24 @@ describe('entrypoint supporting services', () => {
     it('URL-encodes the environment id in portal settings path', async () => {
         await getPortalSettingsByEnvironmentId('env with spaces');
         expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/environments/env%20with%20spaces/settings');
+    });
+
+    it('savePortalSettingsByEnvironmentId calls POST /environments/:id/settings', async () => {
+        const settings = { portal: { entrypoint: 'https://api.example.com', tcpPort: 4082 } };
+        await savePortalSettingsByEnvironmentId('env-1', settings);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/environments/env-1/settings', {
+            method: 'POST',
+            body: JSON.stringify(settings),
+        });
+    });
+
+    it('URL-encodes the environment id when saving portal settings', async () => {
+        const settings = { portal: { entrypoint: 'https://api.example.com' } };
+        await savePortalSettingsByEnvironmentId('env with spaces', settings);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/environments/env%20with%20spaces/settings', {
+            method: 'POST',
+            body: JSON.stringify(settings),
+        });
     });
 
     it('listOrgTags calls GET /configuration/tags', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/types/entrypoint.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/types/entrypoint.ts
@@ -36,10 +36,13 @@ export interface EntrypointPortalSettings {
         tcpPort?: number;
         kafkaDomain?: string;
         kafkaPort?: number;
+        [key: string]: unknown;
     };
     metadata?: {
         readonly?: string[];
     };
+    /** Full portal-settings document is preserved for round-trip save. */
+    [key: string]: unknown;
 }
 
 export interface OrgTag {
@@ -63,4 +66,19 @@ export interface EntrypointMappingRow {
     tagsName: string[];
     environmentIds: string[];
     environmentNames: string[];
+}
+
+export interface NewEntrypointPayload {
+    target: EntrypointTarget;
+    value: string;
+    tags: string[];
+    environmentIds: string[];
+}
+
+export interface UpdateEntrypointPayload {
+    id: string;
+    target: EntrypointTarget;
+    value: string;
+    tags: string[];
+    environmentIds: string[];
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/buildEntrypointPayload.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/buildEntrypointPayload.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { EntrypointTarget, NewEntrypointPayload, OrgEnvironment, OrgTag, UpdateEntrypointPayload } from '../types/entrypoint';
+
+export interface SelectOption {
+    id: string;
+    name: string;
+}
+
+export function toTagOptions(tags: OrgTag[]): SelectOption[] {
+    return tags.map(tag => ({ id: tag.key, name: tag.name || tag.key }));
+}
+
+export function toEnvironmentOptions(environments: OrgEnvironment[]): SelectOption[] {
+    return environments.map(env => ({ id: env.id, name: env.name || env.id }));
+}
+
+export interface SheetSelectOptions {
+    tagOptions: SelectOption[];
+    environmentOptions: SelectOption[];
+}
+
+export function buildSheetSelectOptions(tags: OrgTag[], environments: OrgEnvironment[]): SheetSelectOptions {
+    return { tagOptions: toTagOptions(tags), environmentOptions: toEnvironmentOptions(environments) };
+}
+
+export function submitEntrypointForm(
+    canSubmit: boolean,
+    onSubmit: (data: NewEntrypointPayload | UpdateEntrypointPayload) => void,
+    existingId: string | undefined,
+    target: EntrypointTarget,
+    value: string,
+    tags: string[],
+    environmentIds: string[],
+): void {
+    if (!canSubmit) return;
+    onSubmit(resolveEntrypointPayload(existingId, target, value, tags, environmentIds));
+}
+
+export function buildNewEntrypointPayload(
+    target: EntrypointTarget,
+    value: string,
+    tags: string[],
+    environmentIds: string[],
+): NewEntrypointPayload {
+    return { target, value, tags, environmentIds };
+}
+
+export function buildUpdateEntrypointPayload(
+    id: string,
+    target: EntrypointTarget,
+    value: string,
+    tags: string[],
+    environmentIds: string[],
+): UpdateEntrypointPayload {
+    return { id, target, value, tags, environmentIds };
+}
+
+export function resolveEntrypointPayload(
+    existingId: string | undefined,
+    target: EntrypointTarget,
+    value: string,
+    tags: string[],
+    environmentIds: string[],
+): NewEntrypointPayload | UpdateEntrypointPayload {
+    if (existingId) {
+        return buildUpdateEntrypointPayload(existingId, target, value, tags, environmentIds);
+    }
+    return buildNewEntrypointPayload(target, value, tags, environmentIds);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointConfigForm.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointConfigForm.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    buildEntrypointPortalSettingsPayload,
+    CONFIG_PORT_MAX,
+    CONFIG_PORT_MIN,
+    isEntrypointConfigFieldReadonly,
+    isEntrypointConfigFormDirty,
+    isEntrypointConfigFormValid,
+    isValidConfigPort,
+    toEntrypointConfigFormValues,
+    type EntrypointConfigFormValues,
+} from './entrypointConfigForm';
+import { KAFKA_DOMAIN_PLACEHOLDER } from './entrypointForm';
+import type { EntrypointPortalSettings } from '../types/entrypoint';
+
+const VALID_FORM: EntrypointConfigFormValues = {
+    entrypoint: 'https://api.example.com',
+    tcpPort: '4082',
+    kafkaDomain: `${KAFKA_DOMAIN_PLACEHOLDER}.example.com`,
+    kafkaPort: '9092',
+};
+
+const SETTINGS: EntrypointPortalSettings = {
+    portal: {
+        entrypoint: 'https://api.example.com',
+        tcpPort: 4082,
+        kafkaDomain: `${KAFKA_DOMAIN_PLACEHOLDER}.example.com`,
+        kafkaPort: 9092,
+        other: 'keep-me',
+    },
+    metadata: { readonly: ['portal.tcpPort'] },
+    cors: { allowOrigin: ['*'] },
+};
+
+describe('entrypointConfigForm utils', () => {
+    it('validates config ports in Classic range 1025-65535', () => {
+        expect(isValidConfigPort(String(CONFIG_PORT_MIN))).toBe(true);
+        expect(isValidConfigPort(String(CONFIG_PORT_MAX))).toBe(true);
+        expect(isValidConfigPort('1024')).toBe(false);
+        expect(isValidConfigPort('65536')).toBe(false);
+        expect(isValidConfigPort('abc')).toBe(false);
+        expect(isValidConfigPort('')).toBe(false);
+    });
+
+    it('maps portal settings into form values', () => {
+        expect(toEntrypointConfigFormValues(SETTINGS)).toEqual(VALID_FORM);
+        expect(toEntrypointConfigFormValues({})).toEqual({
+            entrypoint: '',
+            tcpPort: '',
+            kafkaDomain: '',
+            kafkaPort: '',
+        });
+    });
+
+    it('detects system-readonly portal fields from metadata', () => {
+        expect(isEntrypointConfigFieldReadonly(SETTINGS, 'tcpPort')).toBe(true);
+        expect(isEntrypointConfigFieldReadonly(SETTINGS, 'entrypoint')).toBe(false);
+        expect(isEntrypointConfigFieldReadonly(undefined, 'entrypoint')).toBe(false);
+    });
+
+    it('marks form valid only when ports and kafka domain are valid', () => {
+        expect(isEntrypointConfigFormValid(VALID_FORM)).toBe(true);
+        expect(isEntrypointConfigFormValid({ ...VALID_FORM, tcpPort: '80' })).toBe(false);
+        expect(isEntrypointConfigFormValid({ ...VALID_FORM, kafkaDomain: 'missing-placeholder' })).toBe(false);
+        expect(isEntrypointConfigFormValid({ ...VALID_FORM, kafkaPort: 'abc' })).toBe(false);
+    });
+
+    it('detects dirty form values', () => {
+        expect(isEntrypointConfigFormDirty(VALID_FORM, VALID_FORM)).toBe(false);
+        expect(isEntrypointConfigFormDirty({ ...VALID_FORM, tcpPort: '8888' }, VALID_FORM)).toBe(true);
+        expect(isEntrypointConfigFormDirty({ ...VALID_FORM, entrypoint: 'https://x' }, VALID_FORM)).toBe(true);
+    });
+
+    it('merges edited portal defaults into the full settings document', () => {
+        const payload = buildEntrypointPortalSettingsPayload(SETTINGS, {
+            ...VALID_FORM,
+            entrypoint: ' https://gateway.example.com ',
+            tcpPort: '8888',
+            kafkaDomain: ` ${KAFKA_DOMAIN_PLACEHOLDER}.new.org `,
+            kafkaPort: '9093',
+        });
+        expect(payload).toEqual({
+            portal: {
+                entrypoint: 'https://gateway.example.com',
+                tcpPort: 8888,
+                kafkaDomain: `${KAFKA_DOMAIN_PLACEHOLDER}.new.org`,
+                kafkaPort: 9093,
+                other: 'keep-me',
+            },
+            metadata: { readonly: ['portal.tcpPort'] },
+            cors: { allowOrigin: ['*'] },
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointConfigForm.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointConfigForm.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KAFKA_DOMAIN_PLACEHOLDER, isValidKafkaDomain } from './entrypointForm';
+import type { EntrypointPortalSettings } from '../types/entrypoint';
+
+/** Classic `portValidator` range for portal entrypoint defaults (TCP / Kafka). */
+export const CONFIG_PORT_MIN = 1025;
+export const CONFIG_PORT_MAX = 65535;
+
+export type EntrypointConfigFieldKey = 'entrypoint' | 'tcpPort' | 'kafkaDomain' | 'kafkaPort';
+
+export interface EntrypointConfigFormValues {
+    entrypoint: string;
+    tcpPort: string;
+    kafkaDomain: string;
+    kafkaPort: string;
+}
+
+export const EMPTY_ENTRYPOINT_CONFIG_FORM: EntrypointConfigFormValues = {
+    entrypoint: '',
+    tcpPort: '',
+    kafkaDomain: '',
+    kafkaPort: '',
+};
+
+const READONLY_PROPERTY_BY_FIELD: Record<EntrypointConfigFieldKey, string> = {
+    entrypoint: 'portal.entrypoint',
+    tcpPort: 'portal.tcpPort',
+    kafkaDomain: 'portal.kafkaDomain',
+    kafkaPort: 'portal.kafkaPort',
+};
+
+export function isValidConfigPort(raw: string): boolean {
+    if (!raw.trim()) return false;
+    if (!/^\d+$/.test(raw.trim())) return false;
+    const port = Number(raw);
+    return port >= CONFIG_PORT_MIN && port <= CONFIG_PORT_MAX;
+}
+
+export function toEntrypointConfigFormValues(settings: EntrypointPortalSettings): EntrypointConfigFormValues {
+    const portal = settings.portal ?? {};
+    return {
+        entrypoint: portal.entrypoint ?? '',
+        tcpPort: portal.tcpPort !== undefined && portal.tcpPort !== null ? String(portal.tcpPort) : '',
+        kafkaDomain: portal.kafkaDomain ?? '',
+        kafkaPort: portal.kafkaPort !== undefined && portal.kafkaPort !== null ? String(portal.kafkaPort) : '',
+    };
+}
+
+export function isEntrypointConfigFieldReadonly(settings: EntrypointPortalSettings | undefined, field: EntrypointConfigFieldKey): boolean {
+    const property = READONLY_PROPERTY_BY_FIELD[field];
+    return settings?.metadata?.readonly?.some(key => key === property) ?? false;
+}
+
+export function isEntrypointConfigFormValid(form: EntrypointConfigFormValues): boolean {
+    return isValidConfigPort(form.tcpPort) && isValidKafkaDomain(form.kafkaDomain) && isValidConfigPort(form.kafkaPort);
+}
+
+export function isEntrypointConfigFormDirty(current: EntrypointConfigFormValues, saved: EntrypointConfigFormValues): boolean {
+    return (
+        current.entrypoint !== saved.entrypoint ||
+        current.tcpPort !== saved.tcpPort ||
+        current.kafkaDomain !== saved.kafkaDomain ||
+        current.kafkaPort !== saved.kafkaPort
+    );
+}
+
+/** Merges edited portal defaults into the full settings document (Classic save shape). */
+export function buildEntrypointPortalSettingsPayload(
+    current: EntrypointPortalSettings,
+    form: EntrypointConfigFormValues,
+): EntrypointPortalSettings {
+    return {
+        ...current,
+        portal: {
+            ...(current.portal ?? {}),
+            entrypoint: form.entrypoint.trim(),
+            tcpPort: Number(form.tcpPort),
+            kafkaDomain: form.kafkaDomain.trim(),
+            kafkaPort: Number(form.kafkaPort),
+        },
+    };
+}
+
+export { KAFKA_DOMAIN_PLACEHOLDER };

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointForm.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointForm.spec.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    composeEntrypointValue,
+    decomposeEntrypointValue,
+    findDuplicateMapping,
+    isEntrypointFormValid,
+    isValidEntrypointHttpUrl,
+    isValidKafkaDomain,
+    isValidPort,
+    KAFKA_DOMAIN_PLACEHOLDER,
+} from './entrypointForm';
+import type { EntrypointMappingRow } from '../types/entrypoint';
+
+const ROW: EntrypointMappingRow = {
+    id: 'ep-1',
+    value: 'https://api.example.com',
+    target: 'HTTP',
+    targetLabel: 'HTTP',
+    tags: ['prod'],
+    tagsName: ['Production'],
+    environmentIds: [],
+    environmentNames: [],
+};
+
+describe('entrypointForm utils', () => {
+    it('validates ports in range 1-65535', () => {
+        expect(isValidPort('1')).toBe(true);
+        expect(isValidPort('65535')).toBe(true);
+        expect(isValidPort('0')).toBe(false);
+        expect(isValidPort('65536')).toBe(false);
+        expect(isValidPort('abc')).toBe(false);
+    });
+
+    it('requires kafka domain to include the apiHost placeholder', () => {
+        expect(isValidKafkaDomain(`${KAFKA_DOMAIN_PLACEHOLDER}.kafka.local`)).toBe(true);
+        expect(isValidKafkaDomain('kafka.local')).toBe(false);
+    });
+
+    it('composes and decomposes values per target', () => {
+        expect(composeEntrypointValue('HTTP', { httpValue: ' https://x ', tcpPort: '', kafkaDomain: '', kafkaPort: '' })).toBe('https://x');
+        expect(composeEntrypointValue('TCP', { httpValue: '', tcpPort: '4082', kafkaDomain: '', kafkaPort: '' })).toBe('4082');
+        expect(
+            composeEntrypointValue('KAFKA', {
+                httpValue: '',
+                tcpPort: '',
+                kafkaDomain: `${KAFKA_DOMAIN_PLACEHOLDER}.example.com`,
+                kafkaPort: '9092',
+            }),
+        ).toBe(`${KAFKA_DOMAIN_PLACEHOLDER}.example.com:9092`);
+
+        expect(decomposeEntrypointValue('HTTP', 'https://x').httpValue).toBe('https://x');
+        expect(decomposeEntrypointValue('TCP', '4082').tcpPort).toBe('4082');
+        const kafka = decomposeEntrypointValue('KAFKA', `${KAFKA_DOMAIN_PLACEHOLDER}.example.com:9092`);
+        expect(kafka.kafkaDomain).toBe(`${KAFKA_DOMAIN_PLACEHOLDER}.example.com`);
+        expect(kafka.kafkaPort).toBe('9092');
+    });
+
+    it('validates HTTP entrypoint URLs like Classic type="url"', () => {
+        expect(isValidEntrypointHttpUrl('https://gateway.example.com')).toBe(true);
+        expect(isValidEntrypointHttpUrl('http://localhost:8082')).toBe(true);
+        expect(isValidEntrypointHttpUrl('ioioo')).toBe(false);
+        expect(isValidEntrypointHttpUrl('gateway.example.com')).toBe(false);
+        expect(isValidEntrypointHttpUrl('ftp://example.com')).toBe(false);
+    });
+
+    it('marks forms valid only when required fields are present', () => {
+        expect(isEntrypointFormValid('HTTP', { httpValue: 'https://x', tcpPort: '', kafkaDomain: '', kafkaPort: '' })).toBe(true);
+        expect(isEntrypointFormValid('TCP', { httpValue: '', tcpPort: '99', kafkaDomain: '', kafkaPort: '' })).toBe(true);
+        expect(
+            isEntrypointFormValid('KAFKA', {
+                httpValue: '',
+                tcpPort: '',
+                kafkaDomain: KAFKA_DOMAIN_PLACEHOLDER,
+                kafkaPort: '9092',
+            }),
+        ).toBe(true);
+        expect(isEntrypointFormValid('HTTP', { httpValue: '  ', tcpPort: '', kafkaDomain: '', kafkaPort: '' })).toBe(false);
+        expect(isEntrypointFormValid('HTTP', { httpValue: 'ioioo', tcpPort: '', kafkaDomain: '', kafkaPort: '' })).toBe(false);
+    });
+
+    it('detects duplicate mappings with overlapping environments', () => {
+        expect(findDuplicateMapping('HTTP', 'https://api.example.com', [], [ROW])).toEqual(ROW);
+        expect(findDuplicateMapping('HTTP', 'https://api.example.com', [], [ROW], 'ep-1')).toBeUndefined();
+        expect(findDuplicateMapping('TCP', '4082', [], [ROW])).toBeUndefined();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointForm.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointForm.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { EntrypointMappingRow, EntrypointTarget } from '../types/entrypoint';
+
+export const KAFKA_DOMAIN_PLACEHOLDER = '{apiHost}';
+export const PORT_MIN = 1;
+export const PORT_MAX = 65535;
+/** Max length of URL (255) - reserved host prefix (63) - separator (1) + `{apiHost}` (10). Mirrors Classic console. */
+const KAFKA_DOMAIN_MAX_LENGTH = 201;
+
+export interface EntrypointFormValues {
+    httpValue: string;
+    tcpPort: string;
+    kafkaDomain: string;
+    kafkaPort: string;
+}
+
+export const EMPTY_ENTRYPOINT_FORM: EntrypointFormValues = {
+    httpValue: '',
+    tcpPort: '',
+    kafkaDomain: '',
+    kafkaPort: '',
+};
+
+export function isValidPort(raw: string): boolean {
+    if (!raw.trim()) return false;
+    if (!/^\d+$/.test(raw.trim())) return false;
+    const port = Number(raw);
+    return port >= PORT_MIN && port <= PORT_MAX;
+}
+
+/**
+ * Mirrors Classic console `type="url"` on the HTTP entrypoint field: absolute http(s) URLs only.
+ * Uses the URL constructor (same approach as Classic `urlValidator`).
+ */
+export function isValidEntrypointHttpUrl(raw: string): boolean {
+    const value = raw.trim();
+    if (!value) return false;
+    try {
+        const url = new URL(value);
+        return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch {
+        return false;
+    }
+}
+
+export function isValidKafkaDomain(raw: string): boolean {
+    const domain = raw.trim();
+    if (!domain) return false;
+    if (!domain.includes(KAFKA_DOMAIN_PLACEHOLDER)) return false;
+    return domain.length <= KAFKA_DOMAIN_MAX_LENGTH;
+}
+
+export function isEntrypointFormValid(target: EntrypointTarget, form: EntrypointFormValues): boolean {
+    if (target === 'HTTP') return isValidEntrypointHttpUrl(form.httpValue);
+    if (target === 'TCP') return isValidPort(form.tcpPort);
+    return isValidKafkaDomain(form.kafkaDomain) && isValidPort(form.kafkaPort);
+}
+
+/** Composes the backend `value` field from per-type form inputs (mirrors Classic console encoding). */
+export function composeEntrypointValue(target: EntrypointTarget, form: EntrypointFormValues): string {
+    if (target === 'HTTP') return form.httpValue.trim();
+    if (target === 'TCP') return form.tcpPort.trim();
+    return `${form.kafkaDomain.trim()}:${form.kafkaPort.trim()}`;
+}
+
+/** Decomposes the backend `value` field back into per-type form inputs, for editing an existing mapping. */
+export function decomposeEntrypointValue(target: EntrypointTarget, value: string): EntrypointFormValues {
+    if (target === 'HTTP') return { ...EMPTY_ENTRYPOINT_FORM, httpValue: value };
+    if (target === 'TCP') return { ...EMPTY_ENTRYPOINT_FORM, tcpPort: value };
+    const separatorIndex = value.lastIndexOf(':');
+    if (separatorIndex === -1) return { ...EMPTY_ENTRYPOINT_FORM, kafkaDomain: value };
+    return {
+        ...EMPTY_ENTRYPOINT_FORM,
+        kafkaDomain: value.slice(0, separatorIndex),
+        kafkaPort: value.slice(separatorIndex + 1),
+    };
+}
+
+function environmentsOverlap(a: string[], b: string[]): boolean {
+    // An empty environment list means "all environments", which overlaps with any selection.
+    if (a.length === 0 || b.length === 0) return true;
+    return a.some(id => b.includes(id));
+}
+
+/** Best-effort client-side duplicate detection: same type + same composed value + overlapping environments. */
+export function findDuplicateMapping(
+    target: EntrypointTarget,
+    value: string,
+    environmentIds: string[],
+    rows: EntrypointMappingRow[],
+    excludeId?: string,
+): EntrypointMappingRow | undefined {
+    const normalizedValue = value.trim().toLowerCase();
+    return rows.find(
+        row =>
+            row.id !== excludeId &&
+            row.target === target &&
+            row.value.trim().toLowerCase() === normalizedValue &&
+            environmentsOverlap(row.environmentIds, environmentIds),
+    );
+}
+
+export interface EntrypointFormSnapshot {
+    form: EntrypointFormValues;
+    tagKeys: string[];
+    environmentIds: string[];
+}
+
+function sameStringSet(a: string[], b: string[]): boolean {
+    return JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
+}
+
+export function isEntrypointFormDirty(
+    target: EntrypointTarget,
+    current: EntrypointFormSnapshot,
+    initial: EntrypointFormSnapshot | null,
+): boolean {
+    if (initial === null) return true;
+    const currentEncodedValue = composeEntrypointValue(target, current.form);
+    const initialEncodedValue = composeEntrypointValue(target, initial.form);
+    if (currentEncodedValue !== initialEncodedValue) return true;
+    if (!sameStringSet(current.tagKeys, initial.tagKeys)) return true;
+    if (!sameStringSet(current.environmentIds, initial.environmentIds)) return true;
+    return false;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointMappings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/entrypointMappings.ts
@@ -32,7 +32,7 @@ export function toEntrypointMappingRows(entrypoints: Entrypoint[], environments:
     const tagNameByKey = new Map(tags.map(tag => [tag.key, tag.name || tag.key]));
 
     return entrypoints.map(entrypoint => {
-        const tagKeys = entrypoint.tags ?? [];
+        const tagKeys = (entrypoint.tags ?? []).map(tag => tag.trim()).filter(Boolean);
         const environmentIds = entrypoint.environmentIds ?? [];
         const target = entrypoint.target ?? 'HTTP';
         return {
@@ -41,7 +41,10 @@ export function toEntrypointMappingRows(entrypoints: Entrypoint[], environments:
             target,
             targetLabel: entrypointTargetLabel(target),
             tags: tagKeys,
-            tagsName: tagKeys.map(key => tagNameByKey.get(key) ?? key),
+            tagsName: tagKeys.map(key => {
+                const name = (tagNameByKey.get(key) ?? key).trim();
+                return name || key;
+            }),
             environmentIds,
             environmentNames: environmentIds.map(id => envNameById.get(id) ?? id),
         };

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/targetDisplayNames.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/entrypoints/utils/targetDisplayNames.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { EntrypointTarget } from '../types/entrypoint';
+
+const DISPLAY_NAMES: Record<EntrypointTarget, string> = {
+    HTTP: 'HTTP',
+    TCP: 'TCP',
+    KAFKA: 'Kafka',
+};
+
+export function displayNameFor(kind: EntrypointTarget): string {
+    return DISPLAY_NAMES[kind];
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EntrypointsAndShardingTagsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EntrypointsAndShardingTagsPage.spec.tsx
@@ -13,33 +13,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { EntrypointsAndShardingTagsPage } from './EntrypointsAndShardingTagsPage';
 import { useEntrypointConfigurations } from '../features/entrypoints/hooks/useEntrypointConfigurations';
 import { useEntrypointMappings } from '../features/entrypoints/hooks/useEntrypointMappings';
-import type { EntrypointMappingRow } from '../features/entrypoints/types/entrypoint';
+import { useCreateEntrypoint, useDeleteEntrypoint, useUpdateEntrypoint } from '../features/entrypoints/hooks/useEntrypointMutations';
+import type { EntrypointMappingRow, EntrypointTarget } from '../features/entrypoints/types/entrypoint';
 
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
 jest.mock('../features/entrypoints/hooks/useEntrypointConfigurations');
 jest.mock('../features/entrypoints/hooks/useEntrypointMappings');
+jest.mock('../features/entrypoints/hooks/useEntrypointMutations');
 
 jest.mock('../features/entrypoints/components/EntrypointConfigurationSection', () => ({
     EntrypointConfigurationSection: () => <div data-testid="entrypoint-configuration-section" />,
 }));
 
 jest.mock('../features/entrypoints/components/EntrypointMappingsTable', () => ({
+    CreateMappingButton: ({ onCreate }: { onCreate: (target: EntrypointTarget) => void }) => (
+        <button type="button" onClick={() => onCreate('HTTP')}>
+            Add a mapping
+        </button>
+    ),
     EntrypointMappingsTable: ({
         rows,
-        canCreate,
         onOpenDetail,
     }: {
         rows: EntrypointMappingRow[];
         canCreate: boolean;
+        canEdit: boolean;
+        canDelete: boolean;
         onOpenDetail: (row: EntrypointMappingRow) => void;
-        onCreate?: () => void;
+        onCreate?: (target: EntrypointTarget) => void;
     }) => (
         <div>
-            <div data-testid="mappings-can-create">{String(canCreate)}</div>
             {rows.map(row => (
                 <button key={row.id} type="button" onClick={() => onOpenDetail(row)}>
                     Open {row.value}
@@ -62,8 +73,20 @@ jest.mock('../features/entrypoints/components/EntrypointDetailSheet', () => ({
         ) : null,
 }));
 
+jest.mock('../features/entrypoints/components/EntrypointSheet', () => ({
+    EntrypointSheet: () => null,
+}));
+
+jest.mock('../features/entrypoints/components/EntrypointDeleteSheet', () => ({
+    EntrypointDeleteSheet: () => null,
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseEntrypointConfigurations = jest.mocked(useEntrypointConfigurations);
 const mockUseEntrypointMappings = jest.mocked(useEntrypointMappings);
+const mockUseCreateEntrypoint = jest.mocked(useCreateEntrypoint);
+const mockUseUpdateEntrypoint = jest.mocked(useUpdateEntrypoint);
+const mockUseDeleteEntrypoint = jest.mocked(useDeleteEntrypoint);
 
 const STUB_ROWS: EntrypointMappingRow[] = [
     {
@@ -78,8 +101,14 @@ const STUB_ROWS: EntrypointMappingRow[] = [
     },
 ];
 
+const idleMutation = {
+    mutateAsync: jest.fn(),
+    isPending: false,
+} as unknown as ReturnType<typeof useCreateEntrypoint>;
+
 describe('EntrypointsAndShardingTagsPage', () => {
     beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(true);
         mockUseEntrypointConfigurations.mockReturnValue({
             data: { configs: [], failedEnvironmentNames: [] },
             isLoading: false,
@@ -87,10 +116,15 @@ describe('EntrypointsAndShardingTagsPage', () => {
         } as ReturnType<typeof useEntrypointConfigurations>);
         mockUseEntrypointMappings.mockReturnValue({
             rows: STUB_ROWS,
+            tags: [],
+            environments: [],
             isLoading: false,
             isError: false,
             isNameResolutionError: false,
         });
+        mockUseCreateEntrypoint.mockReturnValue(idleMutation);
+        mockUseUpdateEntrypoint.mockReturnValue(idleMutation as ReturnType<typeof useUpdateEntrypoint>);
+        mockUseDeleteEntrypoint.mockReturnValue(idleMutation as ReturnType<typeof useDeleteEntrypoint>);
     });
 
     afterEach(() => {
@@ -104,13 +138,18 @@ describe('EntrypointsAndShardingTagsPage', () => {
         expect(screen.getByText('Entrypoint Mappings')).not.toBeNull();
     });
 
-    it('uses read-only page copy without create CTA', () => {
+    it('shows header create button when user can create and mappings exist', () => {
         render(<EntrypointsAndShardingTagsPage />);
-        expect(
-            screen.getByText(/View entrypoint configuration and mappings used by the Developer Portal based on API sharding tags/),
-        ).not.toBeNull();
+        expect(screen.getByRole('button', { name: /Add a mapping/i })).not.toBeNull();
+    });
+
+    it('hides create button when user lacks create permission', () => {
+        mockUseHasPermission.mockImplementation(options => {
+            const anyOf = 'anyOf' in options ? options.anyOf : [];
+            return anyOf.includes('environment-entrypoint-r') || anyOf.includes('organization-entrypoint-r');
+        });
+        render(<EntrypointsAndShardingTagsPage />);
         expect(screen.queryByRole('button', { name: /Add a mapping/i })).toBeNull();
-        expect(screen.getByTestId('mappings-can-create').textContent).toBe('false');
     });
 
     it('opens detail sheet when a mapping row is selected', () => {
@@ -124,6 +163,8 @@ describe('EntrypointsAndShardingTagsPage', () => {
     it('shows inline error when mappings fail to load', () => {
         mockUseEntrypointMappings.mockReturnValue({
             rows: [],
+            tags: [],
+            environments: [],
             isLoading: false,
             isError: true,
             isNameResolutionError: false,
@@ -132,9 +173,31 @@ describe('EntrypointsAndShardingTagsPage', () => {
         expect(screen.getByText(/Failed to load entrypoint mappings/)).not.toBeNull();
     });
 
+    describe('role-scoped create permission', () => {
+        it('treats organization-entrypoint-c alone as sufficient for create', () => {
+            mockUseHasPermission.mockImplementation(options => {
+                const anyOf = 'anyOf' in options ? options.anyOf : [];
+                return anyOf.includes('organization-entrypoint-c');
+            });
+            render(<EntrypointsAndShardingTagsPage />);
+            expect(screen.getByRole('button', { name: /Add a mapping/i })).not.toBeNull();
+        });
+
+        it('treats environment-entrypoint-c alone as sufficient for create', () => {
+            mockUseHasPermission.mockImplementation(options => {
+                const anyOf = 'anyOf' in options ? options.anyOf : [];
+                return anyOf.includes('environment-entrypoint-c');
+            });
+            render(<EntrypointsAndShardingTagsPage />);
+            expect(screen.getByRole('button', { name: /Add a mapping/i })).not.toBeNull();
+        });
+    });
+
     it('warns when environment or tag name resolution fails', () => {
         mockUseEntrypointMappings.mockReturnValue({
             rows: STUB_ROWS,
+            tags: [],
+            environments: [],
             isLoading: false,
             isError: false,
             isNameResolutionError: true,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EntrypointsAndShardingTagsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EntrypointsAndShardingTagsPage.tsx
@@ -14,29 +14,118 @@
  * limitations under the License.
  */
 
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { Alert, AlertDescription, Card, CardContent, CardDescription, CardHeader, CardTitle, Skeleton } from '@gravitee/graphene-core';
 import { InfoIcon } from '@gravitee/graphene-core/icons';
 import { useState } from 'react';
 
 import { EntrypointConfigurationSection } from '../features/entrypoints/components/EntrypointConfigurationSection';
+import { EntrypointDeleteSheet } from '../features/entrypoints/components/EntrypointDeleteSheet';
 import { EntrypointDetailSheet } from '../features/entrypoints/components/EntrypointDetailSheet';
-import { EntrypointMappingsTable } from '../features/entrypoints/components/EntrypointMappingsTable';
+import { CreateMappingButton, EntrypointMappingsTable } from '../features/entrypoints/components/EntrypointMappingsTable';
+import { EntrypointSheet } from '../features/entrypoints/components/EntrypointSheet';
 import { useEntrypointConfigurations } from '../features/entrypoints/hooks/useEntrypointConfigurations';
 import { useEntrypointMappings } from '../features/entrypoints/hooks/useEntrypointMappings';
-import type { EntrypointMappingRow } from '../features/entrypoints/types/entrypoint';
+import { useCreateEntrypoint, useDeleteEntrypoint, useUpdateEntrypoint } from '../features/entrypoints/hooks/useEntrypointMutations';
+import type {
+    EntrypointMappingRow,
+    EntrypointTarget,
+    NewEntrypointPayload,
+    UpdateEntrypointPayload,
+} from '../features/entrypoints/types/entrypoint';
+import { KAFKA_DOMAIN_PLACEHOLDER } from '../features/entrypoints/utils/entrypointForm';
+import { notify } from '../shared/notify';
+
+type SheetState =
+    | { type: 'closed' }
+    | { type: 'create'; target: EntrypointTarget }
+    | { type: 'edit'; entrypoint: EntrypointMappingRow }
+    | { type: 'delete'; entrypoint: EntrypointMappingRow };
 
 export function EntrypointsAndShardingTagsPage() {
+    const canCreate = useHasPermission({ anyOf: ['environment-entrypoint-c', 'organization-entrypoint-c'] });
+    const canEdit = useHasPermission({ anyOf: ['environment-entrypoint-u', 'organization-entrypoint-u'] });
+    const canDelete = useHasPermission({ anyOf: ['environment-entrypoint-d', 'organization-entrypoint-d'] });
+    const canEditConfig = useHasPermission({ anyOf: ['environment-settings-u'] });
+
     const { data: configurationData, isLoading: isConfigurationLoading, isError: isConfigurationError } = useEntrypointConfigurations();
-    const { rows, isLoading: isMappingsLoading, isError: isMappingsError, isNameResolutionError } = useEntrypointMappings();
+    const {
+        rows,
+        tags,
+        environments,
+        isLoading: isMappingsLoading,
+        isError: isMappingsError,
+        isNameResolutionError,
+    } = useEntrypointMappings();
+
+    const createMutation = useCreateEntrypoint();
+    const updateMutation = useUpdateEntrypoint();
+    const deleteMutation = useDeleteEntrypoint();
 
     const [selected, setSelected] = useState<EntrypointMappingRow | null>(null);
+    const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
+
+    function closeSheet() {
+        setSheet({ type: 'closed' });
+    }
+
+    function openCreate(target: EntrypointTarget) {
+        setSelected(null);
+        setSheet({ type: 'create', target });
+    }
+
+    function openEdit(row: EntrypointMappingRow) {
+        setSelected(null);
+        setSheet({ type: 'edit', entrypoint: row });
+    }
+
+    function openDelete(row: EntrypointMappingRow) {
+        setSelected(null);
+        setSheet({ type: 'delete', entrypoint: row });
+    }
+
+    async function handleCreate(data: NewEntrypointPayload | UpdateEntrypointPayload) {
+        try {
+            await createMutation.mutateAsync(data as NewEntrypointPayload);
+            notify.success('Entrypoint mapping created successfully');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to create entrypoint mapping');
+        }
+    }
+
+    async function handleUpdate(data: NewEntrypointPayload | UpdateEntrypointPayload) {
+        try {
+            await updateMutation.mutateAsync(data as UpdateEntrypointPayload);
+            notify.success('Entrypoint mapping updated successfully');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to update entrypoint mapping');
+        }
+    }
+
+    async function handleDelete() {
+        if (sheet.type !== 'delete') return;
+        try {
+            await deleteMutation.mutateAsync(sheet.entrypoint.id);
+            notify.success('Entrypoint mapping deleted successfully');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to delete entrypoint mapping');
+        }
+    }
+
+    const showMappingsHeaderCreate = canCreate && rows.length > 0;
+    const formTarget = sheet.type === 'create' ? sheet.target : sheet.type === 'edit' ? sheet.entrypoint.target : 'HTTP';
+    const defaultForm =
+        sheet.type === 'create' && sheet.target === 'KAFKA' ? { kafkaDomain: KAFKA_DOMAIN_PLACEHOLDER, kafkaPort: '9092' } : undefined;
 
     return (
         <div className="space-y-6">
             <div className="space-y-1">
                 <h1 className="text-2xl font-semibold tracking-tight">Entrypoints & Sharding Tags</h1>
                 <p className="text-sm text-muted-foreground">
-                    View entrypoint configuration and mappings used by the Developer Portal based on API sharding tags.
+                    Manage sharding tags, entrypoints, and mappings between them both for Console and the Developer Portal.
                 </p>
             </div>
 
@@ -52,6 +141,7 @@ export function EntrypointsAndShardingTagsPage() {
                 failedEnvironmentNames={configurationData?.failedEnvironmentNames ?? []}
                 isLoading={isConfigurationLoading}
                 isError={isConfigurationError}
+                canEdit={canEditConfig}
             />
 
             <Card>
@@ -60,6 +150,7 @@ export function EntrypointsAndShardingTagsPage() {
                         <CardTitle>Entrypoint Mappings</CardTitle>
                         <CardDescription>Entrypoint to be displayed in the Developer Portal if an API has a given tag</CardDescription>
                     </div>
+                    {showMappingsHeaderCreate ? <CreateMappingButton onCreate={openCreate} /> : null}
                 </CardHeader>
                 <CardContent className="space-y-3">
                     {isNameResolutionError && !isMappingsLoading && !isMappingsError ? (
@@ -81,12 +172,48 @@ export function EntrypointsAndShardingTagsPage() {
                             <AlertDescription>Failed to load entrypoint mappings. Please refresh and try again.</AlertDescription>
                         </Alert>
                     ) : (
-                        <EntrypointMappingsTable rows={rows} canCreate={false} onOpenDetail={setSelected} />
+                        <EntrypointMappingsTable
+                            rows={rows}
+                            canCreate={canCreate}
+                            canEdit={canEdit}
+                            canDelete={canDelete}
+                            onOpenDetail={setSelected}
+                            onCreate={canCreate ? openCreate : undefined}
+                            onEdit={canEdit ? openEdit : undefined}
+                            onDelete={canDelete ? openDelete : undefined}
+                        />
                     )}
                 </CardContent>
             </Card>
 
-            <EntrypointDetailSheet entrypoint={selected} onClose={() => setSelected(null)} />
+            <EntrypointDetailSheet
+                entrypoint={selected}
+                canEdit={canEdit}
+                onClose={() => setSelected(null)}
+                onEdit={canEdit ? openEdit : undefined}
+            />
+
+            <EntrypointSheet
+                open={sheet.type === 'create' || sheet.type === 'edit'}
+                mode={sheet.type === 'edit' ? 'edit' : 'create'}
+                target={formTarget}
+                entrypoint={sheet.type === 'edit' ? sheet.entrypoint : undefined}
+                tags={tags}
+                environments={environments}
+                defaultForm={defaultForm}
+                existingRows={rows}
+                onClose={closeSheet}
+                onSubmit={sheet.type === 'edit' ? handleUpdate : handleCreate}
+                isSaving={createMutation.isPending || updateMutation.isPending}
+            />
+
+            <EntrypointDeleteSheet
+                open={sheet.type === 'delete'}
+                entrypoint={sheet.type === 'delete' ? sheet.entrypoint : undefined}
+                onClose={closeSheet}
+                onConfirm={handleDelete}
+                isDeleting={deleteMutation.isPending}
+            />
         </div>
     );
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-37

## Description

Adds create, edit, and delete for Entrypoint Mappings in Gamma Platform, plus editable Entrypoint Configuration defaults with Discard/Save.

- Mapping sheets for HTTP / TCP / Kafka (validation, duplicate check)
- Editable portal defaults (multi-env) with Classic-aligned port/{apiHost} checks
- Tag chips in the mappings table; stacked sheet actions aligned with the prototype


## Additional context


https://github.com/user-attachments/assets/68e5ead7-f192-4672-8330-988610f15bda



