### PR TITLE
chore(deps): bump gravitee-reactor-llm-proxy to 3.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
     <gravitee-reactor-native-kafka.version>7.0.1</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.1.4</gravitee-reactor-mcp-proxy.version>
-    <gravitee-reactor-llm-proxy.version>3.3.3</gravitee-reactor-llm-proxy.version>
+    <gravitee-reactor-llm-proxy.version>3.3.4</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.0.0</gravitee-reactor-a2a-proxy.version>
     <gravitee-reactor-authz.version>1.0.0</gravitee-reactor-authz.version>
     <gravitee-reactor-edge.version>1.0.0</gravitee-reactor-edge.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Bumps the llm proxy plugins from 3.3.3 to 3.3.4 on the 4.12 line.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

