### PR TITLE
fix: reject V4 APIs on MAPI v1 plans

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AbstractResource.java
@@ -21,6 +21,7 @@ import static io.gravitee.rest.api.model.MembershipReferenceType.GROUP;
 
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.node.api.license.License;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
@@ -40,6 +41,7 @@ import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
+import io.gravitee.rest.api.service.exceptions.ManagementV1UnsupportedApiDefinitionVersionException;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import jakarta.inject.Inject;
@@ -266,5 +268,19 @@ public abstract class AbstractResource {
             .environmentId(executionContext.getEnvironmentId())
             .actor(AuditActor.builder().userId(user.getUsername()).userSource(user.getSource()).userSourceId(user.getSourceId()).build())
             .build();
+    }
+
+    protected void assertLegacyApiSupported(ExecutionContext executionContext, String apiId) {
+        assertLegacyApiSupported(apiSearchService.findGenericById(executionContext, apiId, false, false, false));
+    }
+
+    protected void assertLegacyApiSupported(GenericApiEntity api) {
+        if (!usesLegacyApiDefinition(api.getDefinitionVersion())) {
+            throw new ManagementV1UnsupportedApiDefinitionVersionException(api.getDefinitionVersion().getLabel());
+        }
+    }
+
+    private static boolean usesLegacyApiDefinition(DefinitionVersion definitionVersion) {
+        return definitionVersion == null || definitionVersion == DefinitionVersion.V2;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPlansResource.java
@@ -30,7 +30,6 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
-import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -60,14 +59,16 @@ import java.util.stream.Collectors;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Tag(name = "API Plans")
+@Tag(
+    name = "API Plans",
+    description = "Manage API plans. Only V2 API definitions are supported on Management API v1. For V4 or Federated APIs, use Management API v2 (/management/v2/environments/{envId}/apis/{apiId}/plans)."
+)
 public class ApiPlansResource extends AbstractResource {
+
+    static final String UNSUPPORTED_DEFINITION_VERSION = "API definition version not supported (use Management API v2 for V4/Federated)";
 
     @Inject
     private PlanService planService;
-
-    @Inject
-    private ApiService apiService;
 
     @Inject
     private GroupService groupService;
@@ -91,6 +92,7 @@ public class ApiPlansResource extends AbstractResource {
             array = @ArraySchema(schema = @Schema(implementation = PlanEntity.class), uniqueItems = true)
         )
     )
+    @ApiResponse(responseCode = "400", description = UNSUPPORTED_DEFINITION_VERSION)
     @ApiResponse(responseCode = "500", description = "Internal server error")
     public List<PlanEntity> getApiPlans(
         @QueryParam("status") @DefaultValue("PUBLISHED") @Parameter(
@@ -100,6 +102,7 @@ public class ApiPlansResource extends AbstractResource {
         @QueryParam("security") @Parameter(explode = Explode.FALSE, schema = @Schema(type = "array")) final PlanSecurityParam security
     ) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        assertLegacyApiSupported(executionContext, api);
         ApiEntity apiEntity = apiService.findById(executionContext, api);
 
         if (
@@ -134,9 +137,11 @@ public class ApiPlansResource extends AbstractResource {
         description = "Plan successfully created",
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PlanEntity.class))
     )
+    @ApiResponse(responseCode = "400", description = UNSUPPORTED_DEFINITION_VERSION)
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = API_PLAN, acls = CREATE) })
     public Response createApiPlan(@Parameter(name = "plan", required = true) @Valid @NotNull NewPlanEntity newPlanEntity) {
+        assertLegacyApiSupported(GraviteeContext.getExecutionContext(), api);
         newPlanEntity.setReferenceId(api);
         newPlanEntity.setReferenceType(GenericPlanEntity.ReferenceType.API);
 
@@ -155,13 +160,14 @@ public class ApiPlansResource extends AbstractResource {
         description = "Plan successfully updated",
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PlanEntity.class))
     )
-    @ApiResponse(responseCode = "400", description = "Bad plan format")
+    @ApiResponse(responseCode = "400", description = "Bad plan format or " + UNSUPPORTED_DEFINITION_VERSION)
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = API_PLAN, acls = UPDATE) })
     public Response updateApiPlan(
         @PathParam("plan") String plan,
         @Parameter(name = "plan", required = true) @Valid @NotNull UpdatePlanEntity updatePlanEntity
     ) {
+        assertLegacyApiSupported(GraviteeContext.getExecutionContext(), api);
         if (updatePlanEntity.getId() != null && !plan.equals(updatePlanEntity.getId())) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity("'plan' parameter does not correspond to the plan to update")
@@ -190,9 +196,11 @@ public class ApiPlansResource extends AbstractResource {
         description = "Plan information",
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PlanEntity.class))
     )
+    @ApiResponse(responseCode = "400", description = UNSUPPORTED_DEFINITION_VERSION)
     @ApiResponse(responseCode = "500", description = "Internal server error")
     public Response getApiPlan(@PathParam("plan") String plan) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        assertLegacyApiSupported(executionContext, api);
         if (
             Visibility.PUBLIC.equals(apiService.findById(executionContext, api).getVisibility()) ||
             hasPermission(GraviteeContext.getExecutionContext(), API_PLAN, api, READ)
@@ -214,9 +222,11 @@ public class ApiPlansResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Delete a plan", description = "User must have the MANAGE_PLANS permission to use this service")
     @ApiResponse(responseCode = "204", description = "Plan successfully deleted")
+    @ApiResponse(responseCode = "400", description = UNSUPPORTED_DEFINITION_VERSION)
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = API_PLAN, acls = DELETE) })
     public Response deleteApiPlan(@PathParam("plan") String plan) {
+        assertLegacyApiSupported(GraviteeContext.getExecutionContext(), api);
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         PlanEntity planEntity = planService.findById(executionContext, plan);
         if (planEntity.getReferenceType().equals(GenericPlanEntity.ReferenceType.API) && !planEntity.getReferenceId().equals(api)) {
@@ -237,9 +247,11 @@ public class ApiPlansResource extends AbstractResource {
         description = "Plan successfully closed",
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PlanEntity.class))
     )
+    @ApiResponse(responseCode = "400", description = UNSUPPORTED_DEFINITION_VERSION)
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = API_PLAN, acls = UPDATE) })
     public Response closeApiPlan(@PathParam("plan") String plan) {
+        assertLegacyApiSupported(GraviteeContext.getExecutionContext(), api);
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         PlanEntity planEntity = planService.findById(executionContext, plan);
         if (planEntity.getReferenceType().equals(GenericPlanEntity.ReferenceType.API) && !planEntity.getReferenceId().equals(api)) {
@@ -260,9 +272,11 @@ public class ApiPlansResource extends AbstractResource {
         description = "Plan successfully published",
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PlanEntity.class))
     )
+    @ApiResponse(responseCode = "400", description = UNSUPPORTED_DEFINITION_VERSION)
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = API_PLAN, acls = UPDATE) })
     public Response publishApiPlan(@PathParam("plan") String plan) {
+        assertLegacyApiSupported(GraviteeContext.getExecutionContext(), api);
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         PlanEntity planEntity = planService.findById(executionContext, plan);
         if (planEntity.getReferenceType().equals(GenericPlanEntity.ReferenceType.API) && !planEntity.getReferenceId().equals(api)) {
@@ -286,6 +300,7 @@ public class ApiPlansResource extends AbstractResource {
         description = "Plan successfully deprecated",
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PlanEntity.class))
     )
+    @ApiResponse(responseCode = "400", description = UNSUPPORTED_DEFINITION_VERSION)
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = API_PLAN, acls = UPDATE) })
     public Response depreciateApiPlan(@PathParam("plan") String plan) {
@@ -301,9 +316,11 @@ public class ApiPlansResource extends AbstractResource {
         description = "Plan successfully deprecated",
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PlanEntity.class))
     )
+    @ApiResponse(responseCode = "400", description = UNSUPPORTED_DEFINITION_VERSION)
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = API_PLAN, acls = UPDATE) })
     public Response deprecateApiPlan(@PathParam("plan") String plan) {
+        assertLegacyApiSupported(GraviteeContext.getExecutionContext(), api);
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         PlanEntity planEntity = planService.findById(executionContext, plan);
         if (planEntity.getReferenceType().equals(GenericPlanEntity.ReferenceType.API) && !planEntity.getReferenceId().equals(api)) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/resources/openapi-configuration.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/resources/openapi-configuration.yaml
@@ -7,3 +7,7 @@ openAPI:
   info:
     version: '${project.version}'
     title: Gravitee.io - Management API
+    description: >
+      Management API v1 for Gravitee APIM. This API supports V2 API
+      definition versions only. For V4 or Federated APIs, use Management API v2
+      (base path /management/v2/environments/{envId}/apis/{apiId}/...).

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiPlansResourceTest.java
@@ -17,18 +17,24 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static io.gravitee.common.http.HttpStatusCode.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.management.rest.model.ErrorEntity;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +57,16 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
 
     @BeforeEach
     public void init() {
-        Mockito.reset(planService, apiService);
+        Mockito.reset(planService, apiService, apiSearchServiceV4, groupService);
+        when(
+            permissionService.hasPermission(
+                any(ExecutionContext.class),
+                any(RolePermission.class),
+                anyString(),
+                any(RolePermissionAction[].class)
+            )
+        ).thenReturn(true);
+        mockLegacyApi();
         GraviteeContext.cleanContext();
     }
 
@@ -61,20 +76,207 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
     }
 
     @Test
+    public void shouldReturnBadRequestWhenGettingPlansForV4Api() {
+        mockUnsupportedApi(DefinitionVersion.V4);
+
+        final Response response = envTarget().path(API).path("plans").request().get();
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(apiService, never()).findById(any(), eq(API));
+        verify(planService, never()).findByApi(any(), any());
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenGettingSinglePlanForV4Api() {
+        mockUnsupportedApi(DefinitionVersion.V4);
+
+        final Response response = envTarget().path(API).path("plans").path(PLAN).request().get();
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(planService, never()).findById(any(), any());
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenGettingPlansForFederatedApi() {
+        mockUnsupportedApi(DefinitionVersion.FEDERATED);
+
+        final Response response = envTarget().path(API).path("plans").request().get();
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(apiService, never()).findById(any(), eq(API));
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenGettingPlansForFederatedAgentApi() {
+        mockUnsupportedApi(DefinitionVersion.FEDERATED_AGENT);
+
+        final Response response = envTarget().path(API).path("plans").request().get();
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(apiService, never()).findById(any(), eq(API));
+    }
+
+    @Test
+    public void shouldReturnBadRequestWithCorrectErrorCodeForV4Api() {
+        mockUnsupportedApi(DefinitionVersion.V4);
+
+        final Response response = envTarget().path(API).path("plans").request().get();
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        ErrorEntity error = response.readEntity(ErrorEntity.class);
+        assertEquals("api.managementV1.definitionVersionNotSupported", error.getTechnicalCode());
+        assertEquals("4.0.0", error.getParameters().get("definitionVersion"));
+    }
+
+    @Test
+    public void shouldGetApiPlansWhenDefinitionVersionIsNull() {
+        ApiEntity legacyApiWithoutVersion = new ApiEntity();
+        legacyApiWithoutVersion.setId(API);
+        legacyApiWithoutVersion.setVisibility(Visibility.PUBLIC);
+        when(apiSearchServiceV4.findGenericById(any(ExecutionContext.class), eq(API), eq(false), eq(false), eq(false))).thenReturn(
+            legacyApiWithoutVersion
+        );
+        when(apiService.findById(any(ExecutionContext.class), eq(API))).thenReturn(legacyApiWithoutVersion);
+
+        PlanEntity publishedPlan = buildPlan("published-plan", PlanStatus.PUBLISHED, 1);
+        when(planService.findByApi(GraviteeContext.getExecutionContext(), API)).thenReturn(Set.of(publishedPlan));
+        when(groupService.isUserAuthorizedToAccessApiData(any(ApiEntity.class), any(), any())).thenReturn(true);
+
+        final Response response = envTarget().path(API).path("plans").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        verify(apiService).findById(GraviteeContext.getExecutionContext(), API);
+    }
+
+    @Test
+    public void shouldReturnForbiddenWhenGettingPlansForPrivateV2ApiWithoutPermission() {
+        ApiEntity privateApi = new ApiEntity();
+        privateApi.setId(API);
+        privateApi.setVisibility(Visibility.PRIVATE);
+        privateApi.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
+        when(apiSearchServiceV4.findGenericById(any(ExecutionContext.class), eq(API), eq(false), eq(false), eq(false))).thenReturn(
+            privateApi
+        );
+        when(apiService.findById(any(ExecutionContext.class), eq(API))).thenReturn(privateApi);
+        when(
+            permissionService.hasPermission(
+                any(ExecutionContext.class),
+                eq(RolePermission.API_PLAN),
+                eq(API),
+                any(RolePermissionAction[].class)
+            )
+        ).thenReturn(false);
+        when(
+            permissionService.hasPermission(
+                any(ExecutionContext.class),
+                eq(RolePermission.API_LOG),
+                eq(API),
+                any(RolePermissionAction[].class)
+            )
+        ).thenReturn(false);
+
+        final Response response = envTarget().path(API).path("plans").request().get();
+
+        assertEquals(FORBIDDEN_403, response.getStatus());
+        verify(planService, never()).findByApi(any(), any());
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenCreatingPlanForV4Api() {
+        mockUnsupportedApi(DefinitionVersion.V4);
+
+        final Response response = envTarget().path(API).path("plans").request().post(Entity.json(newPlanEntity()));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(planService, never()).create(any(), any());
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenUpdatingPlanForV4Api() {
+        mockUnsupportedApi(DefinitionVersion.V4);
+
+        UpdatePlanEntity updatePlanEntity = new UpdatePlanEntity();
+        updatePlanEntity.setName("updated-plan");
+        updatePlanEntity.setValidation(PlanValidationType.AUTO);
+
+        final Response response = envTarget().path(API).path("plans").path(PLAN).request().put(Entity.json(updatePlanEntity));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(planService, never()).update(any(), any());
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenDeletingPlanForV4Api() {
+        mockUnsupportedApi(DefinitionVersion.V4);
+
+        final Response response = envTarget().path(API).path("plans").path(PLAN).request().delete();
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(planService, never()).delete(any(), any());
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenClosingPlanForV4Api() {
+        mockUnsupportedApi(DefinitionVersion.V4);
+
+        final Response response = envTarget().path(API).path("plans").path(PLAN).path("_close").request().post(Entity.json(""));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(planService, never()).close(any(), any());
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenPublishingPlanForV4Api() {
+        mockUnsupportedApi(DefinitionVersion.V4);
+
+        final Response response = envTarget().path(API).path("plans").path(PLAN).path("_publish").request().post(Entity.json(""));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(planService, never()).publish(any(), any());
+    }
+
+    @Test
+    public void shouldReturnBadRequestWhenDeprecatingPlanForV4Api() {
+        mockUnsupportedApi(DefinitionVersion.V4);
+
+        final Response response = envTarget().path(API).path("plans").path(PLAN).path("_deprecate").request().post(Entity.json(""));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(planService, never()).deprecate(any(), any());
+    }
+
+    @Test
+    public void shouldGetApiPlansForV2Api() {
+        PlanEntity publishedPlan = buildPlan("published-plan", PlanStatus.PUBLISHED, 1);
+        PlanEntity stagingPlan = buildPlan("staging-plan", PlanStatus.STAGING, 2);
+        when(planService.findByApi(GraviteeContext.getExecutionContext(), API)).thenReturn(Set.of(publishedPlan, stagingPlan));
+        when(groupService.isUserAuthorizedToAccessApiData(any(ApiEntity.class), any(), any())).thenReturn(true);
+
+        final Response response = envTarget().path(API).path("plans").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        List<PlanEntity> plans = response.readEntity(new GenericType<>() {});
+        assertNotNull(plans);
+        assertEquals(1, plans.size());
+        assertEquals("published-plan", plans.get(0).getId());
+        verify(apiService).findById(GraviteeContext.getExecutionContext(), API);
+    }
+
+    @Test
+    public void shouldGetSingleApiPlanForPublicV2Api() {
+        PlanEntity planEntity = buildPlan(PLAN, PlanStatus.PUBLISHED, 1);
+        when(planService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
+
+        final Response response = envTarget().path(API).path("plans").path(PLAN).request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        assertEquals(PLAN, response.readEntity(PlanEntity.class).getId());
+        verify(apiService).findById(GraviteeContext.getExecutionContext(), API);
+    }
+
+    @Test
     public void shouldCreateApiPlan() {
-        NewPlanEntity newPlanEntity = new NewPlanEntity();
-        newPlanEntity.setName(PLAN);
-        newPlanEntity.setDescription("my-plan-description");
-        newPlanEntity.setValidation(PlanValidationType.AUTO);
-        newPlanEntity.setSecurity(PlanSecurityType.KEY_LESS);
-        newPlanEntity.setType(PlanType.API);
-        newPlanEntity.setStatus(PlanStatus.STAGING);
-
-        PlanEntity createdPlanEntity = new PlanEntity();
-        createdPlanEntity.setId("new-plan-id");
-        when(planService.create(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(createdPlanEntity);
-
-        final Response response = envTarget().path(API).path("plans").request().post(Entity.json(newPlanEntity));
+        final Response response = envTarget().path(API).path("plans").request().post(Entity.json(newPlanEntity()));
         assertEquals(CREATED_201, response.getStatus());
         assertEquals(
             envTarget().path(API).path("plans").path("new-plan-id").getUri().toString(),
@@ -84,8 +286,6 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldCloseApiPlan() {
-        ApiEntity api = getApi(DefinitionVersion.V2);
-
         PlanEntity existingPlan = new PlanEntity();
         existingPlan.setName(PLAN);
         existingPlan.setReferenceId(API);
@@ -93,7 +293,6 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
 
         PlanEntity closedPlan = new PlanEntity();
         closedPlan.setId("closed-plan-id");
-        when(apiService.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(api);
         when(planService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(existingPlan);
         when(planService.close(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(closedPlan);
 
@@ -106,14 +305,11 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldDeleteApiPlan() {
-        ApiEntity api = getApi(DefinitionVersion.V2);
-
         PlanEntity existingPlan = new PlanEntity();
         existingPlan.setName(PLAN);
         existingPlan.setReferenceId(API);
         existingPlan.setReferenceType(GenericPlanEntity.ReferenceType.API);
 
-        when(apiService.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(api);
         when(planService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(existingPlan);
 
         final Response response = envTarget().path(API).path("plans").path(PLAN).request().delete();
@@ -122,20 +318,47 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
         verify(planService, times(1)).delete(eq(GraviteeContext.getExecutionContext()), eq(PLAN));
     }
 
-    private ApiEntity getApi(DefinitionVersion version) {
-        ApiEntity api = new ApiEntity();
+    private void mockLegacyApi() {
+        ApiEntity legacyApi = new ApiEntity();
+        legacyApi.setId(API);
+        legacyApi.setVisibility(Visibility.PUBLIC);
+        legacyApi.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
+        when(apiSearchServiceV4.findGenericById(any(ExecutionContext.class), eq(API), eq(false), eq(false), eq(false))).thenReturn(
+            legacyApi
+        );
+        when(apiService.findById(any(ExecutionContext.class), eq(API))).thenReturn(legacyApi);
+
+        PlanEntity createdPlanEntity = new PlanEntity();
+        createdPlanEntity.setId("new-plan-id");
+        when(planService.create(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(createdPlanEntity);
+    }
+
+    private void mockUnsupportedApi(DefinitionVersion definitionVersion) {
+        io.gravitee.rest.api.model.v4.api.ApiEntity api = new io.gravitee.rest.api.model.v4.api.ApiEntity();
         api.setId(API);
-        api.setGraviteeDefinitionVersion(version.getLabel());
+        api.setDefinitionVersion(definitionVersion);
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(api);
+    }
 
-        if (DefinitionVersion.V2.equals(version)) {
-            PlanEntity plan1 = new PlanEntity();
-            plan1.setId(PLAN);
+    private static NewPlanEntity newPlanEntity() {
+        NewPlanEntity newPlanEntity = new NewPlanEntity();
+        newPlanEntity.setName(PLAN);
+        newPlanEntity.setDescription("my-plan-description");
+        newPlanEntity.setValidation(PlanValidationType.AUTO);
+        newPlanEntity.setSecurity(PlanSecurityType.KEY_LESS);
+        newPlanEntity.setType(PlanType.API);
+        newPlanEntity.setStatus(PlanStatus.STAGING);
+        return newPlanEntity;
+    }
 
-            PlanEntity plan2 = new PlanEntity();
-            plan2.setId("plan-2");
-            api.setPlans(Set.of(plan1, plan2));
-        }
-
-        return api;
+    private static PlanEntity buildPlan(String id, PlanStatus status, int order) {
+        PlanEntity plan = new PlanEntity();
+        plan.setId(id);
+        plan.setReferenceId(API);
+        plan.setReferenceType(GenericPlanEntity.ReferenceType.API);
+        plan.setStatus(status);
+        plan.setOrder(order);
+        plan.setSecurity(PlanSecurityType.KEY_LESS);
+        return plan;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ManagementV1UnsupportedApiDefinitionVersionException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ManagementV1UnsupportedApiDefinitionVersionException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.Collections;
+import java.util.Map;
+
+public class ManagementV1UnsupportedApiDefinitionVersionException extends AbstractManagementException {
+
+    private final String version;
+
+    public ManagementV1UnsupportedApiDefinitionVersionException(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "api.managementV1.definitionVersionNotSupported";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Collections.singletonMap("definitionVersion", version);
+    }
+
+    @Override
+    public String getMessage() {
+        return (
+            "API definition version " +
+            version +
+            " is not supported by Management API v1. Use Management API v2 instead (/management/v2/environments/{envId}/apis/{apiId}/...)."
+        );
+    }
+}


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-14587

**Description**
Calling Management API v1 plan endpoints (/management/organizations/{orgId}/environments/{envId}/apis/{apiId}/plans) against a V4 or Federated API previously resulted in a 500 Internal Server Error (e.g. JsonMappingException when legacy code tried to deserialize a V4 definition).

MAPI v1 is intended for V1 and V2 API definitions only. V4 and Federated APIs must be managed through Management API v2.

This PR rejects unsupported API definition versions early on all MAPI v1 plan endpoints and returns a clear 400 Bad Request instead, directing callers to MAPI v2.

**Changes**

Add ManagementV1UnsupportedApiDefinitionVersionException (HTTP 400, technical code api.managementV1.definitionVersionNotSupported) with a message pointing to MAPI v2
Add assertLegacyApiSupported() on AbstractResource to check the API definition version via apiSearchService.findGenericById() before any legacy v1 logic runs
Guard all 8 plan endpoints in ApiPlansResource (list, get, create, update, delete, close, publish, deprecate)
Document the V1/V2-only scope in OpenAPI (@tag, @apiresponse(400)) and in openapi-configuration.yaml
Update ApiPlansResourceTest to assert 400 for V4/Federated APIs and 200 for V2 APIs

**After fix:**
<img width="1142" height="868" alt="image" src="https://github.com/user-attachments/assets/d6a24917-8a9e-4465-9483-5ce13f3fcd39" />