### PR TITLE
chore(deps): bump gravitee-gamma-module-aim to 1.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
     <gravitee-resource-ai-model-token-classification.version>2.0.0</gravitee-resource-ai-model-token-classification.version>
 
     <!-- Gamma plugins -->
-    <gravitee-gamma-module-aim.version>1.7.1</gravitee-gamma-module-aim.version>
+    <gravitee-gamma-module-aim.version>1.7.3</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.2.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>1.1.0</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.0.0</gravitee-gamma-module-esm.version>


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/GMA-956

## What

Bumps `gravitee-gamma-module-aim` from **1.7.1** to **1.7.3** on `4.12.x`.

## Why

1.7.2 and 1.7.3 carry the fix for the **Create API tool** wizard, which failed with *"Could not load APIs"* on APIM 4.12.13:

```
GET .../modules/aim/catalog/api-tools/sources?page=1&perPage=10

{ "message": "Pagination is not valid", "technicalCode": "pagination.invalid", "http_status": 400 }
```

The module shifted the requested page number by one (`PageableImpl(page + 1, perPage)`) before handing it to `ApiSearchService`, while both its own resource and `PageableImpl` are 1-based. Asking for page 1 therefore asked APIM for page 2, and `ApiSearchServiceImpl.getApiIdPageSubset` threw `PaginationInvalidException` as soon as the environment held fewer eligible APIs than `perPage`. Environments with more of them silently skipped a page worth of results.

Module-side fix: gravitee-io/gravitee-gamma-module-aim#590 (1.x), gravitee-io/gravitee-gamma-module-aim#589 (main).

## Scope

Single property change in the root `pom.xml`; `gravitee-apim-distribution` picks it up through `${gravitee-gamma-module-aim.version}`.

The equivalent bump for `master` (2.12.0 → 2.14.1) is handled separately — the `bump-from-module` workflow only targets `master`, which is why this one is opened by hand.
