### PR TITLE
fix: seed API Product API Overview pages on single-item creation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCase.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
@@ -32,6 +33,7 @@ public class CreatePortalNavigationItemUseCase {
     private final PortalNavigationItemDomainService domainService;
     private final PortalNavigationItemValidatorService validatorService;
     private final PortalNavigationItemCreationExpansionDomainService creationExpansionDomainService;
+    private final PortalNavigationApiDefaultPageDomainService defaultPageDomainService;
 
     public Output execute(Input input) {
         final var organizationId = input.organizationId();
@@ -44,6 +46,8 @@ public class CreatePortalNavigationItemUseCase {
         for (var itemToCreate : expansion.itemsToCreate()) {
             createdItems.add(domainService.create(organizationId, environmentId, itemToCreate));
         }
+
+        defaultPageDomainService.seedDefaultPages(organizationId, environmentId, expansion.generatedApiNavigationItemIds());
 
         return new CreatePortalNavigationItemUseCase.Output(expansion.selectRequestedItems(createdItems).getFirst());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
@@ -33,6 +33,7 @@ import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
@@ -45,6 +46,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.ArrayList;
@@ -68,6 +70,8 @@ class CreatePortalNavigationItemUseCaseTest {
     private PortalNavigationItemsCrudServiceInMemory crudService;
     private PortalNavigationItemsQueryServiceInMemory queryService;
     private PortalPageContentCrudServiceInMemory pageContentCrudService;
+    private PortalNavigationItemValidatorService validatorService;
+    private PortalNavigationItemCreationExpansionDomainService creationExpansionDomainService;
     private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
 
@@ -81,23 +85,27 @@ class CreatePortalNavigationItemUseCaseTest {
         PortalPageContentQueryServiceInMemory pageContentQueryService = new PortalPageContentQueryServiceInMemory(
             pageContentCrudService.storage()
         );
-        PortalNavigationItemValidatorService validatorService = new PortalNavigationItemValidatorService(
-            queryService,
-            pageContentQueryService,
-            apiProductQueryService
-        );
+        validatorService = new PortalNavigationItemValidatorService(queryService, pageContentQueryService, apiProductQueryService);
         domainService = new PortalNavigationItemDomainService(crudService, queryService, pageContentCrudService, apiCrudService);
+        creationExpansionDomainService = new PortalNavigationItemCreationExpansionDomainService(apiProductQueryService, apiCrudService);
+        var defaultPageDomainService = new PortalNavigationApiDefaultPageDomainService(
+            queryService,
+            domainService,
+            pageContentCrudService,
+            apiCrudService
+        );
         useCase = new CreatePortalNavigationItemUseCase(
             domainService,
             validatorService,
-            new PortalNavigationItemCreationExpansionDomainService(apiProductQueryService, apiCrudService)
+            creationExpansionDomainService,
+            defaultPageDomainService
         );
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
         apiCrudService.initWith(List.of(Api.builder().id("apiId").name("apiIdName").build()));
     }
 
     @Test
-    void should_create_product_and_its_api_children_but_return_only_product() {
+    void should_create_product_and_its_api_children_with_default_pages_but_return_only_product() {
         apiProductQueryService.initWith(
             List.of(ApiProduct.builder().id("product-id").environmentId(ENV_ID).apiIds(Set.of("api-1", "api-2")).build())
         );
@@ -123,6 +131,59 @@ class CreatePortalNavigationItemUseCaseTest {
         assertThat(children)
             .extracting(item -> ((io.gravitee.apim.core.portal_page.model.PortalNavigationApi) item).getApiId())
             .containsExactly("api-1", "api-2");
+        assertThat(children).allSatisfy(apiItem ->
+            assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, apiItem.getId()))
+                .singleElement()
+                .isInstanceOfSatisfying(PortalNavigationPage.class, page -> {
+                    assertThat(page.getTitle()).isEqualTo("Overview");
+                    assertThat(page.getPublished()).isFalse();
+                    assertThat(page.getParentId()).isEqualTo(apiItem.getId());
+                })
+        );
+        assertThat(pageContentCrudService.storage())
+            .hasSize(2)
+            .allSatisfy(content -> assertThat(content).isInstanceOf(GraviteeMarkdownPageContent.class));
+    }
+
+    @Test
+    void should_keep_created_product_and_api_children_when_default_page_seeding_fails() {
+        apiProductQueryService.initWith(
+            List.of(ApiProduct.builder().id("product-id").environmentId(ENV_ID).apiIds(Set.of("api-1")).build())
+        );
+        apiCrudService.initWith(List.of(Api.builder().id("api-1").name("Alpha").environmentId(ENV_ID).build()));
+        var failingPageContentCrudService = new PortalPageContentCrudServiceInMemory() {
+            @Override
+            public PortalPageContent<?> create(PortalPageContent<?> content) {
+                throw new IllegalStateException("page content persistence failure");
+            }
+        };
+        var failingDefaultPageDomainService = new PortalNavigationApiDefaultPageDomainService(
+            queryService,
+            domainService,
+            failingPageContentCrudService,
+            apiCrudService
+        );
+        var failingSeedUseCase = new CreatePortalNavigationItemUseCase(
+            domainService,
+            validatorService,
+            creationExpansionDomainService,
+            failingDefaultPageDomainService
+        );
+        var toCreate = CreatePortalNavigationItem.builder()
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .apiProductId("product-id")
+            .title("Product")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .parentId(PortalNavigationItemId.of(APIS_ID))
+            .build();
+
+        var output = failingSeedUseCase.execute(new CreatePortalNavigationItemUseCase.Input(ORG_ID, ENV_ID, toCreate));
+
+        assertThat(output.item().getType()).isEqualTo(PortalNavigationItemType.API_PRODUCT);
+        assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, output.item().getId()))
+            .singleElement()
+            .satisfies(apiItem -> assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, apiItem.getId())).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-99

## Description

Seeds default Overview pages for APIs generated when an API Product navigation item is created through the single-item endpoint.

The implementation reuses the existing API default-page domain service introduced for bulk creation.




