### PR TITLE
fix: handle requests without a Host header in the gateway dispatcher

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
@@ -258,8 +258,14 @@ public class VertxHttpServerRequest implements Request {
      * In Vert.x 5, {@code authority().host()} returns only the hostname without the port, which would cause the port
      * to be silently dropped in URLs built from {@code originalHost()} (e.g. in {@code XForwardProcessor} when
      * computing {@code ContextAttributes.ATTR_REQUEST_ORIGINAL_URL}).
+     * <p>
+     * The authority is {@code null} when the request carries neither a {@code Host} header nor an HTTP/2
+     * {@code :authority} pseudo-header. Vert.x 4 returned {@code null} in that case as well.
      */
     private static String hostWithPort(HostAndPort authority) {
+        if (authority == null) {
+            return null;
+        }
         int port = authority.port();
         return port > 0 ? authority.host() + ":" + port : authority.host();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequest.java
@@ -206,8 +206,14 @@ public class VertxHttpServerRequest extends AbstractRequest {
      * In Vert.x 5, {@code authority().host()} returns only the hostname without the port, which would cause the port
      * to be silently dropped in URLs built from {@code originalHost()} (e.g. in {@code XForwardProcessor} when
      * computing {@code ContextAttributes.ATTR_REQUEST_ORIGINAL_URL}).
+     * <p>
+     * The authority is {@code null} when the request carries neither a {@code Host} header nor an HTTP/2
+     * {@code :authority} pseudo-header. Vert.x 4 returned {@code null} in that case as well.
      */
     private static String hostWithPort(HostAndPort authority) {
+        if (authority == null) {
+            return null;
+        }
         int port = authority.port();
         return port > 0 ? authority.host() + ":" + port : authority.host();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequestTest.java
@@ -127,6 +127,16 @@ class VertxHttpServerRequestTest {
             assertEquals("original.host", cut.originalHost());
             assertEquals("changed.host", cut.host());
         }
+
+        @Test
+        void should_return_null_host_when_the_request_has_no_host_header() {
+            // No Host header (nor :authority pseudo-header) means a null authority, as Vertx4 host() returned null.
+            when(httpServerRequest.authority()).thenReturn(null);
+            cut = new VertxHttpServerRequest(httpServerRequest, idGenerator);
+
+            assertNull(cut.originalHost());
+            assertNull(cut.host());
+        }
     }
 
     @Nested

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -64,6 +64,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.rxjava3.core.http.HttpHeaders;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import java.util.List;
@@ -142,10 +143,12 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
      */
     @Override
     public Completable dispatch(HttpServerRequest httpServerRequest, String serverId) {
-        //Keep same behavior as in Vertx4 when host was also returning the port
-        final String host = httpServerRequest.authority().port() > 0
-            ? httpServerRequest.authority().host() + ":" + httpServerRequest.authority().port()
-            : httpServerRequest.authority().host();
+        //Keep same behavior as in Vertx4 when host was also returning the port.
+        //The authority is null when the request has no Host header (nor :authority pseudo-header), as Vertx4 host() was.
+        final HostAndPort authority = httpServerRequest.authority();
+        final String host = authority == null
+            ? null
+            : (authority.port() > 0 ? authority.host() + ":" + authority.port() : authority.host());
         log.debug("Dispatching request on host {} and path {}", host, httpServerRequest.path());
 
         final HttpAcceptor httpAcceptor = httpAcceptorResolver.resolve(host, httpServerRequest.path(), serverId);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -146,9 +146,12 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         //Keep same behavior as in Vertx4 when host was also returning the port.
         //The authority is null when the request has no Host header (nor :authority pseudo-header), as Vertx4 host() was.
         final HostAndPort authority = httpServerRequest.authority();
-        final String host = authority == null
-            ? null
-            : (authority.port() > 0 ? authority.host() + ":" + authority.port() : authority.host());
+        final String host;
+        if (authority == null) {
+            host = null;
+        } else {
+            host = authority.port() > 0 ? authority.host() + ":" + authority.port() : authority.host();
+        }
         log.debug("Dispatching request on host {} and path {}", host, httpServerRequest.path());
 
         final HttpAcceptor httpAcceptor = httpAcceptorResolver.resolve(host, httpServerRequest.path(), serverId);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/OverlappingHttpAcceptor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/OverlappingHttpAcceptor.java
@@ -76,6 +76,11 @@ public class OverlappingHttpAcceptor extends AbstractHttpAcceptor implements Htt
         if (this.host == null) {
             return true;
         }
+        if (host == null) {
+            // A request carrying no Host header cannot match an acceptor scoped to a virtual host.
+            // DefaultHttpAcceptor already answers false in that case, through equalsIgnoreCase.
+            return false;
+        }
         var hostWithoutPort = host.replaceAll(HOST_HEADER_PORT_MATCHER, "");
         return (this.hasWildCardHost ? hostWithoutPort.endsWith(this.host) : this.host.equalsIgnoreCase(hostWithoutPort));
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
@@ -518,6 +518,20 @@ class DefaultHttpRequestDispatcherTest {
         }
 
         @Test
+        void should_resolve_with_a_null_host_when_the_request_carries_no_host_header() {
+            // A request without a Host header (nor an HTTP/2 :authority pseudo-header) has a null authority.
+            when(rxRequest.authority()).thenReturn(null);
+
+            ProcessorChain processorChain = spy(new ProcessorChain("id", List.of()));
+            when(notFoundProcessorChainFactory.processorChain()).thenReturn(processorChain);
+            when(httpAcceptorResolver.resolve(null, PATH, SERVER_ID)).thenReturn(null);
+
+            cut.dispatch(rxRequest, SERVER_ID).test().assertResult();
+
+            verify(httpAcceptorResolver).resolve(null, PATH, SERVER_ID);
+        }
+
+        @Test
         void shouldInitiateTracingWhenNotFoundAPI() {
             ProcessorChain processorChain = spy(new ProcessorChain("id", List.of()));
             when(notFoundProcessorChainFactory.processorChain()).thenReturn(processorChain);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/OverlappingHttpAcceptorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/OverlappingHttpAcceptorTest.java
@@ -34,4 +34,16 @@ class OverlappingHttpAcceptorTest {
         var acceptor = new OverlappingHttpAcceptor("very.specific.com", "/s1", Set.of());
         assertThat(acceptor.matchHost("very.specific.com:1234")).isTrue();
     }
+
+    @Test
+    void match_host_should_not_match_a_request_without_a_host() {
+        var acceptor = new OverlappingHttpAcceptor("very.specific.com", "/s1", Set.of());
+        assertThat(acceptor.matchHost(null)).isFalse();
+    }
+
+    @Test
+    void match_host_should_match_a_request_without_a_host_when_the_acceptor_has_none() {
+        var acceptor = new OverlappingHttpAcceptor(null, "/s1", Set.of());
+        assertThat(acceptor.matchHost(null)).isTrue();
+    }
 }


### PR DESCRIPTION
## Description

APIM-14814 — Debug mode fails with an unhandled `NullPointerException` in the gateway when the request has no `Host` header.

Vert.x 5 returns `null` from `HttpServerRequest.authority()` when the request carries neither a `Host` header nor an HTTP/2 `:authority` pseudo-header. Three call sites dereferenced it unconditionally:

- `DefaultHttpRequestDispatcher.dispatch` (the one in the reported stack trace)
- `io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest.hostWithPort`
- `io.gravitee.gateway.http.vertx.VertxHttpServerRequest.hostWithPort`

The dispatcher is what blows up first, but fixing it alone just moves the NPE into `prepareExecutionContext`, so all three are handled.

The fallback is `null`, which is exactly what Vert.x 4 `host()` returned for a request with no `Host` header. `DefaultHttpAcceptor.matchHost` already accepts a null host for context-path-only APIs, so a debug request against `/debug/` now resolves normally; a request with no Host against a vhost API still falls through to not-found, which is correct.

## Tests

- `DefaultHttpRequestDispatcherTest`: dispatching a request with a null authority resolves with a null host instead of throwing.
- `VertxHttpServerRequestTest.HostsTest`: `host()` / `originalHost()` return null instead of throwing.

## Backport

`apply-on-master`.