### PR TITLE
fix(console): remove 160-char limit when editing dictionary property value + added hint text

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.controller.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.controller.spec.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type {} from 'angular-material';
+
+import DictionaryController from './dictionary.controller';
+
+describe('DictionaryController', () => {
+  let controller: DictionaryController;
+  let $mdEditDialog: { small: jest.Mock };
+  let $mdDialog: any;
+  let NotificationService: any;
+  let DictionaryService: any;
+  let ngRouter: any;
+
+  beforeEach(() => {
+    $mdEditDialog = {
+      small: jest.fn(),
+    };
+    $mdDialog = { show: jest.fn() };
+    NotificationService = { show: jest.fn() };
+    DictionaryService = {
+      get: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      deploy: jest.fn(),
+      start: jest.fn(),
+      stop: jest.fn(),
+    };
+    ngRouter = { navigate: jest.fn() };
+
+    controller = new DictionaryController($mdEditDialog, $mdDialog, NotificationService, DictionaryService, ngRouter);
+    controller['dictionary'] = {
+      properties: {
+        large_value: 'short',
+      },
+    };
+    controller['dictProperties'] = controller.computeProperties();
+    controller['query'] = { total: 1 };
+  });
+
+  describe('editProperty', () => {
+    it('should open the inline edit dialog without an md-maxlength validator', () => {
+      const event = { stopPropagation: jest.fn() };
+
+      controller.editProperty(event, 'large_value', 'short');
+
+      expect(event.stopPropagation).toHaveBeenCalled();
+      expect($mdEditDialog.small).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelValue: 'short',
+          placeholder: 'Set property value',
+          targetEvent: event,
+        }),
+      );
+
+      const dialogOptions = $mdEditDialog.small.mock.calls[0][0];
+      expect(dialogOptions.validators).toBeUndefined();
+    });
+
+    it('should update the property with a value longer than 160 characters and refresh the table', () => {
+      const event = { stopPropagation: jest.fn() };
+      const longValue = 'a'.repeat(200);
+
+      controller.editProperty(event, 'large_value', 'short');
+
+      const dialogOptions = $mdEditDialog.small.mock.calls[0][0];
+      dialogOptions.save({ $modelValue: longValue });
+
+      expect(controller['dictionary'].properties.large_value).toBe(longValue);
+      expect(controller['dictionary'].properties.large_value.length).toBeGreaterThan(160);
+      expect(controller['dictProperties']).toEqual([{ key: 'large_value', value: longValue }]);
+      expect(controller['propertiesDirty']).toBe(true);
+    });
+  });
+
+  describe('saveProperties', () => {
+    it('should clear the unsaved properties hint after a successful save', async () => {
+      controller['propertiesDirty'] = true;
+      DictionaryService.update.mockResolvedValue({
+        data: {
+          properties: { large_value: 'saved' },
+        },
+      });
+
+      await controller.saveProperties();
+
+      expect(DictionaryService.update).toHaveBeenCalled();
+      expect(NotificationService.show).toHaveBeenCalledWith('Properties has been updated');
+      expect(controller['propertiesDirty']).toBe(false);
+      expect(controller['dictProperties']).toEqual([{ key: 'large_value', value: 'saved' }]);
+    });
+  });
+
+  describe('propertiesDirty lifecycle', () => {
+    beforeEach(() => {
+      controller['propertiesDirty'] = true;
+      controller['initialDictionary'] = {
+        properties: { large_value: 'initial' },
+      };
+      controller['formDictionary'] = { $setPristine: jest.fn() };
+      controller['updateMode'] = true;
+    });
+
+    it('should clear propertiesDirty on reset', () => {
+      controller.reset();
+
+      expect(controller['propertiesDirty']).toBe(false);
+      expect(controller['dictProperties']).toEqual([{ key: 'large_value', value: 'initial' }]);
+      expect(controller['formDictionary'].$setPristine).toHaveBeenCalled();
+    });
+
+    it('should clear propertiesDirty after a successful general update', async () => {
+      DictionaryService.update.mockResolvedValue({
+        data: {
+          properties: { large_value: 'updated' },
+        },
+      });
+
+      await controller.update();
+
+      expect(DictionaryService.update).toHaveBeenCalled();
+      expect(controller['propertiesDirty']).toBe(false);
+      expect(controller['dictProperties']).toEqual([{ key: 'large_value', value: 'updated' }]);
+    });
+
+    it('should clear propertiesDirty after deploy reloads dictionary state', async () => {
+      DictionaryService.deploy.mockResolvedValue({
+        data: {
+          properties: { large_value: 'deployed' },
+        },
+      });
+
+      await controller.deploy();
+
+      expect(DictionaryService.deploy).toHaveBeenCalled();
+      expect(controller['propertiesDirty']).toBe(false);
+      expect(controller['dictProperties']).toEqual([{ key: 'large_value', value: 'deployed' }]);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.controller.ts
+++ b/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.controller.ts
@@ -35,6 +35,7 @@ class DictionaryController {
   private updateMode: boolean;
 
   private selectedProperties: any = {};
+  private propertiesDirty = false;
 
   private query: any;
   private selectAll: boolean;
@@ -141,6 +142,7 @@ class DictionaryController {
   reset() {
     this.dictionary = cloneDeep(this.initialDictionary);
     this.dictProperties = this.computeProperties();
+    this.propertiesDirty = false;
     this.formDictionary.$setPristine();
   }
 
@@ -155,6 +157,7 @@ class DictionaryController {
         this.NotificationService.show('Dictionary ' + this.dictionary.name + ' has been updated');
         this.dictionary = response.data;
         this.dictProperties = this.computeProperties();
+        this.propertiesDirty = false;
       });
     }
   }
@@ -186,6 +189,7 @@ class DictionaryController {
       this.NotificationService.show('Dictionary ' + this.dictionary.name + ' has been deployed');
       this.dictionary = response.data;
       this.dictProperties = this.computeProperties();
+      this.propertiesDirty = false;
     });
   }
 
@@ -194,6 +198,7 @@ class DictionaryController {
       this.NotificationService.show('Dictionary ' + this.dictionary.name + ' has been started');
       this.dictionary = response.data;
       this.dictProperties = this.computeProperties();
+      this.propertiesDirty = false;
     });
   }
 
@@ -202,6 +207,7 @@ class DictionaryController {
       this.NotificationService.show('Dictionary ' + this.dictionary.name + ' has been stopped');
       this.dictionary = response.data;
       this.dictProperties = this.computeProperties();
+      this.propertiesDirty = false;
     });
   }
 
@@ -225,6 +231,7 @@ class DictionaryController {
         if (property) {
           this.dictionary.properties[property.key] = property.value;
           ++this.query.total;
+          this.propertiesDirty = true;
         }
 
         this.dictProperties = this.computeProperties();
@@ -239,11 +246,10 @@ class DictionaryController {
       placeholder: 'Set property value',
       save: input => {
         this.dictionary.properties[key] = input.$modelValue;
+        this.dictProperties = this.computeProperties();
+        this.propertiesDirty = true;
       },
       targetEvent: event,
-      validators: {
-        'md-maxlength': 160,
-      },
     });
   }
 
@@ -251,6 +257,7 @@ class DictionaryController {
     delete this.dictionary.properties[key];
     --this.query.total;
     this.dictProperties = this.computeProperties();
+    this.propertiesDirty = true;
   }
 
   deleteSelectedProperties() {
@@ -267,6 +274,7 @@ class DictionaryController {
       this.NotificationService.show('Properties has been updated');
       this.dictionary = response.data;
       this.dictProperties = this.computeProperties();
+      this.propertiesDirty = false;
     });
   }
 

--- a/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.html
+++ b/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.html
@@ -344,20 +344,26 @@
           create-mode="!$ctrl.updateMode"
         ></gravitee-empty-state>
 
-        <div class="md-actions gravitee-api-save-button" layout="row" ng-if="$ctrl.dictionary.type === 'MANUAL'">
-          <md-button class="md-raised md-primary" type="submit" permission permission-only="['environment-dictionary-u']">
-            Save properties
-          </md-button>
-          <md-button
-            class="md-raised md-warn float-right"
-            type="button"
-            ng-click="$ctrl.deleteSelectedProperties()"
-            permission
-            permission-only="['environment-dictionary-u']"
-            ng-disabled="!$ctrl.hasSelectedProperties()"
-          >
-            Delete
-          </md-button>
+        <div layout="column" ng-if="$ctrl.dictionary.type === 'MANUAL'">
+          <div class="hint" ng-if="$ctrl.propertiesDirty" style="position: static; margin: 0 8px 8px">
+            Edited properties are not saved until you click Save properties.
+          </div>
+
+          <div class="md-actions gravitee-api-save-button" layout="row">
+            <md-button class="md-raised md-primary" type="submit" permission permission-only="['environment-dictionary-u']">
+              Save properties
+            </md-button>
+            <md-button
+              class="md-raised md-warn float-right"
+              type="button"
+              ng-click="$ctrl.deleteSelectedProperties()"
+              permission
+              permission-only="['environment-dictionary-u']"
+              ng-disabled="!$ctrl.hasSelectedProperties()"
+            >
+              Delete
+            </md-button>
+          </div>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14827

## Description

- Removed the arbitrary md-maxlength: 160 validator from the dictionary property inline edit dialog in Console. Editing a property value now allows the same length as creating one (and as the backend, which stores values as nclob). 
Added unit tests covering the edit path.


- Added hint for edit mode.

## Additional context

- Before :

<img width="1719" height="935" alt="image" src="https://github.com/user-attachments/assets/0a509b49-f114-456c-8717-f25187ba3190" />

- After :

<img width="1719" height="935" alt="image" src="https://github.com/user-attachments/assets/da1b7245-cd60-4334-bbb7-7631a97810df" />


- video : 

https://github.com/user-attachments/assets/2974a10a-d83d-4466-b97e-6c3e01200ccb


