### PR TITLE
chore: replace the deprecated javascript policy with gravitee-policy-js

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -2598,19 +2598,6 @@
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.policy</groupId>
-                    <artifactId>gravitee-policy-javascript</artifactId>
-                    <version>${gravitee-policy-javascript.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>io.gravitee.policy</groupId>
                     <artifactId>gravitee-policy-js</artifactId>
                     <version>${gravitee-policy-js.version}</version>
                     <type>zip</type>

--- a/gravitee-apim-integration-tests/pom.xml
+++ b/gravitee-apim-integration-tests/pom.xml
@@ -678,12 +678,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.gravitee.policy</groupId>
-            <artifactId>gravitee-policy-javascript</artifactId>
-            <version>${gravitee-policy-javascript.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.graviteesource.policy</groupId>
             <artifactId>gravitee-policy-wssecurity-authentication</artifactId>
             <version>${gravitee-policy-wssecurity-authentication.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -201,8 +201,7 @@
     <gravitee-policy-http-signature.version>1.7.0</gravitee-policy-http-signature.version>
     <gravitee-policy-interrupt.version>2.2.1</gravitee-policy-interrupt.version>
     <gravitee-policy-ipfiltering.version>3.0.0</gravitee-policy-ipfiltering.version>
-    <gravitee-policy-javascript.version>3.0.0</gravitee-policy-javascript.version>
-    <gravitee-policy-js.version>1.0.1</gravitee-policy-js.version>
+    <gravitee-policy-js.version>1.2.0</gravitee-policy-js.version>
     <gravitee-policy-json-threat-protection.version>2.1.0</gravitee-policy-json-threat-protection.version>
     <gravitee-policy-json-to-json.version>3.1.0</gravitee-policy-json-to-json.version>
     <gravitee-policy-json-to-toon.version>1.0.2</gravitee-policy-json-to-toon.version>


### PR DESCRIPTION
## Issue

N/A — cleanup around the deprecation of `gravitee-policy-javascript`.

## Description

`gravitee-policy-javascript` is deprecated in favour of [`gravitee-policy-js`](https://github.com/gravitee-io/gravitee-policy-js). The two do not share an engine: the former embeds a standalone Nashorn, the latter GraalJS.

**Removed from `bundle-dev`.** Only that profile shipped the deprecated policy, so nothing changes for the official distribution, which builds from `bundle-default` — clients who want it add it themselves. The now-orphaned `gravitee-policy-javascript.version` property goes with it, as does its dependency in the integration tests, which no test and no API definition ever referenced.

**No replacement dependency in the integration tests.** `gravitee-policy-js` carries its own suite — 117 tests, including gateway integration tests — so declaring it here would only swap one unused dependency for another.

**Bumped `gravitee-policy-js` to 1.2.0.** Worth calling out, because 1.0.1 is broken on JDK 25: it pins GraalVM 23.1.11, whose Truffle calls `sun.misc.Unsafe.ensureClassInitialized`, removed in JDK 25. The engine fails to initialise and no script runs at all:

```
java.lang.NoSuchMethodError: 'void sun.misc.Unsafe.ensureClassInitialized(java.lang.Class)'
	at com.oracle.truffle.api.library.LibraryFactory.ensureLibraryInitialized(LibraryFactory.java:385)
```

1.2.0 ships GraalVM 25.2.4. Verified against the policy's own suite: 117/117 pass on JDK 25, and still on JDK 21, so the bump is backward compatible.

## Additional context

This matters for sequencing with the JDK 25 migration: on 1.0.1 the replacement policy would have been unusable there while the deprecated one it replaces still worked.