### PR TITLE
feat(analytics): native kafka connections time-series

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/TimeSeriesQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/TimeSeriesQuery.java
@@ -30,6 +30,16 @@ public record TimeSeriesQuery(
     Integer limit,
     List<NumberRange> ranges
 ) implements Query {
+    public TimeSeriesQuery {
+        // The convenience constructors below default the limit to 0 to mean "no explicit cap", but a
+        // terms `size` of 0 is rejected by Elasticsearch. Normalise it to null once here (FacetsQuery
+        // already defaults to null) so the terms adapters simply omit `size` — closing the size:0 hazard
+        // for both the HTTP and native time-series paths at the source rather than in each adapter.
+        if (limit != null && limit <= 0) {
+            limit = null;
+        }
+    }
+
     public TimeSeriesQuery(TimeRange timeRange, List<Filter> filters, Long interval, List<MetricMeasuresQuery> metrics) {
         this(timeRange, filters, interval, metrics, List.of(), 0, List.of());
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
@@ -74,6 +74,8 @@ public interface AnalyticsRepository {
 
     TimeSeriesResult searchHTTPTimeSeries(QueryContext queryContext, TimeSeriesQuery query);
 
+    TimeSeriesResult searchNativeApiTimeSeries(QueryContext queryContext, TimeSeriesQuery query);
+
     MeasuresResult searchMessageMeasures(QueryContext queryContext, MeasuresQuery query);
 
     FilterValuesResult searchFilterValues(QueryContext queryContext, FilterValuesQuery query);

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
@@ -54,6 +54,7 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
     private final HTTPFacetsQueryAdapter httpFacetsQueryAdapter = new HTTPFacetsQueryAdapter();
     private final NativeFacetsQueryAdapter nativeFacetsQueryAdapter = new NativeFacetsQueryAdapter();
     private final HTTPTimeSeriesQueryAdapter httpTimeSeriesQueryAdapter = new HTTPTimeSeriesQueryAdapter();
+    private final NativeTimeSeriesQueryAdapter nativeTimeSeriesQueryAdapter = new NativeTimeSeriesQueryAdapter();
     private final MeasuresResponseAdapter measuresResponseAdapter = new MeasuresResponseAdapter();
     private final FacetsResponseAdapter facetsResponseAdapter = new FacetsResponseAdapter();
     private final TimeSeriesResponseAdapter timeSeriesResponseAdapter = new TimeSeriesResponseAdapter();
@@ -316,6 +317,19 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
         var esQuery = httpTimeSeriesQueryAdapter.adapt(query);
 
         log.debug("HTTP time series query: {}", esQuery);
+
+        return client
+            .search(index, null, esQuery)
+            .map(response -> timeSeriesResponseAdapter.adapt(response, query))
+            .blockingGet();
+    }
+
+    @Override
+    public TimeSeriesResult searchNativeApiTimeSeries(QueryContext queryContext, TimeSeriesQuery query) {
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_METRICS, clusters);
+        var esQuery = nativeTimeSeriesQueryAdapter.adapt(query);
+
+        log.debug("Native time series query: {}", esQuery);
 
         return client
             .search(index, null, esQuery)

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeFacetsQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeFacetsQueryAdapter.java
@@ -67,9 +67,11 @@ public class NativeFacetsQueryAdapter {
 
     private JsonObject toTermsLeaf(Facet facet, Integer limit) {
         var terms = new JsonObject().put("field", fieldResolver.fromFacet(facet));
-        // Elasticsearch rejects a terms `size` of 0. Both a null limit (native facets can carry one)
-        // and the default 0 that TimeSeriesQuery injects when the caller sets none mean "no explicit cap".
-        if (limit != null && limit > 0) {
+        // A null limit means "no explicit size", so Elasticsearch applies its default terms size of 10.
+        // Fine for low-cardinality facets like NATIVE_CONNECTION_STATUS; a caller needing every bucket of
+        // a high-cardinality facet (APPLICATION/PLAN) must pass an explicit limit. TimeSeriesQuery already
+        // normalises its 0 default to null, so the `size: 0` that ES rejects never reaches here.
+        if (limit != null) {
             terms.put("size", limit);
         }
         return new JsonObject().put("terms", terms);

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeFacetsQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeFacetsQueryAdapter.java
@@ -67,13 +67,15 @@ public class NativeFacetsQueryAdapter {
 
     private JsonObject toTermsLeaf(Facet facet, Integer limit) {
         var terms = new JsonObject().put("field", fieldResolver.fromFacet(facet));
-        if (limit != null) {
+        // Elasticsearch rejects a terms `size` of 0. Both a null limit (native facets can carry one)
+        // and the default 0 that TimeSeriesQuery injects when the caller sets none mean "no explicit cap".
+        if (limit != null && limit > 0) {
             terms.put("size", limit);
         }
         return new JsonObject().put("terms", terms);
     }
 
-    private JsonObject adaptMeasures(MetricMeasuresQuery metric) {
+    JsonObject adaptMeasures(MetricMeasuresQuery metric) {
         var aggs = new JsonObject();
         var field = fieldResolver.fromMetric(metric.metric());
         for (var measure : metric.measures()) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeTimeSeriesQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeTimeSeriesQueryAdapter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.AggregationAdapter.TIME_SERIES_AGG_NAME;
+
+import io.gravitee.repository.analytics.engine.api.query.MetricMeasuresQuery;
+import io.gravitee.repository.analytics.engine.api.query.TimeSeriesQuery;
+import io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.api.FieldResolver;
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+
+/**
+ * Native-Kafka counterpart of {@link HTTPTimeSeriesQueryAdapter}: a {@code date_histogram} over the
+ * {@code v4-metrics} index whose per-bucket sub-aggregation is the native connection facet/measure
+ * (reused from {@link NativeFacetsQueryAdapter}, e.g. a {@code terms} on
+ * {@code NATIVE_CONNECTION_STATUS} with a COUNT leaf). Native metrics only support COUNT.
+ */
+public class NativeTimeSeriesQueryAdapter {
+
+    private final FieldResolver fieldResolver = new NativeApiFieldResolver();
+
+    private final FilterAdapter filterAdapter = new FilterAdapter(fieldResolver);
+
+    private final BoolQueryAdapter boolAdapter = new BoolQueryAdapter(filterAdapter);
+
+    private final NativeFacetsQueryAdapter facetsQueryAdapter = new NativeFacetsQueryAdapter();
+
+    public String adapt(TimeSeriesQuery query) {
+        return json(query).toString();
+    }
+
+    private JsonObject json(TimeSeriesQuery query) {
+        return new JsonObject().put("size", 0).put("query", boolAdapter.adaptForNative(query)).put("aggs", adaptTimeSeries(query));
+    }
+
+    public JsonObject adaptTimeSeries(TimeSeriesQuery query) {
+        var aggs = new JsonObject();
+        for (var metric : query.metrics()) {
+            aggs.mergeIn(adaptTimeSeries(metric, query));
+        }
+        return aggs;
+    }
+
+    public JsonObject adaptTimeSeries(MetricMeasuresQuery metric, TimeSeriesQuery query) {
+        var dateHistogram = DateHistogramAdapter.adapt(query.interval(), query.timeRange());
+        if (query.facets() != null && !query.facets().isEmpty()) {
+            // Native facets are plain terms aggregations; unlike HTTP there are no numeric-range facets,
+            // so query.ranges() is intentionally not forwarded.
+            dateHistogram.put("aggs", facetsQueryAdapter.adaptFacets(List.of(metric), query.facets(), query.limit()));
+        } else {
+            dateHistogram.put("aggs", facetsQueryAdapter.adaptMeasures(metric));
+        }
+        var aggName = AggregationAdapter.adaptName(metric.metric(), TIME_SERIES_AGG_NAME);
+        return new JsonObject().put(aggName, dateHistogram);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeTimeSeriesQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeTimeSeriesQueryAdapter.java
@@ -28,6 +28,8 @@ import java.util.List;
  * {@code v4-metrics} index whose per-bucket sub-aggregation is the native connection facet/measure
  * (reused from {@link NativeFacetsQueryAdapter}, e.g. a {@code terms} on
  * {@code NATIVE_CONNECTION_STATUS} with a COUNT leaf). Native metrics only support COUNT.
+ *
+ * @author GraviteeSource Team
  */
 public class NativeTimeSeriesQueryAdapter {
 
@@ -48,6 +50,13 @@ public class NativeTimeSeriesQueryAdapter {
     }
 
     public JsonObject adaptTimeSeries(TimeSeriesQuery query) {
+        if (query.facets() != null && query.facets().size() > 1) {
+            // Native facets are not stacked recursively (unlike the HTTP adapter): adaptFacets keeps only
+            // the first facet as a terms bucket. AnalyticsQueryValidator allows up to 2 time-series facets,
+            // so a 2nd would otherwise be silently dropped — reject it loudly instead of returning a chart
+            // grouped by the first facet only. Recurse here only if Gamma ever needs two native dimensions.
+            throw new UnsupportedOperationException("Native time series supports a single facet, got: " + query.facets());
+        }
         var aggs = new JsonObject();
         for (var metric : query.metrics()) {
             aggs.mergeIn(adaptTimeSeries(metric, query));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -1521,6 +1521,35 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                     assertThat(facetBucket.measures().get(Measure.COUNT).longValue()).isPositive();
                 });
             }
+
+            @Test
+            void should_return_native_connection_time_series_total_count_without_a_facet() {
+                // No facet: the per-bucket sub-agg is a plain COUNT under the date_histogram (adaptMeasures),
+                // not a terms stack. This exercises the no-facet branch round-tripping through
+                // TimeSeriesResponseAdapter — the buckets carry measures directly (ofMeasures), not buckets.
+                var timeRange = buildTimeRange();
+                var metrics = List.of(new MetricMeasuresQuery(Metric.NATIVE_CONNECTIONS_SUMMARY, Set.of(Measure.COUNT)));
+                var filter = new Filter(Filter.Name.API, Filter.Operator.IN, List.of("kafka-api-001"));
+                var query = new TimeSeriesQuery(timeRange, List.of(filter), Duration.ofHours(1).toMillis(), metrics);
+
+                var result = cut.searchNativeApiTimeSeries(QUERY_CONTEXT, query);
+
+                assertThat(result).isNotNull();
+                assertThat(result.metrics()).hasSize(1);
+
+                var timeSeriesBuckets = result.metrics().getFirst().buckets();
+                assertThat(timeSeriesBuckets).isNotEmpty();
+                // COUNT sits on the time buckets themselves (no facet sub-buckets); the fixtures seed
+                // connections for this API so the total across the window is positive.
+                assertThat(timeSeriesBuckets).allSatisfy(bucket -> assertThat(bucket.buckets()).isNull());
+                var total = timeSeriesBuckets
+                    .stream()
+                    .map(bucket -> bucket.measures().get(Measure.COUNT))
+                    .filter(java.util.Objects::nonNull)
+                    .mapToLong(Number::longValue)
+                    .sum();
+                assertThat(total).isPositive();
+            }
         }
 
         @Nested

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -1485,6 +1485,45 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
         }
 
         @Nested
+        class NativeTimeSeries {
+
+            static TimeSeriesQuery buildQuery() {
+                var timeRange = buildTimeRange();
+                var metrics = List.of(new MetricMeasuresQuery(Metric.NATIVE_CONNECTIONS_SUMMARY, Set.of(Measure.COUNT)));
+                var interval = Duration.ofHours(1).toMillis();
+                var filter = new Filter(Filter.Name.API, Filter.Operator.IN, List.of("kafka-api-001"));
+                var facets = List.of(Facet.NATIVE_CONNECTION_STATUS);
+                return new TimeSeriesQuery(timeRange, List.of(filter), interval, metrics, facets);
+            }
+
+            @Test
+            void should_return_native_connection_time_series_buckets_stacked_by_status() {
+                var query = buildQuery();
+                var result = cut.searchNativeApiTimeSeries(QUERY_CONTEXT, query);
+
+                assertThat(result).isNotNull();
+                assertThat(result.metrics()).hasSize(1);
+
+                var timeSeriesBuckets = result.metrics().getFirst().buckets();
+                assertThat(timeSeriesBuckets).isNotEmpty();
+
+                // The date_histogram spans the whole window (empty hours included). Flatten the per-status
+                // (NATIVE_CONNECTION_STATUS) facet buckets and assert the stacking contract: a known status
+                // is keyed and counted (the fixtures seed CONNECTED connections for this API).
+                var statusBuckets = timeSeriesBuckets
+                    .stream()
+                    .filter(bucket -> bucket.buckets() != null)
+                    .flatMap(bucket -> bucket.buckets().stream())
+                    .toList();
+                assertThat(statusBuckets).isNotEmpty();
+                assertThat(statusBuckets).anySatisfy(facetBucket -> {
+                    assertThat(facetBucket.key()).isEqualTo("CONNECTED");
+                    assertThat(facetBucket.measures().get(Measure.COUNT).longValue()).isPositive();
+                });
+            }
+        }
+
+        @Nested
         class MessageMeasures {
 
             static MeasuresQuery buildQuery() {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeFacetsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeFacetsQueryAdapterTest.java
@@ -82,22 +82,6 @@ class NativeFacetsQueryAdapterTest {
     }
 
     @Test
-    void omits_size_when_limit_is_zero() throws Exception {
-        // 0 is the default limit a TimeSeriesQuery carries; Elasticsearch rejects a terms size of 0.
-        var query = new FacetsQuery(
-            new TimeRange(Instant.ofEpochMilli(FROM), Instant.ofEpochMilli(TO)),
-            List.of(),
-            List.of(new MetricMeasuresQuery(Metric.NATIVE_CONNECTIONS_SUMMARY, Set.of(Measure.COUNT))),
-            List.of(Facet.NATIVE_CONNECTION_STATUS),
-            0
-        );
-
-        var json = JSON.readTree(adapter.adapt(query));
-
-        assertThat(json.at("/aggs/NATIVE_CONNECTIONS_SUMMARY#NATIVE_CONNECTION_STATUS/terms/size").isMissingNode()).isTrue();
-    }
-
-    @Test
     void throws_UnsupportedOperationException_for_non_count_measure() {
         var query = new FacetsQuery(
             new TimeRange(Instant.ofEpochMilli(FROM), Instant.ofEpochMilli(TO)),

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeTimeSeriesQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeTimeSeriesQueryAdapterTest.java
@@ -16,13 +16,13 @@
 package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.repository.analytics.engine.api.metric.Measure;
 import io.gravitee.repository.analytics.engine.api.metric.Metric;
 import io.gravitee.repository.analytics.engine.api.query.*;
 import io.gravitee.repository.log.v4.model.connection.NativeApiMetricKeys;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
@@ -31,81 +31,63 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class NativeFacetsQueryAdapterTest {
+class NativeTimeSeriesQueryAdapterTest {
 
     private static final ObjectMapper JSON = new ObjectMapper();
     private static final long FROM = 1_700_000_000_000L;
     private static final long TO = 1_700_003_600_000L;
     private static final String API_ID = "api-1";
 
-    private final NativeFacetsQueryAdapter adapter = new NativeFacetsQueryAdapter();
+    private final NativeTimeSeriesQueryAdapter adapter = new NativeTimeSeriesQueryAdapter();
 
     @Test
-    void builds_terms_aggregation_on_native_connection_status_with_count_sub_agg() throws Exception {
-        var query = new FacetsQuery(
+    void builds_a_date_histogram_stacked_by_native_connection_status() throws Exception {
+        var query = new TimeSeriesQuery(
             new TimeRange(Instant.ofEpochMilli(FROM), Instant.ofEpochMilli(TO)),
             List.of(new Filter(Filter.Name.API, Filter.Operator.IN, List.of(API_ID))),
+            Duration.ofHours(1).toMillis(),
             List.of(new MetricMeasuresQuery(Metric.NATIVE_CONNECTIONS_SUMMARY, Set.of(Measure.COUNT))),
-            List.of(Facet.NATIVE_CONNECTION_STATUS),
-            4
+            List.of(Facet.NATIVE_CONNECTION_STATUS)
         );
 
         var json = JSON.readTree(adapter.adapt(query));
 
+        // Native filter (v4-metrics, not HTTP) applied
         var filters = json.at("/query/bool/filter");
         assertThat(filters.at("/0/range/@timestamp/gte").asLong()).isEqualTo(FROM);
         assertThat(filters.at("/0/range/@timestamp/lte").asLong()).isEqualTo(TO);
         assertThat(filters.at("/1/terms/api-id/0").asText()).isEqualTo(API_ID);
 
-        var terms = json.at("/aggs/NATIVE_CONNECTIONS_SUMMARY#NATIVE_CONNECTION_STATUS/terms");
+        // Time-series wrapper is a date_histogram
+        var dateHistogram = json.at("/aggs/NATIVE_CONNECTIONS_SUMMARY#TIME_SERIES/date_histogram");
+        assertThat(dateHistogram.isMissingNode()).isFalse();
+
+        // Per-bucket terms sub-agg on the native connection status field
+        var terms = json.at("/aggs/NATIVE_CONNECTIONS_SUMMARY#TIME_SERIES/aggs/NATIVE_CONNECTIONS_SUMMARY#NATIVE_CONNECTION_STATUS/terms");
         assertThat(terms.get("field").asText()).isEqualTo("additional-metrics." + NativeApiMetricKeys.CONNECTION_STATUS);
-        assertThat(terms.get("size").asInt()).isEqualTo(4);
 
-        var countSubAgg = json.at(
-            "/aggs/NATIVE_CONNECTIONS_SUMMARY#NATIVE_CONNECTION_STATUS/aggs/NATIVE_CONNECTIONS_SUMMARY#COUNT/value_count"
+        // COUNT leaf under the terms
+        var countLeaf = json.at(
+            "/aggs/NATIVE_CONNECTIONS_SUMMARY#TIME_SERIES/aggs/NATIVE_CONNECTIONS_SUMMARY#NATIVE_CONNECTION_STATUS" +
+                "/aggs/NATIVE_CONNECTIONS_SUMMARY#COUNT/value_count"
         );
-        assertThat(countSubAgg.get("field").asText()).isEqualTo("@timestamp");
+        assertThat(countLeaf.get("field").asText()).isEqualTo("@timestamp");
     }
 
     @Test
-    void omits_size_when_limit_is_null() throws Exception {
-        var query = new FacetsQuery(
+    void falls_back_to_a_plain_count_when_no_facet_is_requested() throws Exception {
+        var query = new TimeSeriesQuery(
             new TimeRange(Instant.ofEpochMilli(FROM), Instant.ofEpochMilli(TO)),
             List.of(),
+            Duration.ofHours(1).toMillis(),
             List.of(new MetricMeasuresQuery(Metric.NATIVE_CONNECTIONS_SUMMARY, Set.of(Measure.COUNT))),
-            List.of(Facet.NATIVE_CONNECTION_STATUS)
+            List.of()
         );
 
         var json = JSON.readTree(adapter.adapt(query));
 
-        assertThat(json.at("/aggs/NATIVE_CONNECTIONS_SUMMARY#NATIVE_CONNECTION_STATUS/terms/size").isMissingNode()).isTrue();
-    }
-
-    @Test
-    void omits_size_when_limit_is_zero() throws Exception {
-        // 0 is the default limit a TimeSeriesQuery carries; Elasticsearch rejects a terms size of 0.
-        var query = new FacetsQuery(
-            new TimeRange(Instant.ofEpochMilli(FROM), Instant.ofEpochMilli(TO)),
-            List.of(),
-            List.of(new MetricMeasuresQuery(Metric.NATIVE_CONNECTIONS_SUMMARY, Set.of(Measure.COUNT))),
-            List.of(Facet.NATIVE_CONNECTION_STATUS),
-            0
-        );
-
-        var json = JSON.readTree(adapter.adapt(query));
-
-        assertThat(json.at("/aggs/NATIVE_CONNECTIONS_SUMMARY#NATIVE_CONNECTION_STATUS/terms/size").isMissingNode()).isTrue();
-    }
-
-    @Test
-    void throws_UnsupportedOperationException_for_non_count_measure() {
-        var query = new FacetsQuery(
-            new TimeRange(Instant.ofEpochMilli(FROM), Instant.ofEpochMilli(TO)),
-            List.of(),
-            List.of(new MetricMeasuresQuery(Metric.NATIVE_CONNECTIONS_SUMMARY, Set.of(Measure.AVG))),
-            List.of(Facet.NATIVE_CONNECTION_STATUS)
-        );
-
-        assertThatThrownBy(() -> adapter.adapt(query)).isInstanceOf(UnsupportedOperationException.class);
+        assertThat(json.at("/aggs/NATIVE_CONNECTIONS_SUMMARY#TIME_SERIES/date_histogram").isMissingNode()).isFalse();
+        var count = json.at("/aggs/NATIVE_CONNECTIONS_SUMMARY#TIME_SERIES/aggs/NATIVE_CONNECTIONS_SUMMARY#COUNT/value_count");
+        assertThat(count.get("field").asText()).isEqualTo("@timestamp");
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeTimeSeriesQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/NativeTimeSeriesQueryAdapterTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.repository.analytics.engine.api.metric.Measure;
@@ -65,6 +66,9 @@ class NativeTimeSeriesQueryAdapterTest {
         // Per-bucket terms sub-agg on the native connection status field
         var terms = json.at("/aggs/NATIVE_CONNECTIONS_SUMMARY#TIME_SERIES/aggs/NATIVE_CONNECTIONS_SUMMARY#NATIVE_CONNECTION_STATUS/terms");
         assertThat(terms.get("field").asText()).isEqualTo("additional-metrics." + NativeApiMetricKeys.CONNECTION_STATUS);
+        // The convenience constructor defaults limit to 0; TimeSeriesQuery normalises it to null so no
+        // `size: 0` (which Elasticsearch rejects) is emitted here.
+        assertThat(terms.get("size")).isNull();
 
         // COUNT leaf under the terms
         var countLeaf = json.at(
@@ -89,5 +93,22 @@ class NativeTimeSeriesQueryAdapterTest {
         assertThat(json.at("/aggs/NATIVE_CONNECTIONS_SUMMARY#TIME_SERIES/date_histogram").isMissingNode()).isFalse();
         var count = json.at("/aggs/NATIVE_CONNECTIONS_SUMMARY#TIME_SERIES/aggs/NATIVE_CONNECTIONS_SUMMARY#COUNT/value_count");
         assertThat(count.get("field").asText()).isEqualTo("@timestamp");
+    }
+
+    @Test
+    void rejects_more_than_one_facet_instead_of_silently_dropping_it() {
+        // Native facets are not stacked recursively, so a 2nd facet (allowed by the validator's max of 2)
+        // would be silently ignored. The adapter must fail loudly rather than return a wrong chart.
+        var query = new TimeSeriesQuery(
+            new TimeRange(Instant.ofEpochMilli(FROM), Instant.ofEpochMilli(TO)),
+            List.of(),
+            Duration.ofHours(1).toMillis(),
+            List.of(new MetricMeasuresQuery(Metric.NATIVE_CONNECTIONS_SUMMARY, Set.of(Measure.COUNT))),
+            List.of(Facet.APPLICATION, Facet.NATIVE_CONNECTION_STATUS)
+        );
+
+        assertThatThrownBy(() -> adapter.adapt(query))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("single facet");
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpAnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpAnalyticsRepository.java
@@ -142,6 +142,11 @@ public class NoOpAnalyticsRepository implements AnalyticsRepository {
     }
 
     @Override
+    public TimeSeriesResult searchNativeApiTimeSeries(QueryContext queryContext, TimeSeriesQuery query) {
+        return new TimeSeriesResult(List.of());
+    }
+
+    @Override
     public MeasuresResult searchMessageMeasures(QueryContext queryContext, MeasuresQuery query) {
         return null;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypeFilterTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypeFilterTransformer.java
@@ -52,7 +52,12 @@ public class ApiTypeFilterTransformer implements QueryFilterTransformer {
         ApiType.MCP_PROXY,
         "A2A",
         ApiType.A2A_PROXY,
+        // Native Kafka is spelled "KAFKA" by the APIM console and "NATIVE" by Gamma / the
+        // observability lib (whose ApiType vocabulary emits the canonical enum name). Accept both so
+        // both callers can scope analytics to native APIs.
         "KAFKA",
+        ApiType.NATIVE,
+        "NATIVE",
         ApiType.NATIVE,
         "EDGE",
         ApiType.EDGE

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/NativeApiAnalyticsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/NativeApiAnalyticsQueryService.java
@@ -55,6 +55,8 @@ public class NativeApiAnalyticsQueryService implements AnalyticsEngineQueryServi
 
     @Override
     public TimeSeriesResponse searchTimeSeries(ExecutionContext context, TimeSeriesRequest request) {
-        throw new UnsupportedOperationException("native API analytics does not support time series");
+        var query = AnalyticsMeasuresAdapter.INSTANCE.fromRequest(request);
+        var result = analyticsRepository.searchNativeApiTimeSeries(context.getQueryContext(), query);
+        return AnalyticsMeasuresAdapter.INSTANCE.fromResult(result);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypeFilterTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypeFilterTransformerTest.java
@@ -35,6 +35,8 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * @author GraviteeSource Team
@@ -134,6 +136,21 @@ class ApiTypeFilterTransformerTest {
         assertThat(filters.getFirst().value())
             .asInstanceOf(InstanceOfAssertFactories.collection(String.class))
             .containsExactlyInAnyOrder("api-2", "api-3");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "NATIVE", "KAFKA" })
+    void should_narrow_to_native_apis_for_both_native_and_kafka_values(String apiTypeValue) {
+        var context = buildContext(Set.of("api-1", "api-native"), Map.of(ApiType.NATIVE, Set.of("api-native")));
+
+        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.IN, List.of(apiTypeValue));
+        var filters = transformer.transform(context, List.of(apiTypeFilter));
+
+        assertThat(filters).hasSize(1);
+        assertThat(filters.getFirst().name()).isEqualTo(FilterSpec.Name.API);
+        assertThat(filters.getFirst().value())
+            .asInstanceOf(InstanceOfAssertFactories.collection(String.class))
+            .containsExactly("api-native");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics_engine/NativeApiAnalyticsQueryServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics_engine/NativeApiAnalyticsQueryServiceTest.java
@@ -26,7 +26,9 @@ import io.gravitee.apim.core.analytics_engine.model.*;
 import io.gravitee.apim.core.observability.model.FilterOperator;
 import io.gravitee.repository.analytics.engine.api.query.Facet;
 import io.gravitee.repository.analytics.engine.api.query.FacetsQuery;
+import io.gravitee.repository.analytics.engine.api.query.TimeSeriesQuery;
 import io.gravitee.repository.analytics.engine.api.result.FacetsResult;
+import io.gravitee.repository.analytics.engine.api.result.TimeSeriesResult;
 import io.gravitee.repository.log.v4.api.AnalyticsRepository;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
@@ -86,11 +88,21 @@ class NativeApiAnalyticsQueryServiceTest {
     }
 
     @Test
-    void searchTimeSeries_throws_UnsupportedOperationException() {
-        assertThatThrownBy(() -> service.searchTimeSeries(EXECUTION_CONTEXT, aTimeSeriesRequest()))
-            .isInstanceOf(UnsupportedOperationException.class)
-            .hasMessageContaining("time series");
-        verifyNoInteractions(analyticsRepository);
+    void searchTimeSeries_forwards_api_filter_and_native_connection_status_facet() {
+        when(analyticsRepository.searchNativeApiTimeSeries(any(), any())).thenReturn(new TimeSeriesResult(List.of()));
+        var queryCaptor = ArgumentCaptor.forClass(TimeSeriesQuery.class);
+
+        var response = service.searchTimeSeries(EXECUTION_CONTEXT, aTimeSeriesRequest());
+
+        assertThat(response).isNotNull();
+        verify(analyticsRepository).searchNativeApiTimeSeries(eq(EXECUTION_CONTEXT.getQueryContext()), queryCaptor.capture());
+        var captured = queryCaptor.getValue();
+        assertThat(captured.facets()).contains(Facet.NATIVE_CONNECTION_STATUS);
+        assertThat(captured.interval()).isEqualTo(3_600_000L);
+        assertThat(captured.filters()).anySatisfy(f -> {
+            assertThat(f.name()).isEqualTo(io.gravitee.repository.analytics.engine.api.query.Filter.Name.API);
+            assertThat(f.value()).isEqualTo(API_ID);
+        });
     }
 
     private static FacetsRequest aFacetsRequest() {
@@ -109,6 +121,21 @@ class NativeApiAnalyticsQueryServiceTest {
     }
 
     private static TimeSeriesRequest aTimeSeriesRequest() {
-        return new TimeSeriesRequest(new TimeRange(FROM, TO), null, List.of());
+        return new TimeSeriesRequest(
+            new TimeRange(FROM, TO),
+            3_600_000L,
+            List.of(new Filter(FilterSpec.Name.API, FilterOperator.EQ, API_ID)),
+            List.of(
+                new FacetMetricMeasuresRequest(
+                    MetricSpec.Name.NATIVE_CONNECTIONS_SUMMARY,
+                    List.of(MetricSpec.Measure.COUNT),
+                    List.of(),
+                    List.of()
+                )
+            ),
+            List.of(FacetSpec.Name.NATIVE_CONNECTION_STATUS),
+            null,
+            List.of()
+        );
     }
 }


### PR DESCRIPTION
## What

Adds a **native-Kafka time-series** capability to the analytics engine so the `NATIVE_CONNECTIONS_SUMMARY` metric can be aggregated over time (`date_histogram`) stacked by `NATIVE_CONNECTION_STATUS`. Two commits:

1. **feat**: implement `searchNativeApiTimeSeries` end to end
   - `AnalyticsRepository.searchNativeApiTimeSeries` (ES impl + noop impl)
   - new `NativeTimeSeriesQueryAdapter` (mirrors `HTTPTimeSeriesQueryAdapter`, reuses `NativeFacetsQueryAdapter` + shared `DateHistogramAdapter`/`TimeSeriesResponseAdapter`)
   - `NativeApiAnalyticsQueryService.searchTimeSeries` (was throwing `UnsupportedOperationException`)
   - fix: omit the terms `size` when `limit <= 0` (ES rejects `size:0`; `TimeSeriesQuery` defaults limit to 0)
2. **fix**: accept `"NATIVE"` as an `API_TYPE` filter value in `ApiTypeFilterTransformer` (Gamma/obs-lib spell native "NATIVE", the engine only mapped "KAFKA") — otherwise native analytics queries threw `unknown API type NATIVE` before reaching the query service.

## Why

Backs a "Logs over time" chart for native Kafka logs in Gamma (gravitee-gamma-module-esm). No validator/YAML change needed — `NATIVE_CONNECTIONS_SUMMARY` already declares COUNT + the `NATIVE_CONNECTION_STATUS` facet.

## Tests

- Unit: `NativeTimeSeriesQueryAdapterTest` (query shape), `NativeFacetsQueryAdapterTest` (incl. `size==0`), `NativeApiAnalyticsQueryServiceTest` (forwarding), `ApiTypeFilterTransformerTest` (NATIVE + KAFKA).
- Integration (Testcontainers ES): `AnalyticsElasticsearchRepositoryTest$Engine$NativeTimeSeries` — real date_histogram stacked by status, asserts a CONNECTED bucket with a positive count.

_Ticket: TBD._