### PR TITLE
refactor(edge)!: rename app route pathPrefix to path with explicit matching semantics (EDGE-20)

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeApp.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeApp.java
@@ -24,7 +24,8 @@ import java.util.List;
  *
  * @param name human-readable application identifier (e.g. {@code Claude Code}, {@code Cursor})
  * @param domains vendor backend hostnames owned by this app, keyed for SNI/DNS interception
- * @param routes path-to-api_path mappings applied to this app's intercepted traffic
+ * @param routes path-to-api_path mappings declaring what this app intercepts; anything they do not match is
+ *               left to its original backend
  * @param format usage-decoder format used to parse token usage from the response
  *               (e.g. {@code anthropic-messages}, {@code openai-chat}), decoupled from the vendor label
  * @param vendor vendor label reported upstream for accounting/attribution, independent of the decoder {@code format}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/RouteMapping.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/RouteMapping.java
@@ -20,7 +20,14 @@ import java.io.Serializable;
 /**
  * Maps an intercepted request path to the gateway api_path it is forwarded to.
  *
- * @param pathPrefix incoming request path prefix that triggers this mapping
+ * <p>Traffic that no route matches is not routed: it is forwarded to its original backend, so an app only
+ * intercepts what it explicitly declares.
+ *
+ * @param path incoming request path that triggers this mapping. A bare path (e.g. {@code /v1/messages}) is an
+ *             exact match, on the path only, query parameters excluded. A path suffixed with {@code *}
+ *             (e.g. {@code /v1/messages*}) is a prefix match, the prefix being the substring before the {@code *}.
+ *             A catch-all route ({@code *} or {@code /*}) explicitly sends all of the app's traffic to its
+ *             {@code apiPath}.
  * @param apiPath gateway api_path the matched traffic is forwarded to
  */
-public record RouteMapping(String pathPrefix, String apiPath) implements Serializable {}
+public record RouteMapping(String path, String apiPath) implements Serializable {}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/v4/edge/EdgeProxyDefinitionTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/v4/edge/EdgeProxyDefinitionTest.java
@@ -58,7 +58,7 @@ class EdgeProxyDefinitionTest {
                 {
                   "name": "Claude Code",
                   "domains": [{ "name": "api.anthropic.com" }],
-                  "routes": [{ "pathPrefix": "/v1/messages", "apiPath": "/anthropic" }],
+                  "routes": [{ "path": "/v1/messages", "apiPath": "/anthropic" }],
                   "format": "anthropic-messages",
                   "vendor": "anthropic"
                 }
@@ -91,7 +91,7 @@ class EdgeProxyDefinitionTest {
                 {
                   "name": "Claude Code",
                   "domains": [{ "name": "api.anthropic.com" }],
-                  "routes": [{ "pathPrefix": "/v1/messages", "apiPath": "/anthropic" }],
+                  "routes": [{ "path": "/v1/messages", "apiPath": "/anthropic" }],
                   "format": "anthropic-messages",
                   "vendor": "anthropic"
                 }
@@ -106,6 +106,48 @@ class EdgeProxyDefinitionTest {
         assertThat(definition.getRoutes()).containsExactly(new EdgeRoute("/v1/messages", "/anthropic", "anthropic"));
         assertThat(definition.getApps()).hasSize(1);
         assertThat(definition.getApps().get(0).name()).isEqualTo("Claude Code");
+    }
+
+    @Test
+    void should_deserialize_the_three_route_path_forms() throws Exception {
+        // Given
+        var json = """
+            {
+              "apps": [
+                {
+                  "name": "Claude Code",
+                  "routes": [
+                    { "path": "/v1/messages", "apiPath": "/anthropic" },
+                    { "path": "/v1/messages*", "apiPath": "/anthropic-all" },
+                    { "path": "*", "apiPath": "/anthropic-catch-all" }
+                  ]
+                }
+              ]
+            }""";
+
+        // When
+        var definition = objectMapper.readValue(json, EdgeProxyDefinition.class);
+
+        // Then
+        assertThat(definition.getApps().get(0).routes()).containsExactly(
+            new RouteMapping("/v1/messages", "/anthropic"),
+            new RouteMapping("/v1/messages*", "/anthropic-all"),
+            new RouteMapping("*", "/anthropic-catch-all")
+        );
+    }
+
+    @Test
+    void should_serialize_app_route_path_under_the_path_property() throws Exception {
+        // Given
+        var definition = EdgeProxyDefinition.builder()
+            .apps(List.of(new EdgeApp("Claude Code", null, List.of(new RouteMapping("/v1/messages", "/anthropic")), null, null)))
+            .build();
+
+        // When
+        var json = objectMapper.writeValueAsString(definition);
+
+        // Then
+        assertThat(json).contains("\"path\":\"/v1/messages\"").doesNotContain("pathPrefix");
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EDGE-20

## Description

Renames the app-centric route field `pathPrefix` to `path` in the v4 edge definition model (`io.gravitee.definition.model.v4.edge.RouteMapping`), and documents the matching semantics that go with it.

A mapped route is no longer a blind capture of everything beneath a prefix:

- a bare path (`/v1/messages`) is an **exact match**, on the path only, query parameters excluded
- a path suffixed with `*` (`/v1/messages*`) is a **prefix match**, the prefix being the substring before the `*`
- a catch-all route (`*` or `/*`) explicitly sends **all** of the app's traffic to its `apiPath`
- anything no route matches is **not routed**: the daemon forwards it to its original backend

This is what lets `/v1/messages/count_tokens` reach Anthropic untouched instead of being captured by the `/v1/messages` route and failing in the LLM proxy.

The legacy flat model (`EdgeProxyDefinition.dnsDomains` / `routes`, `EdgeRoute`) is untouched and keeps `pathPrefix`.

## Additional context

**Breaking change**: no `@JsonAlias` was added, so a stored definition using `pathPrefix` under `apps[].routes[]` deserializes to `path = null`. This is deliberate: the app-centric model landed days ago in #18625 (EDGE-58) and its consumers are still on SNAPSHOTs, so no durable definition depends on the old name. Keeping the alias would also have silently reinterpreted stored prefix routes as exact ones.

`RouteMapping` stays a pure data record: the matching itself (most-specific-wins, passthrough, dropping the manual `count_tokens` workaround route) lives in `gravitee-gamma-edge-daemon` and is not part of this PR. `gravitee-gamma-module-edge` and `gravitee-reactor-edge` need to follow the rename once this merges.

## Test plan

- `EdgeProxyDefinitionTest` covers the three `path` forms on deserialization, serialization under the `path` property, and the unchanged legacy flat payloads: 6/6 green
- `gravitee-apim-definition-model` compiles (main + test); a repo-wide search confirms no other module referenced the renamed field
