### PR TITLE
fix(http): allow origin header on web-socket

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/websocket/v4/WebsocketHeadersTest.java
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/websocket/v4/WebsocketHeadersTest.java
@@ -81,4 +81,54 @@ public class WebsocketHeadersTest extends AbstractWebsocketV4GatewayTest {
             .test()
             .await();
     }
+
+    @Test
+    @DeployApi({ "/apis/v4/http/api.json" })
+    public void websocket_should_forward_origin_header(VertxTestContext testContext, WebSocketClient webSocketClient) throws Throwable {
+        // Origin is special-cased by Vert.x, unlike arbitrary headers, so the custom-header test does not cover it.
+        var serverConnected = testContext.checkpoint();
+        var serverMessageSent = testContext.checkpoint();
+        var serverMessageChecked = testContext.checkpoint();
+
+        final String originValue = "http://my-origin-host";
+        WebSocketConnectOptions options = new WebSocketConnectOptions();
+        options.setURI("/test").setHeaders(MultiMap.caseInsensitiveMultiMap().add("Origin", originValue));
+
+        Promise<Void> clientReady = Promise.promise();
+
+        websocketServerHandler = serverWebSocket ->
+            Completable.fromRunnable(() -> {
+                serverConnected.flag();
+
+                String origin = serverWebSocket.headers().get("Origin");
+                testContext.verify(() -> assertThat(origin).isEqualTo(originValue));
+
+                clientReady
+                    .future()
+                    .onSuccess(__ ->
+                        serverWebSocket
+                            .writeTextMessage("PING")
+                            .doOnComplete(serverMessageSent::flag)
+                            .doOnError(testContext::failNow)
+                            .subscribe()
+                    );
+            })
+                .subscribeOn(Schedulers.io())
+                .subscribe();
+
+        webSocketClient
+            .connect(options)
+            .doOnSuccess(webSocket -> {
+                webSocket.exceptionHandler(testContext::failNow);
+                webSocket.frameHandler(frame -> {
+                    testContext.verify(() -> assertThat(frame.isText()).isTrue());
+                    testContext.verify(() -> assertThat(frame.textData()).isEqualTo("PING"));
+                    serverMessageChecked.flag();
+                });
+                clientReady.complete();
+            })
+            .doOnError(testContext::failNow)
+            .test()
+            .await();
+    }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/WebSocketConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/WebSocketConnector.java
@@ -83,6 +83,10 @@ public class WebSocketConnector extends HttpConnector {
             ctx.metrics().setEndpoint(buildWebSocketUri(options));
             WebSocketConnectOptions webSocketConnectOptions = new WebSocketConnectOptions(options.toJson());
 
+            // Building from a RequestOptions JSON skips the WebSocketConnectOptions default, leaving allowOriginHeader
+            // false, which makes Vert.x strip the Origin header. Restore the default so it is forwarded.
+            webSocketConnectOptions.setAllowOriginHeader(true);
+
             // Add subprotocols: handle comma-separated values, trim whitespace, filter empty strings
             if (request.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL)) {
                 webSocketConnectOptions.setSubProtocols(parseSubProtocols(request));

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
@@ -543,6 +543,17 @@ class HttpProxyEndpointConnectorTest {
         }
 
         @Test
+        void should_keep_origin_header_allowed_on_websocket_upgrade() {
+            ArgumentCaptor<WebSocketConnectOptions> connectOptionsCaptor = ArgumentCaptor.forClass(WebSocketConnectOptions.class);
+            when(mockWebSocketClient.rxConnect(connectOptionsCaptor.capture())).thenThrow(new IllegalStateException());
+            when(request.isWebSocket()).thenReturn(true);
+
+            cut.connect(ctx).onErrorComplete(IllegalStateException.class::isInstance).test().assertComplete();
+
+            assertThat(connectOptionsCaptor.getValue().getAllowOriginHeader()).isTrue();
+        }
+
+        @Test
         void should_use_http_client_factory() {
             // We don't want to test the request itself just that the correct factory is used
             when(mockDelegateHttpClient.request(any(RequestOptions.class))).thenReturn(Future.failedFuture(new IllegalStateException()));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14024

## Description

WebSocket Upgrade requests through the v4 http-proxy endpoint were silently stripped of the `Origin` header before reaching the backend. `WebSocketConnector` builds its Vert.x `WebSocketConnectOptions` from a `RequestOptions` JSON blob (`new WebSocketConnectOptions(options.toJson())`), which bypasses Vert.x's no-arg constructor default and leaves `allowOriginHeader` false — so Vert.x drops the header on the outbound Upgrade.

Fix: explicitly set `allowOriginHeader(true)` on the built `WebSocketConnectOptions` before the connection is established, restoring the header.

Present since the v4 http-proxy WebSocket connector was introduced (APIM 4.0.0) — every 4.x release up to this fix is affected. Only impacts v4 Proxy APIs using the http-proxy endpoint on WebSocket Upgrade; v2 APIs are unaffected.

## Additional context

Root-caused from a customer escalation where a backend app (Streamlit, OIDC login) validates the `Origin` header on WebSocket Upgrade against a signed cookie; without the header the app rejected the session and looped back to login.

Covered by:
- Unit test on `HttpProxyEndpointConnectorTest` asserting `allowOriginHeader` is set.
- Integration test (`WebsocketHeadersTest`) asserting the Origin header is actually forwarded to the backend on Upgrade.