### PR TITLE
feat: filter Add API dialog by API Product

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.html
@@ -21,7 +21,7 @@
   <mat-dialog-content class="mat-elevation-z0">
     <div class="api-search-description-box">
       <div class="selected-panel__title">APIs</div>
-      <div class="api-search-description">Pick the unpublished APIs you want to add to your navigation menu.</div>
+      <div class="api-search-description" data-testid="api-picker-description">{{ description }}</div>
     </div>
 
     <gio-table-wrapper [searchLabel]="'Search'" [length]="total" [filters]="filters" (filtersChange)="onFiltersChanged($event)">

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.spec.ts
@@ -108,6 +108,19 @@ describe('ApiSectionEditorDialogComponent', () => {
     });
   }
 
+  function expectApiProductApisRequest(apiProductId: string, options: { page?: number; perPage?: number; query?: string } = {}) {
+    const { page = 1, perPage = 10, query } = options;
+    return httpTestingController.expectOne(request => {
+      if (request.method !== 'GET' || request.url !== `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${apiProductId}/apis`) {
+        return false;
+      }
+      if (request.params.get('page') !== page.toString() || request.params.get('perPage') !== perPage.toString()) {
+        return false;
+      }
+      return query === undefined ? !request.params.has('query') : request.params.get('query') === query;
+    });
+  }
+
   it('should not allow submit when no api is selected', fakeAsync(() => {
     component.clicked();
     fixture.detectChanges();
@@ -151,6 +164,123 @@ describe('ApiSectionEditorDialogComponent', () => {
     expect(Array.isArray(component.dialogValue?.apiIds)).toEqual(true);
     expect(component.dialogValue?.apiIds?.length).toBeGreaterThan(1);
     expect(component.dialogValue?.apiId).toEqual(component.dialogValue?.apiIds?.[0]);
+  }));
+
+  it('should load APIs from the owning API Product and display the product-specific description', fakeAsync(async () => {
+    component.clicked({
+      apiProductContext: { navigationItemId: 'api-product-navigation-item', apiProductId: 'api-product-id' },
+    });
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductApisRequest('api-product-id').flush({
+      data: [fakeApiV2({ id: 'product-api', name: 'Product API' })],
+      pagination: { totalCount: 1 },
+    });
+    fixture.detectChanges();
+    tick();
+
+    const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+    expect(await dialog.getDescription()).toBe('Pick the APIs included in this API Product that you want to add to its navigation.');
+
+    const checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' }));
+    expect(checkboxes).toHaveLength(1);
+    expect(await (await checkboxes[0].host()).getAttribute('data-testid')).toBe('api-picker-checkbox-product-api');
+  }));
+
+  it('should forward product search and pagination to the API Product APIs endpoint', fakeAsync(async () => {
+    component.clicked({
+      apiProductContext: { navigationItemId: 'api-product-navigation-item', apiProductId: 'api-product-id' },
+    });
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductApisRequest('api-product-id').flush({
+      data: [fakeApiV2({ id: 'first-api', name: 'First API' })],
+      pagination: { totalCount: 20 },
+    });
+    fixture.detectChanges();
+    tick();
+
+    const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+    await dialog.goToNextPage();
+    tick(450);
+    expectApiProductApisRequest('api-product-id', { page: 2 }).flush({
+      data: [fakeApiV2({ id: 'second-page-api', name: 'Second page API' })],
+      pagination: { totalCount: 20 },
+    });
+    fixture.detectChanges();
+    tick();
+
+    await dialog.setSearchValue('Orders');
+    tick(450);
+    expectApiProductApisRequest('api-product-id', { query: 'Orders' }).flush({
+      data: [fakeApiV2({ id: 'orders-api', name: 'Orders API' })],
+      pagination: { totalCount: 1 },
+    });
+    fixture.detectChanges();
+    tick();
+  }));
+
+  it('should preserve selected product APIs while searching', fakeAsync(async () => {
+    component.clicked({
+      apiProductContext: { navigationItemId: 'api-product-navigation-item', apiProductId: 'api-product-id' },
+    });
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductApisRequest('api-product-id').flush({
+      data: [fakeApiV2({ id: 'first-api', name: 'First API' })],
+      pagination: { totalCount: 2 },
+    });
+    fixture.detectChanges();
+    tick();
+
+    let checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' }));
+    await checkboxes[0].check();
+
+    const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+    await dialog.setSearchValue('Second');
+    tick(450);
+    expectApiProductApisRequest('api-product-id', { query: 'Second' }).flush({
+      data: [fakeApiV2({ id: 'second-api', name: 'Second API' })],
+      pagination: { totalCount: 1 },
+    });
+    fixture.detectChanges();
+    tick();
+
+    checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' }));
+    await checkboxes[0].check();
+    await dialog.clickSubmitButton();
+    tick();
+
+    expect(component.dialogValue?.apiIds).toEqual(['first-api', 'second-api']);
+  }));
+
+  it('should not fall back to the environment API search when loading product APIs fails', fakeAsync(() => {
+    component.clicked({
+      apiProductContext: { navigationItemId: 'api-product-navigation-item', apiProductId: 'api-product-id' },
+    });
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductApisRequest('api-product-id').flush('Server error', { status: 500, statusText: 'Internal Server Error' });
+    tick();
+
+    httpTestingController.expectNone(request => request.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search`);
+  }));
+
+  it('should preserve the standalone dialog description and environment API search', fakeAsync(async () => {
+    component.clicked();
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiSearchResponse();
+    fixture.detectChanges();
+    tick();
+
+    const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+    expect(await dialog.getDescription()).toBe('Pick the unpublished APIs you want to add to your navigation menu.');
   }));
 
   it('should hide checkbox, show "Already added" label and grey out row for already-added API', fakeAsync(async () => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.ts
@@ -28,10 +28,11 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTableModule } from '@angular/material/table';
 import { isEqual } from 'lodash';
-import { Observable, Subject, of, BehaviorSubject } from 'rxjs';
-import { catchError, debounceTime, distinctUntilChanged, map, startWith, switchMap, tap } from 'rxjs/operators';
+import { Observable, of, BehaviorSubject } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
 
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 import { Api, ApiV2, ApiV4, PortalNavigationItem, PortalVisibility, ApisResponse } from '../../../entities/management-api-v2';
 import { getApiAccess } from '../../../shared/utils';
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
@@ -104,12 +105,16 @@ type ApiSectionForm = FormGroup<ApiSectionFormControls>;
 })
 export class ApiSectionEditorDialogComponent implements OnInit {
   private readonly apiService = inject(ApiV2Service);
+  private readonly apiProductService = inject(ApiProductV2Service);
   private readonly dialogData = inject<ApiSectionEditorDialogData>(MAT_DIALOG_DATA);
 
   form!: ApiSectionForm;
   public initialFormValues: ApiSectionFormValues;
 
   public title = 'Add APIs';
+  readonly description = this.dialogData.apiProductContext
+    ? 'Pick the APIs included in this API Product that you want to add to its navigation.'
+    : 'Pick the unpublished APIs you want to add to your navigation menu.';
 
   displayedColumns = ['select', 'name', 'path', 'labels'];
 
@@ -122,7 +127,6 @@ export class ApiSectionEditorDialogComponent implements OnInit {
   isLoading = true;
 
   private readonly filters$ = new BehaviorSubject<GioTableWrapperFilters>(this.filters);
-  private readonly refresh$ = new Subject<void>();
 
   private selectedOrderedApis = signal<SelectedApi[]>([]);
   selectedCount = computed(() => this.selectedOrderedApis().length);
@@ -173,20 +177,16 @@ export class ApiSectionEditorDialogComponent implements OnInit {
     this.rows$ = this.filters$.pipe(
       debounceTime(100),
       distinctUntilChanged(isEqual),
+      tap(() => (this.isLoading = true)),
       switchMap(filters =>
-        this.refresh$.pipe(
-          startWith(undefined),
-          tap(() => (this.isLoading = true)),
-          switchMap(() =>
-            this.apiService.search({ query: filters.searchTerm }, undefined, filters.pagination.index, filters.pagination.size, false),
-          ),
+        this.searchApis(filters).pipe(
           catchError((): Observable<ApisResponse> => {
             this.total = 0;
             return of({ data: [], pagination: undefined, links: undefined });
           }),
-          tap(() => (this.isLoading = false)),
         ),
       ),
+      tap(() => (this.isLoading = false)),
       tap(resp => {
         this.total = resp.pagination?.totalCount ?? 0;
       }),
@@ -225,7 +225,6 @@ export class ApiSectionEditorDialogComponent implements OnInit {
   onFiltersChanged(filters: GioTableWrapperFilters): void {
     this.filters = { ...this.filters, ...filters };
     this.filters$.next(this.filters);
-    this.refresh$.next();
   }
 
   isChecked(apiId: string): boolean {
@@ -293,5 +292,14 @@ export class ApiSectionEditorDialogComponent implements OnInit {
 
   private isApiV2OrV4(api: Api): api is ApiV2 | ApiV4 {
     return api.definitionVersion === 'V2' || api.definitionVersion === 'V4';
+  }
+
+  private searchApis(filters: GioTableWrapperFilters): Observable<ApisResponse> {
+    const apiProductId = this.dialogData.apiProductContext?.apiProductId;
+    if (apiProductId) {
+      return this.apiProductService.getApis(apiProductId, filters.pagination.index, filters.pagination.size, filters.searchTerm);
+    }
+
+    return this.apiService.search({ query: filters.searchTerm }, undefined, filters.pagination.index, filters.pagination.size, false);
   }
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.harness.ts
@@ -18,6 +18,8 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { DivHarness, SpanHarness } from '@gravitee/ui-particles-angular/testing';
 
+import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
+
 export class ApiSectionEditorDialogHarness extends ComponentHarness {
   static hostSelector = 'api-section-editor-dialog';
 
@@ -25,6 +27,8 @@ export class ApiSectionEditorDialogHarness extends ComponentHarness {
   private locateSubmitButton = this.locatorFor(MatButtonHarness.with({ text: /Add|Save/ }));
   private locateFormTitle = this.locatorFor(DivHarness.with({ selector: '[mat-dialog-title]' }));
   private locateAuthenticationToggle = this.locatorFor(MatSlideToggleHarness);
+  private locateDescription = this.locatorFor(DivHarness.with({ selector: '[data-testid="api-picker-description"]' }));
+  private locateTableWrapper = this.locatorFor(GioTableWrapperHarness);
   private locateAlreadyAddedLabels = this.locatorForAll(SpanHarness.with({ selector: '[data-testid^="api-picker-already-added-"]' }));
 
   async clickCancelButton(): Promise<void> {
@@ -45,6 +49,19 @@ export class ApiSectionEditorDialogHarness extends ComponentHarness {
   async getDialogTitle(): Promise<string> {
     const titleElement = await this.locateFormTitle();
     return titleElement.getText();
+  }
+
+  async getDescription(): Promise<string> {
+    return (await this.locateDescription()).getText();
+  }
+
+  async setSearchValue(value: string): Promise<void> {
+    return (await this.locateTableWrapper()).setSearchValue(value);
+  }
+
+  async goToNextPage(): Promise<void> {
+    const paginator = await (await this.locateTableWrapper()).getPaginator();
+    await paginator?.goToNextPage();
   }
 
   async getAuthenticationToggle(): Promise<MatSlideToggleHarness> {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -3051,6 +3051,25 @@ describe('PortalNavigationItemsComponent', () => {
     fixture.detectChanges();
   }
 
+  function expectApiProductApisResponse(apiProductId: string, apiIds: string[]) {
+    const req = httpTestingController.expectOne(request => {
+      return (
+        request.method === 'GET' &&
+        request.url === `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${apiProductId}/apis` &&
+        request.params.get('page') === '1' &&
+        request.params.get('perPage') === '10' &&
+        !request.params.has('query')
+      );
+    });
+
+    req.flush({
+      data: apiIds.map(id => ({ id, name: id })),
+      pagination: { totalCount: apiIds.length },
+    });
+
+    fixture.detectChanges();
+  }
+
   function expectApiProductSearchResponse(apiProducts: ApiProduct[]) {
     const req = httpTestingController.expectOne(request => {
       return (
@@ -3116,8 +3135,11 @@ describe('PortalNavigationItemsComponent', () => {
   }
 
   function flushPendingLinkedApiProductRequests() {
+    const apiProductsUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/`;
     const requests = httpTestingController.match(request => {
-      return request.method === 'GET' && request.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/`);
+      return (
+        request.method === 'GET' && request.url.startsWith(apiProductsUrl) && !request.url.substring(apiProductsUrl.length).includes('/')
+      );
     });
 
     requests
@@ -3351,7 +3373,7 @@ describe('PortalNavigationItemsComponent', () => {
   });
 
   describe('API Product context passed to API section dialog', () => {
-    async function openApiSectionDialog(parentItem: PortalNavigationItem): Promise<SpyInstance> {
+    async function openApiSectionDialog(parentItem: PortalNavigationItem, apiProductId?: string): Promise<SpyInstance> {
       const openSpy = jest.spyOn(TestBed.inject(MatDialog), 'open');
       const parentNode: SectionNode = {
         id: parentItem.id,
@@ -3362,9 +3384,14 @@ describe('PortalNavigationItemsComponent', () => {
 
       component.onNodeMenuAction({ action: 'create', itemType: 'API', node: parentNode });
       fixture.detectChanges();
+      flushPendingLinkedApiSearchRequests();
       flushPendingLinkedApiProductRequests();
       await fixture.whenStable();
-      expectApiSearchResponse([]);
+      if (apiProductId) {
+        expectApiProductApisResponse(apiProductId, []);
+      } else {
+        expectApiSearchResponse([]);
+      }
 
       return openSpy;
     }
@@ -3379,7 +3406,7 @@ describe('PortalNavigationItemsComponent', () => {
       });
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct] }));
 
-      const openSpy = await openApiSectionDialog(apiProduct);
+      const openSpy = await openApiSectionDialog(apiProduct, apiProduct.apiProductId);
 
       expect(openSpy).toHaveBeenCalledWith(
         expect.anything(),
@@ -3416,7 +3443,7 @@ describe('PortalNavigationItemsComponent', () => {
         fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct, firstNestedFolder, secondNestedFolder] }),
       );
 
-      const openSpy = await openApiSectionDialog(secondNestedFolder);
+      const openSpy = await openApiSectionDialog(secondNestedFolder, apiProduct.apiProductId);
 
       expect(openSpy).toHaveBeenCalledWith(
         expect.anything(),
@@ -3456,6 +3483,75 @@ describe('PortalNavigationItemsComponent', () => {
         expect.anything(),
         expect.objectContaining({
           data: expect.objectContaining({ apiProductContext: undefined }),
+        }),
+      );
+    });
+
+    it('should only pass API ids from the current API Product subtree', async () => {
+      const rootFolder = fakePortalNavigationFolder({ id: 'root-folder', title: 'Root folder' });
+      const firstApiProduct = fakePortalNavigationApiProduct({
+        id: 'first-product-navigation-item',
+        apiProductId: 'first-api-product-id',
+        title: 'First API Product',
+        parentId: rootFolder.id,
+      });
+      const nestedFolder = fakePortalNavigationFolder({
+        id: 'nested-folder',
+        title: 'Nested folder',
+        parentId: firstApiProduct.id,
+      });
+      const directApi = fakePortalNavigationApi({ id: 'direct-api-item', apiId: 'direct-api', parentId: firstApiProduct.id });
+      const nestedApi = fakePortalNavigationApi({ id: 'nested-api-item', apiId: 'nested-api', parentId: nestedFolder.id });
+      const secondApiProduct = fakePortalNavigationApiProduct({
+        id: 'second-product-navigation-item',
+        apiProductId: 'second-api-product-id',
+        title: 'Second API Product',
+        parentId: rootFolder.id,
+      });
+      const otherProductApi = fakePortalNavigationApi({
+        id: 'other-product-api-item',
+        apiId: 'other-product-api',
+        parentId: secondApiProduct.id,
+      });
+      const standaloneApi = fakePortalNavigationApi({ id: 'standalone-api-item', apiId: 'standalone-api', parentId: rootFolder.id });
+      await expectGetNavigationItems(
+        fakePortalNavigationItemsResponse({
+          items: [rootFolder, firstApiProduct, nestedFolder, directApi, nestedApi, secondApiProduct, otherProductApi, standaloneApi],
+        }),
+      );
+
+      const openSpy = await openApiSectionDialog(nestedFolder, firstApiProduct.apiProductId);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            existingApiIds: ['direct-api', 'nested-api'],
+          }),
+        }),
+      );
+    });
+
+    it('should not treat APIs from an API Product subtree as already added in standalone context', async () => {
+      const rootFolder = fakePortalNavigationFolder({ id: 'root-folder', title: 'Root folder' });
+      const apiProduct = fakePortalNavigationApiProduct({
+        id: 'product-navigation-item',
+        apiProductId: 'api-product-id',
+        title: 'API Product',
+        parentId: rootFolder.id,
+      });
+      const productApi = fakePortalNavigationApi({ id: 'product-api-item', apiId: 'product-api', parentId: apiProduct.id });
+      const standaloneApi = fakePortalNavigationApi({ id: 'standalone-api-item', apiId: 'standalone-api', parentId: rootFolder.id });
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct, productApi, standaloneApi] }));
+
+      const openSpy = await openApiSectionDialog(rootFolder);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            existingApiIds: ['standalone-api'],
+          }),
         }),
       );
     });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -354,7 +354,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         width: GIO_DIALOG_WIDTH.LARGE,
         data: {
           mode: 'create',
-          existingApiIds: this.extractApiIdsFromNavigationItems(),
+          existingApiIds: this.extractApiIdsFromNavigationContext(apiProductContext),
           parentItem: existingItem,
           apiProductContext,
         },
@@ -994,10 +994,19 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     );
   }
 
-  private extractApiIdsFromNavigationItems(): string[] {
-    return this.menuLinks()
-      .filter(i => i.type === 'API')
-      .map(i => i.apiId);
+  private extractApiIdsFromNavigationContext(apiProductContext?: ApiProductNavigationContext): string[] {
+    const navigationItems = this.menuLinks();
+    const itemsById = new Map(navigationItems.map(item => [item.id, item]));
+
+    return navigationItems
+      .filter(item => item.type === 'API')
+      .filter(item => {
+        const itemApiProductContext = this.findApiProductNavigationContext(item, itemsById);
+        return apiProductContext
+          ? itemApiProductContext?.navigationItemId === apiProductContext.navigationItemId
+          : itemApiProductContext === undefined;
+      })
+      .map(item => item.apiId);
   }
 
   private extractApiProductIdsFromNavigationItems(): string[] {
@@ -1006,8 +1015,10 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
       .map(item => item.apiProductId);
   }
 
-  private findApiProductNavigationContext(item: PortalNavigationItem): ApiProductNavigationContext | undefined {
-    const itemsById = new Map(this.menuLinks().map(menuItem => [menuItem.id, menuItem]));
+  private findApiProductNavigationContext(
+    item: PortalNavigationItem,
+    itemsById = new Map(this.menuLinks().map(menuItem => [menuItem.id, menuItem])),
+  ): ApiProductNavigationContext | undefined {
     const visitedItemIds = new Set<string>();
     let currentItem: PortalNavigationItem | undefined = item;
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-98

## Summary

Filter the Add API dialog to APIs belonging to the current API Product when adding an API within its navigation subtree.

## Changes

- Detect the nearest API Product context for direct and nested navigation folders.
- Load APIs from the API Product endpoint with search and pagination support.
- Preserve selected APIs while searching or changing pages.
- Scope already-added API detection to the current API Product subtree.
- Preserve the existing environment-wide behavior outside an API Product.
- Add component and harness tests for both product and standalone contexts.

https://github.com/user-attachments/assets/5eb52e0d-4ed9-4acc-8aff-342883601343


