### PR TITLE
fix: reject V4 APIs on MAPI v1 plans with 400 and document v2 usage

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPlansResource.java
@@ -21,20 +21,22 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.*;
 import static java.util.Comparator.comparingInt;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.management.rest.resource.param.PlanSecurityParam;
 import io.gravitee.rest.api.management.rest.resource.param.PlanStatusParam;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
-import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
+import io.gravitee.rest.api.service.exceptions.ManagementV1UnsupportedApiDefinitionVersionException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.Explode;
@@ -59,14 +61,16 @@ import java.util.stream.Collectors;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Tag(name = "API Plans")
+@Tag(
+    name = "API Plans",
+    description = "Manage API plans. Listing plans for V4 or Federated APIs is not supported on Management API v1 (use /management/v2/environments/{envId}/apis/{apiId}/plans)."
+)
 public class ApiPlansResource extends AbstractResource {
+
+    static final String UNSUPPORTED_DEFINITION_VERSION = "API definition version not supported (use Management API v2 for V4/Federated)";
 
     @Inject
     private PlanService planService;
-
-    @Inject
-    private ApiService apiService;
 
     @Inject
     private GroupService groupService;
@@ -90,6 +94,7 @@ public class ApiPlansResource extends AbstractResource {
             array = @ArraySchema(schema = @Schema(implementation = PlanEntity.class), uniqueItems = true)
         )
     )
+    @ApiResponse(responseCode = "400", description = UNSUPPORTED_DEFINITION_VERSION)
     @ApiResponse(responseCode = "500", description = "Internal server error")
     public List<PlanEntity> getApiPlans(
         @QueryParam("status") @DefaultValue("PUBLISHED") @Parameter(
@@ -99,6 +104,7 @@ public class ApiPlansResource extends AbstractResource {
         @QueryParam("security") @Parameter(explode = Explode.FALSE, schema = @Schema(type = "array")) final PlanSecurityParam security
     ) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        checkLegacyApiReadable(executionContext);
         ApiEntity apiEntity = apiService.findById(executionContext, api);
 
         if (
@@ -189,9 +195,11 @@ public class ApiPlansResource extends AbstractResource {
         description = "Plan information",
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PlanEntity.class))
     )
+    @ApiResponse(responseCode = "400", description = UNSUPPORTED_DEFINITION_VERSION)
     @ApiResponse(responseCode = "500", description = "Internal server error")
     public Response getApiPlan(@PathParam("plan") String plan) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        checkLegacyApiReadable(executionContext);
         if (
             Visibility.PUBLIC.equals(apiService.findById(executionContext, api).getVisibility()) ||
             hasPermission(GraviteeContext.getExecutionContext(), API_PLAN, api, READ)
@@ -336,5 +344,13 @@ public class ApiPlansResource extends AbstractResource {
         filtered.setGeneralConditions(entity.getGeneralConditions());
 
         return filtered;
+    }
+
+    private void checkLegacyApiReadable(ExecutionContext executionContext) {
+        GenericApiEntity apiEntity = apiSearchService.findGenericById(executionContext, api, false, false, false);
+        DefinitionVersion definitionVersion = apiEntity.getDefinitionVersion();
+        if (definitionVersion != null && definitionVersion != DefinitionVersion.V1 && definitionVersion != DefinitionVersion.V2) {
+            throw new ManagementV1UnsupportedApiDefinitionVersionException(definitionVersion.getLabel());
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/resources/openapi-configuration.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/resources/openapi-configuration.yaml
@@ -7,3 +7,7 @@ openAPI:
   info:
     version: '${project.version}'
     title: Gravitee.io - Management API
+    description: >
+      Management API v1 for Gravitee APIM, primarily for V1 and V2 API definitions.
+      For V4 or Federated APIs, use Management API v2
+      (base path /management/v2/environments/{envId}/apis/{apiId}/...).

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiPlansResourceTest.java
@@ -17,17 +17,22 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static io.gravitee.common.http.HttpStatusCode.*;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
@@ -50,13 +55,94 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
 
     @Before
     public void init() {
-        Mockito.reset(planService, apiService);
+        Mockito.reset(planService, apiService, apiSearchServiceV4, groupService);
+        when(
+            permissionService.hasPermission(
+                any(ExecutionContext.class),
+                any(RolePermission.class),
+                anyString(),
+                any(RolePermissionAction[].class)
+            )
+        ).thenReturn(true);
         GraviteeContext.cleanContext();
     }
 
     @After
     public void tearDown() {
         GraviteeContext.cleanContext();
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenGettingPlansForV4Api() {
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(
+            v4Api(DefinitionVersion.V4)
+        );
+
+        final Response response = envTarget().path(API).path("plans").request().get();
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(apiService, never()).findById(any(), eq(API));
+        verify(planService, never()).findByApi(any(), any());
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenGettingSinglePlanForV4Api() {
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(
+            v4Api(DefinitionVersion.V4)
+        );
+
+        final Response response = envTarget().path(API).path("plans").path(PLAN).request().get();
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(apiService, never()).findById(any(), eq(API));
+        verify(planService, never()).findById(any(), any());
+    }
+
+    @Test
+    public void shouldGetApiPlansForV2Api() {
+        ApiEntity v2Api = readableV2Api();
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(v2Api);
+        when(apiService.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(v2Api);
+
+        PlanEntity publishedPlan = new PlanEntity();
+        publishedPlan.setId("published-plan");
+        publishedPlan.setApi(API);
+        publishedPlan.setStatus(PlanStatus.PUBLISHED);
+        publishedPlan.setOrder(1);
+        publishedPlan.setSecurity(PlanSecurityType.KEY_LESS);
+        when(planService.findByApi(GraviteeContext.getExecutionContext(), API)).thenReturn(Set.of(publishedPlan));
+        when(groupService.isUserAuthorizedToAccessApiData(any(ApiEntity.class), any(), any())).thenReturn(true);
+
+        final Response response = envTarget().path(API).path("plans").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        List<PlanEntity> plans = response.readEntity(new GenericType<>() {});
+        assertNotNull(plans);
+        assertEquals(1, plans.size());
+    }
+
+    @Test
+    public void shouldCreateApiPlanForV4Api() {
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(
+            v4Api(DefinitionVersion.V4)
+        );
+
+        NewPlanEntity newPlanEntity = new NewPlanEntity();
+        newPlanEntity.setName(PLAN);
+        newPlanEntity.setDescription("my-plan-description");
+        newPlanEntity.setValidation(PlanValidationType.AUTO);
+        newPlanEntity.setSecurity(PlanSecurityType.KEY_LESS);
+        newPlanEntity.setType(PlanType.API);
+        newPlanEntity.setStatus(PlanStatus.STAGING);
+
+        PlanEntity createdPlanEntity = new PlanEntity();
+        createdPlanEntity.setId("new-plan-id");
+        when(planService.create(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(createdPlanEntity);
+
+        final Response response = envTarget().path(API).path("plans").request().post(Entity.json(newPlanEntity));
+
+        assertEquals(CREATED_201, response.getStatus());
+        verify(planService).create(eq(GraviteeContext.getExecutionContext()), any());
     }
 
     @Test
@@ -117,6 +203,21 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
 
         assertEquals(NO_CONTENT_204, response.getStatus());
         verify(planService, times(1)).delete(eq(GraviteeContext.getExecutionContext()), eq(PLAN));
+    }
+
+    private static io.gravitee.rest.api.model.v4.api.ApiEntity v4Api(DefinitionVersion definitionVersion) {
+        io.gravitee.rest.api.model.v4.api.ApiEntity api = new io.gravitee.rest.api.model.v4.api.ApiEntity();
+        api.setId(API);
+        api.setDefinitionVersion(definitionVersion);
+        return api;
+    }
+
+    private static ApiEntity readableV2Api() {
+        ApiEntity api = new ApiEntity();
+        api.setId(API);
+        api.setVisibility(Visibility.PUBLIC);
+        api.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
+        return api;
     }
 
     private ApiEntity getApi(DefinitionVersion version) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ManagementV1UnsupportedApiDefinitionVersionException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ManagementV1UnsupportedApiDefinitionVersionException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.Collections;
+import java.util.Map;
+
+public class ManagementV1UnsupportedApiDefinitionVersionException extends AbstractManagementException {
+
+    private final String version;
+
+    public ManagementV1UnsupportedApiDefinitionVersionException(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "api.managementV1.definitionVersionNotSupported";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Collections.singletonMap("definitionVersion", version);
+    }
+
+    @Override
+    public String getMessage() {
+        return (
+            "API definition version " +
+            version +
+            " is not supported by Management API v1. Use Management API v2 instead (/management/v2/environments/{envId}/apis/{apiId}/...)."
+        );
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14587

## Description

Calling Management API v1 GET plan endpoints for V4 or Federated APIs could fail with 500 errors when legacy v1 code attempted to load the API definition (JsonMappingException in logs).

MAPI v1 is intended for V1/V2 API definitions. V4 and Federated APIs should use Management API v2 for plan management.

This PR adds an explicit 400 Bad Request on GET plan endpoints only (maintenance-safe, non-breaking for mutations):

GET /management/.../apis/{apiId}/plans — list plans
GET /management/.../apis/{apiId}/plans/{planId} — get single plan

**Changes**

- Add checkLegacyApiReadable() in ApiPlansResource — checks definition version via apiSearchService.findGenericById() before legacy apiService.findById()
- Add ManagementV1UnsupportedApiDefinitionVersionException (HTTP 400) with message pointing to MAPI v2
- Document limitation in OpenAPI (@Tag, @ApiResponse(400) on GET endpoints, openapi-configuration.yaml)



**After fix:**
<img width="1142" height="868" alt="image" src="https://github.com/user-attachments/assets/d6a24917-8a9e-4465-9483-5ce13f3fcd39" />
