### PR TITLE
fix(repository): detect Mongo compatibility via buildInfo storageEngines

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/groups/RemoveDeletedGroupsFromApisUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/groups/RemoveDeletedGroupsFromApisUpgrader.java
@@ -39,7 +39,6 @@ public class RemoveDeletedGroupsFromApisUpgrader extends MongoUpgrader {
 
     private static final String ATTR_GROUPS = "groups";
     private static final String ATTR_ID = "_id";
-    private static final String DOCUMENTDB_ENGINE_VERSION_PREFIX = "5.0.0";
 
     @Override
     public String version() {
@@ -73,13 +72,13 @@ public class RemoveDeletedGroupsFromApisUpgrader extends MongoUpgrader {
         return true;
     }
 
-    private boolean checkDatabaseCompatibility(Document document) {
+    boolean checkDatabaseCompatibility(Document document) {
         var version = document.getString("version");
         var majorVersion = Integer.parseInt(version.split("\\.")[0]);
-        var hasStorageEngine = document.containsKey("storageEngine");
+        // buildInfo reports the supported engines as "storageEngines"; its absence is a strong indicator of DocumentDB
+        var hasStorageEngines = document.containsKey("storageEngines");
 
-        // The absence of storageEngine is a strong indicator of DocumentDB
-        return hasStorageEngine && majorVersion >= 5;
+        return hasStorageEngines && majorVersion >= 5;
     }
 
     private List<String> findDeletedGroups() {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/groups/RemoveDeletedGroupsFromApisUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/groups/RemoveDeletedGroupsFromApisUpgrader.java
@@ -40,9 +40,14 @@ public class RemoveDeletedGroupsFromApisUpgrader extends MongoUpgrader {
     private static final String ATTR_GROUPS = "groups";
     private static final String ATTR_ID = "_id";
 
+    /**
+     * v2 because the compatibility check above used to reject every MongoDB deployment. upgrade returns true
+     * even when it skips, so v1 was recorded as applied on first boot everywhere, and the upgrader identifier
+     * is derived from this version: without bumping it the corrected check would never run on those installs.
+     */
     @Override
     public String version() {
-        return "v1";
+        return "v2";
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/groups/RemoveDeletedGroupsFromApisUpgraderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/groups/RemoveDeletedGroupsFromApisUpgraderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.groups;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.bson.Document;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RemoveDeletedGroupsFromApisUpgraderTest {
+
+    private final RemoveDeletedGroupsFromApisUpgrader upgrader = new RemoveDeletedGroupsFromApisUpgrader();
+
+    @Test
+    void mongo_build_info_is_compatible() {
+        // buildInfo of a real MongoDB (including Atlas) reports "storageEngines", not "storageEngine"
+        var buildInfo = new Document("version", "7.0.38").append("storageEngines", List.of("wiredTiger"));
+
+        assertThat(upgrader.checkDatabaseCompatibility(buildInfo)).isTrue();
+    }
+
+    @Test
+    void documentdb_build_info_is_not_compatible() {
+        assertThat(upgrader.checkDatabaseCompatibility(new Document("version", "5.0.0"))).isFalse();
+    }
+
+    @Test
+    void mongo_before_5_is_not_compatible() {
+        var buildInfo = new Document("version", "4.4.29").append("storageEngines", List.of("wiredTiger"));
+
+        assertThat(upgrader.checkDatabaseCompatibility(buildInfo)).isFalse();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14808

## Description

`RemoveDeletedGroupsFromApisUpgrader` gated itself on `buildInfo` containing a
`storageEngine` key, as a way to tell a real MongoDB apart from DocumentDB.
`buildInfo` never returns that key — `storageEngine` is a `serverStatus` field.
The supported engines are reported by `buildInfo` under **`storageEngines`**
(plural).

The check was therefore always `false`, and the upgrader logged
`Skipping this upgrade because database is not compatible` and did nothing.

**This is broader than the ticket suggests:** it was never Atlas-specific. Every
MongoDB deployment has been silently skipping this upgrader since the check was
introduced, so the deleted-group cleanup has not run for anyone on Mongo.

The fix probes `storageEngines` instead. DocumentDB's `buildInfo` does not
report it, so DocumentDB stays excluded as intended, and the
`majorVersion >= 5` guard is untouched. The now-unused
`DOCUMENTDB_ENGINE_VERSION_PREFIX` constant is removed.

## Additional context

Added `RemoveDeletedGroupsFromApisUpgraderTest` covering the three shapes that
matter — Atlas/MongoDB `buildInfo` (compatible), DocumentDB `buildInfo` with no
`storageEngines` (not compatible), and MongoDB 4.4 (not compatible, version
guard).

Targets `4.11.x` (version reported by the customer); labelled for
`4.12.x` and `master`.
