### PR TITLE
feat(gamma): Group list, expand Create Group form fields and add role/ownership badges

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -78,6 +78,10 @@ jest.mock('../pages/UserDetailPage', () => ({
     UserDetailPage: () => <div data-testid="user-detail-page" />,
 }));
 
+jest.mock('../pages/GroupsPage', () => ({
+    GroupsPage: () => <div data-testid="groups-page" />,
+}));
+
 jest.mock('../pages/RegisterApplicationPage', () => ({
     RegisterApplicationPage: () => <div data-testid="register-application-page" />,
 }));
@@ -138,6 +142,30 @@ describe('AppRoutes', () => {
         );
 
         expect(screen.getByTestId('users-page')).not.toBeNull();
+    });
+
+    it('routes to the User Groups page under the platform module', () => {
+        render(
+            <MemoryRouter initialEntries={['/user-groups']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('groups-page')).not.toBeNull();
+    });
+
+    it('shows the User Groups nav item when the user has read permission', () => {
+        renderPlatform();
+
+        expect(visibleNavKeys()).toContain('user-groups');
+    });
+
+    it('hides the User Groups nav item when the user lacks environment-group-r', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-group-r'));
+
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('user-groups');
     });
 
     it('shows the Dictionaries nav item when the user has read permission', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -26,6 +26,7 @@ import { NAV_GROUPS } from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
 import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
+import { ENVIRONMENT_GROUP_READ_PERMISSION } from '../features/groups/utils/groupPermissions';
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
 import { SecurityPlanTypesPage } from '../features/security-plan-types/SecurityPlanTypesPage';
 import { ORGANIZATION_USER_ACCESS_PERMISSIONS } from '../features/users/utils/userPermissions';
@@ -35,6 +36,7 @@ import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { DictionariesPage } from '../pages/DictionariesPage';
 import { DictionaryDetailPage } from '../pages/DictionaryDetailPage';
 import { EntrypointsAndShardingTagsPage } from '../pages/EntrypointsAndShardingTagsPage';
+import { GroupsPage } from '../pages/GroupsPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
 import { UserDetailPage } from '../pages/UserDetailPage';
@@ -85,9 +87,13 @@ function isNavItemVisible(
     canReadDictionaries: boolean,
     canAccessUsers: boolean,
     canReadEntrypoints: boolean,
+    canReadGroups: boolean,
 ): boolean {
     if (itemKey === 'users') {
         return !permissionsReady || canAccessUsers;
+    }
+    if (itemKey === 'user-groups') {
+        return !permissionsReady || canReadGroups;
     }
     if (itemKey === 'metadata') {
         return !permissionsReady || canReadMetadata;
@@ -127,6 +133,7 @@ function ModuleLayout() {
 
     const canAccessUsers = useHasPermission({ anyOf: [...ORGANIZATION_USER_ACCESS_PERMISSIONS] });
     const canReadEntrypoints = useHasPermission({ anyOf: ['environment-entrypoint-r', 'organization-entrypoint-r'] });
+    const canReadGroups = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_READ_PERMISSION] });
 
     const navigate = useNavigate();
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
@@ -136,10 +143,18 @@ function ModuleLayout() {
             NAV_GROUPS.map(group => ({
                 ...group,
                 items: group.items.filter(item =>
-                    isNavItemVisible(item.key, permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers, canReadEntrypoints),
+                    isNavItemVisible(
+                        item.key,
+                        permissionsReady,
+                        canReadMetadata,
+                        canReadDictionaries,
+                        canAccessUsers,
+                        canReadEntrypoints,
+                        canReadGroups,
+                    ),
                 ),
             })).filter(group => group.items.length > 0),
-        [permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers, canReadEntrypoints],
+        [permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers, canReadEntrypoints, canReadGroups],
     );
 
     const breadcrumbs = useMemo(
@@ -198,6 +213,14 @@ export function AppRoutes() {
                                 }
                             />
                         </Route>
+                        <Route
+                            path="user-groups"
+                            element={
+                                <PermissionPageGuard permission={ENVIRONMENT_GROUP_READ_PERMISSION}>
+                                    <GroupsPage />
+                                </PermissionPageGuard>
+                            }
+                        />
                         <Route
                             path="metadata"
                             element={

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -17,16 +17,23 @@ import { NAV_GROUPS } from './navigation';
 import { PLATFORM_ROUTE_CONFIG, ROUTES } from './routes';
 
 describe('platform navigation config', () => {
-    it('registers Users under Identity & Access', () => {
+    it('registers Users and User Groups under Identity & Access', () => {
         const identityGroup = NAV_GROUPS.find(group => group.label === 'Identity & Access');
         expect(identityGroup).toBeDefined();
-        expect(identityGroup?.items.map(item => item.key)).toEqual(['users']);
+        expect(identityGroup?.items.map(item => item.key)).toEqual(['users', 'user-groups']);
         expect(identityGroup?.items[0]?.title).toBe('Users');
         expect(identityGroup?.items[0]?.icon).toBeUndefined();
+        expect(identityGroup?.items[1]?.title).toBe('User Groups');
+        expect(identityGroup?.items[1]?.icon).toBeUndefined();
     });
 
     it('declares the users route in platform routing config', () => {
         expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('users');
         expect(ROUTES.users).toEqual({ path: 'users', label: 'Users' });
+    });
+
+    it('declares the user-groups route in platform routing config', () => {
+        expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('user-groups');
+        expect(ROUTES['user-groups']).toEqual({ path: 'user-groups', label: 'User Groups' });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -25,7 +25,10 @@ export const NAV_GROUPS: NavGroup[] = [
     },
     {
         label: 'Identity & Access',
-        items: [{ key: 'users', title: ROUTES.users.label }],
+        items: [
+            { key: 'users', title: ROUTES.users.label },
+            { key: 'user-groups', title: ROUTES['user-groups'].label },
+        ],
     },
     {
         label: 'APIs & Assets',

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -18,6 +18,7 @@ import type { ModuleRouteConfig } from '@gravitee/gamma-modules-sdk/routing';
 export const ROUTE_KEYS: readonly string[] = [
     'applications',
     'users',
+    'user-groups',
     'access-management',
     'metadata',
     'dictionaries',
@@ -31,6 +32,7 @@ const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
 export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: string }> = {
     applications: { path: 'applications', label: 'Applications' },
     users: { path: 'users', label: 'Users' },
+    'user-groups': { path: 'user-groups', label: 'User Groups' },
     'access-management': { path: 'access-management', label: 'Access Management' },
     'security-plan-types': { path: 'security-plan-types', label: 'Security Plan Types' },
     metadata: { path: 'metadata', label: 'Metadata' },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+
+import type { Group } from '../types/group';
+
+export function GroupDeleteSheet({
+    open,
+    group,
+    onClose,
+    onConfirm,
+    isDeleting,
+}: Readonly<{
+    open: boolean;
+    group: Group | undefined;
+    onClose: () => void;
+    onConfirm: () => void;
+    isDeleting: boolean;
+}>) {
+    return (
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Delete Group</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to delete <span className="font-medium text-foreground">{group?.name}</span>? Members will
+                        lose any access granted through this group.
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || !group}>
+                        {isDeleting ? 'Deleting…' : 'Delete'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupSheet.spec.tsx
@@ -1,0 +1,370 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupSheet } from './GroupSheet';
+import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
+import type { Group, GroupRole } from '../types/group';
+
+// Radix Switch measures its thumb via ResizeObserver, and Radix Select scrolls the highlighted
+// option into view — neither is implemented in jsdom.
+beforeAll(() => {
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as typeof ResizeObserver;
+    Element.prototype.scrollIntoView = jest.fn();
+});
+
+const API_ROLES: GroupRole[] = [
+    { name: 'USER', scope: 'API', default: true },
+    { name: 'OWNER', scope: 'API' },
+];
+
+const APPLICATION_ROLES: GroupRole[] = [{ name: 'USER', scope: 'APPLICATION', default: true }];
+
+const API_PRODUCT_ROLES: GroupRole[] = [{ name: 'USER', scope: 'API_PRODUCT', default: true }];
+
+const EXISTING_GROUP: Group = {
+    id: 'group-1',
+    name: 'Support Team',
+    event_rules: [{ event: 'API_CREATE' }, { event: 'APPLICATION_CREATE' }],
+    roles: { API: 'OWNER', APPLICATION: 'USER', API_PRODUCT: 'USER' },
+    lock_api_role: false,
+    lock_api_product_role: true,
+    lock_application_role: false,
+    max_invitation: 25,
+    system_invitation: true,
+    email_invitation: false,
+    disable_membership_notifications: true,
+};
+
+function renderSheet({
+    open = true,
+    mode,
+    group,
+    isSaving = false,
+    apiRoles = API_ROLES,
+    applicationRoles = APPLICATION_ROLES,
+    apiProductRoles = API_PRODUCT_ROLES,
+}: {
+    open?: boolean;
+    mode: 'create' | 'edit';
+    group?: Group;
+    isSaving?: boolean;
+    apiRoles?: GroupRole[];
+    applicationRoles?: GroupRole[];
+    apiProductRoles?: GroupRole[];
+}) {
+    const onClose = jest.fn();
+    const onSubmit = jest.fn();
+    render(
+        <GroupSheet
+            open={open}
+            mode={mode}
+            group={group}
+            apiRoles={apiRoles}
+            applicationRoles={applicationRoles}
+            apiProductRoles={apiProductRoles}
+            rolesLoading={false}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={isSaving}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('GroupSheet', () => {
+    describe('visibility', () => {
+        it('does not show sheet content when closed', () => {
+            renderSheet({ open: false, mode: 'create' });
+            expect(querySheetHeading('Create group')).toBeNull();
+        });
+
+        it('shows create title when mode is create', () => {
+            renderSheet({ mode: 'create' });
+            expect(screen.getByRole('heading', { name: 'Create group' })).not.toBeNull();
+        });
+
+        it('shows edit title when mode is edit', () => {
+            renderSheet({ mode: 'edit', group: EXISTING_GROUP });
+            expect(screen.getByRole('heading', { name: 'Edit group' })).not.toBeNull();
+        });
+    });
+
+    describe('create mode', () => {
+        it('renders an empty name field', () => {
+            renderSheet({ mode: 'create' });
+            expect((screen.getByLabelText(/Name/i) as HTMLInputElement).value).toBe('');
+        });
+
+        // Classic mirror (group.component.ts:initializeForm): a brand-new group has no server-side
+        // state yet, so every lock/association/invitation toggle defaults off.
+        it('defaults every toggle off', () => {
+            renderSheet({ mode: 'create' });
+            expect(screen.getByLabelText('Lock API role').getAttribute('aria-checked')).toBe('false');
+            expect(screen.getByLabelText('Lock API product role').getAttribute('aria-checked')).toBe('false');
+            expect(screen.getByLabelText('Lock application role').getAttribute('aria-checked')).toBe('false');
+            expect(screen.getByLabelText('Associate with new APIs').getAttribute('aria-checked')).toBe('false');
+            expect(screen.getByLabelText('Associate with new API products').getAttribute('aria-checked')).toBe('false');
+            expect(screen.getByLabelText('Associate with new applications').getAttribute('aria-checked')).toBe('false');
+            expect(screen.getByLabelText('Allow invitation via user search').getAttribute('aria-checked')).toBe('false');
+            expect(screen.getByLabelText('Allow invitation via email').getAttribute('aria-checked')).toBe('false');
+            expect(screen.getByLabelText('Notify members when added').getAttribute('aria-checked')).toBe('true');
+        });
+
+        it('leaves Maximum members blank by default', () => {
+            renderSheet({ mode: 'create' });
+            expect((screen.getByLabelText('Maximum members') as HTMLInputElement).value).toBe('');
+        });
+
+        it('pre-selects the default role for each scope', () => {
+            renderSheet({ mode: 'create' });
+            expect(screen.getAllByText('USER').length).toBeGreaterThan(0);
+        });
+
+        it('keeps Create disabled until name is filled', () => {
+            renderSheet({ mode: 'create' });
+            const createBtn = screen.getByRole('button', { name: 'Create group' }) as HTMLButtonElement;
+            expect(createBtn.disabled).toBe(true);
+
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Group' } });
+            expect(createBtn.disabled).toBe(false);
+        });
+
+        it('submits trimmed name with default toggles and roles', () => {
+            const { onSubmit } = renderSheet({ mode: 'create' });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: '  My Group  ' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Create group' }));
+            expect(onSubmit).toHaveBeenCalledWith({
+                name: 'My Group',
+                apiRole: 'USER',
+                applicationRole: 'USER',
+                apiProductRole: 'USER',
+                lockApiRole: false,
+                lockApiProductRole: false,
+                lockApplicationRole: false,
+                defaultGroupForNewApis: false,
+                defaultGroupForNewApiProducts: false,
+                defaultGroupForNewApplications: false,
+                maxInvitation: '',
+                systemInvitation: false,
+                emailInvitation: false,
+                notifyOnMemberAdded: true,
+            });
+        });
+
+        it('toggles Associate with new APIs into the submitted payload', () => {
+            const { onSubmit } = renderSheet({ mode: 'create' });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Group' } });
+            fireEvent.click(screen.getByLabelText('Associate with new APIs'));
+            fireEvent.click(screen.getByRole('button', { name: 'Create group' }));
+            expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ defaultGroupForNewApis: true }));
+        });
+
+        it('accepts a positive Maximum members value', () => {
+            const { onSubmit } = renderSheet({ mode: 'create' });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Group' } });
+            fireEvent.change(screen.getByLabelText('Maximum members'), { target: { value: '10' } });
+            expect(screen.queryByText('Enter a positive number or leave blank')).toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Create group' }));
+            expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ maxInvitation: '10' }));
+        });
+
+        it('rejects a non-positive Maximum members value and blocks submit', () => {
+            const { onSubmit } = renderSheet({ mode: 'create' });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Group' } });
+            fireEvent.change(screen.getByLabelText('Maximum members'), { target: { value: '0' } });
+            expect(screen.getByText('Enter a positive number or leave blank')).not.toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Create group' }));
+            expect(onSubmit).not.toHaveBeenCalled();
+        });
+
+        it('shows "Creating…" label while saving', () => {
+            renderSheet({ mode: 'create', isSaving: true });
+            expect(screen.queryByRole('button', { name: 'Creating…' })).not.toBeNull();
+        });
+    });
+
+    describe('edit mode', () => {
+        it('pre-fills every field from the existing group', () => {
+            renderSheet({ mode: 'edit', group: EXISTING_GROUP });
+            expect((screen.getByLabelText(/Name/i) as HTMLInputElement).value).toBe('Support Team');
+            expect(screen.getByLabelText('Lock API role').getAttribute('aria-checked')).toBe('false');
+            expect(screen.getByLabelText('Lock API product role').getAttribute('aria-checked')).toBe('true');
+            expect(screen.getByLabelText('Lock application role').getAttribute('aria-checked')).toBe('false');
+            expect(screen.getByLabelText('Associate with new APIs').getAttribute('aria-checked')).toBe('true');
+            expect(screen.getByLabelText('Associate with new API products').getAttribute('aria-checked')).toBe('false');
+            expect(screen.getByLabelText('Associate with new applications').getAttribute('aria-checked')).toBe('true');
+            expect((screen.getByLabelText('Maximum members') as HTMLInputElement).value).toBe('25');
+            expect(screen.getByLabelText('Allow invitation via user search').getAttribute('aria-checked')).toBe('true');
+            expect(screen.getByLabelText('Allow invitation via email').getAttribute('aria-checked')).toBe('false');
+            // disable_membership_notifications: true -> "Notify members when added" is off.
+            expect(screen.getByLabelText('Notify members when added').getAttribute('aria-checked')).toBe('false');
+            expect(screen.getAllByText('OWNER').length).toBeGreaterThan(0);
+        });
+
+        it('disables Save when nothing has changed', () => {
+            renderSheet({ mode: 'edit', group: EXISTING_GROUP });
+            expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(true);
+        });
+
+        it('enables Save after changing the name', () => {
+            renderSheet({ mode: 'edit', group: EXISTING_GROUP });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'New Name' } });
+            expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(false);
+        });
+
+        it('enables Save after toggling Lock API role', () => {
+            renderSheet({ mode: 'edit', group: EXISTING_GROUP });
+            fireEvent.click(screen.getByLabelText('Lock API role'));
+            expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(false);
+        });
+
+        it('enables Save after toggling Notify members when added', () => {
+            renderSheet({ mode: 'edit', group: EXISTING_GROUP });
+            fireEvent.click(screen.getByLabelText('Notify members when added'));
+            expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(false);
+        });
+
+        it('submits updated values for the existing group', () => {
+            const { onSubmit } = renderSheet({ mode: 'edit', group: EXISTING_GROUP });
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Updated Name' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+            expect(onSubmit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    name: 'Updated Name',
+                    apiRole: 'OWNER',
+                    applicationRole: 'USER',
+                    apiProductRole: 'USER',
+                    lockApiProductRole: true,
+                    maxInvitation: '25',
+                    systemInvitation: true,
+                    emailInvitation: false,
+                    notifyOnMemberAdded: false,
+                }),
+            );
+        });
+
+        it('shows "Saving…" label while saving', () => {
+            renderSheet({ mode: 'edit', group: EXISTING_GROUP, isSaving: true });
+            expect(screen.queryByRole('button', { name: 'Saving…' })).not.toBeNull();
+        });
+    });
+
+    describe('cancel', () => {
+        it('invokes onClose when Cancel is clicked', () => {
+            const { onClose } = renderSheet({ mode: 'create' });
+            fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('system roles', () => {
+        const rolesWithSystem: GroupRole[] = [
+            { name: 'USER', scope: 'API', default: true },
+            { name: 'PRIMARY_OWNER', scope: 'API', system: true },
+        ];
+
+        it('excludes system roles from the picker', () => {
+            renderSheet({ mode: 'create', apiRoles: rolesWithSystem });
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            expect(screen.queryByRole('option', { name: 'PRIMARY_OWNER' })).toBeNull();
+        });
+
+        it('keeps an already-selected system role visible', () => {
+            const groupWithSystemRole: Group = { ...EXISTING_GROUP, roles: { ...EXISTING_GROUP.roles, API: 'PRIMARY_OWNER' } };
+            renderSheet({ mode: 'edit', group: groupWithSystemRole, apiRoles: rolesWithSystem });
+            expect(screen.getAllByText('PRIMARY_OWNER').length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('role backfill on cold-cache create', () => {
+        it('fills in default roles once they resolve, if Create was opened before they loaded', () => {
+            const { rerender } = render(
+                <GroupSheet
+                    open
+                    mode="create"
+                    apiRoles={[]}
+                    applicationRoles={[]}
+                    apiProductRoles={[]}
+                    rolesLoading
+                    onClose={jest.fn()}
+                    onSubmit={jest.fn()}
+                    isSaving={false}
+                />,
+            );
+
+            expect(screen.getByLabelText('Default API role').textContent).not.toContain('USER');
+
+            // Roles resolve.
+            rerender(
+                <GroupSheet
+                    open
+                    mode="create"
+                    apiRoles={API_ROLES}
+                    applicationRoles={APPLICATION_ROLES}
+                    apiProductRoles={API_PRODUCT_ROLES}
+                    rolesLoading={false}
+                    onClose={jest.fn()}
+                    onSubmit={jest.fn()}
+                    isSaving={false}
+                />,
+            );
+
+            expect(screen.getByLabelText('Default API role').textContent).toContain('USER');
+        });
+
+        it('does not re-apply a default over a role the user explicitly cleared to None', () => {
+            const { rerender } = render(
+                <GroupSheet
+                    open
+                    mode="create"
+                    apiRoles={API_ROLES}
+                    applicationRoles={APPLICATION_ROLES}
+                    apiProductRoles={API_PRODUCT_ROLES}
+                    rolesLoading={false}
+                    onClose={jest.fn()}
+                    onSubmit={jest.fn()}
+                    isSaving={false}
+                />,
+            );
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'None' }));
+            expect(screen.getByLabelText('Default API role').textContent).not.toContain('USER');
+
+            // Simulate a background roles refetch producing a fresh array reference with the same data.
+            rerender(
+                <GroupSheet
+                    open
+                    mode="create"
+                    apiRoles={[...API_ROLES]}
+                    applicationRoles={APPLICATION_ROLES}
+                    apiProductRoles={API_PRODUCT_ROLES}
+                    rolesLoading={false}
+                    onClose={jest.fn()}
+                    onSubmit={jest.fn()}
+                    isSaving={false}
+                />,
+            );
+
+            expect(screen.getByLabelText('Default API role').textContent).not.toContain('USER');
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupSheet.tsx
@@ -1,0 +1,445 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Field,
+    FieldLabel,
+    Input,
+    ScrollArea,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+    Switch,
+} from '@gravitee/graphene-core';
+import { useCallback, useEffect, useMemo, useState, type FormEvent, type ReactNode } from 'react';
+
+import { STANDARD_SHEET_WIDTH } from '../../applications/components/sheetLayout';
+import type { Group, GroupRole } from '../types/group';
+
+export type GroupSheetMode = 'create' | 'edit';
+
+export interface GroupFormValues {
+    name: string;
+    apiRole: string;
+    applicationRole: string;
+    apiProductRole: string;
+    lockApiRole: boolean;
+    lockApiProductRole: boolean;
+    lockApplicationRole: boolean;
+    defaultGroupForNewApis: boolean;
+    defaultGroupForNewApiProducts: boolean;
+    defaultGroupForNewApplications: boolean;
+    maxInvitation: string;
+    systemInvitation: boolean;
+    emailInvitation: boolean;
+    notifyOnMemberAdded: boolean;
+}
+
+const NO_ROLE_VALUE = '__none__';
+
+function defaultRoleValue(roles: GroupRole[]): string {
+    return roles.find(role => role.default)?.name ?? '';
+}
+
+function hasEventRule(group: Group, event: string): boolean {
+    return (group.event_rules ?? []).some(rule => rule.event === event);
+}
+
+// Classic Console mirror (group.component.ts:initializeForm): a brand-new group has no
+// server-side state yet, so admins can change every role (canAdminChangeAPIRole defaults true,
+// i.e. lock_api_role saves as false), invitations start off, and membership-change
+// notifications are on (`!disable_membership_notifications` defaults true).
+function buildEmptyForm(apiRoles: GroupRole[], applicationRoles: GroupRole[], apiProductRoles: GroupRole[]): GroupFormValues {
+    return {
+        name: '',
+        apiRole: defaultRoleValue(apiRoles),
+        applicationRole: defaultRoleValue(applicationRoles),
+        apiProductRole: defaultRoleValue(apiProductRoles),
+        lockApiRole: false,
+        lockApiProductRole: false,
+        lockApplicationRole: false,
+        defaultGroupForNewApis: false,
+        defaultGroupForNewApiProducts: false,
+        defaultGroupForNewApplications: false,
+        maxInvitation: '',
+        systemInvitation: false,
+        emailInvitation: false,
+        notifyOnMemberAdded: true,
+    };
+}
+
+function buildFormFromGroup(group: Group): GroupFormValues {
+    return {
+        name: group.name,
+        apiRole: group.roles?.API ?? '',
+        applicationRole: group.roles?.APPLICATION ?? '',
+        apiProductRole: group.roles?.API_PRODUCT ?? '',
+        lockApiRole: Boolean(group.lock_api_role),
+        lockApiProductRole: Boolean(group.lock_api_product_role),
+        lockApplicationRole: Boolean(group.lock_application_role),
+        defaultGroupForNewApis: hasEventRule(group, 'API_CREATE'),
+        defaultGroupForNewApiProducts: hasEventRule(group, 'API_PRODUCT_CREATE'),
+        defaultGroupForNewApplications: hasEventRule(group, 'APPLICATION_CREATE'),
+        maxInvitation: String(group.max_invitation ?? ''),
+        systemInvitation: Boolean(group.system_invitation),
+        emailInvitation: Boolean(group.email_invitation),
+        notifyOnMemberAdded: !group.disable_membership_notifications,
+    };
+}
+
+function ToggleRow({
+    id,
+    title,
+    description,
+    checked,
+    onCheckedChange,
+    disabled,
+}: Readonly<{
+    id: string;
+    title: string;
+    description: string;
+    checked: boolean;
+    onCheckedChange: (checked: boolean) => void;
+    disabled?: boolean;
+}>) {
+    return (
+        <div className="flex items-center justify-between gap-4 rounded-lg border px-3 py-2">
+            <div className="space-y-0.5">
+                <FieldLabel htmlFor={id}>{title}</FieldLabel>
+                <p className="text-xs text-muted-foreground">{description}</p>
+            </div>
+            <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} disabled={disabled} />
+        </div>
+    );
+}
+
+function RoleSelect({
+    id,
+    label,
+    value,
+    roles,
+    disabled,
+    onChange,
+}: Readonly<{
+    id: string;
+    label: ReactNode;
+    value: string;
+    roles: GroupRole[];
+    disabled: boolean;
+    onChange: (value: string) => void;
+}>) {
+    // Classic Console hides system roles (e.g. PRIMARY_OWNER) from the default-role pickers — they're
+    // assigned automatically, not chosen. Keep the currently-selected value visible even if it's a
+    // system role (e.g. an existing group saved with one before this filter existed).
+    const selectableRoles = roles.filter(role => !role.system || role.name === value);
+
+    return (
+        <Field orientation="vertical" className="gap-1.5">
+            <FieldLabel htmlFor={id}>{label}</FieldLabel>
+            <Select value={value || NO_ROLE_VALUE} onValueChange={val => onChange(val === NO_ROLE_VALUE ? '' : val)} disabled={disabled}>
+                <SelectTrigger id={id}>
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value={NO_ROLE_VALUE}>None</SelectItem>
+                    {selectableRoles.map(role => (
+                        <SelectItem key={role.name} value={role.name}>
+                            {role.name}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+        </Field>
+    );
+}
+
+export function GroupSheet({
+    open,
+    mode,
+    group,
+    apiRoles,
+    applicationRoles,
+    apiProductRoles,
+    rolesLoading,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    mode: GroupSheetMode;
+    group?: Group;
+    apiRoles: GroupRole[];
+    applicationRoles: GroupRole[];
+    apiProductRoles: GroupRole[];
+    rolesLoading: boolean;
+    onClose: () => void;
+    onSubmit: (values: GroupFormValues) => void;
+    isSaving: boolean;
+}>) {
+    const [form, setForm] = useState<GroupFormValues>(() => buildEmptyForm([], [], []));
+    const [initialForm, setInitialForm] = useState<GroupFormValues | null>(null);
+    const [maxInvitationError, setMaxInvitationError] = useState<string | null>(null);
+    const [rolesTouched, setRolesTouched] = useState(false);
+
+    useEffect(() => {
+        if (!open) return;
+        if (mode === 'edit' && group) {
+            const initial = buildFormFromGroup(group);
+            setForm(initial);
+            setInitialForm(initial);
+        } else {
+            const initial = buildEmptyForm(apiRoles, applicationRoles, apiProductRoles);
+            setForm(initial);
+            setInitialForm(null);
+        }
+        setMaxInvitationError(null);
+        setRolesTouched(false);
+        // Intentionally re-runs only on open/mode/group, not on role-list identity: resetting the whole
+        // form whenever a role query refetches would wipe out whatever the user already typed.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open, mode, group]);
+
+    // Handles the case where Create is opened before the role queries resolve (cold cache): buildEmptyForm
+    // above ran with empty role lists, so once the roles arrive here we backfill only the fields the user
+    // hasn't touched yet — a targeted merge, not a full form reset.
+    useEffect(() => {
+        if (!open || mode !== 'create' || rolesLoading || rolesTouched) return;
+        setForm(prev => ({
+            ...prev,
+            apiRole: prev.apiRole || defaultRoleValue(apiRoles),
+            applicationRole: prev.applicationRole || defaultRoleValue(applicationRoles),
+            apiProductRole: prev.apiProductRole || defaultRoleValue(apiProductRoles),
+        }));
+    }, [open, mode, rolesLoading, rolesTouched, apiRoles, applicationRoles, apiProductRoles]);
+
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    function setField<K extends keyof GroupFormValues>(key: K, value: GroupFormValues[K]) {
+        setForm(prev => ({ ...prev, [key]: value }));
+    }
+
+    function setRoleField(key: 'apiRole' | 'applicationRole' | 'apiProductRole', value: string) {
+        setRolesTouched(true);
+        setField(key, value);
+    }
+
+    function handleMaxInvitationChange(value: string) {
+        setField('maxInvitation', value);
+        if (!value.trim()) {
+            setMaxInvitationError(null);
+            return;
+        }
+        const parsed = Number(value);
+        setMaxInvitationError(Number.isFinite(parsed) && parsed >= 1 ? null : 'Enter a positive number or leave blank');
+    }
+
+    const isValid = form.name.trim() !== '' && !maxInvitationError;
+
+    const hasChanged = useMemo(() => {
+        if (mode === 'create') return true;
+        if (!initialForm) return false;
+        return (Object.keys(form) as Array<keyof GroupFormValues>).some(key => form[key] !== initialForm[key]);
+    }, [mode, form, initialForm]);
+
+    function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        if (!isValid || !hasChanged) return;
+        onSubmit({ ...form, name: form.name.trim() });
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: STANDARD_SHEET_WIDTH }}>
+                <SheetHeader>
+                    <SheetTitle>{mode === 'create' ? 'Create group' : 'Edit group'}</SheetTitle>
+                    <SheetDescription>
+                        {mode === 'create'
+                            ? 'New groups can receive default API and application roles, and be used in IdP mappings.'
+                            : 'Update the group name, default roles, and association settings.'}
+                    </SheetDescription>
+                </SheetHeader>
+
+                <ScrollArea className="flex-1 min-h-0">
+                    <form id="group-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-4 py-4">
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="group-name">
+                                Name{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            <Input
+                                id="group-name"
+                                value={form.name}
+                                onChange={e => setField('name', e.target.value)}
+                                placeholder="e.g. Support Team"
+                                disabled={isSaving}
+                                required
+                            />
+                        </Field>
+
+                        <div className="grid grid-cols-2 gap-4">
+                            <RoleSelect
+                                id="group-api-role"
+                                label="Default API role"
+                                value={form.apiRole}
+                                roles={apiRoles}
+                                disabled={isSaving || rolesLoading}
+                                onChange={val => setRoleField('apiRole', val)}
+                            />
+                            <RoleSelect
+                                id="group-application-role"
+                                label="Default application role"
+                                value={form.applicationRole}
+                                roles={applicationRoles}
+                                disabled={isSaving || rolesLoading}
+                                onChange={val => setRoleField('applicationRole', val)}
+                            />
+                            <div className="col-span-2">
+                                <RoleSelect
+                                    id="group-api-product-role"
+                                    label="Default API product role"
+                                    value={form.apiProductRole}
+                                    roles={apiProductRoles}
+                                    disabled={isSaving || rolesLoading}
+                                    onChange={val => setRoleField('apiProductRole', val)}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="flex flex-col gap-2">
+                            <ToggleRow
+                                id="group-lock-api-role"
+                                title="Lock API role"
+                                description="Members can't change their API role in this group."
+                                checked={form.lockApiRole}
+                                onCheckedChange={val => setField('lockApiRole', val)}
+                                disabled={isSaving}
+                            />
+                            <ToggleRow
+                                id="group-lock-api-product-role"
+                                title="Lock API product role"
+                                description="Members can't change their API product role in this group."
+                                checked={form.lockApiProductRole}
+                                onCheckedChange={val => setField('lockApiProductRole', val)}
+                                disabled={isSaving}
+                            />
+                            <ToggleRow
+                                id="group-lock-application-role"
+                                title="Lock application role"
+                                description="Members can't change their application role in this group."
+                                checked={form.lockApplicationRole}
+                                onCheckedChange={val => setField('lockApplicationRole', val)}
+                                disabled={isSaving}
+                            />
+                            <ToggleRow
+                                id="group-add-new-apis"
+                                title="Associate with new APIs"
+                                description="Automatically add this group when APIs are created."
+                                checked={form.defaultGroupForNewApis}
+                                onCheckedChange={val => setField('defaultGroupForNewApis', val)}
+                                disabled={isSaving}
+                            />
+                            <ToggleRow
+                                id="group-add-new-api-products"
+                                title="Associate with new API products"
+                                description="Automatically add this group when API products are created."
+                                checked={form.defaultGroupForNewApiProducts}
+                                onCheckedChange={val => setField('defaultGroupForNewApiProducts', val)}
+                                disabled={isSaving}
+                            />
+                            <ToggleRow
+                                id="group-add-new-applications"
+                                title="Associate with new applications"
+                                description="Automatically add this group when applications are created."
+                                checked={form.defaultGroupForNewApplications}
+                                onCheckedChange={val => setField('defaultGroupForNewApplications', val)}
+                                disabled={isSaving}
+                            />
+                        </div>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="group-max">Maximum members</FieldLabel>
+                            <Input
+                                id="group-max"
+                                type="number"
+                                min={1}
+                                value={form.maxInvitation}
+                                onChange={e => handleMaxInvitationChange(e.target.value)}
+                                placeholder="Unlimited"
+                                disabled={isSaving}
+                                aria-invalid={Boolean(maxInvitationError)}
+                            />
+                            <p className={maxInvitationError ? 'text-xs text-destructive' : 'text-xs text-muted-foreground'}>
+                                {maxInvitationError ?? 'Leave blank for no limit.'}
+                            </p>
+                        </Field>
+
+                        <div className="flex flex-col gap-2">
+                            <ToggleRow
+                                id="group-system-invitation"
+                                title="Allow invitation via user search"
+                                description="Admins can search and add existing platform users."
+                                checked={form.systemInvitation}
+                                onCheckedChange={val => setField('systemInvitation', val)}
+                                disabled={isSaving}
+                            />
+                            <ToggleRow
+                                id="group-email-invitation"
+                                title="Allow invitation via email"
+                                description="Admins can invite people who are not yet registered."
+                                checked={form.emailInvitation}
+                                onCheckedChange={val => setField('emailInvitation', val)}
+                                disabled={isSaving}
+                            />
+                            <ToggleRow
+                                id="group-notify-on-member-added"
+                                title="Notify members when added"
+                                description="Send a notification when membership changes."
+                                checked={form.notifyOnMemberAdded}
+                                onCheckedChange={val => setField('notifyOnMemberAdded', val)}
+                                disabled={isSaving}
+                            />
+                        </div>
+                    </form>
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-row justify-end gap-2 border-t pt-4">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="submit" form="group-form" disabled={!isValid || !hasChanged || isSaving}>
+                        {isSaving ? (mode === 'create' ? 'Creating…' : 'Saving…') : mode === 'create' ? 'Create group' : 'Save'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.spec.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { GroupsTable } from './GroupsTable';
+import type { Group } from '../types/group';
+
+const GROUP: Group = { id: 'group-1', name: 'Support Team', created_at: 1700000000000 };
+
+function renderTable(overrides: Partial<React.ComponentProps<typeof GroupsTable>> = {}) {
+    return render(
+        <GroupsTable
+            groups={[GROUP]}
+            totalCount={1}
+            loading={false}
+            isFirstUse={false}
+            search=""
+            page={1}
+            pageSize={10}
+            canEdit={false}
+            canDelete={false}
+            onSearchChange={jest.fn()}
+            onPageChange={jest.fn()}
+            onPageSizeChange={jest.fn()}
+            onEdit={jest.fn()}
+            onDelete={jest.fn()}
+            {...overrides}
+        />,
+    );
+}
+
+describe('GroupsTable', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('Primary owner badge', () => {
+        it.each([
+            ['primary_owner is true', { primary_owner: true }],
+            ['apiPrimaryOwner is set (API Product PO-only groups miss primary_owner)', { apiPrimaryOwner: 'user-1' }],
+            ['apiProductPrimaryOwner is set', { apiProductPrimaryOwner: 'user-1' }],
+        ])('shows the badge when %s', (_label, override) => {
+            renderTable({ groups: [{ ...GROUP, ...override }] });
+            expect(screen.queryByText('Primary owner')).not.toBeNull();
+        });
+
+        it('hides the badge when the group has no primary-owner field set', () => {
+            renderTable({ groups: [GROUP] });
+            expect(screen.queryByText('Primary owner')).toBeNull();
+        });
+    });
+
+    describe('row-level action gating', () => {
+        it('hides Edit/Delete entirely when manageable is false, even with global permissions', () => {
+            renderTable({ groups: [{ ...GROUP, manageable: false }], canEdit: true, canDelete: true });
+            expect(screen.queryByRole('button', { name: 'Group actions' })).toBeNull();
+        });
+
+        it('disables Delete (but keeps Edit) for a primary-owner group', async () => {
+            const user = userEvent.setup();
+            renderTable({ groups: [{ ...GROUP, primary_owner: true }], canEdit: true, canDelete: true });
+            await user.click(screen.getByRole('button', { name: 'Group actions' }));
+            expect(await screen.findByRole('menuitem', { name: /^Edit$/ })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: /^Delete$/ })).toBeNull();
+        });
+
+        it('allows Delete for a non-primary-owner, manageable group', async () => {
+            const user = userEvent.setup();
+            renderTable({ groups: [GROUP], canEdit: true, canDelete: true });
+            await user.click(screen.getByRole('button', { name: 'Group actions' }));
+            expect(await screen.findByRole('menuitem', { name: /^Delete$/ })).not.toBeNull();
+        });
+    });
+
+    describe('search', () => {
+        it('calls onSearchChange when typing in the search box', () => {
+            const onSearchChange = jest.fn();
+            renderTable({ onSearchChange });
+            fireEvent.change(screen.getByPlaceholderText('Search by name…'), { target: { value: 'support' } });
+            expect(onSearchChange).toHaveBeenCalledWith('support');
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.tsx
@@ -1,0 +1,253 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Badge,
+    Button,
+    DataTable,
+    DataTableColumnHeader,
+    DataTableEmptyState,
+    DateCell,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
+import { useMemo } from 'react';
+
+import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+import type { Group } from '../types/group';
+import { isPrimaryOwnerGroup } from '../utils/groupPermissions';
+
+function hasEventRule(group: Group, event: 'API_CREATE' | 'APPLICATION_CREATE' | 'API_PRODUCT_CREATE'): boolean {
+    return (group.event_rules ?? []).some(rule => rule.event === event);
+}
+
+function buildColumns({
+    canEdit,
+    canDelete,
+    onEdit,
+    onDelete,
+}: {
+    canEdit: boolean;
+    canDelete: boolean;
+    onEdit: (group: Group) => void;
+    onDelete: (group: Group) => void;
+}): DataTableProps<Group>['columns'] {
+    const columns: DataTableProps<Group>['columns'] = [
+        {
+            id: 'name',
+            accessorKey: 'name',
+            header: ({ column }: ColHeader<Group>) => <DataTableColumnHeader column={column} title="Name" />,
+            cell: ({ row }: ColCell<Group>) => (
+                <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium">{row.original.name}</span>
+                    {isPrimaryOwnerGroup(row.original) && (
+                        <Badge variant="default" className="text-xs font-normal">
+                            Primary owner
+                        </Badge>
+                    )}
+                    {hasEventRule(row.original, 'API_CREATE') && (
+                        <Badge variant="default" className="text-xs font-normal">
+                            Auto APIs
+                        </Badge>
+                    )}
+                    {hasEventRule(row.original, 'API_PRODUCT_CREATE') && (
+                        <Badge variant="default" className="text-xs font-normal">
+                            Auto API Products
+                        </Badge>
+                    )}
+                    {hasEventRule(row.original, 'APPLICATION_CREATE') && (
+                        <Badge variant="default" className="text-xs font-normal">
+                            Auto Applications
+                        </Badge>
+                    )}
+                </div>
+            ),
+        },
+        {
+            id: 'created',
+            accessorFn: (row: Group) => row.created_at ?? 0,
+            header: ({ column }: ColHeader<Group>) => <DataTableColumnHeader column={column} title="Created" />,
+            cell: ({ row }: ColCell<Group>) =>
+                row.original.created_at ? (
+                    <DateCell value={new Date(row.original.created_at)} format="absolute" />
+                ) : (
+                    <span className="text-sm text-muted-foreground">—</span>
+                ),
+        },
+    ];
+
+    if (canEdit || canDelete) {
+        columns.push({
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            size: 56,
+            enableSorting: false,
+            enableHiding: false,
+            cell: ({ row }: ColCell<Group>) => {
+                // Mirrors classic Console's group.component.ts: a group with manageable === false can't be
+                // edited/deleted by the current user even if they hold the global environment-group-u/d
+                // permission, and a primary-owner group can never be deleted (backend rejects with
+                // StillPrimaryOwnerException regardless). Absent manageable (undefined) means the backend
+                // didn't send the flag — default to allowed.
+                const manageable = row.original.manageable ?? true;
+                const canEditRow = canEdit && manageable;
+                const canDeleteRow = canDelete && manageable && !isPrimaryOwnerGroup(row.original);
+                if (!canEditRow && !canDeleteRow) return null;
+                return (
+                    <div className="flex justify-end">
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="ghost" size="icon" className="size-8" aria-label="Group actions">
+                                    <MoreHorizontalIcon className="size-4" aria-hidden />
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                                {canEditRow && (
+                                    <DropdownMenuItem onSelect={() => onEdit(row.original)}>
+                                        <PencilIcon className="size-4 mr-2" aria-hidden />
+                                        Edit
+                                    </DropdownMenuItem>
+                                )}
+                                {canEditRow && canDeleteRow && <DropdownMenuSeparator />}
+                                {canDeleteRow && (
+                                    <DropdownMenuItem variant="destructive" onSelect={() => onDelete(row.original)}>
+                                        <Trash2Icon className="size-4 mr-2" aria-hidden />
+                                        Delete
+                                    </DropdownMenuItem>
+                                )}
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </div>
+                );
+            },
+        });
+    }
+
+    return columns;
+}
+
+interface GroupsTableProps {
+    readonly groups: Group[];
+    readonly totalCount: number;
+    readonly loading: boolean;
+    readonly isFirstUse: boolean;
+    readonly search: string;
+    readonly page: number;
+    readonly pageSize: number;
+    readonly canEdit: boolean;
+    readonly canDelete: boolean;
+    readonly onSearchChange: (value: string) => void;
+    readonly onPageChange: (page: number) => void;
+    readonly onPageSizeChange: (size: number) => void;
+    readonly onEdit: (group: Group) => void;
+    readonly onDelete: (group: Group) => void;
+    readonly onCreateGroup?: () => void;
+}
+
+export function GroupsTable({
+    groups,
+    totalCount,
+    loading,
+    isFirstUse,
+    search,
+    page,
+    pageSize,
+    canEdit,
+    canDelete,
+    onSearchChange,
+    onPageChange,
+    onPageSizeChange,
+    onEdit,
+    onDelete,
+    onCreateGroup,
+}: GroupsTableProps) {
+    const columns = useMemo(() => buildColumns({ canEdit, canDelete, onEdit, onDelete }), [canEdit, canDelete, onEdit, onDelete]);
+
+    if (isFirstUse) {
+        return (
+            <div className="rounded-lg border">
+                <DataTableEmptyState
+                    variant="first-use"
+                    icon={<UsersRoundIcon className="size-8" aria-hidden />}
+                    title="No groups"
+                    description="Create groups to organize users and assign shared permissions."
+                    primaryAction={onCreateGroup ? <Button onClick={onCreateGroup}>Create Group</Button> : undefined}
+                />
+            </div>
+        );
+    }
+
+    return (
+        <DataTable
+            aria-label="Groups"
+            columns={columns}
+            data={groups}
+            loading={loading}
+            skeletonCount={pageSize}
+            serverSide
+            pagination={{
+                page,
+                pageSize,
+                totalCount,
+                pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                onPageChange,
+                onPageSizeChange: size => {
+                    onPageSizeChange(size);
+                    onPageChange(1);
+                },
+            }}
+            emptyMessage={
+                <DataTableEmptyState
+                    variant="no-results"
+                    icon={<SearchIcon className="size-8" aria-hidden />}
+                    title="No groups match your search"
+                    description="Try adjusting your search terms."
+                    action={
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => {
+                                onSearchChange('');
+                                onPageChange(1);
+                            }}
+                        >
+                            Clear search
+                        </Button>
+                    }
+                />
+            }
+            toolbar={
+                <div className="w-64">
+                    <InputGroup>
+                        <InputGroupAddon align="inline-start">
+                            <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                        </InputGroupAddon>
+                        <InputGroupInput placeholder="Search by name…" value={search} onChange={e => onSearchChange(e.target.value)} />
+                    </InputGroup>
+                </div>
+            }
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { createGroup, deleteGroup, updateGroup } from '../services/groups';
+import type { Group, NewGroupPayload, UpdateGroupPayload } from '../types/group';
+import { groupKeys } from '../utils/queryKeys';
+
+function useGroupMutation<TData, TResult>(mutationFn: (envId: string, data: TData) => Promise<TResult>) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (data: TData) => {
+            if (!env?.id) {
+                return Promise.reject(new Error('No active environment'));
+            }
+            return mutationFn(env.id, data);
+        },
+        onSuccess: () => {
+            if (env?.id) {
+                void queryClient.invalidateQueries({ queryKey: groupKeys.all });
+            }
+        },
+    });
+}
+
+export function useCreateGroup() {
+    return useGroupMutation<NewGroupPayload, Group>(createGroup);
+}
+
+export function useUpdateGroup() {
+    return useGroupMutation<{ groupId: string; data: UpdateGroupPayload }, Group>((envId, { groupId, data }) =>
+        updateGroup(envId, groupId, data),
+    );
+}
+
+export function useDeleteGroup() {
+    return useGroupMutation<string, void>(deleteGroup);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupRoles.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupRoles.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { listGroupApiProductRoles, listGroupApiRoles, listGroupApplicationRoles } from '../services/groups';
+import type { GroupRole } from '../types/group';
+import { groupKeys } from '../utils/queryKeys';
+
+function useGroupRolesQuery(queryKey: readonly unknown[], queryFn: () => Promise<GroupRole[]>) {
+    return useQuery({
+        queryKey,
+        queryFn,
+        staleTime: 5 * 60_000,
+    });
+}
+
+export function useGroupApiRoles() {
+    return useGroupRolesQuery(groupKeys.apiRoles(), listGroupApiRoles);
+}
+
+export function useGroupApplicationRoles() {
+    return useGroupRolesQuery(groupKeys.applicationRoles(), listGroupApplicationRoles);
+}
+
+export function useGroupApiProductRoles() {
+    return useGroupRolesQuery(groupKeys.apiProductRoles(), listGroupApiProductRoles);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroups.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { listGroupsPaged } from '../services/groups';
+import { groupKeys } from '../utils/queryKeys';
+
+export function useGroupsPaged({ query, page, size }: { query: string; page: number; size: number }) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: groupKeys.list(env?.id ?? '', query, page, size),
+        queryFn: () => listGroupsPaged(env!.id, { query, page, size }),
+        enabled: Boolean(env),
+        staleTime: 30_000,
+        placeholderData: keepPreviousData,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonOrg, apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { Group, GroupRole, GroupsPagedResponse, NewGroupPayload, UpdateGroupPayload } from '../types/group';
+
+export async function listGroupsPaged(
+    environmentId: string,
+    params: { query: string; page: number; size: number },
+): Promise<GroupsPagedResponse> {
+    const searchParams = new URLSearchParams();
+    searchParams.set('page', String(params.page));
+    searchParams.set('size', String(params.size));
+    const query = params.query.trim();
+    if (query) {
+        searchParams.set('query', query);
+    }
+    return apimFetchJsonV1Env<GroupsPagedResponse>(environmentId, `/configuration/groups/_paged?${searchParams.toString()}`);
+}
+
+export async function createGroup(environmentId: string, data: NewGroupPayload): Promise<Group> {
+    return apimFetchJsonV1Env<Group>(environmentId, '/configuration/groups', {
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+}
+
+export async function updateGroup(environmentId: string, groupId: string, data: UpdateGroupPayload): Promise<Group> {
+    return apimFetchJsonV1Env<Group>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}`, {
+        method: 'PUT',
+        body: JSON.stringify(data),
+    });
+}
+
+export async function deleteGroup(environmentId: string, groupId: string): Promise<void> {
+    return apimFetchJsonV1Env<void>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}`, {
+        method: 'DELETE',
+    });
+}
+
+async function listGroupRolesByScope(scope: 'API' | 'APPLICATION' | 'API_PRODUCT'): Promise<GroupRole[]> {
+    return apimFetchJsonOrg<GroupRole[]>(`/configuration/rolescopes/${scope}/roles`);
+}
+
+export async function listGroupApiRoles(): Promise<GroupRole[]> {
+    return listGroupRolesByScope('API');
+}
+
+export async function listGroupApplicationRoles(): Promise<GroupRole[]> {
+    return listGroupRolesByScope('APPLICATION');
+}
+
+export async function listGroupApiProductRoles(): Promise<GroupRole[]> {
+    return listGroupRolesByScope('API_PRODUCT');
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/types/group.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/types/group.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Mirrors classic `GroupEventRuleEntity` — `API_CREATE` is "default group for new APIs". */
+export type GroupEventName = 'API_CREATE' | 'APPLICATION_CREATE' | 'API_PRODUCT_CREATE';
+
+export interface GroupEventRule {
+    event: GroupEventName;
+}
+
+/** v1 `GroupEntity` (GET .../configuration/groups...). */
+export interface Group {
+    id: string;
+    name: string;
+    event_rules?: GroupEventRule[];
+    manageable?: boolean;
+    roles?: Record<string, string>;
+    created_at?: number;
+    updated_at?: number;
+    lock_api_role?: boolean;
+    lock_api_product_role?: boolean;
+    lock_application_role?: boolean;
+    max_invitation?: number | null;
+    system_invitation?: boolean;
+    email_invitation?: boolean;
+    disable_membership_notifications?: boolean;
+    /**
+     * True when this group is a primary owner for at least one API — either via a group-level
+     * default API primary owner (`apiPrimaryOwner`) or an actual API-scope PRIMARY_OWNER
+     * membership role. Not about the current user, and doesn't cover API Product primary
+     * ownership — check `apiProductPrimaryOwner` separately (mirrors classic Console's
+     * `apiPrimaryOwner || apiProductPrimaryOwner` badge/delete-guard condition).
+     */
+    primary_owner?: boolean;
+    /** Group-level default primary owner (user ID) forced onto new APIs created within this group. */
+    apiPrimaryOwner?: string;
+    /** Group-level default primary owner (user ID) forced onto new API Products created within this group. */
+    apiProductPrimaryOwner?: string;
+}
+
+export interface GroupsPageMeta {
+    current: number;
+    size: number;
+    per_page: number;
+    total_pages: number;
+    total_elements: number;
+}
+
+/** v1 `PagedResult<GroupEntity>` (GET .../configuration/groups/_paged). */
+export interface GroupsPagedResponse {
+    data: Group[];
+    metadata?: Record<string, Record<string, unknown>>;
+    page: GroupsPageMeta;
+}
+
+/** v1 `NewGroupEntity` (POST .../configuration/groups). No `roles` — set via a follow-up update. */
+export interface NewGroupPayload {
+    name: string;
+    lock_api_role: boolean;
+    lock_api_product_role: boolean;
+    lock_application_role: boolean;
+    event_rules: GroupEventRule[];
+    max_invitation: number | null;
+    system_invitation: boolean;
+    email_invitation: boolean;
+    disable_membership_notifications: boolean;
+}
+
+/** v1 `UpdateGroupEntity` (PUT .../configuration/groups/{id}). */
+export interface UpdateGroupPayload {
+    name: string;
+    lock_api_role: boolean;
+    lock_api_product_role: boolean;
+    lock_application_role: boolean;
+    event_rules: GroupEventRule[];
+    roles?: Record<string, string>;
+    max_invitation: number | null;
+    system_invitation: boolean;
+    email_invitation: boolean;
+    disable_membership_notifications: boolean;
+}
+
+/** v1 role (GET .../configuration/rolescopes/{scope}/roles). */
+export interface GroupRole {
+    name: string;
+    scope: string;
+    system?: boolean;
+    default?: boolean;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPayload.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPayload.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GroupEventRule } from '../types/group';
+
+/** Rebuilds the full event-rules list from the three toggles the UI manages. */
+export function buildEventRules(events: { apiCreate: boolean; applicationCreate: boolean; apiProductCreate: boolean }): GroupEventRule[] {
+    const rules: GroupEventRule[] = [];
+    if (events.apiCreate) rules.push({ event: 'API_CREATE' });
+    if (events.applicationCreate) rules.push({ event: 'APPLICATION_CREATE' });
+    if (events.apiProductCreate) rules.push({ event: 'API_PRODUCT_CREATE' });
+    return rules;
+}
+
+/**
+ * Keeps any other role scope untouched — only sets/clears API, APPLICATION, and API_PRODUCT.
+ * Always returns a map (possibly `{}`), never `undefined`: the v1 API treats an absent `roles`
+ * field on the PUT body as "no change", so clearing every role to "None" must still send `{}`
+ * to actually clear them — omitting the field would silently leave the old roles in place.
+ */
+export function buildRolesMap(
+    existingRoles: Record<string, string> | undefined,
+    apiRole: string,
+    applicationRole: string,
+    apiProductRole: string,
+): Record<string, string> {
+    const roles = { ...(existingRoles ?? {}) };
+    if (apiRole) {
+        roles.API = apiRole;
+    } else {
+        delete roles.API;
+    }
+    if (applicationRole) {
+        roles.APPLICATION = applicationRole;
+    } else {
+        delete roles.APPLICATION;
+    }
+    if (apiProductRole) {
+        roles.API_PRODUCT = apiProductRole;
+    } else {
+        delete roles.API_PRODUCT;
+    }
+    return roles;
+}
+
+/** Parses the "Maximum members" text input — blank, non-positive, or non-numeric all mean unlimited (`null`). */
+export function parseMaxInvitation(value: string): number | null {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) && parsed >= 1 ? parsed : null;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPermissions.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Group } from '../types/group';
+
+/** Mirrors classic settings-routing.module.ts groups route guard + groups.component.ts permission checks. */
+export const ENVIRONMENT_GROUP_READ_PERMISSION = 'environment-group-r' as const;
+export const ENVIRONMENT_GROUP_CREATE_PERMISSION = 'environment-group-c' as const;
+export const ENVIRONMENT_GROUP_UPDATE_PERMISSION = 'environment-group-u' as const;
+export const ENVIRONMENT_GROUP_DELETE_PERMISSION = 'environment-group-d' as const;
+
+/**
+ * Mirrors classic Console's `apiPrimaryOwner || apiProductPrimaryOwner` badge/delete-guard condition
+ * (groups.component.html / groups.component.ts) — `primary_owner` alone misses groups that are only
+ * an API Product primary owner, since the backend only sets `primary_owner` from API-scope PO state.
+ */
+export function isPrimaryOwnerGroup(group: Pick<Group, 'primary_owner' | 'apiPrimaryOwner' | 'apiProductPrimaryOwner'>): boolean {
+    return Boolean(group.primary_owner || group.apiPrimaryOwner || group.apiProductPrimaryOwner);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/paginationConstants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/paginationConstants.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const DEFAULT_GROUP_LIST_PAGE_SIZE = 10;
+
+export const GROUP_SEARCH_DEBOUNCE_MS = 300;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/queryKeys.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const groupKeys = {
+    all: ['environment-groups'] as const,
+    list: (envId: string, query: string, page: number, size: number) => [...groupKeys.all, 'list', envId, query, page, size] as const,
+    roles: (scope: 'API' | 'APPLICATION' | 'API_PRODUCT') => [...groupKeys.all, 'roles', scope] as const,
+    apiRoles: () => groupKeys.roles('API'),
+    applicationRoles: () => groupKeys.roles('APPLICATION'),
+    apiProductRoles: () => groupKeys.roles('API_PRODUCT'),
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
@@ -1,0 +1,319 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { GroupsPage } from './GroupsPage';
+import { useCreateGroup, useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
+import { useGroupApiProductRoles, useGroupApiRoles, useGroupApplicationRoles } from '../features/groups/hooks/useGroupRoles';
+import { useGroupsPaged } from '../features/groups/hooks/useGroups';
+import type { Group } from '../features/groups/types/group';
+import { notify } from '../shared/notify';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+jest.mock('../features/groups/hooks/useGroups');
+jest.mock('../features/groups/hooks/useGroupRoles');
+jest.mock('../features/groups/hooks/useGroupMutations');
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
+}));
+
+// Stub GroupsTable to avoid DataTable/DropdownMenu Radix pointer-event complexity in jsdom.
+// Exposes Edit/Delete buttons and the first-use CTA wired directly to the page's callbacks.
+jest.mock('../features/groups/components/GroupsTable', () => ({
+    GroupsTable: ({
+        groups,
+        isFirstUse,
+        canEdit,
+        canDelete,
+        onEdit,
+        onDelete,
+        onCreateGroup,
+    }: {
+        groups: Group[];
+        isFirstUse: boolean;
+        canEdit: boolean;
+        canDelete: boolean;
+        onEdit: (g: Group) => void;
+        onDelete: (g: Group) => void;
+        onCreateGroup?: () => void;
+    }) =>
+        isFirstUse ? (
+            <div>
+                <p>No groups</p>
+                {onCreateGroup && (
+                    <button type="button" onClick={onCreateGroup}>
+                        Create Group
+                    </button>
+                )}
+            </div>
+        ) : (
+            <div>
+                {groups.map(g => (
+                    <div key={g.id} data-testid={`row-${g.id}`}>
+                        <span>{g.name}</span>
+                        {canEdit && (
+                            <button type="button" onClick={() => onEdit(g)}>
+                                Edit {g.name}
+                            </button>
+                        )}
+                        {canDelete && (
+                            <button type="button" onClick={() => onDelete(g)}>
+                                Delete {g.name}
+                            </button>
+                        )}
+                    </div>
+                ))}
+            </div>
+        ),
+}));
+
+// Radix Switch (rendered inside the real GroupSheet) measures its thumb via ResizeObserver, which jsdom lacks.
+beforeAll(() => {
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as typeof ResizeObserver;
+});
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseGroupsPaged = jest.mocked(useGroupsPaged);
+const mockUseGroupApiRoles = jest.mocked(useGroupApiRoles);
+const mockUseGroupApplicationRoles = jest.mocked(useGroupApplicationRoles);
+const mockUseGroupApiProductRoles = jest.mocked(useGroupApiProductRoles);
+const mockUseCreateGroup = jest.mocked(useCreateGroup);
+const mockUseUpdateGroup = jest.mocked(useUpdateGroup);
+const mockUseDeleteGroup = jest.mocked(useDeleteGroup);
+
+const SAMPLE_GROUPS: Group[] = [
+    { id: 'group-1', name: 'Support Team', created_at: 1700000000000 },
+    { id: 'group-2', name: 'Dev Team', created_at: 1700100000000 },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeMutation(mutateAsync = jest.fn()): any {
+    return { mutateAsync, isPending: false };
+}
+
+function makeGroupsResult(groups: Group[] = SAMPLE_GROUPS, totalElements = groups.length) {
+    return {
+        data: { data: groups, page: { current: 1, size: 10, per_page: 10, total_pages: 1, total_elements: totalElements } },
+        isLoading: false,
+        isError: false,
+    } as ReturnType<typeof useGroupsPaged>;
+}
+
+function renderPage() {
+    return render(<GroupsPage />);
+}
+
+describe('GroupsPage', () => {
+    beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseGroupsPaged.mockReturnValue(makeGroupsResult());
+        mockUseGroupApiRoles.mockReturnValue({ data: [{ name: 'USER', scope: 'API', default: true }], isLoading: false } as ReturnType<
+            typeof useGroupApiRoles
+        >);
+        mockUseGroupApplicationRoles.mockReturnValue({
+            data: [{ name: 'USER', scope: 'APPLICATION', default: true }],
+            isLoading: false,
+        } as ReturnType<typeof useGroupApplicationRoles>);
+        mockUseGroupApiProductRoles.mockReturnValue({
+            data: [{ name: 'USER', scope: 'API_PRODUCT', default: true }],
+            isLoading: false,
+        } as ReturnType<typeof useGroupApiProductRoles>);
+        mockUseCreateGroup.mockReturnValue(makeMutation());
+        mockUseUpdateGroup.mockReturnValue(makeMutation());
+        mockUseDeleteGroup.mockReturnValue(makeMutation());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('page header', () => {
+        it('renders the page title', () => {
+            renderPage();
+            expect(screen.queryByRole('heading', { name: 'User Groups' })).not.toBeNull();
+        });
+
+        it('shows the Create Group button when user can create', () => {
+            renderPage();
+            expect(screen.queryByRole('button', { name: /Create Group/i })).not.toBeNull();
+        });
+
+        it('hides the Create Group button when user lacks create permission', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            renderPage();
+            expect(screen.queryByRole('button', { name: /Create Group/i })).toBeNull();
+        });
+    });
+
+    describe('list', () => {
+        it('renders groups from the API', () => {
+            renderPage();
+            expect(screen.queryByText('Support Team')).not.toBeNull();
+            expect(screen.queryByText('Dev Team')).not.toBeNull();
+        });
+
+        it('shows an error message when the query fails', () => {
+            mockUseGroupsPaged.mockReturnValue({ data: undefined, isLoading: false, isError: true } as ReturnType<typeof useGroupsPaged>);
+            renderPage();
+            expect(screen.queryByText('Failed to load groups. Please refresh and try again.')).not.toBeNull();
+        });
+
+        it('hides the header Create Group button during first-use and keeps the empty-state CTA', () => {
+            mockUseGroupsPaged.mockReturnValue(makeGroupsResult([], 0));
+            renderPage();
+
+            expect(screen.queryByText('No groups')).not.toBeNull();
+            expect(screen.getAllByRole('button', { name: /Create Group/i })).toHaveLength(1);
+        });
+    });
+
+    describe('create flow', () => {
+        it('creates the group, then follows up with a role update, and shows a success toast', async () => {
+            const createMutateAsync = jest.fn().mockResolvedValue({
+                id: 'new-group-id',
+                name: 'My Group',
+                lock_api_role: false,
+                event_rules: [],
+                lock_api_product_role: false,
+                lock_application_role: false,
+                roles: {},
+            });
+            const updateMutateAsync = jest.fn().mockResolvedValue({});
+            mockUseCreateGroup.mockReturnValue(makeMutation(createMutateAsync));
+            mockUseUpdateGroup.mockReturnValue(makeMutation(updateMutateAsync));
+
+            renderPage();
+            fireEvent.click(screen.getByRole('button', { name: /Create Group/i }));
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Group' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Create group' }));
+
+            await waitFor(() => {
+                expect(createMutateAsync).toHaveBeenCalledWith({
+                    name: 'My Group',
+                    lock_api_role: false,
+                    lock_api_product_role: false,
+                    lock_application_role: false,
+                    event_rules: [],
+                    max_invitation: null,
+                    system_invitation: false,
+                    email_invitation: false,
+                    disable_membership_notifications: false,
+                });
+            });
+            await waitFor(() => {
+                expect(updateMutateAsync).toHaveBeenCalledWith({
+                    groupId: 'new-group-id',
+                    data: expect.objectContaining({ roles: { API: 'USER', APPLICATION: 'USER', API_PRODUCT: 'USER' } }),
+                });
+            });
+            expect(notify.success).toHaveBeenCalledWith('Group created successfully');
+        });
+
+        it('shows an error toast when create fails', async () => {
+            const error = new Error('create failed');
+            mockUseCreateGroup.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: /Create Group/i }));
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Group' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Create group' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to create group'));
+        });
+
+        it('closes the sheet and warns (not errors) when the group was created but the role update fails', async () => {
+            const createMutateAsync = jest.fn().mockResolvedValue({
+                id: 'new-group-id',
+                name: 'My Group',
+                lock_api_role: false,
+                event_rules: [],
+                lock_api_product_role: false,
+                lock_application_role: false,
+                roles: {},
+            });
+            const updateMutateAsync = jest.fn().mockRejectedValue(new Error('role update failed'));
+            mockUseCreateGroup.mockReturnValue(makeMutation(createMutateAsync));
+            mockUseUpdateGroup.mockReturnValue(makeMutation(updateMutateAsync));
+
+            renderPage();
+            fireEvent.click(screen.getByRole('button', { name: /Create Group/i }));
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My Group' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Create group' }));
+
+            await waitFor(() => expect(updateMutateAsync).toHaveBeenCalled());
+            expect(notify.warning).toHaveBeenCalledWith(
+                'Group "My Group" was created, but default roles could not be applied. Edit the group to set them.',
+            );
+            expect(notify.error).not.toHaveBeenCalled();
+            expect(notify.success).not.toHaveBeenCalled();
+            await waitFor(() => expect(screen.queryByRole('heading', { name: 'Create group' })).toBeNull());
+        });
+    });
+
+    describe('edit flow', () => {
+        it('updates the group and shows a success toast', async () => {
+            const updateMutateAsync = jest.fn().mockResolvedValue({});
+            mockUseUpdateGroup.mockReturnValue(makeMutation(updateMutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit Support Team' }));
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Support Team v2' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            await waitFor(() =>
+                expect(updateMutateAsync).toHaveBeenCalledWith(
+                    expect.objectContaining({ groupId: 'group-1', data: expect.objectContaining({ name: 'Support Team v2' }) }),
+                ),
+            );
+            expect(notify.success).toHaveBeenCalledWith('Group updated successfully');
+        });
+
+        it('shows an error toast when update fails', async () => {
+            const error = new Error('update failed');
+            mockUseUpdateGroup.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit Support Team' }));
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Support Team v2' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to update group'));
+        });
+    });
+
+    describe('delete flow', () => {
+        it('deletes the selected group and shows a success toast', async () => {
+            const deleteMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseDeleteGroup.mockReturnValue(makeMutation(deleteMutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete Support Team' }));
+            expect(screen.queryByRole('heading', { name: 'Delete Group' })).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+            await waitFor(() => expect(deleteMutateAsync).toHaveBeenCalledWith('group-1'));
+            expect(notify.success).toHaveBeenCalledWith('Group deleted successfully');
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.tsx
@@ -1,0 +1,240 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Button } from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useState } from 'react';
+
+import { GroupDeleteSheet } from '../features/groups/components/GroupDeleteSheet';
+import { GroupSheet, type GroupFormValues } from '../features/groups/components/GroupSheet';
+import { GroupsTable } from '../features/groups/components/GroupsTable';
+import { useCreateGroup, useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
+import { useGroupApiProductRoles, useGroupApiRoles, useGroupApplicationRoles } from '../features/groups/hooks/useGroupRoles';
+import { useGroupsPaged } from '../features/groups/hooks/useGroups';
+import type { Group, UpdateGroupPayload } from '../features/groups/types/group';
+import { buildEventRules, buildRolesMap, parseMaxInvitation } from '../features/groups/utils/groupPayload';
+import {
+    ENVIRONMENT_GROUP_CREATE_PERMISSION,
+    ENVIRONMENT_GROUP_DELETE_PERMISSION,
+    ENVIRONMENT_GROUP_UPDATE_PERMISSION,
+} from '../features/groups/utils/groupPermissions';
+import { DEFAULT_GROUP_LIST_PAGE_SIZE, GROUP_SEARCH_DEBOUNCE_MS } from '../features/groups/utils/paginationConstants';
+import { notify } from '../shared/notify';
+
+type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'edit'; group: Group } | { type: 'delete'; group: Group };
+
+export function GroupsPage() {
+    const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_CREATE_PERMISSION] });
+    const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_UPDATE_PERMISSION] });
+    const canDelete = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_DELETE_PERMISSION] });
+
+    const [search, setSearch] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DEFAULT_GROUP_LIST_PAGE_SIZE);
+    const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
+
+    useEffect(() => {
+        const timer = setTimeout(() => setDebouncedSearch(search), GROUP_SEARCH_DEBOUNCE_MS);
+        return () => clearTimeout(timer);
+    }, [search]);
+
+    const { data, isLoading, isError } = useGroupsPaged({ query: debouncedSearch, page, size: pageSize });
+    const { data: apiRoles = [], isLoading: apiRolesLoading } = useGroupApiRoles();
+    const { data: applicationRoles = [], isLoading: applicationRolesLoading } = useGroupApplicationRoles();
+    const { data: apiProductRoles = [], isLoading: apiProductRolesLoading } = useGroupApiProductRoles();
+
+    const createMutation = useCreateGroup();
+    const updateMutation = useUpdateGroup();
+    const deleteMutation = useDeleteGroup();
+
+    const groups = data?.data ?? [];
+    const totalCount = data?.page.total_elements ?? 0;
+    const isFirstUse = !isLoading && totalCount === 0 && !search.trim() && !debouncedSearch.trim();
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function closeSheet() {
+        setSheet({ type: 'closed' });
+    }
+
+    function openCreateSheet() {
+        setSheet({ type: 'create' });
+    }
+
+    async function handleCreate(values: GroupFormValues) {
+        let created: Group;
+        try {
+            created = await createMutation.mutateAsync({
+                name: values.name,
+                lock_api_role: values.lockApiRole,
+                lock_api_product_role: values.lockApiProductRole,
+                lock_application_role: values.lockApplicationRole,
+                event_rules: buildEventRules({
+                    apiCreate: values.defaultGroupForNewApis,
+                    applicationCreate: values.defaultGroupForNewApplications,
+                    apiProductCreate: values.defaultGroupForNewApiProducts,
+                }),
+                max_invitation: parseMaxInvitation(values.maxInvitation),
+                system_invitation: values.systemInvitation,
+                email_invitation: values.emailInvitation,
+                disable_membership_notifications: !values.notifyOnMemberAdded,
+            });
+        } catch (error) {
+            notify.error(error, 'Failed to create group');
+            return;
+        }
+
+        // The group already exists at this point (POST succeeded) — close the sheet and refresh the list
+        // regardless of what happens next, so a failure below can't be mistaken for "nothing was created"
+        // and lead to a duplicate on retry.
+        closeSheet();
+
+        if (values.apiRole || values.applicationRole || values.apiProductRole) {
+            try {
+                const rolesUpdate: UpdateGroupPayload = {
+                    name: created.name,
+                    lock_api_role: created.lock_api_role ?? values.lockApiRole,
+                    lock_api_product_role: created.lock_api_product_role ?? values.lockApiProductRole,
+                    lock_application_role: created.lock_application_role ?? values.lockApplicationRole,
+                    event_rules: created.event_rules ?? [],
+                    roles: buildRolesMap(created.roles, values.apiRole, values.applicationRole, values.apiProductRole),
+                    max_invitation: created.max_invitation ?? parseMaxInvitation(values.maxInvitation),
+                    system_invitation: created.system_invitation ?? values.systemInvitation,
+                    email_invitation: created.email_invitation ?? values.emailInvitation,
+                    disable_membership_notifications: created.disable_membership_notifications ?? !values.notifyOnMemberAdded,
+                };
+                await updateMutation.mutateAsync({ groupId: created.id, data: rolesUpdate });
+            } catch {
+                notify.warning(`Group "${created.name}" was created, but default roles could not be applied. Edit the group to set them.`);
+                return;
+            }
+        }
+
+        notify.success('Group created successfully');
+    }
+
+    async function handleUpdate(values: GroupFormValues) {
+        if (sheet.type !== 'edit') return;
+        const group = sheet.group;
+        try {
+            await updateMutation.mutateAsync({
+                groupId: group.id,
+                data: {
+                    name: values.name,
+                    lock_api_role: values.lockApiRole,
+                    lock_api_product_role: values.lockApiProductRole,
+                    lock_application_role: values.lockApplicationRole,
+                    event_rules: buildEventRules({
+                        apiCreate: values.defaultGroupForNewApis,
+                        applicationCreate: values.defaultGroupForNewApplications,
+                        apiProductCreate: values.defaultGroupForNewApiProducts,
+                    }),
+                    roles: buildRolesMap(group.roles, values.apiRole, values.applicationRole, values.apiProductRole),
+                    max_invitation: parseMaxInvitation(values.maxInvitation),
+                    system_invitation: values.systemInvitation,
+                    email_invitation: values.emailInvitation,
+                    disable_membership_notifications: !values.notifyOnMemberAdded,
+                },
+            });
+            notify.success('Group updated successfully');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to update group');
+        }
+    }
+
+    async function handleDelete() {
+        if (sheet.type !== 'delete') return;
+        try {
+            await deleteMutation.mutateAsync(sheet.group.id);
+            notify.success('Group deleted successfully');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to delete group');
+        }
+    }
+
+    if (isError) {
+        return (
+            <div className="flex items-center justify-center p-8">
+                <p className="text-sm text-muted-foreground">Failed to load groups. Please refresh and try again.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">User Groups</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Organize users into groups to share default roles and simplify access management.
+                    </p>
+                </div>
+                {canCreate && !isFirstUse ? (
+                    <Button className="shrink-0" size="sm" onClick={openCreateSheet}>
+                        <PlusIcon className="size-4" aria-hidden />
+                        Create Group
+                    </Button>
+                ) : null}
+            </div>
+
+            <GroupsTable
+                groups={groups}
+                totalCount={totalCount}
+                loading={isLoading}
+                isFirstUse={isFirstUse}
+                search={search}
+                page={page}
+                pageSize={pageSize}
+                canEdit={canEdit}
+                canDelete={canDelete}
+                onSearchChange={handleSearchChange}
+                onPageChange={setPage}
+                onPageSizeChange={setPageSize}
+                onEdit={group => setSheet({ type: 'edit', group })}
+                onDelete={group => setSheet({ type: 'delete', group })}
+                onCreateGroup={canCreate ? openCreateSheet : undefined}
+            />
+
+            <GroupSheet
+                open={sheet.type === 'create' || sheet.type === 'edit'}
+                mode={sheet.type === 'edit' ? 'edit' : 'create'}
+                group={sheet.type === 'edit' ? sheet.group : undefined}
+                apiRoles={apiRoles}
+                applicationRoles={applicationRoles}
+                apiProductRoles={apiProductRoles}
+                rolesLoading={apiRolesLoading || applicationRolesLoading || apiProductRolesLoading}
+                onClose={closeSheet}
+                onSubmit={sheet.type === 'edit' ? handleUpdate : handleCreate}
+                isSaving={createMutation.isPending || updateMutation.isPending}
+            />
+
+            <GroupDeleteSheet
+                open={sheet.type === 'delete'}
+                group={sheet.type === 'delete' ? sheet.group : undefined}
+                onClose={closeSheet}
+                onConfirm={handleDelete}
+                isDeleting={deleteMutation.isPending}
+            />
+        </div>
+    );
+}


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/FOUND-101

## Description

This adds the **User Groups** page under Identity & Access in the new Gamma Console (Platform Management).

**What you can now do:**

- **See all groups** in a searchable, paginated table, with badges showing at a glance if a group is: the Primary owner of resources, and set to auto-associate with **new APIs, API Products, or Applications.**
- **Create a group** with a name, default roles for APIs/Applications/API Products, whether members can change their own role in each of those, whether the group should be auto-added to new APIs/API Products/Applications, a max member limit, how people can be invited (search existing users vs. email), and whether members get notified when added.
- **Edit** an existing group's settings, same fields as above.
- **Delete** a group, with a confirmation step.
- All actions (create/edit/delete) are gated by permissions, matching classic Console — buttons only show up for users who are actually allowed to perform them.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

