### PR TITLE
feat(rest-api): expose categoryIds on API navigation items via management and portal REST APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForApiNavigationItemsUseCase;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItem;
@@ -233,4 +234,18 @@ public interface PortalNavigationItemsMapper {
     );
 
     io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem map(UpdatePortalNavigationApiProduct apiProduct);
+
+    default PortalCategoryId mapCategoryId(UUID id) {
+        if (id == null) {
+            return null;
+        }
+        return new PortalCategoryId(id);
+    }
+
+    default UUID mapCategoryId(PortalCategoryId id) {
+        if (id == null) {
+            return null;
+        }
+        return id.id();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -2442,6 +2442,13 @@ components:
               type: string
               description: ApiId referenced from the navItem
               example: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
+            categoryIds:
+              type: array
+              description: The IDs of the Portal Next categories this API navigation item is assigned to
+              items:
+                type: string
+                format: uuid
+              example: [ "00f8c9e7-78fc-4907-b8c9-e778fc790750" ]
           required: [ apiId ]
     PortalNavigationApiProduct:
       description: Portal navigation item of type API_PRODUCT
@@ -2555,6 +2562,13 @@ components:
               type: string
               description: The apiId for the navigationItem
               example: "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+            categoryIds:
+              type: array
+              description: The IDs of the Portal Next categories this API navigation item is assigned to. Defaults to an empty list if not provided.
+              items:
+                type: string
+                format: uuid
+              example: [ "00f8c9e7-78fc-4907-b8c9-e778fc790750" ]
           required: [ apiId ]
     CreatePortalNavigationApiProduct:
       type: object
@@ -2695,6 +2709,13 @@ components:
               type: string
               description: The apiId for the navigationItem
               example: "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+            categoryIds:
+              type: array
+              description: The IDs of the Portal Next categories this API navigation item is assigned to. Defaults to an empty list if not provided.
+              items:
+                type: string
+                format: uuid
+              example: [ "00f8c9e7-78fc-4907-b8c9-e778fc790750" ]
           required: [ apiId ]
     UpdatePortalNavigationApiProduct:
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PortalNavigationItemsFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PortalNavigationItemsFixtures.java
@@ -33,6 +33,7 @@ import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
 import io.gravitee.rest.api.management.v2.rest.model.PortalVisibility;
+import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApi;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApiProduct;
 import java.util.UUID;
 
@@ -113,6 +114,15 @@ public class PortalNavigationItemsFixtures {
             .order(4)
             .parentId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
             .visibility(PortalVisibility.PUBLIC);
+    }
+
+    public static BaseUpdatePortalNavigationItem anUpdatePortalNavigationApi() {
+        return new UpdatePortalNavigationApi()
+            .type(PortalNavigationItemType.API)
+            .title("Updated Api")
+            .order(1)
+            .published(false)
+            .visibility(PortalVisibility.PRIVATE);
     }
 
     public static BaseUpdatePortalNavigationItem anUpdatePortalNavigationApiProduct() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -19,16 +19,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import fixtures.PortalNavigationItemsFixtures;
 import fixtures.core.model.PortalNavigationItemFixtures;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.rest.api.management.v2.rest.model.BasePortalNavigationItem;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApiProduct;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
 import io.gravitee.rest.api.management.v2.rest.model.PortalPageContentType;
+import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApi;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -128,6 +132,20 @@ class PortalNavigationItemsMapperTest {
             assertThat(result.getParentId()).isNull();
             assertThat(result.getApiId()).isEqualTo("apiId");
             assertThat(result.getRootId()).isEqualTo(api.getRootId().id());
+            assertThat(result.getCategoryIds()).isEmpty();
+        }
+
+        @Test
+        void should_map_portal_navigation_api_category_ids() {
+            var api = PortalNavigationItemFixtures.anApi();
+            var category1 = PortalCategoryId.random();
+            var category2 = PortalCategoryId.random();
+            api.update(PortalNavigationItemFixtures.anUpdatePortalNavigationApi(List.of(category1, category2)));
+
+            var result = mapper.map(api);
+
+            assertThat(result).isInstanceOf(io.gravitee.rest.api.management.v2.rest.model.PortalNavigationApi.class);
+            assertThat(result.getCategoryIds()).containsExactly(category1.id(), category2.id());
         }
 
         @Test
@@ -258,6 +276,31 @@ class PortalNavigationItemsMapperTest {
             assertThat(result.getOrder()).isEqualTo(3);
             assertThat(result.getParentId().id()).isEqualTo(link.getParentId());
             assertThat(result.getUrl()).isEqualTo(((CreatePortalNavigationLink) link).getUrl());
+        }
+
+        @Test
+        void should_map_create_portal_navigation_api_category_ids() {
+            final var api = (CreatePortalNavigationApi) PortalNavigationItemsFixtures.aCreatePortalNavigationApi();
+            var category1 = UUID.randomUUID();
+            var category2 = UUID.randomUUID();
+            api.setCategoryIds(List.of(category1, category2));
+
+            var result = mapper.map(api);
+
+            assertThat(result.getType()).isEqualTo(io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.API);
+            assertThat(result.getCategoryIds()).containsExactly(new PortalCategoryId(category1), new PortalCategoryId(category2));
+        }
+
+        @Test
+        void should_map_update_portal_navigation_api_category_ids() {
+            final var api = (UpdatePortalNavigationApi) PortalNavigationItemsFixtures.anUpdatePortalNavigationApi();
+            var category1 = UUID.randomUUID();
+            api.setCategoryIds(List.of(category1));
+
+            var result = mapper.map(api);
+
+            assertThat(result.getType()).isEqualTo(io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.API);
+            assertThat(result.getCategoryIds()).containsExactly(new PortalCategoryId(category1));
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.portal.rest.mapper;
 
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.OpenApiConfiguration;
@@ -37,6 +38,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -133,6 +135,20 @@ public interface PortalNavigationItemMapper {
 
     default String map(PortalPageContentId portalPageContentId) {
         return portalPageContentId.json();
+    }
+
+    default PortalCategoryId mapCategoryId(UUID id) {
+        if (id == null) {
+            return null;
+        }
+        return new PortalCategoryId(id);
+    }
+
+    default UUID mapCategoryId(PortalCategoryId id) {
+        if (id == null) {
+            return null;
+        }
+        return id.id();
     }
 
     default Set<io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude> map(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -8190,6 +8190,12 @@ components:
                 apiId:
                   type: string
                   description: The ApiId for the navigation item
+                categoryIds:
+                  type: array
+                  description: The IDs of the Portal Next categories this API navigation item is assigned to
+                  items:
+                    type: string
+                    format: uuid
               required: [ apiId ]
         PortalNavigationApiProduct:
           allOf:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapperTest.java
@@ -17,7 +17,9 @@ package io.gravitee.rest.api.portal.rest.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -77,6 +79,30 @@ class PortalNavigationItemMapperTest {
         PortalPageContentId pageId = PortalNavigationFixtures.randomPageId();
         String pageJson = PortalNavigationItemMapper.INSTANCE.map(pageId);
         assertThat(pageJson).isEqualTo(pageId.json());
+    }
+
+    @Test
+    void should_map_api_category_ids() {
+        var category1 = PortalCategoryId.random();
+        var category2 = PortalCategoryId.random();
+        var api = PortalNavigationApi.builder()
+            .id(PortalNavigationFixtures.randomNavigationId())
+            .organizationId("org")
+            .environmentId("env")
+            .title("My Api")
+            .segment("my-api")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(1)
+            .apiId("api-id")
+            .categoryIds(List.of(category1, category2))
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+
+        var result = PortalNavigationItemMapper.INSTANCE.map(api);
+
+        assertThat(result.getApiId()).isEqualTo("api-id");
+        assertThat(result.getCategoryIds()).containsExactly(category1.id(), category2.id());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-17

## Description

Exposes `categoryIds` on the API-type Portal Navigation Item DTOs: create/update/read schemas in the
management v2 OpenAPI spec, and the read-only schema in the portal OpenAPI spec (covers
`GET /portal-navigation-items` and `_search`). Adds `UUID <-> PortalCategoryId` mapping to both MapStruct
mappers.

## Additional context

Part 2/2 of a stacked chain for PORTAL-17, stacked on #18851 (domain model and persistence). **Draft — do
not review or merge until the full chain lands.**

### Manual testing

Verified end-to-end against a locally rebuilt Docker stack (`docker/quick-setup/mongodb`), organization/environment `DEFAULT`:

```bash
TOKEN=$(curl -sf -X POST http://localhost:8083/management/organizations/DEFAULT/user/login \
  -H "Authorization: Basic $(echo -n 'admin:admin' | base64)" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")

# Create without categoryIds -> defaults to []
curl -X POST http://localhost:8083/management/v2/environments/DEFAULT/portal-navigation-items \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"type":"API","title":"...","area":"TOP_NAVBAR","parentId":"...","visibility":"PUBLIC","apiId":"..."}'

# Create with categoryIds set directly -> persisted
curl -X POST http://localhost:8083/management/v2/environments/DEFAULT/portal-navigation-items \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"type":"API", ..., "categoryIds":["<uuid>"]}'

# Update an existing item's categoryIds -> round-trips correctly
curl -X PUT http://localhost:8083/management/v2/environments/DEFAULT/portal-navigation-items/{id} \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"type":"API","title":"...","order":7,"published":true,"visibility":"PUBLIC","apiId":"...","parentId":"...","categoryIds":["<uuid1>","<uuid2>"]}'

# Confirm persistence (fresh GET, no caching)
curl http://localhost:8083/management/v2/environments/DEFAULT/portal-navigation-items -H "Authorization: Bearer $TOKEN"

# Confirm portal REST (read-only) exposes it too
curl http://localhost:8083/portal/environments/DEFAULT/portal-navigation-items
curl "http://localhost:8083/portal/environments/DEFAULT/portal-navigation-items/_search?query=Analytics&type=API&include=api"
```

All paths (management-v2 create/update/list, portal REST list, portal REST `_search`) correctly persisted
and exposed `categoryIds`. No regressions in existing validation (`parentId` requirement, `apiId` uniqueness
check). Test data cleaned up afterward. JDBC/Postgres backend covered separately by the automated
`PortalNavigationItemRepositoryTest` against a real Postgres testcontainer (see PR 1).