### PR TITLE
chore(deps): bump gravitee-policy-apikey to 6.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>2.3.1</gravitee-alert-engine-connectors-ws.version>
         <gravitee-connector-http.version>5.0.9</gravitee-connector-http.version>
-        <gravitee-policy-apikey.version>6.0.1</gravitee-policy-apikey.version>
+        <gravitee-policy-apikey.version>6.0.2</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>3.2.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>3.1.1</gravitee-policy-assign-content.version>
         <gravitee-policy-assign-metrics.version>4.1.0</gravitee-policy-assign-metrics.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14651

**Description**

A null apiKeyHeader must mean "not configured on this plan" so the gateway-wide header setting can apply. Hardcoding X-Gravitee-Api-Key in ApiKeyPolicyConfiguration.DEFAULT broke that contract for any plan without an explicit security configuration.

**Additional context**
## Test scenarios (APIM-14651)

### Automated
- `ApiKeyPolicyTest#shouldCompleteWhenNullConfigurationAndGlobalCustomHeaderConfigured` — a plan with `null` security configuration now correctly falls through to the gateway-wide `policy.api-key.header` setting instead of being shadowed by a hardcoded default.

### Manual verification (gateway, live API with 3 published API_KEY plans, no selection rules)

| # | Plan config | Gateway `policy.api-key.header` | Request header | Expected | Verifies |
|---|---|---|---|---|---|
| 1 | none (`apiKeyHeader` unset) | unset | `X-Gravitee-Api-Key` | 200 | Default behavior unchanged when nothing is customized |
| 1b | none | unset | `X-Custom-Api-Key` | 401 | No unintended fallback when no custom header is configured anywhere |
| 2 | none | `X-Custom-Api-Key` | `X-Custom-Api-Key` | 200 | **Core fix** — gateway-wide header now honored for plans with no explicit config |
| 2b | none | `X-Custom-Api-Key` | `X-Gravitee-Api-Key` | 401 | Old default is correctly rejected once gateway-wide override is active — proves it isn't silently ignored (the original bug) |
<!-- Version placeholder -->


gravitee-policy-apikey : https://github.com/gravitee-io/gravitee-policy-apikey/pull/110