### PR TITLE
fix(gateway): evaluate v4 flow conditions once the previous flow completed

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/reactive/v4/flow/BestMatchFlowResolverConditionTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/reactive/v4/flow/BestMatchFlowResolverConditionTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.v4.flow;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.ConditionSelector;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
+import io.gravitee.gateway.reactive.core.condition.CompositeConditionFilter;
+import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
+import io.gravitee.gateway.reactive.v4.flow.selection.ConditionSelectorConditionFilter;
+import io.gravitee.gateway.reactive.v4.flow.selection.HttpSelectorConditionFilter;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.helpers.NOPLogger;
+
+/**
+ * Characterizes how a flow condition takes part in the BEST_MATCH selection.
+ *
+ * In BEST_MATCH mode, a condition is not a filter applied to the flow that won the selection: it makes the flow
+ * eligible, or not, <b>before</b> the most specific one is picked. A flow whose condition evaluates to false is
+ * therefore not a candidate at all, and a less specific flow can be selected in its place.
+ *
+ * These tests describe the behaviour as it stands, so that it cannot be changed unknowingly.
+ *
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class BestMatchFlowResolverConditionTest {
+
+    private static final String REQUEST_PATH = "/books/145";
+    private static final String GOLD_TIER_CONDITION = "{#request.headers['X-Tier'][0] == 'gold'}";
+
+    /**
+     * Same wiring as the one built by DefaultApiReactorFactory: http selector and condition selector are both
+     * evaluated by the resolver, hence during the selection. The raw type mirrors the production code, the two
+     * filters not being bound to the same context type.
+     */
+    @SuppressWarnings("rawtypes")
+    private static final ConditionFilter API_FLOW_FILTER = new CompositeConditionFilter(
+        new HttpSelectorConditionFilter(),
+        new ConditionSelectorConditionFilter()
+    );
+
+    @Mock
+    private HttpPlainExecutionContext ctx;
+
+    @Mock
+    private HttpPlainRequest request;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(ctx.withLogger(any())).thenReturn(NOPLogger.NOP_LOGGER);
+        lenient().when(ctx.request()).thenReturn(request);
+        lenient().when(request.pathInfo()).thenReturn(REQUEST_PATH);
+        lenient().when(ctx.getTemplateEngine()).thenReturn(templateEngine);
+    }
+
+    @Test
+    void should_select_the_most_specific_flow_when_its_condition_is_true() {
+        givenConditionEvaluatesTo(true);
+        final Flow mostSpecific = conditionalFlow("book detail", "/books/:bookId", GOLD_TIER_CONDITION);
+        final Flow lessSpecific = flow("all books", "/books");
+
+        final TestSubscriber<Flow> resolved = resolve(mostSpecific, lessSpecific);
+
+        resolved.assertValue(mostSpecific).assertComplete();
+    }
+
+    @Test
+    void should_select_the_less_specific_flow_when_the_most_specific_condition_is_false() {
+        givenConditionEvaluatesTo(false);
+        final Flow mostSpecific = conditionalFlow("book detail", "/books/:bookId", GOLD_TIER_CONDITION);
+        final Flow lessSpecific = flow("all books", "/books");
+
+        final TestSubscriber<Flow> resolved = resolve(mostSpecific, lessSpecific);
+
+        // The condition removes the flow from the candidates, it does not discard the whole selection.
+        resolved.assertValue(lessSpecific).assertComplete();
+    }
+
+    @Test
+    void should_select_no_flow_when_every_candidate_condition_is_false() {
+        givenConditionEvaluatesTo(false);
+        final Flow mostSpecific = conditionalFlow("book detail", "/books/:bookId", GOLD_TIER_CONDITION);
+        final Flow lessSpecific = conditionalFlow("all books", "/books", GOLD_TIER_CONDITION);
+
+        final TestSubscriber<Flow> resolved = resolve(mostSpecific, lessSpecific);
+
+        resolved.assertNoValues().assertComplete();
+    }
+
+    private void givenConditionEvaluatesTo(final boolean result) {
+        when(templateEngine.eval(GOLD_TIER_CONDITION, Boolean.class)).thenReturn(Maybe.just(result));
+    }
+
+    private TestSubscriber<Flow> resolve(final Flow... flows) {
+        final BestMatchFlowResolver cut = new BestMatchFlowResolver(flowResolver(List.of(flows)), new BestMatchFlowSelector());
+        return cut.resolve(ctx).test();
+    }
+
+    private AbstractFlowResolver flowResolver(final List<Flow> flows) {
+        return new AbstractFlowResolver(API_FLOW_FILTER) {
+            @Override
+            public Flowable<Flow> provideFlows(final BaseExecutionContext ctx) {
+                return Flowable.fromIterable(flows);
+            }
+        };
+    }
+
+    private Flow flow(final String name, final String path) {
+        final Flow flow = new Flow();
+        flow.setName(name);
+        flow.setSelectors(List.of(httpSelector(path)));
+        return flow;
+    }
+
+    private Flow conditionalFlow(final String name, final String path, final String condition) {
+        final Flow flow = new Flow();
+        flow.setName(name);
+        final ConditionSelector conditionSelector = new ConditionSelector();
+        conditionSelector.setCondition(condition);
+        flow.setSelectors(List.of(httpSelector(path), conditionSelector));
+        return flow;
+    }
+
+    private HttpSelector httpSelector(final String path) {
+        final HttpSelector httpSelector = new HttpSelector();
+        httpSelector.setPath(path);
+        httpSelector.setPathOperator(Operator.STARTS_WITH);
+        return httpSelector;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -202,10 +202,17 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         );
     }
 
+    /**
+     * The condition selector filter is given apart from the selection filters: outside of BEST_MATCH mode, the flow
+     * condition is then not evaluated while resolving the flows but by the FlowChain, right before the flow runs.
+     * A subclass overriding this method with the two-argument constructor keeps the historical behaviour, where
+     * conditions are evaluated upfront.
+     */
     @SuppressWarnings("java:S1845")
     protected FlowResolverFactory flowResolverFactory() {
         return new FlowResolverFactory(
-            new CompositeConditionFilter(new HttpSelectorConditionFilter(), new ConditionSelectorConditionFilter()),
+            new CompositeConditionFilter(new HttpSelectorConditionFilter()),
+            new ConditionSelectorConditionFilter(),
             new BestMatchFlowSelector()
         );
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChain.java
@@ -21,11 +21,13 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
-import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.hook.ChainHook;
 import io.gravitee.gateway.reactive.api.hook.Hookable;
+import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
 import io.gravitee.gateway.reactive.core.hook.HookHelper;
+import io.gravitee.gateway.reactive.handlers.api.v4.flow.resolver.FlowResolverFactory;
 import io.gravitee.gateway.reactive.policy.HttpPolicyChain;
 import io.gravitee.gateway.reactive.v4.flow.FlowResolver;
 import io.gravitee.gateway.reactive.v4.policy.PolicyChainFactory;
@@ -49,23 +51,26 @@ import lombok.CustomLog;
 public class FlowChain implements Hookable<ChainHook> {
 
     protected static final String INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED = "flowExecution.flowsMatched";
+
     private static final String EXECUTION_FAILURE_KEY_FAILURE = "FLOW_EXECUTION_FLOW_MATCHED_FAILURE";
     private final String id;
     private final FlowResolver flowResolver;
     private final String resolvedFlowAttribute;
     private final PolicyChainFactory<HttpPolicyChain, Flow> policyChainFactory;
+    private final ConditionFilter<BaseExecutionContext, Flow> conditionFilter;
     private final boolean validateFlowMatching;
     private final boolean interruptIfNoMatch;
     private List<ChainHook> hooks;
 
     public FlowChain(final String id, final FlowResolver flowResolver, final PolicyChainFactory<HttpPolicyChain, Flow> policyChainFactory) {
-        this(id, flowResolver, policyChainFactory, false, false);
+        this(id, flowResolver, policyChainFactory, FlowResolverFactory.NO_DEFERRED_CONDITION, false, false);
     }
 
     public FlowChain(
         final String id,
         final FlowResolver flowResolver,
         final PolicyChainFactory<HttpPolicyChain, Flow> policyChainFactory,
+        final ConditionFilter<BaseExecutionContext, Flow> conditionFilter,
         final boolean validateFlowMatching,
         final boolean interruptIfNoMatch
     ) {
@@ -73,6 +78,7 @@ public class FlowChain implements Hookable<ChainHook> {
         this.flowResolver = flowResolver;
         this.resolvedFlowAttribute = "flow." + id;
         this.policyChainFactory = policyChainFactory;
+        this.conditionFilter = conditionFilter;
         this.validateFlowMatching = validateFlowMatching;
         this.interruptIfNoMatch = interruptIfNoMatch;
     }
@@ -87,8 +93,11 @@ public class FlowChain implements Hookable<ChainHook> {
 
     /**
      * Executes the flow chain for the specified phase.
-     * The flows composing the chain are resolved dynamically at the first execution.
-     * Subsequent executions related to other phases will reuse the flows resolved during the previous execution to guarantee the same flows can be executed for all the phases.
+     * The flows composing the chain are resolved dynamically at the first execution, and the condition of each of
+     * them is evaluated right before it is executed, so that it observes what the previous flows did, whether they
+     * completed synchronously or not.
+     * The flows that have been executed are stored into an internal attribute of the context: subsequent executions
+     * related to other phases replay exactly the same flows, without evaluating their condition again.
      *
      * @param ctx the execution context that will be passed to each policy of each resolved flow.
      * @param phase the phase to execute.
@@ -97,69 +106,85 @@ public class FlowChain implements Hookable<ChainHook> {
      * The {@link Completable} may complete in error in case of any error occurred during the execution.
      */
     public Completable execute(HttpExecutionContext ctx, ExecutionPhase phase) {
-        Flowable<Flow> flowable = callResolveFlows(ctx, phase);
+        return Completable.defer(() -> {
+            final List<Flow> alreadyExecutedFlows = ctx.getInternalAttribute(resolvedFlowAttribute);
 
-        return flowable
-            .doOnNext(flow -> {
-                ctx.withLogger(log).debug("Executing flow {} ({} level, {} phase)", flow.getName(), id, phase.name());
-                ctx.putInternalAttribute(ATTR_INTERNAL_FLOW_STAGE, id);
-
-                // Only deal with flow matching if required
-                if (validateFlowMatching && phase == ExecutionPhase.REQUEST) {
-                    ctx.setInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED, true);
-                }
-            })
-            .concatMapCompletable(flow -> executeFlow(ctx, flow, phase))
-            .doOnComplete(() -> ctx.removeInternalAttribute(ATTR_INTERNAL_FLOW_STAGE));
-    }
-
-    private Flowable<Flow> callResolveFlows(HttpExecutionContext ctx, ExecutionPhase phase) {
-        if (validateFlowMatching && ExecutionPhase.REQUEST == phase) {
-            // Only deal with execution flow matching if required
-            return resolveFlows(ctx).switchIfEmpty(
-                Flowable.defer(() -> {
-                    boolean flowsMatch = false;
-                    // Retrieve previous flow chain resolution value
-                    Boolean previousChainFlowsMatch = ctx.getInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED);
-                    if (previousChainFlowsMatch == null) {
-                        ctx.setInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED, false);
-                    } else {
-                        flowsMatch = previousChainFlowsMatch;
-                    }
-                    if (interruptIfNoMatch && !flowsMatch) {
-                        ctx.withLogger(log).debug("No flow matched for chain [{}], interrupting with 404", id);
-                        return ctx
-                            .interruptWith(new ExecutionFailure(HttpStatusCode.NOT_FOUND_404).key(EXECUTION_FAILURE_KEY_FAILURE))
-                            .toFlowable();
-                    }
-                    return Flowable.empty();
-                })
-            );
-        } else {
-            return resolveFlows(ctx);
-        }
+            return alreadyExecutedFlows != null
+                ? replayExecutedFlows(ctx, phase, alreadyExecutedFlows)
+                : resolveAndExecuteFlows(ctx, phase);
+        }).doOnComplete(() -> ctx.removeInternalAttribute(ATTR_INTERNAL_FLOW_STAGE));
     }
 
     /**
-     * Resolves the flows to execute once and stores the resolved flows into an internal attribute of the context for later reuse.
-     * This allows to make sure the flow resolved during the execution phase (usually, {@link ExecutionPhase#REQUEST}) will be the same to be executed during the other phases.
-     * If flows have already been resolved, they will be returned without triggering a new resolution.
-     *
-     * @param ctx the context used to temporary store the resolved flows.
-     * @return the resolved flows.
+     * Replays, in the same order, the flows a previous phase has executed. Their condition is not evaluated again:
+     * it is evaluated once for the whole chain, and the outcome then applies to every phase.
      */
-    private Flowable<Flow> resolveFlows(HttpPlainExecutionContext ctx) {
-        return Flowable.defer(() -> {
-            Flowable<Flow> flows = ctx.getInternalAttribute(resolvedFlowAttribute);
+    private Completable replayExecutedFlows(final HttpExecutionContext ctx, final ExecutionPhase phase, final List<Flow> executedFlows) {
+        return Flowable.fromIterable(executedFlows).concatMapCompletable(flow -> executeFlow(ctx, flow, phase));
+    }
 
-            if (flows == null) {
-                // Resolves the flows once. Subsequent resolutions will return the same flows.
-                flows = flowResolver.resolve(ctx).cache();
-                ctx.setInternalAttribute(resolvedFlowAttribute, flows);
-            }
+    /**
+     * Resolves the flows and executes those whose condition matches, keeping them for the next phases.
+     * The list is published into the context before the resolution starts, so that a phase running after an
+     * interruption still finds it. It is then filled as the flows run: {@link Flowable#concatMapCompletable} runs
+     * them one at a time and serializes the access, hence a plain list.
+     */
+    private Completable resolveAndExecuteFlows(final HttpExecutionContext ctx, final ExecutionPhase phase) {
+        final List<Flow> executedFlows = new ArrayList<>();
+        ctx.setInternalAttribute(resolvedFlowAttribute, executedFlows);
 
-            return flows;
-        });
+        final Flowable<Flow> resolvedFlows = flowResolver.resolve(ctx);
+
+        return resolvedFlows
+            .concatMapCompletable(flow -> executeFlowIfConditionMatches(ctx, flow, phase, executedFlows))
+            .andThen(Completable.defer(() -> interruptIfNoFlowExecuted(ctx, phase, executedFlows.isEmpty())));
+    }
+
+    /**
+     * Evaluates the condition of the given flow and, when it matches, executes it and keeps it for the next phases.
+     * The condition is evaluated here, and not while the flows are resolved, so that it is only evaluated once the
+     * previous flow of the chain has fully completed.
+     */
+    private Completable executeFlowIfConditionMatches(
+        final HttpExecutionContext ctx,
+        final Flow flow,
+        final ExecutionPhase phase,
+        final List<Flow> executedFlows
+    ) {
+        return conditionFilter
+            .filter(ctx, flow)
+            .flatMapCompletable(matchedFlow -> {
+                executedFlows.add(matchedFlow);
+                return executeFlow(ctx, matchedFlow, phase);
+            });
+    }
+
+    private Completable interruptIfNoFlowExecuted(
+        final HttpExecutionContext ctx,
+        final ExecutionPhase phase,
+        final boolean noFlowExecuted
+    ) {
+        // Chains sharing the same request report whether any of them matched a flow, so that the last one can
+        // interrupt with a 404 when none did. Only the request phase feeds that decision.
+        if (!noFlowExecuted || !validateFlowMatching || ExecutionPhase.REQUEST != phase) {
+            return Completable.complete();
+        }
+
+        boolean flowsMatch = false;
+        // Retrieve previous flow chain resolution value
+        final Boolean previousChainFlowsMatch = ctx.getInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED);
+        if (previousChainFlowsMatch == null) {
+            ctx.setInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED, false);
+        } else {
+            flowsMatch = previousChainFlowsMatch;
+        }
+
+        if (interruptIfNoMatch && !flowsMatch) {
+            ctx.withLogger(log).debug("No flow matched for chain [{}], interrupting with 404", id);
+            return ctx.interruptWith(new ExecutionFailure(HttpStatusCode.NOT_FOUND_404).key(EXECUTION_FAILURE_KEY_FAILURE));
+        }
+
+        return Completable.complete();
     }
 
     /**
@@ -173,6 +198,14 @@ public class FlowChain implements Hookable<ChainHook> {
      * @return a {@link Completable} that completes when the flow policy chain completes.
      */
     private Completable executeFlow(final HttpExecutionContext ctx, final Flow flow, final ExecutionPhase phase) {
+        ctx.withLogger(log).debug("Executing flow {} ({} level, {} phase)", flow.getName(), id, phase.name());
+        ctx.putInternalAttribute(ATTR_INTERNAL_FLOW_STAGE, id);
+
+        // Report to the other chains of this request that a flow did match, see interruptIfNoFlowExecuted.
+        if (validateFlowMatching && phase == ExecutionPhase.REQUEST) {
+            ctx.setInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED, true);
+        }
+
         if (phase == ExecutionPhase.RESPONSE) {
             // Before executing response phase, execute eventual response actions registered during request phase.
             final HttpPolicyChain policyChain = policyChainFactory.create(id, flow, ExecutionPhase.REQUEST);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChainFactory.java
@@ -42,7 +42,14 @@ public class FlowChainFactory {
     }
 
     public FlowChain createPlanFlow(final Api api, final TracingContext tracingContext) {
-        FlowChain flowPlanChain = new FlowChain("plan", flowResolverFactory.forApiPlan(api), policyChainFactory, true, false);
+        FlowChain flowPlanChain = new FlowChain(
+            "plan",
+            flowResolverFactory.forApiPlan(api),
+            policyChainFactory,
+            flowResolverFactory.deferredConditionFilter(api),
+            true,
+            false
+        );
         flowPlanChain.addHooks(flowHooks(tracingContext));
         return flowPlanChain;
     }
@@ -53,6 +60,7 @@ public class FlowChainFactory {
             "api",
             flowResolverFactory.forApi(api),
             policyChainFactory,
+            flowResolverFactory.deferredConditionFilter(api),
             true,
             flowExecution != null && flowExecution.isMatchRequired()
         );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/FlowResolverFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/FlowResolverFactory.java
@@ -19,11 +19,13 @@ import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.core.condition.CompositeConditionFilter;
 import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
 import io.gravitee.gateway.reactive.v4.flow.AbstractBestMatchFlowSelector;
 import io.gravitee.gateway.reactive.v4.flow.BestMatchFlowResolver;
 import io.gravitee.gateway.reactive.v4.flow.FlowResolver;
+import io.reactivex.rxjava3.core.Maybe;
 
 /**
  * Factory allowing to create a {@link FlowResolver} to be used to resolve flows to execute at api plan level, api level or platform level.
@@ -34,31 +36,82 @@ import io.gravitee.gateway.reactive.v4.flow.FlowResolver;
 @SuppressWarnings("common-java:DuplicatedBlocks") // Needed for v4 definition. Will replace the other one at the end.
 public class FlowResolverFactory {
 
+    /**
+     * Filter to evaluate before running a flow when the resolver already evaluated everything it had to.
+     */
+    public static final ConditionFilter<BaseExecutionContext, Flow> NO_DEFERRED_CONDITION = (ctx, flow) -> Maybe.just(flow);
+
     private final ConditionFilter<BaseExecutionContext, Flow> apiFlowFilter;
+    private final ConditionFilter<BaseExecutionContext, Flow> deferrableConditionFilter;
+    private final ConditionFilter<BaseExecutionContext, Flow> bestMatchApiFlowFilter;
     private final AbstractBestMatchFlowSelector<Flow> bestMatchFlowSelector;
 
+    /**
+     * Builds a factory resolving the flows with a single filter, conditions included: nothing is left to be
+     * evaluated later on, {@link #deferredConditionFilter(Api)} returns a no-op filter.
+     */
     public FlowResolverFactory(
         final ConditionFilter<BaseExecutionContext, Flow> apiFlowFilter,
         final AbstractBestMatchFlowSelector<Flow> bestMatchFlowSelector
     ) {
         this.apiFlowFilter = apiFlowFilter;
+        this.deferrableConditionFilter = null;
+        this.bestMatchApiFlowFilter = apiFlowFilter;
         this.bestMatchFlowSelector = bestMatchFlowSelector;
     }
 
+    /**
+     * Builds a factory keeping the flow condition apart from the selection filters.
+     *
+     * @param apiFlowFilter the filter applied while resolving the flows, in every mode.
+     * @param conditionFilter the flow condition filter. It is applied here in BEST_MATCH mode only, where the
+     * condition takes part in the selection of the single flow to execute. In the other modes it is left to the
+     * caller through {@link #deferredConditionFilter(Api)}, to be evaluated right before a flow runs so that it
+     * observes what the previous flows did.
+     */
+    public FlowResolverFactory(
+        final ConditionFilter<BaseExecutionContext, Flow> apiFlowFilter,
+        final ConditionFilter<BaseExecutionContext, Flow> conditionFilter,
+        final AbstractBestMatchFlowSelector<Flow> bestMatchFlowSelector
+    ) {
+        this.apiFlowFilter = apiFlowFilter;
+        this.deferrableConditionFilter = conditionFilter;
+        this.bestMatchApiFlowFilter = new CompositeConditionFilter<>(apiFlowFilter, conditionFilter);
+        this.bestMatchFlowSelector = bestMatchFlowSelector;
+    }
+
+    /**
+     * Returns the filter that still has to be evaluated before a flow is executed, which is what the resolvers
+     * built by this factory did not evaluate themselves. This factory is the only one to know it, so that a
+     * resolver evaluating conditions upfront can never see them evaluated a second time.
+     */
+    public ConditionFilter<BaseExecutionContext, Flow> deferredConditionFilter(final Api api) {
+        if (deferrableConditionFilter == null || isBestMatchFlowMode(api.getDefinition().getFlowExecution())) {
+            return NO_DEFERRED_CONDITION;
+        }
+        return deferrableConditionFilter;
+    }
+
     public FlowResolver<? extends BaseExecutionContext> forApi(Api api) {
-        ApiFlowResolver apiFlowResolver = new ApiFlowResolver(api.getDefinition(), apiFlowFilter);
-        if (isBestMatchFlowMode(api.getDefinition().getFlowExecution())) {
+        final FlowExecution flowExecution = api.getDefinition().getFlowExecution();
+        ApiFlowResolver apiFlowResolver = new ApiFlowResolver(api.getDefinition(), flowFilter(flowExecution));
+        if (isBestMatchFlowMode(flowExecution)) {
             return new BestMatchFlowResolver(apiFlowResolver, bestMatchFlowSelector);
         }
         return apiFlowResolver;
     }
 
     public FlowResolver forApiPlan(Api api) {
-        ApiPlanFlowResolver apiPlanFlowResolver = new ApiPlanFlowResolver(api.getDefinition(), apiFlowFilter);
-        if (isBestMatchFlowMode(api.getDefinition().getFlowExecution())) {
+        final FlowExecution flowExecution = api.getDefinition().getFlowExecution();
+        ApiPlanFlowResolver apiPlanFlowResolver = new ApiPlanFlowResolver(api.getDefinition(), flowFilter(flowExecution));
+        if (isBestMatchFlowMode(flowExecution)) {
             return new BestMatchFlowResolver(apiPlanFlowResolver, bestMatchFlowSelector);
         }
         return apiPlanFlowResolver;
+    }
+
+    private ConditionFilter<BaseExecutionContext, Flow> flowFilter(final FlowExecution flowExecution) {
+        return isBestMatchFlowMode(flowExecution) ? bestMatchApiFlowFilter : apiFlowFilter;
     }
 
     private static boolean isBestMatchFlowMode(final FlowExecution flowExecution) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChainTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChainTest.java
@@ -30,13 +30,16 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpMessageExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
+import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
 import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
 import io.gravitee.gateway.reactive.core.context.MutableRequest;
 import io.gravitee.gateway.reactive.core.context.MutableResponse;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
+import io.gravitee.gateway.reactive.handlers.api.v4.flow.resolver.FlowResolverFactory;
 import io.gravitee.gateway.reactive.policy.HttpPolicyChain;
 import io.gravitee.gateway.reactive.v4.flow.FlowResolver;
 import io.gravitee.gateway.reactive.v4.policy.PolicyChainFactory;
@@ -44,9 +47,12 @@ import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.subjects.CompletableSubject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -153,8 +159,8 @@ class FlowChainTest {
         buildPolicyChain("pc-flow1", flow1, REQUEST, policy1);
         buildPolicyChain("pc-flow2", flow2, REQUEST, policy2);
 
-        // Force the resolved flows to be already present in the context.
-        ctx.setInternalAttribute("flow." + FLOW_CHAIN_ID, Flowable.just(flow1, flow2));
+        // Force the flows executed during a previous phase to be already present in the context.
+        ctx.setInternalAttribute("flow." + FLOW_CHAIN_ID, List.of(flow1, flow2));
 
         final TestObserver<Void> obs = cut.execute(ctx, REQUEST).test();
 
@@ -164,6 +170,67 @@ class FlowChainTest {
 
         // Make sure no flow resolution occurred when already resolved.
         verifyNoInteractions(flowResolver);
+    }
+
+    @Test
+    void should_evaluate_the_condition_of_a_flow_only_once_the_previous_asynchronous_flow_completed() {
+        final CompletableSubject flow1Completion = CompletableSubject.create();
+        final AtomicInteger flow2ConditionEvaluations = new AtomicInteger();
+        final ConditionFilter<BaseExecutionContext, Flow> conditionFilter = (context, flow) -> {
+            if (flow == flow2) {
+                flow2ConditionEvaluations.incrementAndGet();
+            }
+            return Maybe.just(flow);
+        };
+        cut = new FlowChain(FLOW_CHAIN_ID, flowResolver, policyChainFactory, conditionFilter, false, false);
+
+        buildPolicyChain("pc-flow1", flow1, REQUEST, asyncPolicy("async-policy", flow1Completion));
+        buildPolicyChain("pc-flow2", flow2, REQUEST, policy2);
+
+        final TestObserver<Void> obs = cut.execute(ctx, REQUEST).test();
+
+        // As long as the first flow has not completed, the condition of the second one must not be evaluated.
+        obs.assertNotComplete();
+        assertThat(flow2ConditionEvaluations).hasValue(0);
+
+        flow1Completion.onComplete();
+
+        obs.assertResult();
+        assertThat(flow2ConditionEvaluations).hasValue(1);
+        assertThat(executionOrder).containsExactly("policy2-onRequest");
+    }
+
+    @Test
+    void should_not_evaluate_the_condition_again_on_the_response_phase() {
+        final AtomicInteger conditionEvaluations = new AtomicInteger();
+        final ConditionFilter<BaseExecutionContext, Flow> conditionFilter = (context, flow) -> {
+            conditionEvaluations.incrementAndGet();
+            return flow == flow1 ? Maybe.just(flow) : Maybe.empty();
+        };
+        cut = new FlowChain(FLOW_CHAIN_ID, flowResolver, policyChainFactory, conditionFilter, false, false);
+
+        buildPolicyChain("pc-flow1-request", flow1, REQUEST, policy1);
+        buildPolicyChain("pc-flow1-response", flow1, RESPONSE, policy2);
+
+        cut.execute(ctx, REQUEST).andThen(cut.execute(ctx, RESPONSE)).test().assertResult();
+
+        // Both flows evaluated once during the request phase, then the response phase replays what has been executed.
+        assertThat(conditionEvaluations).hasValue(2);
+        assertThat(executionOrder).containsExactly("policy1-onRequest", "policy1-actionActionOnResponse", "policy2-onResponse");
+    }
+
+    private static HttpPolicy asyncPolicy(final String id, final Completable completion) {
+        return new HttpPolicy() {
+            @Override
+            public String id() {
+                return id;
+            }
+
+            @Override
+            public Completable onRequest(final HttpPlainExecutionContext ctx) {
+                return completion;
+            }
+        };
     }
 
     @Test
@@ -182,7 +249,7 @@ class FlowChainTest {
 
     @Test
     void should_interrupt_when_no_current_match_and_no_previous_match() {
-        cut = new FlowChain(FLOW_CHAIN_ID, flowResolver, policyChainFactory, true, true);
+        cut = new FlowChain(FLOW_CHAIN_ID, flowResolver, policyChainFactory, FlowResolverFactory.NO_DEFERRED_CONDITION, true, true);
         ctx.setInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED, false);
 
         when(flowResolver.resolve(ctx)).thenReturn(Flowable.empty());
@@ -194,7 +261,7 @@ class FlowChainTest {
 
     @Test
     void should_interrupt_when_no_current_match_and_no_previous_value() {
-        cut = new FlowChain(FLOW_CHAIN_ID, flowResolver, policyChainFactory, true, true);
+        cut = new FlowChain(FLOW_CHAIN_ID, flowResolver, policyChainFactory, FlowResolverFactory.NO_DEFERRED_CONDITION, true, true);
         ctx.setInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED, null);
 
         when(flowResolver.resolve(ctx)).thenReturn(Flowable.empty());
@@ -208,7 +275,7 @@ class FlowChainTest {
 
     @Test
     void should_not_interrupt_when_no_match_but_previous_match() {
-        cut = new FlowChain(FLOW_CHAIN_ID, flowResolver, policyChainFactory, true, true);
+        cut = new FlowChain(FLOW_CHAIN_ID, flowResolver, policyChainFactory, FlowResolverFactory.NO_DEFERRED_CONDITION, true, true);
         ctx.setInternalAttribute(INTERNAL_CONTEXT_ATTRIBUTES_FLOWS_MATCHED, true);
 
         when(flowResolver.resolve(ctx)).thenReturn(Flowable.empty());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/FlowResolverFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/resolver/FlowResolverFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactive.handlers.api.v4.flow.resolver;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,6 +46,9 @@ class FlowResolverFactoryTest {
     private ConditionFilter<BaseExecutionContext, Flow> conditionFilter;
 
     @Mock
+    private ConditionFilter<BaseExecutionContext, Flow> selectorFilter;
+
+    @Mock
     private AbstractBestMatchFlowSelector<Flow> bestMatchFlowSelector;
 
     private FlowResolverFactory cut;
@@ -73,5 +77,28 @@ class FlowResolverFactoryTest {
 
         assertNotNull(flowResolver);
         assertTrue(flowResolver instanceof ApiPlanFlowResolver);
+    }
+
+    @Test
+    void should_not_defer_any_condition_when_built_with_a_single_filter() {
+        // Factories built that way resolve the flows with one filter, conditions included. Nothing is left to be
+        // evaluated before a flow runs, otherwise the condition would be evaluated twice.
+        assertThat(cut.deferredConditionFilter(api)).isSameAs(FlowResolverFactory.NO_DEFERRED_CONDITION);
+    }
+
+    @Test
+    void should_defer_the_condition_when_built_with_a_dedicated_condition_filter() {
+        cut = new FlowResolverFactory(selectorFilter, conditionFilter, bestMatchFlowSelector);
+
+        assertThat(cut.deferredConditionFilter(api)).isSameAs(conditionFilter);
+    }
+
+    @Test
+    void should_not_defer_the_condition_in_best_match_mode() {
+        cut = new FlowResolverFactory(selectorFilter, conditionFilter, bestMatchFlowSelector);
+        api.getDefinition().getFlowExecution().setMode(FlowMode.BEST_MATCH);
+
+        // The condition took part in the selection of the single flow to execute.
+        assertThat(cut.deferredConditionFilter(api)).isSameAs(FlowResolverFactory.NO_DEFERRED_CONDITION);
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/bestmatch/BestMatchWithConditionV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/bestmatch/BestMatchWithConditionV4IntegrationTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.bestmatch;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.transformheaders.TransformHeadersPolicy;
+import io.gravitee.policy.transformheaders.configuration.TransformHeadersPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Characterizes how a flow condition takes part in the BEST_MATCH selection, end to end.
+ *
+ * A condition makes a flow eligible, or not, <b>before</b> the most specific flow is picked. It is not a filter
+ * applied afterwards to the winner: when the most specific flow is ruled out by its condition, a less specific one
+ * is selected in its place.
+ *
+ * The API declares, both at plan and at API level, a specific flow reserved to the gold tier and a broader
+ * unconditional one, so that both chains are covered by the same requests.
+ *
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DeployApi("/apis/v4/http/bestmatch/api-condition.json")
+class BestMatchWithConditionV4IntegrationTest extends AbstractGatewayTest {
+
+    private static final String PLAN_FLOW_SELECTED = "X-Plan-Flow-Selected";
+    private static final String API_FLOW_SELECTED = "X-Api-Flow-Selected";
+    private static final String TIER = "X-Tier";
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.putIfAbsent(
+            "transform-headers",
+            PolicyBuilder.build("transform-headers", TransformHeadersPolicy.class, TransformHeadersPolicyConfiguration.class)
+        );
+    }
+
+    @Test
+    void should_select_the_most_specific_flow_when_its_condition_is_true(HttpClient client) {
+        callApi(client, "/books/145", "gold");
+
+        wiremock.verify(
+            getRequestedFor(urlPathEqualTo("/endpoint/books/145"))
+                .withHeader(PLAN_FLOW_SELECTED, equalTo("/books/:bookId"))
+                .withHeader(API_FLOW_SELECTED, equalTo("/books/:bookId"))
+        );
+    }
+
+    @Test
+    void should_select_the_less_specific_flow_when_the_most_specific_condition_is_false(HttpClient client) {
+        callApi(client, "/books/145", "silver");
+
+        // The gold flow is not a candidate at all, so the broader flow wins the selection.
+        wiremock.verify(
+            getRequestedFor(urlPathEqualTo("/endpoint/books/145"))
+                .withHeader(PLAN_FLOW_SELECTED, equalTo("/books"))
+                .withHeader(API_FLOW_SELECTED, equalTo("/books"))
+        );
+    }
+
+    @Test
+    void should_select_no_flow_when_the_only_candidate_condition_is_false(HttpClient client) {
+        callApi(client, "/vip", "silver");
+
+        // No fallback flow is declared under /vip: the request is still proxied, without any flow being executed.
+        wiremock.verify(
+            getRequestedFor(urlPathEqualTo("/endpoint/vip"))
+                .withHeader(PLAN_FLOW_SELECTED, absent())
+                .withHeader(API_FLOW_SELECTED, absent())
+        );
+    }
+
+    @Test
+    void should_select_the_conditional_flow_when_no_other_flow_matches_the_path(HttpClient client) {
+        callApi(client, "/vip", "gold");
+
+        wiremock.verify(
+            getRequestedFor(urlPathEqualTo("/endpoint/vip"))
+                .withHeader(PLAN_FLOW_SELECTED, absent())
+                .withHeader(API_FLOW_SELECTED, equalTo("/vip"))
+        );
+    }
+
+    private void callApi(final HttpClient client, final String path, final String tier) {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        client
+            .rxRequest(HttpMethod.GET, "/test-bestmatch-condition" + path)
+            .flatMap(request -> request.putHeader(TIER, tier).rxSend())
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.body();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowConditionAfterAsyncPolicyV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowConditionAfterAsyncPolicyV4IntegrationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.flows;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.integration.tests.fake.LatencyPolicy;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.assignattributes.AssignAttributesPolicy;
+import io.gravitee.policy.assignattributes.configuration.AssignAttributesPolicyConfiguration;
+import io.gravitee.policy.transformheaders.TransformHeadersPolicy;
+import io.gravitee.policy.transformheaders.configuration.TransformHeadersPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * In DEFAULT flow mode, the condition of a flow must be evaluated once the previous flow has fully completed, so
+ * that it observes the attributes this flow has set. A previous flow holding an asynchronous policy must not change
+ * that: the condition of the next flow is not to be evaluated while the previous one is still in flight.
+ *
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DeployApi("/apis/v4/http/flows/api-condition-after-async-policy.json")
+class FlowConditionAfterAsyncPolicyV4IntegrationTest extends AbstractGatewayTest {
+
+    private static final String NEXT_FLOW_EXECUTED = "X-Next-Flow-Executed";
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.putIfAbsent("latency", PolicyBuilder.build("latency", LatencyPolicy.class, LatencyPolicy.LatencyConfiguration.class));
+        policies.putIfAbsent(
+            "assign-attributes",
+            PolicyBuilder.build("assign-attributes", AssignAttributesPolicy.class, AssignAttributesPolicyConfiguration.class)
+        );
+        policies.putIfAbsent(
+            "transform-headers",
+            PolicyBuilder.build("transform-headers", TransformHeadersPolicy.class, TransformHeadersPolicyConfiguration.class)
+        );
+    }
+
+    @Test
+    void should_skip_the_next_flow_when_a_previous_asynchronous_flow_made_its_condition_false(HttpClient client) {
+        callApi(client, "/async");
+
+        wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint/async")).withHeader(NEXT_FLOW_EXECUTED, absent()));
+    }
+
+    @Test
+    void should_execute_the_next_flow_when_a_previous_asynchronous_flow_made_its_condition_true(HttpClient client) {
+        callApi(client, "/async-matching");
+
+        wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint/async-matching")).withHeader(NEXT_FLOW_EXECUTED, equalTo("true")));
+    }
+
+    @Test
+    void should_skip_the_next_flow_when_a_previous_synchronous_flow_made_its_condition_false(HttpClient client) {
+        callApi(client, "/sync");
+
+        wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint/sync")).withHeader(NEXT_FLOW_EXECUTED, absent()));
+    }
+
+    private void callApi(final HttpClient client, final String path) {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        client
+            .rxRequest(HttpMethod.GET, "/test-condition-after-async" + path)
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.body();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/bestmatch/api-condition.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/bestmatch/api-condition.json
@@ -1,0 +1,232 @@
+{
+  "id": "my-api-v4-bestmatch-condition",
+  "name": "my-api-v4-bestmatch-condition",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "flowExecution": {
+    "mode": "best-match",
+    "matchRequired": false
+  },
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test-bestmatch-condition"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "plans": [
+    {
+      "id": "plan-id",
+      "name": "Keyless",
+      "description": "keyless",
+      "security": {
+        "type": "key-less"
+      },
+      "mode": "STANDARD",
+      "flows": [
+        {
+          "name": "A book, for gold tier only",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/books/:bookId",
+              "pathOperator": "START_WITH",
+              "methods": []
+            },
+            {
+              "type": "condition",
+              "condition": "{#request.headers['X-Tier'][0] == 'gold'}"
+            }
+          ],
+          "methods": [],
+          "request": [
+            {
+              "name": "Transform headers",
+              "description": "",
+              "enabled": true,
+              "policy": "transform-headers",
+              "configuration": {
+                "scope": "REQUEST",
+                "addHeaders": [
+                  {
+                    "name": "X-Plan-Flow-Selected",
+                    "value": "/books/:bookId"
+                  }
+                ]
+              }
+            }
+          ],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "All books",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/books",
+              "pathOperator": "START_WITH",
+              "methods": []
+            }
+          ],
+          "methods": [],
+          "request": [
+            {
+              "name": "Transform headers",
+              "description": "",
+              "enabled": true,
+              "policy": "transform-headers",
+              "configuration": {
+                "scope": "REQUEST",
+                "addHeaders": [
+                  {
+                    "name": "X-Plan-Flow-Selected",
+                    "value": "/books"
+                  }
+                ]
+              }
+            }
+          ],
+          "post": [],
+          "enabled": true
+        }
+      ],
+      "comment_required": false
+    }
+  ],
+  "flows": [
+    {
+      "name": "A book, for gold tier only",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/books/:bookId",
+          "pathOperator": "START_WITH",
+          "methods": []
+        },
+        {
+          "type": "condition",
+          "condition": "{#request.headers['X-Tier'][0] == 'gold'}"
+        }
+      ],
+      "methods": [],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books/:bookId"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "All books",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/books",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "methods": [],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "VIP area, for gold tier only",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/vip",
+          "pathOperator": "START_WITH",
+          "methods": []
+        },
+        {
+          "type": "condition",
+          "condition": "{#request.headers['X-Tier'][0] == 'gold'}"
+        }
+      ],
+      "methods": [],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/vip"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/flows/api-condition-after-async-policy.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/flows/api-condition-after-async-policy.json
@@ -1,0 +1,280 @@
+{
+  "id": "my-api-v4-condition-after-async-policy",
+  "name": "my-api-v4-condition-after-async-policy",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "flowExecution": {
+    "mode": "default",
+    "matchRequired": false
+  },
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test-condition-after-async"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "plans": [
+    {
+      "id": "plan-id",
+      "name": "Keyless",
+      "description": "keyless",
+      "security": {
+        "type": "key-less"
+      },
+      "mode": "STANDARD",
+      "flows": [],
+      "comment_required": false
+    }
+  ],
+  "flows": [
+    {
+      "name": "Async - set the marker behind an asynchronous policy",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/async",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "methods": [],
+      "request": [
+        {
+          "name": "Latency",
+          "description": "Introduces an asynchronous boundary before the marker is set",
+          "enabled": true,
+          "policy": "latency",
+          "configuration": {
+            "delay": 50
+          }
+        },
+        {
+          "name": "Assign attributes",
+          "description": "",
+          "enabled": true,
+          "policy": "assign-attributes",
+          "configuration": {
+            "scope": "REQUEST",
+            "attributes": [
+              {
+                "name": "flow1-marker",
+                "value": "done"
+              }
+            ]
+          }
+        }
+      ],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Async - must be skipped once the marker is set",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/async",
+          "pathOperator": "START_WITH",
+          "methods": []
+        },
+        {
+          "type": "condition",
+          "condition": "{#context.attributes['flow1-marker'] == null}"
+        }
+      ],
+      "methods": [],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Next-Flow-Executed",
+                "value": "true"
+              }
+            ]
+          }
+        }
+      ],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Async matching - set the marker behind an asynchronous policy",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/async-matching",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "methods": [],
+      "request": [
+        {
+          "name": "Latency",
+          "description": "Introduces an asynchronous boundary before the marker is set",
+          "enabled": true,
+          "policy": "latency",
+          "configuration": {
+            "delay": 50
+          }
+        },
+        {
+          "name": "Assign attributes",
+          "description": "",
+          "enabled": true,
+          "policy": "assign-attributes",
+          "configuration": {
+            "scope": "REQUEST",
+            "attributes": [
+              {
+                "name": "flow1-marker",
+                "value": "done"
+              }
+            ]
+          }
+        }
+      ],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Async matching - must run once the marker is set",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/async-matching",
+          "pathOperator": "START_WITH",
+          "methods": []
+        },
+        {
+          "type": "condition",
+          "condition": "{#context.attributes['flow1-marker'] == 'done'}"
+        }
+      ],
+      "methods": [],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Next-Flow-Executed",
+                "value": "true"
+              }
+            ]
+          }
+        }
+      ],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Sync - set the marker without any asynchronous policy",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/sync",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "methods": [],
+      "request": [
+        {
+          "name": "Assign attributes",
+          "description": "",
+          "enabled": true,
+          "policy": "assign-attributes",
+          "configuration": {
+            "scope": "REQUEST",
+            "attributes": [
+              {
+                "name": "flow1-marker",
+                "value": "done"
+              }
+            ]
+          }
+        }
+      ],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Sync - must be skipped once the marker is set",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/sync",
+          "pathOperator": "START_WITH",
+          "methods": []
+        },
+        {
+          "type": "condition",
+          "condition": "{#context.attributes['flow1-marker'] == null}"
+        }
+      ],
+      "methods": [],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Next-Flow-Executed",
+                "value": "true"
+              }
+            ]
+          }
+        }
+      ],
+      "response": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-83

## Description

Backport of https://github.com/gravitee-io/gravitee-api-management/pull/18951 to the maintenance branches. Same
two commits, written directly against `4.12.x` rather than backported by Mergify — see below.

In `DEFAULT` flow mode, flow conditions were evaluated while the flows were being resolved, ahead of their
execution. As soon as a flow held an asynchronous policy, the condition of the next flow was therefore evaluated
while that flow was still in flight, and could not observe the attributes it was about to set. A flow meant to be
skipped was executed, and the other way around.

The condition is now evaluated by the `FlowChain`, right before a flow runs. The flows that have been executed are
kept in the execution context, and the following phases replay exactly those. `BEST_MATCH` is left untouched: a
single flow runs per chain, and the condition has to take part in its selection.

Refer to the master PR for the full rationale, the root cause analysis and the diagrams.

## Additional context

### Why this is not a Mergify backport

The integration test module moved to `gravitee-apim-distribution/gravitee-apim-distribution-integration-tests` on
`master`, while `4.9.x` → `4.12.x` still use `gravitee-apim-integration-tests`. A backport of the master PR would
conflict on all four test files, on every branch. Writing them at the right path directly avoids it, and the
module keeps the same name on 4.11.x, 4.10.x and 4.9.x, so the labelled backports should apply cleanly.

### Differences with the master PR

The *API product* feature does not exist on this branch, so the following were left out — nothing else differs,
the production and test files are otherwise identical to the master PR:

- `FlowChainFactory#createProductPlanFlow`
- `FlowResolverFactory#forApiProductPlan` and its unit test

`FlowResolverFactory#flowFilter(FlowExecution)` **is** part of this backport: it sits in the same hunk as
`forApiProductPlan` but is required by `forApi` and `forApiPlan`.

### Impact on the reactors overriding `DefaultApiReactorFactory#flowResolverFactory()`

`MessageApiReactorFactory` and `MCPProxyApiReactorFactory` build their `FlowResolverFactory` with a single filter,
conditions included. They keep the two-argument constructor, so `deferredConditionFilter()` returns a no-op filter:
their behaviour is strictly unchanged, conditions still evaluated upfront and never twice. Message and MCP APIs
are therefore **not** fixed by this PR, and need a follow-up in their own repository.

The other reactors (a2a-proxy, authz, llm-proxy) do not override that method and are fixed; edge and native-kafka
do not use these factories.

### Validation on this branch

- `gravitee-apim-gateway-handlers-api` + `gravitee-apim-gateway-flow`: 982 tests green.
- Integration tests: 109 green, covering the new reproduction and characterization suites plus `FlowPhaseExecution`
  (V4/emulation) and `BestMatch` (V3/V4/emulation/messages).
- License and formatting checks pass on the three modules.
