### PR TITLE
fix (observability): update relative time range on refresh.

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-filters.store.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-filters.store.spec.ts
@@ -17,6 +17,7 @@ import { FilterCondition } from '@gravitee/gravitee-dashboard';
 
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
+import moment from 'moment';
 import { Subject } from 'rxjs';
 
 import { DashboardFiltersStore } from './dashboard-filters.store';
@@ -94,6 +95,41 @@ describe('DashboardFiltersStore', () => {
     expect(store.refreshToken()).toBe(0);
     store.refresh();
     expect(store.refreshToken()).toBe(1);
+  });
+
+  it('should re-anchor relative timeRange on refresh', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-01T12:00:00.000Z'));
+
+    store.periodControl.setValue({ period: '1h', from: null, to: null });
+    const before = store.timeRange();
+    expect(before.to).toBe('2026-01-01T12:00:00.000Z');
+    expect(before.from).toBe('2026-01-01T11:00:00.000Z');
+
+    jest.setSystemTime(new Date('2026-01-01T12:30:00.000Z'));
+    store.refresh();
+
+    const after = store.timeRange();
+    expect(store.refreshToken()).toBe(1);
+    expect(after.to).toBe('2026-01-01T12:30:00.000Z');
+    expect(after.from).toBe('2026-01-01T11:30:00.000Z');
+
+    jest.useRealTimers();
+  });
+
+  it('should keep custom timeRange bounds on refresh while bumping refreshToken', () => {
+    const from = moment('2026-01-01T10:00:00.000Z');
+    const to = moment('2026-01-01T11:00:00.000Z');
+    store.periodControl.setValue({ period: 'custom', from, to });
+
+    const before = store.timeRange();
+    store.refresh();
+    const after = store.timeRange();
+
+    expect(store.refreshToken()).toBe(1);
+    expect(after).toEqual(before);
+    expect(after.from).toBe('2026-01-01T10:00:00.000Z');
+    expect(after.to).toBe('2026-01-01T11:00:00.000Z');
   });
 
   it('should expose timeRange as ISO strings', () => {

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-filters.store.ts
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-filters.store.ts
@@ -63,6 +63,13 @@ export class DashboardFiltersStore {
   private readonly _refreshToken = signal(0);
   readonly refreshToken = this._refreshToken.asReadonly();
 
+  /**
+   * Bumped on refresh so relative `timeRange` / `interval` recompute against
+   * "now". Without this, refresh reuses the bounds from the last period
+   * selection and dashboards show stale stats.
+   */
+  private readonly _clockToken = signal(0);
+
   private _skipNextQueryParamsEmit = false;
   private labelResolutionSubscription?: Subscription;
   private labelResolutionGeneration = 0;
@@ -83,6 +90,7 @@ export class DashboardFiltersStore {
   private readonly _periodValue = signal<TimeframeValue>({ period: DEFAULT_PERIOD, from: null, to: null });
 
   readonly timeRange = computed<TimeRange>(() => {
+    this._clockToken();
     const tv = this._periodValue();
     if (tv.period === 'custom' && tv.from && tv.to) {
       return {
@@ -99,6 +107,7 @@ export class DashboardFiltersStore {
   });
 
   readonly interval = computed<number | undefined>(() => {
+    this._clockToken();
     const tv = this._periodValue();
     if (tv.period === 'custom' && tv.from && tv.to) {
       return calculateCustomInterval(tv.from.valueOf(), tv.to.valueOf());
@@ -108,6 +117,7 @@ export class DashboardFiltersStore {
   });
 
   readonly timeRangeEpoch = computed<{ from: number; to: number }>(() => {
+    this._clockToken();
     const tv = this._periodValue();
     if (tv.period === 'custom' && tv.from && tv.to) {
       return { from: tv.from.valueOf(), to: tv.to.valueOf() };
@@ -177,6 +187,7 @@ export class DashboardFiltersStore {
   }
 
   refresh(): void {
+    this._clockToken.update(n => n + 1);
     this._refreshToken.update(n => n + 1);
   }
 

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
@@ -761,6 +761,7 @@ describe('EnvLogsComponent', () => {
       tick(1);
       flushSearch(EMPTY_RESPONSE, `${CONSTANTS_TESTING.env.v2BaseURL}/logs/search?page=2&perPage=10`);
 
+      const timeRangeBefore = store().timeRange();
       onRefresh();
       fixture.detectChanges();
       tick(1);
@@ -768,6 +769,9 @@ describe('EnvLogsComponent', () => {
 
       expect(pagination().page).toBe(1);
       expect(logs().length).toBe(1);
+      expect(store().refreshToken()).toBe(1);
+      // Relative window was re-anchored (or at least recomputed) via filtersStore.refresh().
+      expect(store().timeRange().to >= timeRangeBefore.to).toBe(true);
     }));
 
     describe('page reset on filter mutation', () => {

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
@@ -123,8 +123,10 @@ export class EnvLogsComponent {
   }));
 
   protected onRefresh() {
-    // Spreading into a new object always produces a new signal reference, which marks
-    // searchParams as dirty and triggers a re-fetch even when the page is already 1.
+    // Re-anchor relative timeRange to "now", then reset pagination. Spreading
+    // pagination always yields a new reference so searchParams re-fetches even
+    // when already on page 1.
+    this.filtersStore.refresh();
     this.pagination.update(prev => ({ ...prev, page: 1 }));
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14825

### Description

Refreshing observability dashboards and env logs with a relative period (for example Last 1 hour) reused the time window from when that period was first selected, so stats and logs stayed stuck on a stale range. Refresh now re-anchors relative ranges to the current time.

### Changes

#### Dashboard filters store

Introduce a clock token bumped on refresh so timeRange, interval, and timeRangeEpoch recompute against now for relative periods. Custom ranges are unchanged.

#### Env logs refresh

Call filtersStore.refresh() from onRefresh so env logs pick up the re-anchored window before resetting pagination and re-fetching.

#### Tests

Cover relative re-anchoring and custom-range stability in the filters store, and assert env logs refresh bumps the refresh token and advances the window.

### Screenshots / video


https://github.com/user-attachments/assets/657f8d82-08b9-4014-ad43-c701fe2f01f6

