### PR TITLE
fix(console): use environment API key header for new plans

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.spec.ts
@@ -88,14 +88,20 @@ describe('PlanEditSecureStepComponent — API Key header schema', () => {
     });
   });
 
-  it('keeps apiKeyHeader default in schema on create', () => {
+  it('strips apiKeyHeader default from schema on create', () => {
     component.mode = 'create';
     fixture.detectChanges();
 
     schema$.next(apiKeySchemaWithDefault);
     fixture.detectChanges();
 
-    expect(component.securityConfigSchema).toBe(apiKeySchemaWithDefault);
+    expect(component.securityConfigSchema).toEqual({
+      type: 'object',
+      properties: {
+        source: { type: 'string', default: 'HEADER' },
+        apiKeyHeader: { type: 'string' },
+      },
+    });
   });
 
   it('keeps apiKeyHeader default in schema on edit when stored plan already has a header', () => {

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -92,6 +92,15 @@ const fakeApiKeySchema = {
   additionalProperties: false,
 };
 
+const fakeApiKeySchemaWithHeaderDefault = {
+  ...fakeApiKeySchema,
+  properties: {
+    ...fakeApiKeySchema.properties,
+    source: { type: 'string', default: 'HEADER' },
+    apiKeyHeader: { type: 'string', default: 'X-Gravitee-Api-Key' },
+  },
+};
+
 describe('ApiPlanFormComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let testComponent: TestComponent;
@@ -901,6 +910,35 @@ describe('ApiPlanFormComponent', () => {
           },
         ],
       } as CreatePlanV4);
+    });
+
+    it('should not persist schema-default apiKeyHeader when creating an API Key plan', async () => {
+      const API = fakeApiV4({ type: 'MESSAGE' });
+      configureTestingModule('create', 'API_KEY', API);
+      fixture.detectChanges();
+
+      const planForm = await loader.getHarness(ApiPlanFormHarness);
+
+      planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+      planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, []);
+      planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
+      planForm.httpRequest(httpTestingController).expectTagsListRequest([]);
+      fixture.detectChanges();
+
+      const nameInput = await planForm.getNameInput();
+      await nameInput.setValue('API Key plan');
+
+      await testComponent.apiPlanForm.waitForNextStep();
+      fixture.detectChanges();
+
+      planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('api-key', fakeApiKeySchemaWithHeaderDefault);
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
+      fixture.detectChanges();
+
+      expect(testComponent.planControl.value.security).toEqual({
+        type: 'API_KEY',
+        configuration: {},
+      });
     });
 
     it('should add new plan with MCP_PROXY API', async () => {

--- a/gravitee-apim-console-webui/src/management/api/component/plan/sanitize-api-key-security-configuration.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/sanitize-api-key-security-configuration.spec.ts
@@ -21,9 +21,9 @@ import {
 } from './sanitize-api-key-security-configuration';
 
 describe('shouldStripApiKeyHeaderSchemaDefault', () => {
-  it('does not strip on create so the default header is shown', () => {
-    expect(shouldStripApiKeyHeaderSchemaDefault('create', {})).toBe(false);
-    expect(shouldStripApiKeyHeaderSchemaDefault('create', { source: 'HEADER' })).toBe(false);
+  it('strips on create so the environment-level header can be used', () => {
+    expect(shouldStripApiKeyHeaderSchemaDefault('create', {})).toBe(true);
+    expect(shouldStripApiKeyHeaderSchemaDefault('create', { source: 'HEADER' })).toBe(true);
   });
 
   it('strips on edit when the stored plan has no apiKeyHeader', () => {
@@ -48,7 +48,7 @@ describe('shouldStripApiKeyHeaderSchemaDefault', () => {
 });
 
 describe('sanitizeApiKeySecurityConfiguration', () => {
-  it('keeps the default header on create', () => {
+  it('keeps an explicitly provided default-named header', () => {
     expect(
       sanitizeApiKeySecurityConfiguration({
         source: 'HEADER',

--- a/gravitee-apim-console-webui/src/management/api/component/plan/sanitize-api-key-security-configuration.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/sanitize-api-key-security-configuration.ts
@@ -18,13 +18,13 @@ import angular from 'angular';
 export const DEFAULT_API_KEY_HEADER = 'X-Gravitee-Api-Key';
 
 /**
- * On edit, gio-form-json-schema applies the apiKeyHeader schema default even when the stored plan
- * has no header set. Strip that default from the schema only in that case so the form stays empty.
- * On create, keep the schema default so the field shows X-Gravitee-Api-Key.
+ * gio-form-json-schema applies the apiKeyHeader schema default when the plan configuration has no
+ * header set. Strip that default on create and when editing a plan without a stored header so the
+ * gateway can use its environment-level configuration.
  */
 export function shouldStripApiKeyHeaderSchemaDefault(mode: 'create' | 'edit', storedConfiguration: unknown): boolean {
-  if (mode !== 'edit') {
-    return false;
+  if (mode === 'create') {
+    return true;
   }
 
   if (!angular.isObject(storedConfiguration) || Array.isArray(storedConfiguration)) {
@@ -36,7 +36,7 @@ export function shouldStripApiKeyHeaderSchemaDefault(mode: 'create' | 'edit', st
 
 /**
  * Remove apiKeyHeader from the persisted config only when the header was cleared.
- * Non-empty header values are kept (including the default name on create).
+ * Non-empty header values are kept.
  */
 export function sanitizeApiKeySecurityConfiguration(configuration: unknown): unknown {
   if (!angular.isObject(configuration) || Array.isArray(configuration)) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14786

## Description

Fixes API Key plan creation so that the `API Key Header` field is no longer pre-filled with the static `X-Gravitee-Api-Key` value.

When no header is explicitly configured, the plan does not persist `apiKeyHeader`, allowing the Gateway to use its environment-level API Key header configuration.

Explicitly configured custom headers and existing plan edit behavior remain unchanged.

## Changes

- Remove the `apiKeyHeader` schema default when creating an API Key plan.
- Preserve explicitly entered API Key headers.
- Add regression tests covering the schema, creation form, and persisted configuration.



