### PR TITLE
fix(console-dictionary): added modal for edit properties

### DIFF
--- a/gravitee-apim-console-webui/src/app.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/app.module.ajs.ts
@@ -147,6 +147,7 @@ import DictionariesController from './management/settings/dictionaries/dictionar
 import DictionaryComponentAjs from './management/settings/dictionaries/dictionary.component.ajs';
 import DictionaryController from './management/settings/dictionaries/dictionary.controller';
 import DialogDictionaryAddPropertyController from './management/settings/dictionaries/add-property.dialog.controller';
+import DialogDictionaryEditPropertyController from './management/settings/dictionaries/edit-property.dialog.controller';
 // Settings - Identity providers
 // Others
 import StringService from './services/string.service';
@@ -607,6 +608,7 @@ graviteeManagementModule.component('settingsDictionaryAjs', DictionaryComponentA
 graviteeManagementModule.controller('DictionariesController', DictionariesController);
 graviteeManagementModule.controller('DictionaryController', DictionaryController);
 graviteeManagementModule.controller('DialogDictionaryAddPropertyController', DialogDictionaryAddPropertyController);
+graviteeManagementModule.controller('DialogDictionaryEditPropertyController', DialogDictionaryEditPropertyController);
 
 // Alerts
 graviteeManagementModule.service('AlertService', AlertService);

--- a/gravitee-apim-console-webui/src/index.scss
+++ b/gravitee-apim-console-webui/src/index.scss
@@ -53,6 +53,7 @@
   @import 'management/application/details/logs/application-log';
 
   @import 'user/my-accout/user';
+  @import 'management/settings/dictionaries/dictionary-properties';
 }
 
 @include gio.import-fonts();

--- a/gravitee-apim-console-webui/src/management/settings/dictionaries/_dictionary-properties.scss
+++ b/gravitee-apim-console-webui/src/management/settings/dictionaries/_dictionary-properties.scss
@@ -1,0 +1,13 @@
+// Keep long dictionary property values from blowing out table/page layout.
+// Full value is editable via the Edit property dialog (textarea).
+td.md-cell.dictionary-property-value {
+  max-width: 420px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+md-dialog.dictionary-edit-property-dialog {
+  width: min(720px, 90vw);
+  max-width: 90vw;
+}

--- a/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.controller.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.controller.spec.ts
@@ -19,16 +19,12 @@ import DictionaryController from './dictionary.controller';
 
 describe('DictionaryController', () => {
   let controller: DictionaryController;
-  let $mdEditDialog: { small: jest.Mock };
   let $mdDialog: any;
   let NotificationService: any;
   let DictionaryService: any;
   let ngRouter: any;
 
   beforeEach(() => {
-    $mdEditDialog = {
-      small: jest.fn(),
-    };
     $mdDialog = { show: jest.fn() };
     NotificationService = { show: jest.fn() };
     DictionaryService = {
@@ -42,7 +38,7 @@ describe('DictionaryController', () => {
     };
     ngRouter = { navigate: jest.fn() };
 
-    controller = new DictionaryController($mdEditDialog, $mdDialog, NotificationService, DictionaryService, ngRouter);
+    controller = new DictionaryController($mdDialog, NotificationService, DictionaryService, ngRouter);
     controller['dictionary'] = {
       properties: {
         large_value: 'short',
@@ -53,37 +49,42 @@ describe('DictionaryController', () => {
   });
 
   describe('editProperty', () => {
-    it('should open the inline edit dialog without an md-maxlength validator', () => {
+    it('should open the edit property dialog with the selected key and value', async () => {
       const event = { stopPropagation: jest.fn() };
+      $mdDialog.show.mockResolvedValue(null);
 
-      controller.editProperty(event, 'large_value', 'short');
+      await controller.editProperty(event, 'large_value', 'short');
 
       expect(event.stopPropagation).toHaveBeenCalled();
-      expect($mdEditDialog.small).toHaveBeenCalledWith(
+      expect($mdDialog.show).toHaveBeenCalledWith(
         expect.objectContaining({
-          modelValue: 'short',
-          placeholder: 'Set property value',
-          targetEvent: event,
+          controller: 'DialogDictionaryEditPropertyController',
+          locals: { key: 'large_value', value: 'short' },
         }),
       );
-
-      const dialogOptions = $mdEditDialog.small.mock.calls[0][0];
-      expect(dialogOptions.validators).toBeUndefined();
     });
 
-    it('should update the property with a value longer than 160 characters and refresh the table', () => {
+    it('should update the property with a value longer than 160 characters and refresh the table', async () => {
       const event = { stopPropagation: jest.fn() };
       const longValue = 'a'.repeat(200);
+      $mdDialog.show.mockResolvedValue({ value: longValue });
 
-      controller.editProperty(event, 'large_value', 'short');
-
-      const dialogOptions = $mdEditDialog.small.mock.calls[0][0];
-      dialogOptions.save({ $modelValue: longValue });
+      await controller.editProperty(event, 'large_value', 'short');
 
       expect(controller['dictionary'].properties.large_value).toBe(longValue);
       expect(controller['dictionary'].properties.large_value.length).toBeGreaterThan(160);
       expect(controller['dictProperties']).toEqual([{ key: 'large_value', value: longValue }]);
       expect(controller['propertiesDirty']).toBe(true);
+    });
+
+    it('should not mark propertiesDirty when edit property dialog is cancelled', async () => {
+      const event = { stopPropagation: jest.fn() };
+      $mdDialog.show.mockRejectedValue('cancel');
+
+      await controller.editProperty(event, 'large_value', 'short');
+
+      expect(controller['dictionary'].properties).toEqual({ large_value: 'short' });
+      expect(controller['propertiesDirty']).toBe(false);
     });
   });
 
@@ -149,6 +150,66 @@ describe('DictionaryController', () => {
       expect(DictionaryService.deploy).toHaveBeenCalled();
       expect(controller['propertiesDirty']).toBe(false);
       expect(controller['dictProperties']).toEqual([{ key: 'large_value', value: 'deployed' }]);
+    });
+  });
+
+  describe('addProperty and deleteProperty', () => {
+    it('should mark propertiesDirty and refresh the table when a property is added', async () => {
+      $mdDialog.show.mockResolvedValue({ key: 'new_key', value: 'new_value' });
+
+      await controller.addProperty();
+
+      expect($mdDialog.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          controller: 'DialogDictionaryAddPropertyController',
+        }),
+      );
+      expect(controller['dictionary'].properties.new_key).toBe('new_value');
+      expect(controller['query'].total).toBe(2);
+      expect(controller['propertiesDirty']).toBe(true);
+      expect(controller['dictProperties']).toEqual(
+        expect.arrayContaining([
+          { key: 'large_value', value: 'short' },
+          { key: 'new_key', value: 'new_value' },
+        ]),
+      );
+    });
+
+    it('should not mark propertiesDirty when add property dialog is cancelled', async () => {
+      $mdDialog.show.mockRejectedValue('cancel');
+
+      await controller.addProperty();
+
+      expect(controller['dictionary'].properties).toEqual({ large_value: 'short' });
+      expect(controller['query'].total).toBe(1);
+      expect(controller['propertiesDirty']).toBe(false);
+    });
+
+    it('should mark propertiesDirty and refresh the table when a property is deleted', () => {
+      controller.deleteProperty('large_value');
+
+      expect(controller['dictionary'].properties.large_value).toBeUndefined();
+      expect(controller['query'].total).toBe(0);
+      expect(controller['propertiesDirty']).toBe(true);
+      expect(controller['dictProperties']).toEqual([]);
+    });
+
+    it('should mark propertiesDirty when deleting selected properties', () => {
+      controller['dictionary'].properties = {
+        keep: '1',
+        remove: '2',
+      };
+      controller['query'] = { total: 2 };
+      controller['dictProperties'] = controller.computeProperties();
+      controller['selectedProperties'] = { remove: true };
+
+      controller.deleteSelectedProperties();
+
+      expect(controller['dictionary'].properties).toEqual({ keep: '1' });
+      expect(controller['selectedProperties'].remove).toBeUndefined();
+      expect(controller['query'].total).toBe(1);
+      expect(controller['propertiesDirty']).toBe(true);
+      expect(controller['dictProperties']).toEqual([{ key: 'keep', value: '1' }]);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.controller.ts
+++ b/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.controller.ts
@@ -43,7 +43,6 @@ class DictionaryController {
   private activatedRoute: ActivatedRoute;
 
   constructor(
-    private $mdEditDialog,
     private $mdDialog: angular.material.IDialogService,
     private NotificationService: NotificationService,
     private DictionaryService: DictionaryService,
@@ -216,7 +215,7 @@ class DictionaryController {
   }
 
   addProperty() {
-    this.$mdDialog
+    return this.$mdDialog
       .show({
         controller: 'DialogDictionaryAddPropertyController',
         controllerAs: 'dialogDictionaryAddPropertyCtrl',
@@ -235,22 +234,32 @@ class DictionaryController {
         }
 
         this.dictProperties = this.computeProperties();
-      });
+      })
+      .catch(() => {});
   }
 
   editProperty(event, key, value) {
     event.stopPropagation();
 
-    this.$mdEditDialog.small({
-      modelValue: value,
-      placeholder: 'Set property value',
-      save: input => {
-        this.dictionary.properties[key] = input.$modelValue;
-        this.dictProperties = this.computeProperties();
-        this.propertiesDirty = true;
-      },
-      targetEvent: event,
-    });
+    return this.$mdDialog
+      .show({
+        controller: 'DialogDictionaryEditPropertyController',
+        controllerAs: 'dialogDictionaryEditPropertyCtrl',
+        template: require('html-loader!./edit-property.dialog.html').default, // eslint-disable-line @typescript-eslint/no-var-requires
+        clickOutsideToClose: true,
+        locals: {
+          key,
+          value,
+        },
+      })
+      .then(property => {
+        if (property) {
+          this.dictionary.properties[key] = property.value;
+          this.dictProperties = this.computeProperties();
+          this.propertiesDirty = true;
+        }
+      })
+      .catch(() => {});
   }
 
   deleteProperty(key) {
@@ -326,6 +335,6 @@ class DictionaryController {
     this.ngRouter.navigate(['..'], { relativeTo: this.activatedRoute });
   }
 }
-DictionaryController.$inject = ['$mdEditDialog', '$mdDialog', 'NotificationService', 'DictionaryService', 'ngRouter'];
+DictionaryController.$inject = ['$mdDialog', 'NotificationService', 'DictionaryService', 'ngRouter'];
 
 export default DictionaryController;

--- a/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.html
+++ b/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.html
@@ -309,7 +309,12 @@
                   ></md-checkbox>
                 </td>
                 <td md-cell>{{::entry.key}}</td>
-                <td md-cell ng-click="$ctrl.editProperty($event, entry.key, entry.value)" ng-class="{'gravitee-placeholder': entry.value}">
+                <td
+                  md-cell
+                  class="dictionary-property-value"
+                  ng-click="$ctrl.editProperty($event, entry.key, entry.value)"
+                  ng-class="{'gravitee-placeholder': entry.value}"
+                >
                   {{entry.value || 'Set value'}}
                 </td>
                 <td md-cell ng-if="$ctrl.dictionary.type === 'MANUAL'">

--- a/gravitee-apim-console-webui/src/management/settings/dictionaries/edit-property.dialog.controller.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/dictionaries/edit-property.dialog.controller.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import DialogDictionaryEditPropertyController from './edit-property.dialog.controller';
+
+describe('DialogDictionaryEditPropertyController', () => {
+  let $scope: any;
+  let $mdDialog: { hide: jest.Mock };
+  let controller: any;
+
+  beforeEach(() => {
+    $scope = {};
+    $mdDialog = { hide: jest.fn() };
+    controller = new (DialogDictionaryEditPropertyController as any)($scope, $mdDialog, {
+      key: 'large_value',
+      value: 'initial',
+    });
+  });
+
+  it('should seed the scope from dialog locals using add-dialog naming (name/value)', () => {
+    expect($scope.property).toEqual({
+      name: 'large_value',
+      value: 'initial',
+    });
+  });
+
+  it('should emit only the edited value on save', () => {
+    $scope.property.value = 'updated-value';
+
+    controller.save();
+
+    expect($mdDialog.hide).toHaveBeenCalledWith({ value: 'updated-value' });
+  });
+
+  it('should close the dialog without a payload on cancel', () => {
+    controller.hide();
+
+    expect($mdDialog.hide).toHaveBeenCalledWith();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/settings/dictionaries/edit-property.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/settings/dictionaries/edit-property.dialog.controller.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+function DialogDictionaryEditPropertyController($scope, $mdDialog, locals) {
+  $scope.property = {
+    name: locals.key,
+    value: locals.value,
+  };
+
+  this.hide = function () {
+    $mdDialog.hide();
+  };
+
+  this.save = function () {
+    $mdDialog.hide({
+      value: $scope.property.value,
+    });
+  };
+}
+DialogDictionaryEditPropertyController.$inject = ['$scope', '$mdDialog', 'locals'];
+
+export default DialogDictionaryEditPropertyController;

--- a/gravitee-apim-console-webui/src/management/settings/dictionaries/edit-property.dialog.html
+++ b/gravitee-apim-console-webui/src/management/settings/dictionaries/edit-property.dialog.html
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<md-dialog aria-label="Edit property" class="dictionary-edit-property-dialog">
+  <form name="formDictionaryEditProperty" ng-submit="dialogDictionaryEditPropertyCtrl.save()" novalidate>
+    <md-dialog-content layout-padding>
+      <h4>Edit property</h4>
+      <md-input-container class="md-block">
+        <label>Name</label>
+        <input ng-model="property.name" id="edit-key" readonly />
+      </md-input-container>
+      <md-input-container class="md-block">
+        <label>Value</label>
+        <textarea ng-model="property.value" id="edit-value" rows="8" required></textarea>
+      </md-input-container>
+    </md-dialog-content>
+
+    <md-dialog-actions layout="row">
+      <md-button ng-click="dialogDictionaryEditPropertyCtrl.hide()" type="button"> Cancel </md-button>
+      <md-button type="submit" class="md-raised md-primary" ng-disabled="formDictionaryEditProperty.$invalid"> Save </md-button>
+    </md-dialog-actions>
+  </form>
+</md-dialog>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14827

## Description

- Replace the inline dictionary property editor with a modal textarea dialog so long values can be edited without overflowing the layout. Truncate long values in the table, and 

- add unit tests for add/delete dirty transitions.

## Additional context

Before :

<img width="1637" height="962" alt="image" src="https://github.com/user-attachments/assets/5270a791-f782-44b7-a069-d80473c2f05f" />


After : 


https://github.com/user-attachments/assets/91ce9ce0-4068-4ff7-8aa8-1a7f9e4a7473



