### PR TITLE
fix: apply the endpoint weight upgrader to V4 native APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiEndpointWeightUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiEndpointWeightUpgrader.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.definition.model.DefinitionVersion;
-import io.gravitee.definition.model.v4.Api;
 import io.gravitee.node.api.upgrader.Upgrader;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
@@ -88,15 +87,18 @@ public class ApiEndpointWeightUpgrader implements Upgrader {
                     boolean updated = false;
 
                     if (defVersion == DefinitionVersion.V4) {
-                        Api v4Api = objectMapper.readValue(definition, Api.class);
-                        updated = fixEndpointWeightsV4(v4Api);
+                        // Work on the raw JSON rather than on io.gravitee.definition.model.v4.Api: a V4 Native API
+                        // deserializes to NativeApi, a sibling of Api, so binding to Api threw and skipped every
+                        // Native API. Both types expose their endpoints under the same /endpointGroups path.
+                        JsonNode rootNode = objectMapper.readTree(definition);
+                        updated = fixEndpointWeights(rootNode.at("/endpointGroups"));
                         if (updated) {
-                            api.setDefinition(objectMapper.writeValueAsString(v4Api));
+                            api.setDefinition(objectMapper.writeValueAsString(rootNode));
                         }
                     } else {
                         if (defVersion != DefinitionVersion.FEDERATED && defVersion != DefinitionVersion.FEDERATED_AGENT) {
                             JsonNode rootNode = objectMapper.readTree(definition);
-                            updated = fixEndpointWeightsV2(rootNode);
+                            updated = fixEndpointWeights(rootNode.at("/proxy/groups"));
                             if (updated) {
                                 api.setDefinition(objectMapper.writeValueAsString(rootNode));
                             }
@@ -113,10 +115,10 @@ public class ApiEndpointWeightUpgrader implements Upgrader {
             });
     }
 
-    private boolean fixEndpointWeightsV2(JsonNode root) {
+    private boolean fixEndpointWeights(JsonNode endpointGroups) {
         boolean updated = false;
 
-        for (JsonNode group : root.at("/proxy/groups")) {
+        for (JsonNode group : endpointGroups) {
             JsonNode endpoints = group.get("endpoints");
             if (endpoints == null || !endpoints.isArray()) continue;
 
@@ -124,22 +126,6 @@ public class ApiEndpointWeightUpgrader implements Upgrader {
                 JsonNode weightNode = endpoint.get("weight");
                 if (weightNode != null && weightNode.isInt() && weightNode.intValue() < 1) {
                     ((ObjectNode) endpoint).put("weight", 1);
-                    updated = true;
-                }
-            }
-        }
-        return updated;
-    }
-
-    private boolean fixEndpointWeightsV4(Api v4Api) {
-        boolean updated = false;
-        if (v4Api.getEndpointGroups() == null) return false;
-
-        for (var group : v4Api.getEndpointGroups()) {
-            for (var ep : group.getEndpoints()) {
-                int weight = ep.getWeight();
-                if (weight < 1) {
-                    ep.setWeight(1);
                     updated = true;
                 }
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiEndpointWeightUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiEndpointWeightUpgraderTest.java
@@ -112,4 +112,47 @@ class ApiEndpointWeightUpgraderTest {
 
         assertEquals(1, weight, "V4 endpoint weight should be updated to 1");
     }
+
+    @Test
+    void shouldUpgradeV4NativeApiWeight() throws Exception {
+        Environment env = new Environment();
+        env.setId("env1");
+        when(environmentRepository.findAll()).thenReturn(Set.of(env));
+
+        // A Native API deserializes to NativeApi, not to io.gravitee.definition.model.v4.Api.
+        Api api = new Api();
+        api.setId("api-v4-native");
+        api.setDefinitionVersion(DefinitionVersion.V4);
+        api.setDefinition(
+            "{\"type\":\"native\",\"endpointGroups\":[{\"type\":\"native-kafka\",\"endpoints\":[{\"name\":\"ep\",\"type\":\"native-kafka\",\"weight\":0}]}]}"
+        );
+
+        when(apiRepository.search(any(), any(), any())).thenReturn(Stream.of(api));
+
+        upgrader.upgrade();
+
+        ArgumentCaptor<Api> captor = ArgumentCaptor.forClass(Api.class);
+        verify(apiRepository).update(captor.capture());
+
+        JsonNode rootNode = objectMapper.readTree(captor.getValue().getDefinition());
+        assertEquals(1, rootNode.at("/endpointGroups/0/endpoints/0/weight").intValue(), "Native endpoint weight should be updated to 1");
+    }
+
+    @Test
+    void shouldLeaveTheDefinitionUntouchedWhenNoWeightNeedsFixing() throws Exception {
+        Environment env = new Environment();
+        env.setId("env1");
+        when(environmentRepository.findAll()).thenReturn(Set.of(env));
+
+        Api api = new Api();
+        api.setId("api-v4-ok");
+        api.setDefinitionVersion(DefinitionVersion.V4);
+        api.setDefinition("{\"endpointGroups\":[{\"endpoints\":[{\"name\":\"ep\",\"weight\":3}]}]}");
+
+        when(apiRepository.search(any(), any(), any())).thenReturn(Stream.of(api));
+
+        upgrader.upgrade();
+
+        verify(apiRepository, never()).update(any());
+    }
 }


### PR DESCRIPTION
## Description

APIM-14789 — `ApiEndpointWeightUpgrader` logs an `InvalidTypeIdException: type id 'native'` WARN (with a ~45-frame stack trace) for every V4 Native API, and skips it.

The V4 branch did `objectMapper.readValue(definition, Api.class)`. A Native API deserializes to `NativeApi`, a *sibling* of `io.gravitee.definition.model.v4.Api` (both extend `AbstractApi`), so Jackson refuses the type id and the `catch` swallows the API. Native endpoints with `weight < 1` are therefore never corrected — the upgrader silently does nothing for them, on every restart.

Rather than branching on the API type, the V4 branch now walks the raw JSON, exactly as the V2 branch already did. Both `Api` and `NativeApi` serialize their endpoints under `/endpointGroups/*/endpoints/*`, so one type-agnostic pass covers both and any future V4 type.

A side benefit: the definition is no longer round-tripped through the model on the way out, so the upgrader can only ever change the `weight` fields it came for.

`fixEndpointWeightsV2` / `fixEndpointWeightsV4` collapse into a single `fixEndpointWeights(JsonNode endpointGroups)` that takes the group array; the caller supplies `/proxy/groups` or `/endpointGroups`.

## Tests

- `shouldUpgradeV4NativeApiWeight` — a `"type":"native"` definition now gets its endpoint weight corrected instead of being skipped.
- `shouldLeaveTheDefinitionUntouchedWhenNoWeightNeedsFixing` — no write when every weight is already valid.
- Existing V2 and V4 tests unchanged and green (4/4).

## Backport

`apply-on-4-12-x`, `apply-on-master`.