### PR TITLE
chore(deps): bump gravitee-common-elasticsearch to 6.6.1

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <gravitee-reporter-common.version>1.9.2</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>6.5.1</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>6.6.1</gravitee-common-elasticsearch.version>
         <opensearch-testcontainers.version>2.1.4</opensearch-testcontainers.version>
 
         <!-- Property used by the publication job in CI-->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11916

## Description

- Upgrade `gravitee-common-elasticsearch` version to `6.6.1`

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

