### PR TITLE
fix: build the gRPC endpoint client from a copy of the shared options

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/AbstractHttpTargetGrpcV4GatewayTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/AbstractHttpTargetGrpcV4GatewayTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.grpc.v4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+
+/**
+ * Shared setup for the tests that send gRPC-flagged requests to a plain {@code http://} target.
+ *
+ * <p>Each of those tests lives in its own class on purpose. The gateway is deployed once per class and
+ * {@code HttpClientFactory} caches the client it builds for the lifetime of the endpoint, so a plain request made by
+ * an earlier test would build a clean client and hide what a later test is trying to observe.
+ */
+abstract class AbstractHttpTargetGrpcV4GatewayTest extends AbstractGatewayTest {
+
+    protected static final String GRPC_CONTENT_TYPE = "application/grpc";
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    protected void callBackend(HttpClient httpClient, String contentType) throws InterruptedException {
+        httpClient
+            .rxRequest(HttpMethod.POST, "/test")
+            .flatMap(request -> {
+                if (contentType != null) {
+                    request.putHeader("Content-Type", contentType);
+                }
+                return request.rxSend("hello");
+            })
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.body().toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertNoErrors();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcContentTypeOnHttpTargetV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcContentTypeOnHttpTargetV4IntegrationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.grpc.v4;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The API deployed here is an ordinary HTTP proxy: its target is a plain {@code http://} backend and its endpoint
+ * configuration says nothing about HTTP/2. What protocol the gateway uses to reach that backend is nevertheless
+ * decided by the caller, because the endpoint connector classifies a request as gRPC on its {@code Content-Type}
+ * alone.
+ *
+ * <p>This documents today's rule. A deliberate decision to stop trusting the request header - requiring the endpoint
+ * to declare gRPC through its target scheme or its configured HTTP version - will make this test fail, which is the
+ * point: the change should be visible rather than silent.
+ */
+@GatewayTest
+@DeployApi({ "/apis/v4/http/api.json" })
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GrpcContentTypeOnHttpTargetV4IntegrationTest extends AbstractHttpTargetGrpcV4GatewayTest {
+
+    @Test
+    void the_content_type_sent_by_the_caller_decides_the_protocol_used_to_reach_the_backend(HttpClient httpClient)
+        throws InterruptedException {
+        wiremock.stubFor(post("/endpoint").willReturn(ok("response from backend")));
+
+        callBackend(httpClient, null);
+        callBackend(httpClient, GRPC_CONTENT_TYPE);
+
+        List<LoggedRequest> backendRequests = wiremock.findAll(postRequestedFor(urlPathEqualTo("/endpoint")));
+        assertThat(backendRequests).hasSize(2);
+        assertThat(backendRequests.get(0).getProtocol()).isEqualTo("HTTP/1.1");
+        assertThat(backendRequests.get(1).getProtocol()).isEqualTo("HTTP/2.0");
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcSharedClientOptionsIsolationV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcSharedClientOptionsIsolationV4IntegrationTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.grpc.v4;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The gRPC client must be built from a copy of the endpoint's shared options. While it was forcing HTTP/2 on the
+ * shared instance itself, one gRPC-flagged request moved every later request of the same endpoint to HTTP/2 as well,
+ * for the lifetime of the node - so a single caller could change the protocol used to reach the backend for everybody.
+ */
+@GatewayTest
+@DeployApi({ "/apis/v4/http/api.json" })
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GrpcSharedClientOptionsIsolationV4IntegrationTest extends AbstractHttpTargetGrpcV4GatewayTest {
+
+    @Test
+    void a_grpc_request_does_not_move_the_following_requests_to_http_2(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(post("/endpoint").willReturn(ok("response from backend")));
+
+        callBackend(httpClient, GRPC_CONTENT_TYPE);
+        callBackend(httpClient, null);
+
+        List<LoggedRequest> backendRequests = wiremock.findAll(postRequestedFor(urlPathEqualTo("/endpoint")));
+        assertThat(backendRequests).hasSize(2);
+        assertThat(backendRequests.get(0).getProtocol()).isEqualTo("HTTP/2.0");
+        assertThat(backendRequests.get(1).getProtocol()).isEqualTo("HTTP/1.1");
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/GrpcHttpClientFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/GrpcHttpClientFactory.java
@@ -17,8 +17,8 @@ package io.gravitee.plugin.endpoint.http.proxy.client;
 
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
 import io.gravitee.node.vertx.client.http.VertxHttpClientFactory;
-import io.gravitee.plugin.configurations.http.HttpClientOptions;
-import io.gravitee.plugin.configurations.http.ProtocolVersion;
+import io.gravitee.node.vertx.client.http.VertxHttpClientOptions;
+import io.gravitee.node.vertx.client.http.VertxHttpProtocolVersion;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
 import io.gravitee.plugin.mappers.HttpClientOptionsMapper;
@@ -35,12 +35,13 @@ public class GrpcHttpClientFactory extends HttpClientFactory {
         final HttpProxyEndpointConnectorConfiguration configuration,
         final HttpProxyEndpointConnectorSharedConfiguration sharedConfiguration
     ) {
-        HttpClientOptions httpOptions = sharedConfiguration.getHttpOptions();
-        httpOptions.setVersion(ProtocolVersion.HTTP_2);
+        // The shared configuration is reused by every request and by the plain HTTP client factory of the same
+        // endpoint group, so it must never be mutated here: forcing HTTP/2 on it would permanently switch the
+        // endpoint to HTTP/2 for all subsequent traffic on this node. Force the version on a fresh copy instead.
+        VertxHttpClientOptions httpOptions = HttpClientOptionsMapper.INSTANCE.map(sharedConfiguration.getHttpOptions());
+        httpOptions.setVersion(VertxHttpProtocolVersion.HTTP_2);
         httpOptions.setClearTextUpgrade(false);
 
-        return super
-            .buildHttpClient(ctx, configuration, sharedConfiguration)
-            .httpOptions(HttpClientOptionsMapper.INSTANCE.map(httpOptions));
+        return super.buildHttpClient(ctx, configuration, sharedConfiguration).httpOptions(httpOptions);
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/client/GrpcHttpClientFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/client/GrpcHttpClientFactoryTest.java
@@ -20,6 +20,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.vertx.client.http.VertxHttpClientOptions;
+import io.gravitee.node.vertx.client.http.VertxHttpProtocolVersion;
+import io.gravitee.plugin.configurations.http.HttpClientOptions;
+import io.gravitee.plugin.configurations.http.ProtocolVersion;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
 import io.vertx.rxjava3.core.Vertx;
@@ -30,6 +34,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -45,5 +50,37 @@ class GrpcHttpClientFactoryTest extends HttpClientFactoryTest {
         configuration = new HttpProxyEndpointConnectorConfiguration();
         configuration.setTarget("grpc://target");
         sharedConfiguration = new HttpProxyEndpointConnectorSharedConfiguration();
+    }
+
+    @Test
+    void should_not_mutate_the_shared_http_options_when_forcing_http_2() {
+        // The shared configuration is the very same object the plain HTTP client factory of the endpoint group
+        // reads from, so a single gRPC-classified request must not switch the whole endpoint to HTTP/2.
+        final HttpClientOptions sharedHttpOptions = sharedConfiguration.getHttpOptions();
+        sharedHttpOptions.setVersion(ProtocolVersion.HTTP_1_1);
+        sharedHttpOptions.setClearTextUpgrade(true);
+
+        when(ctx.getComponent(Vertx.class)).thenReturn(mock(Vertx.class));
+        when(ctx.getComponent(Configuration.class)).thenReturn(mock(Configuration.class));
+        cut.getOrBuildHttpClient(ctx, configuration, sharedConfiguration);
+
+        assertSame(sharedHttpOptions, sharedConfiguration.getHttpOptions());
+        assertEquals(ProtocolVersion.HTTP_1_1, sharedHttpOptions.getVersion());
+        assertTrue(sharedHttpOptions.isClearTextUpgrade());
+    }
+
+    @Test
+    void should_build_the_grpc_client_over_http_2_without_clear_text_upgrade() {
+        sharedConfiguration.getHttpOptions().setVersion(ProtocolVersion.HTTP_1_1);
+        sharedConfiguration.getHttpOptions().setClearTextUpgrade(true);
+        when(ctx.getComponent(Vertx.class)).thenReturn(mock(Vertx.class));
+        when(ctx.getComponent(Configuration.class)).thenReturn(mock(Configuration.class));
+
+        final var builder = cut.buildHttpClient(ctx, configuration, sharedConfiguration);
+        final var grpcHttpOptions = (VertxHttpClientOptions) ReflectionTestUtils.getField(builder, "httpOptions");
+
+        assertNotNull(grpcHttpOptions);
+        assertEquals(VertxHttpProtocolVersion.HTTP_2, grpcHttpOptions.getVersion());
+        assertFalse(grpcHttpOptions.isClearTextUpgrade());
     }
 }


### PR DESCRIPTION
## Description

APIM-14820 — a single inbound request carrying `Content-Type: application/grpc` permanently breaks an HTTP/1.1 API on a gateway node.

`GrpcHttpClientFactory.buildHttpClient` did:

```java
HttpClientOptions httpOptions = sharedConfiguration.getHttpOptions(); // shared instance
httpOptions.setVersion(ProtocolVersion.HTTP_2);
httpOptions.setClearTextUpgrade(false);
```

`sharedConfiguration` is the endpoint group's shared configuration — the same object `HttpClientFactory` (the plain, non-gRPC one) reads from on every `getOrBuildHttpClient`. Because both factories are held by the same `HttpProxyEndpointConnector`, forcing HTTP/2 there leaks into the plain client: if the gRPC-classified request is the first the API sees on a fresh node, the plain client is then built as HTTP/2 too, and every subsequent request to a HTTP/1.1-only backend fails with a 502 (`First received frame was not SETTINGS`) until the pod restarts.

Classification is header-only, so any anonymous caller can trigger this against a keyless API.

The fix maps the shared options into a fresh `VertxHttpClientOptions` first and forces the version on that copy — the shared configuration is never mutated.

## Tests

Unit:

- `should_not_mutate_the_shared_http_options_when_forcing_http_2` — the regression guard: the shared `HttpClientOptions` still reads `HTTP_1_1` / `clearTextUpgrade=true` after a gRPC client is built.
- `should_build_the_grpc_client_over_http_2_without_clear_text_upgrade` — the gRPC client itself is still HTTP/2 without clear-text upgrade.
- Full `gravitee-apim-plugin-endpoint-http-proxy` suite green (63 tests).

Gateway integration, both against an ordinary v4 HTTP proxy API whose target is a plain `http://` backend, asserting the protocol the backend actually saw:

- `GrpcSharedClientOptionsIsolationV4IntegrationTest` — sends the gRPC-flagged request first, then a plain one, and asserts the plain one is still HTTP/1.1. Reverting `GrpcHttpClientFactory` to the previous code makes it fail with `expected "HTTP/1.1" but was "HTTP/2.0"`.
- `GrpcContentTypeOnHttpTargetV4IntegrationTest` — records the detection rule itself (see below). It passes both before and after this fix, on purpose.

They live in separate classes because the gateway is deployed once per class and `HttpClientFactory` caches its client for the endpoint's lifetime — a plain request made by an earlier test method builds a clean client and masks what a later method is trying to observe.

## Not included: the hardening change

The ticket also proposes gating `isGrpc()` classification on the endpoint being configured for HTTP/2, which would close the remote trigger entirely. That is a behaviour change, so it needs a product decision and is deliberately left out of this fix.

What the new characterization test measures, on an endpoint with a plain `http://` target and no HTTP/2 in its configuration:

| Request | Protocol the backend saw |
|---|---|
| no `Content-Type` | HTTP/1.1 |
| `Content-Type: application/grpc` | HTTP/2.0 |

So the caller, not the configuration, decides the protocol used to reach the backend. Against a backend that accepts h2c the call still succeeds; against one that does not, it fails.

Evidence that the `http://`-target-plus-header combination was never a supported way to configure a gRPC endpoint:

- the `gravitee-apim-plugin-endpoint-http-proxy` README does not mention gRPC at all;
- all 11 gRPC fixtures in this repository — v2 and v4 integration tests, the gateway test SDK, the definition and export fixtures — use a `grpc://` target;
- before this PR, no test exercised the `Content-Type` branch of `isGrpc()`;
- the public gRPC tutorial and the v4 endpoint reference prescribe `grpc://host:port` **and** HTTP/2 on the endpoint, in every version from 4.4 to current;
- the branch arrived inside a broad 2023 protocol-support commit (`85d2314294`) and has since only been touched for a parse-exception guard and a caching change.

Every configuration we document or test satisfies both conditions the hardening would require, so it should be invisible to users following the documentation. If it is taken, it belongs on `master` only — and `GrpcContentTypeOnHttpTargetV4IntegrationTest` is what will flag it.

## Backport

`apply-on-4-11-x`, `apply-on-4-12-x`, `apply-on-master`.
