### PR TITLE
fix(observability): scope filters per surface and wire transaction/request id in logs search

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-filters.store.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-filters.store.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FilterCondition } from '@gravitee/gravitee-dashboard';
+import { FILTER_DEFINITION_PROVIDER, FilterCondition, FilterDefinition } from '@gravitee/gravitee-dashboard';
 
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -314,6 +314,82 @@ describe('DashboardFiltersStore', () => {
     expect(hydratedStore.periodControl.value.period).toBe('custom');
     expect(hydratedStore.periodControl.value.from!.valueOf()).toBe(1000000);
     expect(hydratedStore.periodControl.value.to!.valueOf()).toBe(2000000);
+  });
+
+  it('should drop URL-hydrated conditions for filters the surface does not offer, once definitions arrive', () => {
+    const definitions$ = new Subject<FilterDefinition[]>();
+    const definitionProviderMock = { getDefinitions: jest.fn().mockReturnValue(definitions$.asObservable()) };
+    const navigate = jest.fn().mockResolvedValue(true);
+    const snapshot = {
+      queryParams: {
+        q: JSON.stringify({
+          filter: [
+            { field: 'API', operator: 'EQ', value: 'id-1' },
+            { field: 'TRANSACTION_ID', operator: 'EQ', value: 'tx-1' },
+          ],
+        }),
+        v: '1',
+      },
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        DashboardFiltersStore,
+        { provide: FILTER_DEFINITION_PROVIDER, useValue: definitionProviderMock },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParams: new Subject<Record<string, string>>().asObservable(),
+            snapshot,
+          },
+        },
+        {
+          provide: Router,
+          useValue: { navigate },
+        },
+      ],
+    });
+
+    const hydratedStore = TestBed.inject(DashboardFiltersStore);
+    // Definitions have not loaded yet: restored conditions stay visible.
+    expect(hydratedStore.conditions().map(c => c.field)).toEqual(['API', 'TRANSACTION_ID']);
+
+    definitions$.next([{ name: 'API', label: 'API', type: 'KEYWORD', operators: ['EQ'] }]);
+    definitions$.complete();
+
+    expect(hydratedStore.conditions().map(c => c.field)).toEqual(['API']);
+    // The URL is re-synced so the pruned filter is not shared onward.
+    expect(navigate).toHaveBeenCalled();
+  });
+
+  it('should keep the same conditions reference when nothing is pruned', () => {
+    const definitions$ = new Subject<FilterDefinition[]>();
+    const definitionProviderMock = { getDefinitions: jest.fn().mockReturnValue(definitions$.asObservable()) };
+    const navigate = jest.fn().mockResolvedValue(true);
+    const snapshot = {
+      queryParams: { q: JSON.stringify({ filter: [{ field: 'API', operator: 'EQ', value: 'id-1' }] }), v: '1' },
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        DashboardFiltersStore,
+        { provide: FILTER_DEFINITION_PROVIDER, useValue: definitionProviderMock },
+        { provide: ActivatedRoute, useValue: { queryParams: new Subject<Record<string, string>>().asObservable(), snapshot } },
+        { provide: Router, useValue: { navigate } },
+      ],
+    });
+
+    const hydratedStore = TestBed.inject(DashboardFiltersStore);
+    const before = hydratedStore.conditions();
+
+    definitions$.next([{ name: 'API', label: 'API', type: 'KEYWORD', operators: ['EQ'] }]);
+    definitions$.complete();
+
+    // Same reference — consumers must not re-query when the prune is a no-op.
+    expect(hydratedStore.conditions()).toBe(before);
+    expect(navigate).not.toHaveBeenCalled();
   });
 
   it('should show a loading value label until URL-hydrated ID labels are resolved', () => {

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-filters.store.ts
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-filters.store.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_VIEW_STATE_PERIOD,
   decodeViewState,
   encodeViewState,
+  FILTER_DEFINITION_PROVIDER,
   FilterCondition,
   ID_BASED_FILTER_NAMES,
   RequestFilter,
@@ -33,7 +34,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl } from '@angular/forms';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import moment, { Moment } from 'moment';
-import { Subscription } from 'rxjs';
+import { catchError, EMPTY, Subscription } from 'rxjs';
 
 import { FilterLabelResolver } from './filter-label.resolver';
 
@@ -54,6 +55,7 @@ export class DashboardFiltersStore {
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
   private readonly labelResolver = inject(FilterLabelResolver, { optional: true });
+  private readonly definitionProvider = inject(FILTER_DEFINITION_PROVIDER, { optional: true });
 
   private readonly _conditions = signal<FilterCondition[]>([]);
   readonly conditions = this._conditions.asReadonly();
@@ -72,6 +74,7 @@ export class DashboardFiltersStore {
 
   private _skipNextQueryParamsEmit = false;
   private labelResolutionSubscription?: Subscription;
+  private definitionsPruneSubscription?: Subscription;
   private labelResolutionGeneration = 0;
 
   /**
@@ -224,6 +227,35 @@ export class DashboardFiltersStore {
         .subscribe(enriched => {
           if (generation !== this.labelResolutionGeneration) return;
           this._conditions.update(current => mergeResolvedLabels(current, enriched));
+        });
+    }
+
+    // Conditions restored from the URL may reference filters this surface does not offer (e.g. a
+    // logs-only filter deep-linked onto an analytics dashboard) — drop them instead of querying an
+    // engine that rejects them (APIM-14828). The prune is asynchronous: until definitions arrive,
+    // an initial query may still carry the unsupported filter and briefly error; it self-heals on
+    // the re-query triggered below.
+    this.definitionsPruneSubscription?.unsubscribe();
+    if (conditions.length > 0 && this.definitionProvider) {
+      this.definitionsPruneSubscription = this.definitionProvider
+        .getDefinitions()
+        .pipe(
+          // Fail open: an unavailable catalog must not wipe restored filters.
+          catchError(() => EMPTY),
+          takeUntilDestroyed(this.destroyRef),
+        )
+        .subscribe(definitions => {
+          if (generation !== this.labelResolutionGeneration) return;
+          const offered = new Set(definitions.map(definition => definition.name as string));
+          const current = this._conditions();
+          const kept = current.filter(condition => offered.has(condition.field as string));
+          if (kept.length === current.length) {
+            // Nothing pruned — keep the same reference so no consumer re-queries.
+            return;
+          }
+          this._conditions.set(kept);
+          // The URL must not keep advertising a filter this surface cannot evaluate.
+          this.syncToRouter();
         });
     }
   }

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-viewer.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-viewer.component.spec.ts
@@ -23,6 +23,7 @@ import { of } from 'rxjs';
 
 import { DashboardViewerComponent } from './dashboard-viewer.component';
 
+import { OBSERVABILITY_FILTER_SIGNAL } from '../../../data-access/observability-filters-api.service';
 import { Constants } from '../../../../../entities/Constants';
 import { GioPermissionService } from '../../../../../shared/components/gio-permission/gio-permission.service';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../shared/testing';
@@ -102,6 +103,10 @@ describe('DashboardViewerComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should gate filter definitions to the ANALYTICS surface', () => {
+    expect(fixture.debugElement.injector.get(OBSERVABILITY_FILTER_SIGNAL)).toBe('ANALYTICS');
   });
 
   it('should render the timeframe selector row', () => {

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-viewer.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-viewer.component.ts
@@ -38,7 +38,11 @@ import { MatDialog } from '@angular/material/dialog';
 import { DashboardFiltersStore } from './dashboard-filters.store';
 import { FilterLabelResolver } from './filter-label.resolver';
 
-import { ObservabilityFiltersApiService } from '../../../data-access/observability-filters-api.service';
+import {
+  OBSERVABILITY_FILTER_SIGNAL,
+  ObservabilityFilterSignal,
+  ObservabilityFiltersApiService,
+} from '../../../data-access/observability-filters-api.service';
 import { Constants } from '../../../../../entities/Constants';
 
 @Component({
@@ -52,6 +56,8 @@ import { Constants } from '../../../../../entities/Constants';
     FilterLabelResolver,
     provideFilterDefinitions(ObservabilityFiltersApiService),
     provideFilterValues(ObservabilityFiltersApiService),
+    // This page queries the analytics engine — logs-only filters must not be offered here (APIM-14828).
+    { provide: OBSERVABILITY_FILTER_SIGNAL, useValue: 'ANALYTICS' satisfies ObservabilityFilterSignal },
   ],
 })
 export class DashboardViewerComponent {

--- a/gravitee-apim-console-webui/src/management/observability/data-access/observability-filters-api.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/data-access/observability-filters-api.service.spec.ts
@@ -17,7 +17,11 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
-import { ObservabilityFiltersApiService } from './observability-filters-api.service';
+import {
+  OBSERVABILITY_FILTER_SIGNAL,
+  ObservabilityFilterSignal,
+  ObservabilityFiltersApiService,
+} from './observability-filters-api.service';
 
 import { Constants } from '../../../entities/Constants';
 import { CONSTANTS_TESTING } from '../../../shared/testing/gio-testing.module';
@@ -168,5 +172,63 @@ describe('ObservabilityFiltersApiService', () => {
       .flush({
         data: new Array(10).fill(0).map((_, i) => ({ value: `g${i}` })),
       });
+  });
+
+  describe('surface signal gating', () => {
+    const DEFINITIONS = {
+      data: [
+        { name: 'API', label: 'API', type: 'KEYWORD', operators: ['EQ'], signals: ['ANALYTICS', 'LOGS'] },
+        { name: 'TRANSACTION_ID', label: 'Transaction ID', type: 'KEYWORD', operators: ['EQ'], signals: ['LOGS'] },
+        // No signals — an older backend: must stay visible on every surface.
+        { name: 'LEGACY', label: 'Legacy', type: 'KEYWORD', operators: ['EQ'] },
+        // Empty signals — no engine supports it: must be excluded from every gated surface.
+        { name: 'ORPHAN', label: 'Orphan', type: 'KEYWORD', operators: ['EQ'], signals: [] },
+      ],
+    };
+
+    function configureWithSignal(signal: ObservabilityFilterSignal) {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          ObservabilityFiltersApiService,
+          { provide: Constants, useValue: CONSTANTS_TESTING },
+          { provide: OBSERVABILITY_FILTER_SIGNAL, useValue: signal },
+          provideHttpClient(withInterceptorsFromDi()),
+          provideHttpClientTesting(),
+        ],
+      });
+      service = TestBed.inject(ObservabilityFiltersApiService);
+      httpMock = TestBed.inject(HttpTestingController);
+    }
+
+    function flushDefinitions() {
+      httpMock.expectOne(`${CONSTANTS_TESTING.env!.v2BaseURL!}/observability/filters/definition`).flush(DEFINITIONS);
+    }
+
+    it('should exclude definitions not supporting the ANALYTICS surface', done => {
+      configureWithSignal('ANALYTICS');
+      service.getDefinitions().subscribe(defs => {
+        expect(defs.map(d => d.name)).toEqual(['API', 'LEGACY']);
+        done();
+      });
+      flushDefinitions();
+    });
+
+    it('should keep logs-only definitions on the LOGS surface', done => {
+      configureWithSignal('LOGS');
+      service.getDefinitions().subscribe(defs => {
+        expect(defs.map(d => d.name)).toEqual(['API', 'TRANSACTION_ID', 'LEGACY']);
+        done();
+      });
+      flushDefinitions();
+    });
+
+    it('should keep every definition when no surface is provided', done => {
+      service.getDefinitions().subscribe(defs => {
+        expect(defs.map(d => d.name)).toEqual(['API', 'TRANSACTION_ID', 'LEGACY', 'ORPHAN']);
+        done();
+      });
+      flushDefinitions();
+    });
   });
 });

--- a/gravitee-apim-console-webui/src/management/observability/data-access/observability-filters-api.service.ts
+++ b/gravitee-apim-console-webui/src/management/observability/data-access/observability-filters-api.service.ts
@@ -22,7 +22,7 @@ import {
 } from '@gravitee/gravitee-dashboard';
 
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, InjectionToken } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -63,14 +63,26 @@ interface FilterValueItemApi {
   id?: string;
 }
 
+/** Observability surface consuming the shared filter catalog — mirrors the backend FilterSignal enum. */
+export type ObservabilityFilterSignal = 'ANALYTICS' | 'LOGS';
+
+/**
+ * Surface hosting the filter bar. When provided, definitions carrying signals are narrowed to that
+ * surface so a page only offers filters its query engine supports (APIM-14828).
+ */
+export const OBSERVABILITY_FILTER_SIGNAL = new InjectionToken<ObservabilityFilterSignal>('OBSERVABILITY_FILTER_SIGNAL');
+
 @Injectable()
 export class ObservabilityFiltersApiService implements FilterDefinitionProvider, FilterValuesProvider {
   private readonly http = inject(HttpClient);
   private readonly constants = inject(Constants);
+  private readonly surfaceSignal = inject(OBSERVABILITY_FILTER_SIGNAL, { optional: true });
 
   getDefinitions(): Observable<FilterDefinition[]> {
     const url = `${this.constants.env?.v2BaseURL}/observability/filters/definition`;
-    return this.http.get<FilterSpecsResponseApi>(url).pipe(map(res => (res.data ?? []).map(item => this.mapDefinition(item))));
+    return this.http
+      .get<FilterSpecsResponseApi>(url)
+      .pipe(map(res => (res.data ?? []).map(item => this.mapDefinition(item)).filter(def => this.isSupportedOnSurface(def))));
   }
 
   getValues(query: FilterValuesQuery): Observable<FilterValuesResult> {
@@ -86,6 +98,14 @@ export class ObservabilityFiltersApiService implements FilterDefinitionProvider,
       params = params.set('to', String(query.to));
     }
     return this.http.get<FilterValuesResponseApi>(url, { params }).pipe(map(res => this.mapValuesResult(res, query.perPage)));
+  }
+
+  /** Definitions without signals (older backends) stay visible on every surface; an empty list means no surface supports it. */
+  private isSupportedOnSurface(def: FilterDefinition): boolean {
+    if (!this.surfaceSignal || def.signals == null) {
+      return true;
+    }
+    return def.signals.includes(this.surfaceSignal);
   }
 
   private mapDefinition(item: FilterSpecApi): FilterDefinition {

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
@@ -31,6 +31,7 @@ import { ReplaySubject } from 'rxjs';
 import { EnvLogsComponent } from './env-logs.component';
 import { EnvLogsTableHarness } from './components/env-logs-table/env-logs-table.harness';
 
+import { OBSERVABILITY_FILTER_SIGNAL } from '../data-access/observability-filters-api.service';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing/gio-testing.module';
 import { EnvironmentApiLog, SearchLogsResponse } from '../../../services-ngx/environment-logs.service';
 import { DashboardFiltersStore } from '../dashboards/ui/dashboard-viewer/dashboard-filters.store';
@@ -188,6 +189,11 @@ describe('EnvLogsComponent', () => {
   it('should create', fakeAsync(() => {
     initComponent();
     expect(component).toBeTruthy();
+  }));
+
+  it('should gate filter definitions to the LOGS surface', fakeAsync(() => {
+    initComponent(MOCK_RESPONSE);
+    expect(fixture.debugElement.injector.get(OBSERVABILITY_FILTER_SIGNAL)).toBe('LOGS');
   }));
 
   it('should render the title', fakeAsync(() => {
@@ -625,6 +631,36 @@ describe('EnvLogsComponent', () => {
       const req = httpTestingController.expectOne({ method: 'POST', url: SEARCH_URL });
       expect(req.request.body.filters).toEqual(
         expect.arrayContaining([expect.objectContaining({ name: 'ENTRYPOINT', operator: 'IN', value: ['http-get', 'http-post'] })]),
+      );
+      req.flush(EMPTY_RESPONSE);
+    }));
+
+    it('should pass PAYLOAD filter from store to search request', fakeAsync(() => {
+      setupWithFilter('PAYLOAD', 'Payload', ['error 500']);
+
+      const req = httpTestingController.expectOne({ method: 'POST', url: SEARCH_URL });
+      expect(req.request.body.filters).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'PAYLOAD', operator: 'CONTAINS', value: 'error 500' })]),
+      );
+      req.flush(EMPTY_RESPONSE);
+    }));
+
+    it('should pass TRANSACTION_ID filter with all values from store to search request', fakeAsync(() => {
+      setupWithFilter('TRANSACTION_ID', 'Transaction ID', ['tx-1', 'tx-2']);
+
+      const req = httpTestingController.expectOne({ method: 'POST', url: SEARCH_URL });
+      expect(req.request.body.filters).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'TRANSACTION_ID', operator: 'IN', value: ['tx-1', 'tx-2'] })]),
+      );
+      req.flush(EMPTY_RESPONSE);
+    }));
+
+    it('should pass REQUEST_ID filter with all values from store to search request', fakeAsync(() => {
+      setupWithFilter('REQUEST_ID', 'Request ID', ['req-1', 'req-2']);
+
+      const req = httpTestingController.expectOne({ method: 'POST', url: SEARCH_URL });
+      expect(req.request.body.filters).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'REQUEST_ID', operator: 'IN', value: ['req-1', 'req-2'] })]),
       );
       req.flush(EMPTY_RESPONSE);
     }));

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
@@ -43,7 +43,11 @@ import { EnvLogsTableComponent } from './components/env-logs-table/env-logs-tabl
 
 import { DashboardFiltersStore } from '../dashboards/ui/dashboard-viewer/dashboard-filters.store';
 import { FilterLabelResolver } from '../dashboards/ui/dashboard-viewer/filter-label.resolver';
-import { ObservabilityFiltersApiService } from '../data-access/observability-filters-api.service';
+import {
+  OBSERVABILITY_FILTER_SIGNAL,
+  ObservabilityFilterSignal,
+  ObservabilityFiltersApiService,
+} from '../data-access/observability-filters-api.service';
 import { EnvironmentLogsService, EnvironmentApiLog, SearchLogsParam, LogApiType } from '../../../services-ngx/environment-logs.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { GioTableWrapperPagination } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
@@ -79,6 +83,8 @@ const API_TYPE_LABELS: Record<LogApiType, string> = {
     FilterLabelResolver,
     provideFilterDefinitions(ObservabilityFiltersApiService),
     provideFilterValues(ObservabilityFiltersApiService),
+    // This page queries the logs engine — analytics-only filters must not be offered here (APIM-14828).
+    { provide: OBSERVABILITY_FILTER_SIGNAL, useValue: 'LOGS' satisfies ObservabilityFilterSignal },
   ],
 })
 export class EnvLogsComponent {
@@ -246,6 +252,8 @@ export class EnvLogsComponent {
       apiProductIds: filterMap.get('API_PRODUCT'),
       uri: filterMap.get('HTTP_PATH')?.[0],
       bodyText: filterMap.get('PAYLOAD')?.[0],
+      requestIds: filterMap.get('REQUEST_ID'),
+      transactionIds: filterMap.get('TRANSACTION_ID'),
     };
   }
 

--- a/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.spec.ts
@@ -154,6 +154,31 @@ describe('EnvironmentLogsService', () => {
       req.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
     });
 
+    it('should include multi-value REQUEST_ID and TRANSACTION_ID filters as IN', done => {
+      service.searchLogs({ requestIds: ['req-1', 'req-2'], transactionIds: ['tx-1', 'tx-2'] }).subscribe(() => done());
+
+      const req = httpTestingController.expectOne({ method: 'POST' });
+      expect(req.request.body.filters).toEqual(
+        expect.arrayContaining([
+          { name: 'REQUEST_ID', operator: 'IN', value: ['req-1', 'req-2'] },
+          { name: 'TRANSACTION_ID', operator: 'IN', value: ['tx-1', 'tx-2'] },
+        ]),
+      );
+      req.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
+    });
+
+    it('should let multi-value ids win over their scalar sibling', done => {
+      service
+        .searchLogs({ requestId: 'req-scalar', requestIds: ['req-1'], transactionId: 'tx-scalar', transactionIds: ['tx-1'] })
+        .subscribe(() => done());
+
+      const req = httpTestingController.expectOne({ method: 'POST' });
+      const names = req.request.body.filters.map((f: { name: string; operator: string }) => `${f.name}:${f.operator}`);
+      expect(names).toEqual(expect.arrayContaining(['REQUEST_ID:IN', 'TRANSACTION_ID:IN']));
+      expect(names).not.toEqual(expect.arrayContaining(['REQUEST_ID:EQ', 'TRANSACTION_ID:EQ']));
+      req.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
+    });
+
     it('should include PAYLOAD filter with CONTAINS operator when bodyText is set', done => {
       service.searchLogs({ bodyText: 'error 500' }).subscribe(() => done());
 

--- a/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.ts
@@ -70,7 +70,9 @@ export type SearchLogsParam = {
   period?: string;
   from?: string;
   to?: string;
+  /** Single-id lookup used by the log-details view; the filter bar uses `requestIds`. */
   requestId?: string;
+  requestIds?: string[];
   apiIds?: string[];
   applicationIds?: string[];
   planIds?: string[];
@@ -78,6 +80,8 @@ export type SearchLogsParam = {
   statuses?: number[];
   entrypoints?: string[];
   transactionId?: string;
+  /** Multi-value variant used by the filter bar (IN). */
+  transactionIds?: string[];
   uri?: string;
   responseTime?: number;
   errorKeys?: string[];
@@ -118,11 +122,14 @@ function buildFilters(param?: SearchLogsParam): LogFilter[] {
     { name: 'ENTRYPOINT', values: param.entrypoints },
     { name: 'ERROR_KEY', values: param.errorKeys },
     { name: 'API_PRODUCT', values: param.apiProductIds },
+    { name: 'REQUEST_ID', values: param.requestIds },
+    { name: 'TRANSACTION_ID', values: param.transactionIds },
   ];
 
   const scalarFilters: { name: string; value: string | undefined; operator?: string }[] = [
-    { name: 'REQUEST_ID', value: param.requestId },
-    { name: 'TRANSACTION_ID', value: param.transactionId },
+    // The multi-value variants win over their scalar sibling — never emit the same name twice.
+    { name: 'REQUEST_ID', value: param.requestIds?.length ? undefined : param.requestId },
+    { name: 'TRANSACTION_ID', value: param.transactionIds?.length ? undefined : param.transactionId },
     { name: 'URI', value: param.uri },
     { name: 'PAYLOAD', value: param.bodyText, operator: 'CONTAINS' },
   ];

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsDefinitionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsDefinitionMapper.java
@@ -54,8 +54,12 @@ public interface AnalyticsDefinitionMapper {
 
     MetricSpec mapMetricSpec(io.gravitee.apim.core.analytics_engine.model.MetricSpec metricSpec);
 
-    // PAYLOAD is observability-only and must not appear on analytics metric filter lists.
+    // The analytics engine rejects the observability-only filters (AnalyticsQueryValidator) — they
+    // must never appear on analytics metric filter lists.
     @ValueMapping(source = "PAYLOAD", target = MappingConstants.THROW_EXCEPTION)
+    @ValueMapping(source = "ERROR_KEY", target = MappingConstants.THROW_EXCEPTION)
+    @ValueMapping(source = "REQUEST_ID", target = MappingConstants.THROW_EXCEPTION)
+    @ValueMapping(source = "TRANSACTION_ID", target = MappingConstants.THROW_EXCEPTION)
     FilterName mapAnalyticsFilterName(io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name name);
 
     List<MetricSpec> mapMetricSpecs(List<io.gravitee.apim.core.analytics_engine.model.MetricSpec> metricSpecs);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -1660,12 +1660,30 @@ components:
                         $ref: "#/components/schemas/ApiName"
                     description: List of API types this filter applies to, derived from the metrics that reference it.
                     example: ["HTTP_PROXY", "LLM"]
+                signals:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/FilterSignal"
+                    description: >-
+                        List of observability surfaces (query engines) supporting this filter, derived from the
+                        engines' own definitions. Only populated by the observability filter-definitions operation;
+                        absent elsewhere (e.g. per-metric filter specs), meaning no surface restriction applies.
+                        An empty list means no surface supports the filter and it must not be offered anywhere.
+                    example: ["ANALYTICS", "LOGS"]
             example:
                 name: "API"
                 label: "API"
                 type: "KEYWORD"
                 operators: ["EQ", "IN"]
                 apiTypes: ["HTTP_PROXY", "MESSAGE", "LLM", "MCP"]
+                signals: ["ANALYTICS", "LOGS"]
+
+        FilterSignal:
+            type: string
+            enum:
+                - ANALYTICS
+                - LOGS
+            description: An observability surface (query engine) able to evaluate a filter.
 
         MetricSpec:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
@@ -19,12 +19,14 @@ import static assertions.MAPIAssertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiName;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSignal;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpecsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Operator;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -70,6 +72,28 @@ class ObservabilityFiltersDefinitionResourceTest extends AbstractResourceTest {
             .asEntity(FilterSpecsResponse.class)
             .extracting(FilterSpecsResponse::getData)
             .satisfies(filters -> assertThat(filters).hasSize(46));
+    }
+
+    @Test
+    void should_advertise_filter_signals_per_surface() {
+        var response = rootTarget().request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterSpecsResponse.class)
+            .extracting(FilterSpecsResponse::getData)
+            .satisfies(filters -> {
+                // Logs-only filters must not be offered on the analytics surface.
+                assertThat(byName(filters, "TRANSACTION_ID").getSignals()).containsExactly(FilterSignal.LOGS);
+                assertThat(byName(filters, "REQUEST_ID").getSignals()).containsExactly(FilterSignal.LOGS);
+                assertThat(byName(filters, "PAYLOAD").getSignals()).containsExactly(FilterSignal.LOGS);
+                assertThat(byName(filters, "ERROR_KEY").getSignals()).containsExactly(FilterSignal.LOGS);
+                // Shared filters carry both surfaces; the logs engine names HTTP_PATH "URI".
+                assertThat(byName(filters, "API").getSignals()).containsExactly(FilterSignal.ANALYTICS, FilterSignal.LOGS);
+                assertThat(byName(filters, "HTTP_PATH").getSignals()).containsExactly(FilterSignal.ANALYTICS, FilterSignal.LOGS);
+                // Analytics-only filters are not advertised for logs.
+                assertThat(byName(filters, "GEO_IP_COUNTRY").getSignals()).containsExactly(FilterSignal.ANALYTICS);
+            });
     }
 
     @Test
@@ -149,5 +173,13 @@ class ObservabilityFiltersDefinitionResourceTest extends AbstractResourceTest {
                 assertThat(apiFilter.getApiTypes()).isNotNull();
                 assertThat(apiFilter.getApiTypes()).isNotEmpty();
             });
+    }
+
+    private static FilterSpec byName(List<FilterSpec> filters, String name) {
+        return filters
+            .stream()
+            .filter(f -> f.getName().getValue().equals(name))
+            .findFirst()
+            .orElseThrow();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidator.java
@@ -55,6 +55,11 @@ public class AnalyticsQueryValidator {
         FilterSpec.Name.TRANSACTION_ID
     );
 
+    /** True when the analytics engine can evaluate this filter; the shared observability catalog also contains logs-only filters. */
+    public static boolean supportsAnalytics(FilterSpec.Name name) {
+        return !ANALYTICS_UNSUPPORTED_FILTERS.contains(name);
+    }
+
     private final AnalyticsDefinitionQueryService definition;
 
     public AnalyticsQueryValidator(AnalyticsDefinitionQueryService analyticsDefinitionQueryService) {
@@ -150,7 +155,7 @@ public class AnalyticsQueryValidator {
             if (filter.name() == null) {
                 throw new InvalidQueryException("Filter name cannot be null");
             }
-            if (ANALYTICS_UNSUPPORTED_FILTERS.contains(filter.name())) {
+            if (!supportsAnalytics(filter.name())) {
                 throw InvalidQueryException.forUnsupportedAnalyticsFilter(filter.name().name());
             }
             if (filter.value() == null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
@@ -16,10 +16,16 @@
 package io.gravitee.apim.core.analytics_engine.model;
 
 import io.gravitee.apim.core.observability.model.FilterOperator;
+import io.gravitee.apim.core.observability.model.FilterSignal;
 import io.gravitee.apim.core.observability.model.FilterType;
 import io.gravitee.apim.core.observability.model.NumberRange;
 import java.util.List;
 
+/**
+ * A filter of the shared observability catalog. {@code signals} lists the surfaces (query engines)
+ * supporting the filter: {@code null} means signals were not derived and no surface restriction
+ * applies; an empty list means no surface supports it and clients must not offer it anywhere.
+ */
 public record FilterSpec(
     Name name,
     String label,
@@ -27,8 +33,29 @@ public record FilterSpec(
     List<String> enumValues,
     NumberRange range,
     List<FilterOperator> operators,
-    List<ApiSpec.Name> apis
+    List<ApiSpec.Name> apis,
+    List<FilterSignal> signals
 ) {
+    /**
+     * Definition-time constructor — signals are derived per filter from each surface's engine, not
+     * declared (see {@code GetAnalyticsFilterDefinitionsUseCase}).
+     */
+    public FilterSpec(
+        Name name,
+        String label,
+        FilterType type,
+        List<String> enumValues,
+        NumberRange range,
+        List<FilterOperator> operators,
+        List<ApiSpec.Name> apis
+    ) {
+        this(name, label, type, enumValues, range, operators, apis, null);
+    }
+
+    public FilterSpec withSignals(List<FilterSignal> signals) {
+        return new FilterSpec(name, label, type, enumValues, range, operators, apis, signals);
+    }
+
     public enum Name {
         API,
         APPLICATION,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/GetAnalyticsFilterDefinitionsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/GetAnalyticsFilterDefinitionsUseCase.java
@@ -16,12 +16,23 @@
 package io.gravitee.apim.core.analytics_engine.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryValidator;
 import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
+import io.gravitee.apim.core.logs_engine.model.FilterName;
+import io.gravitee.apim.core.observability.model.FilterSignal;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @UseCase
 public class GetAnalyticsFilterDefinitionsUseCase {
+
+    private static final Set<String> LOGS_ENGINE_FILTER_NAMES = Arrays.stream(FilterName.values())
+        .map(Enum::name)
+        .collect(Collectors.toUnmodifiableSet());
 
     private final AnalyticsDefinitionQueryService definition;
 
@@ -32,6 +43,39 @@ public class GetAnalyticsFilterDefinitionsUseCase {
     public record Output(List<FilterSpec> specs) {}
 
     public Output execute() {
-        return new Output(definition.getAllFilters());
+        return new Output(
+            definition
+                .getAllFilters()
+                .stream()
+                .map(spec -> spec.withSignals(signalsFor(spec.name())))
+                .toList()
+        );
+    }
+
+    /**
+     * The filter catalog serves two observability surfaces (analytics dashboards and logs); each
+     * filter advertises the ones that actually support it so clients only offer applicable filters.
+     * Both sides derive from the engines' own definitions — {@link AnalyticsQueryValidator#supportsAnalytics}
+     * for analytics, the logs engine {@link FilterName}s for logs (matched by name, see
+     * {@link #supportsLogs} for the exceptions).
+     */
+    private static List<FilterSignal> signalsFor(FilterSpec.Name name) {
+        var signals = new ArrayList<FilterSignal>(2);
+        if (AnalyticsQueryValidator.supportsAnalytics(name)) {
+            signals.add(FilterSignal.ANALYTICS);
+        }
+        if (supportsLogs(name)) {
+            signals.add(FilterSignal.LOGS);
+        }
+        return List.copyOf(signals);
+    }
+
+    private static boolean supportsLogs(FilterSpec.Name name) {
+        // The logs engine names the path filter URI. Its MCP_METHOD and RESPONSE_TIME have no
+        // same-named catalog filter and stay unmapped until the logs page can actually apply them.
+        if (name == FilterSpec.Name.HTTP_PATH) {
+            return true;
+        }
+        return LOGS_ENGINE_FILTER_NAMES.contains(name.name());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/observability/model/FilterSignal.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/observability/model/FilterSignal.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.observability.model;
+
+/**
+ * An observability surface (query engine) able to evaluate a filter. Filters advertise their
+ * supported signals so clients only offer a filter where the backing engine accepts it.
+ */
+public enum FilterSignal {
+    ANALYTICS,
+    LOGS,
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/GetAnalyticsFilterDefinitionsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/GetAnalyticsFilterDefinitionsUseCaseTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics_engine.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryValidator;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
+import io.gravitee.apim.core.logs_engine.model.FilterName;
+import io.gravitee.apim.core.observability.model.FilterOperator;
+import io.gravitee.apim.core.observability.model.FilterSignal;
+import io.gravitee.apim.core.observability.model.FilterType;
+import io.gravitee.apim.infra.domain_service.analytics_engine.definition.AnalyticsDefinitionYAMLQueryService;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetAnalyticsFilterDefinitionsUseCaseTest {
+
+    private final AnalyticsDefinitionQueryService definition = mock(AnalyticsDefinitionQueryService.class);
+    private final GetAnalyticsFilterDefinitionsUseCase useCase = new GetAnalyticsFilterDefinitionsUseCase(definition);
+
+    @Test
+    void should_advertise_the_surfaces_supporting_each_filter() {
+        when(definition.getAllFilters()).thenReturn(
+            List.of(
+                filter(FilterSpec.Name.API),
+                filter(FilterSpec.Name.TRANSACTION_ID),
+                filter(FilterSpec.Name.GEO_IP_COUNTRY),
+                filter(FilterSpec.Name.HTTP_PATH)
+            )
+        );
+
+        var specs = useCase.execute().specs();
+
+        assertThat(specs)
+            .extracting(FilterSpec::name, FilterSpec::signals)
+            .containsExactly(
+                tuple(FilterSpec.Name.API, List.of(FilterSignal.ANALYTICS, FilterSignal.LOGS)),
+                // Logs-only: rejected by the analytics engine.
+                tuple(FilterSpec.Name.TRANSACTION_ID, List.of(FilterSignal.LOGS)),
+                tuple(FilterSpec.Name.GEO_IP_COUNTRY, List.of(FilterSignal.ANALYTICS)),
+                // The logs engine names the path filter URI — still a logs-supported filter.
+                tuple(FilterSpec.Name.HTTP_PATH, List.of(FilterSignal.ANALYTICS, FilterSignal.LOGS))
+            );
+    }
+
+    /**
+     * Guards the name-based mapping in {@code supportsLogs} against silent drift: every logs-engine
+     * filter must either share a catalog name, be an explicit translation, or be a documented
+     * exception. Adding or renaming a value in either enum without updating the mapping fails here.
+     */
+    @Test
+    void should_account_for_every_logs_engine_filter_in_the_catalog_mapping() {
+        var catalogNames = Arrays.stream(FilterSpec.Name.values()).map(Enum::name).collect(Collectors.toSet());
+        var translatedToCatalog = Map.of("URI", "HTTP_PATH");
+        // Logs-engine filters with no same-named catalog filter, intentionally not advertised (see supportsLogs).
+        var intentionallyUnmapped = Set.of("MCP_METHOD", "RESPONSE_TIME");
+
+        for (var logsFilter : FilterName.values()) {
+            var name = logsFilter.name();
+            var accounted = catalogNames.contains(name) || translatedToCatalog.containsKey(name) || intentionallyUnmapped.contains(name);
+            assertThat(accounted)
+                .withFailMessage(
+                    "Logs filter %s is neither a catalog filter name, a documented translation, nor a documented exception — update GetAnalyticsFilterDefinitionsUseCase.supportsLogs and this test",
+                    name
+                )
+                .isTrue();
+        }
+        assertThat(translatedToCatalog.values()).allSatisfy(catalog -> assertThat(catalogNames).contains(catalog));
+    }
+
+    /**
+     * The per-metric endpoint advertises whatever the yaml metric filter lists declare, and the
+     * analytics engine rejects the observability-only filters. Walking the real definition here
+     * makes adding one of them to any metric's list a build failure instead of an
+     * advertised-but-rejected filter in production.
+     */
+    @Test
+    void should_not_declare_an_analytics_rejected_filter_on_any_metric() {
+        var yaml = new AnalyticsDefinitionYAMLQueryService();
+
+        for (var api : yaml.getApis()) {
+            for (var metric : yaml.getMetrics(api.name())) {
+                var rejected = yaml
+                    .getFilters(metric.name())
+                    .stream()
+                    .map(FilterSpec::name)
+                    .filter(name -> !AnalyticsQueryValidator.supportsAnalytics(name))
+                    .toList();
+                assertThat(rejected)
+                    .withFailMessage("Metric %s declares filters the analytics engine rejects: %s", metric.name(), rejected)
+                    .isEmpty();
+            }
+        }
+    }
+
+    private static FilterSpec filter(FilterSpec.Name name) {
+        return new FilterSpec(name, name.name(), FilterType.KEYWORD, null, null, List.of(FilterOperator.EQ), List.of());
+    }
+}


### PR DESCRIPTION
##  Issue 
  https://gravitee.atlassian.net/browse/APIM-14828
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
  On the Observability dashboards, the Transaction ID filter was broken on both surfaces (APIM-14828):                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  1. Overview (analytics) — the filter was offered in the Add-filter dialog, but applying it failed with Filter 'TRANSACTION_ID' is not supported for analytics queries (the analytics engine rejects it by design).                                                                                                                                                                                                             
  2. Logs — the filter was accepted but had no effect: the page's search-param builder only copied a fixed set of filter keys, and TRANSACTION_ID (and REQUEST_ID, same family) was silently dropped before the request was built — even though the whole backend chain (logs use case → CRUD → Elasticsearch adapter, v2 transaction/v4 transaction-id field mapping) already supported it.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                 
##  Fix
                                                                                                                                                                                                                                                                                                                                                                                                                                     
  Per-filter surface signals (backend-derived, no drift possible). The observability filter catalog serves two surfaces; each filter now advertises which ones support it:                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  - New core enum FilterSignal { ANALYTICS, LOGS }; FilterSpec gains a signals list (compat constructor keeps existing call sites untouched).                                                                                                                                                                                                                                                                                    
  - GetAnalyticsFilterDefinitionsUseCase derives signals from the engines' own definitions: AnalyticsQueryValidator.supportsAnalytics(...) (the exact set the validator rejects — now exposed and reused) and the logs engine's FilterName enum (name-matched; HTTP_PATH ↔ URI translation documented). The 4 logs-only filters (TRANSACTION_ID, REQUEST_ID, PAYLOAD, ERROR_KEY) come out as [LOGS].                             
  - Exposed via a new optional signals property in openapi-analytics.yaml (additive; omitted when null on the sibling per-metric endpoints).                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  Frontend gate per surface. New OBSERVABILITY_FILTER_SIGNAL injection token; ObservabilityFiltersApiService.getDefinitions() drops definitions not supporting the provided surface. Overview (dashboard-viewer) provides ANALYTICS, the Logs page provides LOGS. Definitions without signals (older backend during rolling upgrade) stay visible everywhere; an empty signals list means excluded. The shared dialog needs no   
  change — its existing "Logs only" badge now lights up on the Logs page.                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  URL-hydration prune. Conditions restored from a bookmarked/shared URL could still smuggle a logs-only filter onto Overview and reproduce the error — DashboardFiltersStore now prunes hydrated conditions whose filter isn't offered on the surface, then the page re-queries cleanly.                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  Logs wiring. buildSearchParam now passes TRANSACTION_ID and REQUEST_ID (all values — new plural transactionIds/requestIds params serialized as IN, so multi-value filters return results for every value; the scalar requestId deep-link path is untouched). 