### PR TITLE
feat(rest-api): add categoryIds to PortalNavigationItem domain model and persistence

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalNavigationItem.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalNavigationItem.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.management.model;
 
 import jakarta.annotation.Nonnull;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -84,4 +85,7 @@ public class PortalNavigationItem {
     private String apiProductId;
 
     private boolean useAutoFetch;
+
+    @Builder.Default
+    private List<String> categoryIds = List.of();
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
@@ -24,10 +24,14 @@ import io.gravitee.repository.management.api.PortalNavigationItemRepository;
 import io.gravitee.repository.management.api.search.PortalNavigationItemCriteria;
 import io.gravitee.repository.management.model.PortalNavigationItem;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Value;
@@ -41,8 +45,11 @@ public class JdbcPortalNavigationItemRepository
 
     private static final String DELETE_FROM = "delete from ";
 
+    private final String PORTAL_NAVIGATION_ITEM_CATEGORIES;
+
     JdbcPortalNavigationItemRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
         super(tablePrefix, "portal_navigation_items");
+        PORTAL_NAVIGATION_ITEM_CATEGORIES = getTableNameFor("portal_navigation_item_categories");
     }
 
     @Override
@@ -68,12 +75,62 @@ public class JdbcPortalNavigationItemRepository
     }
 
     @Override
+    public PortalNavigationItem create(PortalNavigationItem item) throws TechnicalException {
+        log.debug("JdbcPortalNavigationItemRepository.create({})", item.getId());
+        try {
+            jdbcTemplate.update(getOrm().buildInsertPreparedStatementCreator(item));
+            storeCategoryIds(item, false);
+            return findById(item.getId()).orElse(null);
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to create portal navigation item", ex);
+        }
+    }
+
+    @Override
+    public PortalNavigationItem update(PortalNavigationItem item) throws TechnicalException {
+        log.debug("JdbcPortalNavigationItemRepository.update({})", item == null ? null : item.getId());
+        if (item == null) {
+            throw new IllegalStateException("Unable to update null item");
+        }
+        try {
+            int rows = jdbcTemplate.update(getOrm().buildUpdatePreparedStatementCreator(item, item.getId()));
+            if (rows == 0) {
+                throw new IllegalStateException("Unable to update portal navigation item " + item.getId());
+            }
+            storeCategoryIds(item, true);
+            return findById(item.getId()).orElse(null);
+        } catch (IllegalStateException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to update portal navigation item", ex);
+        }
+    }
+
+    @Override
+    public void delete(String id) throws TechnicalException {
+        log.debug("JdbcPortalNavigationItemRepository.delete({})", id);
+        try {
+            jdbcTemplate.update(DELETE_FROM + PORTAL_NAVIGATION_ITEM_CATEGORIES + " where nav_item_id = ?", id);
+            jdbcTemplate.update(getOrm().getDeleteSql(), id);
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to delete portal navigation item", ex);
+        }
+    }
+
+    @Override
+    public Optional<PortalNavigationItem> findById(String id) throws TechnicalException {
+        Optional<PortalNavigationItem> item = super.findById(id);
+        item.ifPresent(this::attachCategoryIds);
+        return item;
+    }
+
+    @Override
     public List<PortalNavigationItem> findAllByOrganizationIdAndEnvironmentId(String organizationId, String environmentId)
         throws TechnicalException {
         log.debug("JdbcPortalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId({}, {})", organizationId, environmentId);
         try {
             final String sql = getOrm().getSelectAllSql() + " where organization_id = ? and environment_id = ?";
-            return jdbcTemplate.query(sql, getOrm().getRowMapper(), organizationId, environmentId);
+            return queryAndEnrichWithCategoryIds(sql, organizationId, environmentId);
         } catch (Exception ex) {
             throw new TechnicalException("Failed to find portal navigation items", ex);
         }
@@ -84,7 +141,7 @@ public class JdbcPortalNavigationItemRepository
         log.debug("JdbcPortalNavigationItemRepository.findAllByParentIdAndEnvironmentId({}, {})", parentId, environmentId);
         try {
             final String sql = getOrm().getSelectAllSql() + " where parent_id = ? and environment_id = ?";
-            return jdbcTemplate.query(sql, getOrm().getRowMapper(), parentId, environmentId);
+            return queryAndEnrichWithCategoryIds(sql, parentId, environmentId);
         } catch (Exception ex) {
             throw new TechnicalException("Failed to find portal navigation items by parentId", ex);
         }
@@ -96,7 +153,7 @@ public class JdbcPortalNavigationItemRepository
         log.debug("JdbcPortalNavigationItemRepository.findAllByAreaAndEnvironmentId({}, {})", area, environmentId);
         try {
             final String sql = getOrm().getSelectAllSql() + " where area = ? and environment_id = ?";
-            return jdbcTemplate.query(sql, getOrm().getRowMapper(), area.name(), environmentId);
+            return queryAndEnrichWithCategoryIds(sql, area.name(), environmentId);
         } catch (Exception ex) {
             throw new TechnicalException("Failed to find portal navigation items by area", ex);
         }
@@ -108,7 +165,7 @@ public class JdbcPortalNavigationItemRepository
         log.debug("JdbcPortalNavigationItemRepository.findAllByAreaAndEnvironmentIdAndParentIdIsNull({}, {})", area, environmentId);
         try {
             final String sql = getOrm().getSelectAllSql() + " where area = ? and environment_id = ? and parent_id is null";
-            return jdbcTemplate.query(sql, getOrm().getRowMapper(), area.name(), environmentId);
+            return queryAndEnrichWithCategoryIds(sql, area.name(), environmentId);
         } catch (Exception ex) {
             throw new TechnicalException("Failed to find top level portal navigation items by area", ex);
         }
@@ -119,7 +176,7 @@ public class JdbcPortalNavigationItemRepository
         log.debug("JdbcPortalNavigationItemRepository.findAllByRootId({}, {})", rootId, environmentId);
         try {
             final String sql = getOrm().getSelectAllSql() + " where root_id = ? and environment_id = ?";
-            return jdbcTemplate.query(sql, getOrm().getRowMapper(), rootId, environmentId);
+            return queryAndEnrichWithCategoryIds(sql, rootId, environmentId);
         } catch (Exception ex) {
             throw new TechnicalException("Failed to find portal navigation items by rootId", ex);
         }
@@ -137,6 +194,10 @@ public class JdbcPortalNavigationItemRepository
                     .stream()
                     .map(id -> "?")
                     .collect(Collectors.joining(", "));
+                jdbcTemplate.update(
+                    DELETE_FROM + PORTAL_NAVIGATION_ITEM_CATEGORIES + " where nav_item_id in (" + placeholders + ")",
+                    batch.toArray()
+                );
                 jdbcTemplate.update(DELETE_FROM + this.tableName + " where id in (" + placeholders + ")", batch.toArray());
             }
         } catch (Exception ex) {
@@ -148,6 +209,14 @@ public class JdbcPortalNavigationItemRepository
     public void deleteByOrganizationId(String organizationId) throws TechnicalException {
         log.debug("JdbcPortalNavigationItemRepository.deleteByOrganizationId({})", organizationId);
         try {
+            jdbcTemplate.update(
+                DELETE_FROM +
+                    PORTAL_NAVIGATION_ITEM_CATEGORIES +
+                    " where nav_item_id in (select id from " +
+                    this.tableName +
+                    " where organization_id = ?)",
+                organizationId
+            );
             jdbcTemplate.update(DELETE_FROM + this.tableName + " where organization_id = ?", organizationId);
         } catch (Exception ex) {
             throw new TechnicalException("Failed to delete portal navigation items by organizationId", ex);
@@ -158,6 +227,14 @@ public class JdbcPortalNavigationItemRepository
     public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
         log.debug("JdbcPortalNavigationItemRepository.deleteByEnvironmentId({})", environmentId);
         try {
+            jdbcTemplate.update(
+                DELETE_FROM +
+                    PORTAL_NAVIGATION_ITEM_CATEGORIES +
+                    " where nav_item_id in (select id from " +
+                    this.tableName +
+                    " where environment_id = ?)",
+                environmentId
+            );
             jdbcTemplate.update(DELETE_FROM + this.tableName + " where environment_id = ?", environmentId);
         } catch (Exception ex) {
             throw new TechnicalException("Failed to delete portal navigation items by environmentId", ex);
@@ -239,7 +316,9 @@ public class JdbcPortalNavigationItemRepository
     }
 
     private List<PortalNavigationItem> executeQueryByCriteria(String sql, List<Object> params) {
-        return jdbcTemplate.query(sql, ps -> fillPreparedStatement(params, ps), getOrm().getRowMapper());
+        List<PortalNavigationItem> items = jdbcTemplate.query(sql, ps -> fillPreparedStatement(params, ps), getOrm().getRowMapper());
+        enrichWithCategoryIds(items);
+        return items;
     }
 
     private void fillPreparedStatement(List<Object> params, PreparedStatement ps) throws java.sql.SQLException {
@@ -256,5 +335,56 @@ public class JdbcPortalNavigationItemRepository
     @Override
     protected String getId(PortalNavigationItem item) {
         return item.getId();
+    }
+
+    private void storeCategoryIds(PortalNavigationItem item, boolean deleteFirst) {
+        if (deleteFirst) {
+            jdbcTemplate.update(DELETE_FROM + PORTAL_NAVIGATION_ITEM_CATEGORIES + " where nav_item_id = ?", item.getId());
+        }
+        List<String> filteredCategoryIds = getOrm().filterStrings(item.getCategoryIds());
+        if (!filteredCategoryIds.isEmpty()) {
+            jdbcTemplate.batchUpdate(
+                "insert into " + PORTAL_NAVIGATION_ITEM_CATEGORIES + " ( nav_item_id, category_id ) values ( ?, ? )",
+                getOrm().getBatchStringSetter(item.getId(), filteredCategoryIds)
+            );
+        }
+    }
+
+    private List<PortalNavigationItem> queryAndEnrichWithCategoryIds(String sql, Object... args) {
+        List<PortalNavigationItem> items = jdbcTemplate.query(sql, getOrm().getRowMapper(), args);
+        enrichWithCategoryIds(items);
+        return items;
+    }
+
+    private void attachCategoryIds(PortalNavigationItem item) {
+        List<String> categoryIds = jdbcTemplate.query(
+            "select category_id from " + PORTAL_NAVIGATION_ITEM_CATEGORIES + " where nav_item_id = ?",
+            (ResultSet rs, int rowNum) -> rs.getString("category_id"),
+            item.getId()
+        );
+        item.setCategoryIds(categoryIds);
+    }
+
+    private void enrichWithCategoryIds(List<PortalNavigationItem> items) {
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+        List<String> ids = items.stream().map(PortalNavigationItem::getId).toList();
+        Map<String, List<String>> categoryIdsByItemId = new HashMap<>();
+        jdbcTemplate.query(
+            "select nav_item_id, category_id from " +
+                PORTAL_NAVIGATION_ITEM_CATEGORIES +
+                " where nav_item_id in (" +
+                getOrm().buildInClause(ids) +
+                ")",
+            rs -> {
+                String navItemId = rs.getString("nav_item_id");
+                String categoryId = rs.getString("category_id");
+                List<String> categoryList = categoryIdsByItemId.computeIfAbsent(navItemId, k -> new ArrayList<>());
+                categoryList.add(categoryId);
+            },
+            ids.toArray()
+        );
+        items.forEach(item -> item.setCategoryIds(categoryIdsByItemId.getOrDefault(item.getId(), List.of())));
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/12_add_portal_navigation_item_categories_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/12_add_portal_navigation_item_categories_table.yml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_12_add_portal_navigation_item_categories_table
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      changes:
+        - createTable:
+            tableName: ${gravitee_prefix}portal_navigation_item_categories
+            columns:
+              - column: {name: nav_item_id, type: nvarchar(64), constraints: {nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}portal_navigation_item_categories"}}
+              - column: {name: category_id, type: nvarchar(64), constraints: {nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}portal_navigation_item_categories"}}
+        - createIndex:
+            indexName: idx_${gravitee_prefix}portal_navigation_item_categories_category_id
+            tableName: ${gravitee_prefix}portal_navigation_item_categories
+            columns:
+              - column:
+                  name: category_id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -409,3 +409,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_13_0/10_add_use_auto_fetch_to_portal_navigation_items.yml
     - include:
         - file: liquibase/changelogs/v4_13_0/11_add_analytics_to_api_products.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/12_add_portal_navigation_item_categories_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalNavigationItemMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalNavigationItemMongo.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.mongodb.management.internal.model;
 
 import io.gravitee.repository.management.model.PortalNavigationItem;
 import jakarta.annotation.Nonnull;
+import java.util.List;
 import lombok.Data;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -43,4 +44,5 @@ public class PortalNavigationItemMongo {
     private String apiId;
     private String apiProductId;
     private boolean useAutoFetch;
+    private List<String> categoryIds = List.of();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/CreatePortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/CreatePortalNavigationItem.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -42,6 +44,7 @@ public final class CreatePortalNavigationItem {
     private String url;
     private String apiId;
     private String apiProductId;
+    private List<PortalCategoryId> categoryIds;
     private PortalVisibility visibility;
     private Boolean published;
     private PortalNavigationItemSource source;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationApi.java
@@ -15,7 +15,11 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import jakarta.annotation.Nonnull;
+import java.util.List;
+import java.util.Objects;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
@@ -30,6 +34,10 @@ public final class PortalNavigationApi extends PortalNavigationItem implements P
     @Nonnull
     private String apiId;
 
+    @Builder.Default
+    @Nonnull
+    private List<PortalCategoryId> categoryIds = List.of();
+
     PortalNavigationApi(
         @Nonnull PortalNavigationItemId id,
         @Nonnull String organizationId,
@@ -39,14 +47,26 @@ public final class PortalNavigationApi extends PortalNavigationItem implements P
         @Nonnull Integer order,
         @Nonnull String apiId,
         @Nonnull Boolean published,
-        @Nonnull PortalVisibility visibility
+        @Nonnull PortalVisibility visibility,
+        List<PortalCategoryId> categoryIds
     ) {
         super(id, organizationId, environmentId, title, area, order, published, visibility);
         this.apiId = apiId;
+        this.categoryIds = normalizeCategoryIds(categoryIds);
     }
 
     @Override
     public PortalNavigationItemType getType() {
         return TYPE;
+    }
+
+    @Override
+    public void update(UpdatePortalNavigationItem navItem) {
+        super.update(navItem);
+        this.categoryIds = normalizeCategoryIds(navItem.getCategoryIds());
+    }
+
+    private static List<PortalCategoryId> normalizeCategoryIds(List<PortalCategoryId> categoryIds) {
+        return Objects.requireNonNullElse(categoryIds, List.of());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -155,6 +155,7 @@ public abstract sealed class PortalNavigationItem
         final var url = item.getUrl();
         final var apiId = item.getApiId();
         final var apiProductId = item.getApiProductId();
+        final var categoryIds = item.getCategoryIds();
         final var order = item.getOrder();
         final var visibility = null != item.getVisibility() ? item.getVisibility() : PortalVisibility.PUBLIC;
         final var published = null != item.getPublished() ? item.getPublished() : false;
@@ -163,7 +164,18 @@ public abstract sealed class PortalNavigationItem
             case FOLDER -> new PortalNavigationFolder(id, organizationId, environmentId, title, area, order, published, visibility);
             case PAGE -> new PortalNavigationPage(id, organizationId, environmentId, title, area, order, contentId, published, visibility);
             case LINK -> new PortalNavigationLink(id, organizationId, environmentId, title, area, order, url, published, visibility);
-            case API -> new PortalNavigationApi(id, organizationId, environmentId, title, area, order, apiId, published, visibility);
+            case API -> new PortalNavigationApi(
+                id,
+                organizationId,
+                environmentId,
+                title,
+                area,
+                order,
+                apiId,
+                published,
+                visibility,
+                categoryIds
+            );
             case API_PRODUCT -> new PortalNavigationApiProduct(
                 id,
                 organizationId,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/UpdatePortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/UpdatePortalNavigationItem.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -32,6 +34,7 @@ public final class UpdatePortalNavigationItem {
     private PortalNavigationItemType type;
     private PortalNavigationItemId parentId;
     private String url;
+    private List<PortalCategoryId> categoryIds;
     private Boolean published;
     private PortalVisibility visibility;
     private PortalNavigationItemSource source;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.*;
 import io.gravitee.node.logging.NodeLoggerFactory;
 import java.util.HashMap;
@@ -244,5 +245,13 @@ public interface PortalNavigationItemAdapter {
 
     default PortalNavigationItemId mapPortalNavigationItemId(String id) {
         return id != null ? PortalNavigationItemId.of(id) : null;
+    }
+
+    default PortalCategoryId mapCategoryId(String id) {
+        return id != null ? PortalCategoryId.of(id) : null;
+    }
+
+    default String mapCategoryId(PortalCategoryId id) {
+        return id != null ? id.toString() : null;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
@@ -15,16 +15,21 @@
  */
 package fixtures.core.model;
 
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import java.util.List;
 
 public class PortalNavigationItemFixtures {
@@ -37,6 +42,7 @@ public class PortalNavigationItemFixtures {
     public static final String LINK_ID = "00000000-0000-0000-0000-000000000016";
     public static final String API_ID = "00000000-0000-0000-0000-000000000017";
     public static final String API_PRODUCT_ID = "00000000-0000-0000-0000-000000000018";
+    public static final String API_TITLE = "My Api";
 
     public static final String APIS_ID = "00000000-0000-0000-0000-000000000001";
     private static final String GUIDES_ID = "00000000-0000-0000-0000-000000000002";
@@ -234,7 +240,7 @@ public class PortalNavigationItemFixtures {
             .id(PortalNavigationItemId.of(API_ID))
             .organizationId(ORG_ID)
             .environmentId(ENV_ID)
-            .title("My Api")
+            .title(API_TITLE)
             .segment("my-api")
             .area(PortalArea.TOP_NAVBAR)
             .order(3)
@@ -242,6 +248,42 @@ public class PortalNavigationItemFixtures {
             .published(true)
             .visibility(PortalVisibility.PUBLIC)
             .build();
+    }
+
+    public static CreatePortalNavigationItem aCreatePortalNavigationApi(String apiId, PortalNavigationItemId parentId) {
+        return CreatePortalNavigationItem.builder()
+            .title(API_TITLE)
+            .segment("my-api")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .type(PortalNavigationItemType.API)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .apiId(apiId)
+            .parentId(parentId)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    public static CreatePortalNavigationItem aCreatePortalNavigationApi(
+        String apiId,
+        PortalNavigationItemId parentId,
+        List<PortalCategoryId> categoryIds
+    ) {
+        return aCreatePortalNavigationApi(apiId, parentId).toBuilder().categoryIds(categoryIds).build();
+    }
+
+    public static UpdatePortalNavigationItem anUpdatePortalNavigationApi() {
+        return UpdatePortalNavigationItem.builder()
+            .title(API_TITLE)
+            .order(0)
+            .type(PortalNavigationItemType.API)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    public static UpdatePortalNavigationItem anUpdatePortalNavigationApi(List<PortalCategoryId> categoryIds) {
+        return anUpdatePortalNavigationApi().toBuilder().categoryIds(categoryIds).build();
     }
 
     public static PortalNavigationApiProduct anApiProduct(String id, String title, PortalNavigationItemId parentId, String apiProductId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemTest.java
@@ -17,6 +17,9 @@ package io.gravitee.apim.core.portal_page.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import fixtures.core.model.PortalNavigationItemFixtures;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -62,5 +65,48 @@ class PortalNavigationItemTest {
 
         assertThat(apiProduct.getApiProductId()).isEqualTo(originalApiProductId);
         assertThat(apiProduct.getTitle()).isEqualTo("Updated product documentation");
+    }
+
+    @Test
+    void should_default_api_category_ids_to_empty_list_when_not_provided() {
+        var create = PortalNavigationItemFixtures.aCreatePortalNavigationApi("api-id", null);
+
+        var item = PortalNavigationItem.from(create, "organization-id", "environment-id", null);
+
+        assertThat(item).isInstanceOf(PortalNavigationApi.class);
+        assertThat(((PortalNavigationApi) item).getCategoryIds()).isEmpty();
+    }
+
+    @Test
+    void should_create_api_with_category_ids() {
+        var categoryIds = List.of(PortalCategoryId.random(), PortalCategoryId.random());
+        var create = PortalNavigationItemFixtures.aCreatePortalNavigationApi("api-id", null, categoryIds);
+
+        var item = PortalNavigationItem.from(create, "organization-id", "environment-id", null);
+
+        assertThat(item).isInstanceOf(PortalNavigationApi.class);
+        assertThat(((PortalNavigationApi) item).getCategoryIds()).containsExactlyElementsOf(categoryIds);
+    }
+
+    @Test
+    void should_update_api_category_ids() {
+        var api = PortalNavigationItemFixtures.anApi();
+        var categoryId = PortalCategoryId.random();
+        var update = PortalNavigationItemFixtures.anUpdatePortalNavigationApi(List.of(categoryId));
+
+        api.update(update);
+
+        assertThat(api.getCategoryIds()).containsExactly(categoryId);
+    }
+
+    @Test
+    void should_reset_api_category_ids_to_empty_list_when_update_omits_them() {
+        var api = PortalNavigationItemFixtures.anApi();
+        api.update(PortalNavigationItemFixtures.anUpdatePortalNavigationApi(List.of(PortalCategoryId.random())));
+        var update = PortalNavigationItemFixtures.anUpdatePortalNavigationApi();
+
+        api.update(update);
+
+        assertThat(api.getCategoryIds()).isEmpty();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
@@ -20,9 +20,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import fixtures.repository.model.PortalNavigationItemsRepositoryFixtures;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.*;
 import io.gravitee.repository.management.model.PortalNavigationItem;
 import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
@@ -236,6 +238,26 @@ class PortalNavigationItemAdapterTest {
         }
 
         @Test
+        void should_map_api_category_ids_to_entity() {
+            // Given
+            var repositoryItem = PortalNavigationItemsRepositoryFixtures.anApi(
+                "550e8400-e29b-41d4-a716-446655440026",
+                "My Api",
+                "apiId",
+                null
+            );
+            var categoryId = PortalCategoryId.random();
+            repositoryItem.setCategoryIds(List.of(categoryId.toString()));
+
+            // When
+            var entity = adapter.toEntity(repositoryItem);
+
+            // Then
+            assertThat(entity).isInstanceOf(PortalNavigationApi.class);
+            assertThat(((PortalNavigationApi) entity).getCategoryIds()).containsExactly(categoryId);
+        }
+
+        @Test
         void should_throw_when_link_configuration_is_missing() {
             // Given
             var repositoryItem = PortalNavigationItemsRepositoryFixtures.aLink("550e8400-e29b-41d4-a716-446655440008", "link", null, null);
@@ -375,6 +397,20 @@ class PortalNavigationItemAdapterTest {
             assertThat(repositoryItem.getApiProductId()).isEqualTo("550e8400-e29b-41d4-a716-446655440023");
             assertThat(repositoryItem.getConfiguration()).isEqualTo("{}");
             assertThat(repositoryItem.getRootId()).isEqualTo("00000000-0000-0000-0000-000000000000");
+        }
+
+        @Test
+        void should_map_api_category_ids_to_repository() {
+            // Given
+            var categoryId = PortalCategoryId.random();
+            var entity = PortalNavigationItemFixtures.anApi("550e8400-e29b-41d4-a716-446655440027", "My Api", null, "apiId");
+            entity.update(PortalNavigationItemFixtures.anUpdatePortalNavigationApi(List.of(categoryId)));
+
+            // When
+            var repositoryItem = adapter.toRepository((io.gravitee.apim.core.portal_page.model.PortalNavigationItem) entity);
+
+            // Then
+            assertThat(repositoryItem.getCategoryIds()).containsExactly(categoryId.toString());
         }
 
         @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-17

## Description

Adds `categoryIds` (a list of `PortalCategoryId`) to the `PortalNavigationApi` domain model, threaded
through `CreatePortalNavigationItem`/`UpdatePortalNavigationItem` and the `PortalNavigationItem.from()`
factory. Persisted via a new `categoryIds` array field on the MongoDB document, and via a new
`portal_navigation_item_categories` join table + Liquibase migration for JDBC/SQL backends (mirroring the
`api_product_tags` pattern already used by `JdbcApiProductRepository`). `categoryIds` can only be set at
creation or through `PortalNavigationApi.update(...)` — no public setter.

## Additional context

Part 1/2 of a stacked chain for PORTAL-17, stacked on #18541 (console wiring, completes PORTAL-16). REST
API exposure (management-v2 + portal) follows in the next PR. **Draft — do not review or merge until the
full chain lands.**