### PR TITLE
fix(ci): bump azure-cli image to 2.88.0

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -64,7 +64,7 @@ const executor = {
     // Version can be found here https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli
     // be careful when updating the version as it looks it is not following semver
     image: 'mcr.microsoft.com/azure-cli',
-    version: '2.34.1',
+    version: '2.88.0',
   },
   base: {
     image: 'cimg/base',

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -1315,7 +1315,7 @@ jobs:
           command: helm push charts/aws/dev/apim-*.tgz oci://430630701098.dkr.ecr.eu-west-2.amazonaws.com/graviteedev/helm/
   job-deploy-on-azure-cluster:
     docker:
-      - image: mcr.microsoft.com/azure-cli:2.34.1
+      - image: mcr.microsoft.com/azure-cli:2.88.0
     resource_class: large
     steps:
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -1315,7 +1315,7 @@ jobs:
           command: helm push charts/aws/dev/apim-*.tgz oci://430630701098.dkr.ecr.eu-west-2.amazonaws.com/graviteedev/helm/
   job-deploy-on-azure-cluster:
     docker:
-      - image: mcr.microsoft.com/azure-cli:2.34.1
+      - image: mcr.microsoft.com/azure-cli:2.88.0
     resource_class: large
     steps:
       - attach_workspace:


### PR DESCRIPTION
## Issue

_No Jira ticket — CI breakage spotted on 4.12.x, see [job 1956556](https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/90489/workflows/b2e4fd64-27d4-4c3e-ac9a-218424ef1e61/jobs/1956556)._

## Description

Bumps the `mcr.microsoft.com/azure-cli` executor image from `2.34.1` to `2.88.0`.

The `Deploy on Azure cluster` job dies with `Segmentation fault` / `Exited with code exit status 139` on the `Initialize Keeper config` step.

`azure-cli:2.34.1` is based on Alpine 3.15, end of life since November 2023. `keeper-circleci-orb` v0.7.1 moved the default KSM CLI from `1.0.9` to `1.3.0`, and every KSM release from 1.1.x on embeds Python 3.12 instead of 3.7.10. That binary no longer starts on this image — it dies before printing anything, which is why the log holds nothing but the segfault, not even the first line of `ksm version`.

The orb is not at fault: `AzureCliExecutor` is only used by `job-deploy-on-azure-cluster`, which is why no other job that consumes the Keeper orb is affected.

## Additional context

Reproduced in the job image itself (`mcr.microsoft.com/azure-cli:2.34.1`, `linux/amd64`), replaying what the orb does — pick the alpine binary, extract to `/tmp/keeper`, `cd /tmp`, run `ksm version`:

| KSM CLI | 2.34.1 (Alpine 3.15) | 2.88.0 (Azure Linux 3.0) |
|---|---|---|
| 1.0.9 (Python 3.7.10) | works | — |
| 1.1.7 / 1.2.0 / 1.3.0 (Python 3.12) | fails, no output | 1.3.0 works |

On `2.88.0` the orb takes the glibc binary through its existing Azure Linux path (`prepareEnvOnAzureLinux`, `LC_ALL`), and `tar` and `curl` are both present for the install script.

Only the executor version changes; the two pipeline test fixtures are updated to match. `npm test` in `.circleci/ci` passes (146 tests).