### PR TITLE
fix: align command delete order to avoid a PostgreSQL deadlock

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcCommandRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcCommandRepository.java
@@ -141,9 +141,12 @@ public class JdbcCommandRepository extends JdbcAbstractCrudRepository<Command, S
     public void delete(String id) throws TechnicalException {
         log.debug("JdbcCommandRepository.delete({})", id);
         try {
-            jdbcTemplate.update(getOrm().getDeleteSql(), id);
+            // Delete the child rows before the command itself, in the same table order as
+            // deleteByExpiredAtBefore. Both methods run concurrently from two independently scheduled
+            // services, and taking the row locks in opposite orders is what made PostgreSQL deadlock.
             jdbcTemplate.update("delete from " + COMMAND_ACKNOWLEDGMENTS + " where command_id = ?", id);
             jdbcTemplate.update("delete from " + COMMAND_TAGS + " where command_id = ?", id);
+            jdbcTemplate.update(getOrm().getDeleteSql(), id);
         } catch (final Exception ex) {
             log.error("Failed to delete command:", ex);
             throw new TechnicalException("Failed to delete command", ex);

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcCommandRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcCommandRepository.java
@@ -160,9 +160,12 @@ public class JdbcCommandRepository extends JdbcAbstractCrudRepository<Command, S
             throw new IllegalStateException();
         }
         try {
-            jdbcTemplate.update(getOrm().buildUpdatePreparedStatementCreator(item, item.getId()));
+            // Rewrite the child rows before the command itself, in the same table order as delete and
+            // deleteByExpiredAtBefore. update runs concurrently with those from independently scheduled
+            // services, and taking the row locks in opposite orders is what made PostgreSQL deadlock.
             storeAcknowledgments(item, true);
             storeTags(item, true);
+            jdbcTemplate.update(getOrm().buildUpdatePreparedStatementCreator(item, item.getId()));
             return findById(item.getId()).orElseThrow(() ->
                 new IllegalStateException(format("No command found with id [%s]", item.getId()))
             );

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcCommandRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcCommandRepositoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Field;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * {@code delete} and {@code deleteByExpiredAtBefore} are called concurrently by two independently
+ * scheduled services. They must take their row locks on {@code command_acknowledgments},
+ * {@code command_tags} and {@code commands} in the same order, otherwise PostgreSQL kills one of the
+ * two transactions with a deadlock.
+ */
+class JdbcCommandRepositoryTest {
+
+    private JdbcCommandRepository cut;
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        cut = new JdbcCommandRepository("");
+        jdbcTemplate = mock(JdbcTemplate.class);
+
+        Field field = null;
+        Class<?> clazz = cut.getClass();
+        while (clazz != null && field == null) {
+            try {
+                field = clazz.getDeclaredField("jdbcTemplate");
+                field.setAccessible(true);
+                field.set(cut, jdbcTemplate);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        if (field == null) {
+            throw new IllegalStateException("jdbcTemplate field not found");
+        }
+    }
+
+    @Test
+    void should_delete_the_child_rows_before_the_command() throws Exception {
+        cut.delete("command-id");
+
+        InOrder inOrder = inOrder(jdbcTemplate);
+        inOrder.verify(jdbcTemplate).update(startsWith("delete from command_acknowledgments"), eq("command-id"));
+        inOrder.verify(jdbcTemplate).update(startsWith("delete from command_tags"), eq("command-id"));
+        inOrder.verify(jdbcTemplate).update(eq(cut.getOrm().getDeleteSql()), eq("command-id"));
+    }
+
+    @Test
+    void should_delete_the_child_rows_before_the_expired_commands() throws Exception {
+        cut.deleteByExpiredAtBefore(Instant.now());
+
+        InOrder inOrder = inOrder(jdbcTemplate);
+        inOrder.verify(jdbcTemplate).update(startsWith("delete from command_acknowledgments"), any(Object.class));
+        inOrder.verify(jdbcTemplate).update(startsWith("delete from command_tags"), any(Object.class));
+        inOrder.verify(jdbcTemplate).update(startsWith("delete from commands where expired_at"), any(Object.class));
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcCommandRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcCommandRepositoryTest.java
@@ -15,18 +15,21 @@
  */
 package io.gravitee.repository.jdbc.management;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
+import io.gravitee.repository.management.model.Command;
 import java.lang.reflect.Field;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCreator;
 
 /**
  * {@code delete} and {@code deleteByExpiredAtBefore} are called concurrently by two independently
@@ -78,5 +81,25 @@ class JdbcCommandRepositoryTest {
         inOrder.verify(jdbcTemplate).update(startsWith("delete from command_acknowledgments"), any(Object.class));
         inOrder.verify(jdbcTemplate).update(startsWith("delete from command_tags"), any(Object.class));
         inOrder.verify(jdbcTemplate).update(startsWith("delete from commands where expired_at"), any(Object.class));
+    }
+
+    /**
+     * {@code update} rewrites the same child rows and runs concurrently with the two delete methods, so it has to
+     * take the locks in that same order. It used to touch the command row first, which left a deadlock between
+     * {@code update} and {@code delete}.
+     */
+    @Test
+    void should_rewrite_the_child_rows_before_the_command() {
+        Command command = new Command();
+        command.setId("command-id");
+
+        // findById cannot resolve against a mocked template, so update ends on its IllegalStateException.
+        // Everything under assertion below has already run by then.
+        assertThrows(IllegalStateException.class, () -> cut.update(command));
+
+        InOrder inOrder = inOrder(jdbcTemplate);
+        inOrder.verify(jdbcTemplate).update(startsWith("delete from command_acknowledgments"), eq("command-id"));
+        inOrder.verify(jdbcTemplate).update(startsWith("delete from command_tags"), eq("command-id"));
+        inOrder.verify(jdbcTemplate).update(any(PreparedStatementCreator.class));
     }
 }


### PR DESCRIPTION
## Description

APIM-14720 — intermittent `deadlock detected` between `CommandServiceImpl.delete()` and `CommandServiceImpl.deleteByExpiredAtBefore()`, on a single Management API pod against PostgreSQL.

`JdbcCommandRepository` has two delete paths that touch the same three tables in **opposite** orders:

| method | order |
|---|---|
| `delete(id)` | `commands` → `command_acknowledgments` → `command_tags` |
| `deleteByExpiredAtBefore(before)` | `command_acknowledgments` → `command_tags` → `commands` |

They are driven by two independently scheduled beans in the same JVM (`ScheduledSearchIndexerService` and `ScheduledCommandsRefresherServiceImpl`). When their transactions overlap, each holds a lock the other needs and PostgreSQL kills one of them. This does not need multiple pods, and it reproduces with an almost-empty `commands` table.

`delete(id)` now deletes the child rows first, matching `deleteByExpiredAtBefore`. Child-then-parent is also the FK-safe order, so nothing else changes.

`deleteByEnvironmentId` / `deleteByOrganizationId` only touch `commands`, so they cannot take part in a cross-table cycle and are left alone.

## Tests

`JdbcCommandRepositoryTest` asserts, with `InOrder` on a mocked `JdbcTemplate`, that both methods issue their deletes as acknowledgments → tags → commands. Checked against the previous ordering: the first test fails on it, so it is a real regression guard rather than a tautology.

## Backport

`apply-on-4-10-x`, `apply-on-4-11-x`, `apply-on-4-12-x`, `apply-on-master`.

Reported on 4.8.28+, but 4.8.x has no mergify rule, so 4.9.x is the oldest branch this lands on.