### PR TITLE
feat(portal): fetch portal page content from external source

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -31,6 +31,7 @@ import inmemory.GroupQueryServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.SharedPolicyGroupHistoryCrudServiceInMemory;
@@ -152,7 +153,9 @@ import io.gravitee.apim.core.portal_listing.use_case.GetPortalListingUseCase;
 import io.gravitee.apim.core.portal_listing.use_case.ValidatePortalListingUseCase;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
@@ -1138,6 +1141,18 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService() {
+        return new PortalNavigationItemSourceDomainServiceInMemory();
+    }
+
+    @Bean
+    public PortalNavigationSourcedItemsDomainService portalNavigationSourcedItemsDomainService(
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService
+    ) {
+        return new PortalNavigationSourcedItemsDomainService(portalNavigationItemsQueryService);
+    }
+
+    @Bean
     public PortalNavigationItemValidatorService portalNavigationItemValidatorService(
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalPageContentQueryService portalPageContentQueryService
@@ -1145,7 +1160,8 @@ public class ResourceContextConfiguration {
         return new PortalNavigationItemValidatorService(
             portalNavigationItemsQueryService,
             portalPageContentQueryService,
-            mock(io.gravitee.apim.core.api_product.query_service.ApiProductQueryService.class)
+            mock(io.gravitee.apim.core.api_product.query_service.ApiProductQueryService.class),
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
     }
 
@@ -1160,7 +1176,12 @@ public class ResourceContextConfiguration {
         PortalNavigationItemValidatorService validatorService,
         PortalNavigationItemDomainService domainService
     ) {
-        return new UpdatePortalNavigationItemUseCase(portalNavigationItemsQueryService, validatorService, domainService);
+        return new UpdatePortalNavigationItemUseCase(
+            portalNavigationItemsQueryService,
+            validatorService,
+            domainService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -37,6 +37,7 @@ import inmemory.NewtAIProviderInMemory;
 import inmemory.PageCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.UserDomainServiceInMemory;
@@ -198,7 +199,9 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProdu
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
@@ -1369,15 +1372,29 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService() {
+        return new PortalNavigationItemSourceDomainServiceInMemory();
+    }
+
+    @Bean
+    public PortalNavigationSourcedItemsDomainService portalNavigationSourcedItemsDomainService(
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService
+    ) {
+        return new PortalNavigationSourcedItemsDomainService(portalNavigationItemsQueryService);
+    }
+
+    @Bean
     public PortalNavigationItemValidatorService portalNavigationItemValidatorService(
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalPageContentQueryService portalPageContentQueryService,
-        io.gravitee.apim.core.api_product.query_service.ApiProductQueryService apiProductQueryService
+        io.gravitee.apim.core.api_product.query_service.ApiProductQueryService apiProductQueryService,
+        PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService
     ) {
         return new PortalNavigationItemValidatorService(
             portalNavigationItemsQueryService,
             portalPageContentQueryService,
-            apiProductQueryService
+            apiProductQueryService,
+            portalNavigationItemSourceDomainService
         );
     }
 
@@ -1385,12 +1402,14 @@ public class ResourceContextConfiguration {
     public UpdatePortalNavigationItemUseCase updatePortalNavigationItemUseCase(
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalNavigationItemValidatorService portalNavigationItemValidatorService,
-        PortalNavigationItemDomainService domainService
+        PortalNavigationItemDomainService domainService,
+        PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService
     ) {
         return new UpdatePortalNavigationItemUseCase(
             portalNavigationItemsQueryService,
             portalNavigationItemValidatorService,
-            domainService
+            domainService,
+            portalNavigationItemSourceDomainService
         );
     }
 
@@ -1399,13 +1418,17 @@ public class ResourceContextConfiguration {
         PortalNavigationItemCrudService portalNavigationItemCrudService,
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalPageContentCrudService portalPageContentCrudService,
-        ApiCrudService apiCrudService
+        PortalPageContentQueryService portalPageContentQueryService,
+        ApiCrudService apiCrudService,
+        PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService
     ) {
         return new PortalNavigationItemDomainService(
             portalNavigationItemCrudService,
             portalNavigationItemsQueryService,
             portalPageContentCrudService,
-            apiCrudService
+            portalPageContentQueryService,
+            apiCrudService,
+            portalNavigationItemSourceDomainService
         );
     }
 
@@ -1440,7 +1463,13 @@ public class ResourceContextConfiguration {
             List.of(gmdContentValidator, openApiContentValidator)
         );
 
-        return new UpdatePortalPageContentUseCase(portalPageContentQueryService, portalPageContentCrudService, validatorService);
+        return new UpdatePortalPageContentUseCase(
+            portalPageContentQueryService,
+            portalPageContentCrudService,
+            validatorService,
+            portalNavigationItemsQueryService,
+            new PortalNavigationSourcedItemsDomainService(portalNavigationItemsQueryService)
+        );
     }
 
     @Bean
@@ -1455,11 +1484,13 @@ public class ResourceContextConfiguration {
     public ListPortalNavigationItemsUseCase listPortalNavigationItemsUseCase(
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService,
-        PortalNavigationApiProductVisibilityDomainService portalNavigationApiProductVisibilityDomainService
+        PortalNavigationApiProductVisibilityDomainService portalNavigationApiProductVisibilityDomainService,
+        PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService
     ) {
         return new ListPortalNavigationItemsUseCase(
             portalNavigationItemsQueryService,
-            List.of(portalNavigationApiVisibilityDomainService, portalNavigationApiProductVisibilityDomainService)
+            List.of(portalNavigationApiVisibilityDomainService, portalNavigationApiProductVisibilityDomainService),
+            portalNavigationItemSourceDomainService
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -27,6 +27,7 @@ import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.CRDMembersDomainServiceInMemory;
 import inmemory.GroupCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
@@ -139,7 +140,9 @@ import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomain
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
@@ -1334,6 +1337,18 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService() {
+        return new PortalNavigationItemSourceDomainServiceInMemory();
+    }
+
+    @Bean
+    public PortalNavigationSourcedItemsDomainService portalNavigationSourcedItemsDomainService(
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService
+    ) {
+        return new PortalNavigationSourcedItemsDomainService(portalNavigationItemsQueryService);
+    }
+
+    @Bean
     public PortalNavigationItemValidatorService portalNavigationItemValidatorService(
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalPageContentQueryService portalPageContentQueryService
@@ -1341,7 +1356,8 @@ public class ResourceContextConfiguration {
         return new PortalNavigationItemValidatorService(
             portalNavigationItemsQueryService,
             portalPageContentQueryService,
-            mock(io.gravitee.apim.core.api_product.query_service.ApiProductQueryService.class)
+            mock(io.gravitee.apim.core.api_product.query_service.ApiProductQueryService.class),
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
     }
 
@@ -1356,7 +1372,12 @@ public class ResourceContextConfiguration {
         PortalNavigationItemValidatorService validatorService,
         PortalNavigationItemDomainService domainService
     ) {
-        return new UpdatePortalNavigationItemUseCase(portalNavigationItemsQueryService, validatorService, domainService);
+        return new UpdatePortalNavigationItemUseCase(
+            portalNavigationItemsQueryService,
+            validatorService,
+            domainService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -29,6 +29,7 @@ import inmemory.GroupCrudServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
@@ -153,7 +154,9 @@ import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransforme
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
@@ -1246,6 +1249,18 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService() {
+        return new PortalNavigationItemSourceDomainServiceInMemory();
+    }
+
+    @Bean
+    public PortalNavigationSourcedItemsDomainService portalNavigationSourcedItemsDomainService(
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService
+    ) {
+        return new PortalNavigationSourcedItemsDomainService(portalNavigationItemsQueryService);
+    }
+
+    @Bean
     public PortalNavigationItemValidatorService portalNavigationItemValidatorService(
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalPageContentQueryService portalPageContentQueryService
@@ -1253,7 +1268,8 @@ public class ResourceContextConfiguration {
         return new PortalNavigationItemValidatorService(
             portalNavigationItemsQueryService,
             portalPageContentQueryService,
-            mock(io.gravitee.apim.core.api_product.query_service.ApiProductQueryService.class)
+            mock(io.gravitee.apim.core.api_product.query_service.ApiProductQueryService.class),
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
     }
 
@@ -1268,7 +1284,12 @@ public class ResourceContextConfiguration {
         PortalNavigationItemValidatorService validatorService,
         PortalNavigationItemDomainService domainService
     ) {
-        return new UpdatePortalNavigationItemUseCase(portalNavigationItemsQueryService, validatorService, domainService);
+        return new UpdatePortalNavigationItemUseCase(
+            portalNavigationItemsQueryService,
+            validatorService,
+            domainService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
+        );
     }
 
     @Bean
@@ -1289,7 +1310,8 @@ public class ResourceContextConfiguration {
     ) {
         return new ListPortalNavigationItemsUseCase(
             portalNavigationItemsQueryService,
-            List.of(portalNavigationApiVisibilityDomainService, portalNavigationApiProductVisibilityDomainService)
+            List.of(portalNavigationApiVisibilityDomainService, portalNavigationApiProductVisibilityDomainService),
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
@@ -20,6 +20,8 @@ import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
@@ -31,7 +33,10 @@ import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.Slug;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import io.gravitee.common.utils.TimeProvider;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,9 +46,11 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
+@CustomLog
 @RequiredArgsConstructor
 public class PortalNavigationItemDomainService {
 
@@ -52,7 +59,9 @@ public class PortalNavigationItemDomainService {
     private final PortalNavigationItemCrudService crudService;
     private final PortalNavigationItemsQueryService queryService;
     private final PortalPageContentCrudService pageContentCrudService;
+    private final PortalPageContentQueryService pageContentQueryService;
     private final ApiCrudService apiCrudService;
+    private final PortalNavigationItemSourceDomainService sourceDomainService;
 
     public PortalNavigationItem create(String organizationId, String environmentId, CreatePortalNavigationItem createPortalNavigationItem) {
         int sanitizedOrder = this.sanitizeOrderForInsertion(
@@ -108,7 +117,44 @@ public class PortalNavigationItemDomainService {
                 this.crudService.update(followingSibling);
             });
 
+        if (portalNavigationItem instanceof PortalNavigationPage page && page.getSource() != null) {
+            return fetchPageContent(page);
+        }
+
         return portalNavigationItem;
+    }
+
+    /**
+     * Fetches the sourced content and overwrites the page content with it. A failed fetch is recorded
+     * in {@code lastFetchError} instead of failing the operation. A missing page content is an
+     * internal inconsistency, not a fetch failure, and is propagated.
+     */
+    public PortalNavigationItem fetchPageContent(PortalNavigationPage page) {
+        final var source = page.getSource();
+        if (source == null) {
+            throw InvalidPortalNavigationItemDataException.noSourceConfigured(page.getId().json());
+        }
+        final var pageContent = pageContentQueryService
+            .findById(page.getPortalPageContentId())
+            .orElseThrow(() -> new PageContentNotFoundException(page.getPortalPageContentId().toString()));
+        try {
+            final var fetchedContent = sourceDomainService.fetchContent(source);
+            pageContent.update(UpdatePortalPageContent.builder().content(fetchedContent).build());
+            pageContentCrudService.update(pageContent);
+            source.setLastFetchedAt(TimeProvider.instantNow());
+            source.setLastFetchError(null);
+        } catch (Exception e) {
+            log.warn(
+                "Failed to fetch content of portal navigation page [id={}, sourceType={}]",
+                page.getId().json(),
+                source.getSourceType(),
+                e
+            );
+            // Built here rather than taken from the exception: the stored message is returned by the
+            // API, and an arbitrary one may quote the configuration and its secrets.
+            source.setLastFetchError("Unable to fetch content from source type %s.".formatted(source.getSourceType()));
+        }
+        return crudService.update(page);
     }
 
     private List<PortalNavigationItem> retrieveSiblingItems(PortalNavigationItemId parentId, String environmentId, PortalArea area) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemSourceDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemSourceDomainService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+
+public interface PortalNavigationItemSourceDomainService {
+    String fetchContent(PortalNavigationItemSource source);
+
+    void removeSensitiveData(PortalNavigationItemSource source);
+
+    void mergeSensitiveData(PortalNavigationItemSource oldSource, PortalNavigationItemSource newSource);
+
+    void validateSourceConfiguration(PortalNavigationItemSource source);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
@@ -31,6 +31,10 @@ import io.gravitee.apim.core.portal_page.domain_service.validation.HomepageUniqu
 import io.gravitee.apim.core.portal_page.domain_service.validation.LinkUrlRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.PageContentExistsRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.ParentRule;
+import io.gravitee.apim.core.portal_page.domain_service.validation.SourceAutomationExclusivityRule;
+import io.gravitee.apim.core.portal_page.domain_service.validation.SourceConfigurationRule;
+import io.gravitee.apim.core.portal_page.domain_service.validation.SourcedAncestorFinder;
+import io.gravitee.apim.core.portal_page.domain_service.validation.SourcedItemReadOnlyRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.TitleRequiredRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.TypeConsistencyRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.UniqueItemIdRule;
@@ -61,7 +65,8 @@ public class PortalNavigationItemValidatorService {
     public PortalNavigationItemValidatorService(
         PortalNavigationItemsQueryService navigationItemsQueryService,
         PortalPageContentQueryService pageContentQueryService,
-        ApiProductQueryService apiProductQueryService
+        ApiProductQueryService apiProductQueryService,
+        PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService
     ) {
         this.navigationItemsQueryService = navigationItemsQueryService;
         this.bulkCreateRules = List.of(new DuplicateApiIdsInPayloadRule(), new DuplicateApiProductIdsInPayloadRule());
@@ -71,6 +76,9 @@ public class PortalNavigationItemValidatorService {
         var parentRule = new ParentRule(navigationItemsQueryService);
         var linkUrlRule = new LinkUrlRule();
         var externalSourceItemTypeRule = new ExternalSourceItemTypeRule();
+        var sourceConfigurationRule = new SourceConfigurationRule(portalNavigationItemSourceDomainService::validateSourceConfiguration);
+        var sourceAutomationExclusivityRule = new SourceAutomationExclusivityRule(navigationItemsQueryService, pageContentQueryService);
+        var sourcedItemReadOnlyRule = new SourcedItemReadOnlyRule(new SourcedAncestorFinder(navigationItemsQueryService));
 
         this.createRules = List.of(
             new UniqueItemIdRule(navigationItemsQueryService),
@@ -81,7 +89,10 @@ public class PortalNavigationItemValidatorService {
             new ApiProductItemCreateRule(apiProductQueryService),
             linkUrlRule,
             parentRule,
-            externalSourceItemTypeRule
+            externalSourceItemTypeRule,
+            sourceConfigurationRule,
+            sourceAutomationExclusivityRule,
+            sourcedItemReadOnlyRule
         );
         this.updateRules = List.of(
             new TypeConsistencyRule(),
@@ -90,7 +101,10 @@ public class PortalNavigationItemValidatorService {
             new ApiProductItemUpdateRule(),
             parentRule,
             linkUrlRule,
-            externalSourceItemTypeRule
+            externalSourceItemTypeRule,
+            sourceConfigurationRule,
+            sourceAutomationExclusivityRule,
+            sourcedItemReadOnlyRule
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationSourcedItemsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationSourcedItemsDomainService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.portal_page.domain_service.validation.SourcedAncestorFinder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.Optional;
+
+/**
+ * Items carrying an external source, and every item below a sourced FOLDER, are managed by the
+ * fetcher and must stay read-only for regular navigation edits.
+ */
+@DomainService
+public class PortalNavigationSourcedItemsDomainService {
+
+    private final SourcedAncestorFinder sourcedAncestorFinder;
+
+    public PortalNavigationSourcedItemsDomainService(PortalNavigationItemsQueryService queryService) {
+        this.sourcedAncestorFinder = new SourcedAncestorFinder(queryService);
+    }
+
+    public Optional<PortalNavigationItem> findSourcedAncestor(String environmentId, PortalNavigationItem item) {
+        return sourcedAncestorFinder.findSourcedAncestor(environmentId, item);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SourceAutomationExclusivityRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SourceAutomationExclusivityRule.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * External sources are mutually exclusive with automation-managed navigation, because both write the
+ * content of the pages they own. Automation ownership is carried by {@code AutomationMetadata} on the
+ * page content.
+ * <p>
+ * The conflict area is exactly what a source would own: the item itself and everything below it.
+ * Ancestors are never checked — only a PAGE can be automation-managed, and a PAGE is never a container.
+ */
+@RequiredArgsConstructor
+public class SourceAutomationExclusivityRule implements CreatePortalNavigationItemValidationRule, UpdatePortalNavigationItemValidationRule {
+
+    private final PortalNavigationItemsQueryService queryService;
+    private final PortalPageContentQueryService contentQueryService;
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getSource() != null;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        // The item does not exist yet, so it owns no subtree: only the content passed in the payload can conflict
+        if (item.getType() == PortalNavigationItemType.PAGE && isAutomationManaged(item.getPortalPageContentId())) {
+            throw InvalidPortalNavigationItemDataException.sourceNotAllowedOnAutomationManagedItem(
+                item.getPortalPageContentId().toString()
+            );
+        }
+    }
+
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        return toUpdate.getSource() != null;
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        if (isAutomationManaged(existingItem)) {
+            throw InvalidPortalNavigationItemDataException.sourceNotAllowedOnAutomationManagedItem(existingItem.getId().json());
+        }
+        findAutomationManagedItemBelow(existingItem.getEnvironmentId(), existingItem.getId(), 0).ifPresent(conflicting -> {
+            throw InvalidPortalNavigationItemDataException.sourceNotAllowedOnAutomationManagedItem(conflicting.getId().json());
+        });
+    }
+
+    private Optional<PortalNavigationItem> findAutomationManagedItemBelow(
+        String environmentId,
+        PortalNavigationItemId parentId,
+        int depth
+    ) {
+        if (ValidationDepth.exceeded(depth, parentId, "the automation exclusivity is not enforced deeper")) {
+            return Optional.empty();
+        }
+        List<PortalNavigationItem> children = queryService.findByParentIdAndEnvironmentId(environmentId, parentId);
+        return children
+            .stream()
+            .map(child ->
+                isAutomationManaged(child) ? Optional.of(child) : findAutomationManagedItemBelow(environmentId, child.getId(), depth + 1)
+            )
+            .flatMap(Optional::stream)
+            .findFirst();
+    }
+
+    private boolean isAutomationManaged(PortalNavigationItem item) {
+        return item instanceof PortalNavigationPage page && isAutomationManaged(page.getPortalPageContentId());
+    }
+
+    private boolean isAutomationManaged(PortalPageContentId contentId) {
+        return (
+            contentId != null &&
+            contentQueryService
+                .findById(contentId)
+                .map(content -> content.getAutomationMetadata() != null)
+                .orElse(false)
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SourceConfigurationRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SourceConfigurationRule.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A provided source must reference a known fetcher plugin, carry a configuration that plugin
+ * accepts, and a valid cron expression when auto-fetch is enabled. The validation itself is
+ * delegated to the source domain service, passed as a consumer to keep this package free of
+ * dependencies on its parent.
+ */
+@RequiredArgsConstructor
+public class SourceConfigurationRule implements CreatePortalNavigationItemValidationRule, UpdatePortalNavigationItemValidationRule {
+
+    private final Consumer<PortalNavigationItemSource> sourceConfigurationValidator;
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getSource() != null;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        sourceConfigurationValidator.accept(item.getSource());
+    }
+
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        return toUpdate.getSource() != null;
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        sourceConfigurationValidator.accept(toUpdate.getSource());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SourcedAncestorFinder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SourcedAncestorFinder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Walks up the parent chain looking for an item carrying an external source — every item below a
+ * sourced FOLDER is managed by the fetcher and read-only.
+ */
+@RequiredArgsConstructor
+public class SourcedAncestorFinder {
+
+    private final PortalNavigationItemsQueryService queryService;
+
+    public Optional<PortalNavigationItem> findSourcedAncestor(String environmentId, PortalNavigationItem item) {
+        return findSourcedAncestorFrom(environmentId, item.getParentId());
+    }
+
+    /** Same walk from a parent id, so an item about to be created can be checked against its target parent. */
+    public Optional<PortalNavigationItem> findSourcedAncestorFrom(String environmentId, PortalNavigationItemId parentId) {
+        int depth = 0;
+        while (parentId != null) {
+            if (ValidationDepth.exceeded(depth++, parentId, "the read-only restriction is not enforced above")) {
+                return Optional.empty();
+            }
+            var parent = queryService.findByIdAndEnvironmentId(environmentId, parentId);
+            if (parent == null) {
+                return Optional.empty();
+            }
+            if (parent.getSource() != null) {
+                return Optional.of(parent);
+            }
+            parentId = parent.getParentId();
+        }
+        return Optional.empty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SourcedItemReadOnlyRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SourcedItemReadOnlyRule.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Sourced items cannot be renamed or moved while their source is kept, and every item below a
+ * sourced FOLDER is fully read-only. Removing the source in the same update lifts the restriction.
+ * <p>
+ * The subtree is closed on the way in as well — create below, or move below — including against a
+ * sourced FOLDER declared earlier in the same bulk payload.
+ */
+@RequiredArgsConstructor
+public class SourcedItemReadOnlyRule implements CreatePortalNavigationItemValidationRule, UpdatePortalNavigationItemValidationRule {
+
+    private final SourcedAncestorFinder sourcedAncestorFinder;
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getParentId() != null;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        // Walk the pending part of the chain first: the parent may only exist in the same payload
+        var parentId = item.getParentId();
+        int depth = 0;
+        while (parentId != null) {
+            if (ValidationDepth.exceeded(depth++, parentId, "the read-only restriction is not enforced above")) {
+                return;
+            }
+            var pendingParent = ctx.pendingItemsById().get(parentId);
+            if (pendingParent == null) {
+                break;
+            }
+            if (pendingParent.getSource() != null) {
+                throw InvalidPortalNavigationItemDataException.cannotCreateBelowSourcedItem(parentId.json());
+            }
+            parentId = pendingParent.getParentId();
+        }
+        sourcedAncestorFinder
+            .findSourcedAncestorFrom(environmentId, parentId)
+            .ifPresent(ancestor -> {
+                throw InvalidPortalNavigationItemDataException.cannotCreateBelowSourcedItem(ancestor.getId().json());
+            });
+    }
+
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        return existingItem.getSource() != null || existingItem.getParentId() != null || toUpdate.getParentId() != null;
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        if (
+            existingItem.getParentId() != null &&
+            sourcedAncestorFinder.findSourcedAncestor(existingItem.getEnvironmentId(), existingItem).isPresent()
+        ) {
+            throw InvalidPortalNavigationItemDataException.childOfSourcedItemIsReadOnly(existingItem.getId().json());
+        }
+
+        // The target position matters as much as the current one
+        if (toUpdate.getParentId() != null && !Objects.equals(toUpdate.getParentId(), existingItem.getParentId())) {
+            sourcedAncestorFinder
+                .findSourcedAncestorFrom(existingItem.getEnvironmentId(), toUpdate.getParentId())
+                .ifPresent(ancestor -> {
+                    throw InvalidPortalNavigationItemDataException.cannotMoveBelowSourcedItem(ancestor.getId().json());
+                });
+        }
+
+        if (existingItem.getSource() == null || toUpdate.getSource() == null) {
+            return;
+        }
+
+        if (
+            !Objects.equals(toUpdate.getTitle(), existingItem.getTitle()) ||
+            !Objects.equals(toUpdate.getParentId(), existingItem.getParentId())
+        ) {
+            throw InvalidPortalNavigationItemDataException.sourcedItemCannotBeRenamedOrMoved(existingItem.getId().json());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ValidationDepth.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ValidationDepth.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import lombok.CustomLog;
+
+/**
+ * Navigation trees are shallow by design; this bound only exists so that a corrupted parent chain
+ * cannot loop forever.
+ */
+@CustomLog
+final class ValidationDepth {
+
+    static final int MAX_TREE_DEPTH = 50;
+
+    private ValidationDepth() {}
+
+    /** Past the bound the restriction silently stops being enforced: give up loudly. */
+    static boolean exceeded(int depth, PortalNavigationItemId itemId, String restriction) {
+        if (depth < MAX_TREE_DEPTH) {
+            return false;
+        }
+        log.warn("Stopped walking the navigation tree at [id={}] after {} levels: {}", itemId.json(), MAX_TREE_DEPTH, restriction);
+        return true;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
@@ -47,6 +47,52 @@ public class InvalidPortalNavigationItemDataException extends ValidationDomainEx
         );
     }
 
+    public static InvalidPortalNavigationItemDataException noSourceConfigured(String itemId) {
+        return new InvalidPortalNavigationItemDataException("Navigation item %s has no external source configured.".formatted(itemId));
+    }
+
+    public static InvalidPortalNavigationItemDataException sourcedItemCannotBeRenamedOrMoved(String itemId) {
+        return new InvalidPortalNavigationItemDataException(
+            "Navigation item %s is managed by an external source and cannot be renamed or moved. Remove the source first.".formatted(itemId)
+        );
+    }
+
+    public static InvalidPortalNavigationItemDataException cannotCreateBelowSourcedItem(String ancestorId) {
+        return new InvalidPortalNavigationItemDataException(
+            "Navigation items cannot be created below %s, whose subtree is managed by an external source.".formatted(ancestorId)
+        );
+    }
+
+    public static InvalidPortalNavigationItemDataException cannotMoveBelowSourcedItem(String ancestorId) {
+        return new InvalidPortalNavigationItemDataException(
+            "Navigation items cannot be moved below %s, whose subtree is managed by an external source.".formatted(ancestorId)
+        );
+    }
+
+    public static InvalidPortalNavigationItemDataException childOfSourcedItemIsReadOnly(String itemId) {
+        return new InvalidPortalNavigationItemDataException(
+            "Navigation item %s belongs to a subtree managed by an external source and is read-only.".formatted(itemId)
+        );
+    }
+
+    public static InvalidPortalNavigationItemDataException sourcedItemCannotBeDeleted(String itemId) {
+        return new InvalidPortalNavigationItemDataException(
+            "Navigation item %s is managed by an external source and cannot be deleted. Remove the source first.".formatted(itemId)
+        );
+    }
+
+    public static InvalidPortalNavigationItemDataException sourcedPageContentIsReadOnly(String contentId) {
+        return new InvalidPortalNavigationItemDataException(
+            "Page content %s is managed by an external source and cannot be edited. Remove the source first.".formatted(contentId)
+        );
+    }
+
+    public static InvalidPortalNavigationItemDataException sourceNotAllowedOnAutomationManagedItem(String itemId) {
+        return new InvalidPortalNavigationItemDataException(
+            "Navigation item %s is managed by the Automation API and cannot carry an external source.".formatted(itemId)
+        );
+    }
+
     public static InvalidPortalNavigationItemDataException apiIdAlreadyExists(String apiId) {
         return new InvalidPortalNavigationItemDataException(
             "The apiId %s is already used by another API navigation item.".formatted(apiId)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemSourceException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemSourceException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.exception;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+public class InvalidPortalNavigationItemSourceException extends ValidationDomainException {
+
+    private InvalidPortalNavigationItemSourceException(String message) {
+        super(message);
+    }
+
+    private InvalidPortalNavigationItemSourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public static InvalidPortalNavigationItemSourceException unknownSourceType(String sourceType) {
+        return new InvalidPortalNavigationItemSourceException("No fetcher plugin found for source type %s.".formatted(sourceType));
+    }
+
+    public static InvalidPortalNavigationItemSourceException invalidSourceConfiguration(String sourceType, Throwable cause) {
+        return new InvalidPortalNavigationItemSourceException(
+            "The source configuration is not valid for source type %s.".formatted(sourceType),
+            cause
+        );
+    }
+
+    public static InvalidPortalNavigationItemSourceException invalidCronExpression(String cron) {
+        return new InvalidPortalNavigationItemSourceException("The fetch cron expression %s is not valid.".formatted(cron));
+    }
+
+    public static InvalidPortalNavigationItemSourceException unresolvedSensitivePlaceholder(String field) {
+        return new InvalidPortalNavigationItemSourceException(
+            "The source configuration field %s still holds the masked placeholder: provide its actual value.".formatted(field)
+        );
+    }
+
+    public static InvalidPortalNavigationItemSourceException cronRequiredForAutoFetch() {
+        return new InvalidPortalNavigationItemSourceException("A fetch cron expression is required when auto-fetch is enabled.");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -17,7 +17,6 @@ package io.gravitee.apim.core.portal_page.model;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import java.util.Objects;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
@@ -217,16 +216,9 @@ public abstract sealed class PortalNavigationItem
             return;
         }
         var builder = newSource.toBuilder().lastFetchedAt(null).lastFetchError(null);
-        if (this.source != null && sameOrigin(this.source, newSource)) {
+        if (this.source != null && this.source.sameOriginAs(newSource)) {
             builder.lastFetchedAt(this.source.getLastFetchedAt()).lastFetchError(this.source.getLastFetchError());
         }
         this.source = builder.build();
-    }
-
-    private static boolean sameOrigin(PortalNavigationItemSource current, PortalNavigationItemSource updated) {
-        return (
-            Objects.equals(current.getSourceType(), updated.getSourceType()) &&
-            Objects.equals(current.getSourceConfiguration(), updated.getSourceConfiguration())
-        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemSource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemSource.java
@@ -15,15 +15,20 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.time.Instant;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder(toBuilder = true)
 public class PortalNavigationItemSource {
+
+    private static final ObjectMapper CONFIGURATION_READER = new ObjectMapper();
 
     @Nonnull
     private String sourceType;
@@ -42,4 +47,28 @@ public class PortalNavigationItemSource {
 
     @Nullable
     private String lastFetchError;
+
+    /** Two sources share an origin when they point at the same thing, whatever the fetch state around them. */
+    public boolean sameOriginAs(@Nullable PortalNavigationItemSource other) {
+        return (
+            other != null &&
+            Objects.equals(sourceType, other.sourceType) &&
+            sameConfiguration(sourceConfiguration, other.sourceConfiguration)
+        );
+    }
+
+    // JSON comparison: formatting and key order must not count as an origin change
+    private static boolean sameConfiguration(String current, String updated) {
+        if (Objects.equals(current, updated)) {
+            return true;
+        }
+        if (current == null || updated == null) {
+            return false;
+        }
+        try {
+            return CONFIGURATION_READER.readTree(current).equals(CONFIGURATION_READER.readTree(updated));
+        } catch (JsonProcessingException e) {
+            return false;
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemUseCase.java
@@ -19,11 +19,13 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -34,6 +36,7 @@ public class BulkCreatePortalNavigationItemUseCase {
     private final PortalNavigationItemValidatorService validatorService;
     private final PortalNavigationItemCreationExpansionDomainService creationExpansionDomainService;
     private final PortalNavigationApiDefaultPageDomainService defaultPageDomainService;
+    private final PortalNavigationItemSourceDomainService sourceDomainService;
 
     public Output execute(Input input) {
         final var organizationId = input.organizationId();
@@ -50,7 +53,14 @@ public class BulkCreatePortalNavigationItemUseCase {
 
         defaultPageDomainService.seedDefaultPages(organizationId, environmentId, expansion.generatedApiNavigationItemIds());
 
-        return new BulkCreatePortalNavigationItemUseCase.Output(expansion.selectRequestedItems(result));
+        var createdItems = expansion.selectRequestedItems(result);
+        createdItems
+            .stream()
+            .map(PortalNavigationItem::getSource)
+            .filter(Objects::nonNull)
+            .forEach(sourceDomainService::removeSensitiveData);
+
+        return new BulkCreatePortalNavigationItemUseCase.Output(createdItems);
     }
 
     public record Input(String organizationId, String environmentId, List<CreatePortalNavigationItem> items) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCase.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
@@ -34,6 +35,7 @@ public class CreatePortalNavigationItemUseCase {
     private final PortalNavigationItemValidatorService validatorService;
     private final PortalNavigationItemCreationExpansionDomainService creationExpansionDomainService;
     private final PortalNavigationApiDefaultPageDomainService defaultPageDomainService;
+    private final PortalNavigationItemSourceDomainService sourceDomainService;
 
     public Output execute(Input input) {
         final var organizationId = input.organizationId();
@@ -49,7 +51,11 @@ public class CreatePortalNavigationItemUseCase {
 
         defaultPageDomainService.seedDefaultPages(organizationId, environmentId, expansion.generatedApiNavigationItemIds());
 
-        return new CreatePortalNavigationItemUseCase.Output(expansion.selectRequestedItems(createdItems).getFirst());
+        var createdItem = expansion.selectRequestedItems(createdItems).getFirst();
+        if (createdItem.getSource() != null) {
+            sourceDomainService.removeSensitiveData(createdItem.getSource());
+        }
+        return new CreatePortalNavigationItemUseCase.Output(createdItem);
     }
 
     public record Input(String organizationId, String environmentId, CreatePortalNavigationItem item) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalNavigationItemUseCase.java
@@ -17,6 +17,8 @@ package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
@@ -28,11 +30,19 @@ public class DeletePortalNavigationItemUseCase {
 
     private final PortalNavigationItemDomainService portalNavigationItemDomainService;
     private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalNavigationSourcedItemsDomainService sourcedItemsDomainService;
 
     public Output execute(Input input) {
         var existing = portalNavigationItemsQueryService.findByIdAndEnvironmentId(input.environmentId(), input.navigationItemId());
         if (existing == null) {
             throw new PortalNavigationItemNotFoundException(input.navigationItemId().json());
+        }
+
+        if (existing.getSource() != null) {
+            throw InvalidPortalNavigationItemDataException.sourcedItemCannotBeDeleted(existing.getId().json());
+        }
+        if (sourcedItemsDomainService.findSourcedAncestor(input.environmentId(), existing).isPresent()) {
+            throw InvalidPortalNavigationItemDataException.childOfSourcedItemIsReadOnly(existing.getId().json());
         }
 
         portalNavigationItemDomainService.deleteWithDescendants(existing);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/FetchPortalPageContentUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/FetchPortalPageContentUseCase.java
@@ -16,42 +16,35 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
-import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
-public class UpdatePortalNavigationItemUseCase {
+public class FetchPortalPageContentUseCase {
 
-    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
-    private final PortalNavigationItemValidatorService validatorService;
+    private final PortalNavigationItemsQueryService queryService;
     private final PortalNavigationItemDomainService domainService;
     private final PortalNavigationItemSourceDomainService sourceDomainService;
 
     public Output execute(Input input) {
-        var toUpdate = input.updatePortalNavigationItem;
-        PortalNavigationItem existing = portalNavigationItemsQueryService.findByIdAndEnvironmentId(
-            input.environmentId(),
-            PortalNavigationItemId.of(input.navigationItemId)
-        );
-        if (existing == null) {
-            throw new PortalNavigationItemNotFoundException(input.navigationItemId);
+        var item = queryService.findByIdAndEnvironmentId(input.environmentId(), PortalNavigationItemId.of(input.navigationItemId()));
+        if (item == null) {
+            throw new PortalNavigationItemNotFoundException(input.navigationItemId());
         }
-        // Restore the masked secrets before validation: the plugin must validate the configuration it will be given
-        if (existing.getSource() != null && toUpdate.getSource() != null) {
-            sourceDomainService.mergeSensitiveData(existing.getSource(), toUpdate.getSource());
+        if (!(item instanceof PortalNavigationPage page) || page.getSource() == null) {
+            throw InvalidPortalNavigationItemDataException.noSourceConfigured(input.navigationItemId());
         }
-        validatorService.validateToUpdate(toUpdate, existing);
-        var updatedItem = domainService.update(toUpdate, existing, input.propagatePublishToChildren());
+
+        var updatedItem = domainService.fetchPageContent(page);
         if (updatedItem.getSource() != null) {
             sourceDomainService.removeSensitiveData(updatedItem.getSource());
         }
@@ -59,13 +52,7 @@ public class UpdatePortalNavigationItemUseCase {
     }
 
     @Builder
-    public record Input(
-        String organizationId,
-        String environmentId,
-        String navigationItemId,
-        UpdatePortalNavigationItem updatePortalNavigationItem,
-        boolean propagatePublishToChildren
-    ) {}
+    public record Input(String environmentId, String navigationItemId) {}
 
     public record Output(PortalNavigationItem updatedItem) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCase.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityEvaluator;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityService;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
@@ -33,6 +34,7 @@ public class GetPortalNavigationItemUseCase {
 
     private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
     private final List<PortalNavigationItemVisibilityService> visibilityServices;
+    private final PortalNavigationItemSourceDomainService sourceDomainService;
 
     public Output execute(Input input) {
         final PortalNavigationItem foundItem = Optional.ofNullable(
@@ -49,6 +51,10 @@ public class GetPortalNavigationItemUseCase {
         );
         if (!visibilityEvaluator.isVisible(foundItem) || visibilityEvaluator.hasHiddenAncestor(foundItem)) {
             throw new PortalNavigationItemNotFoundException(foundItem.getId().json());
+        }
+
+        if (foundItem.getSource() != null) {
+            sourceDomainService.removeSensitiveData(foundItem.getSource());
         }
 
         return new Output(foundItem);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCase.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityEvaluator;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityService;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
@@ -30,6 +31,7 @@ import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQuer
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +42,7 @@ public class ListPortalNavigationItemsUseCase {
 
     private final PortalNavigationItemsQueryService queryService;
     private final List<PortalNavigationItemVisibilityService> visibilityServices;
+    private final PortalNavigationItemSourceDomainService sourceDomainService;
     private static final Predicate<PortalNavigationItem> IS_CONTAINER_PREDICATE = i -> i instanceof PortalNavigationItemContainer;
 
     public Output execute(Input input) {
@@ -71,6 +74,8 @@ public class ListPortalNavigationItemsUseCase {
             List<PortalNavigationItem> descendants = loadDescendants(rootItems, input, visibilityEvaluator);
             allItems.addAll(descendants);
         }
+
+        allItems.stream().map(PortalNavigationItem::getSource).filter(Objects::nonNull).forEach(sourceDomainService::removeSensitiveData);
 
         return new Output(sortItems(allItems));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCase.java
@@ -17,11 +17,15 @@ package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +37,8 @@ public class UpdatePortalPageContentUseCase {
     private final PortalPageContentQueryService portalPageContentQueryService;
     private final PortalPageContentCrudService portalPageContentCrudService;
     private final PortalPageContentValidatorService validatorService;
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalNavigationSourcedItemsDomainService sourcedItemsDomainService;
 
     public Output execute(Input input) {
         // Check if portal page content is existing
@@ -48,11 +54,23 @@ public class UpdatePortalPageContentUseCase {
             throw new PageContentNotFoundException(input.portalPageContentId());
         }
 
+        boolean managedByFetcher = portalNavigationItemsQueryService
+            .findNavigationPageByPortalPageContentId(input.environmentId(), existingContent.getId())
+            .filter(page -> isSourced(page, input.environmentId()))
+            .isPresent();
+        if (managedByFetcher) {
+            throw InvalidPortalNavigationItemDataException.sourcedPageContentIsReadOnly(input.portalPageContentId());
+        }
+
         validatorService.validateForUpdate(existingContent, input.updatePortalPageContent());
 
         existingContent.update(input.updatePortalPageContent());
 
         return new Output(portalPageContentCrudService.update(existingContent));
+    }
+
+    private boolean isSourced(PortalNavigationPage page, String environmentId) {
+        return page.getSource() != null || sourcedItemsDomainService.findSourcedAncestor(environmentId, page).isPresent();
     }
 
     @Builder

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationItemSourceDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationItemSourceDomainServiceImpl.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.portal_page;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import io.gravitee.fetcher.api.Fetcher;
+import io.gravitee.fetcher.api.FetcherConfiguration;
+import io.gravitee.fetcher.api.FetcherException;
+import io.gravitee.fetcher.api.Sensitive;
+import io.gravitee.plugin.core.api.PluginManager;
+import io.gravitee.plugin.fetcher.FetcherPlugin;
+import io.gravitee.rest.api.fetcher.FetcherConfigurationFactory;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.CustomLog;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.support.CronExpression;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+@CustomLog
+public class PortalNavigationItemSourceDomainServiceImpl implements PortalNavigationItemSourceDomainService {
+
+    public static final String SENSITIVE_DATA_REPLACEMENT = "********";
+    public static final String BLANKED_CONFIGURATION = "{}";
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    private final FetcherConfigurationFactory fetcherConfigurationFactory;
+    private final PluginManager<FetcherPlugin<?>> pluginManager;
+    private final ApplicationContext applicationContext;
+
+    private final Map<String, Set<String>> sensitiveKeysBySourceType = new ConcurrentHashMap<>();
+
+    @Override
+    public String fetchContent(PortalNavigationItemSource source) {
+        var fetcher = loadFetcher(source).orElseThrow(() ->
+            InvalidPortalNavigationItemSourceException.unknownSourceType(source.getSourceType())
+        );
+        return readContent(fetcher, source);
+    }
+
+    /** Never throws: if the sensitive keys cannot be resolved, the configuration is blanked from the response. */
+    @Override
+    public void removeSensitiveData(PortalNavigationItemSource source) {
+        try {
+            var sensitiveKeys = sensitiveConfigurationKeys(source.getSourceType());
+            if (sensitiveKeys == null) {
+                source.setSourceConfiguration(BLANKED_CONFIGURATION);
+                return;
+            }
+            var configuration = (ObjectNode) JSON_MAPPER.readTree(source.getSourceConfiguration());
+            boolean masked = false;
+            for (String key : sensitiveKeys) {
+                var value = configuration.get(key);
+                if (value != null && !value.isNull()) {
+                    configuration.put(key, SENSITIVE_DATA_REPLACEMENT);
+                    masked = true;
+                }
+            }
+            if (masked) {
+                source.setSourceConfiguration(JSON_MAPPER.writeValueAsString(configuration));
+            }
+        } catch (Exception e) {
+            log.warn(
+                "Unable to mask sensitive data of portal page source [type={}], blanking its configuration",
+                source.getSourceType(),
+                e
+            );
+            source.setSourceConfiguration(BLANKED_CONFIGURATION);
+        }
+    }
+
+    /**
+     * Restores stored secrets only within the same source type: a placeholder sent against another
+     * fetcher would otherwise hand that fetcher the previous one's credentials. Across a type change
+     * the placeholder is left unresolved, and validation rejects it.
+     */
+    @Override
+    public void mergeSensitiveData(PortalNavigationItemSource oldSource, PortalNavigationItemSource newSource) {
+        if (oldSource == null || newSource == null || !Objects.equals(oldSource.getSourceType(), newSource.getSourceType())) {
+            return;
+        }
+        try {
+            var sensitiveKeys = sensitiveConfigurationKeys(newSource.getSourceType());
+            if (sensitiveKeys == null || sensitiveKeys.isEmpty()) {
+                return;
+            }
+            var updated = (ObjectNode) JSON_MAPPER.readTree(newSource.getSourceConfiguration());
+            var original = (ObjectNode) JSON_MAPPER.readTree(oldSource.getSourceConfiguration());
+            boolean merged = false;
+            for (String key : sensitiveKeys) {
+                var value = updated.get(key);
+                if (value != null && value.isTextual() && SENSITIVE_DATA_REPLACEMENT.equals(value.textValue())) {
+                    var originalValue = original.get(key);
+                    if (originalValue != null) {
+                        updated.set(key, originalValue);
+                    } else {
+                        updated.remove(key);
+                    }
+                    merged = true;
+                }
+            }
+            if (merged) {
+                newSource.setSourceConfiguration(JSON_MAPPER.writeValueAsString(updated));
+            }
+        } catch (Exception e) {
+            log.warn("Unable to merge sensitive data of portal page source [type={}]", newSource.getSourceType(), e);
+        }
+    }
+
+    /** Only successful resolutions are cached, so a plugin loaded later is not stuck on a missed lookup. */
+    private Set<String> sensitiveConfigurationKeys(String sourceType) throws ClassNotFoundException {
+        var cached = sensitiveKeysBySourceType.get(sourceType);
+        if (cached != null) {
+            return cached;
+        }
+        var plugin = pluginManager.get(sourceType);
+        if (plugin == null) {
+            return null;
+        }
+        var configurationClass = plugin.fetcher().getClassLoader().loadClass(plugin.configuration().getName());
+        var sensitiveKeys = Arrays.stream(configurationClass.getDeclaredFields())
+            .filter(field -> field.isAnnotationPresent(Sensitive.class))
+            .map(Field::getName)
+            .collect(Collectors.toUnmodifiableSet());
+        sensitiveKeysBySourceType.put(sourceType, sensitiveKeys);
+        return sensitiveKeys;
+    }
+
+    @Override
+    public void validateSourceConfiguration(PortalNavigationItemSource source) {
+        var plugin = loadPlugin(source).orElseThrow(() ->
+            InvalidPortalNavigationItemSourceException.unknownSourceType(source.getSourceType())
+        );
+        rejectUnresolvedPlaceholders(source);
+        try {
+            buildFetcher(plugin, source);
+        } catch (Exception e) {
+            throw InvalidPortalNavigationItemSourceException.invalidSourceConfiguration(source.getSourceType(), e);
+        }
+        if (source.isUseAutoFetch() && source.getFetchCron() == null) {
+            throw InvalidPortalNavigationItemSourceException.cronRequiredForAutoFetch();
+        }
+        if (source.getFetchCron() != null && !CronExpression.isValidExpression(source.getFetchCron())) {
+            throw InvalidPortalNavigationItemSourceException.invalidCronExpression(source.getFetchCron());
+        }
+    }
+
+    /**
+     * Runs after the merge: a placeholder still there had no stored value to restore, and would be
+     * persisted as the secret itself.
+     */
+    private void rejectUnresolvedPlaceholders(PortalNavigationItemSource source) {
+        try {
+            var sensitiveKeys = sensitiveConfigurationKeys(source.getSourceType());
+            if (sensitiveKeys == null || sensitiveKeys.isEmpty()) {
+                return;
+            }
+            var configuration = (ObjectNode) JSON_MAPPER.readTree(source.getSourceConfiguration());
+            for (String key : sensitiveKeys) {
+                var value = configuration.get(key);
+                if (value != null && value.isTextual() && SENSITIVE_DATA_REPLACEMENT.equals(value.textValue())) {
+                    throw InvalidPortalNavigationItemSourceException.unresolvedSensitivePlaceholder(key);
+                }
+            }
+        } catch (InvalidPortalNavigationItemSourceException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("Unable to check sensitive placeholders of portal page source [type={}]", source.getSourceType(), e);
+        }
+    }
+
+    private String readContent(Fetcher fetcher, PortalNavigationItemSource source) {
+        try {
+            var resource = fetcher.fetch();
+            try (var content = resource.getContent()) {
+                return new String(content.readAllBytes(), StandardCharsets.UTF_8);
+            }
+        } catch (FetcherException | IOException e) {
+            throw new TechnicalDomainException("unable to fetch content from source type " + source.getSourceType(), e);
+        }
+    }
+
+    private Optional<Fetcher> loadFetcher(PortalNavigationItemSource source) {
+        return loadPlugin(source).map(plugin -> buildFetcher(plugin, source));
+    }
+
+    private Optional<FetcherPlugin<?>> loadPlugin(PortalNavigationItemSource source) {
+        return Optional.ofNullable(pluginManager.get(source.getSourceType()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Fetcher buildFetcher(FetcherPlugin<?> plugin, PortalNavigationItemSource source) {
+        try {
+            var classLoader = plugin.fetcher().getClassLoader();
+            var configClass = (Class<? extends FetcherConfiguration>) classLoader.loadClass(plugin.configuration().getName());
+            var config = fetcherConfigurationFactory.create(configClass, source.getSourceConfiguration());
+            if (config == null) {
+                throw new TechnicalDomainException("configuration cannot be read by fetcher type " + source.getSourceType());
+            }
+            var fetcherClass = (Class<? extends Fetcher>) classLoader.loadClass(plugin.clazz());
+            var fetcher = fetcherClass.getConstructor(configClass).newInstance(config);
+            applicationContext.getAutowireCapableBeanFactory().autowireBean(fetcher);
+            return fetcher;
+        } catch (Exception e) {
+            throw new TechnicalDomainException("unable to build fetcher instance", e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemSourceDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemSourceDomainServiceInMemory.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import org.springframework.scheduling.support.CronExpression;
+
+public class PortalNavigationItemSourceDomainServiceInMemory implements PortalNavigationItemSourceDomainService {
+
+    public static final String MARKDOWN = "# In memory markdown";
+    public static final String SENSITIVE_DATA = "I'm a sensitive data";
+    public static final String SENSITIVE_DATA_REPLACEMENT = "********";
+
+    private RuntimeException fetchFailure;
+    private String lastValidatedConfiguration;
+
+    public void failNextFetchWith(RuntimeException failure) {
+        this.fetchFailure = failure;
+    }
+
+    /** Configuration the last validation was given, to assert what the plugin actually sees. */
+    public String lastValidatedConfiguration() {
+        return lastValidatedConfiguration;
+    }
+
+    @Override
+    public String fetchContent(PortalNavigationItemSource source) {
+        if (fetchFailure != null) {
+            var failure = fetchFailure;
+            fetchFailure = null;
+            throw failure;
+        }
+        return MARKDOWN;
+    }
+
+    @Override
+    public void removeSensitiveData(PortalNavigationItemSource source) {
+        if (source.getSourceConfiguration() != null) {
+            source.setSourceConfiguration(source.getSourceConfiguration().replace(SENSITIVE_DATA, SENSITIVE_DATA_REPLACEMENT));
+        }
+    }
+
+    @Override
+    public void mergeSensitiveData(PortalNavigationItemSource oldSource, PortalNavigationItemSource newSource) {
+        if (oldSource == null || newSource == null) {
+            return;
+        }
+        if (
+            newSource.getSourceConfiguration().contains(SENSITIVE_DATA_REPLACEMENT) &&
+            oldSource.getSourceConfiguration().contains(SENSITIVE_DATA)
+        ) {
+            newSource.setSourceConfiguration(newSource.getSourceConfiguration().replace(SENSITIVE_DATA_REPLACEMENT, SENSITIVE_DATA));
+        }
+    }
+
+    @Override
+    public void validateSourceConfiguration(PortalNavigationItemSource source) {
+        this.lastValidatedConfiguration = source.getSourceConfiguration();
+        if (source.getSourceConfiguration() != null && source.getSourceConfiguration().contains(SENSITIVE_DATA_REPLACEMENT)) {
+            throw InvalidPortalNavigationItemSourceException.unresolvedSensitivePlaceholder("sensitiveData");
+        }
+        if (source.isUseAutoFetch() && source.getFetchCron() == null) {
+            throw InvalidPortalNavigationItemSourceException.cronRequiredForAutoFetch();
+        }
+        if (source.getFetchCron() != null && !CronExpression.isValidExpression(source.getFetchCron())) {
+            throw InvalidPortalNavigationItemSourceException.invalidCronExpression(source.getFetchCron());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentQueryServiceInMemory.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 public class PortalPageContentQueryServiceInMemory implements InMemoryAlternative<PortalPageContent<?>>, PortalPageContentQueryService {
 
-    ArrayList<PortalPageContent<?>> storage = new ArrayList<>();
+    List<PortalPageContent<?>> storage = new ArrayList<>();
 
     public PortalPageContentQueryServiceInMemory() {
         initWith(List.of());
@@ -33,6 +33,16 @@ public class PortalPageContentQueryServiceInMemory implements InMemoryAlternativ
 
     public PortalPageContentQueryServiceInMemory(List<PortalPageContent<?>> items) {
         initWith(items);
+    }
+
+    /**
+     * Builds a query service backed by the given live list (typically a crud service's storage), so
+     * contents created at runtime are visible to queries — unlike the copying constructor.
+     */
+    public static PortalPageContentQueryServiceInMemory sharing(List<PortalPageContent<?>> sharedStorage) {
+        var service = new PortalPageContentQueryServiceInMemory();
+        service.storage = sharedStorage;
+        return service;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/CreatePortalNavigationItemValidatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/CreatePortalNavigationItemValidatorServiceTest.java
@@ -28,9 +28,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import fixtures.core.model.PortalNavigationItemFixtures;
 import fixtures.core.model.PortalPageContentFixtures;
 import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.exception.HomepageAlreadyExistsException;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.InvalidUrlFormatException;
@@ -39,7 +42,9 @@ import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.ParentAreaMismatchException;
 import io.gravitee.apim.core.portal_page.exception.ParentNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.ParentTypeMismatchException;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -50,6 +55,7 @@ import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -76,7 +82,8 @@ class CreatePortalNavigationItemValidatorServiceTest {
         validatorService = new PortalNavigationItemValidatorService(
             navigationItemsQueryService,
             pageContentQueryService,
-            apiProductQueryService
+            apiProductQueryService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
         navigationItemsQueryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
         pageContentQueryService.initWith(PortalPageContentFixtures.samplePortalPageContents());
@@ -689,6 +696,65 @@ class CreatePortalNavigationItemValidatorServiceTest {
             assertDoesNotThrow(() -> validatorService.validateOne(createPortalNavigationItem, ENV_ID));
         }
 
+        private GraviteeMarkdownPageContent givenAnAutomationManagedContent() {
+            var automationContent = new GraviteeMarkdownPageContent(
+                PortalPageContentId.random(),
+                ORG_ID,
+                ENV_ID,
+                GraviteeMarkdown.of("# automation"),
+                new AutomationMetadata(AutomationMetadata.ReferenceType.PORTAL, "portal-id", "page", Optional.empty(), Optional.empty())
+            );
+            pageContentQueryService.storage().add(automationContent);
+            return automationContent;
+        }
+
+        private PortalNavigationItem givenAnAutomationManagedPage(String id, PortalNavigationItemId parentId) {
+            var page = PortalNavigationItemFixtures.aPage(id, "Automation page", parentId, givenAnAutomationManagedContent().getId());
+            navigationItemsQueryService.storage().add(page);
+            return page;
+        }
+
+        private CreatePortalNavigationItem.CreatePortalNavigationItemBuilder aSourcedPageUnder(PortalNavigationItemId parentId) {
+            return CreatePortalNavigationItem.builder()
+                .type(PortalNavigationItemType.PAGE)
+                .title("Sourced page")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                .parentId(parentId)
+                .source(aSource());
+        }
+
+        @Test
+        void should_reject_source_on_a_page_whose_content_is_automation_managed() {
+            var automationContent = givenAnAutomationManagedContent();
+
+            var error = assertThrows(InvalidPortalNavigationItemDataException.class, () ->
+                validatorService.validateOne(aSourcedPageUnder(null).portalPageContentId(automationContent.getId()).build(), ENV_ID)
+            );
+
+            assertThat(error).hasMessageContaining("Automation API");
+        }
+
+        @Test
+        void should_accept_source_next_to_an_automation_managed_page() {
+            // Siblings are owned by neither the fetcher nor automation: no conflict
+            var parent = PortalNavigationItemFixtures.aFolder("Parent");
+            parent.markAsRoot();
+            navigationItemsQueryService.storage().add(parent);
+            givenAnAutomationManagedPage("00000000-0000-0000-0000-00000000aa01", parent.getId());
+
+            assertDoesNotThrow(() -> validatorService.validateOne(aSourcedPageUnder(parent.getId()).build(), ENV_ID));
+        }
+
+        @Test
+        void should_accept_source_at_root_level_when_another_top_level_item_is_automation_managed() {
+            var automationPage = givenAnAutomationManagedPage("00000000-0000-0000-0000-00000000aa02", null);
+            automationPage.markAsRoot();
+
+            assertDoesNotThrow(() -> validatorService.validateOne(aSourcedPageUnder(null).build(), ENV_ID));
+        }
+
         @Test
         void should_accept_source_on_folder() {
             final var createPortalNavigationItem = CreatePortalNavigationItem.builder()
@@ -742,6 +808,84 @@ class CreatePortalNavigationItemValidatorServiceTest {
             assertThat(exception.getMessage()).isEqualTo(
                 "An external source can only be configured on PAGE and FOLDER navigation items (got API)."
             );
+        }
+    }
+
+    @Nested
+    class CreateBelowSourcedItem {
+
+        private PortalNavigationItem givenASourcedFolder() {
+            var folder = PortalNavigationItemFixtures.aFolder("Sourced folder")
+                .toBuilder()
+                .source(PortalNavigationItemSource.builder().sourceType("http-fetcher").sourceConfiguration("{}").build())
+                .build();
+            folder.markAsRoot();
+            navigationItemsQueryService.storage().add(folder);
+            return folder;
+        }
+
+        private CreatePortalNavigationItem.CreatePortalNavigationItemBuilder aPageUnder(PortalNavigationItemId parentId) {
+            return CreatePortalNavigationItem.builder()
+                .type(PortalNavigationItemType.PAGE)
+                .title("Manual page")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                .parentId(parentId);
+        }
+
+        @Test
+        void should_reject_creation_directly_below_a_sourced_folder() {
+            var folder = givenASourcedFolder();
+
+            var error = assertThrows(InvalidPortalNavigationItemDataException.class, () ->
+                validatorService.validateOne(aPageUnder(folder.getId()).build(), ENV_ID)
+            );
+
+            assertThat(error).hasMessageContaining("subtree is managed by an external source");
+        }
+
+        @Test
+        void should_reject_creation_deeper_in_the_subtree_of_a_sourced_folder() {
+            var folder = givenASourcedFolder();
+            var intermediate = PortalNavigationItemFixtures.aFolder("Intermediate", folder.getId());
+            navigationItemsQueryService.storage().add(intermediate);
+
+            var error = assertThrows(InvalidPortalNavigationItemDataException.class, () ->
+                validatorService.validateOne(aPageUnder(intermediate.getId()).build(), ENV_ID)
+            );
+
+            assertThat(error).hasMessageContaining("subtree is managed by an external source");
+        }
+
+        @Test
+        void should_reject_child_of_a_sourced_folder_declared_in_the_same_bulk_payload() {
+            var folderId = PortalNavigationItemId.random();
+            var sourcedFolder = CreatePortalNavigationItem.builder()
+                .id(folderId)
+                .type(PortalNavigationItemType.FOLDER)
+                .title("Sourced folder")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                .source(PortalNavigationItemSource.builder().sourceType("http-fetcher").sourceConfiguration("{}").build())
+                .build();
+            var child = aPageUnder(folderId).build();
+
+            var error = assertThrows(InvalidPortalNavigationItemDataException.class, () ->
+                validatorService.validateAll(List.of(sourcedFolder, child), ENV_ID)
+            );
+
+            assertThat(error).hasMessageContaining("subtree is managed by an external source");
+        }
+
+        @Test
+        void should_accept_creation_below_a_folder_without_source() {
+            var folder = PortalNavigationItemFixtures.aFolder("Plain folder");
+            folder.markAsRoot();
+            navigationItemsQueryService.storage().add(folder);
+
+            assertDoesNotThrow(() -> validatorService.validateOne(aPageUnder(folder.getId()).build(), ENV_ID));
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainServiceTest.java
@@ -19,12 +19,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiCrudServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
@@ -48,6 +54,7 @@ public class PortalNavigationItemDomainServiceTest {
         new PortalNavigationItemsQueryServiceInMemory(portalNavigationItemsCrudService.storage());
     private final PortalPageContentCrudServiceInMemory portalPageContentCrudService = new PortalPageContentCrudServiceInMemory();
     private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    private PortalNavigationItemSourceDomainServiceInMemory sourceDomainService;
     private PortalNavigationItemDomainService domainService;
 
     @BeforeEach
@@ -57,12 +64,97 @@ public class PortalNavigationItemDomainServiceTest {
         portalPageContentCrudService.reset();
         apiCrudService.reset();
 
+        sourceDomainService = new PortalNavigationItemSourceDomainServiceInMemory();
         domainService = new PortalNavigationItemDomainService(
             portalNavigationItemsCrudService,
             portalNavigationItemsQueryService,
             portalPageContentCrudService,
-            apiCrudService
+            PortalPageContentQueryServiceInMemory.sharing(portalPageContentCrudService.storage()),
+            apiCrudService,
+            sourceDomainService
         );
+    }
+
+    @Nested
+    class CreateWithSource {
+
+        private PortalNavigationItemSource.PortalNavigationItemSourceBuilder aSource() {
+            return PortalNavigationItemSource.builder()
+                .sourceType("http-fetcher")
+                .sourceConfiguration("{\"url\":\"https://example.com/doc.md\"}");
+        }
+
+        private CreatePortalNavigationItem aPageToCreate(PortalNavigationItemSource source) {
+            return CreatePortalNavigationItem.builder()
+                .type(PortalNavigationItemType.PAGE)
+                .title("Sourced Page")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                .source(source)
+                .build();
+        }
+
+        @Test
+        void should_trigger_initial_fetch_overwriting_default_content() {
+            var created = domainService.create(
+                PortalNavigationItemFixtures.ORG_ID,
+                PortalNavigationItemFixtures.ENV_ID,
+                aPageToCreate(aSource().build())
+            );
+
+            assertThat(created.getSource()).isNotNull();
+            assertThat(created.getSource().getLastFetchedAt()).isNotNull();
+            assertThat(created.getSource().getLastFetchError()).isNull();
+            assertThat(portalPageContentCrudService.storage())
+                .singleElement()
+                .satisfies(content ->
+                    assertThat(((GraviteeMarkdownPageContent) content).getContent().value()).isEqualTo(
+                        PortalNavigationItemSourceDomainServiceInMemory.MARKDOWN
+                    )
+                );
+        }
+
+        @Test
+        void should_create_item_with_fetch_error_when_initial_fetch_fails() {
+            sourceDomainService.failNextFetchWith(new TechnicalDomainException("initial fetch failed"));
+
+            var created = domainService.create(
+                PortalNavigationItemFixtures.ORG_ID,
+                PortalNavigationItemFixtures.ENV_ID,
+                aPageToCreate(aSource().build())
+            );
+
+            assertThat(created.getSource()).isNotNull();
+            assertThat(created.getSource().getLastFetchedAt()).isNull();
+            assertThat(created.getSource().getLastFetchError()).isEqualTo("Unable to fetch content from source type http-fetcher.");
+            assertThat(portalNavigationItemsCrudService.storage()).hasSize(1);
+        }
+
+        @Test
+        void should_not_expose_the_underlying_failure_message_in_the_fetch_error() {
+            sourceDomainService.failNextFetchWith(new TechnicalDomainException("failed for {\"token\":\"s3cr3t\"}"));
+
+            var created = domainService.create(
+                PortalNavigationItemFixtures.ORG_ID,
+                PortalNavigationItemFixtures.ENV_ID,
+                aPageToCreate(aSource().build())
+            );
+
+            assertThat(created.getSource().getLastFetchError()).doesNotContain("s3cr3t");
+        }
+
+        @Test
+        void should_create_page_without_source_as_before() {
+            var created = domainService.create(
+                PortalNavigationItemFixtures.ORG_ID,
+                PortalNavigationItemFixtures.ENV_ID,
+                aPageToCreate(null)
+            );
+
+            assertThat(created.getSource()).isNull();
+            assertThat(portalPageContentCrudService.storage()).hasSize(1);
+        }
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemSourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemSourceTest.java
@@ -124,6 +124,31 @@ class PortalNavigationItemSourceTest {
     }
 
     @Test
+    void should_preserve_fetch_state_when_configuration_only_differs_in_formatting() {
+        var item = aPageWithSource(
+            PortalNavigationItemSource.builder()
+                .sourceType("http-fetcher")
+                .sourceConfiguration("{\n  \"url\" : \"https://example.com/a.md\",\n  \"useAuth\" : true\n}")
+                .lastFetchedAt(LAST_FETCHED_AT)
+                .build()
+        );
+
+        item.update(
+            anUpdate()
+                .source(
+                    PortalNavigationItemSource.builder()
+                        .sourceType("http-fetcher")
+                        .sourceConfiguration("{\"useAuth\":true,\"url\":\"https://example.com/a.md\"}")
+                        .build()
+                )
+                .build()
+        );
+
+        assertThat(item.getSource()).isNotNull();
+        assertThat(item.getSource().getLastFetchedAt()).isEqualTo(LAST_FETCHED_AT);
+    }
+
+    @Test
     void should_reset_fetch_state_when_source_configuration_changes() {
         var item = aPageWithSource(
             PortalNavigationItemSource.builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/BulkCreatePortalNavigationItemsUseCaseTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
@@ -41,6 +42,7 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefau
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
@@ -76,11 +78,23 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
         queryService = new PortalNavigationItemsQueryServiceInMemory(storage);
         final var pageContentQueryService = new PortalPageContentQueryServiceInMemory();
         apiProductQueryService = new ApiProductQueryServiceInMemory();
-        validatorService = new PortalNavigationItemValidatorService(queryService, pageContentQueryService, apiProductQueryService);
+        validatorService = new PortalNavigationItemValidatorService(
+            queryService,
+            pageContentQueryService,
+            apiProductQueryService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
+        );
         final var pageContentCrudService = new PortalPageContentCrudServiceInMemory();
         apiCrudService = new ApiCrudServiceInMemory();
 
-        final var domainService = new PortalNavigationItemDomainService(crudService, queryService, pageContentCrudService, apiCrudService);
+        final var domainService = new PortalNavigationItemDomainService(
+            crudService,
+            queryService,
+            pageContentCrudService,
+            PortalPageContentQueryServiceInMemory.sharing(pageContentCrudService.storage()),
+            apiCrudService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
+        );
         creationExpansionDomainService = new PortalNavigationItemCreationExpansionDomainService(apiProductQueryService, apiCrudService);
         defaultPageDomainService = new PortalNavigationApiDefaultPageDomainService(
             queryService,
@@ -92,7 +106,8 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
             domainService,
             validatorService,
             creationExpansionDomainService,
-            defaultPageDomainService
+            defaultPageDomainService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
     }
@@ -193,7 +208,8 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
             domainService,
             validatorService,
             creationExpansionDomainService,
-            defaultPageDomainService
+            defaultPageDomainService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
 
         final var validItem = CreatePortalNavigationItem.builder()
@@ -256,7 +272,8 @@ class BulkCreatePortalNavigationItemsUseCaseTest {
             domainService,
             validatorService,
             creationExpansionDomainService,
-            defaultPageDomainService
+            defaultPageDomainService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
 
         assertThrows(IllegalStateException.class, () ->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCaseTest.java
@@ -20,9 +20,11 @@ import static fixtures.core.model.PortalNavigationItemFixtures.ORG_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import inmemory.ApiCrudServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
@@ -56,7 +58,9 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
             crudService,
             queryService,
             pageContentCrudService,
-            apiCrudService
+            PortalPageContentQueryServiceInMemory.sharing(pageContentCrudService.storage()),
+            apiCrudService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
         useCase = new CreateDefaultPortalNavigationItemsUseCase(portalNavigationItemDomainService, pageContentCrudService);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
@@ -37,6 +38,7 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefau
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemCreationExpansionDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
@@ -85,8 +87,20 @@ class CreatePortalNavigationItemUseCaseTest {
         PortalPageContentQueryServiceInMemory pageContentQueryService = new PortalPageContentQueryServiceInMemory(
             pageContentCrudService.storage()
         );
-        validatorService = new PortalNavigationItemValidatorService(queryService, pageContentQueryService, apiProductQueryService);
-        domainService = new PortalNavigationItemDomainService(crudService, queryService, pageContentCrudService, apiCrudService);
+        validatorService = new PortalNavigationItemValidatorService(
+            queryService,
+            pageContentQueryService,
+            apiProductQueryService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
+        );
+        domainService = new PortalNavigationItemDomainService(
+            crudService,
+            queryService,
+            pageContentCrudService,
+            PortalPageContentQueryServiceInMemory.sharing(pageContentCrudService.storage()),
+            apiCrudService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
+        );
         creationExpansionDomainService = new PortalNavigationItemCreationExpansionDomainService(apiProductQueryService, apiCrudService);
         var defaultPageDomainService = new PortalNavigationApiDefaultPageDomainService(
             queryService,
@@ -98,7 +112,8 @@ class CreatePortalNavigationItemUseCaseTest {
             domainService,
             validatorService,
             creationExpansionDomainService,
-            defaultPageDomainService
+            defaultPageDomainService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
         apiCrudService.initWith(List.of(Api.builder().id("apiId").name("apiIdName").build()));
@@ -167,7 +182,8 @@ class CreatePortalNavigationItemUseCaseTest {
             domainService,
             validatorService,
             creationExpansionDomainService,
-            failingDefaultPageDomainService
+            failingDefaultPageDomainService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
         var toCreate = CreatePortalNavigationItem.builder()
             .type(PortalNavigationItemType.API_PRODUCT)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalNavigationItemUseCaseTest.java
@@ -19,10 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiCrudServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -55,10 +58,16 @@ public class DeletePortalNavigationItemUseCaseTest {
             portalNavigationItemsCrudService,
             portalNavigationItemsQueryService,
             portalPageContentCrudService,
-            apiCrudService
+            PortalPageContentQueryServiceInMemory.sharing(portalPageContentCrudService.storage()),
+            apiCrudService,
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
 
-        deletePortalNavigationItemUseCase = new DeletePortalNavigationItemUseCase(domainService, portalNavigationItemsQueryService);
+        deletePortalNavigationItemUseCase = new DeletePortalNavigationItemUseCase(
+            domainService,
+            portalNavigationItemsQueryService,
+            new PortalNavigationSourcedItemsDomainService(portalNavigationItemsQueryService)
+        );
     }
 
     @AfterEach
@@ -202,5 +211,65 @@ public class DeletePortalNavigationItemUseCaseTest {
         );
 
         assertThat(portalNavigationItemsCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_reject_delete_of_sourced_item() {
+        var sourcedPage = PortalNavigationItemFixtures.aPage(PortalNavigationItemFixtures.PAGE11_ID, "page11", null)
+            .toBuilder()
+            .source(aSource())
+            .build();
+        sourcedPage.markAsRoot();
+        portalNavigationItemsCrudService.initWith(List.of(sourcedPage));
+        portalNavigationItemsQueryService.initWith(List.of(sourcedPage));
+
+        var error = org.junit.jupiter.api.Assertions.assertThrows(
+            io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException.class,
+            () ->
+                deletePortalNavigationItemUseCase.execute(
+                    new DeletePortalNavigationItemUseCase.Input(
+                        PortalNavigationItemFixtures.ORG_ID,
+                        PortalNavigationItemFixtures.ENV_ID,
+                        sourcedPage.getId()
+                    )
+                )
+        );
+
+        assertThat(error).hasMessageContaining("cannot be deleted");
+        assertThat(portalNavigationItemsCrudService.storage()).hasSize(1);
+    }
+
+    @Test
+    void should_reject_delete_of_child_of_sourced_folder() {
+        var sourcedFolder = PortalNavigationItemFixtures.aFolder(PortalNavigationItemFixtures.FOLDER_ID, "Sourced Folder")
+            .toBuilder()
+            .source(aSource())
+            .build();
+        sourcedFolder.markAsRoot();
+        var child = PortalNavigationItemFixtures.aPage(PortalNavigationItemFixtures.PAGE11_ID, "Child Page", sourcedFolder.getId());
+        portalNavigationItemsCrudService.initWith(List.of(sourcedFolder, child));
+        portalNavigationItemsQueryService.initWith(List.of(sourcedFolder, child));
+
+        var error = org.junit.jupiter.api.Assertions.assertThrows(
+            io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException.class,
+            () ->
+                deletePortalNavigationItemUseCase.execute(
+                    new DeletePortalNavigationItemUseCase.Input(
+                        PortalNavigationItemFixtures.ORG_ID,
+                        PortalNavigationItemFixtures.ENV_ID,
+                        child.getId()
+                    )
+                )
+        );
+
+        assertThat(error).hasMessageContaining("read-only");
+        assertThat(portalNavigationItemsCrudService.storage()).hasSize(2);
+    }
+
+    private static io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource aSource() {
+        return io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource.builder()
+            .sourceType("http-fetcher")
+            .sourceConfiguration("{\"url\":\"https://example.com/doc.md\"}")
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/FetchPortalPageContentUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/FetchPortalPageContentUseCaseTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import java.util.ArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FetchPortalPageContentUseCaseTest {
+
+    private static final String ORG_ID = "org-id";
+    private static final String ENV_ID = "env-id";
+
+    private PortalNavigationItemsCrudServiceInMemory crudService;
+    private PortalNavigationItemsQueryServiceInMemory queryService;
+    private PortalPageContentCrudServiceInMemory pageContentCrudService;
+    private PortalNavigationItemSourceDomainServiceInMemory sourceDomainService;
+    private FetchPortalPageContentUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        var storage = new ArrayList<PortalNavigationItem>();
+        crudService = new PortalNavigationItemsCrudServiceInMemory(storage);
+        queryService = new PortalNavigationItemsQueryServiceInMemory(storage);
+        pageContentCrudService = new PortalPageContentCrudServiceInMemory();
+        sourceDomainService = new PortalNavigationItemSourceDomainServiceInMemory();
+
+        var domainService = new PortalNavigationItemDomainService(
+            crudService,
+            queryService,
+            pageContentCrudService,
+            PortalPageContentQueryServiceInMemory.sharing(pageContentCrudService.storage()),
+            new ApiCrudServiceInMemory(),
+            sourceDomainService
+        );
+        useCase = new FetchPortalPageContentUseCase(queryService, domainService, sourceDomainService);
+    }
+
+    private PortalNavigationPage aSourcedPage(PortalNavigationItemSource source) {
+        var content = GraviteeMarkdownPageContent.create(ORG_ID, ENV_ID, "# Default content");
+        pageContentCrudService.create(content);
+
+        var page = (PortalNavigationPage) PortalNavigationItem.from(
+            CreatePortalNavigationItem.builder()
+                .type(PortalNavigationItemType.PAGE)
+                .title("Sourced Page")
+                .segment("sourced-page")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .portalPageContentId(content.getId())
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                .source(source)
+                .build(),
+            ORG_ID,
+            ENV_ID,
+            null
+        );
+        crudService.create(page);
+        return page;
+    }
+
+    private PortalNavigationItemSource.PortalNavigationItemSourceBuilder aSource() {
+        return PortalNavigationItemSource.builder()
+            .sourceType("http-fetcher")
+            .sourceConfiguration("{\"url\":\"https://example.com/doc.md\"}");
+    }
+
+    @Test
+    void should_fetch_content_overwrite_page_content_and_clear_previous_error() {
+        var page = aSourcedPage(aSource().lastFetchError("previous error").build());
+
+        var output = useCase.execute(new FetchPortalPageContentUseCase.Input(ENV_ID, page.getId().toString()));
+
+        var source = output.updatedItem().getSource();
+        assertThat(source).isNotNull();
+        assertThat(source.getLastFetchedAt()).isNotNull();
+        assertThat(source.getLastFetchError()).isNull();
+        assertThat(pageContentCrudService.storage())
+            .singleElement()
+            .satisfies(content ->
+                assertThat(((GraviteeMarkdownPageContent) content).getContent().value()).isEqualTo(
+                    PortalNavigationItemSourceDomainServiceInMemory.MARKDOWN
+                )
+            );
+    }
+
+    @Test
+    void should_record_fetch_error_and_keep_existing_content_when_fetch_fails() {
+        var page = aSourcedPage(aSource().build());
+        sourceDomainService.failNextFetchWith(new TechnicalDomainException("fetch went wrong"));
+
+        var output = useCase.execute(new FetchPortalPageContentUseCase.Input(ENV_ID, page.getId().toString()));
+
+        var source = output.updatedItem().getSource();
+        assertThat(source).isNotNull();
+        assertThat(source.getLastFetchedAt()).isNull();
+        assertThat(source.getLastFetchError()).isEqualTo("Unable to fetch content from source type http-fetcher.");
+        assertThat(pageContentCrudService.storage())
+            .singleElement()
+            .satisfies(content -> assertThat(((GraviteeMarkdownPageContent) content).getContent().value()).isEqualTo("# Default content"));
+    }
+
+    @Test
+    void should_record_fetch_error_even_when_the_exception_has_no_message() {
+        var page = aSourcedPage(aSource().build());
+        sourceDomainService.failNextFetchWith(new RuntimeException());
+
+        var output = useCase.execute(new FetchPortalPageContentUseCase.Input(ENV_ID, page.getId().toString()));
+
+        assertThat(output.updatedItem().getSource().getLastFetchError()).isNotBlank();
+    }
+
+    @Test
+    void should_throw_when_item_not_found() {
+        assertThatThrownBy(() ->
+            useCase.execute(new FetchPortalPageContentUseCase.Input(ENV_ID, "00000000-0000-0000-0000-000000000099"))
+        ).isInstanceOf(PortalNavigationItemNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_when_page_has_no_source() {
+        var page = aSourcedPage(null);
+
+        assertThatThrownBy(() -> useCase.execute(new FetchPortalPageContentUseCase.Input(ENV_ID, page.getId().toString())))
+            .isInstanceOf(InvalidPortalNavigationItemDataException.class)
+            .hasMessageContaining("no external source");
+    }
+
+    @Test
+    void should_throw_when_item_is_not_a_page() {
+        var folder = PortalNavigationItem.from(
+            CreatePortalNavigationItem.builder()
+                .type(PortalNavigationItemType.FOLDER)
+                .title("Folder")
+                .segment("folder")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .build(),
+            ORG_ID,
+            ENV_ID,
+            null
+        );
+        crudService.create(folder);
+
+        assertThatThrownBy(() -> useCase.execute(new FetchPortalPageContentUseCase.Input(ENV_ID, folder.getId().toString())))
+            .isInstanceOf(InvalidPortalNavigationItemDataException.class)
+            .hasMessageContaining("no external source");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCaseTest.java
@@ -26,6 +26,7 @@ import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
@@ -68,7 +69,11 @@ class GetPortalNavigationItemUseCaseTest {
             queryService,
             new ApiProductAccessibleIdsDomainService(new ApiProductQueryServiceInMemory(), membershipQueryService)
         );
-        useCase = new GetPortalNavigationItemUseCase(queryService, List.of(apiVisibilityDomainService, apiProductVisibilityDomainService));
+        useCase = new GetPortalNavigationItemUseCase(
+            queryService,
+            List.of(apiVisibilityDomainService, apiProductVisibilityDomainService),
+            new PortalNavigationItemSourceDomainServiceInMemory()
+        );
 
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
@@ -25,6 +25,7 @@ import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
@@ -76,7 +77,8 @@ class ListPortalNavigationItemsUseCaseTest {
         );
         useCase = new ListPortalNavigationItemsUseCase(
             queryService,
-            List.of(apiVisibilityDomainService, apiProductVisibilityDomainService)
+            List.of(apiVisibilityDomainService, apiProductVisibilityDomainService),
+            new PortalNavigationItemSourceDomainServiceInMemory()
         );
 
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCaseTest.java
@@ -23,9 +23,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiCrudServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiDefaultPageDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
@@ -71,7 +73,9 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
                     portalNavigationItemsCrudService,
                     portalNavigationItemsQueryService,
                     portalPageContentCrudService,
-                    apiCrudService
+                    PortalPageContentQueryServiceInMemory.sharing(portalPageContentCrudService.storage()),
+                    apiCrudService,
+                    new PortalNavigationItemSourceDomainServiceInMemory()
                 ),
                 portalPageContentCrudService,
                 apiCrudService

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCaseTest.java
@@ -26,31 +26,40 @@ import static fixtures.core.model.PortalNavigationItemFixtures.LINK1_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.ORG_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.PAGE11_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.ParentNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -68,6 +77,8 @@ class UpdatePortalNavigationItemUseCaseTest {
     private PortalNavigationItemDomainService domainService;
     private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
+    private PortalPageContentCrudServiceInMemory pageContentCrudService;
+    private PortalNavigationItemSourceDomainServiceInMemory sourceDomainService;
 
     @BeforeEach
     void setUp() {
@@ -75,14 +86,30 @@ class UpdatePortalNavigationItemUseCaseTest {
         crudService = new PortalNavigationItemsCrudServiceInMemory(storage);
         queryService = new PortalNavigationItemsQueryServiceInMemory(storage);
 
-        PortalPageContentCrudServiceInMemory pageContentCrudService = new PortalPageContentCrudServiceInMemory();
-        PortalPageContentQueryServiceInMemory pageContentQueryService = new PortalPageContentQueryServiceInMemory(
+        pageContentCrudService = new PortalPageContentCrudServiceInMemory();
+        PortalPageContentQueryServiceInMemory pageContentQueryService = PortalPageContentQueryServiceInMemory.sharing(
             pageContentCrudService.storage()
         );
 
-        validatorService = new PortalNavigationItemValidatorService(queryService, pageContentQueryService, apiProductQueryService);
-        domainService = new PortalNavigationItemDomainService(crudService, queryService, pageContentCrudService, apiCrudService);
-        useCase = new UpdatePortalNavigationItemUseCase(queryService, validatorService, domainService);
+        // A single instance shared by the three collaborators, so that a test can observe what the
+        // validation was given and in which order masking and merging happened.
+        sourceDomainService = new PortalNavigationItemSourceDomainServiceInMemory();
+
+        validatorService = new PortalNavigationItemValidatorService(
+            queryService,
+            pageContentQueryService,
+            apiProductQueryService,
+            sourceDomainService
+        );
+        domainService = new PortalNavigationItemDomainService(
+            crudService,
+            queryService,
+            pageContentCrudService,
+            PortalPageContentQueryServiceInMemory.sharing(pageContentCrudService.storage()),
+            apiCrudService,
+            sourceDomainService
+        );
+        useCase = new UpdatePortalNavigationItemUseCase(queryService, validatorService, domainService, sourceDomainService);
 
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
     }
@@ -868,5 +895,261 @@ class UpdatePortalNavigationItemUseCaseTest {
             .navigationItemId(apiProduct.getId().toString())
             .updatePortalNavigationItem(toUpdate)
             .build();
+    }
+
+    @Nested
+    class SourcedItems {
+
+        private static final String SOURCED_FOLDER_ID = "00000000-0000-0000-0000-00000000f001";
+        private static final String CHILD_PAGE_ID = "00000000-0000-0000-0000-00000000f002";
+        private static final String SOURCED_PAGE_ID = "00000000-0000-0000-0000-00000000f003";
+
+        private PortalNavigationItemSource aSource() {
+            return PortalNavigationItemSource.builder()
+                .sourceType("http-fetcher")
+                .sourceConfiguration("{\"url\":\"https://example.com/doc.md\"}")
+                .build();
+        }
+
+        private PortalNavigationItemSource aSourceWithSecret(String token) {
+            return PortalNavigationItemSource.builder()
+                .sourceType("http-fetcher")
+                .sourceConfiguration("{\"token\":\"" + token + "\"}")
+                .build();
+        }
+
+        /** What the client sends back after a read: the secret replaced by its placeholder. */
+        private PortalNavigationItemSource aMaskedSource() {
+            return aSourceWithSecret(PortalNavigationItemSourceDomainServiceInMemory.SENSITIVE_DATA_REPLACEMENT);
+        }
+
+        private PortalNavigationItem givenASourcedPageWithSecret() {
+            var page = PortalNavigationItemFixtures.aPage(SOURCED_PAGE_ID, "Sourced Page", null)
+                .toBuilder()
+                .source(aSourceWithSecret(PortalNavigationItemSourceDomainServiceInMemory.SENSITIVE_DATA))
+                .build();
+            page.markAsRoot();
+            queryService.storage().add(page);
+            return page;
+        }
+
+        private PortalNavigationItem givenASourcedPage() {
+            var page = PortalNavigationItemFixtures.aPage(SOURCED_PAGE_ID, "Sourced Page", null).toBuilder().source(aSource()).build();
+            page.markAsRoot();
+            queryService.storage().add(page);
+            return page;
+        }
+
+        private PortalNavigationItem givenAChildOfSourcedFolder() {
+            var folder = PortalNavigationItemFixtures.aFolder(SOURCED_FOLDER_ID, "Sourced Folder").toBuilder().source(aSource()).build();
+            folder.markAsRoot();
+            var child = PortalNavigationItemFixtures.aPage(CHILD_PAGE_ID, "Child Page", folder.getId());
+            queryService.storage().add(folder);
+            queryService.storage().add(child);
+            return child;
+        }
+
+        private UpdatePortalNavigationItemUseCase.Input anUpdateInput(PortalNavigationItem item, UpdatePortalNavigationItem toUpdate) {
+            return UpdatePortalNavigationItemUseCase.Input.builder()
+                .organizationId(ORG_ID)
+                .environmentId(ENV_ID)
+                .navigationItemId(item.getId().toString())
+                .updatePortalNavigationItem(toUpdate)
+                .build();
+        }
+
+        private UpdatePortalNavigationItem.UpdatePortalNavigationItemBuilder anUpdateKeeping(PortalNavigationItem item) {
+            return UpdatePortalNavigationItem.builder()
+                .type(item.getType())
+                .title(item.getTitle())
+                .order(item.getOrder())
+                .parentId(item.getParentId())
+                .published(item.getPublished())
+                .visibility(item.getVisibility());
+        }
+
+        @Test
+        void should_reject_rename_of_sourced_item() {
+            var page = givenASourcedPage();
+            var input = anUpdateInput(page, anUpdateKeeping(page).title("Renamed").source(aSource()).build());
+
+            var error = assertThrows(InvalidPortalNavigationItemDataException.class, () -> useCase.execute(input));
+
+            assertThat(error).hasMessageContaining("cannot be renamed or moved");
+        }
+
+        @Test
+        void should_reject_move_of_sourced_item() {
+            var page = givenASourcedPage();
+            var input = anUpdateInput(
+                page,
+                anUpdateKeeping(page).parentId(PortalNavigationItemId.of(CATEGORY1_ID)).source(aSource()).build()
+            );
+
+            var error = assertThrows(InvalidPortalNavigationItemDataException.class, () -> useCase.execute(input));
+
+            assertThat(error).hasMessageContaining("cannot be renamed or moved");
+        }
+
+        @Test
+        void should_allow_rename_when_source_is_removed_in_same_update() {
+            var page = givenASourcedPage();
+            var input = anUpdateInput(page, anUpdateKeeping(page).title("Renamed").segment("renamed").build());
+
+            var output = useCase.execute(input);
+
+            assertThat(output.updatedItem().getTitle()).isEqualTo("Renamed");
+            assertThat(output.updatedItem().getSource()).isNull();
+        }
+
+        @Test
+        void should_restore_the_masked_secret_before_the_configuration_is_validated() {
+            var page = givenASourcedPageWithSecret();
+            var input = anUpdateInput(page, anUpdateKeeping(page).source(aMaskedSource()).build());
+
+            useCase.execute(input);
+
+            assertThat(sourceDomainService.lastValidatedConfiguration())
+                .contains(PortalNavigationItemSourceDomainServiceInMemory.SENSITIVE_DATA)
+                .doesNotContain(PortalNavigationItemSourceDomainServiceInMemory.SENSITIVE_DATA_REPLACEMENT);
+        }
+
+        @Test
+        void should_mask_the_secret_again_in_the_response() {
+            var page = givenASourcedPageWithSecret();
+            var input = anUpdateInput(page, anUpdateKeeping(page).source(aMaskedSource()).build());
+
+            var output = useCase.execute(input);
+
+            assertThat(output.updatedItem().getSource().getSourceConfiguration())
+                .contains(PortalNavigationItemSourceDomainServiceInMemory.SENSITIVE_DATA_REPLACEMENT)
+                .doesNotContain(PortalNavigationItemSourceDomainServiceInMemory.SENSITIVE_DATA);
+        }
+
+        @Test
+        void should_reject_moving_an_item_below_a_sourced_folder() {
+            var folder = PortalNavigationItemFixtures.aFolder(SOURCED_FOLDER_ID, "Sourced Folder").toBuilder().source(aSource()).build();
+            folder.markAsRoot();
+            var rootPage = PortalNavigationItemFixtures.aPage(CHILD_PAGE_ID, "Root Page", null);
+            rootPage.markAsRoot();
+            queryService.storage().addAll(List.of(folder, rootPage));
+
+            var input = anUpdateInput(rootPage, anUpdateKeeping(rootPage).parentId(folder.getId()).build());
+
+            var error = assertThrows(InvalidPortalNavigationItemDataException.class, () -> useCase.execute(input));
+
+            assertThat(error).hasMessageContaining("cannot be moved below");
+        }
+
+        @Test
+        void should_allow_moving_an_item_below_a_folder_without_source() {
+            var folder = PortalNavigationItemFixtures.aFolder(SOURCED_FOLDER_ID, "Plain Folder");
+            folder.markAsRoot();
+            var rootPage = PortalNavigationItemFixtures.aPage(CHILD_PAGE_ID, "Root Page", null);
+            rootPage.markAsRoot();
+            queryService.storage().addAll(List.of(folder, rootPage));
+
+            var input = anUpdateInput(rootPage, anUpdateKeeping(rootPage).parentId(folder.getId()).build());
+
+            var output = useCase.execute(input);
+
+            assertThat(output.updatedItem().getParentId()).isEqualTo(folder.getId());
+        }
+
+        @Test
+        void should_reject_update_of_child_of_sourced_folder() {
+            var child = givenAChildOfSourcedFolder();
+            var input = anUpdateInput(child, anUpdateKeeping(child).title("Renamed child").build());
+
+            var error = assertThrows(InvalidPortalNavigationItemDataException.class, () -> useCase.execute(input));
+
+            assertThat(error).hasMessageContaining("read-only");
+        }
+
+        private GraviteeMarkdownPageContent givenAnAutomationManagedContent() {
+            var content = new GraviteeMarkdownPageContent(
+                PortalPageContentId.random(),
+                ORG_ID,
+                ENV_ID,
+                GraviteeMarkdown.of("# automation content"),
+                new AutomationMetadata(AutomationMetadata.ReferenceType.PORTAL, "portal-id", "page", Optional.empty(), Optional.empty())
+            );
+            pageContentCrudService.create(content);
+            return content;
+        }
+
+        @Test
+        void should_reject_adding_source_on_automation_managed_page() {
+            var page = PortalNavigationItemFixtures.aPage(
+                SOURCED_PAGE_ID,
+                "Automation Page",
+                null,
+                givenAnAutomationManagedContent().getId()
+            );
+            page.markAsRoot();
+            queryService.storage().add(page);
+
+            var input = anUpdateInput(page, anUpdateKeeping(page).source(aSource()).build());
+
+            var error = assertThrows(InvalidPortalNavigationItemDataException.class, () -> useCase.execute(input));
+
+            assertThat(error).hasMessageContaining("Automation API");
+        }
+
+        @Test
+        void should_reject_adding_source_on_a_folder_whose_subtree_contains_an_automation_managed_page() {
+            var folder = PortalNavigationItemFixtures.aFolder(SOURCED_FOLDER_ID, "Folder");
+            folder.markAsRoot();
+            var intermediate = PortalNavigationItemFixtures.aFolder("00000000-0000-0000-0000-00000000f010", "Intermediate", folder.getId());
+            var automationPage = PortalNavigationItemFixtures.aPage(
+                "00000000-0000-0000-0000-00000000f011",
+                "Automation Page",
+                intermediate.getId(),
+                givenAnAutomationManagedContent().getId()
+            );
+            queryService.storage().addAll(List.of(folder, intermediate, automationPage));
+
+            var input = anUpdateInput(folder, anUpdateKeeping(folder).source(aSource()).build());
+
+            var error = assertThrows(InvalidPortalNavigationItemDataException.class, () -> useCase.execute(input));
+
+            assertThat(error).hasMessageContaining("Automation API");
+        }
+
+        @Test
+        void should_accept_adding_source_when_the_automation_managed_page_is_outside_the_subtree() {
+            var folder = PortalNavigationItemFixtures.aFolder(SOURCED_FOLDER_ID, "Folder");
+            folder.markAsRoot();
+            var sibling = PortalNavigationItemFixtures.aPage(
+                "00000000-0000-0000-0000-00000000f012",
+                "Automation Page",
+                null,
+                givenAnAutomationManagedContent().getId()
+            );
+            sibling.markAsRoot();
+            queryService.storage().addAll(List.of(folder, sibling));
+
+            var input = anUpdateInput(folder, anUpdateKeeping(folder).source(aSource()).build());
+
+            assertDoesNotThrow(() -> useCase.execute(input));
+        }
+
+        @Test
+        void should_reject_invalid_cron_expression_on_update() {
+            var page = givenASourcedPage();
+            var invalidSource = PortalNavigationItemSource.builder()
+                .sourceType("http-fetcher")
+                .sourceConfiguration("{}")
+                .useAutoFetch(true)
+                .fetchCron("not-a-cron")
+                .build();
+            var input = anUpdateInput(page, anUpdateKeeping(page).source(invalidSource).build());
+
+            var error = assertThrows(io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException.class, () ->
+                useCase.execute(input)
+            );
+
+            assertThat(error).hasMessageContaining("not-a-cron");
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.PortalPageContentFixtures;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
@@ -34,6 +36,7 @@ import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
 import io.gravitee.apim.core.gravitee_markdown.exception.GraviteeMarkdownContentEmptyException;
 import io.gravitee.apim.core.portal_page.domain_service.GraviteePortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
@@ -55,11 +58,13 @@ class UpdatePortalPageContentUseCaseTest {
     private UpdatePortalPageContentUseCase useCase;
     private PortalPageContentQueryServiceInMemory queryService;
     private PortalPageContentCrudServiceInMemory crudService;
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
 
     @BeforeEach
     void setUp() {
         queryService = new PortalPageContentQueryServiceInMemory();
         crudService = new PortalPageContentCrudServiceInMemory();
+        navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory(new java.util.ArrayList<>());
 
         GraviteeMarkdownValidator gmdValidator = new GraviteeMarkdownValidator();
         PortalNavigationItemsQueryService portalNavigationItemsQueryService = mock(PortalNavigationItemsQueryService.class);
@@ -74,10 +79,52 @@ class UpdatePortalPageContentUseCaseTest {
         );
         PortalPageContentValidatorService validatorService = new PortalPageContentValidatorService(java.util.List.of(gmdContentValidator));
 
-        useCase = new UpdatePortalPageContentUseCase(queryService, crudService, validatorService);
+        useCase = new UpdatePortalPageContentUseCase(
+            queryService,
+            crudService,
+            validatorService,
+            navigationItemsQueryService,
+            new PortalNavigationSourcedItemsDomainService(navigationItemsQueryService)
+        );
 
         queryService.initWith(PortalPageContentFixtures.samplePortalPageContents());
         crudService.initWith(PortalPageContentFixtures.samplePortalPageContents());
+    }
+
+    @Test
+    void should_reject_content_edit_when_page_is_managed_by_a_source() {
+        var sourcedPage = io.gravitee.apim.core.portal_page.model.PortalNavigationPage.builder()
+            .id(io.gravitee.apim.core.portal_page.model.PortalNavigationItemId.of("00000000-0000-0000-0000-00000000ff01"))
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .title("Sourced Page")
+            .segment("sourced-page")
+            .area(io.gravitee.apim.core.portal_page.model.PortalArea.TOP_NAVBAR)
+            .order(0)
+            .portalPageContentId(PortalPageContentId.of(CONTENT_ID))
+            .published(true)
+            .visibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PUBLIC)
+            .source(
+                io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource.builder()
+                    .sourceType("http-fetcher")
+                    .sourceConfiguration("{}")
+                    .build()
+            )
+            .build();
+        sourcedPage.markAsRoot();
+        navigationItemsQueryService.storage().add(sourcedPage);
+
+        final var updateContent = UpdatePortalPageContent.builder().content("Updated content").build();
+        final var input = UpdatePortalPageContentUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId(CONTENT_ID)
+            .updatePortalPageContent(updateContent)
+            .build();
+
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException.class)
+            .hasMessageContaining("cannot be edited");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationItemSourceDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationItemSourceDomainServiceImplTest.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.portal_page;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import io.gravitee.apim.infra.domain_service.documentation.DummyFetcher;
+import io.gravitee.apim.infra.domain_service.documentation.DummyFetcherConfiguration;
+import io.gravitee.plugin.core.api.PluginManager;
+import io.gravitee.plugin.fetcher.FetcherPlugin;
+import io.gravitee.rest.api.fetcher.FetcherConfigurationFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+
+@ExtendWith(MockitoExtension.class)
+class PortalNavigationItemSourceDomainServiceImplTest {
+
+    private static final String DUMMY_FETCHER = "dummy-fetcher";
+    private static final String SENSITIVE_VALUE = "I'm a sensitive data";
+    private static final String DUMMY_FETCHER_CLASS = "io.gravitee.apim.infra.domain_service.documentation.DummyFetcher";
+
+    @Mock
+    FetcherConfigurationFactory fetcherConfigurationFactory;
+
+    @Mock
+    PluginManager<FetcherPlugin<?>> pluginManager;
+
+    @Mock
+    ApplicationContext applicationContext;
+
+    @Mock
+    @SuppressWarnings("rawtypes")
+    FetcherPlugin fetcherPlugin;
+
+    PortalNavigationItemSourceDomainServiceImpl cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new PortalNavigationItemSourceDomainServiceImpl(fetcherConfigurationFactory, pluginManager, applicationContext);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void mockDummyFetcherPlugin(DummyFetcherConfiguration... configurations) {
+        when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(mock(AutowireCapableBeanFactory.class));
+        when(fetcherPlugin.fetcher()).thenReturn(DummyFetcher.class);
+        when(fetcherPlugin.configuration()).thenReturn(DummyFetcherConfiguration.class);
+        when(fetcherPlugin.clazz()).thenReturn(DUMMY_FETCHER_CLASS);
+        when(pluginManager.get(DUMMY_FETCHER)).thenReturn(fetcherPlugin);
+        var stubbing = when(fetcherConfigurationFactory.create(any(), any()));
+        for (DummyFetcherConfiguration configuration : configurations) {
+            stubbing = stubbing.thenReturn(configuration);
+        }
+    }
+
+    @Nested
+    class FetchContent {
+
+        @Test
+        void should_fetch_content() {
+            mockDummyFetcherPlugin(new DummyFetcherConfiguration("data", "secret"));
+            DummyFetcher.nextStream.set(new ByteArrayInputStream("# fetched markdown".getBytes()));
+
+            var content = cut.fetchContent(dummySource());
+
+            assertThat(content).isEqualTo("# fetched markdown");
+        }
+
+        @Test
+        void should_throw_when_no_plugin_found_for_source_type() {
+            when(pluginManager.get(DUMMY_FETCHER)).thenReturn(null);
+
+            assertThatThrownBy(() -> cut.fetchContent(dummySource()))
+                .isInstanceOf(InvalidPortalNavigationItemSourceException.class)
+                .hasMessageContaining(DUMMY_FETCHER);
+        }
+
+        @Test
+        void should_report_build_fetcher_error() {
+            when(pluginManager.get(DUMMY_FETCHER)).thenReturn(fetcherPlugin);
+
+            assertThatThrownBy(() -> cut.fetchContent(dummySource()))
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("unable to build fetcher instance");
+        }
+
+        @Test
+        void should_not_leak_the_configuration_in_the_fetch_error() {
+            mockDummyFetcherPlugin(new DummyFetcherConfiguration("data", "secret"));
+            DummyFetcher.nextStream.set(
+                new InputStream() {
+                    @Override
+                    public int read() throws IOException {
+                        throw new IOException("stream failure");
+                    }
+                }
+            );
+
+            // This message is stored in lastFetchError and returned by the API: it must carry no secret
+            assertThatThrownBy(() -> cut.fetchContent(dummySource()))
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessageContaining(DUMMY_FETCHER)
+                .hasMessageNotContaining(SENSITIVE_VALUE);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void mockDummyConfigurationClass() {
+        when(fetcherPlugin.fetcher()).thenReturn(DummyFetcher.class);
+        when(fetcherPlugin.configuration()).thenReturn(DummyFetcherConfiguration.class);
+        when(pluginManager.get(DUMMY_FETCHER)).thenReturn(fetcherPlugin);
+    }
+
+    @Nested
+    class RemoveSensitiveData {
+
+        @Test
+        void should_mask_sensitive_fields() throws Exception {
+            mockDummyConfigurationClass();
+            var source = dummySource();
+
+            cut.removeSensitiveData(source);
+
+            JsonNode configuration = new ObjectMapper().readTree(source.getSourceConfiguration());
+            assertThat(configuration.get("sensitiveData").textValue()).isEqualTo(
+                PortalNavigationItemSourceDomainServiceImpl.SENSITIVE_DATA_REPLACEMENT
+            );
+            assertThat(configuration.get("nonSensitiveData").textValue()).isEqualTo("I'm not a sensitive data");
+            assertThat(configuration.size()).isEqualTo(2);
+        }
+
+        @Test
+        void should_not_rewrite_configuration_when_no_sensitive_value_is_set() {
+            mockDummyConfigurationClass();
+            var source = dummySource("{\"nonSensitiveData\":\"I'm not a sensitive data\"}");
+            var originalConfiguration = source.getSourceConfiguration();
+
+            cut.removeSensitiveData(source);
+
+            assertThat(source.getSourceConfiguration()).isEqualTo(originalConfiguration);
+        }
+
+        @Test
+        void should_resolve_the_sensitive_keys_only_once_per_source_type() {
+            mockDummyConfigurationClass();
+
+            cut.removeSensitiveData(dummySource());
+            cut.removeSensitiveData(dummySource());
+
+            verify(pluginManager, times(1)).get(DUMMY_FETCHER);
+        }
+
+        @Test
+        void should_blank_configuration_when_plugin_cannot_be_loaded() {
+            when(pluginManager.get(DUMMY_FETCHER)).thenReturn(null);
+            var source = dummySource();
+
+            cut.removeSensitiveData(source);
+
+            assertThat(source.getSourceConfiguration()).isEqualTo(PortalNavigationItemSourceDomainServiceImpl.BLANKED_CONFIGURATION);
+        }
+
+        @Test
+        void should_blank_configuration_when_sensitive_keys_cannot_be_resolved() {
+            when(pluginManager.get(DUMMY_FETCHER)).thenReturn(fetcherPlugin);
+            var source = dummySource();
+
+            cut.removeSensitiveData(source);
+
+            assertThat(source.getSourceConfiguration()).isEqualTo(PortalNavigationItemSourceDomainServiceImpl.BLANKED_CONFIGURATION);
+        }
+    }
+
+    @Nested
+    class MergeSensitiveData {
+
+        @Test
+        void should_restore_masked_values_from_old_source() throws Exception {
+            mockDummyConfigurationClass();
+            var oldSource = dummySource("{\"nonSensitiveData\":\"data\",\"sensitiveData\":\"original-secret-token\"}");
+            var newSource = dummySource(
+                "{\"nonSensitiveData\":\"data\",\"sensitiveData\":\"" +
+                    PortalNavigationItemSourceDomainServiceImpl.SENSITIVE_DATA_REPLACEMENT +
+                    "\"}"
+            );
+
+            cut.mergeSensitiveData(oldSource, newSource);
+
+            JsonNode configuration = new ObjectMapper().readTree(newSource.getSourceConfiguration());
+            assertThat(configuration.get("sensitiveData").textValue()).isEqualTo("original-secret-token");
+            assertThat(configuration.get("nonSensitiveData").textValue()).isEqualTo("data");
+        }
+
+        @Test
+        void should_not_restore_masked_values_across_a_source_type_change() {
+            var oldSource = dummySource("{\"nonSensitiveData\":\"data\",\"sensitiveData\":\"original-secret-token\"}");
+            var maskedConfiguration =
+                "{\"nonSensitiveData\":\"data\",\"sensitiveData\":\"" +
+                PortalNavigationItemSourceDomainServiceImpl.SENSITIVE_DATA_REPLACEMENT +
+                "\"}";
+            var newSource = PortalNavigationItemSource.builder()
+                .sourceType("another-fetcher")
+                .sourceConfiguration(maskedConfiguration)
+                .build();
+
+            cut.mergeSensitiveData(oldSource, newSource);
+
+            assertThat(newSource.getSourceConfiguration()).isEqualTo(maskedConfiguration);
+            assertThat(newSource.getSourceConfiguration()).doesNotContain("original-secret-token");
+        }
+
+        @Test
+        void should_keep_new_value_when_not_masked() {
+            mockDummyConfigurationClass();
+            var newSource = dummySource("{\"nonSensitiveData\":\"data\",\"sensitiveData\":\"new-secret-token\"}");
+            var originalConfiguration = newSource.getSourceConfiguration();
+
+            cut.mergeSensitiveData(dummySource(), newSource);
+
+            assertThat(newSource.getSourceConfiguration()).isEqualTo(originalConfiguration);
+        }
+
+        @Test
+        void should_do_nothing_when_old_source_is_null() {
+            cut.mergeSensitiveData(null, dummySource());
+
+            verifyNoInteractions(fetcherConfigurationFactory, pluginManager, applicationContext);
+        }
+
+        @Test
+        void should_keep_client_configuration_when_sensitive_keys_cannot_be_resolved() {
+            when(pluginManager.get(DUMMY_FETCHER)).thenReturn(fetcherPlugin);
+            var newSource = dummySource();
+            var clientConfiguration = newSource.getSourceConfiguration();
+
+            cut.mergeSensitiveData(dummySource(), newSource);
+
+            assertThat(newSource.getSourceConfiguration()).isEqualTo(clientConfiguration);
+        }
+
+        @Test
+        void should_keep_the_configuration_key_set_stable_across_mask_and_merge() {
+            mockDummyConfigurationClass();
+            var storedConfiguration = "{\"nonSensitiveData\":\"data\",\"sensitiveData\":\"secret-token\"}";
+            var stored = dummySource(storedConfiguration);
+
+            var exposed = dummySource(storedConfiguration);
+            cut.removeSensitiveData(exposed);
+            cut.mergeSensitiveData(stored, exposed);
+
+            assertThat(exposed.getSourceConfiguration()).isEqualTo(storedConfiguration);
+        }
+    }
+
+    @Nested
+    class ValidateSourceConfiguration {
+
+        @Test
+        void should_accept_valid_configuration() {
+            mockDummyFetcherPlugin(new DummyFetcherConfiguration("data", "secret"));
+
+            cut.validateSourceConfiguration(dummySource());
+        }
+
+        @Test
+        void should_reject_unknown_source_type() {
+            when(pluginManager.get(DUMMY_FETCHER)).thenReturn(null);
+
+            assertThatThrownBy(() -> cut.validateSourceConfiguration(dummySource()))
+                .isInstanceOf(InvalidPortalNavigationItemSourceException.class)
+                .hasMessageContaining(DUMMY_FETCHER);
+        }
+
+        @Test
+        void should_reject_configuration_that_cannot_build_a_fetcher() {
+            when(pluginManager.get(DUMMY_FETCHER)).thenReturn(fetcherPlugin);
+
+            assertThatThrownBy(() -> cut.validateSourceConfiguration(dummySource()))
+                .isInstanceOf(InvalidPortalNavigationItemSourceException.class)
+                .hasMessageContaining("not valid");
+        }
+
+        @Test
+        void should_reject_a_sensitive_field_still_holding_the_masked_placeholder() {
+            // Validation runs after the merge: a leftover placeholder means there was nothing to restore
+            mockDummyConfigurationClass();
+            var source = dummySource(
+                "{\"nonSensitiveData\":\"data\",\"sensitiveData\":\"%s\"}".formatted(
+                    PortalNavigationItemSourceDomainServiceImpl.SENSITIVE_DATA_REPLACEMENT
+                )
+            );
+
+            assertThatThrownBy(() -> cut.validateSourceConfiguration(source))
+                .isInstanceOf(InvalidPortalNavigationItemSourceException.class)
+                .hasMessageContaining("sensitiveData")
+                .hasMessageContaining("actual value");
+        }
+
+        @Test
+        void should_reject_a_configuration_the_fetcher_cannot_read() {
+            // The factory swallows deserialization errors and returns null instead of throwing
+            mockDummyConfigurationClass();
+            when(fetcherConfigurationFactory.create(any(), any())).thenReturn(null);
+
+            assertThatThrownBy(() -> cut.validateSourceConfiguration(dummySource()))
+                .isInstanceOf(InvalidPortalNavigationItemSourceException.class)
+                .hasMessageContaining("not valid");
+        }
+
+        @Test
+        void should_reject_invalid_cron_expression() {
+            mockDummyFetcherPlugin(new DummyFetcherConfiguration("data", "secret"));
+            var source = dummySource().toBuilder().useAutoFetch(true).fetchCron("not-a-cron").build();
+
+            assertThatThrownBy(() -> cut.validateSourceConfiguration(source))
+                .isInstanceOf(InvalidPortalNavigationItemSourceException.class)
+                .hasMessageContaining("not-a-cron");
+        }
+
+        @Test
+        void should_reject_auto_fetch_without_cron() {
+            mockDummyFetcherPlugin(new DummyFetcherConfiguration("data", "secret"));
+            var source = dummySource().toBuilder().useAutoFetch(true).fetchCron(null).build();
+
+            assertThatThrownBy(() -> cut.validateSourceConfiguration(source))
+                .isInstanceOf(InvalidPortalNavigationItemSourceException.class)
+                .hasMessageContaining("auto-fetch");
+        }
+
+        @Test
+        void should_accept_valid_cron_expression() {
+            mockDummyFetcherPlugin(new DummyFetcherConfiguration("data", "secret"));
+            var source = dummySource().toBuilder().useAutoFetch(true).fetchCron("0 */5 * * * *").build();
+
+            cut.validateSourceConfiguration(source);
+        }
+    }
+
+    private static PortalNavigationItemSource dummySource() {
+        return dummySource(
+            """
+            {
+               "nonSensitiveData" : "I'm not a sensitive data",
+               "sensitiveData" : "%s"
+            }
+            """.formatted(SENSITIVE_VALUE)
+        );
+    }
+
+    private static PortalNavigationItemSource dummySource(String configuration) {
+        return PortalNavigationItemSource.builder().sourceType(DUMMY_FETCHER).sourceConfiguration(configuration).build();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-85

## Description

Executes the fetch through the existing fetcher plugins. Creating a PAGE with a `source` now replaces its default content with the fetched one. Model and persistence came with #18818; this PR adds execution, validation and the read-only rules.

### What it does
- **Fetch on create**: content replaced, `lastFetchedAt` set, previous error cleared.
- **Failed fetch**: recorded in `lastFetchError` without failing the operation. The stored message is built from the source type only — never the exception's, which could quote the configuration.
- **Secrets**: fields annotated `@Sensitive` on the plugin configuration are masked on read. Resending the mask restores the stored value; on a new source it is rejected rather than persisted as the secret itself.
- **Validation**: unknown fetcher, configuration the plugin refuses, invalid or missing cron.
- **Read-only**: a sourced item cannot be renamed, moved, deleted, nor its content edited.
  Its subtree is closed on the way in too (create below, move below, bulk payload). Removing the source lifts every restriction.
- **Automation**: a source is rejected on an automation-managed item or anywhere in its subtree.

