### PR TITLE
fix: keep API key values out of audit records

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/domain_service/GenerateApiKeyDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/domain_service/GenerateApiKeyDomainService.java
@@ -207,11 +207,15 @@ public class GenerateApiKeyDomainService {
         String referenceId = isApiProduct ? subscription.getReferenceId() : subscription.getApiId();
 
         Map<AuditProperties, String> properties = new HashMap<>();
-        properties.put(AuditProperties.API_KEY, createdApiKeyEntity.getKey());
+        // Audit records are readable by anyone holding the audit permission, so they identify the API key by its
+        // id: the key value itself is a credential that can be replayed against the gateway.
+        properties.put(AuditProperties.API_KEY, createdApiKeyEntity.getId());
         if (referenceId != null) {
             properties.put(isApiProduct ? AuditProperties.API_PRODUCT : AuditProperties.API, referenceId);
         }
         properties.put(AuditProperties.APPLICATION, subscription.getApplicationId());
+
+        var auditedApiKey = createdApiKeyEntity.toBuilder().key(null).build();
 
         if (isApiProduct) {
             auditService.createApiProductAuditLog(
@@ -222,7 +226,7 @@ public class GenerateApiKeyDomainService {
                     .event(event)
                     .actor(auditInfo.actor())
                     .oldValue(null)
-                    .newValue(createdApiKeyEntity)
+                    .newValue(auditedApiKey)
                     .createdAt(createdApiKeyEntity.getCreatedAt())
                     .properties(properties)
                     .build()
@@ -236,7 +240,7 @@ public class GenerateApiKeyDomainService {
                     .event(event)
                     .actor(auditInfo.actor())
                     .oldValue(null)
-                    .newValue(createdApiKeyEntity)
+                    .newValue(auditedApiKey)
                     .createdAt(createdApiKeyEntity.getCreatedAt())
                     .properties(properties)
                     .build()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/domain_service/RevokeApiKeyDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/domain_service/RevokeApiKeyDomainService.java
@@ -118,11 +118,16 @@ public class RevokeApiKeyDomainService {
         String referenceId = isApiProduct ? subscription.getReferenceId() : subscription.getApiId();
 
         Map<AuditProperties, String> properties = new HashMap<>();
-        properties.put(AuditProperties.API_KEY, apiKeyEntity.getKey());
+        // Audit records are readable by anyone holding the audit permission, so they identify the API key by its
+        // id: the key value itself is a credential that can be replayed against the gateway.
+        properties.put(AuditProperties.API_KEY, apiKeyEntity.getId());
         if (referenceId != null) {
             properties.put(isApiProduct ? AuditProperties.API_PRODUCT : AuditProperties.API, referenceId);
         }
         properties.put(AuditProperties.APPLICATION, subscription.getApplicationId());
+
+        var auditedApiKey = apiKeyEntity.toBuilder().key(null).build();
+        var auditedRevokedApiKey = revokedApiKeyEntity.toBuilder().key(null).build();
 
         if (isApiProduct) {
             auditService.createApiProductAuditLog(
@@ -132,8 +137,8 @@ public class RevokeApiKeyDomainService {
                     .apiProductId(referenceId)
                     .event(ApiKeyAuditEvent.APIKEY_REVOKED)
                     .actor(auditInfo.actor())
-                    .oldValue(apiKeyEntity)
-                    .newValue(revokedApiKeyEntity)
+                    .oldValue(auditedApiKey)
+                    .newValue(auditedRevokedApiKey)
                     .createdAt(ZonedDateTime.ofInstant(revokedApiKeyEntity.getRevokedAt().toInstant(), ZoneId.systemDefault()))
                     .properties(properties)
                     .build()
@@ -146,8 +151,8 @@ public class RevokeApiKeyDomainService {
                     .apiId(referenceId)
                     .event(ApiKeyAuditEvent.APIKEY_REVOKED)
                     .actor(auditInfo.actor())
-                    .oldValue(apiKeyEntity)
-                    .newValue(revokedApiKeyEntity)
+                    .oldValue(auditedApiKey)
+                    .newValue(auditedRevokedApiKey)
                     .createdAt(ZonedDateTime.ofInstant(revokedApiKeyEntity.getRevokedAt().toInstant(), ZoneId.systemDefault()))
                     .properties(properties)
                     .build()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -812,7 +812,10 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                     .event(event)
                     .createdAt(eventDate)
                     .oldValue(previousApiKey == null ? null : previousApiKey.toBuilder().key(null).build())
-                    .newValue(key.toBuilder().key(null).build())
+                    // hash is the MD5 of the key and doubles as a credential for Native Kafka
+                    // authentication, so it leaves the audit record along with the key itself. The
+                    // repository ApiKey used as the old value carries no such field.
+                    .newValue(key.toBuilder().key(null).hash(null).build())
                     .build();
 
                 if (isApiProduct) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -801,7 +801,9 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                 String applicationId = key.getApplication() != null ? key.getApplication().getId() : null;
 
                 Map<Audit.AuditProperties, String> properties = new LinkedHashMap<>();
-                properties.put(API_KEY, key.getKey());
+                // Audit records are readable by anyone holding the audit permission, so they identify the API key
+                // by its id: the key value itself is a credential that can be replayed against the gateway.
+                properties.put(API_KEY, key.getId());
                 properties.put(isApiProduct ? API_PRODUCT : API, referenceId);
                 properties.put(APPLICATION, applicationId);
 
@@ -809,8 +811,8 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                     .properties(properties)
                     .event(event)
                     .createdAt(eventDate)
-                    .oldValue(previousApiKey)
-                    .newValue(key)
+                    .oldValue(previousApiKey == null ? null : previousApiKey.toBuilder().key(null).build())
+                    .newValue(key.toBuilder().key(null).build())
                     .build();
 
                 if (isApiProduct) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/GenerateApiKeyDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/GenerateApiKeyDomainServiceTest.java
@@ -176,12 +176,23 @@ class GenerateApiKeyDomainServiceTest {
                     AuditEntity.AuditReferenceType.API,
                     API_ID_1,
                     USER_ID,
-                    Map.of("API_KEY", result.getKey(), "API", API_ID_1, "APPLICATION", APPLICATION_ID),
+                    Map.of("API_KEY", result.getId(), "API", API_ID_1, "APPLICATION", APPLICATION_ID),
                     ApiKeyAuditEvent.APIKEY_CREATED.name(),
                     result.getCreatedAt(),
                     ""
                 )
             );
+    }
+
+    @Test
+    void should_keep_the_api_key_value_out_of_the_audit() {
+        var result = service.generate(SUBSCRIPTION_1, AUDIT_INFO, "custom-key");
+
+        assertThat(result.getKey()).isEqualTo("custom-key");
+        assertThat(auditCrudService.storage()).allSatisfy(audit -> {
+            assertThat(audit.getProperties()).doesNotContainValue("custom-key");
+            assertThat(audit.getPatch()).doesNotContain("custom-key");
+        });
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/RevokeApiKeyDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/RevokeApiKeyDomainServiceTest.java
@@ -189,7 +189,7 @@ class RevokeApiKeyDomainServiceTest {
                         .referenceType(AuditEntity.AuditReferenceType.API)
                         .referenceId("api-id")
                         .user(USER_ID)
-                        .properties(Map.of("APPLICATION", "application-id", "API", "api-id", "API_KEY", "key"))
+                        .properties(Map.of("APPLICATION", "application-id", "API", "api-id", "API_KEY", "api-key"))
                         .event(ApiKeyAuditEvent.APIKEY_REVOKED.name())
                         .build()
                 );
@@ -228,7 +228,7 @@ class RevokeApiKeyDomainServiceTest {
                         .referenceType(AuditEntity.AuditReferenceType.API)
                         .referenceId("api-id")
                         .user(USER_ID)
-                        .properties(Map.of("APPLICATION", "application-id", "API", "api-id", "API_KEY", "key"))
+                        .properties(Map.of("APPLICATION", "application-id", "API", "api-id", "API_KEY", "api-key"))
                         .event(ApiKeyAuditEvent.APIKEY_REVOKED.name())
                         .build()
                 );
@@ -308,7 +308,7 @@ class RevokeApiKeyDomainServiceTest {
                         AuditEntity.AuditReferenceType.API,
                         API_ID_2,
                         USER_ID,
-                        Map.of("API_KEY", apiKey.getKey(), "API", API_ID_2, "APPLICATION", APPLICATION_ID_2),
+                        Map.of("API_KEY", apiKey.getId(), "API", API_ID_2, "APPLICATION", APPLICATION_ID_2),
                         ApiKeyAuditEvent.APIKEY_REVOKED.name(),
                         result.getRevokedAt(),
                         ""
@@ -320,7 +320,7 @@ class RevokeApiKeyDomainServiceTest {
                         AuditEntity.AuditReferenceType.API,
                         API_ID_1,
                         USER_ID,
-                        Map.of("API_KEY", apiKey.getKey(), "API", API_ID_1, "APPLICATION", APPLICATION_ID_1),
+                        Map.of("API_KEY", apiKey.getId(), "API", API_ID_1, "APPLICATION", APPLICATION_ID_1),
                         ApiKeyAuditEvent.APIKEY_REVOKED.name(),
                         result.getRevokedAt(),
                         ""

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApiSubscriptionApiKeyUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApiSubscriptionApiKeyUseCaseTest.java
@@ -261,7 +261,7 @@ class RevokeApiSubscriptionApiKeyUseCaseTest {
                     AuditEntity.AuditReferenceType.API,
                     API_ID,
                     USER_ID,
-                    Map.of("API_KEY", apiKey.getKey(), "API", API_ID, "APPLICATION", APPLICATION_ID),
+                    Map.of("API_KEY", apiKey.getId(), "API", API_ID, "APPLICATION", APPLICATION_ID),
                     ApiKeyAuditEvent.APIKEY_REVOKED.name(),
                     result.apiKey().getRevokedAt(),
                     ""

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApplicationApiKeyUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApplicationApiKeyUseCaseTest.java
@@ -211,7 +211,7 @@ class RevokeApplicationApiKeyUseCaseTest {
                     AuditEntity.AuditReferenceType.API,
                     API_2,
                     USER_ID,
-                    Map.of("API_KEY", apiKey.getKey(), "API", API_2, "APPLICATION", APPLICATION_ID),
+                    Map.of("API_KEY", apiKey.getId(), "API", API_2, "APPLICATION", APPLICATION_ID),
                     ApiKeyAuditEvent.APIKEY_REVOKED.name(),
                     result.apiKey().getRevokedAt(),
                     ""
@@ -223,7 +223,7 @@ class RevokeApplicationApiKeyUseCaseTest {
                     AuditEntity.AuditReferenceType.API,
                     API_1,
                     USER_ID,
-                    Map.of("API_KEY", apiKey.getKey(), "API", API_1, "APPLICATION", APPLICATION_ID),
+                    Map.of("API_KEY", apiKey.getId(), "API", API_1, "APPLICATION", APPLICATION_ID),
                     ApiKeyAuditEvent.APIKEY_REVOKED.name(),
                     result.apiKey().getRevokedAt(),
                     ""

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApplicationSubscriptionApiKeyUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApplicationSubscriptionApiKeyUseCaseTest.java
@@ -243,7 +243,7 @@ class RevokeApplicationSubscriptionApiKeyUseCaseTest {
                     AuditEntity.AuditReferenceType.API,
                     API_ID,
                     USER_ID,
-                    Map.of("API_KEY", apiKey.getKey(), "API", API_ID, "APPLICATION", APPLICATION_ID),
+                    Map.of("API_KEY", apiKey.getId(), "API", API_ID, "APPLICATION", APPLICATION_ID),
                     ApiKeyAuditEvent.APIKEY_REVOKED.name(),
                     result.apiKey().getRevokedAt(),
                     ""

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeSubscriptionApiKeyUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeSubscriptionApiKeyUseCaseTest.java
@@ -231,7 +231,7 @@ class RevokeSubscriptionApiKeyUseCaseTest {
                     AuditEntity.AuditReferenceType.API,
                     API_ID,
                     USER_ID,
-                    Map.of("API_KEY", apiKey.getKey(), "API", API_ID, "APPLICATION", APPLICATION_ID),
+                    Map.of("API_KEY", apiKey.getId(), "API", API_ID, "APPLICATION", APPLICATION_ID),
                     ApiKeyAuditEvent.APIKEY_REVOKED.name(),
                     result.apiKey().getRevokedAt(),
                     ""

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -188,6 +188,8 @@ public class ApiKeyServiceTest {
         assertEquals(apiKey.getId(), properties.get(Audit.AuditProperties.API_KEY));
         assertFalse(properties.containsValue(API_KEY));
         assertNull(((ApiKeyEntity) argument.getValue().getNewValue()).getKey());
+        // hash is the MD5 of the key and authenticates Native Kafka clients, so it must go too.
+        assertNull(((ApiKeyEntity) argument.getValue().getNewValue()).getHash());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -187,9 +187,7 @@ public class ApiKeyServiceTest {
         // from an audit record.
         assertEquals(apiKey.getId(), properties.get(Audit.AuditProperties.API_KEY));
         assertFalse(properties.containsValue(API_KEY));
-        assertNull(((ApiKeyEntity) argument.getValue().getNewValue()).getKey());
-        // hash is the MD5 of the key and authenticates Native Kafka clients, so it must go too.
-        assertNull(((ApiKeyEntity) argument.getValue().getNewValue()).getHash());
+        assertNoCredentialInAudit(argument.getValue());
     }
 
     @Test
@@ -314,6 +312,7 @@ public class ApiKeyServiceTest {
         assertTrue(properties.containsKey(Audit.AuditProperties.API));
         assertTrue(properties.containsKey(Audit.AuditProperties.API_KEY));
         assertTrue(properties.containsKey(Audit.AuditProperties.APPLICATION));
+        assertNoCredentialInAudit(argument.getValue());
 
         verify(apiKeyGenerator, times(0)).generate();
         assertEquals(CUSTOM_API_KEY, apiKey.getKey());
@@ -403,6 +402,7 @@ public class ApiKeyServiceTest {
         assertTrue(properties.containsKey(Audit.AuditProperties.API));
         assertTrue(properties.containsKey(Audit.AuditProperties.API_KEY));
         assertTrue(properties.containsKey(Audit.AuditProperties.APPLICATION));
+        assertNoCredentialInAudit(argument.getValue());
     }
 
     @Test
@@ -444,6 +444,7 @@ public class ApiKeyServiceTest {
         assertTrue(properties.containsKey(Audit.AuditProperties.API));
         assertTrue(properties.containsKey(Audit.AuditProperties.API_KEY));
         assertTrue(properties.containsKey(Audit.AuditProperties.APPLICATION));
+        assertNoCredentialInAudit(argument.getValue());
     }
 
     @Test(expected = ApiKeyAlreadyActivatedException.class)
@@ -559,6 +560,7 @@ public class ApiKeyServiceTest {
             assertTrue(properties.containsKey(Audit.AuditProperties.API));
             assertTrue(properties.containsKey(Audit.AuditProperties.API_KEY));
             assertTrue(properties.containsKey(Audit.AuditProperties.APPLICATION));
+            assertNoCredentialInAudit(auditLogData);
         }
 
         // Old API Key has been revoked
@@ -801,6 +803,9 @@ public class ApiKeyServiceTest {
     public void shouldUpdateExpired() throws TechnicalException {
         ApiKey existingApiKey = new ApiKey();
         existingApiKey.setApplication(APPLICATION_ID);
+        // The audited value is built from the stored key rather than from the entity passed to update, so this
+        // is the value that must not reach the record.
+        existingApiKey.setKey("123-456-789");
         when(apiKeyRepository.findById("api-key-id")).thenReturn(Optional.of(existingApiKey));
 
         SubscriptionEntity subscription = new SubscriptionEntity();
@@ -830,11 +835,10 @@ public class ApiKeyServiceTest {
         assertFalse("isRevoked", existingApiKey.isRevoked());
         assertTrue("isPaused", existingApiKey.isPaused());
         verify(notifierService, times(1)).trigger(eq(GraviteeContext.getExecutionContext()), eq(ApiHook.APIKEY_EXPIRED), any(), any());
-        verify(auditService, times(1)).createApiAuditLog(
-            eq(GraviteeContext.getExecutionContext()),
-            argThat(auditLogData -> auditLogData.getEvent().equals(APIKEY_EXPIRED)),
-            any()
-        );
+        ArgumentCaptor<AuditService.AuditLogData> argument = ArgumentCaptor.forClass(AuditService.AuditLogData.class);
+        verify(auditService, times(1)).createApiAuditLog(eq(GraviteeContext.getExecutionContext()), argument.capture(), any());
+        assertEquals(APIKEY_EXPIRED, argument.getValue().getEvent());
+        assertNoCredentialInAudit(argument.getValue());
     }
 
     @Test
@@ -1486,6 +1490,19 @@ public class ApiKeyServiceTest {
             eq(apiProductId),
             any()
         );
+    }
+
+    /**
+     * Neither the key value nor its MD5 hash may reach an audit record: the hash authenticates Native Kafka
+     * clients, so it is a usable credential on its own.
+     */
+    private void assertNoCredentialInAudit(AuditService.AuditLogData auditLogData) {
+        for (Object value : new Object[] { auditLogData.getOldValue(), auditLogData.getNewValue() }) {
+            if (value instanceof ApiKeyEntity auditedApiKey) {
+                assertNull(auditedApiKey.getKey());
+                assertNull(auditedApiKey.getHash());
+            }
+        }
     }
 
     private ApiKey buildTestApiKey(String id) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -182,6 +182,12 @@ public class ApiKeyServiceTest {
         assertTrue(properties.containsKey(Audit.AuditProperties.API));
         assertTrue(properties.containsKey(Audit.AuditProperties.API_KEY));
         assertTrue(properties.containsKey(Audit.AuditProperties.APPLICATION));
+
+        // The audit identifies the key by its id: the key value is a credential and must not be recoverable
+        // from an audit record.
+        assertEquals(apiKey.getId(), properties.get(Audit.AuditProperties.API_KEY));
+        assertFalse(properties.containsValue(API_KEY));
+        assertNull(((ApiKeyEntity) argument.getValue().getNewValue()).getKey());
     }
 
     @Test


### PR DESCRIPTION
## Description

APIM-14809 — subscription API keys were stored in clear text in Management API audit records, in two places:

1. the `API_KEY` audit **property**, set to the full key string;
2. the audit **patch**, because the serialised `ApiKeyEntity` carries its `key` field.

Anyone with the audit read permission could therefore lift a usable credential out of an `APIKEY_CREATED` / `RENEWED` / `REVOKED` / `EXPIRED` / `REACTIVATED` event and replay it against the gateway.

Three call sites wrote these audits:

- `ApiKeyServiceImpl.createAuditLog` (v3 service, all lifecycle events)
- `GenerateApiKeyDomainService.createAuditLog`
- `RevokeApiKeyDomainService.createAuditLog`

All three now put the **API key id** in the `API_KEY` property and audit a copy of the entity with `key` cleared. Everything that makes the record useful — key id, application, API / API product, event, actor, timestamp — is untouched.

### Why clear the field rather than use `pathsToAnonymize`

`AuditService.AuditLogData` has a `pathsToAnonymize` hook that rewrites a JSON-patch value to `*****`. I did not use it: it only exists on the v3 audit path (the core `ApiAuditLogEntity` has no equivalent), and it matches on an exact patch path, so it would silently stop covering the key if the payload shape ever changed. Clearing the field before serialisation cannot miss, and it works identically on both paths. Happy to switch if you would rather see an explicit `*****` in the diff.

### Scope note

This redacts records written from now on. **Audit records already in the database keep their plaintext keys.** Rewriting them is deliberately not part of this PR: it would mean mutating an audit trail, and the exposure is better addressed by rotating any key that could have been read from an old audit record than by editing history. No migration is planned.

## Tests

- `ApiKeyServiceTest` — the `API_KEY` property is the key id, the plaintext key appears in no property, and the audited new value carries no `key`.
- `GenerateApiKeyDomainServiceTest.should_keep_the_api_key_value_out_of_the_audit` — end to end over the in-memory audit store: neither the properties nor the patch contain the key value.
- The existing audit assertions in the revoke use cases and domain service were asserting the leak (`API_KEY` == key value); they now assert the id.
- Full `*ApiKey*` suite green (225 tests).

## Backport

`apply-on-master`.
