### PR TITLE
fix(build): move nx cache out of target into a per-module root cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ gravitee-apim-distribution/gravitee-apim-distribution-e2e/ui-test/screenshots/
 .flattened-pom.xml
 
 # Nx
-.nx/cache
+**/.nx/cache*
 .nx/workspace-data
 .nx/polygraph
 .cursor/rules/nx-rules.mdc

--- a/gravitee-gamma/gravitee-gamma-module-apim/pom.xml
+++ b/gravitee-gamma/gravitee-gamma-module-apim/pom.xml
@@ -115,7 +115,7 @@
                             <environmentVariables>
                                 <NX_DAEMON>false</NX_DAEMON>
                                 <NODE_OPTIONS>--max-old-space-size=4096</NODE_OPTIONS>
-                                <NX_CACHE_DIRECTORY>${project.build.directory}/.nx/cache</NX_CACHE_DIRECTORY>
+                                <NX_CACHE_DIRECTORY>${maven.multiModuleProjectDirectory}/.nx/cache-${project.artifactId}</NX_CACHE_DIRECTORY>
                             </environmentVariables>
                             <arguments>
                                 <argument>nx</argument>

--- a/gravitee-gamma/gravitee-gamma-module-platform/pom.xml
+++ b/gravitee-gamma/gravitee-gamma-module-platform/pom.xml
@@ -227,7 +227,7 @@
                             <environmentVariables>
                                 <NX_DAEMON>false</NX_DAEMON>
                                 <NODE_OPTIONS>--max-old-space-size=4096</NODE_OPTIONS>
-                                <NX_CACHE_DIRECTORY>${project.build.directory}/.nx/cache</NX_CACHE_DIRECTORY>
+                                <NX_CACHE_DIRECTORY>${maven.multiModuleProjectDirectory}/.nx/cache-${project.artifactId}</NX_CACHE_DIRECTORY>
                             </environmentVariables>
                             <arguments>
                                 <argument>nx</argument>


### PR DESCRIPTION
## Description

The Nx cache used by the `gravitee-gamma-module-apim` and `gravitee-gamma-module-platform` frontend builds was stored under `${project.build.directory}/.nx/cache`, so every `mvn clean` wiped it and the two modules could collide when built concurrently.

It now points to `${maven.multiModuleProjectDirectory}/.nx/cache-${project.artifactId}`: one cache per module, at the reactor root, surviving `clean`.

The `.gitignore` Nx entry becomes `**/.nx/cache*` so the new suffixed directories are ignored, including when Maven is invoked from a module directory (there is no `.mvn/` at the repo root, so `maven.multiModuleProjectDirectory` falls back to the invocation cwd).

## Test plan

- `git check-ignore` confirms `.nx/cache`, `.nx/cache-<artifactId>/` and `<module>/.nx/cache-<artifactId>/` are all ignored.
- Build the gamma modules twice with a `mvn clean` in between and verify the second Nx run hits the cache.
