### PR TITLE
test: fix two tests failing outside CI conditions

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromSwaggerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromSwaggerTest.java
@@ -144,7 +144,7 @@ public class ApisResource_CreateApiFromSwaggerTest extends AbstractResourceTest 
         var apiWithFlows = new ApiWithFlows(createdApi, List.of());
         when(createApiDomainService.create(any(), any(), any(), any(), any())).thenReturn(apiWithFlows);
 
-        var swagger = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
+        var swagger = Resources.getResource("io/gravitee/rest/api/management/v2/rest/resource/api/openapi-withExtensions.json");
 
         // When
         var response = rootTarget()
@@ -174,7 +174,7 @@ public class ApisResource_CreateApiFromSwaggerTest extends AbstractResourceTest 
         );
         when(createApiDomainService.create(any(), any(), any(), any(), any())).thenThrow(new InvalidPathsException("Invalid paths"));
 
-        var resource = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
+        var resource = Resources.getResource("io/gravitee/rest/api/management/v2/rest/resource/api/openapi-withExtensions.json");
 
         // When
         var response = rootTarget()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/resources/io/gravitee/rest/api/management/v2/rest/resource/api/openapi-withExtensions.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/resources/io/gravitee/rest/api/management/v2/rest/resource/api/openapi-withExtensions.json
@@ -1,0 +1,270 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.2.3",
+    "title": "Gravitee.io Swagger API",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://demo.gravitee.io/gateway/echo"
+    }
+  ],
+  "x-graviteeio-definition": {
+    "categories": [
+      "cat1",
+      "cat2"
+    ],
+    "virtualHosts": [
+      {
+        "host": "myHost",
+        "path": "myPath",
+        "overrideEntrypoint": false
+      }
+    ],
+    "groups": [
+      "group1",
+      "group2"
+    ],
+    "labels": [
+      "label1",
+      "label2"
+    ],
+    "metadata": [
+      {
+        "name": "meta1",
+        "value": 1234,
+        "format": "NUMERIC"
+      },
+      {
+        "name": "meta2",
+        "value": "metaValue2"
+      }
+    ],
+    "picture": "data:image/png;base64,XXXXXXX",
+    "properties": [
+      {
+        "key": "prop1",
+        "value": "propValue1"
+      },
+      {
+        "key": "prop2",
+        "value": "propValue2"
+      }
+    ],
+    "tags": [
+      "tag1",
+      "tag2"
+    ],
+    "visibility": "PRIVATE"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "description": "A link to the next page of responses",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pets"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pets"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/definitions/errorModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://example.com/authorize",
+            "tokenUrl": "https://example.com/token",
+            "scopes": {
+              "user": "simple user rights"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Pet": {
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Pets": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Pet"
+        }
+      },
+      "Error": {
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/test/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/test/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationServiceTest.java
@@ -36,6 +36,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -147,7 +148,7 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
     void shouldPassActualApiKeyValueToEmailNotification() throws Exception {
         setNotificationDays(List.of(30));
 
-        ZonedDateTime expire30 = ZonedDateTime.now().plusDays(30).plusMinutes(5);
+        ZonedDateTime expire30 = ZonedDateTime.now().plus(Duration.ofDays(30)).plusMinutes(5);
         ExpiringApiKey key = new ExpiringApiKey(
             "key-id",
             "actual-key-value",
@@ -183,7 +184,7 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
     void shouldSkipApiKeySubscriptionAlreadyNotifiedThroughSubscriptionPath() throws Exception {
         setNotificationDays(List.of(30));
 
-        ZonedDateTime expire30 = ZonedDateTime.now().plusDays(30).plusMinutes(5);
+        ZonedDateTime expire30 = ZonedDateTime.now().plus(Duration.ofDays(30)).plusMinutes(5);
         ExpiringSubscription expiringSub = new ExpiringSubscription(
             "sub-already",
             "api-already",
@@ -225,7 +226,7 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
     void shouldSkipApiKeyAlreadyNotifiedForCurrentOrSmallerDay() throws Exception {
         setNotificationDays(List.of(30));
 
-        ZonedDateTime expire30 = ZonedDateTime.now().plusDays(30).plusMinutes(5);
+        ZonedDateTime expire30 = ZonedDateTime.now().plus(Duration.ofDays(30)).plusMinutes(5);
 
         ExpiringApiKey alreadyNotifiedAtSameDay = new ExpiringApiKey("already-30", null, expire30, 30, null, List.of());
         ExpiringApiKey alreadyNotifiedAtSmallerDay = new ExpiringApiKey("already-15", null, expire30, 15, null, List.of());
@@ -314,10 +315,11 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
     void shouldBucketSubscriptionsByLargestMatchingDay() throws Exception {
         setNotificationDays(List.of(90, 45, 30));
 
-        // run() uses Instant.now() internally — build endingAts relative to wall clock so they land in the cron-hour window.
-        ZonedDateTime ending30 = ZonedDateTime.now().plusDays(30).plusMinutes(5);
-        ZonedDateTime ending45 = ZonedDateTime.now().plusDays(45).plusMinutes(5);
-        ZonedDateTime ending90 = ZonedDateTime.now().plusDays(90).plusMinutes(5);
+        // bucketExpiringSubscriptions compares epoch millis against now + d * 86_400_000, so the endingAts
+        // have to be exact durations. plusDays is calendar-based and drifts by an hour across a DST switch.
+        ZonedDateTime ending30 = ZonedDateTime.now().plus(Duration.ofDays(30)).plusMinutes(5);
+        ZonedDateTime ending45 = ZonedDateTime.now().plus(Duration.ofDays(45)).plusMinutes(5);
+        ZonedDateTime ending90 = ZonedDateTime.now().plus(Duration.ofDays(90)).plusMinutes(5);
 
         ExpiringSubscription sub30 = new ExpiringSubscription("s30", "api1", "plan1", "app1", "user1", ending30, null);
         ExpiringSubscription sub45 = new ExpiringSubscription("s45", "api1", "plan1", "app1", "user1", ending45, null);


### PR DESCRIPTION
## Issue

N/A — both predate this branch and are unrelated to each other, hence one commit each.

## Description

**`ScheduledSubscriptionPreExpirationNotificationServiceTest`** built its `endingAt` values with `ZonedDateTime.plusDays`, which is calendar-based, while the service buckets on `now + d * 86_400_000`. Across a DST switch the two disagree by an hour and the subscription falls outside the cron window. Switched the six occurrences to `plus(Duration.ofDays(n))`. Only the 90-day case fails today; the 30-day ones have the same defect and would follow from late September.

**`ApisResource_CreateApiFromSwaggerTest`** loads `openapi-withExtensions.json` from `gravitee-apim-rest-api-service`, whose test-jar only packages `fakes/**`, `inmemory/**` and `fixtures/**`. The resource never reaches this module, so the test has failed on any clean build since June 2026 and only passes on a stale `target/`. Gave the module its own copy rather than widening the test-jar includes, which would push that whole tree onto every consumer.

## Additional context

Neither is caught by CI: the first is green under `TZ=UTC`, the second needs a clean `target/`.

Verified failing before and passing after — the DST one in `Europe/Paris` on the same date, the other on a clean build of its module.