### PR TITLE
feat(cluster): server-side lifecycle-state filter + /clusters/_stats counts

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ClusterCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ClusterCriteria.java
@@ -28,5 +28,6 @@ public class ClusterCriteria {
     private String environmentId;
     private List<String> ids;
     private String type;
+    private List<String> lifecycleStates;
     private String query;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClusterRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClusterRepository.java
@@ -163,6 +163,11 @@ public class JdbcClusterRepository extends JdbcAbstractCrudRepository<Cluster, S
             andWhereParams.add(criteria.getType());
         }
 
+        if (!CollectionUtils.isEmpty(criteria.getLifecycleStates())) {
+            andWhere.add("lifecycle_state in (" + getOrm().buildInClause(criteria.getLifecycleStates()) + ")");
+            andWhereParams.addAll(criteria.getLifecycleStates());
+        }
+
         if (criteria.getQuery() != null) {
             andWhere.add("((lower(name) like ?) OR (lower(description) like ?))");
             andWhereParams.add("%" + criteria.getQuery().toLowerCase() + "%");

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/08_backfill_cluster_lifecycle_state.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/08_backfill_cluster_lifecycle_state.yml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_08_backfill_cluster_lifecycle_state
+      author: GraviteeSource Team
+      changes:
+        # Clusters created before the lifecycle_state column existed (added nullable in 4.12) have a NULL
+        # state. The domain layer reads NULL as UNDEPLOYED, but the server-side lifecycleState filter and
+        # the /clusters/_stats counts query the column directly, so a NULL row would neither match the
+        # Undeployed facet nor be counted. Backfill so the pushdown stays consistent with the read model.
+        - update:
+            tableName: ${gravitee_prefix}clusters
+            columns:
+              - column:
+                  name: lifecycle_state
+                  value: UNDEPLOYED
+            where: lifecycle_state IS NULL

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -401,3 +401,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_13_0/06_add_idp_claims_to_users.yml
     - include:
         - file: liquibase/changelogs/v4_13_0/07_add_api_product_id_to_portal_navigation_items.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/08_backfill_cluster_lifecycle_state.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/clusters/ClusterMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/clusters/ClusterMongoRepositoryImpl.java
@@ -58,6 +58,10 @@ public class ClusterMongoRepositoryImpl implements ClusterMongoRepositoryCustom 
             query.addCriteria(where("type").is(criteria.getType()));
         }
 
+        if (!CollectionUtils.isEmpty(criteria.getLifecycleStates())) {
+            query.addCriteria(where("lifecycleState").in(criteria.getLifecycleStates()));
+        }
+
         if (criteria.getQuery() != null) {
             query.addCriteria(
                 new Criteria().orOperator(

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/clusters/ClusterLifecycleStateUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/clusters/ClusterLifecycleStateUpgrader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.clusters;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.themes.ThemeTypeUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Backfills the cluster {@code lifecycleState} for documents created before the field existed. The read
+ * model coerces a missing/null value to {@code UNDEPLOYED}, but the server-side lifecycleState filter and
+ * the {@code /clusters/_stats} counts query the field directly — so a null document would neither match
+ * the Undeployed facet nor be counted. Setting it makes the pushdown consistent with the read model.
+ */
+@Component
+public class ClusterLifecycleStateUpgrader extends MongoUpgrader {
+
+    public static final int CLUSTER_LIFECYCLE_STATE_UPGRADER_ORDER = ThemeTypeUpgrader.THEME_TYPE_UPGRADER_ORDER + 1;
+
+    @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
+    public boolean upgrade() {
+        // Filters.eq(field, null) matches documents where the field is null or absent.
+        getCollection("clusters").updateMany(Filters.eq("lifecycleState", null), Updates.set("lifecycleState", "UNDEPLOYED"));
+        return true;
+    }
+
+    @Override
+    public int getOrder() {
+        return CLUSTER_LIFECYCLE_STATE_UPGRADER_ORDER;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClusterRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClusterRepositoryTest.java
@@ -223,6 +223,25 @@ public class ClusterRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void search_by_lifecycle_state_criteria() {
+        ClusterCriteria criteria = ClusterCriteria.builder().environmentId("env-1").lifecycleStates(List.of("DEPLOYED")).build();
+        Pageable pageable = new PageableBuilder().pageNumber(0).pageSize(10).build();
+        Page<Cluster> clusters = clusterRepository.search(criteria, pageable, Optional.empty());
+        assertAll(
+            () -> assertThat(clusters.getTotalElements()).isEqualTo(1),
+            () -> assertThat(clusters.getContent().stream().map(Cluster::getName).toList()).isEqualTo(List.of("cluster-1"))
+        );
+    }
+
+    @Test
+    public void search_by_lifecycle_state_criteria_returns_empty_when_no_match() {
+        ClusterCriteria criteria = ClusterCriteria.builder().environmentId("env-1").lifecycleStates(List.of("UNDEPLOYED")).build();
+        Pageable pageable = new PageableBuilder().pageNumber(0).pageSize(10).build();
+        Page<Cluster> clusters = clusterRepository.search(criteria, pageable, Optional.empty());
+        assertThat(clusters.getContent()).isEmpty();
+    }
+
+    @Test
     public void search_by_description_in_query_criteria() {
         ClusterCriteria criteria = ClusterCriteria.builder().environmentId("env-2").query("the cluster no 4").build();
         Pageable pageable = new PageableBuilder().pageNumber(0).pageSize(3).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResource.java
@@ -18,13 +18,16 @@ package io.gravitee.rest.api.management.v2.rest.resource.cluster;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.cluster.domain_service.ClusterConfigurationSchemaService;
+import io.gravitee.apim.core.cluster.model.ClusterLifecycleState;
 import io.gravitee.apim.core.cluster.model.DeployedCluster;
+import io.gravitee.apim.core.cluster.use_case.CountClustersByLifecycleStateUseCase;
 import io.gravitee.apim.core.cluster.use_case.CreateClusterUseCase;
 import io.gravitee.apim.core.cluster.use_case.GetDeployedClustersUseCase;
 import io.gravitee.apim.core.cluster.use_case.SearchClusterUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.cluster.ClusterType;
 import io.gravitee.rest.api.management.v2.rest.mapper.ClusterMapper;
+import io.gravitee.rest.api.management.v2.rest.model.ClusterLifecycleStateStats;
 import io.gravitee.rest.api.management.v2.rest.model.ClustersResponse;
 import io.gravitee.rest.api.management.v2.rest.model.CreateCluster;
 import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
@@ -70,6 +73,9 @@ public class ClustersResource extends AbstractResource {
     @Inject
     private GetDeployedClustersUseCase getDeployedClustersUseCase;
 
+    @Inject
+    private CountClustersByLifecycleStateUseCase countClustersByLifecycleStateUseCase;
+
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
@@ -103,21 +109,23 @@ public class ClustersResource extends AbstractResource {
     public ClustersResponse searchClusters(
         @QueryParam("q") String q,
         @QueryParam("type") ClusterType type,
+        @QueryParam("lifecycleState") List<ClusterLifecycleState> lifecycleStates,
         @BeanParam @Valid PaginationParam paginationParam,
         @QueryParam("sortBy") String sortBy
     ) {
         var executionContext = GraviteeContext.getExecutionContext();
 
         SearchClusterUseCase.Output result = searchClusterUseCase.execute(
-            new SearchClusterUseCase.Input(
-                executionContext.getEnvironmentId(),
-                type,
-                q,
-                paginationParam.toPageable(),
-                sortBy,
-                isAdmin(),
-                getAuthenticatedUser()
-            )
+            SearchClusterUseCase.Input.builder()
+                .environmentId(executionContext.getEnvironmentId())
+                .type(type)
+                .lifecycleStates(lifecycleStates == null ? null : lifecycleStates.stream().map(Enum::name).toList())
+                .query(q)
+                .pageable(paginationParam.toPageable())
+                .sortBy(sortBy)
+                .isAdmin(isAdmin())
+                .userId(getAuthenticatedUser())
+                .build()
         );
 
         return new ClustersResponse()
@@ -130,6 +138,22 @@ public class ClustersResource extends AbstractResource {
                 )
             )
             .links(computePaginationLinks(result.pageResult().getTotalElements(), paginationParam));
+    }
+
+    @GET
+    @Path("_stats")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CLUSTER, acls = { RolePermissionAction.READ }) })
+    public ClusterLifecycleStateStats getClusterLifecycleStateStats(@QueryParam("type") ClusterType type) {
+        var executionContext = GraviteeContext.getExecutionContext();
+        var result = countClustersByLifecycleStateUseCase.execute(
+            new CountClustersByLifecycleStateUseCase.Input(executionContext.getEnvironmentId(), type, isAdmin(), getAuthenticatedUser())
+        );
+        return new ClusterLifecycleStateStats()
+            .total(result.total())
+            .deployed(result.deployed())
+            .pending(result.pending())
+            .undeployed(result.undeployed());
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/kafka_console/ProxyKafkaConsoleResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/kafka_console/ProxyKafkaConsoleResource.java
@@ -281,15 +281,13 @@ public class ProxyKafkaConsoleResource extends AbstractResource {
         // Get available clusters for current user
         var executionContext = GraviteeContext.getExecutionContext();
         SearchClusterUseCase.Output result = searchClusterUseCase.execute(
-            new SearchClusterUseCase.Input(
-                executionContext.getEnvironmentId(),
-                null,
-                null,
-                new PageableImpl(1, 1000),
-                "name",
-                isAdmin(),
-                getAuthenticatedUser()
-            )
+            SearchClusterUseCase.Input.builder()
+                .environmentId(executionContext.getEnvironmentId())
+                .pageable(new PageableImpl(1, 1000))
+                .sortBy("name")
+                .isAdmin(isAdmin())
+                .userId(getAuthenticatedUser())
+                .build()
         );
         List<String> listOfAvailableClusters = result.pageResult().getContent().stream().map(Cluster::getName).toList();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -517,9 +517,31 @@ paths:
         - $ref: "#/components/parameters/clusterSortByParam"
         - $ref: "#/components/parameters/clusterSearchParam"
         - $ref: "#/components/parameters/clusterTypeParam"
+        - $ref: "#/components/parameters/clusterLifecycleStateParam"
       responses:
         "200":
           $ref: "#/components/responses/ClustersResponse"
+        default:
+          $ref: "#/components/responses/Error"
+  /clusters/_stats:
+    get:
+      tags:
+        - Clusters
+      summary: Count clusters by lifecycle state
+      description: |-
+        Returns the total number of clusters and the count per lifecycle state (Deployed / Pending /
+        Undeployed) for the environment, optionally scoped to a cluster type — the numbers behind the
+        console cluster stat-strip. User must have the ENVIRONMENT_CLUSTER[READ] permission.
+      operationId: getClusterLifecycleStateStats
+      parameters:
+        - $ref: "#/components/parameters/clusterTypeParam"
+      responses:
+        "200":
+          description: Cluster counts by lifecycle state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClusterLifecycleStateStats"
         default:
           $ref: "#/components/responses/Error"
   /clusters/{clusterId}:
@@ -1565,6 +1587,26 @@ components:
     ClusterType:
       type: string
       enum: [ KAFKA_CLUSTER_STANDALONE, KAFKA_CLUSTER, KAFKA_VIRTUAL_CLUSTER ]
+    ClusterLifecycleStateStats:
+      type: object
+      description: Cluster counts by lifecycle state for the environment (optionally scoped to a type).
+      properties:
+        total:
+          type: integer
+          format: int64
+          description: Total number of clusters.
+        deployed:
+          type: integer
+          format: int64
+          description: Number of clusters in the DEPLOYED state.
+        pending:
+          type: integer
+          format: int64
+          description: Number of clusters in the PENDING state.
+        undeployed:
+          type: integer
+          format: int64
+          description: Number of clusters in the UNDEPLOYED state.
     CreateCluster:
       type: object
       properties:
@@ -2901,6 +2943,18 @@ components:
         Filter clusters by type.
       schema:
         $ref: "#/components/schemas/ClusterType"
+
+    clusterLifecycleStateParam:
+      name: lifecycleState
+      in: query
+      required: false
+      description: |-
+        Filter clusters by lifecycle state. Repeat the parameter to match several states.
+      schema:
+        type: array
+        items:
+          type: string
+          enum: [ UNDEPLOYED, DEPLOYED, PENDING ]
 
     # Instances
     instanceId:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResourceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.DeployedCluster;
+import io.gravitee.apim.core.cluster.use_case.CountClustersByLifecycleStateUseCase;
 import io.gravitee.apim.core.cluster.use_case.CreateClusterUseCase;
 import io.gravitee.apim.core.cluster.use_case.GetDeployedClustersUseCase;
 import io.gravitee.apim.core.cluster.use_case.SearchClusterUseCase;
@@ -65,6 +66,9 @@ class ClustersResourceTest extends AbstractResourceTest {
 
     @Inject
     private GetDeployedClustersUseCase getDeployedClustersUseCase;
+
+    @Inject
+    private CountClustersByLifecycleStateUseCase countClustersByLifecycleStateUseCase;
 
     @Override
     protected String contextPath() {
@@ -250,6 +254,35 @@ class ClustersResourceTest extends AbstractResourceTest {
         @Test
         public void should_return_403_if_incorrect_permissions() {
             shouldReturn403(RolePermission.ENVIRONMENT_CLUSTER, ENV_ID, RolePermissionAction.READ, () -> rootTarget().request().get());
+        }
+    }
+
+    @Nested
+    class ClusterStatsTest {
+
+        @Test
+        void should_return_lifecycle_state_stats() {
+            when(countClustersByLifecycleStateUseCase.execute(any())).thenReturn(
+                new CountClustersByLifecycleStateUseCase.Output(17, 12, 2, 3)
+            );
+
+            final Response response = rootTarget().path("_stats").request().get();
+
+            assertThat(response.getStatus()).isEqualTo(OK_200);
+            var stats = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.ClusterLifecycleStateStats.class);
+            assertAll(
+                () -> assertThat(stats.getTotal()).isEqualTo(17L),
+                () -> assertThat(stats.getDeployed()).isEqualTo(12L),
+                () -> assertThat(stats.getPending()).isEqualTo(2L),
+                () -> assertThat(stats.getUndeployed()).isEqualTo(3L)
+            );
+        }
+
+        @Test
+        public void should_return_403_if_incorrect_permissions() {
+            shouldReturn403(RolePermission.ENVIRONMENT_CLUSTER, ENV_ID, RolePermissionAction.READ, () ->
+                rootTarget().path("_stats").request().get()
+            );
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -116,6 +116,7 @@ import io.gravitee.apim.core.audit.query_service.AuditMetadataQueryService;
 import io.gravitee.apim.core.audit.query_service.AuditQueryService;
 import io.gravitee.apim.core.category.domain_service.ValidateCategoryIdsDomainService;
 import io.gravitee.apim.core.cluster.domain_service.ClusterConfigurationSchemaService;
+import io.gravitee.apim.core.cluster.use_case.CountClustersByLifecycleStateUseCase;
 import io.gravitee.apim.core.cluster.use_case.CreateClusterUseCase;
 import io.gravitee.apim.core.cluster.use_case.DeleteClusterUseCase;
 import io.gravitee.apim.core.cluster.use_case.DeployClusterUseCase;
@@ -1144,6 +1145,11 @@ public class ResourceContextConfiguration {
     @Bean
     public SearchClusterUseCase searchClusterUseCase() {
         return mock(SearchClusterUseCase.class);
+    }
+
+    @Bean
+    public CountClustersByLifecycleStateUseCase countClustersByLifecycleStateUseCase() {
+        return mock(CountClustersByLifecycleStateUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/ClusterSearchCriteria.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/ClusterSearchCriteria.java
@@ -27,5 +27,6 @@ public class ClusterSearchCriteria {
     private String environmentId;
     private List<String> ids;
     private ClusterType type;
+    private List<String> lifecycleStates;
     private String query;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/CountClustersByLifecycleStateUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/CountClustersByLifecycleStateUseCase.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.cluster.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.cluster.model.ClusterLifecycleState;
+import io.gravitee.apim.core.cluster.model.ClusterSearchCriteria;
+import io.gravitee.apim.core.cluster.query_service.ClusterQueryService;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
+import io.gravitee.definition.model.cluster.ClusterType;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import java.util.List;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+/**
+ * Counts the environment's clusters by lifecycle state — the numbers behind the console's cluster
+ * stat-strip (Total / Deployed / Pending / Undeployed). Kept independent of the search text and the
+ * lifecycle facet: it always reports the whole (type-scoped, membership-visible) inventory so the
+ * strip stays correct even when the list is paginated and filtered server-side.
+ *
+ * <p>Reuses the existing {@code search} + {@code lifecycleState} filter (one count query per bucket)
+ * rather than a bespoke aggregation, so there is nothing new to keep in sync in the repositories.
+ */
+@AllArgsConstructor
+@UseCase
+public class CountClustersByLifecycleStateUseCase {
+
+    private final ClusterQueryService clusterQueryService;
+    private final MembershipQueryService membershipQueryService;
+
+    @Builder
+    public record Input(String environmentId, ClusterType type, boolean isAdmin, String userId) {}
+
+    public record Output(long total, long deployed, long pending, long undeployed) {}
+
+    public Output execute(Input input) {
+        List<String> readableIds = null;
+        if (!input.isAdmin()) {
+            var clustersIdsUserCanRead = membershipQueryService.findClustersIdsThatUserBelongsTo(input.userId());
+            if (clustersIdsUserCanRead.isEmpty()) {
+                // The user is a member of no cluster — nothing to count.
+                return new Output(0, 0, 0, 0);
+            }
+            readableIds = clustersIdsUserCanRead;
+        }
+
+        return new Output(
+            count(input, readableIds, null),
+            count(input, readableIds, List.of(ClusterLifecycleState.DEPLOYED.name())),
+            count(input, readableIds, List.of(ClusterLifecycleState.PENDING.name())),
+            count(input, readableIds, List.of(ClusterLifecycleState.UNDEPLOYED.name()))
+        );
+    }
+
+    private long count(Input input, List<String> ids, List<String> lifecycleStates) {
+        var criteria = ClusterSearchCriteria.builder()
+            .environmentId(input.environmentId())
+            .type(input.type())
+            .ids(ids)
+            .lifecycleStates(lifecycleStates)
+            .build();
+        // pageSize 1 — only the total count is read, the page content is ignored
+        return clusterQueryService.search(criteria, new PageableImpl(1, 1), Optional.empty()).getTotalElements();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/SearchClusterUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/SearchClusterUseCase.java
@@ -30,6 +30,7 @@ import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,6 +47,7 @@ public class SearchClusterUseCase {
     public record Input(
         String environmentId,
         ClusterType type,
+        List<String> lifecycleStates,
         String query,
         Pageable pageable,
         String sortBy,
@@ -71,6 +73,10 @@ public class SearchClusterUseCase {
 
         if (input.type != null) {
             criteriaBuilder.type(input.type);
+        }
+
+        if (input.lifecycleStates != null && !input.lifecycleStates.isEmpty()) {
+            criteriaBuilder.lifecycleStates(input.lifecycleStates);
         }
 
         if (input.query != null && !input.query.isBlank()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClusterQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClusterQueryServiceInMemory.java
@@ -70,6 +70,12 @@ public class ClusterQueryServiceInMemory extends AbstractQueryServiceInMemory<Cl
             stream = stream.filter(cluster -> criteria.getType().equals(cluster.getType()));
         }
 
+        if (CollectionUtils.isNotEmpty(criteria.getLifecycleStates())) {
+            stream = stream.filter(
+                cluster -> cluster.getLifecycleState() != null && criteria.getLifecycleStates().contains(cluster.getLifecycleState().name())
+            );
+        }
+
         if (criteria.getQuery() != null && !criteria.getQuery().isBlank()) {
             stream = stream.filter(
                 cluster ->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/CountClustersByLifecycleStateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/CountClustersByLifecycleStateUseCaseTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.cluster.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import inmemory.ClusterQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.apim.core.cluster.model.ClusterLifecycleState;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.definition.model.cluster.ClusterType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CountClustersByLifecycleStateUseCaseTest {
+
+    private static final String ENV_ID = "env-1";
+
+    private final ClusterQueryServiceInMemory clusterQueryService = new ClusterQueryServiceInMemory();
+    private final MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
+    private CountClustersByLifecycleStateUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new CountClustersByLifecycleStateUseCase(clusterQueryService, membershipQueryService);
+        clusterQueryService.initWith(
+            List.of(
+                cluster("c1", ClusterType.KAFKA_CLUSTER, ClusterLifecycleState.DEPLOYED),
+                cluster("c2", ClusterType.KAFKA_CLUSTER, ClusterLifecycleState.DEPLOYED),
+                cluster("c3", ClusterType.KAFKA_CLUSTER, ClusterLifecycleState.PENDING),
+                cluster("c4", ClusterType.KAFKA_CLUSTER, ClusterLifecycleState.UNDEPLOYED),
+                cluster("v1", ClusterType.KAFKA_VIRTUAL_CLUSTER, ClusterLifecycleState.DEPLOYED)
+            )
+        );
+    }
+
+    @Test
+    void should_count_all_by_state_for_admin() {
+        var out = useCase.execute(new CountClustersByLifecycleStateUseCase.Input(ENV_ID, null, true, "admin"));
+        assertAll(
+            () -> assertThat(out.total()).isEqualTo(5),
+            () -> assertThat(out.deployed()).isEqualTo(3),
+            () -> assertThat(out.pending()).isEqualTo(1),
+            () -> assertThat(out.undeployed()).isEqualTo(1)
+        );
+    }
+
+    @Test
+    void should_scope_counts_by_type() {
+        var out = useCase.execute(new CountClustersByLifecycleStateUseCase.Input(ENV_ID, ClusterType.KAFKA_CLUSTER, true, "admin"));
+        assertAll(
+            () -> assertThat(out.total()).isEqualTo(4),
+            () -> assertThat(out.deployed()).isEqualTo(2),
+            () -> assertThat(out.pending()).isEqualTo(1),
+            () -> assertThat(out.undeployed()).isEqualTo(1)
+        );
+    }
+
+    @Test
+    void should_return_zero_for_non_admin_without_membership() {
+        var out = useCase.execute(new CountClustersByLifecycleStateUseCase.Input(ENV_ID, null, false, "nobody"));
+        assertThat(out.total()).isZero();
+    }
+
+    @Test
+    void should_count_only_visible_clusters_for_non_admin() {
+        membershipQueryService.initWith(List.of(clusterMembership("member-1", "c1"), clusterMembership("member-1", "c3")));
+
+        var out = useCase.execute(new CountClustersByLifecycleStateUseCase.Input(ENV_ID, null, false, "member-1"));
+
+        assertAll(
+            () -> assertThat(out.total()).isEqualTo(2),
+            () -> assertThat(out.deployed()).isEqualTo(1), // c1
+            () -> assertThat(out.pending()).isEqualTo(1), // c3
+            () -> assertThat(out.undeployed()).isZero()
+        );
+    }
+
+    private static Cluster cluster(String id, ClusterType type, ClusterLifecycleState lifecycleState) {
+        return Cluster.builder()
+            .id(id)
+            .name(id)
+            .environmentId(ENV_ID)
+            .organizationId("org-1")
+            .type(type)
+            .lifecycleState(lifecycleState)
+            .build();
+    }
+
+    private static Membership clusterMembership(String userId, String clusterId) {
+        return Membership.builder()
+            .referenceId(clusterId)
+            .referenceType(Membership.ReferenceType.CLUSTER)
+            .memberType(Membership.Type.USER)
+            .memberId(userId)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/SearchClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/SearchClusterUseCaseTest.java
@@ -55,7 +55,7 @@ class SearchClusterUseCaseTest extends AbstractUseCaseTest {
     @Test
     void should_search_admin_no_pageable_no_sort_by() {
         // When
-        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, null, null, true, "admin"));
+        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, null, null, null, true, "admin"));
         // Then
         assertAll(
             () -> assertThat(result.pageResult().getPageNumber()).isEqualTo(1),
@@ -71,7 +71,7 @@ class SearchClusterUseCaseTest extends AbstractUseCaseTest {
     @Test
     void should_search_not_admin_no_pageable_no_sort_by() {
         // When
-        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, null, null, false, "member-1"));
+        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, null, null, null, false, "member-1"));
         // Then
         assertAll(
             () -> assertThat(result.pageResult().getPageNumber()).isEqualTo(1),
@@ -87,7 +87,9 @@ class SearchClusterUseCaseTest extends AbstractUseCaseTest {
     @Test
     void sould_search_not_admin_no_membership_no_pageable_no_sort_by() {
         // When
-        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, null, null, false, "unknown-member"));
+        var result = searchClusterUseCase.execute(
+            new SearchClusterUseCase.Input(ENV_ID, null, null, null, null, null, false, "unknown-member")
+        );
         // Then
         assertAll(
             () -> assertThat(result.pageResult().getPageNumber()).isEqualTo(1),
@@ -101,7 +103,7 @@ class SearchClusterUseCaseTest extends AbstractUseCaseTest {
     void should_search_admin_with_pageable_no_sort_by() {
         Pageable pageable = new PageableImpl(2, 5);
         // When
-        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, pageable, null, true, "admin"));
+        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, null, pageable, null, true, "admin"));
         // Then
         assertAll(
             () -> assertThat(result.pageResult().getPageNumber()).isEqualTo(2),
@@ -118,7 +120,7 @@ class SearchClusterUseCaseTest extends AbstractUseCaseTest {
     void should_search_admin_no_pageable_with_sort_by() {
         String sortBy = "id";
         // When
-        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, null, sortBy, true, "admin"));
+        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, null, null, sortBy, true, "admin"));
         // Then
         assertAll(
             () -> assertThat(result.pageResult().getPageNumber()).isEqualTo(1),
@@ -136,7 +138,9 @@ class SearchClusterUseCaseTest extends AbstractUseCaseTest {
         Pageable pageable = new PageableImpl(2, 5);
         String sortBy = "id";
         // When
-        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, pageable, sortBy, true, "admin"));
+        var result = searchClusterUseCase.execute(
+            new SearchClusterUseCase.Input(ENV_ID, null, null, null, pageable, sortBy, true, "admin")
+        );
         // Then
         assertAll(
             () -> assertThat(result.pageResult().getPageNumber()).isEqualTo(2),
@@ -154,7 +158,7 @@ class SearchClusterUseCaseTest extends AbstractUseCaseTest {
         Pageable pageable = new PageableImpl(1, 10);
         String query = "Cluster 1";
         // When
-        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, query, pageable, null, true, "admin"));
+        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, query, pageable, null, true, "admin"));
         // Then
         assertAll(
             () -> assertThat(result.pageResult().getPageNumber()).isEqualTo(1),
@@ -181,7 +185,7 @@ class SearchClusterUseCaseTest extends AbstractUseCaseTest {
                 )
             )
             .thenReturn(false);
-        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, null, null, false, "member-2"));
+        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, null, null, null, false, "member-2"));
         // Then
         assertAll(
             () -> assertThat(result.pageResult().getTotalElements()).isEqualTo(1),
@@ -204,7 +208,7 @@ class SearchClusterUseCaseTest extends AbstractUseCaseTest {
                 )
             )
             .thenReturn(true);
-        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, null, null, false, "member-1"));
+        var result = searchClusterUseCase.execute(new SearchClusterUseCase.Input(ENV_ID, null, null, null, null, null, false, "member-1"));
         // Then
         assertAll(
             () -> assertThat(result.pageResult().getTotalElements()).isEqualTo(3),
@@ -254,7 +258,7 @@ class SearchClusterUseCaseTest extends AbstractUseCaseTest {
     void should_search_by_type_kafka_cluster() {
         Pageable pageable = new PageableImpl(1, 10);
         var result = searchClusterUseCase.execute(
-            new SearchClusterUseCase.Input(ENV_ID, ClusterType.KAFKA_CLUSTER, null, pageable, null, true, "admin")
+            new SearchClusterUseCase.Input(ENV_ID, ClusterType.KAFKA_CLUSTER, null, null, pageable, null, true, "admin")
         );
         assertAll(
             () -> assertThat(result.pageResult().getTotalElements()).isEqualTo(2),


### PR DESCRIPTION
## Description

Adds the server-side pieces the Gamma ESM clusters landing needs (drop the client-side `perPage: 100`
cap; resolve search / filter / pagination / stat-strip on the backend). Two additions to the shared v2
clusters API, plus repository coverage.

### 1. Filter the clusters search by lifecycle state
`GET /clusters` gains a repeatable `lifecycleState` query param (bound to the `ClusterLifecycleState`
enum → proper 400 on garbage), threaded through `SearchClusterUseCase` → core `ClusterSearchCriteria` →
repository `ClusterCriteria` (MapStruct maps it by name) → Mongo (`where lifecycleState in`) and JDBC
(`lifecycle_state in (?)`). OpenAPI updated.

### 2. `GET /clusters/_stats` — counts by lifecycle state
New `CountClustersByLifecycleStateUseCase` returns the total plus per-state counts (Deployed / Pending /
Undeployed), optionally scoped to a `type` and restricted to the caller's readable clusters. Reuses the
existing search + lifecycleState filter (one count query per bucket) — no bespoke aggregation to keep in
sync across Mongo/JDBC. Backs the console cluster stat-strip.

## Review follow-ups (all addressed)

- **🔴 Blocking — legacy `NULL lifecycle_state` rows.** Pre-4.12 clusters have a NULL state; the read
  model coerces it to `UNDEPLOYED` but the pushdown filter/counts query the column directly, so a NULL
  cluster would vanish under the Undeployed facet and `_stats` would report `total != sum`. **Fixed by
  backfilling** `NULL → UNDEPLOYED`: a new JDBC Liquibase changeset + a new Mongo upgrader. The pushdown
  is now consistent with the read model.
- **No REST test for `_stats`** → added `ClusterStatsTest` (mapped counts + `ENVIRONMENT_CLUSTER[READ]`
  gate) and registered the use case as a mock bean in `ResourceContextConfiguration`.
- **`_stats` runs 4 queries** — kept the separate `total` (`count(*)`) query as a deliberate defensive
  measure so the strip stays honest even if a row ever falls outside the three buckets; it is now
  redundant-but-correct after the backfill.
- **8 positional args on `SearchClusterUseCase.Input`** → both call sites now use the `@Builder`.
- **enum validation / single source of truth / import cleanup** (earlier round) — done.

## Tests

- Repository: `ClusterRepositoryTest` — lifecycleState filter (match / no-match), run against **Mongo (16)**
  and **JDBC (16)**; the backfill changeset + Mongo upgrader run in setup without breaking fixtures.
- Use case: `CountClustersByLifecycleStateUseCase` (4), `SearchClusterUseCase` (10).
- REST: `ClustersResourceTest` incl. `ClusterStatsTest` (13 total).

## Notes

- No schema migration for the column (it already exists) — only a data backfill.
- Consumer: the Gamma ESM module PR wires `ClustersPage` to these (`useClusters({ lifecycleState })` +
  `useClusterStats` → `/clusters/_stats`). This PR is the backend half.
