### PR TITLE
fix: make promotion createOrUpdate tolerate a concurrent insert

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
@@ -238,7 +238,7 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
                 createdOrUpdatedPromotion = promotionRepository.update(promotion);
             } else {
                 log.debug("Creating promotion: {}", promotion.getId());
-                createdOrUpdatedPromotion = promotionRepository.create(promotion);
+                createdOrUpdatedPromotion = createOrUpdateOnConflict(promotion);
             }
 
             return convert(createdOrUpdatedPromotion);
@@ -247,6 +247,24 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
                 "An error occurs while trying to create or update a promotion using its id {}" + promotionEntity.getId(),
                 e
             );
+        }
+    }
+
+    /**
+     * The existence check above and the insert are not atomic. A promotion is written concurrently by the
+     * environment that starts it and by the Cockpit bridge that receives it, and when both share a database the
+     * check can miss a row the other transaction has not committed yet, which surfaced as a raw primary key
+     * violation. Treat the conflict as what it means - somebody else got there first - and update instead.
+     */
+    private Promotion createOrUpdateOnConflict(Promotion promotion) throws TechnicalException {
+        try {
+            return promotionRepository.create(promotion);
+        } catch (Exception e) {
+            if (promotionRepository.findById(promotion.getId()).isEmpty()) {
+                throw e;
+            }
+            log.debug("Promotion {} was created concurrently, updating it instead", promotion.getId());
+            return promotionRepository.update(promotion);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
@@ -77,6 +77,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.dao.DuplicateKeyException;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -198,6 +199,27 @@ public class PromotionServiceTest {
     @Test(expected = TechnicalManagementException.class)
     public void shouldNotCreateOrUpdateException() throws TechnicalException {
         when(promotionRepository.findById(any())).thenThrow(new TechnicalException());
+
+        promotionService.createOrUpdate(getAPromotionEntity());
+    }
+
+    @Test
+    public void shouldUpdateWhenThePromotionWasCreatedConcurrently() throws TechnicalException {
+        // The first lookup misses the row another transaction has not committed yet, so the insert conflicts.
+        when(promotionRepository.findById(any())).thenReturn(Optional.empty(), Optional.of(new Promotion()));
+        when(promotionRepository.create(any())).thenThrow(new DuplicateKeyException("Violation of PRIMARY KEY constraint"));
+        when(promotionRepository.update(any())).thenReturn(getAPromotion());
+
+        promotionService.createOrUpdate(getAPromotionEntity());
+
+        verify(promotionRepository, times(1)).create(any());
+        verify(promotionRepository, times(1)).update(any());
+    }
+
+    @Test(expected = DuplicateKeyException.class)
+    public void shouldRethrowWhenTheCreateFailureIsNotAConflict() throws TechnicalException {
+        when(promotionRepository.findById(any())).thenReturn(Optional.empty());
+        when(promotionRepository.create(any())).thenThrow(new DuplicateKeyException("boom"));
 
         promotionService.createOrUpdate(getAPromotionEntity());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
@@ -203,6 +203,7 @@ public class PromotionServiceTest {
         promotionService.createOrUpdate(getAPromotionEntity());
     }
 
+    // The Mongo repository lets the driver's unchecked DuplicateKeyException escape create().
     @Test
     public void shouldUpdateWhenThePromotionWasCreatedConcurrently() throws TechnicalException {
         // The first lookup misses the row another transaction has not committed yet, so the insert conflicts.
@@ -220,6 +221,32 @@ public class PromotionServiceTest {
     public void shouldRethrowWhenTheCreateFailureIsNotAConflict() throws TechnicalException {
         when(promotionRepository.findById(any())).thenReturn(Optional.empty());
         when(promotionRepository.create(any())).thenThrow(new DuplicateKeyException("boom"));
+
+        promotionService.createOrUpdate(getAPromotionEntity());
+    }
+
+    // JdbcAbstractCrudRepository.create wraps every failure into a checked TechnicalException, so on the JDBC
+    // repositories the conflict never surfaces as a DuplicateKeyException - it arrives as its cause.
+    @Test
+    public void shouldUpdateWhenTheConcurrentCreateFailureIsWrappedInATechnicalException() throws TechnicalException {
+        when(promotionRepository.findById(any())).thenReturn(Optional.empty(), Optional.of(new Promotion()));
+        when(promotionRepository.create(any())).thenThrow(
+            new TechnicalException("Failed to create promotion", new DuplicateKeyException("Violation of PRIMARY KEY constraint"))
+        );
+        when(promotionRepository.update(any())).thenReturn(getAPromotion());
+
+        promotionService.createOrUpdate(getAPromotionEntity());
+
+        verify(promotionRepository, times(1)).create(any());
+        verify(promotionRepository, times(1)).update(any());
+    }
+
+    @Test(expected = TechnicalManagementException.class)
+    public void shouldRethrowWhenTheWrappedCreateFailureIsNotAConflict() throws TechnicalException {
+        when(promotionRepository.findById(any())).thenReturn(Optional.empty());
+        when(promotionRepository.create(any())).thenThrow(
+            new TechnicalException("Failed to create promotion", new RuntimeException("boom"))
+        );
 
         promotionService.createOrUpdate(getAPromotionEntity());
     }


### PR DESCRIPTION
## Description

APIM-14594 — promoting an API fails with `DuplicateKeyException: Violation of PRIMARY KEY constraint 'pk_apim_promotions'`.

`PromotionServiceImpl.createOrUpdate` is a check-then-act:

```java
final Optional<Promotion> existingPromotion = promotionRepository.findById(promotionEntity.getId());
...
if (existingPromotion.isPresent()) { update } else { create }
```

The lookup and the insert are not atomic. The environment that starts the promotion (`create`) and the Cockpit bridge that receives it (`createOrUpdate`) write the same promotion id, and when both sit on the same database the `findById` can run before the other transaction commits. The reporter's SQL trace shows exactly that, two SPIDs on the same primary node, 37 ms apart.

The second writer then takes the `create` branch and blows up. The promotion stays in error and retries with a new id, failing the same way — which is why deleting the offending row does not help.

`create` now falls back to `update` when it conflicts **and** a second lookup confirms the row is there. If the row still is not there, or the failure was something else, it propagates unchanged.

### Why the catch is broad

The conflict does not surface the same way on every repository implementation, so pinning `org.springframework.dao.DuplicateKeyException` would only fix half the problem:

| Repository | What `create()` throws on a PK violation |
|---|---|
| JDBC (the reported case) | `JdbcAbstractCrudRepository.create` catches `Exception` and rethrows a checked `TechnicalException` with the `DuplicateKeyException` as its cause |
| Mongo | the driver's unchecked `DuplicateKeyException` escapes directly |

Catching `Exception` covers both. The `findById` re-check is what keeps it specific: nothing is swallowed unless a promotion with that id genuinely exists.

## Tests

Mongo shape — the unchecked exception escapes `create()`:

- `shouldUpdateWhenThePromotionWasCreatedConcurrently` — first lookup empty, insert conflicts, second lookup finds the row → one `create`, one `update`, no exception.
- `shouldRethrowWhenTheCreateFailureIsNotAConflict` — insert fails and the row is still absent → the original exception propagates.

JDBC shape — the failure arrives wrapped in a `TechnicalException`:

- `shouldUpdateWhenTheConcurrentCreateFailureIsWrappedInATechnicalException` — same fallback through the wrapped conflict.
- `shouldRethrowWhenTheWrappedCreateFailureIsNotAConflict` — a wrapped non-conflict failure surfaces as `TechnicalManagementException` via the existing outer catch.

`PromotionServiceTest` green, 27 tests.

## Backport

`apply-on-4-12-x`, `apply-on-master`.

The ticket carries no reported version, so this targets 4.11.x as the current LTS. The code is identical on 4.9.x and 4.10.x — say the word if the backport should be widened.
