### PR TITLE
fix(console): include inactive plans in subscription filter

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.spec.ts
@@ -67,6 +67,8 @@ describe('ApiSubscriptionListComponent', () => {
   const APPLICATION_ID = 'application_1';
   const anAPI = fakeApiV4({ id: API_ID });
   const aPlan = fakePlanV4({ id: PLAN_ID, apiId: API_ID });
+  const aDeprecatedPlan = fakePlanV4({ id: 'deprecated-plan', apiId: API_ID, name: 'Deprecated plan', status: 'DEPRECATED' });
+  const aClosedPlan = fakePlanV4({ id: 'closed-plan', apiId: API_ID, name: 'Closed plan', status: 'CLOSED' });
   const aKeylessPlan = fakePlanV4({ id: 'keyless-plan', apiId: API_ID, name: 'Keyless plan', security: { type: 'KEY_LESS' } });
   const anApplication = fakeApplication({ id: APPLICATION_ID, owner: { displayName: 'Gravitee.io' } });
 
@@ -162,8 +164,8 @@ describe('ApiSubscriptionListComponent', () => {
       expect(await apiKeyInput.getValue()).toEqual('apiKey_1');
     }));
 
-    it('should not include keyless plan in plan filters', fakeAsync(async () => {
-      await initComponent([], anAPI, [aPlan, aKeylessPlan], [anApplication], {
+    it('should include deprecated and closed plans and exclude keyless plans from plan filters', fakeAsync(async () => {
+      await initComponent([], anAPI, [aPlan, aDeprecatedPlan, aClosedPlan, aKeylessPlan], [anApplication], {
         plan: PLAN_ID,
         application: APPLICATION_ID,
         status: 'CLOSED,REJECTED',
@@ -174,8 +176,21 @@ describe('ApiSubscriptionListComponent', () => {
       const planSelectInput = await harness.getPlanSelectInput();
       await planSelectInput.open();
       const planSelectOptions = await planSelectInput.getOptions();
-      expect(planSelectOptions.length).toEqual(1);
-      expect(await planSelectOptions[0].getText()).toEqual('Default plan');
+      expect(await parallel(() => planSelectOptions.map(option => option.getText()))).toEqual([
+        'Default plan',
+        'Deprecated plan',
+        'Closed plan',
+      ]);
+    }));
+
+    it('should filter subscriptions by deprecated and closed plans', fakeAsync(async () => {
+      await initComponent([], anAPI, [aDeprecatedPlan, aClosedPlan]);
+      const harness = await loader.getHarness(ApiSubscriptionListHarness);
+
+      const planSelectInput = await harness.getPlanSelectInput();
+      await planSelectInput.clickOptions({ text: /Deprecated plan|Closed plan/ });
+      tick(400);
+      expectApiSubscriptionsGetRequest([], undefined, undefined, [aDeprecatedPlan.id, aClosedPlan.id]);
     }));
 
     it('should reset filters from params', fakeAsync(async () => {
@@ -399,6 +414,24 @@ describe('ApiSubscriptionListComponent', () => {
   });
 
   describe('create subscription', () => {
+    it('should only display published plans', fakeAsync(async () => {
+      await init();
+      await initComponent([], fakeApiV4({ id: API_ID, listeners: [] }), [aPlan, aDeprecatedPlan, aClosedPlan]);
+      const harness = await loader.getHarness(ApiSubscriptionListHarness);
+
+      const createSubBtn = await harness.getCreateSubscriptionButton();
+      await createSubBtn.click();
+
+      const creationDialogHarness = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(
+        ApiPortalSubscriptionCreationDialogHarness,
+      );
+      const planRadioButtons = await creationDialogHarness.getRadioButtons();
+      expect(await parallel(() => planRadioButtons.map(radioButton => radioButton.getLabelText()))).toEqual(['Default plan']);
+
+      await creationDialogHarness.cancelSubscription();
+      flush();
+    }));
+
     it('should create subscription to an API Key plan in exclusive API Key mode without customApiKey', fakeAsync(async () => {
       await init({
         customApiKey: { enabled: true },
@@ -853,7 +886,7 @@ describe('ApiSubscriptionListComponent', () => {
     };
     httpTestingController
       .expectOne({
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans?page=1&perPage=9999`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans?page=1&perPage=9999&statuses=PUBLISHED,DEPRECATED,CLOSED`,
         method: 'GET',
       })
       .flush(response);

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.ts
@@ -129,7 +129,17 @@ export class ApiSubscriptionListComponent implements OnInit, OnDestroy {
           this.isKubernetesOrigin = api.definitionContext?.origin === 'KUBERNETES';
           this.canUpdate = this.permissionService.hasAnyMatching(['api-subscription-u']) && !this.isKubernetesOrigin;
         }),
-        switchMap(() => this.apiPlanService.list(this.activatedRoute.snapshot.params.apiId, null, null, null, undefined, 1, 9999)),
+        switchMap(() =>
+          this.apiPlanService.list(
+            this.activatedRoute.snapshot.params.apiId,
+            undefined,
+            ['PUBLISHED', 'DEPRECATED', 'CLOSED'],
+            undefined,
+            undefined,
+            1,
+            9999,
+          ),
+        ),
         tap(plansResponse => (this.plans = plansResponse.data.filter(plan => plan.security?.type !== 'KEY_LESS'))),
         catchError(error => {
           this.snackBarService.error(error.message);
@@ -253,7 +263,7 @@ export class ApiSubscriptionListComponent implements OnInit, OnDestroy {
         data: {
           isFederatedApi: this.api.definitionVersion === 'FEDERATED',
           availableSubscriptionEntrypoints: this.getApiSubscriptionEntrypoints(this.api),
-          plans: this.plans.filter(plan => plan.status),
+          plans: this.plans.filter(plan => plan.status === 'PUBLISHED'),
         },
       })
       .afterClosed()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14795

## Description

Fixes the API subscription list Plan filter so that subscriptions can be filtered by deprecated and closed plans.

## Changes

- Request `PUBLISHED`, `DEPRECATED`, and `CLOSED` plans for the Plan filter.
- Keep `KEY_LESS` plans excluded.
- Keep the Create a subscription dialog limited to `PUBLISHED` plans.
- Add regression tests for inactive plan visibility, `planIds` filtering, and subscription creation.

https://github.com/user-attachments/assets/2b68f5d1-267b-4ea5-a720-a96b478a3711


## How to test

https://github.com/gravitee-io/gravitee-api-management/pull/18829#issuecomment-5128758094