### PR TITLE
fix: scope portal user permissions to current environment

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/UserMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/UserMapper.java
@@ -20,11 +20,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.portal.rest.model.*;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.springframework.stereotype.Component;
 
 /**
@@ -48,13 +52,7 @@ public class UserMapper {
     }
 
     public User convert(UserEntity user) {
-        final User userItem = new User();
-        userItem.setEmail(user.getEmail());
-        userItem.setFirstName(user.getFirstname());
-        userItem.setLastName(user.getLastname());
-        userItem.setDisplayName(user.getDisplayName());
-        userItem.setId(user.getId());
-        userItem.setEditableProfile(IDP_SOURCE_GRAVITEE.equals(user.getSource()) || IDP_SOURCE_MEMORY.equalsIgnoreCase(user.getSource()));
+        final User userItem = convertUser(user);
         if (user.getRoles() != null) {
             Map<String, List<String>> userPermissions = user
                 .getRoles()
@@ -81,7 +79,27 @@ public class UserMapper {
                 });
             userItem.setPermissions(objectMapper.convertValue(userPermissions, UserPermissions.class));
         }
-        userItem.setCustomFields(user.getCustomFields());
+        return userItem;
+    }
+
+    public User convertForEnvironment(UserEntity user, String environmentId) {
+        final User userItem = convertUser(user);
+        Stream<UserRoleEntity> organizationRoles = user.getRoles() == null
+            ? Stream.empty()
+            : user
+                .getRoles()
+                .stream()
+                .filter(role -> RoleScope.ORGANIZATION.equals(role.getScope()));
+
+        Set<UserRoleEntity> environmentRoles = user.getEnvRoles() == null || environmentId == null
+            ? Set.of()
+            : user.getEnvRoles().getOrDefault(environmentId, Set.of());
+
+        userItem.setPermissions(
+            convertPermissions(
+                Stream.concat(organizationRoles, environmentRoles.stream().filter(role -> RoleScope.ENVIRONMENT.equals(role.getScope())))
+            )
+        );
         return userItem;
     }
 
@@ -138,5 +156,37 @@ public class UserMapper {
         userLinks.setNotifications(basePath + "/notifications");
         userLinks.setSelf(basePath);
         return userLinks;
+    }
+
+    private User convertUser(UserEntity user) {
+        final User userItem = new User();
+        userItem.setEmail(user.getEmail());
+        userItem.setFirstName(user.getFirstname());
+        userItem.setLastName(user.getLastname());
+        userItem.setDisplayName(user.getDisplayName());
+        userItem.setId(user.getId());
+        userItem.setEditableProfile(IDP_SOURCE_GRAVITEE.equals(user.getSource()) || IDP_SOURCE_MEMORY.equalsIgnoreCase(user.getSource()));
+        userItem.setCustomFields(user.getCustomFields());
+        return userItem;
+    }
+
+    private UserPermissions convertPermissions(Stream<UserRoleEntity> roles) {
+        Map<String, Set<String>> mergedPermissions = new HashMap<>();
+        roles
+            .map(UserRoleEntity::getPermissions)
+            .flatMap(rolePermissions -> rolePermissions.entrySet().stream())
+            .forEach(permission -> {
+                Set<String> actions = mergedPermissions.computeIfAbsent(permission.getKey(), ignored -> new LinkedHashSet<>());
+                new String(permission.getValue())
+                    .chars()
+                    .mapToObj(action -> String.valueOf((char) action))
+                    .forEach(actions::add);
+            });
+
+        Map<String, List<String>> userPermissions = mergedPermissions
+            .entrySet()
+            .stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, permission -> new ArrayList<>(permission.getValue())));
+        return objectMapper.convertValue(userPermissions, UserPermissions.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/UserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/UserResource.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.portal.rest.model.UserInput;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.service.ConfigService;
 import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.UnauthorizedAccessException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
@@ -71,13 +72,14 @@ public class UserResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getCurrentUser() {
         final String authenticatedUser = getAuthenticatedUser();
+        final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         try {
-            UserEntity userEntity = userService.findByIdWithRoles(GraviteeContext.getExecutionContext(), authenticatedUser);
-            User currentUser = userMapper.convert(userEntity);
+            UserEntity userEntity = userService.findByIdWithRoles(executionContext, authenticatedUser);
+            User currentUser = userMapper.convertForEnvironment(userEntity, executionContext.getEnvironmentId());
             boolean withManagement = (authenticatedUser != null &&
-                permissionService.hasManagementRights(GraviteeContext.getExecutionContext(), authenticatedUser));
+                permissionService.hasManagementRights(executionContext, authenticatedUser));
             if (withManagement) {
-                Management managementConfig = this.configService.getConsoleSettings(GraviteeContext.getExecutionContext()).getManagement();
+                Management managementConfig = this.configService.getConsoleSettings(executionContext).getManagement();
                 if (managementConfig != null && managementConfig.getUrl() != null) {
                     UserConfig userConfig = new UserConfig();
                     userConfig.setManagementUrl(managementConfig.getUrl());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/UserMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/UserMapperTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.portal.rest.mapper;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.gravitee.rest.api.model.NewExternalUserEntity;
@@ -33,6 +34,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -145,6 +147,50 @@ public class UserMapperTest {
     }
 
     @Test
+    void should_scope_permissions_to_current_environment() {
+        UserRoleEntity organizationRole = role("organization-role", RoleScope.ORGANIZATION, "USER", 'R');
+        UserRoleEntity devRole = role("dev-role", RoleScope.ENVIRONMENT, "APPLICATION", 'C', 'R');
+        UserRoleEntity testRole = role("test-role", RoleScope.ENVIRONMENT, "APPLICATION", 'R');
+        UserEntity userEntity = new UserEntity();
+        userEntity.setRoles(Set.of(organizationRole, devRole, testRole));
+        userEntity.setEnvRoles(Map.of("DEV", Set.of(devRole), "TEST", Set.of(testRole)));
+
+        User devUser = userMapper.convertForEnvironment(userEntity, "DEV");
+        User testUser = userMapper.convertForEnvironment(userEntity, "TEST");
+
+        assertThat(devUser.getPermissions().getAPPLICATION()).containsExactlyInAnyOrder("C", "R");
+        assertThat(devUser.getPermissions().getUSER()).containsExactly("R");
+        assertThat(testUser.getPermissions().getAPPLICATION()).containsExactly("R");
+        assertThat(testUser.getPermissions().getUSER()).containsExactly("R");
+    }
+
+    @Test
+    void should_union_permissions_from_roles_in_current_environment() {
+        UserRoleEntity createRole = role("create-role", RoleScope.ENVIRONMENT, "APPLICATION", 'C');
+        UserRoleEntity updateRole = role("update-role", RoleScope.ENVIRONMENT, "APPLICATION", 'R', 'U');
+        UserEntity userEntity = new UserEntity();
+        userEntity.setRoles(Set.of(createRole, updateRole));
+        userEntity.setEnvRoles(Map.of("DEV", Set.of(createRole, updateRole)));
+
+        User user = userMapper.convertForEnvironment(userEntity, "DEV");
+
+        assertThat(user.getPermissions().getAPPLICATION()).containsExactlyInAnyOrder("C", "R", "U");
+    }
+
+    @Test
+    void should_not_fall_back_to_flat_environment_roles_when_scoped_roles_are_missing() {
+        UserRoleEntity organizationRole = role("organization-role", RoleScope.ORGANIZATION, "USER", 'R');
+        UserRoleEntity environmentRole = role("environment-role", RoleScope.ENVIRONMENT, "APPLICATION", 'C');
+        UserEntity userEntity = new UserEntity();
+        userEntity.setRoles(Set.of(organizationRole, environmentRole));
+
+        User user = userMapper.convertForEnvironment(userEntity, "DEV");
+
+        assertThat(user.getPermissions().getUSER()).containsExactly("R");
+        assertThat(user.getPermissions().getAPPLICATION()).isNull();
+    }
+
+    @Test
     public void testConvertSearchUser() {
         // init
         io.gravitee.apim.core.user.model.User searchUser = io.gravitee.apim.core.user.model.User.builder()
@@ -220,5 +266,13 @@ public class UserMapperTest {
         assertEquals(basePath + "/avatar?", links.getAvatar());
         assertEquals(basePath + "/notifications", links.getNotifications());
         assertEquals(basePath, links.getSelf());
+    }
+
+    private static UserRoleEntity role(String id, RoleScope scope, String permission, char... actions) {
+        UserRoleEntity role = new UserRoleEntity();
+        role.setId(id);
+        role.setScope(scope);
+        role.setPermissions(Map.of(permission, actions));
+        return role;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/UserResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/UserResourceTest.java
@@ -65,6 +65,7 @@ public class UserResourceTest extends AbstractResourceTest {
         resetAllMocks();
 
         doReturn(new User()).when(userMapper).convert(nullable(UserEntity.class));
+        doReturn(new User()).when(userMapper).convertForEnvironment(nullable(UserEntity.class), nullable(String.class));
         doReturn(new UserLinks()).when(userMapper).computeUserLinks(any(), any());
 
         InlinePictureEntity mockImage = new InlinePictureEntity();
@@ -76,7 +77,8 @@ public class UserResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetCurrentUserWithoutConfig() {
-        when(userService.findByIdWithRoles(GraviteeContext.getExecutionContext(), USER_NAME)).thenReturn(new UserEntity());
+        UserEntity userEntity = new UserEntity();
+        when(userService.findByIdWithRoles(GraviteeContext.getExecutionContext(), USER_NAME)).thenReturn(userEntity);
         when(permissionService.hasManagementRights(GraviteeContext.getExecutionContext(), USER_NAME)).thenReturn(Boolean.FALSE);
 
         final Response response = target().request().get();
@@ -84,6 +86,7 @@ public class UserResourceTest extends AbstractResourceTest {
 
         ArgumentCaptor<String> userId = ArgumentCaptor.forClass(String.class);
         Mockito.verify(userService).findByIdWithRoles(eq(GraviteeContext.getExecutionContext()), userId.capture());
+        Mockito.verify(userMapper).convertForEnvironment(userEntity, GraviteeContext.getCurrentEnvironment());
 
         assertEquals(USER_NAME, userId.getValue());
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13995

## Description

Fixes Portal user permissions being aggregated across all environments instead of being scoped to the currently selected environment.

The Portal current-user endpoint now combines:

- Organization-level permissions.
- Environment-level permissions assigned only in the current environment.

Permissions from multiple roles within the same environment are merged and deduplicated.

## Tests

Added unit tests covering:

- Permission isolation between environments.
- Merging permissions from multiple roles in one environment.
- No fallback to unscoped environment roles.
- Use of the current environment when mapping the Portal user.


## Manual test

https://github.com/gravitee-io/gravitee-api-management/pull/18837#issuecomment-5130320704
