### PR TITLE
fix(plan): enforce native keyless/secure plan exclusivity across DEPRECATED plans

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/ValidatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/ValidatePlanDomainService.java
@@ -20,12 +20,14 @@ import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
 import io.gravitee.apim.core.api.model.crd.PlanCRD;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.documentation.model.Page;
+import io.gravitee.apim.core.plan.model.NativePlanSecurityCategory;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.plan.model.factory.PlanModelFactory;
 import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.listener.AbstractListener;
 import io.gravitee.definition.model.v4.nativeapi.NativePlan;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -98,6 +100,33 @@ public class ValidatePlanDomainService implements Validator<ValidatePlanDomainSe
             }
         });
 
+        if (input.apiCRDSpec.isNative()) {
+            validateNoConflictingNativeSecurity(input.plans(), errors);
+        }
+
         return Result.ofBoth(input.sanitized(sanitizedPlans), errors);
+    }
+
+    /**
+     * Same mutual-exclusivity rule as {@code NativePlanSecurityValidator} (publish paths), applied
+     * here over the whole imported plan set. Keep both in sync via {@link NativePlanSecurityCategory}.
+     */
+    private static void validateNoConflictingNativeSecurity(Map<String, PlanCRD> plans, List<Error> errors) {
+        long distinctSecurityCategories = plans
+            .values()
+            .stream()
+            .filter(plan -> plan.getStatus() == PlanStatus.PUBLISHED || plan.getStatus() == PlanStatus.DEPRECATED)
+            .filter(plan -> plan.getSecurity() != null)
+            .map(plan -> NativePlanSecurityCategory.fromSecurityTypeLabel(plan.getSecurity().getType()))
+            .distinct()
+            .count();
+
+        if (distinctSecurityCategories > 1) {
+            errors.add(
+                Error.severe(
+                    "a Native API cannot combine Keyless, mTLS and authentication plans: keyless, mTLS and authentication plans are mutually exclusive"
+                )
+            );
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/NativePlanSecurityCategory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/NativePlanSecurityCategory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.model;
+
+import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
+
+/**
+ * Security categories that are mutually exclusive on a Native (Kafka) API: a plan of a given
+ * category cannot coexist with a plan of a different category. All authentication mechanisms
+ * (API key, JWT, OAuth2) share the same {@link #AUTHENTICATION} category and can coexist together.
+ *
+ * <p>Single source of truth shared by the two enforcement sites:
+ * {@code NativePlanSecurityValidator} (publish paths) and {@code ValidatePlanDomainService} (CRD
+ * import). It mirrors the gateway's native-Kafka reactor guard.
+ */
+public enum NativePlanSecurityCategory {
+    KEY_LESS,
+    MTLS,
+    AUTHENTICATION;
+
+    public static NativePlanSecurityCategory fromSecurityTypeLabel(String securityTypeLabel) {
+        if (PlanSecurityType.KEY_LESS.getLabel().equals(securityTypeLabel)) {
+            return KEY_LESS;
+        }
+        if (PlanSecurityType.MTLS.getLabel().equals(securityTypeLabel)) {
+            return MTLS;
+        }
+        return AUTHENTICATION;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/plan/PublishPlanDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/plan/PublishPlanDomainServiceImpl.java
@@ -32,6 +32,7 @@ import io.gravitee.rest.api.service.exceptions.PlanAlreadyDeprecatedException;
 import io.gravitee.rest.api.service.exceptions.PlanAlreadyPublishedException;
 import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.v4.validation.NativePlanSecurityValidator;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -94,6 +95,8 @@ public class PublishPlanDomainServiceImpl implements PublishPlanDomainService {
                     throw new KeylessPlanAlreadyPublishedException(planId);
                 }
             }
+
+            NativePlanSecurityValidator.validateNoConflictingSecurity(plan, plans);
 
             // Update plan status
             plan.setStatus(io.gravitee.repository.management.model.Plan.Status.PUBLISHED);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/NativePlanAuthenticationConflictException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/NativePlanAuthenticationConflictException.java
@@ -35,11 +35,11 @@ public class NativePlanAuthenticationConflictException extends AbstractManagemen
     @Override
     public String getMessage() {
         if (planToPublishType == Plan.PlanSecurityType.KEY_LESS) {
-            return "A plan with mTLS or authentication is already published for the Native API. Keyless plans cannot be combined with mTLS or authentication plans.";
+            return "A plan with mTLS or authentication is already published or deprecated for the Native API. Keyless plans cannot be combined with mTLS or authentication plans.";
         } else if (planToPublishType == Plan.PlanSecurityType.MTLS) {
-            return "A Keyless or authentication plan is already published for the Native API. mTLS plans cannot be combined with Keyless or authentication plans.";
+            return "A Keyless or authentication plan is already published or deprecated for the Native API. mTLS plans cannot be combined with Keyless or authentication plans.";
         } else {
-            return "A Keyless or mTLS plan is already published for the Native API. Authentication plans cannot be combined with Keyless or mTLS plans.";
+            return "A Keyless or mTLS plan is already published or deprecated for the Native API. Authentication plans cannot be combined with Keyless or mTLS plans.";
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
@@ -66,7 +66,6 @@ import io.gravitee.rest.api.service.exceptions.ApiDeprecatedException;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
 import io.gravitee.rest.api.service.exceptions.KeylessPlanAlreadyPublishedException;
-import io.gravitee.rest.api.service.exceptions.NativePlanAuthenticationConflictException;
 import io.gravitee.rest.api.service.exceptions.PlanAlreadyClosedException;
 import io.gravitee.rest.api.service.exceptions.PlanAlreadyDeprecatedException;
 import io.gravitee.rest.api.service.exceptions.PlanAlreadyPublishedException;
@@ -87,6 +86,7 @@ import io.gravitee.rest.api.service.v4.PlanService;
 import io.gravitee.rest.api.service.v4.mapper.GenericPlanMapper;
 import io.gravitee.rest.api.service.v4.mapper.PlanMapper;
 import io.gravitee.rest.api.service.v4.validation.FlowValidationService;
+import io.gravitee.rest.api.service.v4.validation.NativePlanSecurityValidator;
 import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import java.util.Arrays;
 import java.util.Collection;
@@ -630,9 +630,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
                 }
             }
 
-            if (plan.getApiType() == ApiType.NATIVE) {
-                validateNoConflictingAuthenticationForNativePlan(plan, plans);
-            }
+            NativePlanSecurityValidator.validateNoConflictingSecurity(plan, plans);
 
             // Update plan status
             plan.setStatus(Plan.Status.PUBLISHED);
@@ -777,29 +775,6 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
                     throw new TechnicalManagementException("An error occurs while trying to update plan " + plan.getId(), ex);
                 }
             });
-    }
-
-    private void validateNoConflictingAuthenticationForNativePlan(final Plan nativePlanToPublish, final Set<Plan> apiPlans) {
-        Plan.PlanSecurityType planToPublishType = nativePlanToPublish.getSecurity();
-
-        boolean hasConflict = apiPlans
-            .stream()
-            .filter(existingPlan -> existingPlan.getStatus() == Plan.Status.PUBLISHED)
-            .anyMatch(existingPlan -> {
-                Plan.PlanSecurityType existingType = existingPlan.getSecurity();
-                // Keyless, MTLS, and other authentication types are mutually exclusive
-                if (planToPublishType == Plan.PlanSecurityType.KEY_LESS) {
-                    return existingType != Plan.PlanSecurityType.KEY_LESS;
-                } else if (planToPublishType == Plan.PlanSecurityType.MTLS) {
-                    return existingType != Plan.PlanSecurityType.MTLS;
-                } else {
-                    return existingType == Plan.PlanSecurityType.KEY_LESS || existingType == Plan.PlanSecurityType.MTLS;
-                }
-            });
-
-        if (hasConflict) {
-            throw new NativePlanAuthenticationConflictException(planToPublishType);
-        }
     }
 
     private PlanEntity mapToEntity(final Plan plan) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/NativePlanSecurityValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/NativePlanSecurityValidator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.validation;
+
+import io.gravitee.apim.core.plan.model.NativePlanSecurityCategory;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.repository.management.model.Plan;
+import io.gravitee.rest.api.service.exceptions.NativePlanAuthenticationConflictException;
+import java.util.Collection;
+
+/**
+ * Enforces, on the publish paths, that a Native API never mixes plans of different security
+ * categories (see {@link NativePlanSecurityCategory}): keyless, mTLS and authentication plans are
+ * mutually exclusive.
+ *
+ * <p>A plan is considered "active" — and therefore conflicting — as soon as it is {@code PUBLISHED}
+ * or {@code DEPRECATED}, matching the gateway's native-Kafka reactor which loads both statuses.
+ *
+ * <p>The same rule is enforced on the CRD import path in
+ * {@code ValidatePlanDomainService#validateNoConflictingNativeSecurity}: keep both in sync.
+ */
+public final class NativePlanSecurityValidator {
+
+    private NativePlanSecurityValidator() {}
+
+    public static void validateNoConflictingSecurity(Plan planToPublish, Collection<Plan> apiPlans) {
+        if (planToPublish.getApiType() != ApiType.NATIVE || planToPublish.getSecurity() == null) {
+            return;
+        }
+
+        NativePlanSecurityCategory categoryToPublish = categoryOf(planToPublish.getSecurity());
+
+        // No self-exclusion needed: callers reject non-STAGING plans before publishing, so the plan
+        // being published never matches the PUBLISHED/DEPRECATED filter below.
+        boolean hasConflict = apiPlans
+            .stream()
+            .filter(existingPlan -> existingPlan.getStatus() == Plan.Status.PUBLISHED || existingPlan.getStatus() == Plan.Status.DEPRECATED)
+            .filter(existingPlan -> existingPlan.getSecurity() != null)
+            .anyMatch(existingPlan -> categoryOf(existingPlan.getSecurity()) != categoryToPublish);
+
+        if (hasConflict) {
+            throw new NativePlanAuthenticationConflictException(planToPublish.getSecurity());
+        }
+    }
+
+    private static NativePlanSecurityCategory categoryOf(Plan.PlanSecurityType securityType) {
+        return switch (securityType) {
+            case KEY_LESS -> NativePlanSecurityCategory.KEY_LESS;
+            case MTLS -> NativePlanSecurityCategory.MTLS;
+            default -> NativePlanSecurityCategory.AUTHENTICATION;
+        };
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/ValidatePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/ValidatePlanDomainServiceTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import fixtures.core.model.ApiCRDFixtures;
+import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
+import io.gravitee.apim.core.api.model.crd.PlanCRD;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ValidatePlanDomainServiceTest {
+
+    private static final AuditInfo AUDIT_INFO = new AuditInfo("org", "env", null);
+
+    private final PlanValidatorDomainService planValidator = mock(PlanValidatorDomainService.class);
+    private final VerifyPlanPortRangesDomainService portRangesValidator = mock(VerifyPlanPortRangesDomainService.class);
+
+    private final ValidatePlanDomainService service = new ValidatePlanDomainService(planValidator, portRangesValidator);
+
+    @Test
+    void should_reject_native_keyless_plan_coexisting_with_active_auth_plan() {
+        ApiCRDSpec spec = ApiCRDFixtures.newBaseNativeSpec().build();
+        Map<String, PlanCRD> plans = Map.of(
+            "keyless",
+            nativePlan("keyless", "key-less", PlanStatus.PUBLISHED),
+            "apikey",
+            nativePlan("apikey", "api-key", PlanStatus.PUBLISHED)
+        );
+
+        var result = service.validateAndSanitize(new ValidatePlanDomainService.Input(AUDIT_INFO, spec, plans, List.of()));
+
+        assertThat(hasMutualExclusivityError(result)).isTrue();
+    }
+
+    @Test
+    void should_reject_native_keyless_plan_coexisting_with_deprecated_auth_plan() {
+        ApiCRDSpec spec = ApiCRDFixtures.newBaseNativeSpec().build();
+        Map<String, PlanCRD> plans = Map.of(
+            "keyless",
+            nativePlan("keyless", "key-less", PlanStatus.PUBLISHED),
+            "apikey",
+            nativePlan("apikey", "api-key", PlanStatus.DEPRECATED)
+        );
+
+        var result = service.validateAndSanitize(new ValidatePlanDomainService.Input(AUDIT_INFO, spec, plans, List.of()));
+
+        assertThat(hasMutualExclusivityError(result)).isTrue();
+    }
+
+    @Test
+    void should_accept_native_keyless_plan_when_the_auth_plan_is_closed() {
+        ApiCRDSpec spec = ApiCRDFixtures.newBaseNativeSpec().build();
+        Map<String, PlanCRD> plans = Map.of(
+            "keyless",
+            nativePlan("keyless", "key-less", PlanStatus.PUBLISHED),
+            "apikey",
+            nativePlan("apikey", "api-key", PlanStatus.CLOSED)
+        );
+
+        var result = service.validateAndSanitize(new ValidatePlanDomainService.Input(AUDIT_INFO, spec, plans, List.of()));
+
+        assertThat(hasMutualExclusivityError(result)).isFalse();
+    }
+
+    @Test
+    void should_accept_native_multiple_authentication_plans() {
+        ApiCRDSpec spec = ApiCRDFixtures.newBaseNativeSpec().build();
+        Map<String, PlanCRD> plans = Map.of(
+            "apikey",
+            nativePlan("apikey", "api-key", PlanStatus.PUBLISHED),
+            "jwt",
+            nativePlan("jwt", "jwt", PlanStatus.PUBLISHED)
+        );
+
+        var result = service.validateAndSanitize(new ValidatePlanDomainService.Input(AUDIT_INFO, spec, plans, List.of()));
+
+        assertThat(hasMutualExclusivityError(result)).isFalse();
+    }
+
+    private static PlanCRD nativePlan(String id, String securityType, PlanStatus status) {
+        return PlanCRD.builder()
+            .id(id)
+            .name(id)
+            .security(new PlanSecurity(securityType, "{}"))
+            .mode(PlanMode.STANDARD)
+            .status(status)
+            .build();
+    }
+
+    private static boolean hasMutualExclusivityError(Validator.Result<ValidatePlanDomainService.Input> result) {
+        return result
+            .errors()
+            .orElseGet(List::of)
+            .stream()
+            .map(Validator.Error::getMessage)
+            .anyMatch(message -> message.contains("mutually exclusive"));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/plan/PlanOperationsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/plan/PlanOperationsDomainServiceTest.java
@@ -44,6 +44,7 @@ import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.KeylessPlanAlreadyPublishedException;
+import io.gravitee.rest.api.service.exceptions.NativePlanAuthenticationConflictException;
 import io.gravitee.rest.api.service.exceptions.PlanAlreadyPublishedException;
 import java.util.Collections;
 import java.util.List;
@@ -173,6 +174,38 @@ class PlanOperationsDomainServiceTest {
         ).thenReturn(Set.of(existingKeyless));
 
         assertThatThrownBy(() -> publicationsService.publish(auditInfo, PLAN_ID)).isInstanceOf(KeylessPlanAlreadyPublishedException.class);
+    }
+
+    @Test
+    void publish_should_throw_when_native_keyless_conflicts_with_deprecated_auth_plan() throws Exception {
+        var plan = io.gravitee.repository.management.model.Plan.builder()
+            .id(PLAN_ID)
+            .referenceType(io.gravitee.repository.management.model.Plan.PlanReferenceType.API)
+            .referenceId(API_ID)
+            .status(io.gravitee.repository.management.model.Plan.Status.STAGING)
+            .apiType(ApiType.NATIVE)
+            .security(io.gravitee.repository.management.model.Plan.PlanSecurityType.KEY_LESS)
+            .build();
+        var deprecatedApiKey = io.gravitee.repository.management.model.Plan.builder()
+            .id("deprecated-api-key")
+            .referenceType(io.gravitee.repository.management.model.Plan.PlanReferenceType.API)
+            .referenceId(API_ID)
+            .status(io.gravitee.repository.management.model.Plan.Status.DEPRECATED)
+            .apiType(ApiType.NATIVE)
+            .security(io.gravitee.repository.management.model.Plan.PlanSecurityType.API_KEY)
+            .build();
+
+        when(planRepository.findById(eq(PLAN_ID))).thenReturn(Optional.of(plan));
+        when(
+            planRepository.findByReferenceIdAndReferenceType(
+                eq(API_ID),
+                eq(io.gravitee.repository.management.model.Plan.PlanReferenceType.API)
+            )
+        ).thenReturn(Set.of(plan, deprecatedApiKey));
+
+        assertThatThrownBy(() -> publicationsService.publish(auditInfo, PLAN_ID)).isInstanceOf(
+            NativePlanAuthenticationConflictException.class
+        );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_PublishTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_PublishTest.java
@@ -393,6 +393,64 @@ public class PlanService_PublishTest {
     }
 
     @Test
+    public void shouldNotPublishApiKeyNativePlanIfKeylessPlanDeprecated() throws TechnicalException {
+        assertThrows(NativePlanAuthenticationConflictException.class, () -> {
+            var stagedApiKeyPlan = Plan.builder()
+                .status(Plan.Status.STAGING)
+                .apiType(ApiType.NATIVE)
+                .validation(Plan.PlanValidationType.AUTO)
+                .referenceType(Plan.PlanReferenceType.API)
+                .referenceId(API_ID)
+                .security(Plan.PlanSecurityType.API_KEY)
+                .build();
+
+            var deprecatedKeylessPlan = Plan.builder()
+                .id("deprecated-keyless")
+                .referenceType(Plan.PlanReferenceType.API)
+                .referenceId(API_ID)
+                .security(Plan.PlanSecurityType.KEY_LESS)
+                .status(Plan.Status.DEPRECATED)
+                .build();
+
+            when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(stagedApiKeyPlan));
+            when(planRepository.findByReferenceIdAndReferenceType(API_ID, Plan.PlanReferenceType.API)).thenReturn(
+                Set.of(stagedApiKeyPlan, deprecatedKeylessPlan)
+            );
+
+            planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
+        });
+    }
+
+    @Test
+    public void shouldNotPublishKeylessNativePlanIfAuthPlanDeprecated() throws TechnicalException {
+        assertThrows(NativePlanAuthenticationConflictException.class, () -> {
+            var stagedKeylessPlan = Plan.builder()
+                .status(Plan.Status.STAGING)
+                .apiType(ApiType.NATIVE)
+                .validation(Plan.PlanValidationType.AUTO)
+                .referenceType(Plan.PlanReferenceType.API)
+                .referenceId(API_ID)
+                .security(Plan.PlanSecurityType.KEY_LESS)
+                .build();
+
+            var deprecatedApiKeyPlan = Plan.builder()
+                .id("deprecated-api-key")
+                .referenceType(Plan.PlanReferenceType.API)
+                .referenceId(API_ID)
+                .security(Plan.PlanSecurityType.API_KEY)
+                .status(Plan.Status.DEPRECATED)
+                .build();
+
+            when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(stagedKeylessPlan));
+            when(planRepository.findByReferenceIdAndReferenceType(API_ID, Plan.PlanReferenceType.API)).thenReturn(
+                Set.of(stagedKeylessPlan, deprecatedApiKeyPlan)
+            );
+
+            planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
+        });
+    }
+
+    @Test
     public void shouldPublish_WithPublishGCPage() throws TechnicalException {
         final String GC_PAGE_ID = "GC_PAGE_ID";
         var plan = Plan.builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/validation/NativePlanSecurityValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/validation/NativePlanSecurityValidatorTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.validation;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.repository.management.model.Plan;
+import io.gravitee.rest.api.service.exceptions.NativePlanAuthenticationConflictException;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class NativePlanSecurityValidatorTest {
+
+    private static Plan plan(String id, ApiType apiType, Plan.PlanSecurityType security, Plan.Status status) {
+        return Plan.builder().id(id).apiType(apiType).security(security).status(status).build();
+    }
+
+    private static Plan nativePlanToPublish(Plan.PlanSecurityType security) {
+        return plan("to-publish", ApiType.NATIVE, security, Plan.Status.STAGING);
+    }
+
+    @Test
+    void should_skip_validation_for_non_native_api() {
+        var proxyKeyless = plan("to-publish", ApiType.PROXY, Plan.PlanSecurityType.KEY_LESS, Plan.Status.STAGING);
+        var existingApiKey = plan("existing", ApiType.PROXY, Plan.PlanSecurityType.API_KEY, Plan.Status.PUBLISHED);
+
+        assertThatCode(() ->
+            NativePlanSecurityValidator.validateNoConflictingSecurity(proxyKeyless, Set.of(proxyKeyless, existingApiKey))
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_not_conflict_with_itself() {
+        var keyless = plan("to-publish", ApiType.NATIVE, Plan.PlanSecurityType.KEY_LESS, Plan.Status.PUBLISHED);
+
+        assertThatCode(() ->
+            NativePlanSecurityValidator.validateNoConflictingSecurity(keyless, Set.of(keyless))
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_reject_keyless_when_authentication_plan_published() {
+        var toPublish = nativePlanToPublish(Plan.PlanSecurityType.KEY_LESS);
+        var existing = plan("existing", ApiType.NATIVE, Plan.PlanSecurityType.API_KEY, Plan.Status.PUBLISHED);
+
+        assertThatThrownBy(() ->
+            NativePlanSecurityValidator.validateNoConflictingSecurity(toPublish, Set.of(toPublish, existing))
+        ).isInstanceOf(NativePlanAuthenticationConflictException.class);
+    }
+
+    @Test
+    void should_reject_keyless_when_authentication_plan_deprecated() {
+        var toPublish = nativePlanToPublish(Plan.PlanSecurityType.KEY_LESS);
+        var existing = plan("existing", ApiType.NATIVE, Plan.PlanSecurityType.API_KEY, Plan.Status.DEPRECATED);
+
+        assertThatThrownBy(() ->
+            NativePlanSecurityValidator.validateNoConflictingSecurity(toPublish, Set.of(toPublish, existing))
+        ).isInstanceOf(NativePlanAuthenticationConflictException.class);
+    }
+
+    @Test
+    void should_reject_mtls_when_authentication_plan_published() {
+        var toPublish = nativePlanToPublish(Plan.PlanSecurityType.MTLS);
+        var existing = plan("existing", ApiType.NATIVE, Plan.PlanSecurityType.OAUTH2, Plan.Status.PUBLISHED);
+
+        assertThatThrownBy(() ->
+            NativePlanSecurityValidator.validateNoConflictingSecurity(toPublish, Set.of(toPublish, existing))
+        ).isInstanceOf(NativePlanAuthenticationConflictException.class);
+    }
+
+    @Test
+    void should_reject_authentication_when_mtls_plan_published() {
+        var toPublish = nativePlanToPublish(Plan.PlanSecurityType.JWT);
+        var existing = plan("existing", ApiType.NATIVE, Plan.PlanSecurityType.MTLS, Plan.Status.PUBLISHED);
+
+        assertThatThrownBy(() ->
+            NativePlanSecurityValidator.validateNoConflictingSecurity(toPublish, Set.of(toPublish, existing))
+        ).isInstanceOf(NativePlanAuthenticationConflictException.class);
+    }
+
+    @Test
+    void should_allow_two_authentication_plans_of_different_types() {
+        var toPublish = nativePlanToPublish(Plan.PlanSecurityType.API_KEY);
+        var existing = plan("existing", ApiType.NATIVE, Plan.PlanSecurityType.JWT, Plan.Status.PUBLISHED);
+
+        assertThatCode(() ->
+            NativePlanSecurityValidator.validateNoConflictingSecurity(toPublish, Set.of(toPublish, existing))
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_allow_keyless_when_conflicting_plan_is_closed() {
+        var toPublish = nativePlanToPublish(Plan.PlanSecurityType.KEY_LESS);
+        var existing = plan("existing", ApiType.NATIVE, Plan.PlanSecurityType.API_KEY, Plan.Status.CLOSED);
+
+        assertThatCode(() ->
+            NativePlanSecurityValidator.validateNoConflictingSecurity(toPublish, Set.of(toPublish, existing))
+        ).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14831

## Description

On a Native (Kafka) API, a keyless plan must never coexist with a secure (mTLS or authentication) plan. When both are active the gateway's Kafka reactor throws `KafkaServerUnsupportedSecureAndUnsecurePlansException` and never mounts the SASL listener, so **every** client of the API fails to authenticate (`enabled mechanisms are []`).

The publish-time guard (`PlanServiceImpl#validateNoConflictingAuthenticationForNativePlan`) only looked at `PUBLISHED` plans. A **`DEPRECATED`** keyless plan was therefore ignored, so you could publish an `API_KEY`/`JWT`/`OAUTH2` plan next to a deprecated keyless one (and vice-versa) — an invalid combination that then broke the reactor. The gateway loads `DEPRECATED` plans as active, so "active" for this rule must mean `PUBLISHED` **or** `DEPRECATED`.

What changed:

- Extract the rule into a shared `NativePlanSecurityValidator` — considers a plan conflicting when it is `PUBLISHED` or `DEPRECATED`, excludes the plan being published, keeps the existing keyless / mTLS / authentication mutual-exclusivity semantics.
- `v4 PlanServiceImpl#publish` delegates to it → closes the `DEPRECATED` gap.
- `PublishPlanDomainServiceImpl#publish` now enforces it too (it previously only had the single-keyless guard) → covers the API_PRODUCT / newer publish flow.
- `ValidatePlanDomainService` cross-checks the whole imported plan set → covers the CRD / GKO import path, which had no such check.

Result: the rest-api can no longer produce a plan combination the gateway would reject; the reactor guard becomes a true last resort. Tests added for each path, including the exact `DEPRECATED keyless + publish API_KEY` scenario.

## Additional context

Reproduction: deprecate then keep a keyless plan while publishing an API_KEY plan on a native Kafka API → gateway reactor fails to start, clients get `Unexpected handshake request with client mechanism PLAIN, enabled mechanisms are []`.
