### PR TITLE
fix(ci): look up the bumped version property in the distribution pom

### DIFF
--- a/.github/workflows/bump-from-module.yml
+++ b/.github/workflows/bump-from-module.yml
@@ -48,7 +48,7 @@ jobs:
                   token: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
                   ref: master
 
-            - name: Update version property in pom.xml
+            - name: Update version property
               env:
                   MODULE: ${{ inputs.module }}
                   VERSION: ${{ inputs.version }}
@@ -58,17 +58,23 @@ jobs:
                   module  = os.environ['MODULE']
                   version = os.environ['VERSION']
                   prop    = f'{module}.version'
-                  content = open('pom.xml').read()
                   pattern = rf'<{re.escape(prop)}>[^<]+</{re.escape(prop)}>'
-                  if not re.search(pattern, content):
-                      print(f'ERROR: <{prop}> not found in pom.xml', file=sys.stderr)
+                  # Bundled plugin versions live in the distribution pom; engine and third-party
+                  # ones stay in the root pom. Look in both, distribution first.
+                  candidates = ['gravitee-apim-distribution/pom.xml', 'pom.xml']
+                  target = next((p for p in candidates if re.search(pattern, open(p).read())), None)
+                  if target is None:
+                      print('ERROR: <' + prop + '> not found in ' + ' or '.join(candidates), file=sys.stderr)
                       sys.exit(1)
+                  content = open(target).read()
                   new_content = re.sub(pattern, f'<{prop}>{version}</{prop}>', content)
                   if new_content != content:
-                      open('pom.xml', 'w').write(new_content)
-                      print(f'Updated <{prop}> to {version}')
+                      open(target, 'w').write(new_content)
+                      print(f'Updated <{prop}> to {version} in {target}')
                   else:
-                      print(f'Already at {version}, nothing to update')
+                      print(f'Already at {version} in {target}, nothing to update')
+                  with open(os.environ['GITHUB_ENV'], 'a') as fh:
+                      fh.write(f'POM_FILE={target}\n')
                   "
 
             - name: Create or update version-bump PR
@@ -84,7 +90,7 @@ jobs:
                   git config user.email "github-actions[bot]@users.noreply.github.com"
 
                   git checkout -B "$BRANCH"
-                  git add pom.xml
+                  git add "${POM_FILE:-pom.xml}"
 
                   if git diff --cached --quiet; then
                     :


### PR DESCRIPTION
## Issue

N/A

## Description

Follow-up fix to the distribution refactor: the **Bump Gamma module version** workflow
(`.github/workflows/bump-from-module.yml`) has been broken since the bundled-plugin version
catalog moved from the root `pom.xml` to `gravitee-apim-distribution/pom.xml`.

The step read the root pom with a hardcoded `open('pom.xml')`, so it now exits with
`ERROR: <gravitee-gamma-module-*.version> not found in pom.xml` for every module bump.

The property is now looked up in **both** poms — the distribution one first, since that is where
bundled plugin versions live, then the root pom which still holds the engine and third-party
versions. The workflow input is a generic Maven artifact ID, so searching both keeps it correct
whichever pom owns the property.

The resolved file is exported as `POM_FILE` and the commit step stages that file instead of a
hardcoded `pom.xml`. Without this second change the workflow would have silently opened an empty
PR — worse than the current visible failure.

## Additional context

Verified locally by extracting the workflow's Python step and running it against the real poms:

| Case | Result |
|---|---|
| `gravitee-gamma-module-aim` (moved to the catalog) | updates `gravitee-apim-distribution/pom.xml`, `POM_FILE` set accordingly |
| `gravitee-connector-http` (still in the root pom) | updates `pom.xml`, `POM_FILE` set accordingly |
| Unknown module | clear error naming both poms, exit code 1 |
| Version already applied | idempotent, no commit (existing `git diff --cached --quiet` guard) |

The workflow YAML still parses and keeps its three steps.

The other GitHub workflows were audited at the same time and need no change: `run-e2e-tests`,
`publish-images-for-test-env` and `trigger-gko-apim-rollout` only POST to the CircleCI API, and
`remove-ready-to-test-labels` only calls the GitHub API. Renovate is unaffected too — its only
`fileMatch` targets the CircleCI manager, while the Maven manager discovers every `pom.xml`.
