### PR TITLE
chore(deps): bump gravitee-reactor-llm-proxy to 4.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
     <gravitee-reactor-native-kafka.version>7.1.0-alpha.3</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.1.4</gravitee-reactor-mcp-proxy.version>
-    <gravitee-reactor-llm-proxy.version>4.0.1</gravitee-reactor-llm-proxy.version>
+    <gravitee-reactor-llm-proxy.version>4.0.3</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.0.0</gravitee-reactor-a2a-proxy.version>
     <gravitee-reactor-authz.version>1.1.0</gravitee-reactor-authz.version>
     <gravitee-reactor-edge.version>1.0.0</gravitee-reactor-edge.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-219 

## Description

 Picks up gravitee-reactor-llm-proxy 4.0.3, which fixes the /models catalog listing each model once per accepted spelling (duplicate group:alias entries when the prefix policy doesn't require a prefix) - AIAM-219, from internal enquiry GMA-952. Routing is unchanged (prefixed spellings stay accepted).                                                                                                                 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

