### PR TITLE
feat: add default documentation pages for API Products

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -18,7 +18,7 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
-import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForApiNavigationItemsUseCase;
+import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForPortalNavigationItemsUseCase;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.BaseUpdatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi;
@@ -141,12 +141,12 @@ public interface PortalNavigationItemsMapper {
         return createPortalNavigationItems.stream().map(this::map).toList();
     }
 
-    default SeedDefaultPagesForApiNavigationItemsUseCase.Input mapSeedDefaultPagesInput(
+    default SeedDefaultPagesForPortalNavigationItemsUseCase.Input mapSeedDefaultPagesInput(
         String organizationId,
         String environmentId,
         SeedDefaultPagesRequest request
     ) {
-        return new SeedDefaultPagesForApiNavigationItemsUseCase.Input(
+        return new SeedDefaultPagesForPortalNavigationItemsUseCase.Input(
             organizationId,
             environmentId,
             request.getIds().stream().map(this::map).toList()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource.java
@@ -21,7 +21,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext
 import io.gravitee.apim.core.portal_page.use_case.BulkCreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
-import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForApiNavigationItemsUseCase;
+import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForPortalNavigationItemsUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.PortalNavigationItemsMapper;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItem;
@@ -70,7 +70,7 @@ public class PortalNavigationItemsResource extends AbstractResource {
     private ListPortalNavigationItemsUseCase listPortalNavigationItemsUseCase;
 
     @Inject
-    private SeedDefaultPagesForApiNavigationItemsUseCase seedDefaultPagesForApiNavigationItemsUseCase;
+    private SeedDefaultPagesForPortalNavigationItemsUseCase seedDefaultPagesForPortalNavigationItemsUseCase;
 
     private final PortalNavigationItemsMapper mapper = PortalNavigationItemsMapper.INSTANCE;
 
@@ -148,7 +148,7 @@ public class PortalNavigationItemsResource extends AbstractResource {
     public Response seedDefaultPages(@Valid @NotNull final SeedDefaultPagesRequest seedDefaultPagesRequest) {
         final var executionContext = GraviteeContext.getExecutionContext();
 
-        seedDefaultPagesForApiNavigationItemsUseCase.execute(
+        seedDefaultPagesForPortalNavigationItemsUseCase.execute(
             mapper.mapSeedDefaultPagesInput(
                 executionContext.getOrganizationId(),
                 executionContext.getEnvironmentId(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1091,8 +1091,10 @@ paths:
     post:
       tags:
         - Portal Navigation Items
-      summary: Seed default pages for API navigation items
-      description: User must have the ENVIRONMENT_DOCUMENTATION[create] permission.
+      summary: Seed default pages for portal navigation items
+      description: |
+        Seeds a default Overview page for API and API Product navigation items.
+        User must have the ENVIRONMENT_DOCUMENTATION[create] permission.
       operationId: seedDefaultPages
       requestBody:
         content:
@@ -1102,7 +1104,7 @@ paths:
         required: true
       responses:
         "204":
-          description: Default pages seeded
+          description: Default pages seeded for supported navigation items
         default:
           $ref: "#/components/responses/Error"
 
@@ -2622,7 +2624,7 @@ components:
 
     SeedDefaultPagesRequest:
       type: object
-      description: Portal navigation API item ids that should receive their default overview page
+      description: Portal navigation API or API Product item ids that should receive their default Overview page
       properties:
         ids:
           type: array

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_SeedDefaultPagesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_SeedDefaultPagesTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForApiNavigationItemsUseCase;
+import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForPortalNavigationItemsUseCase;
 import io.gravitee.rest.api.management.v2.rest.model.SeedDefaultPagesRequest;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
@@ -53,7 +53,7 @@ class PortalNavigationItemsResource_SeedDefaultPagesTest extends AbstractResourc
     private static final String ENVIRONMENT = "environment-id";
 
     @Inject
-    private SeedDefaultPagesForApiNavigationItemsUseCase seedDefaultPagesForApiNavigationItemsUseCase;
+    private SeedDefaultPagesForPortalNavigationItemsUseCase seedDefaultPagesForPortalNavigationItemsUseCase;
 
     @Inject
     private EnvironmentService environmentService;
@@ -89,7 +89,7 @@ class PortalNavigationItemsResource_SeedDefaultPagesTest extends AbstractResourc
     @AfterEach
     public void tearDown() {
         GraviteeContext.cleanContext();
-        Mockito.reset(seedDefaultPagesForApiNavigationItemsUseCase);
+        Mockito.reset(seedDefaultPagesForPortalNavigationItemsUseCase);
     }
 
     @Test
@@ -112,14 +112,14 @@ class PortalNavigationItemsResource_SeedDefaultPagesTest extends AbstractResourc
     @Test
     void should_seed_default_pages() {
         var request = new SeedDefaultPagesRequest().ids(List.of(UUID.fromString(API1_ID), UUID.fromString(API2_ID)));
-        when(seedDefaultPagesForApiNavigationItemsUseCase.execute(any())).thenReturn(
-            new SeedDefaultPagesForApiNavigationItemsUseCase.Output(List.of())
+        when(seedDefaultPagesForPortalNavigationItemsUseCase.execute(any())).thenReturn(
+            new SeedDefaultPagesForPortalNavigationItemsUseCase.Output(List.of())
         );
 
         Response response = target.request().post(json(request));
 
         assertThat(response).hasStatus(NO_CONTENT_204);
-        verify(seedDefaultPagesForApiNavigationItemsUseCase).execute(any());
+        verify(seedDefaultPagesForPortalNavigationItemsUseCase).execute(any());
     }
 
     @Test
@@ -129,6 +129,6 @@ class PortalNavigationItemsResource_SeedDefaultPagesTest extends AbstractResourc
         Response response = target.request().post(json(request));
 
         assertThat(response).hasStatus(BAD_REQUEST_400);
-        verifyNoInteractions(seedDefaultPagesForApiNavigationItemsUseCase);
+        verifyNoInteractions(seedDefaultPagesForPortalNavigationItemsUseCase);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -212,7 +212,7 @@ import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseC
 import io.gravitee.apim.core.portal_page.use_case.DeletePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
-import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForApiNavigationItemsUseCase;
+import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageContentConfigurationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageContentUseCase;
@@ -1367,8 +1367,8 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public SeedDefaultPagesForApiNavigationItemsUseCase seedDefaultPagesForApiNavigationItemsUseCase() {
-        return mock(SeedDefaultPagesForApiNavigationItemsUseCase.class);
+    public SeedDefaultPagesForPortalNavigationItemsUseCase seedDefaultPagesForPortalNavigationItemsUseCase() {
+        return mock(SeedDefaultPagesForPortalNavigationItemsUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationDefaultPageDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationDefaultPageDomainService.java
@@ -20,8 +20,9 @@ import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
-import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
@@ -36,11 +37,12 @@ import lombok.RequiredArgsConstructor;
 @DomainService
 @RequiredArgsConstructor
 @CustomLog
-public class PortalNavigationApiDefaultPageDomainService {
+public class PortalNavigationDefaultPageDomainService {
 
     private static final String DEFAULT_PAGE_TITLE = "Overview";
     private static final String DEFAULT_OVERVIEW_TEMPLATE = "api-overview-page-content.md";
     private static final String MCP_PROXY_OVERVIEW_TEMPLATE = "api-overview-mcp-proxy-page-content.md";
+    private static final String API_PRODUCT_OVERVIEW_TEMPLATE = "api-product-overview-page-content.md";
 
     private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
     private final PortalNavigationItemDomainService portalNavigationItemDomainService;
@@ -50,47 +52,37 @@ public class PortalNavigationApiDefaultPageDomainService {
     public List<PortalNavigationItemId> seedDefaultPages(
         String organizationId,
         String environmentId,
-        List<PortalNavigationItemId> apiNavigationItemIds
+        List<PortalNavigationItemId> navigationItemIds
     ) {
         var seededNavigationItemIds = new ArrayList<PortalNavigationItemId>();
 
-        for (var apiNavigationItemId : apiNavigationItemIds) {
+        for (var navigationItemId : navigationItemIds) {
             try {
-                if (seedDefaultPage(organizationId, environmentId, apiNavigationItemId)) {
-                    seededNavigationItemIds.add(apiNavigationItemId);
+                if (seedDefaultPage(organizationId, environmentId, navigationItemId)) {
+                    seededNavigationItemIds.add(navigationItemId);
                 }
             } catch (Exception e) {
-                log.warn(
-                    "Skipping default page seed for portal navigation item {} in environment {}",
-                    apiNavigationItemId,
-                    environmentId,
-                    e
-                );
+                log.warn("Skipping default page seed for portal navigation item {} in environment {}", navigationItemId, environmentId, e);
             }
         }
 
         return List.copyOf(seededNavigationItemIds);
     }
 
-    private boolean seedDefaultPage(String organizationId, String environmentId, PortalNavigationItemId apiNavigationItemId) {
-        var navigationItem = portalNavigationItemsQueryService.findByIdAndEnvironmentId(environmentId, apiNavigationItemId);
-        if (!(navigationItem instanceof PortalNavigationApi apiNavigationItem)) {
+    private boolean seedDefaultPage(String organizationId, String environmentId, PortalNavigationItemId navigationItemId) {
+        var navigationItem = portalNavigationItemsQueryService.findByIdAndEnvironmentId(environmentId, navigationItemId);
+        var templatePath = resolveTemplatePath(navigationItem);
+        if (templatePath == null) {
             return false;
         }
 
         var hasChildPage = portalNavigationItemsQueryService
-            .findByParentIdAndEnvironmentId(environmentId, apiNavigationItemId)
+            .findByParentIdAndEnvironmentId(environmentId, navigationItemId)
             .stream()
             .anyMatch(PortalNavigationPage.class::isInstance);
         if (hasChildPage) {
             return false;
         }
-
-        var templatePath = apiCrudService
-            .findById(apiNavigationItem.getApiId())
-            .filter(api -> ApiType.MCP_PROXY == api.getType())
-            .map(api -> MCP_PROXY_OVERVIEW_TEMPLATE)
-            .orElse(DEFAULT_OVERVIEW_TEMPLATE);
 
         var content = portalPageContentCrudService.create(
             GraviteeMarkdownPageContent.create(organizationId, environmentId, loadContent(templatePath))
@@ -102,17 +94,31 @@ public class PortalNavigationApiDefaultPageDomainService {
             CreatePortalNavigationItem.builder()
                 .title(DEFAULT_PAGE_TITLE)
                 .type(PortalNavigationItemType.PAGE)
-                .area(PortalArea.TOP_NAVBAR)
-                .parentId(apiNavigationItemId)
+                .area(navigationItem.getArea())
+                .parentId(navigationItemId)
                 .portalPageContentId(content.getId())
                 .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
                 .order(0)
                 .published(false)
-                .visibility(apiNavigationItem.getVisibility())
+                .visibility(navigationItem.getVisibility())
                 .build()
         );
 
         return true;
+    }
+
+    private String resolveTemplatePath(PortalNavigationItem navigationItem) {
+        if (navigationItem instanceof PortalNavigationApi apiNavigationItem) {
+            return apiCrudService
+                .findById(apiNavigationItem.getApiId())
+                .filter(api -> ApiType.MCP_PROXY == api.getType())
+                .map(api -> MCP_PROXY_OVERVIEW_TEMPLATE)
+                .orElse(DEFAULT_OVERVIEW_TEMPLATE);
+        }
+        if (navigationItem instanceof PortalNavigationApiProduct) {
+            return API_PRODUCT_OVERVIEW_TEMPLATE;
+        }
+        return null;
     }
 
     private String loadContent(String contentPath) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemUseCase.java
@@ -16,16 +16,18 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -35,7 +37,7 @@ public class BulkCreatePortalNavigationItemUseCase {
     private final PortalNavigationItemDomainService domainService;
     private final PortalNavigationItemValidatorService validatorService;
     private final PortalNavigationItemCreationExpansionDomainService creationExpansionDomainService;
-    private final PortalNavigationApiDefaultPageDomainService defaultPageDomainService;
+    private final PortalNavigationDefaultPageDomainService defaultPageDomainService;
     private final PortalNavigationItemSourceDomainService sourceDomainService;
 
     public Output execute(Input input) {
@@ -51,7 +53,11 @@ public class BulkCreatePortalNavigationItemUseCase {
             result.add(domainService.create(organizationId, environmentId, itemToCreate));
         }
 
-        defaultPageDomainService.seedDefaultPages(organizationId, environmentId, expansion.generatedApiNavigationItemIds());
+        var defaultPageNavigationItemIds = Stream.concat(
+            result.stream().filter(PortalNavigationApiProduct.class::isInstance).map(PortalNavigationItem::getId),
+            expansion.generatedApiNavigationItemIds().stream()
+        ).toList();
+        defaultPageDomainService.seedDefaultPages(organizationId, environmentId, defaultPageNavigationItemIds);
 
         var createdItems = expansion.selectRequestedItems(result);
         createdItems

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCase.java
@@ -16,15 +16,17 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -34,7 +36,7 @@ public class CreatePortalNavigationItemUseCase {
     private final PortalNavigationItemDomainService domainService;
     private final PortalNavigationItemValidatorService validatorService;
     private final PortalNavigationItemCreationExpansionDomainService creationExpansionDomainService;
-    private final PortalNavigationApiDefaultPageDomainService defaultPageDomainService;
+    private final PortalNavigationDefaultPageDomainService defaultPageDomainService;
     private final PortalNavigationItemSourceDomainService sourceDomainService;
 
     public Output execute(Input input) {
@@ -49,7 +51,11 @@ public class CreatePortalNavigationItemUseCase {
             createdItems.add(domainService.create(organizationId, environmentId, itemToCreate));
         }
 
-        defaultPageDomainService.seedDefaultPages(organizationId, environmentId, expansion.generatedApiNavigationItemIds());
+        var defaultPageNavigationItemIds = Stream.concat(
+            createdItems.stream().filter(PortalNavigationApiProduct.class::isInstance).map(PortalNavigationItem::getId),
+            expansion.generatedApiNavigationItemIds().stream()
+        ).toList();
+        defaultPageDomainService.seedDefaultPages(organizationId, environmentId, defaultPageNavigationItemIds);
 
         var createdItem = expansion.selectRequestedItems(createdItems).getFirst();
         if (createdItem.getSource() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForPortalNavigationItemsUseCase.java
@@ -16,24 +16,24 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
-public class SeedDefaultPagesForApiNavigationItemsUseCase {
+public class SeedDefaultPagesForPortalNavigationItemsUseCase {
 
-    private final PortalNavigationApiDefaultPageDomainService defaultPageDomainService;
+    private final PortalNavigationDefaultPageDomainService defaultPageDomainService;
 
     public Output execute(Input input) {
         return new Output(
-            defaultPageDomainService.seedDefaultPages(input.organizationId(), input.environmentId(), input.apiNavigationItemIds())
+            defaultPageDomainService.seedDefaultPages(input.organizationId(), input.environmentId(), input.navigationItemIds())
         );
     }
 
-    public record Input(String organizationId, String environmentId, List<PortalNavigationItemId> apiNavigationItemIds) {}
+    public record Input(String organizationId, String environmentId, List<PortalNavigationItemId> navigationItemIds) {}
 
     public record Output(List<PortalNavigationItemId> seededNavigationItemIds) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/api-product-overview-page-content.md
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/api-product-overview-page-content.md
@@ -1,0 +1,22 @@
+# API Product overview
+
+Use this page to introduce the API Product, explain the business capability it provides, and help consumers choose the APIs they need.
+
+## About this product
+
+Describe the problem this API Product solves, its intended audience, and the main use cases it supports.
+
+## Included APIs
+
+Summarize how the APIs in this product work together. Add links to important API documentation, integration guides, or examples where appropriate.
+
+## Get started
+
+1. Explore the APIs included in this product.
+2. Review the available plans and access requirements.
+3. Subscribe with an application.
+4. Follow the API documentation to complete the integration.
+
+## Customize this page
+
+Replace this starter content with product-specific guidance, prerequisites, support information, and links to related resources.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemsUseCaseTest.java
@@ -38,7 +38,7 @@ import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
@@ -46,6 +46,7 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedI
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
@@ -66,7 +67,7 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
     private PortalNavigationItemsQueryServiceInMemory queryService;
     private PortalNavigationItemValidatorService validatorService;
     private PortalNavigationItemCreationExpansionDomainService creationExpansionDomainService;
-    private PortalNavigationApiDefaultPageDomainService defaultPageDomainService;
+    private PortalNavigationDefaultPageDomainService defaultPageDomainService;
     private ApiProductQueryServiceInMemory apiProductQueryService;
     private ApiCrudServiceInMemory apiCrudService;
 
@@ -96,7 +97,7 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
             new PortalNavigationItemSourceDomainServiceInMemory()
         );
         creationExpansionDomainService = new PortalNavigationItemCreationExpansionDomainService(apiProductQueryService, apiCrudService);
-        defaultPageDomainService = new PortalNavigationApiDefaultPageDomainService(
+        defaultPageDomainService = new PortalNavigationDefaultPageDomainService(
             queryService,
             domainService,
             pageContentCrudService,
@@ -113,7 +114,7 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
     }
 
     @Test
-    void should_bootstrap_multiple_products_with_default_api_pages_and_return_only_requested_roots_in_request_order() {
+    void should_bootstrap_multiple_products_with_default_product_and_api_pages_and_return_only_requested_roots_in_request_order() {
         apiProductQueryService.initWith(
             List.of(
                 ApiProduct.builder().id("product-1").environmentId(ENV_ID).apiIds(Set.of("shared-api")).build(),
@@ -129,20 +130,25 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
         assertThat(output.items())
             .extracting(item -> ((io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct) item).getApiProductId())
             .containsExactly("product-1", "product-2");
-        assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, output.items().get(0).getId()))
+        assertDefaultProductAndApiPages(output.items().get(0).getId());
+        assertDefaultProductAndApiPages(output.items().get(1).getId());
+    }
+
+    @Test
+    void should_create_default_product_page_when_product_has_no_apis() {
+        apiProductQueryService.initWith(List.of(ApiProduct.builder().id("product-1").environmentId(ENV_ID).apiIds(Set.of()).build()));
+        var product = productItem("product-1", "Product without APIs", 0);
+
+        var output = useCase.execute(new BulkCreatePortalNavigationItemUseCase.Input(ORG_ID, ENV_ID, List.of(product)));
+
+        assertThat(output.items()).singleElement();
+        assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, output.items().getFirst().getId()))
             .singleElement()
-            .satisfies(apiItem ->
-                assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, apiItem.getId()))
-                    .singleElement()
-                    .isInstanceOfSatisfying(PortalNavigationPage.class, page -> assertThat(page.getTitle()).isEqualTo("Overview"))
-            );
-        assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, output.items().get(1).getId()))
-            .singleElement()
-            .satisfies(apiItem ->
-                assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, apiItem.getId()))
-                    .singleElement()
-                    .isInstanceOfSatisfying(PortalNavigationPage.class, page -> assertThat(page.getTitle()).isEqualTo("Overview"))
-            );
+            .isInstanceOfSatisfying(PortalNavigationPage.class, page -> {
+                assertThat(page.getTitle()).isEqualTo("Overview");
+                assertThat(page.getOrder()).isZero();
+                assertThat(page.getPublished()).isFalse();
+            });
     }
 
     @Test
@@ -245,7 +251,7 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
         var domainService = mock(PortalNavigationItemDomainService.class);
         var validatorService = mock(PortalNavigationItemValidatorService.class);
         var creationExpansionDomainService = mock(PortalNavigationItemCreationExpansionDomainService.class);
-        var defaultPageDomainService = mock(PortalNavigationApiDefaultPageDomainService.class);
+        var defaultPageDomainService = mock(PortalNavigationDefaultPageDomainService.class);
         var rootId = PortalNavigationItemId.random();
         var root = productItem("product-1", "Product", 0).toBuilder().id(rootId).build();
         var firstChild = CreatePortalNavigationItem.builder()
@@ -294,5 +300,26 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
             .order(order)
             .parentId(PortalNavigationItemId.of(APIS_ID))
             .build();
+    }
+
+    private void assertDefaultProductAndApiPages(PortalNavigationItemId productNavigationItemId) {
+        var productChildren = queryService.findByParentIdAndEnvironmentId(ENV_ID, productNavigationItemId);
+        assertThat(productChildren)
+            .filteredOn(PortalNavigationPage.class::isInstance)
+            .singleElement()
+            .satisfies(page -> {
+                assertThat(page.getTitle()).isEqualTo("Overview");
+                assertThat(page.getOrder()).isZero();
+                assertThat(page.getPublished()).isFalse();
+            });
+        assertThat(productChildren)
+            .filteredOn(PortalNavigationApi.class::isInstance)
+            .singleElement()
+            .satisfies(apiItem -> {
+                assertThat(apiItem.getOrder()).isEqualTo(1);
+                assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, apiItem.getId()))
+                    .singleElement()
+                    .isInstanceOfSatisfying(PortalNavigationPage.class, page -> assertThat(page.getTitle()).isEqualTo("Overview"));
+            });
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
@@ -34,7 +34,7 @@ import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
@@ -44,6 +44,7 @@ import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
@@ -102,7 +103,7 @@ class CreatePortalNavigationItemUseCaseTest {
             new PortalNavigationItemSourceDomainServiceInMemory()
         );
         creationExpansionDomainService = new PortalNavigationItemCreationExpansionDomainService(apiProductQueryService, apiCrudService);
-        var defaultPageDomainService = new PortalNavigationApiDefaultPageDomainService(
+        var defaultPageDomainService = new PortalNavigationDefaultPageDomainService(
             queryService,
             domainService,
             pageContentCrudService,
@@ -144,19 +145,30 @@ class CreatePortalNavigationItemUseCaseTest {
         assertThat(output.item().getType()).isEqualTo(PortalNavigationItemType.API_PRODUCT);
         var children = queryService.findByParentIdAndEnvironmentId(ENV_ID, output.item().getId());
         assertThat(children)
-            .extracting(item -> ((io.gravitee.apim.core.portal_page.model.PortalNavigationApi) item).getApiId())
+            .filteredOn(PortalNavigationApi.class::isInstance)
+            .extracting(item -> ((PortalNavigationApi) item).getApiId())
             .containsExactly("api-1", "api-2");
-        assertThat(children).allSatisfy(apiItem ->
-            assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, apiItem.getId()))
-                .singleElement()
-                .isInstanceOfSatisfying(PortalNavigationPage.class, page -> {
-                    assertThat(page.getTitle()).isEqualTo("Overview");
-                    assertThat(page.getPublished()).isFalse();
-                    assertThat(page.getParentId()).isEqualTo(apiItem.getId());
-                })
-        );
+        assertThat(children)
+            .filteredOn(PortalNavigationPage.class::isInstance)
+            .singleElement()
+            .satisfies(page -> {
+                assertThat(page.getTitle()).isEqualTo("Overview");
+                assertThat(page.getPublished()).isFalse();
+                assertThat(page.getParentId()).isEqualTo(output.item().getId());
+            });
+        assertThat(children)
+            .filteredOn(PortalNavigationApi.class::isInstance)
+            .allSatisfy(apiItem ->
+                assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, apiItem.getId()))
+                    .singleElement()
+                    .isInstanceOfSatisfying(PortalNavigationPage.class, page -> {
+                        assertThat(page.getTitle()).isEqualTo("Overview");
+                        assertThat(page.getPublished()).isFalse();
+                        assertThat(page.getParentId()).isEqualTo(apiItem.getId());
+                    })
+            );
         assertThat(pageContentCrudService.storage())
-            .hasSize(2)
+            .hasSize(3)
             .allSatisfy(content -> assertThat(content).isInstanceOf(GraviteeMarkdownPageContent.class));
     }
 
@@ -172,7 +184,7 @@ class CreatePortalNavigationItemUseCaseTest {
                 throw new IllegalStateException("page content persistence failure");
             }
         };
-        var failingDefaultPageDomainService = new PortalNavigationApiDefaultPageDomainService(
+        var failingDefaultPageDomainService = new PortalNavigationDefaultPageDomainService(
             queryService,
             domainService,
             failingPageContentCrudService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForPortalNavigationItemsUseCaseTest.java
@@ -17,9 +17,11 @@ package io.gravitee.apim.core.portal_page.use_case;
 
 import static fixtures.core.model.PortalNavigationItemFixtures.API1_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.APIS_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.API_PRODUCT_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.ENV_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.ORG_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiCrudServiceInMemory;
@@ -29,16 +31,19 @@ import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.definition.model.v4.ApiType;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -46,9 +51,9 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
+class SeedDefaultPagesForPortalNavigationItemsUseCaseTest {
 
-    private SeedDefaultPagesForApiNavigationItemsUseCase useCase;
+    private SeedDefaultPagesForPortalNavigationItemsUseCase useCase;
     private ApiCrudServiceInMemory apiCrudService;
     private PortalNavigationItemsCrudServiceInMemory portalNavigationItemsCrudService;
     private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
@@ -66,8 +71,8 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
 
         portalNavigationItemsQueryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
 
-        useCase = new SeedDefaultPagesForApiNavigationItemsUseCase(
-            new PortalNavigationApiDefaultPageDomainService(
+        useCase = new SeedDefaultPagesForPortalNavigationItemsUseCase(
+            new PortalNavigationDefaultPageDomainService(
                 portalNavigationItemsQueryService,
                 new PortalNavigationItemDomainService(
                     portalNavigationItemsCrudService,
@@ -86,7 +91,7 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
     @Test
     void should_seed_default_overview_page_for_api() {
         var output = useCase.execute(
-            new SeedDefaultPagesForApiNavigationItemsUseCase.Input(ORG_ID, ENV_ID, List.of(PortalNavigationItemId.of(API1_ID)))
+            new SeedDefaultPagesForPortalNavigationItemsUseCase.Input(ORG_ID, ENV_ID, List.of(PortalNavigationItemId.of(API1_ID)))
         );
 
         assertThat(output.seededNavigationItemIds()).containsExactly(PortalNavigationItemId.of(API1_ID));
@@ -101,6 +106,63 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
             .singleElement()
             .isInstanceOfSatisfying(GraviteeMarkdownPageContent.class, content ->
                 assertThat(content.getContent().value()).isEqualTo(loadTemplate("api-overview-page-content.md"))
+            );
+    }
+
+    @Test
+    void should_seed_default_overview_page_before_generated_apis_for_api_product() {
+        var parent = (PortalNavigationFolder) portalNavigationItemsQueryService.findByIdAndEnvironmentId(
+            ENV_ID,
+            PortalNavigationItemId.of(APIS_ID)
+        );
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            API_PRODUCT_ID,
+            "My API Product",
+            parent.getId(),
+            "00000000-0000-0000-0000-000000000019"
+        )
+            .toBuilder()
+            .visibility(PortalVisibility.PRIVATE)
+            .build();
+        apiProduct.updateParent(parent);
+        var generatedApi = PortalNavigationItemFixtures.anApi(
+            "00000000-0000-0000-0000-000000000020",
+            "Generated API",
+            apiProduct.getId(),
+            "api-1"
+        );
+        generatedApi.setVisibility(PortalVisibility.PRIVATE);
+        generatedApi.setOrder(0);
+        generatedApi.updateParent(apiProduct);
+        portalNavigationItemsCrudService.create(apiProduct);
+        portalNavigationItemsCrudService.create(generatedApi);
+
+        var output = useCase.execute(
+            new SeedDefaultPagesForPortalNavigationItemsUseCase.Input(ORG_ID, ENV_ID, List.of(apiProduct.getId()))
+        );
+
+        assertThat(output.seededNavigationItemIds()).containsExactly(apiProduct.getId());
+        assertThat(
+            portalNavigationItemsQueryService
+                .findByParentIdAndEnvironmentId(ENV_ID, apiProduct.getId())
+                .stream()
+                .sorted(Comparator.comparing(PortalNavigationItem::getOrder))
+                .toList()
+        )
+            .extracting(
+                PortalNavigationItem::getTitle,
+                PortalNavigationItem::getOrder,
+                PortalNavigationItem::getPublished,
+                PortalNavigationItem::getVisibility
+            )
+            .containsExactly(
+                tuple("Overview", 0, false, PortalVisibility.PRIVATE),
+                tuple("Generated API", 1, true, PortalVisibility.PRIVATE)
+            );
+        assertThat(portalPageContentCrudService.storage())
+            .singleElement()
+            .isInstanceOfSatisfying(GraviteeMarkdownPageContent.class, content ->
+                assertThat(content.getContent().value()).isEqualTo(loadTemplate("api-product-overview-page-content.md"))
             );
     }
 
@@ -120,10 +182,44 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
         portalNavigationItemsCrudService.create(existingPage);
 
         var output = useCase.execute(
-            new SeedDefaultPagesForApiNavigationItemsUseCase.Input(ORG_ID, ENV_ID, List.of(PortalNavigationItemId.of(API1_ID)))
+            new SeedDefaultPagesForPortalNavigationItemsUseCase.Input(ORG_ID, ENV_ID, List.of(PortalNavigationItemId.of(API1_ID)))
         );
 
         assertThat(output.seededNavigationItemIds()).isEmpty();
+        assertThat(portalPageContentCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_skip_seeding_when_api_product_already_has_a_child_page() {
+        var parent = (PortalNavigationFolder) portalNavigationItemsQueryService.findByIdAndEnvironmentId(
+            ENV_ID,
+            PortalNavigationItemId.of(APIS_ID)
+        );
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct(
+            API_PRODUCT_ID,
+            "My API Product",
+            parent.getId(),
+            "00000000-0000-0000-0000-000000000019"
+        );
+        apiProduct.updateParent(parent);
+        var existingPage = PortalNavigationItemFixtures.aPage(
+            "00000000-0000-0000-0000-000000000020",
+            "Existing page",
+            apiProduct.getId(),
+            PortalPageContentId.random()
+        );
+        existingPage.updateParent(apiProduct);
+        portalNavigationItemsCrudService.create(apiProduct);
+        portalNavigationItemsCrudService.create(existingPage);
+
+        var output = useCase.execute(
+            new SeedDefaultPagesForPortalNavigationItemsUseCase.Input(ORG_ID, ENV_ID, List.of(apiProduct.getId()))
+        );
+
+        assertThat(output.seededNavigationItemIds()).isEmpty();
+        assertThat(portalNavigationItemsQueryService.findByParentIdAndEnvironmentId(ENV_ID, apiProduct.getId())).containsExactly(
+            existingPage
+        );
         assertThat(portalPageContentCrudService.storage()).isEmpty();
     }
 
@@ -132,7 +228,7 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
         apiCrudService.initWith(List.of(Api.builder().id("api-1").name("MCP API").version("1.0.0").type(ApiType.MCP_PROXY).build()));
 
         var output = useCase.execute(
-            new SeedDefaultPagesForApiNavigationItemsUseCase.Input(ORG_ID, ENV_ID, List.of(PortalNavigationItemId.of(API1_ID)))
+            new SeedDefaultPagesForPortalNavigationItemsUseCase.Input(ORG_ID, ENV_ID, List.of(PortalNavigationItemId.of(API1_ID)))
         );
 
         assertThat(output.seededNavigationItemIds()).containsExactly(PortalNavigationItemId.of(API1_ID));
@@ -144,9 +240,9 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
     }
 
     @Test
-    void should_skip_navigation_items_that_are_not_api_type() {
+    void should_skip_navigation_items_that_do_not_support_default_pages() {
         var output = useCase.execute(
-            new SeedDefaultPagesForApiNavigationItemsUseCase.Input(
+            new SeedDefaultPagesForPortalNavigationItemsUseCase.Input(
                 ORG_ID,
                 ENV_ID,
                 List.of(PortalNavigationItemId.of(APIS_ID), PortalNavigationItemId.of(API1_ID))


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-96

## Description

Add automatic creation of a default Overview documentation page for API Products.

The implementation extends the default-page mechanism introduced for APIs and integrates it with the backend `_bulk` navigation flow.

## Changes

- Generalize the default-page domain service to support APIs and API Products.
- Create an unpublished Gravitee Markdown `Overview` page for each newly created API Product.
- Add the API Product Overview content template.
- Preserve API-specific templates, including MCP Proxy support.
- Keep page creation idempotent when a product already has a child page.
- Seed API Product and generated API pages automatically during bulk navigation creation.
- Update the Management API contract and resource integration.
- Add focused domain, bulk-creation, and REST resource tests.

## Stacked PR

This PR is based on the PORTAL-97 implementation, which creates default Overview pages for APIs generated under API Products.

https://github.com/user-attachments/assets/0b979dd0-2f62-4994-a39b-ac8c1503cfd0



