### PR TITLE
fix: name the no-op v4 health check bean so it reaches the host context

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpAnalyticsRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpAnalyticsRepositoryConfiguration.java
@@ -49,7 +49,7 @@ public class NoOpAnalyticsRepositoryConfiguration {
     }
 
     @Bean
-    public io.gravitee.repository.healthcheck.v4.api.HealthCheckRepository healthCheckRepositoryV4() {
+    public io.gravitee.repository.healthcheck.v4.api.HealthCheckRepository healthCheckV4Repository() {
         return new io.gravitee.repository.noop.healthcheck.v4.NoOpHealthCheckRepository();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpRepositoryBeanNamingTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpRepositoryBeanNamingTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Repository plugins run in their own Spring context. {@code RepositoryPluginHandler} copies a bean into the
+ * host context only when its <b>name</b> ends with {@code Repository} (or {@code TransactionManager}), and a
+ * bean declared with {@code @Bean} is named after its method. A repository whose method is named otherwise is
+ * therefore built, never published, and only shows up as a "No qualifying bean" error the first time a page
+ * needs it - which is how the v4 health check repository stayed invisible while analytics were disabled.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class NoOpRepositoryBeanNamingTest {
+
+    static Stream<Class<?>> configurations() {
+        return Stream.of(
+            NoOpAnalyticsRepositoryConfiguration.class,
+            NoOpManagementRepositoryConfiguration.class,
+            NoOpRateLimitRepositoryConfiguration.class
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("configurations")
+    void every_repository_bean_is_named_so_the_plugin_handler_publishes_it(Class<?> configuration) {
+        List<String> beanNames = Arrays.stream(configuration.getDeclaredMethods())
+            .filter(method -> method.isAnnotationPresent(Bean.class))
+            .map(Method::getName)
+            .toList();
+
+        assertThat(beanNames).isNotEmpty();
+        assertThat(beanNames).allSatisfy(name -> assertThat(name).endsWith("Repository"));
+    }
+}


### PR DESCRIPTION
## Description

APIM-14383 — with `analytics.type=none`, opening the v4 endpoint health check dashboard fails with:

> No qualifying bean of type 'io.gravitee.repository.healthcheck.v4.api.HealthCheckRepository' available […] Dependency annotations: {@Lazy(true)}

### Root cause

Repository plugins are instantiated in their own Spring context. `RepositoryPluginHandler` (gravitee-plugin-repository) then copies beans into the host context, but **only those whose bean name ends with `Repository`** — or `TransactionManager`:

```java
for (String beanName : pluginContext.getBeanDefinitionNames()) {
    Object bean = pluginContext.getBean(beanName);
    if (beanName.endsWith("Repository")
        || (beanName.endsWith("TransactionManager") && !provider.getClass().equals(bean.getClass()))) {
        if (bean.getClass().getInterfaces().length > 0) {
            beanFactory.registerSingleton(beanName, bean);
        }
    }
}
```

A `@Bean` method names its bean after itself, and ours was `healthCheckRepositoryV4()` — ending in `V4`. The no-op v4 health check repository was built on every startup and then silently left behind in the plugin context. Its neighbours `analyticsV4Repository()` and `logV4Repository()` follow the convention and are published normally, which is why only this one page broke.

Elasticsearch was never affected: it declares `healthCheckElasticsearchRepository(...)`, which ends correctly. That is exactly why the bug only shows up "in case of disabled ElasticSearch DB".

`@Lazy` on the `ApiHealthQueryServiceImpl` constructor parameter is what delays the failure to the first call, so this surfaces as a broken dashboard rather than a startup error.

Present since 4.9.0 (`cf7cce7ba`, the commit that introduced the bean), on every branch through master.

### Fix

Rename the method to `healthCheckV4Repository()`. One line, no behaviour change beyond the bean actually being published.

## Tests

`NoOpRepositoryBeanNamingTest` asserts every `@Bean` in the three `NoOp*RepositoryConfiguration` classes is named so the handler will publish it. Checked against the old name: it fails, naming `healthCheckRepositoryV4` — so it is a real guard, not a tautology. Full no-op suite green (65 tests).

The rule this encodes is invisible in the code today and has now cost one production bug; the test makes a bean that can never be published fail the build instead of a page at runtime.

## Note for reviewers

This supersedes #18826, which I opened earlier tonight before finding the cause. That PR made `ApiHealthQueryServiceImpl` tolerate a missing repository via `ObjectProvider`. I have closed it: it would have turned this bug into a silently empty dashboard, which is what made it hard to find in the first place. If we still want graceful degradation for a genuinely absent repository, it is worth doing deliberately and separately.

## Backport

`apply-on-4-10-x`, `apply-on-4-11-x`, `apply-on-4-12-x`, `apply-on-master`.