### PR TITLE
feat(api-product): store reporter settings on the API Product

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ReactableApiProduct.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ReactableApiProduct.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.handlers.api;
 
+import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.gateway.reactor.Reactable;
 import java.io.Serializable;
@@ -58,6 +59,7 @@ public class ReactableApiProduct implements Reactable, Serializable {
     private Date deployedAt;
 
     private List<Plan> plans;
+    private Analytics analytics;
     private Set<String> tags;
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiProductMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiProductMapper.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.sync.process.repository.mapper;
 import static io.gravitee.repository.management.model.Event.EventProperties.API_PRODUCT_ID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
@@ -84,6 +85,7 @@ public class ApiProductMapper {
                     .tags(payload.getTags())
                     .deployedAt(new Date(event.getCreatedAt().getTime()))
                     .plans(filteredPlans(payload.getPlans()))
+                    .analytics(payload.getAnalytics())
                     .build();
 
                 // Fill environment and organization details
@@ -129,5 +131,6 @@ public class ApiProductMapper {
         private String organizationHrid;
         private Set<String> tags;
         private List<Plan> plans;
+        private Analytics analytics;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiProductMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiProductMapperTest.java
@@ -213,6 +213,54 @@ class ApiProductMapperTest {
                     assertThat(reactableApiProduct.getVersion()).isEqualTo("2.0");
                     assertThat(reactableApiProduct.getApiIds()).containsExactly("api-1");
                     assertThat(reactableApiProduct.getEnvironmentId()).isEqualTo("env-id");
+                    assertThat(reactableApiProduct.getAnalytics()).isNull();
+                    return true;
+                })
+                .assertComplete();
+        }
+
+        @SneakyThrows
+        @Test
+        void should_map_analytics_from_payload() {
+            Organization organization = new Organization();
+            organization.setId("org-id");
+            organization.setHrids(List.of("org-hrid"));
+            when(organizationRepository.findById(organization.getId())).thenReturn(Optional.of(organization));
+
+            Environment environment = new Environment();
+            environment.setId("env-id");
+            environment.setHrids(List.of("env-hrid"));
+            environment.setOrganizationId(organization.getId());
+            when(environmentRepository.findById("env-id")).thenReturn(Optional.of(environment));
+
+            Event event = new Event();
+            event.setCreatedAt(new Date());
+            event.setPayload(
+                objectMapper.writeValueAsString(
+                    Map.of(
+                        "id",
+                        "api-product-789",
+                        "name",
+                        "Analytics Product",
+                        "version",
+                        "1.0",
+                        "apiIds",
+                        Set.of("api-1"),
+                        "environmentId",
+                        "env-id",
+                        "analytics",
+                        Map.of("enabled", true, "logging", Map.of("content", Map.of("headers", true)))
+                    )
+                )
+            );
+
+            cut
+                .to(event)
+                .test()
+                .assertValue(reactableApiProduct -> {
+                    assertThat(reactableApiProduct.getAnalytics()).isNotNull();
+                    assertThat(reactableApiProduct.getAnalytics().isEnabled()).isTrue();
+                    assertThat(reactableApiProduct.getAnalytics().getLogging().getContent().isHeaders()).isTrue();
                     return true;
                 })
                 .assertComplete();

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiProduct.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiProduct.java
@@ -47,6 +47,7 @@ public class ApiProduct {
     private Date updatedAt;
     private boolean disableMembershipNotifications;
     private ApiProductKind kind;
+    private String analytics;
 
     public boolean addGroup(String groupId) {
         if (groups == null) {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiProductRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiProductRepository.java
@@ -63,6 +63,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             .addColumn("updated_at", Types.TIMESTAMP, Date.class)
             .addColumn("disable_membership_notifications", Types.BOOLEAN, boolean.class)
             .addColumn("kind", Types.NVARCHAR, ApiProductKind.class)
+            .addColumn("analytics", Types.NVARCHAR, String.class)
             .build();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/11_add_analytics_to_api_products.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/11_add_analytics_to_api_products.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_11_add_analytics_to_api_products
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}api_products
+            columns:
+              - column:
+                  name: analytics
+                  type: nclob
+                  constraints:
+                    nullable: true

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -407,3 +407,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_13_0/09_create_gamma_dashboards_table.yml
     - include:
         - file: liquibase/changelogs/v4_13_0/10_add_use_auto_fetch_to_portal_navigation_items.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/11_add_analytics_to_api_products.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiProductMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiProductMongo.java
@@ -54,4 +54,5 @@ public class ApiProductMongo {
     private Date updatedAt;
     private boolean disableMembershipNotifications;
     private ApiProductKind kind;
+    private String analytics;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiProductRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiProductRepositoryTest.java
@@ -246,6 +246,32 @@ public class ApiProductRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void shouldCreateAndUpdateAnalytics() throws TechnicalException {
+        var date = new Date();
+        var uuid = UUID.random().toString();
+        ApiProduct apiProduct = createApiProduct(uuid, date, "my-env", "my-api-product", "1.0.0", List.of("api1"));
+        apiProduct.setAnalytics("{\"enabled\":true}");
+
+        ApiProduct created = apiProductsRepository.create(apiProduct);
+        assertThat(created.getAnalytics()).isEqualTo("{\"enabled\":true}");
+        assertThat(apiProductsRepository.findById(uuid)).get().extracting(ApiProduct::getAnalytics).isEqualTo("{\"enabled\":true}");
+
+        apiProduct.setAnalytics("{\"enabled\":false}");
+        assertThat(apiProductsRepository.update(apiProduct).getAnalytics()).isEqualTo("{\"enabled\":false}");
+
+        apiProduct.setAnalytics(null);
+        assertThat(apiProductsRepository.update(apiProduct).getAnalytics()).isNull();
+    }
+
+    @Test
+    public void shouldReadNullAnalyticsOnApiProductStoredBeforeTheColumnExisted() throws TechnicalException {
+        assertThat(apiProductsRepository.findById("f66274c9-3d8f-44c5-a274-c93d8fb4c5f3"))
+            .get()
+            .extracting(ApiProduct::getAnalytics)
+            .isNull();
+    }
+
+    @Test
     public void shouldThrowExceptionWhenApiProductToUpdateNotFound() {
         var id = "not-existing-id";
         var date = new Date(1_470_157_767_000L);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -2103,6 +2103,13 @@ components:
           example:
             - "eu"
             - "secured-edge"
+        analytics:
+          allOf:
+            - $ref: "./openapi-apis.yaml#/components/schemas/Analytics"
+          description: |
+            Reporter settings governing every API this product exposes.
+            Always applied as given, same as an API's own analytics field: send a value to set it,
+            send null to clear it back to null so each API reports as it does on its own.
       required:
         - name
         - version
@@ -2173,6 +2180,10 @@ components:
           example:
             - "eu"
             - "secured-edge"
+        analytics:
+          allOf:
+            - $ref: "./openapi-apis.yaml#/components/schemas/Analytics"
+          description: Reporter settings governing every API this product exposes.
 
     ApiProductDeploymentState:
       type: string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResourceTest.java
@@ -283,6 +283,52 @@ class ApiProductResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_update_api_product_analytics() {
+            var analytics = io.gravitee.definition.model.v4.analytics.Analytics.builder().enabled(false).build();
+            ApiProduct updatedApiProduct = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .environmentId(ENV_ID)
+                .name("Existing Product")
+                .analytics(analytics)
+                .build();
+
+            when(updateApiProductUseCase.execute(any())).thenReturn(new UpdateApiProductUseCase.Output(updatedApiProduct));
+
+            var updatePayload = new io.gravitee.rest.api.management.v2.rest.model.UpdateApiProduct();
+            updatePayload.setName("Existing Product");
+            updatePayload.setAnalytics(new io.gravitee.rest.api.management.v2.rest.model.Analytics().enabled(false));
+
+            try (Response response = rootTarget().request().put(json(updatePayload))) {
+                assertThat(response.getStatus()).isEqualTo(OK_200);
+            }
+
+            var captor = ArgumentCaptor.forClass(UpdateApiProductUseCase.Input.class);
+            verify(updateApiProductUseCase).execute(captor.capture());
+            var input = captor.getValue().updateApiProduct();
+            assertThat(input.getAnalytics()).isNotNull();
+            assertThat(input.getAnalytics().isEnabled()).isFalse();
+        }
+
+        @Test
+        void should_clear_api_product_analytics_when_sent_as_null() {
+            ApiProduct updatedApiProduct = ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENV_ID).name("Existing Product").build();
+
+            when(updateApiProductUseCase.execute(any())).thenReturn(new UpdateApiProductUseCase.Output(updatedApiProduct));
+
+            var updatePayload = new io.gravitee.rest.api.management.v2.rest.model.UpdateApiProduct();
+            updatePayload.setName("Existing Product");
+            updatePayload.setAnalytics(null);
+
+            try (Response response = rootTarget().request().put(json(updatePayload))) {
+                assertThat(response.getStatus()).isEqualTo(OK_200);
+            }
+
+            var captor = ArgumentCaptor.forClass(UpdateApiProductUseCase.Input.class);
+            verify(updateApiProductUseCase).execute(captor.capture());
+            assertThat(captor.getValue().updateApiProduct().getAnalytics()).isNull();
+        }
+
+        @Test
         void should_return_400_if_execute_fails_with_invalid_data_exception() {
             when(updateApiProductUseCase.execute(any())).thenThrow(new InvalidDataException("Name is required."));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/DeployApiProductDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/DeployApiProductDomainService.java
@@ -74,6 +74,7 @@ public class DeployApiProductDomainService {
             .environmentId(apiProduct.getEnvironmentId())
             .tags(apiProduct.getTags())
             .plans(plans)
+            .analytics(apiProduct.getAnalytics())
             .build();
 
         final Event event = eventCrudService.createEvent(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProduct.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.api_product.model;
 
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.definition.model.v4.analytics.Analytics;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
@@ -50,6 +51,7 @@ public class ApiProduct {
     private DeploymentState deploymentState;
     private boolean disableMembershipNotifications;
     private ApiProductKind kind;
+    private Analytics analytics;
 
     public void update(UpdateApiProduct updateApiProduct) {
         this.updatedAt = ZonedDateTime.now(TimeProvider.clock());
@@ -71,6 +73,9 @@ public class ApiProduct {
         if (updateApiProduct.getDisableMembershipNotifications() != null) {
             this.disableMembershipNotifications = updateApiProduct.getDisableMembershipNotifications();
         }
+        // Always applied, unlike the fields above: mirrors how an API's own analytics field is updated
+        // (ApiMapper#toApiDefinition), so a caller can explicitly clear it back to null (inherit from each API).
+        this.analytics = updateApiProduct.getAnalytics();
     }
 
     public boolean addApiId(String apiId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductDeploymentPayload.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductDeploymentPayload.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.api_product.model;
 
+import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.plan.Plan;
 import java.util.List;
 import java.util.Set;
@@ -38,4 +39,5 @@ public class ApiProductDeploymentPayload {
     private String environmentId;
     private Set<String> tags;
     private List<Plan> plans;
+    private Analytics analytics;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/UpdateApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/UpdateApiProduct.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.api_product.model;
 
+import io.gravitee.definition.model.v4.analytics.Analytics;
 import java.time.ZonedDateTime;
 import java.util.Set;
 import lombok.AllArgsConstructor;
@@ -37,4 +38,5 @@ public class UpdateApiProduct {
     private Set<String> tags;
     private ZonedDateTime updatedAt;
     private Boolean disableMembershipNotifications;
+    private Analytics analytics;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/AiWorkspaceAuditEvent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/AiWorkspaceAuditEvent.java
@@ -30,4 +30,5 @@ public enum AiWorkspaceAuditEvent implements AuditEvent {
     AI_WORKSPACE_USER_ADDED,
     AI_WORKSPACE_USER_REMOVED,
     AI_WORKSPACE_USER_TIER_CHANGED,
+    AI_WORKSPACE_ANALYTICS_UPDATED,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiProductAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiProductAdapter.java
@@ -15,26 +15,59 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.repository.management.model.ApiProduct;
+import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
+import org.slf4j.Logger;
 
 @Mapper
 public interface ApiProductAdapter {
     ApiProductAdapter INSTANCE = Mappers.getMapper(ApiProductAdapter.class);
 
+    Logger log = NodeLoggerFactory.getLogger(ApiProductAdapter.class);
+
     @Mapping(target = "createdAt", qualifiedByName = "dateToZonedDateTime")
     @Mapping(target = "updatedAt", qualifiedByName = "dateToZonedDateTime")
     @Mapping(target = "primaryOwner", ignore = true)
+    @Mapping(target = "analytics", qualifiedByName = "deserializeAnalytics")
     io.gravitee.apim.core.api_product.model.ApiProduct toModel(ApiProduct repositoryApiProduct);
 
     @Mapping(target = "createdAt", qualifiedByName = "zonedDateTimeToDate")
     @Mapping(target = "updatedAt", qualifiedByName = "zonedDateTimeToDate")
+    @Mapping(target = "analytics", qualifiedByName = "serializeAnalytics")
     io.gravitee.repository.management.model.ApiProduct toRepository(io.gravitee.apim.core.api_product.model.ApiProduct domainApiProduct);
+
+    @Named("deserializeAnalytics")
+    default Analytics deserializeAnalytics(String analytics) {
+        if (analytics == null || analytics.isBlank()) {
+            return null;
+        }
+        try {
+            return GraviteeJacksonMapper.getInstance().readValue(analytics, Analytics.class);
+        } catch (IOException e) {
+            log.error("Unexpected error while deserializing API Product analytics", e);
+            return null;
+        }
+    }
+
+    @Named("serializeAnalytics")
+    default String serializeAnalytics(Analytics analytics) {
+        if (analytics == null) {
+            return null;
+        }
+        try {
+            return GraviteeJacksonMapper.getInstance().writeValueAsString(analytics);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to serialize API Product analytics", e);
+        }
+    }
 
     @Named("dateToZonedDateTime")
     default ZonedDateTime dateToZonedDateTime(Date date) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
@@ -683,6 +683,40 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
         assertThat(planCrudService.getById("product-plan-1").getPlanDefinitionHttpV4().getTags()).isNull();
     }
 
+    @Test
+    void should_set_api_product_analytics() {
+        ApiProduct existing = ApiProduct.builder().id("api-product-id").name("API Product").version("1.0.0").environmentId(ENV_ID).build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        var analytics = io.gravitee.definition.model.v4.analytics.Analytics.builder().enabled(false).build();
+        var toUpdate = UpdateApiProduct.builder().analytics(analytics).build();
+        var output = updateApiProductUseCase.execute(new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getAnalytics()).isEqualTo(analytics);
+    }
+
+    @Test
+    void should_clear_api_product_analytics_when_explicitly_set_to_null() {
+        var analytics = io.gravitee.definition.model.v4.analytics.Analytics.builder().enabled(false).build();
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .environmentId(ENV_ID)
+            .analytics(analytics)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        // Same semantics as an API's own analytics field: always applied, so null clears it back to
+        // "inherit from each API" rather than being ignored like the other, guarded fields.
+        var toUpdate = UpdateApiProduct.builder().name("API Product").analytics(null).build();
+        var output = updateApiProductUseCase.execute(new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getAnalytics()).isNull();
+    }
+
     private Plan productPlanWithTags(String planId, Set<String> tags) {
         var planDefinition = PlanFixtures.aPlanHttpV4()
             .getPlanDefinitionHttpV4()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiProductAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiProductAdapterTest.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.repository.management.model.ApiProduct;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -47,6 +50,42 @@ class ApiProductAdapterTest {
                 soft.assertThat(api.getName()).isEqualTo("api-product-name");
                 soft.assertThat(api.getCreatedAt()).isEqualTo(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneOffset.UTC));
                 soft.assertThat(api.getUpdatedAt()).isEqualTo(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneOffset.UTC));
+                soft.assertThat(api.getAnalytics()).isNull();
+            });
+        }
+
+        @Test
+        void should_deserialize_analytics() {
+            var repository = apiProduct().analytics("{\"enabled\":true,\"logging\":{\"content\":{\"headers\":true}}}").build();
+
+            var analytics = ApiProductAdapter.INSTANCE.toModel(repository).getAnalytics();
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(analytics).isNotNull();
+                soft.assertThat(analytics.isEnabled()).isTrue();
+                soft.assertThat(analytics.getLogging().getContent().isHeaders()).isTrue();
+            });
+        }
+
+        @Test
+        void should_read_unparseable_analytics_as_absent_rather_than_failing() {
+            var repository = apiProduct().analytics("not json").build();
+
+            assertThat(ApiProductAdapter.INSTANCE.toModel(repository).getAnalytics()).isNull();
+        }
+
+        @Test
+        void should_ignore_unknown_properties_rather_than_dropping_the_whole_analytics_config() {
+            var repository = apiProduct()
+                .analytics("{\"enabled\":true,\"logging\":{\"content\":{\"headers\":true}},\"someFutureField\":{\"any\":\"thing\"}}")
+                .build();
+
+            var analytics = ApiProductAdapter.INSTANCE.toModel(repository).getAnalytics();
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(analytics).isNotNull();
+                soft.assertThat(analytics.isEnabled()).isTrue();
+                soft.assertThat(analytics.getLogging().getContent().isHeaders()).isTrue();
             });
         }
     }
@@ -68,7 +107,16 @@ class ApiProductAdapterTest {
                 soft.assertThat(api.getName()).isEqualTo("my-api-product");
                 soft.assertThat(api.getUpdatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")));
                 soft.assertThat(api.getVersion()).isEqualTo("1.0.0");
+                soft.assertThat(api.getAnalytics()).isNull();
             });
+        }
+
+        @Test
+        void should_serialize_analytics() {
+            var analytics = Analytics.builder().enabled(true).build();
+            var model = BASE().analytics(analytics).build();
+
+            assertThat(ApiProductAdapter.INSTANCE.toRepository(model).getAnalytics()).contains("\"enabled\":true");
         }
     }
 


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/AIAM-220

## Why

An API Product exposes several APIs, and until now the only place reporter settings could live was each API's own definition. There was no way to state them once for the product — which is what the AI Workspace (an API Product) needs in order to govern logging and analytics for everything it exposes.

## What

A nullable `analytics` field on the API Product, carried end to end:

| Layer | Change |
|---|---|
| Repository model | `ApiProduct.analytics` (JSON string) |
| JDBC | new nullable `analytics` column + Liquibase changelog `v4_13_0/11` |
| Mongo | `ApiProductMongo.analytics` (schemaless, no migration) |
| Core | `ApiProduct.analytics` / `UpdateApiProduct.analytics` (`io.gravitee.definition.model.v4.analytics.Analytics`) |
| Adapter | JSON (de)serialization; unreadable stored JSON degrades to `null` instead of failing the read |
| Deployment | `ApiProductDeploymentPayload.analytics` |
| Gateway | `ReactableApiProduct.analytics`, populated by the sync `ApiProductMapper` |
| OpenAPI | documented on `ApiProduct` and `UpdateApiProduct` |

## Compatibility

Purely additive; there is no behaviour change in this PR.

- `null` — every product that exists today, and every product that never sets it — means the product states nothing, so each API keeps reporting exactly as it does now.
- The Liquibase change is an `addColumn` with `nullable: true`; existing rows read back `null`. Mongo needs no migration.
- Nothing on the gateway reads the new field yet, so a 4.13 gateway behaves identically whether or not a product carries it.
- `CreateApiProduct` is untouched — the field is set through update only.

## Tests

- `ApiProductRepositoryTest` — create/update/clear round-trip, and a product stored before the column existed reads back `null`. Green on both JDBC (30) and Mongo (30).
- `ApiProductAdapterTest` — serialize, deserialize, and unparseable-JSON-reads-as-absent.
- sync `ApiProductMapperTest` — analytics carried from the event payload onto the reactable product.
- `mvn test -Dtest='*ApiProduct*'` in `rest-api-service`: 488 green; `gateway-handlers-api`: 992 green.