### PR TITLE
feat(gamma-platform): user details page

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.spec.ts
@@ -216,19 +216,20 @@ describe('toTaskView', () => {
         expect(view.toModuleId).toBe('apim');
     });
 
-    it('builds a user registration task without a deep link until approval UI exists', () => {
+    it('deep-links a user registration task to the platform user detail page', () => {
         const entity: TaskEntity = {
             type: 'USER_REGISTRATION_APPROVAL',
             created_at: 1,
-            data: { id: 'user-1', displayName: 'Maria Schneider' },
+            data: { id: 'user-1', displayName: 'Maria Schneider', email: 'maria@example.com' },
         };
 
         const view = toTaskView(entity, {}, resolveEnvHrid);
 
         expect(view.area.key).toBe('users');
         expect(view.title).toBe('Maria Schneider');
-        expect(view.to).toBeNull();
-        expect(view.toModuleId).toBeNull();
+        expect(view.subtitle).toBe('maria@example.com');
+        expect(view.to).toBe('/environments/prod/platform/users/user-1');
+        expect(view.toModuleId).toBe('platform');
     });
 
     it('builds a promotion task linking to the target API', () => {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.ts
@@ -238,14 +238,15 @@ export function toTaskView(entity: TaskEntity, metadata: TaskMetadata, resolveEn
         case 'USER_REGISTRATION_APPROVAL': {
             const userId = str(data.id) ?? '';
             const displayName = str(data.displayName) ?? 'New user';
+            const envHrid = resolveEnvHrid(undefined);
             return {
                 ...base,
                 id: `USER_REGISTRATION_APPROVAL:${userId || displayName}`,
                 area: USERS_AREA,
                 title: displayName,
                 subtitle: str(data.email) ?? 'Awaiting validation',
-                to: null,
-                toModuleId: null,
+                to: userId ? envPath(envHrid, 'platform', 'users', userId) : envPath(envHrid, 'platform', 'users'),
+                toModuleId: 'platform',
             };
         }
         case 'PROMOTION_APPROVAL': {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -74,6 +74,10 @@ jest.mock('../pages/UsersPage', () => ({
     UsersPage: () => <div data-testid="users-page" />,
 }));
 
+jest.mock('../pages/UserDetailPage', () => ({
+    UserDetailPage: () => <div data-testid="user-detail-page" />,
+}));
+
 jest.mock('../pages/RegisterApplicationPage', () => ({
     RegisterApplicationPage: () => <div data-testid="register-application-page" />,
 }));
@@ -110,13 +114,13 @@ describe('AppRoutes', () => {
             isLoading: false,
             isError: false,
             error: null,
-        } as ReturnType<typeof useEnvironmentDictionaries>);
+        } as unknown as ReturnType<typeof useEnvironmentDictionaries>);
         mockUseEnvironmentMetadata.mockReturnValue({
             data: [],
             isLoading: false,
             isError: false,
             error: null,
-        } as ReturnType<typeof useEnvironmentMetadata>);
+        } as unknown as ReturnType<typeof useEnvironmentMetadata>);
     });
 
     it('mounts PlatformToaster for module-wide toast feedback', () => {
@@ -158,7 +162,7 @@ describe('AppRoutes', () => {
             isLoading: false,
             isError: true,
             error: new ApimApiError(403, 'Forbidden'),
-        } as ReturnType<typeof useEnvironmentDictionaries>);
+        } as unknown as ReturnType<typeof useEnvironmentDictionaries>);
 
         renderPlatform();
 
@@ -185,10 +189,20 @@ describe('AppRoutes', () => {
             isLoading: false,
             isError: true,
             error: new ApimApiError(403, 'Forbidden'),
-        } as ReturnType<typeof useEnvironmentMetadata>);
+        } as unknown as ReturnType<typeof useEnvironmentMetadata>);
 
         renderPlatform();
 
         expect(visibleNavKeys()).not.toContain('metadata');
+    });
+
+    it('routes to the user detail page under the platform module', () => {
+        render(
+            <MemoryRouter initialEntries={['/users/user-1']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('user-detail-page')).not.toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -37,6 +37,7 @@ import { DictionaryDetailPage } from '../pages/DictionaryDetailPage';
 import { EntrypointsAndShardingTagsPage } from '../pages/EntrypointsAndShardingTagsPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
+import { UserDetailPage } from '../pages/UserDetailPage';
 import { UsersPage } from '../pages/UsersPage';
 import { retryTransientRequest } from '../shared/api/queryRetry';
 import { ConsoleSettingsProvider } from '../shared/console-settings';
@@ -179,14 +180,24 @@ export function AppRoutes() {
                             </Route>
                         </Route>
                         <Route path="access-management" element={<AccessManagementPage />} />
-                        <Route
-                            path="users"
-                            element={
-                                <PermissionPageGuard anyOf={ORGANIZATION_USER_ACCESS_PERMISSIONS}>
-                                    <UsersPage />
-                                </PermissionPageGuard>
-                            }
-                        />
+                        <Route path="users">
+                            <Route
+                                index
+                                element={
+                                    <PermissionPageGuard anyOf={ORGANIZATION_USER_ACCESS_PERMISSIONS}>
+                                        <UsersPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                            <Route
+                                path=":userId"
+                                element={
+                                    <PermissionPageGuard anyOf={ORGANIZATION_USER_ACCESS_PERMISSIONS}>
+                                        <UserDetailPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                        </Route>
                         <Route
                             path="metadata"
                             element={

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/RoleListTooltip.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/RoleListTooltip.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const ROLE_LIST_TOOLTIP_CONTENT_CLASS = 'block max-w-xs items-start p-1 text-left text-xs';
+
+export function RoleListTooltipContent({ labels }: Readonly<{ labels: string[] }>) {
+    return <span className="min-w-0 max-h-48 overflow-y-auto [overflow-wrap:anywhere]">{labels.join(', ')}</span>;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserAvatar.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserAvatar.tsx
@@ -13,9 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Avatar, AvatarFallback } from '@gravitee/graphene-core';
+import { Avatar, AvatarFallback, cn } from '@gravitee/graphene-core';
 
-export function UserAvatar({ name }: Readonly<{ name: string }>) {
+type UserAvatarSize = 'sm' | 'lg';
+
+const sizeClasses: Record<UserAvatarSize, string> = {
+    sm: 'text-xs',
+    lg: 'text-lg',
+};
+
+export function UserAvatar({ name, size = 'sm' }: Readonly<{ name: string; size?: UserAvatarSize }>) {
     const initials = name
         .split(' ')
         .map(part => part[0] ?? '')
@@ -24,8 +31,8 @@ export function UserAvatar({ name }: Readonly<{ name: string }>) {
         .slice(0, 2);
 
     return (
-        <Avatar size="sm" className="shrink-0">
-            <AvatarFallback className="bg-primary/10 text-primary text-xs font-semibold">{initials || '?'}</AvatarFallback>
+        <Avatar size={size} className="shrink-0">
+            <AvatarFallback className={cn('bg-primary/10 text-primary font-semibold', sizeClasses[size])}>{initials || '?'}</AvatarFallback>
         </Avatar>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserEnvironmentRolesCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserEnvironmentRolesCard.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { useMemo } from 'react';
+
+import { UserRoleMultiSelect } from './UserRoleMultiSelect';
+import type { OrganizationEnvironment, OrganizationRole, OrganizationUser } from '../types/user';
+import { resolveAssignedRoleIds } from '../utils/userDetailDisplay';
+
+interface UserEnvironmentRolesCardProps {
+    readonly user: OrganizationUser;
+    readonly environments: OrganizationEnvironment[];
+    readonly roles: OrganizationRole[];
+    readonly loading: boolean;
+    readonly disabled: boolean;
+    readonly savingEnvironmentId?: string;
+    readonly onEnvironmentRolesChange: (environmentId: string, roleIds: string[]) => void | Promise<void>;
+}
+
+function EnvironmentRoleRow({
+    environment,
+    roleOptions,
+    assignedRoleIds,
+    disabled,
+    saving,
+    onRolesChange,
+}: Readonly<{
+    environment: OrganizationEnvironment;
+    roleOptions: { value: string; label: string }[];
+    assignedRoleIds: string[];
+    disabled: boolean;
+    saving: boolean;
+    onRolesChange: (roleIds: string[]) => void | Promise<void>;
+}>) {
+    return (
+        <TableRow>
+            <TableCell className="px-4 py-4 align-middle font-medium">{environment.name ?? environment.id}</TableCell>
+            <TableCell className="px-4 py-4 align-middle text-muted-foreground">{environment.description ?? '—'}</TableCell>
+            <TableCell className="px-4 py-4 align-middle">
+                <UserRoleMultiSelect
+                    options={roleOptions}
+                    selectedValues={assignedRoleIds}
+                    onSelectedValuesChange={onRolesChange}
+                    placeholder="Select environment roles"
+                    ariaLabel={`Environment roles for ${environment.name ?? environment.id}`}
+                    disabled={disabled || saving}
+                />
+            </TableCell>
+        </TableRow>
+    );
+}
+
+export function UserEnvironmentRolesCard({
+    user,
+    environments,
+    roles,
+    loading,
+    disabled,
+    savingEnvironmentId,
+    onEnvironmentRolesChange,
+}: UserEnvironmentRolesCardProps) {
+    const roleOptions = useMemo(
+        () =>
+            [...roles]
+                .sort((a, b) => (a.name ?? a.id).localeCompare(b.name ?? b.id))
+                .map(role => ({
+                    value: role.id,
+                    label: role.name ?? role.id,
+                })),
+        [roles],
+    );
+
+    const assignedRoleIdsByEnvironment = useMemo(
+        () =>
+            Object.fromEntries(
+                environments.map(environment => [environment.id, resolveAssignedRoleIds(user.envRoles?.[environment.id], roles)]),
+            ),
+        [environments, roles, user.envRoles],
+    );
+
+    return (
+        <Card>
+            <CardHeader className="pb-3">
+                <CardTitle className="text-base">Environment Roles</CardTitle>
+            </CardHeader>
+            <CardContent>
+                {loading ? (
+                    <div className="space-y-3">
+                        {Array.from({ length: 3 }).map((_, index) => (
+                            <Skeleton key={index} className="h-12 w-full rounded-lg" />
+                        ))}
+                    </div>
+                ) : environments.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No environments available.</p>
+                ) : (
+                    <div className="rounded-lg border">
+                        <Table aria-label="Environments table">
+                            <TableHeader>
+                                <TableRow className="bg-muted/30">
+                                    <TableHead scope="col" className="w-1/3 px-4 text-muted-foreground">
+                                        Name
+                                    </TableHead>
+                                    <TableHead scope="col" className="w-1/3 px-4 text-muted-foreground">
+                                        Description
+                                    </TableHead>
+                                    <TableHead scope="col" className="w-1/3 px-4 text-muted-foreground">
+                                        Roles
+                                    </TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {environments.map(environment => (
+                                    <EnvironmentRoleRow
+                                        key={environment.id}
+                                        environment={environment}
+                                        roleOptions={roleOptions}
+                                        assignedRoleIds={assignedRoleIdsByEnvironment[environment.id] ?? []}
+                                        disabled={disabled}
+                                        saving={savingEnvironmentId === environment.id}
+                                        onRolesChange={roleIds => onEnvironmentRolesChange(environment.id, roleIds)}
+                                    />
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserGroupMembershipsCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserGroupMembershipsCard.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    Empty,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyTitle,
+    Skeleton,
+} from '@gravitee/graphene-core';
+import { UsersIcon } from '@gravitee/graphene-core/icons';
+
+import type { OrganizationUserGroup } from '../types/user';
+
+interface UserGroupMembershipsCardProps {
+    readonly groups: OrganizationUserGroup[];
+    readonly loading: boolean;
+}
+
+export function UserGroupMembershipsCard({ groups, loading }: UserGroupMembershipsCardProps) {
+    return (
+        <Card>
+            <CardHeader className="pb-3">
+                <CardTitle className="text-base">Group Memberships</CardTitle>
+            </CardHeader>
+            <CardContent>
+                {loading ? (
+                    <div className="space-y-2">
+                        {Array.from({ length: 2 }).map((_, index) => (
+                            <Skeleton key={index} className="h-10 rounded-lg" />
+                        ))}
+                    </div>
+                ) : groups.length === 0 ? (
+                    <Empty className="border-none p-0">
+                        <EmptyHeader>
+                            <UsersIcon className="size-8 text-muted-foreground" aria-hidden />
+                            <EmptyTitle>Not a member of any groups</EmptyTitle>
+                            <EmptyDescription>Group memberships grant shared access across APIs and applications.</EmptyDescription>
+                        </EmptyHeader>
+                    </Empty>
+                ) : (
+                    <ul className="space-y-2">
+                        {groups.map(group => (
+                            <li key={group.id} className="flex items-center gap-2 rounded-lg border px-3 py-2">
+                                <Badge variant="outline">{group.name ?? group.id}</Badge>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserOrganizationRolesCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserOrganizationRolesCard.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent, CardHeader, CardTitle, Skeleton } from '@gravitee/graphene-core';
+import { useMemo } from 'react';
+
+import { UserRoleMultiSelect } from './UserRoleMultiSelect';
+import type { OrganizationRole, OrganizationUser } from '../types/user';
+import { getOrganizationRoles, resolveAssignedRoleIds } from '../utils/userDetailDisplay';
+
+interface UserOrganizationRolesCardProps {
+    readonly user: OrganizationUser;
+    readonly roles: OrganizationRole[];
+    readonly loading: boolean;
+    readonly disabled: boolean;
+    readonly saving: boolean;
+    readonly onRolesChange: (roleIds: string[]) => void | Promise<void>;
+}
+
+export function UserOrganizationRolesCard({ user, roles, loading, disabled, saving, onRolesChange }: UserOrganizationRolesCardProps) {
+    const assignedRoleIds = useMemo(() => resolveAssignedRoleIds(getOrganizationRoles(user.roles), roles), [roles, user.roles]);
+
+    const options = useMemo(
+        () =>
+            [...roles]
+                .sort((a, b) => (a.name ?? a.id).localeCompare(b.name ?? b.id))
+                .map(role => ({
+                    value: role.id,
+                    label: role.name ?? role.id,
+                })),
+        [roles],
+    );
+
+    return (
+        <Card>
+            <CardHeader className="pb-3">
+                <CardTitle className="text-base">Organization Roles</CardTitle>
+            </CardHeader>
+            <CardContent>
+                {loading ? (
+                    <Skeleton className="h-10 w-full rounded-md" />
+                ) : (
+                    <UserRoleMultiSelect
+                        options={options}
+                        selectedValues={assignedRoleIds}
+                        onSelectedValuesChange={onRolesChange}
+                        placeholder="Select organization roles"
+                        ariaLabel="Organization roles"
+                        disabled={disabled || saving}
+                    />
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserProfileCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserProfileCard.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge, Card, CardContent, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@gravitee/graphene-core';
+import { CalendarIcon, ClockIcon } from '@gravitee/graphene-core/icons';
+import type { ReactNode } from 'react';
+
+import { ROLE_LIST_TOOLTIP_CONTENT_CLASS, RoleListTooltipContent } from './RoleListTooltip';
+import { UserAvatar } from './UserAvatar';
+import type { OrganizationUser } from '../types/user';
+import {
+    formatCustomFieldValue,
+    formatRoleNames,
+    formatUserDisplayName,
+    formatUserTimestamp,
+    getOrganizationRoles,
+} from '../utils/userDetailDisplay';
+import {
+    detailStatusBadgeVariant,
+    formatSourceLabel,
+    formatTruncatedRoleSummary,
+    formatUserStatus,
+    sourceBadgeVariant,
+} from '../utils/userDisplay';
+
+interface UserProfileCardProps {
+    readonly user: OrganizationUser;
+}
+
+function ProfileMetaColumn({ label, icon, children }: Readonly<{ label: string; icon?: ReactNode; children: ReactNode }>) {
+    return (
+        <div className="space-y-1">
+            <p className="text-sm text-muted-foreground">{label}</p>
+            <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                {icon}
+                {children}
+            </div>
+        </div>
+    );
+}
+
+export function UserProfileCard({ user }: UserProfileCardProps) {
+    const displayName = formatUserDisplayName(user);
+    const organizationRoles = getOrganizationRoles(user.roles);
+    const organizationRoleLabels = formatRoleNames(organizationRoles);
+    const roleSummary = formatTruncatedRoleSummary(organizationRoles, 3);
+    const customFieldEntries = Object.entries(user.customFields ?? {});
+
+    return (
+        <Card>
+            <CardContent className="space-y-6 pt-6">
+                <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
+                    <UserAvatar name={displayName} size="lg" />
+                    <div className="min-w-0 flex-1 space-y-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <h1 className="text-2xl font-semibold tracking-tight">{displayName}</h1>
+                            <Badge variant={detailStatusBadgeVariant(user.status)}>{formatUserStatus(user.status)}</Badge>
+                            {user.isServiceAccount ? (
+                                <Badge variant="outline" className="text-xs uppercase">
+                                    Service account
+                                </Badge>
+                            ) : null}
+                            {user.primary_owner ? (
+                                <Badge variant="outline" className="text-xs uppercase">
+                                    Owner
+                                </Badge>
+                            ) : null}
+                        </div>
+                        {user.email ? <p className="text-sm text-muted-foreground">{user.email}</p> : null}
+                    </div>
+                </div>
+
+                <div className="grid gap-6 border-t pt-6 sm:grid-cols-2 lg:grid-cols-4">
+                    <ProfileMetaColumn label="Source">
+                        <Badge variant={sourceBadgeVariant(user.source)} className="font-normal">
+                            {formatSourceLabel(user.source)}
+                        </Badge>
+                    </ProfileMetaColumn>
+                    <ProfileMetaColumn label="Organization Roles">
+                        {roleSummary.truncated ? (
+                            <TooltipProvider delayDuration={200}>
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <span className="cursor-default">{roleSummary.display}</span>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="bottom" align="start" className={ROLE_LIST_TOOLTIP_CONTENT_CLASS}>
+                                        <RoleListTooltipContent labels={organizationRoleLabels} />
+                                    </TooltipContent>
+                                </Tooltip>
+                            </TooltipProvider>
+                        ) : (
+                            roleSummary.display
+                        )}
+                    </ProfileMetaColumn>
+                    <ProfileMetaColumn label="Last Login" icon={<ClockIcon className="size-4 text-muted-foreground" aria-hidden />}>
+                        {formatUserTimestamp(user.lastConnectionAt)}
+                    </ProfileMetaColumn>
+                    <ProfileMetaColumn label="Created" icon={<CalendarIcon className="size-4 text-muted-foreground" aria-hidden />}>
+                        {formatUserTimestamp(user.created_at)}
+                    </ProfileMetaColumn>
+                </div>
+
+                {customFieldEntries.length > 0 ? (
+                    <dl className="grid gap-4 border-t pt-6 sm:grid-cols-2 lg:grid-cols-3">
+                        {customFieldEntries.map(([key, value]) => (
+                            <div key={key} className="space-y-1">
+                                <dt className="text-sm font-medium">{key}</dt>
+                                <dd className="text-sm text-muted-foreground [overflow-wrap:anywhere]">{formatCustomFieldValue(value)}</dd>
+                            </div>
+                        ))}
+                    </dl>
+                ) : null}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserRegistrationPendingBanner.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserRegistrationPendingBanner.spec.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { UserRegistrationPendingBanner } from './UserRegistrationPendingBanner';
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
+});
+
+describe('UserRegistrationPendingBanner', () => {
+    it('invokes accept and reject callbacks from the banner actions', async () => {
+        const user = userEvent.setup();
+        const onAccept = jest.fn();
+        const onReject = jest.fn();
+
+        renderWithGraphene(<UserRegistrationPendingBanner isPending={false} onAccept={onAccept} onReject={onReject} />);
+
+        await user.click(screen.getByRole('button', { name: 'Accept user registration' }));
+        await user.click(screen.getByRole('button', { name: 'Reject user registration' }));
+
+        expect(onAccept).toHaveBeenCalledTimes(1);
+        expect(onReject).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables banner actions while registration is processing', () => {
+        renderWithGraphene(<UserRegistrationPendingBanner isPending onAccept={jest.fn()} onReject={jest.fn()} />);
+
+        expect(screen.getByRole('button', { name: 'Accept user registration' })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('button', { name: 'Reject user registration' })).toHaveProperty('disabled', true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserRegistrationPendingBanner.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserRegistrationPendingBanner.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Alert, AlertDescription, AlertTitle, Button } from '@gravitee/graphene-core';
+import { CheckIcon, TriangleAlertIcon, XIcon } from '@gravitee/graphene-core/icons';
+
+interface UserRegistrationPendingBannerProps {
+    readonly onAccept: () => void;
+    readonly onReject: () => void;
+    readonly isPending: boolean;
+}
+
+export function UserRegistrationPendingBanner({ onAccept, onReject, isPending }: UserRegistrationPendingBannerProps) {
+    return (
+        <Alert variant="default" className="border-warning/40 bg-warning/10">
+            <TriangleAlertIcon className="size-4 text-warning" aria-hidden />
+            <AlertTitle className="text-warning-foreground">Registration Pending</AlertTitle>
+            <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <span>This user has been pre-registered and is waiting for approval.</span>
+                <div className="flex shrink-0 gap-2">
+                    <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        disabled={isPending}
+                        aria-label="Reject user registration"
+                        onClick={onReject}
+                    >
+                        <XIcon className="size-4" aria-hidden />
+                        Reject
+                    </Button>
+                    <Button type="button" size="sm" disabled={isPending} aria-label="Accept user registration" onClick={onAccept}>
+                        <CheckIcon className="size-4" aria-hidden />
+                        Accept
+                    </Button>
+                </div>
+            </AlertDescription>
+        </Alert>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserRoleMultiSelect.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserRoleMultiSelect.spec.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { RoleListTooltipContent } from './RoleListTooltip';
+import { UserRoleMultiSelect } from './UserRoleMultiSelect';
+
+const OPTIONS = [
+    { value: 'admin', label: 'ADMIN' },
+    { value: 'publisher', label: 'API_PUBLISHER' },
+];
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as typeof ResizeObserver;
+});
+
+describe('UserRoleMultiSelect', () => {
+    it('opens a checkbox list and commits selected roles when the popover closes', async () => {
+        const user = userEvent.setup();
+        const onSelectedValuesChange = jest.fn();
+
+        renderWithGraphene(
+            <UserRoleMultiSelect
+                options={OPTIONS}
+                selectedValues={['admin']}
+                onSelectedValuesChange={onSelectedValuesChange}
+                ariaLabel="Organization roles"
+            />,
+        );
+
+        expect(screen.getByText('ADMIN')).toBeTruthy();
+
+        await user.click(screen.getByRole('button', { name: 'Organization roles' }));
+        expect(screen.getByRole('checkbox', { name: 'API_PUBLISHER' })).toBeTruthy();
+
+        await user.click(screen.getByRole('checkbox', { name: 'API_PUBLISHER' }));
+        expect(onSelectedValuesChange).not.toHaveBeenCalled();
+
+        await user.click(screen.getByRole('button', { name: 'Organization roles' }));
+        expect(onSelectedValuesChange).toHaveBeenCalledWith(['admin', 'publisher']);
+    });
+
+    it('does not commit when the popover closes without changes', async () => {
+        const user = userEvent.setup();
+        const onSelectedValuesChange = jest.fn();
+
+        renderWithGraphene(
+            <UserRoleMultiSelect
+                options={OPTIONS}
+                selectedValues={['admin']}
+                onSelectedValuesChange={onSelectedValuesChange}
+                ariaLabel="Organization roles"
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Organization roles' }));
+        await user.click(screen.getByRole('button', { name: 'Organization roles' }));
+
+        expect(onSelectedValuesChange).not.toHaveBeenCalled();
+    });
+
+    it('restores the previous selection when commit fails', async () => {
+        const user = userEvent.setup();
+        const onSelectedValuesChange = jest.fn().mockRejectedValue(new Error('Update failed'));
+
+        renderWithGraphene(
+            <UserRoleMultiSelect
+                options={OPTIONS}
+                selectedValues={['admin']}
+                onSelectedValuesChange={onSelectedValuesChange}
+                ariaLabel="Organization roles"
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Organization roles' }));
+        await user.click(screen.getByRole('checkbox', { name: 'API_PUBLISHER' }));
+        await user.click(screen.getByRole('button', { name: 'Organization roles' }));
+
+        await waitFor(() => expect(onSelectedValuesChange).toHaveBeenCalledWith(['admin', 'publisher']));
+        expect(screen.getByText('ADMIN')).toBeTruthy();
+        expect(screen.queryByText(/ADMIN, API_PUBLISHER/)).toBeNull();
+    });
+
+    it('does not open or commit when disabled', async () => {
+        const user = userEvent.setup();
+        const onSelectedValuesChange = jest.fn();
+
+        renderWithGraphene(
+            <UserRoleMultiSelect
+                options={OPTIONS}
+                selectedValues={[]}
+                onSelectedValuesChange={onSelectedValuesChange}
+                ariaLabel="Organization roles"
+                disabled
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Organization roles' }));
+
+        expect(screen.queryByRole('checkbox', { name: 'ADMIN' })).toBeNull();
+        expect(onSelectedValuesChange).not.toHaveBeenCalled();
+    });
+
+    it('shows an empty message when no roles are available', async () => {
+        const user = userEvent.setup();
+
+        renderWithGraphene(
+            <UserRoleMultiSelect
+                options={[]}
+                selectedValues={[]}
+                onSelectedValuesChange={jest.fn()}
+                ariaLabel="Organization roles"
+                emptyMessage="No organization roles"
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Organization roles' }));
+
+        expect(screen.getByText('No organization roles')).toBeTruthy();
+    });
+
+    it('renders a comma-separated tooltip with every role name intact', () => {
+        const labels = ['Admin', 'ORG_TEST1', 'ORG_TEST10', 'AAASKLNG_LSDJGH_OSRGUH_OURGHS_OUGOSUHG_SOUHFOSDUHAOUGI', 'User'];
+
+        renderWithGraphene(<RoleListTooltipContent labels={labels} />);
+
+        expect(screen.getByText(labels.join(', '))).toBeTruthy();
+    });
+
+    it('lists every role option when many roles are available', async () => {
+        const user = userEvent.setup();
+        const manyOptions = Array.from({ length: 20 }, (_, index) => ({
+            value: `role-${index}`,
+            label: `ORG_TEST${index}`,
+        }));
+
+        renderWithGraphene(
+            <UserRoleMultiSelect
+                options={manyOptions}
+                selectedValues={[]}
+                onSelectedValuesChange={jest.fn()}
+                ariaLabel="Organization roles"
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Organization roles' }));
+
+        expect(screen.getByRole('checkbox', { name: 'ORG_TEST0' })).toBeTruthy();
+        expect(screen.getByRole('checkbox', { name: 'ORG_TEST19' })).toBeTruthy();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserRoleMultiSelect.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserRoleMultiSelect.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Checkbox,
+    cn,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    ScrollArea,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@gravitee/graphene-core';
+import { ChevronDownIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+
+import { ROLE_LIST_TOOLTIP_CONTENT_CLASS, RoleListTooltipContent } from './RoleListTooltip';
+
+export interface RoleMultiSelectOption {
+    value: string;
+    label: string;
+}
+
+interface UserRoleMultiSelectProps {
+    readonly options: RoleMultiSelectOption[];
+    readonly selectedValues: string[];
+    readonly onSelectedValuesChange: (values: string[]) => void | Promise<void>;
+    readonly placeholder?: string;
+    readonly ariaLabel: string;
+    readonly disabled?: boolean;
+    readonly emptyMessage?: string;
+    readonly className?: string;
+}
+
+function RoleDisplayText({
+    displayText,
+    isPlaceholder,
+    showTooltip,
+    labels,
+}: Readonly<{
+    displayText: string;
+    isPlaceholder: boolean;
+    showTooltip: boolean;
+    labels: string[];
+}>) {
+    const textClassName = cn('min-w-0 flex-1 truncate text-left', isPlaceholder && 'text-muted-foreground');
+
+    if (!showTooltip) {
+        return <span className={textClassName}>{displayText}</span>;
+    }
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <span className={textClassName}>{displayText}</span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" align="start" className={ROLE_LIST_TOOLTIP_CONTENT_CLASS}>
+                <RoleListTooltipContent labels={labels} />
+            </TooltipContent>
+        </Tooltip>
+    );
+}
+
+export function UserRoleMultiSelect({
+    options,
+    selectedValues,
+    onSelectedValuesChange,
+    placeholder = 'Select roles',
+    ariaLabel,
+    disabled = false,
+    emptyMessage = 'No roles available',
+    className,
+}: UserRoleMultiSelectProps) {
+    const [popoverOpen, setPopoverOpen] = useState(false);
+    const [draftValues, setDraftValues] = useState(selectedValues);
+
+    useEffect(() => {
+        setDraftValues(selectedValues);
+    }, [selectedValues]);
+
+    const selectedLabels = useMemo(
+        () => options.filter(option => draftValues.includes(option.value)).map(option => option.label),
+        [draftValues, options],
+    );
+    const displayText = selectedLabels.length === 0 ? placeholder : selectedLabels.join(', ');
+    const showTooltip = selectedLabels.length > 0 && !popoverOpen;
+
+    function toggleRole(roleId: string) {
+        setDraftValues(current => (current.includes(roleId) ? current.filter(value => value !== roleId) : [...current, roleId]));
+    }
+
+    function handlePopoverOpenChange(open: boolean) {
+        setPopoverOpen(open);
+        if (!open) {
+            const unchanged = draftValues.length === selectedValues.length && draftValues.every(value => selectedValues.includes(value));
+            if (!unchanged) {
+                const committedValues = draftValues;
+                const previousValues = selectedValues;
+                void Promise.resolve(onSelectedValuesChange(committedValues)).catch(() => {
+                    setDraftValues(previousValues);
+                });
+            }
+        }
+    }
+
+    const triggerButton = (
+        <Button
+            type="button"
+            variant="outline"
+            aria-label={ariaLabel}
+            disabled={disabled}
+            className="h-10 w-full justify-between gap-2 border-0 px-0 font-normal shadow-none hover:bg-transparent"
+        >
+            <RoleDisplayText
+                displayText={displayText}
+                isPlaceholder={selectedLabels.length === 0}
+                showTooltip={showTooltip}
+                labels={selectedLabels}
+            />
+            <ChevronDownIcon className="size-4 shrink-0 opacity-50" aria-hidden />
+        </Button>
+    );
+
+    return (
+        <div className={cn('w-72 max-w-full rounded-md border px-3 py-2', className)}>
+            <TooltipProvider delayDuration={300}>
+                <Popover open={popoverOpen} onOpenChange={handlePopoverOpenChange}>
+                    <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
+                    <PopoverContent className="block w-72 p-0" align="start">
+                        {options.length === 0 ? (
+                            <p className="p-3 text-sm text-muted-foreground">{emptyMessage}</p>
+                        ) : (
+                            <ScrollArea className="max-h-48">
+                                <div className="space-y-2 p-3">
+                                    {options.map(option => (
+                                        <label key={option.value} className="flex cursor-pointer items-center gap-2 text-sm">
+                                            <Checkbox
+                                                checked={draftValues.includes(option.value)}
+                                                onCheckedChange={() => toggleRole(option.value)}
+                                                disabled={disabled}
+                                                aria-label={option.label}
+                                            />
+                                            <span className="truncate" title={option.label}>
+                                                {option.label}
+                                            </span>
+                                        </label>
+                                    ))}
+                                </div>
+                            </ScrollArea>
+                        )}
+                    </PopoverContent>
+                </Popover>
+            </TooltipProvider>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UsersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UsersTable.tsx
@@ -16,6 +16,7 @@
 import { Badge, Button, DataTable, DataTableEmptyState, DateCell, Input } from '@gravitee/graphene-core';
 import { SearchIcon } from '@gravitee/graphene-core/icons';
 import { useId, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 
 import { UserAvatar } from './UserAvatar';
 import { NON_SORTABLE_COLUMN } from '../../applications/utils/dataTableHeaders';
@@ -39,7 +40,13 @@ function buildColumns() {
                         <UserAvatar name={displayName} />
                         <div className="min-w-0">
                             <div className="flex flex-wrap items-center gap-2">
-                                <span className="font-medium truncate">{displayName}</span>
+                                <Button asChild variant="link" className="h-auto p-0 font-medium">
+                                    <Link to={user.id}>
+                                        <span className="truncate" title={displayName}>
+                                            {displayName}
+                                        </span>
+                                    </Link>
+                                </Button>
                                 {user.primary_owner ? (
                                     <Badge variant="outline" className="text-xs uppercase">
                                         Owner

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useOrganizationUser.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useOrganizationUser.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useQuery } from '@tanstack/react-query';
+
+import {
+    getOrganizationUser,
+    getOrganizationUserGroups,
+    listEnvironmentRoles,
+    listOrganizationEnvironments,
+    listOrganizationRoles,
+} from '../services/organizationUsers';
+import { organizationUserKeys } from '../utils/queryKeys';
+
+export function useOrganizationUser(userId: string | undefined) {
+    return useQuery({
+        queryKey: organizationUserKeys.detail(userId ?? ''),
+        queryFn: () => getOrganizationUser(userId!),
+        enabled: Boolean(userId),
+    });
+}
+
+export function useOrganizationEnvironments() {
+    return useQuery({
+        queryKey: organizationUserKeys.environments(),
+        queryFn: listOrganizationEnvironments,
+    });
+}
+
+export function useOrganizationUserGroups(userId: string | undefined) {
+    return useQuery({
+        queryKey: organizationUserKeys.groups(userId ?? ''),
+        queryFn: () => getOrganizationUserGroups(userId!),
+        enabled: Boolean(userId),
+    });
+}
+
+export function useOrganizationRoleCatalog() {
+    return useQuery({
+        queryKey: organizationUserKeys.organizationRoles(),
+        queryFn: listOrganizationRoles,
+    });
+}
+
+export function useEnvironmentRoleCatalog() {
+    return useQuery({
+        queryKey: organizationUserKeys.environmentRoles(),
+        queryFn: listEnvironmentRoles,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useUserMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useUserMutations.ts
@@ -15,8 +15,9 @@
  */
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createOrganizationUser } from '../services/organizationUsers';
-import type { NewPreRegisterUserPayload } from '../types/user';
+import { resolveOrganizationId } from '../../../shared/api/apimClient';
+import { createOrganizationUser, processUserRegistration, updateOrganizationUserRoles } from '../services/organizationUsers';
+import type { NewPreRegisterUserPayload, UpdateUserRolesPayload } from '../types/user';
 import { organizationUserKeys } from '../utils/queryKeys';
 
 export function useCreateOrganizationUser() {
@@ -26,6 +27,41 @@ export function useCreateOrganizationUser() {
         mutationFn: (payload: NewPreRegisterUserPayload) => createOrganizationUser(payload),
         onSuccess: () => {
             void queryClient.invalidateQueries({ queryKey: organizationUserKeys.all });
+        },
+    });
+}
+
+export function useProcessUserRegistration(userId: string | undefined) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (accepted: boolean) => processUserRegistration(userId!, accepted),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: organizationUserKeys.all });
+        },
+    });
+}
+
+export function useUpdateOrganizationUserRoles(userId: string | undefined) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (payload: Omit<UpdateUserRolesPayload, 'referenceId'> & { referenceId?: string }) => {
+            const referenceId =
+                payload.referenceId ?? (payload.referenceType === 'ORGANIZATION' ? await resolveOrganizationId() : undefined);
+            if (!referenceId) {
+                throw new Error('Reference id is required to update user roles.');
+            }
+            await updateOrganizationUserRoles(userId!, {
+                referenceType: payload.referenceType,
+                referenceId,
+                roles: payload.roles,
+            });
+        },
+        onSettled: () => {
+            if (userId) {
+                void queryClient.invalidateQueries({ queryKey: organizationUserKeys.detail(userId) });
+            }
         },
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.spec.ts
@@ -13,18 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createOrganizationUser, listIdentityProviders, listOrganizationUsers } from './organizationUsers';
-import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
+import {
+    createOrganizationUser,
+    getOrganizationUser,
+    getOrganizationUserGroups,
+    listEnvironmentRoles,
+    listIdentityProviders,
+    listOrganizationEnvironments,
+    listOrganizationRoles,
+    listOrganizationUsers,
+    processUserRegistration,
+    updateOrganizationUserRoles,
+} from './organizationUsers';
+import { apimFetchJsonOrg, resolveOrganizationId } from '../../../shared/api/apimClient';
 
 jest.mock('../../../shared/api/apimClient', () => ({
     apimFetchJsonOrg: jest.fn(),
+    resolveOrganizationId: jest.fn(),
 }));
 
 const mockApimFetchJsonOrg = jest.mocked(apimFetchJsonOrg);
+const mockResolveOrganizationId = jest.mocked(resolveOrganizationId);
 
 describe('organizationUsers service', () => {
     beforeEach(() => {
         mockApimFetchJsonOrg.mockReset();
+        mockResolveOrganizationId.mockReset();
+        mockResolveOrganizationId.mockResolvedValue('DEFAULT');
     });
 
     it('lists organization users with pagination and the search query sent verbatim', async () => {
@@ -73,5 +88,67 @@ describe('organizationUsers service', () => {
 
         await expect(listIdentityProviders()).resolves.toEqual([{ id: 'ldap', name: 'LDAP' }]);
         expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/identities');
+    });
+
+    it('loads a single organization user by id', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue({ id: 'user-1', email: 'jane@company.com' });
+
+        await expect(getOrganizationUser('user-1')).resolves.toEqual({ id: 'user-1', email: 'jane@company.com' });
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users/user-1');
+    });
+
+    it('lists organization environments', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue([{ id: 'DEFAULT', name: 'Default' }]);
+
+        await expect(listOrganizationEnvironments()).resolves.toEqual([{ id: 'DEFAULT', name: 'Default' }]);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/environments');
+    });
+
+    it('loads user group memberships', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue([{ id: 'group-1', name: 'Platform Admins' }]);
+
+        await expect(getOrganizationUserGroups('user-1')).resolves.toEqual([{ id: 'group-1', name: 'Platform Admins' }]);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users/user-1/groups');
+    });
+
+    it('processes pending user registration', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue(undefined);
+
+        await processUserRegistration('user-1', true);
+
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users/user-1/_process', {
+            method: 'POST',
+            body: JSON.stringify(true),
+        });
+    });
+
+    it('loads organization and environment role catalogs', async () => {
+        mockApimFetchJsonOrg.mockResolvedValueOnce([{ id: 'org-user', name: 'User' }]);
+        await expect(listOrganizationRoles()).resolves.toEqual([{ id: 'org-user', name: 'User' }]);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/rolescopes/ORGANIZATION/roles');
+
+        mockApimFetchJsonOrg.mockResolvedValueOnce([{ id: 'env-user', name: 'API_USER' }]);
+        await expect(listEnvironmentRoles()).resolves.toEqual([{ id: 'env-user', name: 'API_USER' }]);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/rolescopes/ENVIRONMENT/roles');
+    });
+
+    it('updates user roles for an organization or environment reference', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue(undefined);
+
+        await updateOrganizationUserRoles('user-1', {
+            referenceType: 'ORGANIZATION',
+            referenceId: 'DEFAULT',
+            roles: ['org-user'],
+        });
+
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users/user-1/roles', {
+            method: 'PUT',
+            body: JSON.stringify({
+                user: 'user-1',
+                referenceType: 'ORGANIZATION',
+                referenceId: 'DEFAULT',
+                roles: ['org-user'],
+            }),
+        });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.ts
@@ -14,7 +14,16 @@
  * limitations under the License.
  */
 import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
-import type { IdentityProviderListItem, NewPreRegisterUserPayload, OrganizationUser, OrganizationUserListResponse } from '../types/user';
+import type {
+    IdentityProviderListItem,
+    NewPreRegisterUserPayload,
+    OrganizationEnvironment,
+    OrganizationRole,
+    OrganizationUser,
+    OrganizationUserGroup,
+    OrganizationUserListResponse,
+    UpdateUserRolesPayload,
+} from '../types/user';
 
 export async function listOrganizationUsers(params: { query: string; page: number; size: number }): Promise<OrganizationUserListResponse> {
     const searchParams = new URLSearchParams();
@@ -34,4 +43,43 @@ export async function createOrganizationUser(payload: NewPreRegisterUserPayload)
 
 export async function listIdentityProviders(): Promise<IdentityProviderListItem[]> {
     return apimFetchJsonOrg<IdentityProviderListItem[]>('/configuration/identities');
+}
+
+export async function getOrganizationUser(userId: string): Promise<OrganizationUser> {
+    return apimFetchJsonOrg<OrganizationUser>(`/users/${encodeURIComponent(userId)}`);
+}
+
+export async function listOrganizationEnvironments(): Promise<OrganizationEnvironment[]> {
+    return apimFetchJsonOrg<OrganizationEnvironment[]>('/environments');
+}
+
+export async function getOrganizationUserGroups(userId: string): Promise<OrganizationUserGroup[]> {
+    return apimFetchJsonOrg<OrganizationUserGroup[]>(`/users/${encodeURIComponent(userId)}/groups`);
+}
+
+export async function processUserRegistration(userId: string, accepted: boolean): Promise<void> {
+    await apimFetchJsonOrg<void>(`/users/${encodeURIComponent(userId)}/_process`, {
+        method: 'POST',
+        body: JSON.stringify(accepted),
+    });
+}
+
+export async function listOrganizationRoles(): Promise<OrganizationRole[]> {
+    return apimFetchJsonOrg<OrganizationRole[]>('/configuration/rolescopes/ORGANIZATION/roles');
+}
+
+export async function listEnvironmentRoles(): Promise<OrganizationRole[]> {
+    return apimFetchJsonOrg<OrganizationRole[]>('/configuration/rolescopes/ENVIRONMENT/roles');
+}
+
+export async function updateOrganizationUserRoles(userId: string, payload: UpdateUserRolesPayload): Promise<void> {
+    await apimFetchJsonOrg<void>(`/users/${encodeURIComponent(userId)}/roles`, {
+        method: 'PUT',
+        body: JSON.stringify({
+            user: userId,
+            referenceType: payload.referenceType,
+            referenceId: payload.referenceId,
+            roles: payload.roles,
+        }),
+    });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/types/user.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/types/user.ts
@@ -22,6 +22,22 @@ export interface UserRole {
     permissions?: Record<string, string[]>;
 }
 
+export interface OrganizationRole {
+    id: string;
+    name?: string;
+    description?: string;
+    scope?: string;
+    system?: boolean;
+}
+
+export type UserRoleReferenceType = 'ORGANIZATION' | 'ENVIRONMENT';
+
+export interface UpdateUserRolesPayload {
+    referenceType: UserRoleReferenceType;
+    referenceId: string;
+    roles: string[];
+}
+
 export interface OrganizationUser {
     id: string;
     firstname?: string;
@@ -29,6 +45,7 @@ export interface OrganizationUser {
     displayName?: string;
     email?: string;
     roles?: UserRole[];
+    envRoles?: Record<string, UserRole[]>;
     source?: string;
     sourceId?: string;
     lastConnectionAt?: number;
@@ -36,6 +53,22 @@ export interface OrganizationUser {
     primary_owner?: boolean;
     number_of_active_tokens?: number;
     isServiceAccount?: boolean;
+    hasPassword?: boolean;
+    customFields?: Record<string, unknown>;
+    created_at?: number;
+    updated_at?: number;
+}
+
+export interface OrganizationEnvironment {
+    id: string;
+    name?: string;
+    description?: string;
+    organizationId?: string;
+}
+
+export interface OrganizationUserGroup {
+    id: string;
+    name?: string;
 }
 
 export interface UserPageMeta {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/queryKeys.ts
@@ -17,4 +17,9 @@ export const organizationUserKeys = {
     all: ['organization-users'] as const,
     list: (query: string, page: number, size: number) => [...organizationUserKeys.all, 'list', query, page, size] as const,
     identityProviders: () => [...organizationUserKeys.all, 'identity-providers'] as const,
+    detail: (userId: string) => [...organizationUserKeys.all, 'detail', userId] as const,
+    groups: (userId: string) => [...organizationUserKeys.all, 'groups', userId] as const,
+    environments: () => [...organizationUserKeys.all, 'environments'] as const,
+    organizationRoles: () => [...organizationUserKeys.all, 'organization-roles'] as const,
+    environmentRoles: () => [...organizationUserKeys.all, 'environment-roles'] as const,
 };

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    formatCustomFieldValue,
+    formatUserDisplayName,
+    formatUserTimestamp,
+    getOrganizationRoles,
+    resolveAssignedRoleIds,
+    roleLabelsForIds,
+} from './userDetailDisplay';
+
+describe('userDetailDisplay utilities', () => {
+    it('builds a display name from available user fields', () => {
+        expect(formatUserDisplayName({ id: '1', displayName: 'Jane Doe' })).toBe('Jane Doe');
+        expect(formatUserDisplayName({ id: '1', firstname: 'Jane', lastname: 'Doe' })).toBe('Jane Doe');
+        expect(formatUserDisplayName({ id: '1', email: 'jane@company.com' })).toBe('jane@company.com');
+    });
+
+    it('filters organization-scoped roles', () => {
+        expect(
+            getOrganizationRoles([
+                { name: 'User', scope: 'ORGANIZATION' },
+                { name: 'API_USER', scope: 'ENVIRONMENT' },
+            ]),
+        ).toEqual([{ name: 'User', scope: 'ORGANIZATION' }]);
+    });
+
+    it('stringifies custom field values for display', () => {
+        expect(formatCustomFieldValue('Engineering')).toBe('Engineering');
+        expect(formatCustomFieldValue(null)).toBe('—');
+        expect(formatCustomFieldValue(undefined)).toBe('—');
+        expect(formatCustomFieldValue({ team: 'Ops' })).toBe('{"team":"Ops"}');
+    });
+
+    it('resolves assigned role ids from user roles and the role catalog', () => {
+        expect(resolveAssignedRoleIds([{ id: 'org-user', name: 'User' }], [{ id: 'org-user', name: 'User' }])).toEqual(['org-user']);
+        expect(resolveAssignedRoleIds([{ name: 'User' }], [{ id: 'org-user', name: 'User' }])).toEqual(['org-user']);
+    });
+
+    it('maps role ids to display labels from the catalog', () => {
+        expect(roleLabelsForIds(['org-admin'], [{ id: 'org-admin', name: 'ADMIN' }])).toEqual(['ADMIN']);
+    });
+
+    it('formats timestamps for profile metadata', () => {
+        expect(formatUserTimestamp(undefined)).toBe('Never');
+        expect(formatUserTimestamp(Date.parse('2025-07-10'))).toMatch(/Jul 10, 2025|10 Jul 2025/);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { OrganizationUser, UserRole } from '../types/user';
+
+export function formatUserDisplayName(user: Pick<OrganizationUser, 'displayName' | 'firstname' | 'lastname' | 'email' | 'id'>): string {
+    if (user.displayName?.trim()) {
+        return user.displayName.trim();
+    }
+    const parts = [user.firstname, user.lastname].filter((part): part is string => Boolean(part?.trim()));
+    if (parts.length > 0) {
+        return parts.join(' ');
+    }
+    return user.email ?? user.id;
+}
+
+export function getOrganizationRoles(roles: UserRole[] | undefined): UserRole[] {
+    return roles?.filter(role => role.scope === 'ORGANIZATION') ?? [];
+}
+
+export function resolveAssignedRoleIds(assignedRoles: UserRole[] | undefined, catalog: { id: string; name?: string }[]): string[] {
+    if (!assignedRoles?.length) {
+        return [];
+    }
+
+    return assignedRoles
+        .map(role => {
+            if (role.id) {
+                return role.id;
+            }
+            const match = catalog.find(item => item.name === role.name);
+            return match?.id;
+        })
+        .filter((id): id is string => Boolean(id));
+}
+
+export function roleLabelsForIds(roleIds: string[], catalog: { id: string; name?: string }[]): string[] {
+    return roleIds.map(id => catalog.find(role => role.id === id)?.name ?? id);
+}
+
+export function formatRoleNames(roles: UserRole[] | undefined): string[] {
+    if (!roles?.length) {
+        return [];
+    }
+    return roles.map(role => role.name ?? role.id).filter((name): name is string => Boolean(name));
+}
+
+export function formatUserTimestamp(timestamp: number | undefined): string {
+    if (!timestamp) {
+        return 'Never';
+    }
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(timestamp));
+}
+
+export function formatCustomFieldValue(value: unknown): string {
+    if (value === null || value === undefined) {
+        return '—';
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+    return JSON.stringify(value);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.spec.ts
@@ -15,6 +15,7 @@
  */
 import {
     formatSourceLabel,
+    formatTruncatedRoleSummary,
     formatUserStatus,
     isDuplicateUserError,
     isValidEmail,
@@ -50,6 +51,19 @@ describe('userDisplay utilities', () => {
         expect(formatSourceLabel('ldap')).toBe('LDAP');
         expect(formatSourceLabel('openid-provider')).toBe('OpenID Provider');
         expect(formatSourceLabel(undefined)).toBe('—');
+    });
+
+    it('truncates long role lists for profile display', () => {
+        expect(formatTruncatedRoleSummary([{ name: 'USER' }, { name: 'ORG_TEST1' }, { name: 'ORG_TEST2' }, { name: 'ADMIN' }])).toEqual({
+            display: 'USER, ORG_TEST1, ORG_TEST2...',
+            full: 'USER, ORG_TEST1, ORG_TEST2, ADMIN',
+            truncated: true,
+        });
+        expect(formatTruncatedRoleSummary([{ name: 'USER' }, { name: 'ADMIN' }])).toEqual({
+            display: 'USER, ADMIN',
+            full: 'USER, ADMIN',
+            truncated: false,
+        });
     });
 
     it('detects duplicate-user API errors without matching unrelated messages', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.ts
@@ -25,12 +25,39 @@ export function isValidEmail(value: string): boolean {
     return EMAIL_REGEX.test(value.trim());
 }
 
-export function formatRoleSummary(roles: { name?: string; scope?: string }[] | undefined): string {
+function roleDisplayNames(
+    roles: { name?: string; id?: string; scope?: string }[] | undefined,
+    options?: { fallbackToId?: boolean },
+): string[] {
     if (!roles?.length) {
-        return '—';
+        return [];
     }
-    const names = roles.map(role => role.name).filter((name): name is string => Boolean(name));
+    return roles.map(role => (options?.fallbackToId ? (role.name ?? role.id) : role.name)).filter((name): name is string => Boolean(name));
+}
+
+export function formatRoleSummary(roles: { name?: string; scope?: string }[] | undefined): string {
+    const names = roleDisplayNames(roles);
     return names.length > 0 ? names.join(', ') : '—';
+}
+
+/** First N role names for compact display; full list is intended for tooltip. */
+export function formatTruncatedRoleSummary(
+    roles: { name?: string; scope?: string }[] | undefined,
+    visibleCount = 3,
+): { display: string; full: string; truncated: boolean } {
+    const names = roleDisplayNames(roles, { fallbackToId: true });
+    if (names.length === 0) {
+        return { display: '—', full: '—', truncated: false };
+    }
+    const full = names.join(', ');
+    if (names.length <= visibleCount) {
+        return { display: full, full, truncated: false };
+    }
+    return {
+        display: `${names.slice(0, visibleCount).join(', ')}...`,
+        full,
+        truncated: true,
+    };
 }
 
 export function formatUserStatus(status: string | undefined): string {
@@ -65,6 +92,7 @@ const KNOWN_IDP_LABELS: Record<string, string> = {
     memory: 'Memory',
     ldap: 'LDAP',
     oidc: 'OIDC',
+    openid: 'OpenID Provider',
     'openid-provider': 'OpenID Provider',
 };
 
@@ -83,6 +111,23 @@ export function formatSourceLabel(source: string | undefined): string {
             .join(' ');
     }
     return source.charAt(0).toUpperCase() + source.slice(1);
+}
+
+export type SourceBadgeVariant = 'warning' | 'outline';
+
+export function sourceBadgeVariant(source: string | undefined): SourceBadgeVariant {
+    const normalized = source?.toLowerCase() ?? '';
+    if (normalized === 'gravitee' || normalized === 'memory') {
+        return 'outline';
+    }
+    return 'warning';
+}
+
+export function detailStatusBadgeVariant(status: string | undefined): StatusBadgeVariant {
+    if (status?.toUpperCase() === 'PENDING') {
+        return 'secondary';
+    }
+    return statusBadgeVariant(status);
 }
 
 export function isDuplicateUserError(message: string): boolean {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.spec.tsx
@@ -1,0 +1,421 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { UserDetailPage } from './UserDetailPage';
+import {
+    useEnvironmentRoleCatalog,
+    useOrganizationEnvironments,
+    useOrganizationRoleCatalog,
+    useOrganizationUser,
+    useOrganizationUserGroups,
+} from '../features/users/hooks/useOrganizationUser';
+import { useProcessUserRegistration, useUpdateOrganizationUserRoles } from '../features/users/hooks/useUserMutations';
+import type { OrganizationUser } from '../features/users/types/user';
+import { notify } from '../shared/notify';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('../features/users/hooks/useOrganizationUser', () => ({
+    useOrganizationUser: jest.fn(),
+    useOrganizationEnvironments: jest.fn(),
+    useOrganizationUserGroups: jest.fn(),
+    useOrganizationRoleCatalog: jest.fn(),
+    useEnvironmentRoleCatalog: jest.fn(),
+}));
+
+jest.mock('../features/users/hooks/useUserMutations', () => ({
+    useProcessUserRegistration: jest.fn(),
+    useUpdateOrganizationUserRoles: jest.fn(),
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseOrganizationUser = jest.mocked(useOrganizationUser);
+const mockUseOrganizationEnvironments = jest.mocked(useOrganizationEnvironments);
+const mockUseOrganizationUserGroups = jest.mocked(useOrganizationUserGroups);
+const mockUseOrganizationRoleCatalog = jest.mocked(useOrganizationRoleCatalog);
+const mockUseEnvironmentRoleCatalog = jest.mocked(useEnvironmentRoleCatalog);
+const mockUseProcessUserRegistration = jest.mocked(useProcessUserRegistration);
+const mockUseUpdateOrganizationUserRoles = jest.mocked(useUpdateOrganizationUserRoles);
+
+async function commitOrganizationRoleChange(user: ReturnType<typeof userEvent.setup>, roleLabel: string) {
+    await user.click(screen.getByRole('button', { name: 'Organization roles' }));
+    await user.click(screen.getByRole('checkbox', { name: roleLabel }));
+    await user.click(screen.getByRole('button', { name: 'Organization roles' }));
+}
+
+async function commitEnvironmentRoleChange(user: ReturnType<typeof userEvent.setup>, environmentName: string, roleLabel: string) {
+    await user.click(screen.getByRole('button', { name: `Environment roles for ${environmentName}` }));
+    await user.click(screen.getByRole('checkbox', { name: roleLabel }));
+    await user.click(screen.getByRole('button', { name: `Environment roles for ${environmentName}` }));
+}
+
+const DETAIL_USER: OrganizationUser = {
+    id: 'user-1',
+    displayName: 'Anna Schmidt',
+    email: 'anna.schmidt@swissport.com',
+    status: 'PENDING',
+    source: 'ldap',
+    hasPassword: false,
+    isServiceAccount: false,
+    created_at: Date.parse('2025-07-10'),
+    roles: [{ id: 'org-user', name: 'USER', scope: 'ORGANIZATION' }],
+    envRoles: {
+        prod: [{ id: 'env-api-user', name: 'API_USER' }],
+        staging: [
+            { id: 'env-api-user', name: 'API_USER' },
+            { id: 'env-api-publisher', name: 'API_PUBLISHER' },
+        ],
+    },
+    customFields: { department: 'Operations' },
+};
+
+function renderUserDetailPage() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return renderWithGraphene(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={['/users/user-1']}>
+                <Routes>
+                    <Route path="/users/:userId" element={<UserDetailPage />} />
+                </Routes>
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+}
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as typeof ResizeObserver;
+});
+
+describe('UserDetailPage', () => {
+    beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(false);
+        mockUseOrganizationUser.mockReturnValue({
+            data: DETAIL_USER,
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+        mockUseOrganizationEnvironments.mockReturnValue({
+            data: [
+                { id: 'prod', name: 'Production', description: 'Live production environment' },
+                { id: 'staging', name: 'Staging', description: 'Pre-production staging' },
+            ],
+            isLoading: false,
+        } as ReturnType<typeof useOrganizationEnvironments>);
+        mockUseOrganizationUserGroups.mockReturnValue({
+            data: [],
+            isLoading: false,
+        } as ReturnType<typeof useOrganizationUserGroups>);
+        mockUseOrganizationRoleCatalog.mockReturnValue({
+            data: [
+                { id: 'org-admin', name: 'ADMIN' },
+                { id: 'org-user', name: 'USER' },
+            ],
+            isLoading: false,
+        } as ReturnType<typeof useOrganizationRoleCatalog>);
+        mockUseEnvironmentRoleCatalog.mockReturnValue({
+            data: [
+                { id: 'env-api-user', name: 'API_USER' },
+                { id: 'env-api-publisher', name: 'API_PUBLISHER' },
+            ],
+            isLoading: false,
+        } as ReturnType<typeof useEnvironmentRoleCatalog>);
+        mockUseProcessUserRegistration.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as unknown as ReturnType<typeof useProcessUserRegistration>);
+        mockUseUpdateOrganizationUserRoles.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as unknown as ReturnType<typeof useUpdateOrganizationUserRoles>);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('shows loading placeholders while the user is loading', () => {
+        mockUseOrganizationUser.mockReturnValue({
+            data: undefined,
+            isLoading: true,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+
+        renderUserDetailPage();
+
+        expect(document.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+        expect(screen.queryByRole('heading', { name: 'Anna Schmidt' })).toBeNull();
+    });
+
+    it('disables role selectors for active users without update permission', async () => {
+        mockUseHasPermission.mockReturnValue(false);
+        mockUseOrganizationUser.mockReturnValue({
+            data: { ...DETAIL_USER, status: 'ACTIVE' },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+
+        renderUserDetailPage();
+
+        const organizationRolesButton = await screen.findByRole('button', { name: 'Organization roles' });
+        expect(organizationRolesButton).toHaveProperty('disabled', true);
+    });
+
+    it('submits an organization role update when roles are changed', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn();
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUser.mockReturnValue({
+            data: { ...DETAIL_USER, status: 'ACTIVE' },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+        mockUseUpdateOrganizationUserRoles.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useUpdateOrganizationUserRoles>);
+
+        renderUserDetailPage();
+        await screen.findByRole('heading', { name: 'Anna Schmidt' });
+
+        await commitOrganizationRoleChange(user, 'ADMIN');
+
+        await waitFor(() =>
+            expect(mutate).toHaveBeenCalledWith({ referenceType: 'ORGANIZATION', roles: ['org-user', 'org-admin'] }, expect.any(Object)),
+        );
+    });
+
+    it('submits an environment role update when environment roles are changed', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn();
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUser.mockReturnValue({
+            data: { ...DETAIL_USER, status: 'ACTIVE' },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+        mockUseUpdateOrganizationUserRoles.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useUpdateOrganizationUserRoles>);
+
+        renderUserDetailPage();
+        await screen.findByRole('heading', { name: 'Anna Schmidt' });
+
+        await commitEnvironmentRoleChange(user, 'Production', 'API_PUBLISHER');
+
+        await waitFor(() =>
+            expect(mutate).toHaveBeenCalledWith(
+                { referenceType: 'ENVIRONMENT', referenceId: 'prod', roles: ['env-api-user', 'env-api-publisher'] },
+                expect.any(Object),
+            ),
+        );
+    });
+
+    it('shows a success toast after registration is accepted', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn((_accepted: boolean, options?: { onSuccess?: () => void }) => options?.onSuccess?.());
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseProcessUserRegistration.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useProcessUserRegistration>);
+
+        renderUserDetailPage();
+
+        await user.click(await screen.findByRole('button', { name: 'Accept user registration' }));
+        await user.click(within(await screen.findByRole('dialog')).getByRole('button', { name: 'Accept' }));
+
+        await waitFor(() => expect(notify.success).toHaveBeenCalledWith('User "Anna Schmidt" has been accepted'));
+    });
+
+    it('renders profile metadata, role selectors, and an empty group memberships state', async () => {
+        renderUserDetailPage();
+
+        expect(await screen.findByRole('heading', { name: 'Anna Schmidt' })).toBeTruthy();
+        expect(screen.getByText('anna.schmidt@swissport.com')).toBeTruthy();
+        expect(screen.getByText('Pending')).toBeTruthy();
+        expect(screen.getByText('LDAP')).toBeTruthy();
+        expect(screen.getAllByText('Organization Roles').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByLabelText('Organization roles')).toBeTruthy();
+        expect(screen.getByText('department')).toBeTruthy();
+        expect(screen.getByText('Operations')).toBeTruthy();
+        expect(screen.getByText('Environment Roles')).toBeTruthy();
+        expect(screen.getByText('Production')).toBeTruthy();
+        expect(screen.getByLabelText('Environment roles for Staging')).toBeTruthy();
+        expect(screen.getByText('Not a member of any groups')).toBeTruthy();
+        expect(screen.queryByText('Password')).toBeNull();
+    });
+
+    it('disables role selectors for pending users even when update permission is granted', async () => {
+        mockUseHasPermission.mockReturnValue(true);
+        renderUserDetailPage();
+
+        const organizationRolesButton = await screen.findByRole('button', { name: 'Organization roles' });
+        const stagingRolesButton = screen.getByRole('button', { name: 'Environment roles for Staging' });
+
+        expect(organizationRolesButton).toHaveProperty('disabled', true);
+        expect(stagingRolesButton).toHaveProperty('disabled', true);
+    });
+
+    it('enables role selectors for active users with update permission', async () => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUser.mockReturnValue({
+            data: { ...DETAIL_USER, status: 'ACTIVE' },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+
+        renderUserDetailPage();
+
+        const organizationRolesButton = await screen.findByRole('button', { name: 'Organization roles' });
+        const stagingRolesButton = screen.getByRole('button', { name: 'Environment roles for Staging' });
+
+        expect(organizationRolesButton).toHaveProperty('disabled', false);
+        expect(stagingRolesButton).toHaveProperty('disabled', false);
+    });
+
+    it('lists group memberships when the user belongs to groups', async () => {
+        mockUseOrganizationUserGroups.mockReturnValue({
+            data: [
+                { id: 'group-1', name: 'Platform Admins' },
+                { id: 'group-2', name: 'API Owners' },
+            ],
+            isLoading: false,
+        } as ReturnType<typeof useOrganizationUserGroups>);
+
+        renderUserDetailPage();
+
+        expect(await screen.findByText('Platform Admins')).toBeTruthy();
+        expect(screen.getByText('API Owners')).toBeTruthy();
+        expect(screen.queryByText('Not a member of any groups')).toBeNull();
+    });
+
+    it('opens a confirmation dialog and submits accept registration after confirm', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn();
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseProcessUserRegistration.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useProcessUserRegistration>);
+
+        renderUserDetailPage();
+
+        await user.click(await screen.findByRole('button', { name: 'Accept user registration' }));
+        const dialog = await screen.findByRole('dialog');
+        expect(within(dialog).getByText(/accept the registration request of Anna Schmidt/i)).toBeTruthy();
+
+        await user.click(within(dialog).getByRole('button', { name: 'Accept' }));
+
+        await waitFor(() => expect(mutate).toHaveBeenCalledWith(true, expect.any(Object)));
+    });
+
+    it('opens a confirmation dialog and submits reject registration after confirm', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn();
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseProcessUserRegistration.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useProcessUserRegistration>);
+
+        renderUserDetailPage();
+
+        await user.click(await screen.findByRole('button', { name: 'Reject user registration' }));
+        const dialog = await screen.findByRole('dialog');
+        expect(within(dialog).getByText(/reject the registration request of Anna Schmidt/i)).toBeTruthy();
+
+        await user.click(within(dialog).getByRole('button', { name: 'Reject' }));
+
+        await waitFor(() => expect(mutate).toHaveBeenCalledWith(false, expect.any(Object)));
+    });
+
+    it('does not submit registration when the confirmation dialog is cancelled', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn();
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseProcessUserRegistration.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useProcessUserRegistration>);
+
+        renderUserDetailPage();
+
+        await user.click(await screen.findByRole('button', { name: 'Accept user registration' }));
+        await user.click(within(await screen.findByRole('dialog')).getByRole('button', { name: 'Cancel' }));
+
+        expect(screen.queryByRole('dialog')).toBeNull();
+        expect(mutate).not.toHaveBeenCalled();
+    });
+
+    it('shows registration actions for pending users when update permission is granted', async () => {
+        mockUseHasPermission.mockReturnValue(true);
+        renderUserDetailPage();
+
+        expect(await screen.findByText('Registration Pending')).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Accept user registration' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Reject user registration' })).toBeTruthy();
+    });
+
+    it('hides registration actions without update permission', async () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderUserDetailPage();
+
+        await screen.findByRole('heading', { name: 'Anna Schmidt' });
+        expect(screen.queryByText('Registration Pending')).toBeNull();
+    });
+
+    it('shows a not-found message when the user fails to load', async () => {
+        mockUseOrganizationUser.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+        } as ReturnType<typeof useOrganizationUser>);
+
+        renderUserDetailPage();
+
+        expect(await screen.findByText('User not found or failed to load.')).toBeTruthy();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.tsx
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Button, Skeleton } from '@gravitee/graphene-core';
+import { ArrowLeftIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { UserEnvironmentRolesCard } from '../features/users/components/UserEnvironmentRolesCard';
+import { UserGroupMembershipsCard } from '../features/users/components/UserGroupMembershipsCard';
+import { UserOrganizationRolesCard } from '../features/users/components/UserOrganizationRolesCard';
+import { UserProfileCard } from '../features/users/components/UserProfileCard';
+import { UserRegistrationPendingBanner } from '../features/users/components/UserRegistrationPendingBanner';
+import {
+    useEnvironmentRoleCatalog,
+    useOrganizationEnvironments,
+    useOrganizationRoleCatalog,
+    useOrganizationUser,
+    useOrganizationUserGroups,
+} from '../features/users/hooks/useOrganizationUser';
+import { useProcessUserRegistration, useUpdateOrganizationUserRoles } from '../features/users/hooks/useUserMutations';
+import { formatUserDisplayName, roleLabelsForIds } from '../features/users/utils/userDetailDisplay';
+import { ORGANIZATION_USER_UPDATE_PERMISSION } from '../features/users/utils/userPermissions';
+import { ConfirmDialog } from '../shared/components/ConfirmDialog';
+import { notify } from '../shared/notify';
+
+type RegistrationConfirmAction = 'accept' | 'reject';
+
+export function UserDetailPage() {
+    const { userId } = useParams<{ userId: string }>();
+    const navigate = useNavigate();
+    const canUpdate = useHasPermission({ anyOf: [ORGANIZATION_USER_UPDATE_PERMISSION] });
+    const [registrationConfirm, setRegistrationConfirm] = useState<RegistrationConfirmAction | null>(null);
+
+    const { data: user, isLoading: userLoading, isError: userError } = useOrganizationUser(userId);
+    const { data: environments = [], isLoading: environmentsLoading } = useOrganizationEnvironments();
+    const { data: groups = [], isLoading: groupsLoading } = useOrganizationUserGroups(userId);
+    const { data: organizationRoles = [], isLoading: organizationRolesLoading } = useOrganizationRoleCatalog();
+    const { data: environmentRoles = [], isLoading: environmentRolesLoading } = useEnvironmentRoleCatalog();
+    const processRegistration = useProcessUserRegistration(userId);
+    const updateUserRoles = useUpdateOrganizationUserRoles(userId);
+
+    const rolesEditable = canUpdate && user?.status?.toUpperCase() === 'ACTIVE';
+    const savingEnvironmentId =
+        updateUserRoles.isPending && updateUserRoles.variables?.referenceType === 'ENVIRONMENT'
+            ? updateUserRoles.variables.referenceId
+            : undefined;
+    const rolesSaving = updateUserRoles.isPending;
+
+    function handleProcessRegistration(accepted: boolean) {
+        processRegistration.mutate(accepted, {
+            onSuccess: () => {
+                setRegistrationConfirm(null);
+                const displayName = user ? formatUserDisplayName(user) : 'User';
+                notify.success(accepted ? `User "${displayName}" has been accepted` : `User "${displayName}" has been rejected`);
+            },
+            onError: error => {
+                notify.error(error, accepted ? 'Failed to accept registration.' : 'Failed to reject registration.');
+            },
+        });
+    }
+
+    function handleRegistrationConfirm() {
+        if (!registrationConfirm) return;
+        handleProcessRegistration(registrationConfirm === 'accept');
+    }
+
+    function handleOrganizationRolesChange(roleIds: string[]) {
+        return new Promise<void>((resolve, reject) => {
+            updateUserRoles.mutate(
+                { referenceType: 'ORGANIZATION', roles: roleIds },
+                {
+                    onSuccess: () => {
+                        const labels = roleLabelsForIds(roleIds, organizationRoles);
+                        if (labels.length === 1) {
+                            notify.success(`Role changed to ${labels[0]}`);
+                        } else {
+                            notify.success('Organization roles successfully updated');
+                        }
+                        resolve();
+                    },
+                    onError: error => {
+                        notify.error(error, 'Failed to update organization roles');
+                        reject(error);
+                    },
+                },
+            );
+        });
+    }
+
+    function handleEnvironmentRolesChange(environmentId: string, roleIds: string[]) {
+        return new Promise<void>((resolve, reject) => {
+            updateUserRoles.mutate(
+                { referenceType: 'ENVIRONMENT', referenceId: environmentId, roles: roleIds },
+                {
+                    onSuccess: () => {
+                        notify.success('Environment roles successfully updated');
+                        resolve();
+                    },
+                    onError: error => {
+                        notify.error(error, 'Failed to update environment roles');
+                        reject(error);
+                    },
+                },
+            );
+        });
+    }
+
+    if (userLoading) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-8 w-32" />
+                <Skeleton className="h-32 w-full rounded-xl" />
+                <Skeleton className="h-32 w-full rounded-xl" />
+                <Skeleton className="h-32 w-full rounded-xl" />
+            </div>
+        );
+    }
+
+    if (userError || !user) {
+        return (
+            <div className="space-y-4">
+                <Button type="button" variant="ghost" className="gap-1.5 px-0" onClick={() => navigate('..')}>
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                    Back to Users
+                </Button>
+                <p className="text-sm text-muted-foreground">User not found or failed to load.</p>
+            </div>
+        );
+    }
+
+    const showRegistrationBanner = canUpdate && user.status?.toUpperCase() === 'PENDING';
+    const userDisplayName = formatUserDisplayName(user);
+
+    return (
+        <div className="space-y-6">
+            <Button type="button" variant="ghost" className="gap-1.5 px-0 text-muted-foreground" asChild>
+                <Link to="..">
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                    Back to Users
+                </Link>
+            </Button>
+
+            <UserProfileCard user={user} />
+
+            {showRegistrationBanner ? (
+                <UserRegistrationPendingBanner
+                    isPending={processRegistration.isPending}
+                    onAccept={() => setRegistrationConfirm('accept')}
+                    onReject={() => setRegistrationConfirm('reject')}
+                />
+            ) : null}
+
+            {registrationConfirm ? (
+                <ConfirmDialog
+                    open
+                    onOpenChange={open => !open && !processRegistration.isPending && setRegistrationConfirm(null)}
+                    title="User registration"
+                    description={
+                        registrationConfirm === 'accept'
+                            ? `Are you sure you want to accept the registration request of ${userDisplayName}?`
+                            : `Are you sure you want to reject the registration request of ${userDisplayName}?`
+                    }
+                    confirmLabel={registrationConfirm === 'accept' ? 'Accept' : 'Reject'}
+                    pendingLabel={registrationConfirm === 'accept' ? 'Accepting…' : 'Rejecting…'}
+                    destructive={registrationConfirm === 'reject'}
+                    isPending={processRegistration.isPending}
+                    onConfirm={handleRegistrationConfirm}
+                />
+            ) : null}
+
+            <UserOrganizationRolesCard
+                user={user}
+                roles={organizationRoles}
+                loading={organizationRolesLoading}
+                disabled={!rolesEditable || rolesSaving}
+                saving={updateUserRoles.isPending && updateUserRoles.variables?.referenceType === 'ORGANIZATION'}
+                onRolesChange={handleOrganizationRolesChange}
+            />
+
+            <UserEnvironmentRolesCard
+                user={user}
+                environments={environments}
+                roles={environmentRoles}
+                loading={environmentsLoading || environmentRolesLoading}
+                disabled={!rolesEditable || rolesSaving}
+                savingEnvironmentId={savingEnvironmentId}
+                onEnvironmentRolesChange={handleEnvironmentRolesChange}
+            />
+
+            <UserGroupMembershipsCard groups={groups} loading={groupsLoading} />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UsersPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UsersPage.spec.tsx
@@ -17,6 +17,7 @@ import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { buttonHarness, inputHarness, renderWithGraphene } from '@gravitee/graphene-core/testing';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { UsersPage } from './UsersPage';
 import { useOrganizationUsers } from '../features/users/hooks/useOrganizationUsers';
@@ -73,7 +74,9 @@ function renderUsersPage() {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     return renderWithGraphene(
         <QueryClientProvider client={queryClient}>
-            <UsersPage />
+            <MemoryRouter>
+                <UsersPage />
+            </MemoryRouter>
         </QueryClientProvider>,
     );
 }
@@ -124,10 +127,19 @@ describe('UsersPage', () => {
         mockUseHasPermission.mockReturnValue(false);
         renderUsersPage();
 
-        expect(await screen.findByText('Jane Doe')).toBeTruthy();
+        expect(await screen.findByRole('link', { name: 'Jane Doe' })).toBeTruthy();
         expect(screen.getByText('john@company.com')).toBeTruthy();
         expect(screen.getByText('Gravitee')).toBeTruthy();
         expect(screen.getByText('Admin')).toBeTruthy();
+    });
+
+    it('links each user name to the user detail page', async () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderUsersPage();
+
+        const janeLink = await screen.findByRole('link', { name: 'Jane Doe' });
+        expect(janeLink.getAttribute('href')).toBe('/user-1');
+        expect(screen.getByRole('link', { name: 'John Doe' }).getAttribute('href')).toBe('/user-2');
     });
 
     it('hides Add User when the user lacks create permission', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/ConfirmDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/ConfirmDialog.spec.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ConfirmDialog } from './ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+    it('confirms a simple action', async () => {
+        const user = userEvent.setup();
+        const onConfirm = jest.fn();
+
+        render(
+            <ConfirmDialog
+                open
+                onOpenChange={() => {}}
+                title="Publish plan?"
+                description="This will make the plan available for subscriptions."
+                confirmLabel="Publish"
+                onConfirm={onConfirm}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Publish' }));
+
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the confirm button disabled until the keyword matches', async () => {
+        const user = userEvent.setup();
+        const onConfirm = jest.fn();
+
+        render(
+            <ConfirmDialog
+                open
+                onOpenChange={() => {}}
+                title="Delete application permanently?"
+                confirmLabel="Delete permanently"
+                destructive
+                confirmKeyword="payments-app"
+                onConfirm={onConfirm}
+            />,
+        );
+
+        const confirmButton = screen.getByRole('button', { name: 'Delete permanently' });
+        expect(confirmButton).toHaveProperty('disabled', true);
+
+        await user.type(screen.getByPlaceholderText('payments-app'), 'payments-app');
+        expect(confirmButton).toHaveProperty('disabled', false);
+
+        await user.click(confirmButton);
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables actions while pending and shows the pending label', () => {
+        render(
+            <ConfirmDialog
+                open
+                onOpenChange={() => {}}
+                title="Close plan?"
+                confirmLabel="Close"
+                pendingLabel="Closing…"
+                destructive
+                isPending
+                onConfirm={() => {}}
+            />,
+        );
+
+        expect(screen.getByRole('button', { name: 'Closing…' })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('button', { name: 'Cancel' })).toHaveProperty('disabled', true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/ConfirmDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/ConfirmDialog.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+} from '@gravitee/graphene-core';
+import { useEffect, useId, useState, type ReactNode } from 'react';
+
+export interface ConfirmDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    title: ReactNode;
+    description?: ReactNode;
+    confirmLabel: string;
+    /** Shown on the confirm button while the action is running (e.g. "Deleting…"). Defaults to `${confirmLabel}…`. */
+    pendingLabel?: string;
+    cancelLabel?: string;
+    destructive?: boolean;
+    isPending?: boolean;
+    /**
+     * When provided, the user must type this exact value to enable the confirm button (type-to-confirm).
+     * Use for irreversible actions (e.g. the API or product name).
+     */
+    confirmKeyword?: string;
+    /** Optional leading icon for the confirm button (e.g. a trash icon for destructive actions). */
+    icon?: ReactNode;
+    onConfirm: () => void;
+}
+
+/**
+ * Reusable confirmation dialog for platform pages.
+ *
+ * Errors are intentionally NOT rendered here: API failures from confirm/action dialogs are
+ * surfaced via `notify.error(...)` (toast-only), keeping this component purely presentational.
+ */
+export function ConfirmDialog({
+    open,
+    onOpenChange,
+    title,
+    description,
+    confirmLabel,
+    pendingLabel,
+    cancelLabel = 'Cancel',
+    destructive = false,
+    isPending = false,
+    confirmKeyword,
+    icon,
+    onConfirm,
+}: Readonly<ConfirmDialogProps>) {
+    const inputId = useId();
+    const [typed, setTyped] = useState('');
+
+    useEffect(() => {
+        if (!open) setTyped('');
+    }, [open]);
+
+    const keywordSatisfied = !confirmKeyword || typed === confirmKeyword;
+    const disabled = isPending || !keywordSatisfied;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent showCloseButton={false}>
+                <DialogHeader>
+                    <DialogTitle>{title}</DialogTitle>
+                    {description ? <DialogDescription>{description}</DialogDescription> : null}
+                </DialogHeader>
+                {confirmKeyword ? (
+                    <div className="space-y-2 py-2">
+                        <Label htmlFor={inputId} className="text-sm">
+                            Type <span className="font-mono font-semibold">{confirmKeyword}</span> to confirm
+                        </Label>
+                        <Input
+                            id={inputId}
+                            value={typed}
+                            onChange={e => setTyped(e.target.value)}
+                            placeholder={confirmKeyword}
+                            autoComplete="off"
+                        />
+                    </div>
+                ) : null}
+                <DialogFooter className="sm:justify-end">
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline" disabled={isPending}>
+                            {cancelLabel}
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" variant={destructive ? 'destructive' : 'default'} disabled={disabled} onClick={onConfirm}>
+                        {icon}
+                        {isPending ? (pendingLabel ?? `${confirmLabel}…`) : confirmLabel}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-83
https://gravitee.atlassian.net/browse/FOUND-84

## Description
Adds the organization **User Detail** page to Gamma Platform (`/users/:userId`), reachable from the users list.
- **Profile card** — name, email, status, source, organization roles summary, last login, created date, custom fields, service-account/owner badges
- **Pending registration** — accept/reject banner for admins with `organization-user-u`, with **ConfirmDialog** before submission (matches classic console flow)
- **Organization roles** — multi-select editor for `ACTIVE` users with update permission
- **Environment roles** — per-environment role table with multi-select editors for `ACTIVE` users
- **Group memberships** — read-only list of groups the user belongs to
- **Routing** — detail route under platform module users; list links navigate to detail


https://github.com/user-attachments/assets/89f1b4a5-6c06-437b-9cd1-3c857a9895b6
