### PR TITLE
fix: report no health check data when no v4 repository is registered

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_health/ApiHealthQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_health/ApiHealthQueryServiceImpl.java
@@ -26,51 +26,69 @@ import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.healthcheck.v4.api.HealthCheckRepository;
 import io.reactivex.rxjava3.core.Maybe;
 import java.util.ArrayList;
-import org.springframework.context.annotation.Lazy;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ApiHealthQueryServiceImpl implements ApiHealthQueryService {
 
-    private final HealthCheckRepository healthCheckRepository;
+    private final ObjectProvider<HealthCheckRepository> healthCheckRepository;
 
-    public ApiHealthQueryServiceImpl(@Lazy HealthCheckRepository healthCheckRepository) {
+    public ApiHealthQueryServiceImpl(ObjectProvider<HealthCheckRepository> healthCheckRepository) {
         this.healthCheckRepository = healthCheckRepository;
+    }
+
+    /**
+     * The analytics repository in use does not always contribute a v4 health check repository - none is
+     * registered when analytics are disabled, for instance. Report an absent result in that case, exactly as a
+     * repository holding no data would, rather than letting the request fail on a Spring
+     * "No qualifying bean of type HealthCheckRepository" error.
+     */
+    private Maybe<HealthCheckRepository> repository() {
+        return Maybe.fromCallable(healthCheckRepository::getIfAvailable);
     }
 
     @Override
     public Maybe<AverageHealthCheckResponseTime> averageResponseTime(ApiFieldPeriodQuery query) {
-        return healthCheckRepository
-            .averageResponseTime(new QueryContext(query.organizationId(), query.environmentId()), ApiHealthAdapter.INSTANCE.map(query))
-            .map(ApiHealthAdapter.INSTANCE::map);
+        return repository().flatMap(repository ->
+            repository
+                .averageResponseTime(new QueryContext(query.organizationId(), query.environmentId()), ApiHealthAdapter.INSTANCE.map(query))
+                .map(ApiHealthAdapter.INSTANCE::map)
+        );
     }
 
     @Override
     public Maybe<AverageHealthCheckResponseTimeOvertime> averageResponseTimeOvertime(AverageHealthCheckResponseTimeOvertimeQuery query) {
-        return healthCheckRepository
-            .averageResponseTimeOvertime(
-                new QueryContext(query.organizationId(), query.environmentId()),
-                ApiHealthAdapter.INSTANCE.map(query)
-            )
-            .map(result ->
-                new AverageHealthCheckResponseTimeOvertime(
-                    new AverageHealthCheckResponseTimeOvertime.TimeRange(query.from(), query.to(), query.interval()),
-                    new ArrayList<>(result.buckets().values())
+        return repository().flatMap(repository ->
+            repository
+                .averageResponseTimeOvertime(
+                    new QueryContext(query.organizationId(), query.environmentId()),
+                    ApiHealthAdapter.INSTANCE.map(query)
                 )
-            );
+                .map(result ->
+                    new AverageHealthCheckResponseTimeOvertime(
+                        new AverageHealthCheckResponseTimeOvertime.TimeRange(query.from(), query.to(), query.interval()),
+                        new ArrayList<>(result.buckets().values())
+                    )
+                )
+        );
     }
 
     @Override
     public Maybe<AvailabilityHealthCheck> availability(ApiFieldPeriodQuery query) {
-        return healthCheckRepository
-            .availability(new QueryContext(query.organizationId(), query.environmentId()), ApiHealthAdapter.INSTANCE.map(query))
-            .map(response -> new AvailabilityHealthCheck(response.global(), response.ratesByFields()));
+        return repository().flatMap(repository ->
+            repository
+                .availability(new QueryContext(query.organizationId(), query.environmentId()), ApiHealthAdapter.INSTANCE.map(query))
+                .map(response -> new AvailabilityHealthCheck(response.global(), response.ratesByFields()))
+        );
     }
 
     @Override
     public Maybe<Page<HealthCheckLog>> searchLogs(SearchLogsQuery query) {
-        return healthCheckRepository
-            .searchLogs(new QueryContext(query.organizationId(), query.environmentId()), ApiHealthAdapter.INSTANCE.map(query))
-            .map(page -> page.map(ApiHealthAdapter.INSTANCE::map));
+        return repository().flatMap(repository ->
+            repository
+                .searchLogs(new QueryContext(query.organizationId(), query.environmentId()), ApiHealthAdapter.INSTANCE.map(query))
+                .map(page -> page.map(ApiHealthAdapter.INSTANCE::map))
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api_health/ApiHealthQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api_health/ApiHealthQueryServiceImplTest.java
@@ -16,6 +16,8 @@
 package io.gravitee.apim.infra.query_service.api_health;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -49,6 +51,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
 
 @ExtendWith(MockitoExtension.class)
 class ApiHealthQueryServiceImplTest {
@@ -71,7 +74,42 @@ class ApiHealthQueryServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        service = new ApiHealthQueryServiceImpl(healthCheckRepository);
+        service = new ApiHealthQueryServiceImpl(providerOf(healthCheckRepository));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ObjectProvider<HealthCheckRepository> providerOf(HealthCheckRepository repository) {
+        ObjectProvider<HealthCheckRepository> provider = mock(ObjectProvider.class);
+        lenient().when(provider.getIfAvailable()).thenReturn(repository);
+        return provider;
+    }
+
+    @Nested
+    class WithoutHealthCheckRepository {
+
+        @Test
+        void should_report_no_data_instead_of_failing() {
+            // No v4 health check repository is registered, for instance when analytics are disabled.
+            var cut = new ApiHealthQueryServiceImpl(providerOf(null));
+            var query = new ApiHealthQueryService.ApiFieldPeriodQuery(ORGANIZATION_ID, ENVIRONMENT_ID, API_ID, "endpoint", FROM, TO);
+
+            cut.averageResponseTime(query).test().assertNoValues().assertComplete();
+            cut.availability(query).test().assertNoValues().assertComplete();
+            cut
+                .averageResponseTimeOvertime(
+                    new ApiHealthQueryService.AverageHealthCheckResponseTimeOvertimeQuery(
+                        ORGANIZATION_ID,
+                        ENVIRONMENT_ID,
+                        API_ID,
+                        FROM,
+                        TO,
+                        INTERVAL
+                    )
+                )
+                .test()
+                .assertNoValues()
+                .assertComplete();
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Description

APIM-14383 — opening the v4 endpoint health check dashboard with analytics disabled pops a raw Spring error:

> No qualifying bean of type 'io.gravitee.repository.healthcheck.v4.api.HealthCheckRepository' available […] Dependency annotations: {@Lazy(true)}

`ApiHealthQueryServiceImpl` took the repository as a hard `@Lazy` constructor dependency. `@Lazy` only defers the resolution to the first call, so when no bean is contributed the failure lands on the user as a broken dashboard instead of at startup. Same shape as the API Logs page fix in gravitee-io/issues#11297.

The repository is now resolved through an `ObjectProvider`, and an absent one yields an absent result. All four methods already return `Maybe`, so callers cannot tell the difference between "no repository" and "repository with no data" — which is exactly the behaviour of `NoOpHealthCheckRepository`.

## A caveat worth reviewing

I could not reproduce the missing bean from the code on any maintained branch: `NoOpAnalyticsRepositoryConfiguration` does register a v4 `healthCheckRepositoryV4` bean on 4.9.x → master, so a plain `analytics.type=none` should be served by the no-op repository. The reporter's environment is listed only as "4.10.x", so the exact trigger (older build, a different analytics repository plugin that ships no v4 health check implementation, or a plugin packaging problem) is still open.

What this PR guarantees is that *whatever* the reason no v4 health check repository is present, the dashboard degrades to "no data" instead of surfacing Spring internals. If we want the dashboard to say "analytics are disabled" explicitly rather than show an empty chart, that is a separate product decision and a different change.

## Tests

`ApiHealthQueryServiceImplTest.WithoutHealthCheckRepository` — with no repository available, `averageResponseTime`, `availability` and `averageResponseTimeOvertime` complete empty instead of throwing. Existing tests unchanged (5/5 green).

## Backport

`apply-on-4-11-x`, `apply-on-4-12-x`, `apply-on-master`.