### PR TITLE
fix: create Overview pages for APIs generated under API Products

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiDefaultPageDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiDefaultPageDomainService.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.definition.model.v4.ApiType;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+@CustomLog
+public class PortalNavigationApiDefaultPageDomainService {
+
+    private static final String DEFAULT_PAGE_TITLE = "Overview";
+    private static final String DEFAULT_OVERVIEW_TEMPLATE = "api-overview-page-content.md";
+    private static final String MCP_PROXY_OVERVIEW_TEMPLATE = "api-overview-mcp-proxy-page-content.md";
+
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalNavigationItemDomainService portalNavigationItemDomainService;
+    private final PortalPageContentCrudService portalPageContentCrudService;
+    private final ApiCrudService apiCrudService;
+
+    public List<PortalNavigationItemId> seedDefaultPages(
+        String organizationId,
+        String environmentId,
+        List<PortalNavigationItemId> apiNavigationItemIds
+    ) {
+        var seededNavigationItemIds = new ArrayList<PortalNavigationItemId>();
+
+        for (var apiNavigationItemId : apiNavigationItemIds) {
+            try {
+                if (seedDefaultPage(organizationId, environmentId, apiNavigationItemId)) {
+                    seededNavigationItemIds.add(apiNavigationItemId);
+                }
+            } catch (Exception e) {
+                log.warn(
+                    "Skipping default page seed for portal navigation item {} in environment {}",
+                    apiNavigationItemId,
+                    environmentId,
+                    e
+                );
+            }
+        }
+
+        return List.copyOf(seededNavigationItemIds);
+    }
+
+    private boolean seedDefaultPage(String organizationId, String environmentId, PortalNavigationItemId apiNavigationItemId) {
+        var navigationItem = portalNavigationItemsQueryService.findByIdAndEnvironmentId(environmentId, apiNavigationItemId);
+        if (!(navigationItem instanceof PortalNavigationApi apiNavigationItem)) {
+            return false;
+        }
+
+        var hasChildPage = portalNavigationItemsQueryService
+            .findByParentIdAndEnvironmentId(environmentId, apiNavigationItemId)
+            .stream()
+            .anyMatch(PortalNavigationPage.class::isInstance);
+        if (hasChildPage) {
+            return false;
+        }
+
+        var templatePath = apiCrudService
+            .findById(apiNavigationItem.getApiId())
+            .filter(api -> ApiType.MCP_PROXY == api.getType())
+            .map(api -> MCP_PROXY_OVERVIEW_TEMPLATE)
+            .orElse(DEFAULT_OVERVIEW_TEMPLATE);
+
+        var content = portalPageContentCrudService.create(
+            GraviteeMarkdownPageContent.create(organizationId, environmentId, loadContent(templatePath))
+        );
+
+        portalNavigationItemDomainService.create(
+            organizationId,
+            environmentId,
+            CreatePortalNavigationItem.builder()
+                .title(DEFAULT_PAGE_TITLE)
+                .type(PortalNavigationItemType.PAGE)
+                .area(PortalArea.TOP_NAVBAR)
+                .parentId(apiNavigationItemId)
+                .portalPageContentId(content.getId())
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                .order(0)
+                .published(false)
+                .visibility(apiNavigationItem.getVisibility())
+                .build()
+        );
+
+        return true;
+    }
+
+    private String loadContent(String contentPath) {
+        try (
+            var inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(String.format("templates/%s", contentPath))
+        ) {
+            if (inputStream == null) {
+                throw new IllegalStateException(String.format("Could not load default portal page template for %s", contentPath));
+            }
+            return new String(inputStream.readAllBytes());
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not load default portal page template", e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemCreationExpansionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemCreationExpansionDomainService.java
@@ -129,6 +129,15 @@ public class PortalNavigationItemCreationExpansionDomainService {
     }
 
     public record Expansion(List<CreatePortalNavigationItem> itemsToCreate, List<PortalNavigationItemId> requestedItemIds) {
+        public List<PortalNavigationItemId> generatedApiNavigationItemIds() {
+            return itemsToCreate
+                .stream()
+                .filter(item -> item.getType() == PortalNavigationItemType.API)
+                .filter(item -> !requestedItemIds.contains(item.getId()))
+                .map(CreatePortalNavigationItem::getId)
+                .toList();
+        }
+
         public List<PortalNavigationItem> selectRequestedItems(List<PortalNavigationItem> createdItems) {
             Map<PortalNavigationItemId, PortalNavigationItem> createdItemsById = createdItems
                 .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemUseCase.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
@@ -32,6 +33,7 @@ public class BulkCreatePortalNavigationItemUseCase {
     private final PortalNavigationItemDomainService domainService;
     private final PortalNavigationItemValidatorService validatorService;
     private final PortalNavigationItemCreationExpansionDomainService creationExpansionDomainService;
+    private final PortalNavigationApiDefaultPageDomainService defaultPageDomainService;
 
     public Output execute(Input input) {
         final var organizationId = input.organizationId();
@@ -45,6 +47,8 @@ public class BulkCreatePortalNavigationItemUseCase {
         for (CreatePortalNavigationItem itemToCreate : expansion.itemsToCreate()) {
             result.add(domainService.create(organizationId, environmentId, itemToCreate));
         }
+
+        defaultPageDomainService.seedDefaultPages(organizationId, environmentId, expansion.generatedApiNavigationItemIds());
 
         return new BulkCreatePortalNavigationItemUseCase.Output(expansion.selectRequestedItems(result));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCase.java
@@ -16,113 +16,21 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.api.crud_service.ApiCrudService;
-import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
-import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
-import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
-import io.gravitee.apim.core.portal_page.model.PortalArea;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
-import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
-import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
-import io.gravitee.definition.model.v4.ApiType;
-import java.util.ArrayList;
 import java.util.List;
-import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
-@CustomLog
 public class SeedDefaultPagesForApiNavigationItemsUseCase {
 
-    private static final String DEFAULT_PAGE_TITLE = "Overview";
-    private static final String DEFAULT_OVERVIEW_TEMPLATE = "api-overview-page-content.md";
-    private static final String MCP_PROXY_OVERVIEW_TEMPLATE = "api-overview-mcp-proxy-page-content.md";
-
-    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
-    private final PortalNavigationItemDomainService portalNavigationItemDomainService;
-    private final PortalPageContentCrudService portalPageContentCrudService;
-    private final ApiCrudService apiCrudService;
+    private final PortalNavigationApiDefaultPageDomainService defaultPageDomainService;
 
     public Output execute(Input input) {
-        var seededNavigationItemIds = new ArrayList<PortalNavigationItemId>();
-
-        for (var apiNavigationItemId : input.apiNavigationItemIds()) {
-            try {
-                if (seedDefaultPage(input.organizationId(), input.environmentId(), apiNavigationItemId)) {
-                    seededNavigationItemIds.add(apiNavigationItemId);
-                }
-            } catch (Exception e) {
-                log.warn(
-                    "Skipping default page seed for portal navigation item {} in environment {}",
-                    apiNavigationItemId,
-                    input.environmentId(),
-                    e
-                );
-            }
-        }
-
-        return new Output(List.copyOf(seededNavigationItemIds));
-    }
-
-    private boolean seedDefaultPage(String organizationId, String environmentId, PortalNavigationItemId apiNavigationItemId) {
-        var navigationItem = portalNavigationItemsQueryService.findByIdAndEnvironmentId(environmentId, apiNavigationItemId);
-        if (!(navigationItem instanceof PortalNavigationApi apiNavigationItem)) {
-            return false;
-        }
-
-        var hasChildPage = portalNavigationItemsQueryService
-            .findByParentIdAndEnvironmentId(environmentId, apiNavigationItemId)
-            .stream()
-            .anyMatch(PortalNavigationPage.class::isInstance);
-        if (hasChildPage) {
-            return false;
-        }
-
-        var templatePath = apiCrudService
-            .findById(apiNavigationItem.getApiId())
-            .filter(api -> ApiType.MCP_PROXY == api.getType())
-            .map(api -> MCP_PROXY_OVERVIEW_TEMPLATE)
-            .orElse(DEFAULT_OVERVIEW_TEMPLATE);
-
-        var content = portalPageContentCrudService.create(
-            GraviteeMarkdownPageContent.create(organizationId, environmentId, loadContent(templatePath))
+        return new Output(
+            defaultPageDomainService.seedDefaultPages(input.organizationId(), input.environmentId(), input.apiNavigationItemIds())
         );
-
-        portalNavigationItemDomainService.create(
-            organizationId,
-            environmentId,
-            CreatePortalNavigationItem.builder()
-                .title(DEFAULT_PAGE_TITLE)
-                .type(PortalNavigationItemType.PAGE)
-                .area(PortalArea.TOP_NAVBAR)
-                .parentId(apiNavigationItemId)
-                .portalPageContentId(content.getId())
-                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
-                .order(0)
-                .published(false)
-                .visibility(apiNavigationItem.getVisibility())
-                .build()
-        );
-
-        return true;
-    }
-
-    private String loadContent(String contentPath) {
-        try (
-            var inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(String.format("templates/%s", contentPath))
-        ) {
-            if (inputStream == null) {
-                throw new IllegalStateException(String.format("Could not load default portal page template for %s", contentPath));
-            }
-            return new String(inputStream.readAllBytes());
-        } catch (Exception e) {
-            throw new IllegalStateException("Could not load default portal page template", e);
-        }
     }
 
     public record Input(String organizationId, String environmentId, List<PortalNavigationItemId> apiNavigationItemIds) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemCreationExpansionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemCreationExpansionDomainServiceTest.java
@@ -89,6 +89,9 @@ class PortalNavigationItemCreationExpansionDomainServiceTest {
         var createdRoot = expansion.itemsToCreate().getFirst();
         var children = expansion.itemsToCreate().subList(1, expansion.itemsToCreate().size());
         assertThat(children).extracting(CreatePortalNavigationItem::getApiId).containsExactly("api-a-1", "api-a-2", "api-z");
+        assertThat(expansion.generatedApiNavigationItemIds()).containsExactlyElementsOf(
+            children.stream().map(CreatePortalNavigationItem::getId).toList()
+        );
         assertThat(children).extracting(CreatePortalNavigationItem::getOrder).containsExactly(0, 1, 2);
         assertThat(children).allSatisfy(child -> {
             assertThat(child.getId()).isNotNull();
@@ -98,6 +101,22 @@ class PortalNavigationItemCreationExpansionDomainServiceTest {
             assertThat(child.getPublished()).isFalse();
             assertThat(child.getContentType()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
         });
+    }
+
+    @Test
+    void should_not_consider_requested_api_items_as_generated() {
+        var apiItem = CreatePortalNavigationItem.builder()
+            .id(PortalNavigationItemId.random())
+            .title("API")
+            .area(PortalArea.TOP_NAVBAR)
+            .type(PortalNavigationItemType.API)
+            .parentId(PortalNavigationItemId.of(PARENT_ID))
+            .apiId("api-1")
+            .build();
+
+        var expansion = service.expand(List.of(apiItem), ENVIRONMENT_ID);
+
+        assertThat(expansion.generatedApiNavigationItemIds()).isEmpty();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemsUseCaseTest.java
@@ -37,6 +37,7 @@ import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
@@ -46,6 +47,7 @@ import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,6 +64,7 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
     private PortalNavigationItemsQueryServiceInMemory queryService;
     private PortalNavigationItemValidatorService validatorService;
     private PortalNavigationItemCreationExpansionDomainService creationExpansionDomainService;
+    private PortalNavigationApiDefaultPageDomainService defaultPageDomainService;
     private ApiProductQueryServiceInMemory apiProductQueryService;
     private ApiCrudServiceInMemory apiCrudService;
 
@@ -79,12 +82,23 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
 
         final var domainService = new PortalNavigationItemDomainService(crudService, queryService, pageContentCrudService, apiCrudService);
         creationExpansionDomainService = new PortalNavigationItemCreationExpansionDomainService(apiProductQueryService, apiCrudService);
-        useCase = new BulkCreatePortalNavigationItemUseCase(domainService, validatorService, creationExpansionDomainService);
+        defaultPageDomainService = new PortalNavigationApiDefaultPageDomainService(
+            queryService,
+            domainService,
+            pageContentCrudService,
+            apiCrudService
+        );
+        useCase = new BulkCreatePortalNavigationItemUseCase(
+            domainService,
+            validatorService,
+            creationExpansionDomainService,
+            defaultPageDomainService
+        );
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
     }
 
     @Test
-    void should_bootstrap_multiple_products_and_return_only_requested_roots_in_request_order() {
+    void should_bootstrap_multiple_products_with_default_api_pages_and_return_only_requested_roots_in_request_order() {
         apiProductQueryService.initWith(
             List.of(
                 ApiProduct.builder().id("product-1").environmentId(ENV_ID).apiIds(Set.of("shared-api")).build(),
@@ -100,8 +114,20 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
         assertThat(output.items())
             .extracting(item -> ((io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct) item).getApiProductId())
             .containsExactly("product-1", "product-2");
-        assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, output.items().get(0).getId())).hasSize(1);
-        assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, output.items().get(1).getId())).hasSize(1);
+        assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, output.items().get(0).getId()))
+            .singleElement()
+            .satisfies(apiItem ->
+                assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, apiItem.getId()))
+                    .singleElement()
+                    .isInstanceOfSatisfying(PortalNavigationPage.class, page -> assertThat(page.getTitle()).isEqualTo("Overview"))
+            );
+        assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, output.items().get(1).getId()))
+            .singleElement()
+            .satisfies(apiItem ->
+                assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, apiItem.getId()))
+                    .singleElement()
+                    .isInstanceOfSatisfying(PortalNavigationPage.class, page -> assertThat(page.getTitle()).isEqualTo("Overview"))
+            );
     }
 
     @Test
@@ -163,7 +189,12 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
     void should_fail_when_at_least_one_item_is_invalid_during_bulk_validation() {
         // Given
         final var domainService = mock(PortalNavigationItemDomainService.class);
-        final var useCase = new BulkCreatePortalNavigationItemUseCase(domainService, validatorService, creationExpansionDomainService);
+        final var useCase = new BulkCreatePortalNavigationItemUseCase(
+            domainService,
+            validatorService,
+            creationExpansionDomainService,
+            defaultPageDomainService
+        );
 
         final var validItem = CreatePortalNavigationItem.builder()
             .id(PortalNavigationItemId.random())
@@ -198,6 +229,7 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
         var domainService = mock(PortalNavigationItemDomainService.class);
         var validatorService = mock(PortalNavigationItemValidatorService.class);
         var creationExpansionDomainService = mock(PortalNavigationItemCreationExpansionDomainService.class);
+        var defaultPageDomainService = mock(PortalNavigationApiDefaultPageDomainService.class);
         var rootId = PortalNavigationItemId.random();
         var root = productItem("product-1", "Product", 0).toBuilder().id(rootId).build();
         var firstChild = CreatePortalNavigationItem.builder()
@@ -220,7 +252,12 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
         when(creationExpansionDomainService.expand(List.of(root), ENV_ID)).thenReturn(expansion);
         when(domainService.create(ORG_ID, ENV_ID, root)).thenReturn(persistedRoot);
         when(domainService.create(ORG_ID, ENV_ID, firstChild)).thenThrow(new IllegalStateException("persistence failure"));
-        var useCase = new BulkCreatePortalNavigationItemUseCase(domainService, validatorService, creationExpansionDomainService);
+        var useCase = new BulkCreatePortalNavigationItemUseCase(
+            domainService,
+            validatorService,
+            creationExpansionDomainService,
+            defaultPageDomainService
+        );
 
         assertThrows(IllegalStateException.class, () ->
             useCase.execute(new BulkCreatePortalNavigationItemUseCase.Input(ORG_ID, ENV_ID, List.of(root)))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCaseTest.java
@@ -27,6 +27,7 @@ import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
@@ -64,15 +65,17 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
         portalNavigationItemsQueryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
 
         useCase = new SeedDefaultPagesForApiNavigationItemsUseCase(
-            portalNavigationItemsQueryService,
-            new PortalNavigationItemDomainService(
-                portalNavigationItemsCrudService,
+            new PortalNavigationApiDefaultPageDomainService(
                 portalNavigationItemsQueryService,
+                new PortalNavigationItemDomainService(
+                    portalNavigationItemsCrudService,
+                    portalNavigationItemsQueryService,
+                    portalPageContentCrudService,
+                    apiCrudService
+                ),
                 portalPageContentCrudService,
                 apiCrudService
-            ),
-            portalPageContentCrudService,
-            apiCrudService
+            )
         );
     }
 


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/PORTAL-97

## Description

Fixes the API Product navigation flow so that APIs generated under newly created API Products receive their default **Overview** pages.

After creating API Products, the navigation tree is refreshed to retrieve the generated API navigation items. Their default pages are then created using the existing default-page endpoint, and the tree is refreshed again to display the new pages.

## Changes

- Collect newly created API Product navigation item IDs from the bulk response.
- Identify API navigation items generated directly under those products.
- Seed default pages only for the identified APIs.
- Skip page creation when the products contain no APIs.
- Keep successfully created products when default-page creation fails and display an error notification.
- Add tests for successful creation, empty products, unrelated APIs, partial bulk failures, and default-page creation failures.

https://github.com/user-attachments/assets/b270de57-3210-47a7-b45e-bdb0fe9413db


