### PR TITLE
fix(console): save group membership roles on the group's own environment

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.ts
@@ -72,6 +72,11 @@ export interface MembershipApplicationDS {
   environmentId: string;
 }
 
+export interface GroupRolesChange {
+  formGroup: UntypedFormGroup;
+  environmentIdByGroupId: Record<string, string>;
+}
+
 const DEFAULT_RESOURCE_TABLE_COLUMNS = ['name', 'version', 'visibility'];
 
 @Component({
@@ -87,7 +92,7 @@ export class OrgSettingsUserDetailMembershipsComponent {
   readonly userDisplayName = input<string>();
   readonly isReadOnly = input(false);
 
-  readonly groupRolesChanged = output<UntypedFormGroup>();
+  readonly groupRolesChanged = output<GroupRolesChange>();
   readonly requestReload = output<void>();
 
   private readonly usersV2Service = inject(UsersV2Service);
@@ -137,6 +142,9 @@ export class OrgSettingsUserDetailMembershipsComponent {
   // Store initial group roles to compare changes
   initialGroupRoles: Record<string, { GROUP?: string; API?: string; APPLICATION?: string; INTEGRATION?: string; API_PRODUCT?: string }> =
     {};
+
+  // Environment each group belongs to, needed to save its membership on the right environment
+  private groupEnvironmentIds: Record<string, string> = {};
 
   constructor() {
     effect(() => {
@@ -372,6 +380,7 @@ export class OrgSettingsUserDetailMembershipsComponent {
 
   private initGroupsRolesForm(groups: Group[]) {
     this.initialGroupRoles = {};
+    this.groupEnvironmentIds = {};
     this.groupsRolesFormGroup = new UntypedFormGroup({
       ...groups.reduce((result, group) => {
         this.initialGroupRoles[group.id] = {
@@ -381,6 +390,7 @@ export class OrgSettingsUserDetailMembershipsComponent {
           INTEGRATION: group.roles['INTEGRATION'],
           API_PRODUCT: group.roles['API_PRODUCT'],
         };
+        this.groupEnvironmentIds[group.id] = group.environmentId ?? this.selectedEnvironmentId;
 
         return {
           ...result,
@@ -391,10 +401,17 @@ export class OrgSettingsUserDetailMembershipsComponent {
 
     this.groupsRolesFormGroup.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       if (this.groupsRolesFormGroup.dirty) {
-        this.groupRolesChanged.emit(this.groupsRolesFormGroup);
+        this.emitGroupRolesChange();
       }
     });
-    this.groupRolesChanged.emit(this.groupsRolesFormGroup);
+    this.emitGroupRolesChange();
+  }
+
+  private emitGroupRolesChange() {
+    this.groupRolesChanged.emit({
+      formGroup: this.groupsRolesFormGroup,
+      environmentIdByGroupId: { ...this.groupEnvironmentIds },
+    });
   }
 
   private createGroupRolesFormGroup(group: Group): UntypedFormGroup {

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
@@ -588,6 +588,7 @@ describe('OrgSettingsUserDetailComponent', () => {
 
     expectAddOrUpdateGroupMembershipRequest(
       'groupA',
+      'envAlphaId',
       [fakeGroupMembership({ id: user.id, roles: [{ scope: 'APPLICATION', name: 'ROLE_APP_USER' }] })],
       [
         {
@@ -602,6 +603,105 @@ describe('OrgSettingsUserDetailComponent', () => {
         },
       ],
     );
+  });
+
+  it('should save group roles on the environment the group belongs to', async () => {
+    const user = fakeUser({
+      id: 'userId',
+      source: 'gravitee',
+      status: 'ACTIVE',
+    });
+    expectInitRequests(user, defaultEnvironments, {}, [], {
+      application: [fakeRole({ id: 'roleAppOwnerId', name: 'ROLE_APP_OWNER' }), fakeRole({ id: 'roleAppUserId', name: 'ROLE_APP_USER' })],
+    });
+
+    const membershipsCard = await loader.getHarness(MatCardHarness.with({ selector: '.org-settings-user-detail__memberships-card' }));
+
+    // Switch to the second (non-default) environment tab
+    const tabGroup = await membershipsCard.getHarness(MatTabGroupHarness);
+    await (await tabGroup.getTabs())[1].select();
+
+    expectUserGroupsV2Request('userId', 'envBetaId', [
+      {
+        id: 'groupB',
+        name: 'Group B',
+        environmentId: 'envBetaId',
+        environmentName: 'Environment Beta',
+        roles: { GROUP: 'ADMIN', APPLICATION: 'ROLE_APP_OWNER' },
+      },
+    ]);
+    expectUserApisV2Request('userId', 'envBetaId', []);
+    expectUserApplicationsV2Request('userId', 'envBetaId', []);
+    expectUserApiProductsV2Request('userId', 'envBetaId', []);
+
+    fixture.detectChanges();
+
+    const groupsTable = await membershipsCard.getHarness(MatTableHarness.with({ selector: '[aria-label="Groups table"]' }));
+    const applicationRoleSelect = await (await (await groupsTable.getRows())[0].getCells())[4].getHarness(MatSelectHarness);
+    await applicationRoleSelect.clickOptions({ text: 'ROLE_APP_USER' });
+
+    const saveBar = await loader.getHarness(GioSaveBarHarness);
+    await saveBar.clickSubmit();
+
+    // Must target the group's own environment, not the current/default one
+    expectAddOrUpdateGroupMembershipRequest('groupB', 'envBetaId', [
+      fakeGroupMembership({ id: user.id, roles: [{ scope: 'APPLICATION', name: 'ROLE_APP_USER' }] }),
+    ]);
+  });
+
+  it('should not replay group roles edited on a previous tab after switching environment', async () => {
+    const user = fakeUser({
+      id: 'userId',
+      source: 'gravitee',
+      status: 'ACTIVE',
+    });
+    expectInitRequests(
+      user,
+      defaultEnvironments,
+      {
+        envAlphaId: {
+          groups: [
+            {
+              id: 'groupA',
+              name: 'Group A',
+              environmentId: 'envAlphaId',
+              environmentName: 'Environment Alpha',
+              roles: { GROUP: 'ADMIN', APPLICATION: 'ROLE_APP_OWNER' },
+            },
+          ],
+        },
+      },
+      [],
+      {
+        application: [fakeRole({ id: 'roleAppOwnerId', name: 'ROLE_APP_OWNER' }), fakeRole({ id: 'roleAppUserId', name: 'ROLE_APP_USER' })],
+      },
+    );
+
+    const membershipsCard = await loader.getHarness(MatCardHarness.with({ selector: '.org-settings-user-detail__memberships-card' }));
+
+    // Make the first tab's group roles dirty, without saving
+    const groupsTable = await membershipsCard.getHarness(MatTableHarness.with({ selector: '[aria-label="Groups table"]' }));
+    const applicationRoleSelect = await (await (await groupsTable.getRows())[0].getCells())[4].getHarness(MatSelectHarness);
+    await applicationRoleSelect.clickOptions({ text: 'ROLE_APP_USER' });
+
+    // Switching tab rebuilds both the roles form and the group/environment mapping
+    const tabGroup = await membershipsCard.getHarness(MatTabGroupHarness);
+    await (await tabGroup.getTabs())[1].select();
+
+    expectUserGroupsV2Request('userId', 'envBetaId', []);
+    expectUserApisV2Request('userId', 'envBetaId', []);
+    expectUserApplicationsV2Request('userId', 'envBetaId', []);
+    expectUserApiProductsV2Request('userId', 'envBetaId', []);
+
+    fixture.detectChanges();
+
+    const saveBar = await loader.getHarness(GioSaveBarHarness);
+    await saveBar.clickSubmit();
+
+    // The stale edit must not be replayed, on any environment
+    httpTestingController.expectNone(`${CONSTANTS_TESTING.org.baseURL}/environments/envAlphaId/configuration/groups/groupA/members`);
+    httpTestingController.expectNone(`${CONSTANTS_TESTING.org.baseURL}/environments/envBetaId/configuration/groups/groupA/members`);
+    httpTestingController.expectNone(`${CONSTANTS_TESTING.env.baseURL}/configuration/groups/groupA/members`);
   });
 
   it('should delete user from group after confirm dialog', async () => {
@@ -937,8 +1037,15 @@ describe('OrgSettingsUserDetailComponent', () => {
     fixture.detectChanges();
   }
 
-  function expectAddOrUpdateGroupMembershipRequest(groupId: string, groupMembership: GroupMembership[] = [], expectedBody?: unknown) {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${groupId}/members`);
+  function expectAddOrUpdateGroupMembershipRequest(
+    groupId: string,
+    environmentId: string,
+    groupMembership: GroupMembership[] = [],
+    expectedBody?: unknown,
+  ) {
+    const req = httpTestingController.expectOne(
+      `${CONSTANTS_TESTING.org.baseURL}/environments/${environmentId}/configuration/groups/${groupId}/members`,
+    );
     expect(req.request.method).toEqual('POST');
     if (expectedBody) {
       expect(req.request.body).toEqual(expectedBody);

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.ts
@@ -26,7 +26,11 @@ import {
   OrgSettingsUserGenerateTokenComponent,
   OrgSettingsUserGenerateTokenDialogData,
 } from './tokens/org-settings-user-generate-token.component';
-import { EnvironmentTab, OrgSettingsUserDetailMembershipsComponent } from './memberships/org-settings-user-detail-memberships.component';
+import {
+  EnvironmentTab,
+  GroupRolesChange,
+  OrgSettingsUserDetailMembershipsComponent,
+} from './memberships/org-settings-user-detail-memberships.component';
 
 import { Environment } from '../../../../entities/environment/environment';
 import { User } from '../../../../entities/user/user';
@@ -90,6 +94,9 @@ export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
 
   // Group roles form group from the memberships sub-component
   private groupsRolesFormGroup: UntypedFormGroup;
+
+  // Environment each group belongs to, provided by the memberships sub-component
+  private groupEnvironmentIds: Record<string, string> = {};
 
   // Store initial group roles from the memberships sub-component
   private membershipInitialGroupRoles: Record<
@@ -178,8 +185,9 @@ export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
     this.unsubscribe$.complete();
   }
 
-  onGroupRolesChanged(groupsRolesFormGroup: UntypedFormGroup) {
-    this.groupsRolesFormGroup = groupsRolesFormGroup;
+  onGroupRolesChanged({ formGroup, environmentIdByGroupId }: GroupRolesChange) {
+    this.groupsRolesFormGroup = formGroup;
+    this.groupEnvironmentIds = environmentIdByGroupId;
 
     merge(this.groupsRolesFormGroup.valueChanges, this.groupsRolesFormGroup.statusChanges)
       .pipe(takeUntil(this.unsubscribe$))
@@ -231,18 +239,22 @@ export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
             if (groupRolesFormGroup.dirty) {
               const { GROUP, API, APPLICATION, INTEGRATION, API_PRODUCT } = groupRolesFormGroup.getRawValue();
 
-              return this.groupService.addOrUpdateMemberships(groupId, [
-                {
-                  id: this.user.id,
-                  roles: [
-                    { scope: 'GROUP' as const, name: GROUP ? 'ADMIN' : '' },
-                    { scope: 'API' as const, name: API },
-                    { scope: 'APPLICATION' as const, name: APPLICATION },
-                    { scope: 'INTEGRATION' as const, name: INTEGRATION },
-                    { scope: 'API_PRODUCT' as const, name: API_PRODUCT },
-                  ],
-                },
-              ]);
+              return this.groupService.addOrUpdateMemberships(
+                groupId,
+                [
+                  {
+                    id: this.user.id,
+                    roles: [
+                      { scope: 'GROUP' as const, name: GROUP ? 'ADMIN' : '' },
+                      { scope: 'API' as const, name: API },
+                      { scope: 'APPLICATION' as const, name: APPLICATION },
+                      { scope: 'INTEGRATION' as const, name: INTEGRATION },
+                      { scope: 'API_PRODUCT' as const, name: API_PRODUCT },
+                    ],
+                  },
+                ],
+                this.groupEnvironmentIds[groupId],
+              );
             }
             return EMPTY;
           }),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14769

## Description

Editing the roles of a user's group membership (Organization > Users > Memberships) always
sent the request to the currently selected environment instead of the environment the group
actually belongs to. In an organization with more than one environment, the backend then
rejected the lookup with `Group [id] cannot be found`, and the change was silently lost.

The memberships sub-component now reports the environment of each group along with the roles
form, and the save action passes it to `addOrUpdateMemberships` — the same way the add and
delete actions already did.

https://github.com/user-attachments/assets/f229105d-f87c-4eda-933e-1c1002eb6aec

