### PR TITLE
feat(observability): add Gamma dashboards read endpoints

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
@@ -15,10 +15,7 @@
  */
 package io.gravitee.rest.api.standalone.spring;
 
-import io.gravitee.gamma.rest.infra.config.GammaAnalyticsConfiguration;
-import io.gravitee.gamma.rest.infra.config.GammaLogsConfiguration;
-import io.gravitee.gamma.rest.infra.config.GammaObservabilityFilterConfiguration;
-import io.gravitee.gamma.rest.infra.config.GammaTracingConfiguration;
+import io.gravitee.gamma.rest.infra.config.GammaObservabilityConfiguration;
 import io.gravitee.integration.controller.spring.IntegrationControllerConfiguration;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.NodeMetadataResolver;
@@ -47,10 +44,7 @@ import org.springframework.context.annotation.Import;
         io.gravitee.rest.api.management.v2.rest.spring.RestManagementConfiguration.class,
         IntegrationControllerConfiguration.class,
         RestPortalConfiguration.class,
-        GammaTracingConfiguration.class,
-        GammaObservabilityFilterConfiguration.class,
-        GammaLogsConfiguration.class,
-        GammaAnalyticsConfiguration.class,
+        GammaObservabilityConfiguration.class,
     }
 )
 public class StandaloneConfiguration {

--- a/gravitee-gamma/gravitee-gamma-rest-api/AGENTS.md
+++ b/gravitee-gamma/gravitee-gamma-rest-api/AGENTS.md
@@ -119,6 +119,8 @@ Only exception: `@UseCase` uses `@Transactional` (accepted trade-off).
     2. Declares `@Bean` factories for the adapter port impls — these aren't Spring components on their own.
     3. Is `@Import`ed from `StandaloneConfiguration` so its beans land in the parent rest-api context (the Jersey `/gamma` app inherits beans from the parent).
 
+When several sibling sub-domains share an umbrella domain (e.g. traces/filters/logs/analytics/dashboards all under Observability, mounted under `/observability/*` by `GammaRootResource`), add a beanless aggregator `Gamma<Umbrella>Configuration` that only `@Import`s the sub-domain configs (see `GammaObservabilityConfiguration`), and `@Import` that single aggregator from `StandaloneConfiguration` instead of every sub-domain config individually. Each sub-domain still owns its own config file — the aggregator doesn't replace step 3 above, it just gives `StandaloneConfiguration` one entry point per umbrella domain instead of one per sub-domain.
+
 Example:
 
 ```java

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/GammaModuleApplication.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/GammaModuleApplication.java
@@ -19,7 +19,10 @@ import com.fasterxml.jackson.core.util.JacksonFeature;
 import io.gravitee.gamma.rest.resources.GammaRootResource;
 import io.gravitee.gamma.rest.resources.GammaUIResource;
 import io.gravitee.gamma.rest.resources.OpenAPIResource;
+import io.gravitee.gamma.rest.resources.observability.GammaObservabilityResource;
 import io.gravitee.gamma.rest.resources.observability.analytics.AnalyticsResource;
+import io.gravitee.gamma.rest.resources.observability.dashboards.ObservabilityDashboardResource;
+import io.gravitee.gamma.rest.resources.observability.dashboards.ObservabilityDashboardsResource;
 import io.gravitee.gamma.rest.resources.observability.filters.ObservabilityFiltersResource;
 import io.gravitee.gamma.rest.resources.observability.logs.LogsResource;
 import io.gravitee.gamma.rest.resources.tracing.TracingResource;
@@ -58,10 +61,13 @@ public class GammaModuleApplication extends ResourceConfig {
         register(GammaRootResource.class);
         register(GammaUIResource.class);
         register(OpenAPIResource.class);
+        register(GammaObservabilityResource.class);
         register(TracingResource.class);
         register(ObservabilityFiltersResource.class);
         register(LogsResource.class);
         register(AnalyticsResource.class);
+        register(ObservabilityDashboardsResource.class);
+        register(ObservabilityDashboardResource.class);
 
         register(MultiPartFeature.class);
         register(PayloadInputBodyReader.class);

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/exception/DashboardNotFoundException.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/exception/DashboardNotFoundException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.exception;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+
+/**
+ * Raised when a dashboard id doesn't resolve within the caller's environment — either it doesn't
+ * exist at all, or it belongs to a different environment. Both cases collapse to this single 404 so
+ * cross-environment existence cannot be probed (see {@code DashboardRepository#findByIdAndEnvironmentId}).
+ *
+ * <p>Distinct from the unrelated, differently-packaged legacy
+ * {@code io.gravitee.rest.api.service.exceptions.DashboardNotFoundException} (v2 analytics dashboards).
+ *
+ * @author GraviteeSource Team
+ */
+public class DashboardNotFoundException extends NotFoundDomainException {
+
+    public DashboardNotFoundException(String dashboardId) {
+        super("Dashboard '" + dashboardId + "' not found", dashboardId);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/exception/InvalidDashboardException.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/exception/InvalidDashboardException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.exception;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+/**
+ * Raised by {@code Dashboard}'s compact constructor when a required field is missing. Reachable
+ * today only if persisted data is corrupt (this ticket only reads dashboards written by OBS-14's
+ * repository layer); the write path introduced by OBS-16 will also route through it.
+ *
+ * @author GraviteeSource Team
+ */
+public class InvalidDashboardException extends ValidationDomainException {
+
+    public InvalidDashboardException(String message) {
+        super(message);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/Dashboard.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/Dashboard.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * A dashboard saved by a Gamma Observability user, served by the read endpoints in this ticket
+ * (OBS-15) and written by OBS-16/17. Distinct from the legacy v2 analytics dashboard and from
+ * {@code CustomDashboard} — see OBS-13 for the rationale.
+ *
+ * <p>{@code widgets} is deliberately opaque: never parsed, only returned verbatim (see
+ * {@code GammaDashboard.widgets}).
+ *
+ * @author GraviteeSource Team
+ */
+public record Dashboard(
+    String id,
+    String environmentId,
+    String title,
+    String description,
+    List<DashboardFilter> filters,
+    TimeRange timeRange,
+    JsonNode widgets,
+    Integer version,
+    String createdBy,
+    Instant createdAt,
+    Instant updatedAt
+) {
+    public Dashboard {
+        requireNonBlank(id, "id");
+        requireNonBlank(environmentId, "environmentId");
+        requireNonBlank(title, "title");
+        filters = filters == null ? List.of() : List.copyOf(filters);
+    }
+
+    private static void requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new InvalidDashboardException("Dashboard " + fieldName + " is required");
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/DashboardFilter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/DashboardFilter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.model;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+
+/**
+ * A dashboard-definition filter, applied to every widget of the dashboard. Composes the shared
+ * {@link FilterCondition} (name/operator/values) rather than redeclaring it, and adds the two fields
+ * a dashboard filter needs on top: a persisted display {@link #label} (not derivable — see
+ * {@code GammaDashboard.Filter}) and whether the viewer may change the value.
+ *
+ * @author GraviteeSource Team
+ */
+public record DashboardFilter(FilterCondition condition, String label, boolean editable) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/TimeRange.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/TimeRange.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.model;
+
+/**
+ * Time window a dashboard opens on. {@code period} is set for {@link TimeRangeType#RELATIVE},
+ * {@code from} / {@code to} (epoch millis) for {@link TimeRangeType#ABSOLUTE}.
+ *
+ * @author GraviteeSource Team
+ */
+public record TimeRange(TimeRangeType type, String period, Long from, Long to) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/TimeRangeType.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/TimeRangeType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.model;
+
+/**
+ * Discriminates a dashboard's time window. Lowercase on the wire ({@code relative}/{@code absolute})
+ * to match the frontend's discriminated union and the persisted {@code GammaDashboard.TimeRange}
+ * shape — see {@code DashboardTimeRangeDto} for the enum-to-lowercase-string mapping.
+ *
+ * @author GraviteeSource Team
+ */
+public enum TimeRangeType {
+    RELATIVE,
+    ABSOLUTE,
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/port/repository/DashboardRepository.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/port/repository/DashboardRepository.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.port.repository;
+
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Port onto Gamma's own dashboard storage — first legitimate use of {@code port/repository/} in this
+ * module (see AGENTS.md §2): unlike {@code TracingPort}, which fronts an external OTel-backed SPI,
+ * dashboards are data this module persists itself (via the {@code GammaDashboardRepository} SPI
+ * shipped by OBS-14).
+ *
+ * <p>Deliberately does not declare {@code findAll()}: it would be unscoped on an environment-scoped
+ * entity, so keeping it off this port makes it unreachable above the adapter.
+ *
+ * @author GraviteeSource Team
+ */
+public interface DashboardRepository {
+    /**
+     * Ordered by creation date, then id — see {@code GammaDashboardRepository#findByEnvironmentId}.
+     */
+    List<Dashboard> findByEnvironmentId(String environmentId);
+
+    /**
+     * Environment-scoped lookup: a dashboard id from another environment resolves to empty here
+     * rather than as a caller-side check the single-dashboard use case would otherwise have to
+     * remember to perform.
+     */
+    Optional<Dashboard> findByIdAndEnvironmentId(String id, String environmentId);
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/GetObservabilityDashboardUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/GetObservabilityDashboardUseCase.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.DashboardNotFoundException;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.DashboardRepository;
+import lombok.AllArgsConstructor;
+
+/**
+ * Fetches a single dashboard, scoped to the caller's environment. A dashboard id from another
+ * environment throws {@link DashboardNotFoundException} — 404, not 403 — via the same
+ * environment-scoped repository lookup used by the list use case, so existence cannot be probed
+ * across environments.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@AllArgsConstructor
+public class GetObservabilityDashboardUseCase {
+
+    private final DashboardRepository dashboardRepository;
+
+    public record Input(String environmentId, String dashboardId) {}
+
+    public record Output(Dashboard dashboard) {}
+
+    public Output execute(Input input) {
+        Dashboard dashboard = dashboardRepository
+            .findByIdAndEnvironmentId(input.dashboardId(), input.environmentId())
+            .orElseThrow(() -> new DashboardNotFoundException(input.dashboardId()));
+        return new Output(dashboard);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/ListObservabilityDashboardUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/ListObservabilityDashboardUseCase.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.DashboardRepository;
+import java.util.List;
+import lombok.AllArgsConstructor;
+
+/**
+ * Lists every dashboard saved in the caller's environment, paginated.
+ *
+ * <p>{@link DashboardRepository#findByEnvironmentId} has no native pagination (the OBS-14 SPI
+ * returns the full, ordered list) — pagination is applied here by slicing the full result, matching
+ * the "fetch, then slice" precedent used by {@code TracingPortAdapter} for the same reason. Fine for
+ * a per-environment dashboard count, which is expected to stay small.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@AllArgsConstructor
+public class ListObservabilityDashboardUseCase {
+
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_PER_PAGE = 20;
+    private static final int MAX_PER_PAGE = 100;
+
+    private final DashboardRepository dashboardRepository;
+
+    public record Input(String environmentId, Integer page, Integer perPage) {}
+
+    public record Output(List<Dashboard> dashboards, long totalCount, int page, int perPage) {}
+
+    public Output execute(Input input) {
+        int page = resolvePage(input);
+        int perPage = resolvePerPage(input);
+
+        List<Dashboard> all = dashboardRepository.findByEnvironmentId(input.environmentId());
+        int fromIndex = Math.min((page - 1) * perPage, all.size());
+        int toIndex = Math.min(fromIndex + perPage, all.size());
+
+        return new Output(all.subList(fromIndex, toIndex), all.size(), page, perPage);
+    }
+
+    private static int resolvePage(Input input) {
+        return (input.page() != null && input.page() > 0) ? input.page() : DEFAULT_PAGE;
+    }
+
+    private static int resolvePerPage(Input input) {
+        return (input.perPage() != null && input.perPage() > 0) ? Math.min(input.perPage(), MAX_PER_PAGE) : DEFAULT_PER_PAGE;
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapter.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardFilter;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRange;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRangeType;
+import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.DashboardRepository;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.repository.management.model.GammaDashboard;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Wraps the {@code GammaDashboardRepository} SPI (shipped by OBS-14, {@code gravitee-apim-repository-api})
+ * for the core layer. Anticorruption mapping is non-trivial: the persisted {@code GammaDashboard.Filter}
+ * uses {@code field}/{@code label}/{@code operator}(lowercase)/{@code value}/{@code editable}, not the
+ * {@code name}/UPPERCASE-{@code operator}/{@code values} shape this endpoint's wire format uses via the
+ * shared {@link FilterCondition}/{@link FilterOperator}.
+ *
+ * @author GraviteeSource Team
+ */
+@RequiredArgsConstructor
+public class GammaDashboardRepositoryAdapter implements DashboardRepository {
+
+    private static final ObjectMapper WIDGETS_MAPPER = new ObjectMapper();
+
+    private final io.gravitee.repository.management.api.GammaDashboardRepository gammaDashboardRepository;
+
+    @Override
+    public List<Dashboard> findByEnvironmentId(String environmentId) {
+        return RepositoryCalls.wrap(
+            () ->
+                gammaDashboardRepository.findByEnvironmentId(environmentId).stream().map(GammaDashboardRepositoryAdapter::toCore).toList(),
+            "Failed to list dashboards for environment '" + environmentId + "'"
+        );
+    }
+
+    @Override
+    public Optional<Dashboard> findByIdAndEnvironmentId(String id, String environmentId) {
+        return RepositoryCalls.wrap(
+            () -> gammaDashboardRepository.findByIdAndEnvironmentId(id, environmentId).map(GammaDashboardRepositoryAdapter::toCore),
+            "Failed to fetch dashboard '" + id + "' for environment '" + environmentId + "'"
+        );
+    }
+
+    private static Dashboard toCore(GammaDashboard source) {
+        return new Dashboard(
+            source.getId(),
+            source.getEnvironmentId(),
+            source.getTitle(),
+            source.getDescription(),
+            source.getFilters() == null ? List.of() : source.getFilters().stream().map(GammaDashboardRepositoryAdapter::toCore).toList(),
+            toCore(source.getTimeRange()),
+            parseWidgets(source.getWidgets()),
+            source.getVersion(),
+            source.getCreatedBy(),
+            source.getCreatedAt() == null ? null : source.getCreatedAt().toInstant(),
+            source.getUpdatedAt() == null ? null : source.getUpdatedAt().toInstant()
+        );
+    }
+
+    private static DashboardFilter toCore(GammaDashboard.Filter source) {
+        List<String> values = source.getValue() == null ? List.of() : List.copyOf(source.getValue());
+        return new DashboardFilter(
+            new FilterCondition(source.getField(), toOperator(source.getField(), source.getOperator()), values),
+            source.getLabel(),
+            source.isEditable()
+        );
+    }
+
+    private static FilterOperator toOperator(String field, String operator) {
+        try {
+            return FilterOperator.valueOf(operator.toUpperCase());
+        } catch (NullPointerException | IllegalArgumentException e) {
+            throw new TechnicalDomainException(
+                "Persisted dashboard filter '" + field + "' has an unsupported operator '" + operator + "'",
+                e
+            );
+        }
+    }
+
+    private static TimeRange toCore(GammaDashboard.TimeRange source) {
+        if (source == null) {
+            return null;
+        }
+        return new TimeRange(toTimeRangeType(source.getType()), source.getPeriod(), source.getFrom(), source.getTo());
+    }
+
+    private static TimeRangeType toTimeRangeType(String type) {
+        try {
+            return TimeRangeType.valueOf(type.toUpperCase());
+        } catch (NullPointerException | IllegalArgumentException e) {
+            throw new TechnicalDomainException("Persisted dashboard has an unsupported time range type '" + type + "'", e);
+        }
+    }
+
+    private static JsonNode parseWidgets(String widgets) {
+        if (widgets == null || widgets.isBlank()) {
+            return NullNode.getInstance();
+        }
+        try {
+            return WIDGETS_MAPPER.readTree(widgets);
+        } catch (JsonProcessingException e) {
+            throw new TechnicalDomainException("Persisted dashboard widgets payload is not valid JSON", e);
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/RepositoryCalls.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/RepositoryCalls.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.repository.exceptions.TechnicalException;
+
+/**
+ * Shared boundary helper for adapters fronting a platform repository SPI: turns the SPI's checked
+ * {@link TechnicalException} into the unchecked {@link TechnicalDomainException} the core layer
+ * expects, preserving the cause and attaching a caller-supplied context message.
+ *
+ * <p>Lives here rather than inside a single adapter so every {@code port/repository/}-backed adapter
+ * maps SPI failures the same way — the alternative is each adapter repeating the same try/catch per
+ * method.
+ *
+ * @author GraviteeSource Team
+ */
+public final class RepositoryCalls {
+
+    private RepositoryCalls() {}
+
+    /**
+     * Runs a repository call, wrapping a {@link TechnicalException} into a
+     * {@link TechnicalDomainException} described by {@code message}.
+     */
+    public static <T> T wrap(RepositoryCall<T> call, String message) {
+        try {
+            return call.execute();
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(message, e);
+        }
+    }
+
+    /**
+     * Lets {@link #wrap} take a lambda that still declares the SPI's checked exception — a plain
+     * {@link java.util.function.Supplier} could not, which would force the {@code try}/{@code catch}
+     * back into every adapter method. Callers pass the repository call itself; translating the
+     * failure is {@link #wrap}'s job, so implementations should let {@link TechnicalException}
+     * propagate rather than handling it.
+     */
+    @FunctionalInterface
+    public interface RepositoryCall<T> {
+        T execute() throws TechnicalException;
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaDashboardsConfiguration.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaDashboardsConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.config;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.DashboardRepository;
+import io.gravitee.gamma.rest.infra.adapter.GammaDashboardRepositoryAdapter;
+import io.gravitee.repository.management.api.GammaDashboardRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Spring wiring for the Gamma dashboards domain.
+ *
+ * <p>{@code @Lazy} on the SPI parameter is load-bearing: the repository plugin handler registers the
+ * {@code GammaDashboardRepository} bean after the rest-api Spring context refresh completes, so eager
+ * resolution at {@code @Bean} processing time throws {@code NoSuchBeanDefinitionException}. Mirrors
+ * {@code GammaTracingConfiguration}.
+ *
+ * @author GraviteeSource Team
+ */
+@Configuration
+@ComponentScan(
+    basePackages = "io.gravitee.gamma.rest.core.observability.dashboard",
+    includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, value = UseCase.class)
+)
+public class GammaDashboardsConfiguration {
+
+    @Bean
+    public DashboardRepository gammaDashboardRepositoryPort(@Lazy GammaDashboardRepository gammaDashboardRepository) {
+        return new GammaDashboardRepositoryAdapter(gammaDashboardRepository);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaObservabilityConfiguration.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaObservabilityConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Aggregates every per-sub-domain configuration under the Gamma Observability perimeter (traces,
+ * filters, logs, analytics, dashboards — all mounted under {@code /observability/*} by
+ * {@code GammaRootResource}) so {@code StandaloneConfiguration} only needs a single entry point.
+ *
+ * <p>Declares no beans of its own: each sub-domain still owns its {@code @ComponentScan} and adapter
+ * {@code @Bean}s in its own {@code infra/config/<DomainName>Configuration.java} per AGENTS.md §6 —
+ * this class is purely a re-export.
+ *
+ * @author GraviteeSource Team
+ */
+@Configuration
+@Import(
+    {
+        GammaTracingConfiguration.class,
+        GammaObservabilityFilterConfiguration.class,
+        GammaLogsConfiguration.class,
+        GammaAnalyticsConfiguration.class,
+        GammaDashboardsConfiguration.class,
+    }
+)
+public class GammaObservabilityConfiguration {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/GammaRootResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/GammaRootResource.java
@@ -15,10 +15,7 @@
  */
 package io.gravitee.gamma.rest.resources;
 
-import io.gravitee.gamma.rest.resources.observability.analytics.AnalyticsResource;
-import io.gravitee.gamma.rest.resources.observability.filters.ObservabilityFiltersResource;
-import io.gravitee.gamma.rest.resources.observability.logs.LogsResource;
-import io.gravitee.gamma.rest.resources.tracing.TracingResource;
+import io.gravitee.gamma.rest.resources.observability.GammaObservabilityResource;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
@@ -43,41 +40,12 @@ public class GammaRootResource {
     }
 
     /**
-     * Global trace explorer mounted outside the per-module namespace so every gamma module's UI can call
-     * it with its own {@code module} query parameter. See {@link TracingResource} for the contract.
+     * Every resource under the shared {@code /observability/*} namespace (traces, filters, logs,
+     * analytics, dashboards) — mounted outside the per-module namespace so every gamma module's UI
+     * can call them. See {@link GammaObservabilityResource} for the sub-routes.
      */
-    @Path("/organizations/{orgId}/environments/{envId}/observability/traces")
-    public TracingResource getTracingResource() {
-        return resourceContext.getResource(TracingResource.class);
-    }
-
-    /**
-     * Unified observability filter catalog (definition / values / resolve) shared by every gamma
-     * module's logs and analytics UI. Mounted outside the per-module namespace; relevance is carried
-     * by the {@code signal} / {@code apiType} discovery axes rather than a module perimeter. See
-     * {@link ObservabilityFiltersResource} for the contract.
-     */
-    @Path("/organizations/{orgId}/environments/{envId}/observability/filters")
-    public ObservabilityFiltersResource getObservabilityFiltersResource() {
-        return resourceContext.getResource(ObservabilityFiltersResource.class);
-    }
-
-    /**
-     * Environment-wide logs search (light rows, v4-only). Server-side RBAC scoping — no mandatory
-     * {@code apiId}. See {@link LogsResource} for the contract.
-     */
-    @Path("/organizations/{orgId}/environments/{envId}/observability/logs")
-    public LogsResource getLogsResource() {
-        return resourceContext.getResource(LogsResource.class);
-    }
-
-    /**
-     * Analytics computation endpoints (measures, facets, time-series) consuming the unified filter
-     * vocabulary and delegating to the proven APIM analytics engine. Server-side RBAC scoping via
-     * {@code AccessibleApiScopeDomainService}. See {@link AnalyticsResource} for the contract.
-     */
-    @Path("/organizations/{orgId}/environments/{envId}/observability/analytics")
-    public AnalyticsResource getAnalyticsResource() {
-        return resourceContext.getResource(AnalyticsResource.class);
+    @Path("/organizations/{orgId}/environments/{envId}/observability")
+    public GammaObservabilityResource getObservabilityResource() {
+        return resourceContext.getResource(GammaObservabilityResource.class);
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/GammaObservabilityResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/GammaObservabilityResource.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability;
+
+import io.gravitee.gamma.rest.resources.observability.analytics.AnalyticsResource;
+import io.gravitee.gamma.rest.resources.observability.dashboards.ObservabilityDashboardsResource;
+import io.gravitee.gamma.rest.resources.observability.filters.ObservabilityFiltersResource;
+import io.gravitee.gamma.rest.resources.observability.logs.LogsResource;
+import io.gravitee.gamma.rest.resources.tracing.TracingResource;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+
+/**
+ * Groups every resource mounted under the shared {@code /observability/*} namespace (traces,
+ * filters, logs, analytics, dashboards), so {@code GammaRootResource} only needs a single locator
+ * for the whole Observability perimeter instead of one per sub-domain. Mirrors, at the REST layer,
+ * the {@code GammaObservabilityConfiguration} aggregator introduced for Spring wiring.
+ *
+ * <p>Purely a routing layer — no behavior of its own, each sub-resource is unchanged and still
+ * individually registered in {@code GammaModuleApplication}.
+ *
+ * @author GraviteeSource Team
+ */
+@Path("/")
+public class GammaObservabilityResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    /**
+     * Global trace explorer. See {@link TracingResource} for the contract.
+     */
+    @Path("/traces")
+    public TracingResource getTracingResource() {
+        return resourceContext.getResource(TracingResource.class);
+    }
+
+    /**
+     * Unified observability filter catalog (definition / values / resolve). See
+     * {@link ObservabilityFiltersResource} for the contract.
+     */
+    @Path("/filters")
+    public ObservabilityFiltersResource getObservabilityFiltersResource() {
+        return resourceContext.getResource(ObservabilityFiltersResource.class);
+    }
+
+    /**
+     * Environment-wide logs search. See {@link LogsResource} for the contract.
+     */
+    @Path("/logs")
+    public LogsResource getLogsResource() {
+        return resourceContext.getResource(LogsResource.class);
+    }
+
+    /**
+     * Analytics computation endpoints. See {@link AnalyticsResource} for the contract.
+     */
+    @Path("/analytics")
+    public AnalyticsResource getAnalyticsResource() {
+        return resourceContext.getResource(AnalyticsResource.class);
+    }
+
+    /**
+     * Saved-dashboard read endpoints. See {@link ObservabilityDashboardsResource} for the contract.
+     */
+    @Path("/dashboards")
+    public ObservabilityDashboardsResource getObservabilityDashboardsResource() {
+        return resourceContext.getResource(ObservabilityDashboardsResource.class);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardResource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.dashboards;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gamma.rest.core.observability.dashboard.use_case.GetObservabilityDashboardUseCase;
+import io.gravitee.gamma.rest.resources.observability.dashboards.dto.DashboardDto;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+
+/**
+ * Single saved-dashboard endpoint, reached via {@link ObservabilityDashboardsResource}'s
+ * {@code {dashboardId}} locator.
+ *
+ * <p>Environment isolation: a dashboard id from another environment resolves to 404, not 403 (see
+ * {@code GetObservabilityDashboardUseCase} / {@code DashboardRepository#findByIdAndEnvironmentId}),
+ * so cross-environment existence cannot be probed.
+ *
+ * @author GraviteeSource Team
+ */
+@Produces(MediaType.APPLICATION_JSON)
+public class ObservabilityDashboardResource {
+
+    @Inject
+    private GetObservabilityDashboardUseCase getDashboardUseCase;
+
+    @GET
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = { RolePermissionAction.READ }) })
+    public DashboardDto get(@PathParam("dashboardId") String dashboardId) {
+        var ctx = GraviteeContext.getExecutionContext();
+        var output = getDashboardUseCase.execute(new GetObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), dashboardId));
+        return DashboardDto.from(output.dashboard());
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResource.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.dashboards;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gamma.rest.core.observability.dashboard.use_case.ListObservabilityDashboardUseCase;
+import io.gravitee.gamma.rest.resources.observability.dashboards.dto.DashboardDto;
+import io.gravitee.gamma.rest.resources.tracing.dto.PaginatedResponseDto;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import java.util.List;
+
+/**
+ * Saved-dashboard endpoints, mounted under
+ * {@code /gamma/organizations/{orgId}/environments/{envId}/observability/dashboards} by
+ * {@code GammaRootResource}.
+ *
+ * <h2>Endpoints</h2>
+ * <ul>
+ *   <li>{@code GET /?page=&perPage=} — dashboards saved in the context environment, paginated
+ *       (1-based, {@code perPage} capped server-side at 100). See {@link ListObservabilityDashboardUseCase}
+ *       for why pagination is applied by slicing rather than a native repository query.</li>
+ *   <li>{@code GET /{dashboardId}} — see {@link ObservabilityDashboardResource}.</li>
+ * </ul>
+ *
+ * <h2>Authorization</h2>
+ * Declarative {@code ENVIRONMENT_DASHBOARD:READ} — a CRUD resource, unlike the deliberately lax
+ * {@code ENVIRONMENT_DASHBOARD:READ || ENVIRONMENT_API:READ} check used by {@code LogsResource} /
+ * {@code ObservabilityFiltersResource} for metadata discovery.
+ *
+ * @author GraviteeSource Team
+ */
+@Produces(MediaType.APPLICATION_JSON)
+public class ObservabilityDashboardsResource {
+
+    @Inject
+    private ListObservabilityDashboardUseCase listDashboardUseCase;
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @GET
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = { RolePermissionAction.READ }) })
+    public PaginatedResponseDto<DashboardDto> list(@QueryParam("page") Integer page, @QueryParam("perPage") Integer perPage) {
+        var ctx = GraviteeContext.getExecutionContext();
+        var output = listDashboardUseCase.execute(new ListObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), page, perPage));
+        List<DashboardDto> data = output.dashboards().stream().map(DashboardDto::from).toList();
+        return PaginatedResponseDto.of(data, output.totalCount(), output.page(), output.perPage());
+    }
+
+    @Path("/{dashboardId}")
+    public ObservabilityDashboardResource getDashboardResource() {
+        return resourceContext.getResource(ObservabilityDashboardResource.class);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/DashboardDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/DashboardDto.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.dashboards.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import java.util.List;
+
+/**
+ * Wire shape for a dashboard. {@code environmentId} and {@code createdBy} are intentionally omitted
+ * — redundant with the URL scope / not needed by the UI. {@code widgets} is returned verbatim
+ * (opaque, never parsed). {@code version} must be present even though nothing enforces it yet —
+ * OBS-16/17 need it on the write path and reads are the only place it can be handed out.
+ */
+public record DashboardDto(
+    String id,
+    String title,
+    String description,
+    List<DashboardFilterDto> filters,
+    DashboardTimeRangeDto timeRange,
+    JsonNode widgets,
+    Integer version,
+    Long createdAt,
+    Long updatedAt
+) {
+    public static DashboardDto from(Dashboard dashboard) {
+        return new DashboardDto(
+            dashboard.id(),
+            dashboard.title(),
+            dashboard.description(),
+            dashboard.filters().stream().map(DashboardFilterDto::from).toList(),
+            DashboardTimeRangeDto.from(dashboard.timeRange()),
+            dashboard.widgets(),
+            dashboard.version(),
+            dashboard.createdAt() == null ? null : dashboard.createdAt().toEpochMilli(),
+            dashboard.updatedAt() == null ? null : dashboard.updatedAt().toEpochMilli()
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/DashboardFilterDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/DashboardFilterDto.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.dashboards.dto;
+
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardFilter;
+import java.util.List;
+
+/**
+ * Wire shape for one dashboard filter. {@code operator} is UPPERCASE; {@code value} is always an
+ * array, even for single-value operators.
+ */
+public record DashboardFilterDto(String name, String label, String operator, List<String> value, boolean editable) {
+    public static DashboardFilterDto from(DashboardFilter filter) {
+        return new DashboardFilterDto(
+            filter.condition().name(),
+            filter.label(),
+            filter.condition().operator().name(),
+            filter.condition().values(),
+            filter.editable()
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/DashboardTimeRangeDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/DashboardTimeRangeDto.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.dashboards.dto;
+
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRange;
+
+/**
+ * Wire shape for a dashboard's time range. {@code type} is lowercase ({@code relative} /
+ * {@code absolute}) to match the frontend's discriminated union.
+ */
+public record DashboardTimeRangeDto(String type, String period, Long from, Long to) {
+    public static DashboardTimeRangeDto from(TimeRange timeRange) {
+        if (timeRange == null) {
+            return null;
+        }
+        return new DashboardTimeRangeDto(timeRange.type().name().toLowerCase(), timeRange.period(), timeRange.from(), timeRange.to());
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -55,6 +55,15 @@ tags:
 
           All three endpoints return opaque JSON produced by the APIM analytics engine — the
           response schemas below document the stable structure but additional fields may appear.
+    - name: Dashboards
+      description: |
+          Read access to dashboards saved by Gamma Observability users, so a dashboard opens from
+          any machine instead of being tied to one browser's local storage. Write endpoints land in
+          a later increment.
+
+          `widgets` is opaque JSON, returned verbatim — the shape belongs to the frontend. `version`
+          is an optimistic-locking counter: nothing enforces it yet, but it must round-trip so a
+          future write can submit it back.
 
 paths:
     /organizations/{orgId}/environments/{envId}/observability/filters/definition:
@@ -1027,6 +1036,180 @@ paths:
                             example:
                                 httpStatus: 403
                                 message: "Insufficient permissions to access observability data."
+
+    /organizations/{orgId}/environments/{envId}/observability/dashboards:
+        parameters:
+            - $ref: "#/components/parameters/orgIdParam"
+            - $ref: "#/components/parameters/envIdParam"
+        get:
+            tags:
+                - Dashboards
+            summary: List every dashboard saved in the environment
+            description: |
+                Paginated dashboards saved in the context environment, most recently created first.
+            operationId: listObservabilityDashboards
+            parameters:
+                - name: page
+                  in: query
+                  required: false
+                  description: 1-based page number.
+                  schema:
+                      type: integer
+                      default: 1
+                      minimum: 1
+                - name: perPage
+                  in: query
+                  required: false
+                  description: Page size (capped server-side at 100).
+                  schema:
+                      type: integer
+                      default: 20
+                      minimum: 1
+                      maximum: 100
+            responses:
+                "200":
+                    description: A page of dashboards.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DashboardsResponse"
+                            examples:
+                                two-dashboards:
+                                    summary: Two saved dashboards
+                                    value:
+                                        data:
+                                            - id: "d7e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+                                              title: "Performance overview"
+                                              description: "MCP traffic health"
+                                              filters:
+                                                  - name: "API_TYPE"
+                                                    label: "API Type"
+                                                    operator: "EQ"
+                                                    value: ["MCP"]
+                                                    editable: false
+                                                  - name: "HTTP_STATUS"
+                                                    label: "Status Code"
+                                                    operator: "EQ"
+                                                    value: []
+                                                    editable: true
+                                              timeRange:
+                                                  type: "relative"
+                                                  period: "24h"
+                                              widgets: []
+                                              version: 3
+                                              createdAt: 1730000000000
+                                              updatedAt: 1730600000000
+                                            - id: "a1b2c3d4-0000-1111-2222-333344445555"
+                                              title: "Error budget"
+                                              filters: []
+                                              timeRange:
+                                                  type: "absolute"
+                                                  from: 1730000000000
+                                                  to: 1730600000000
+                                              widgets: []
+                                              version: 1
+                                              createdAt: 1730000000000
+                                              updatedAt: 1730000000000
+                                        pagination:
+                                            totalCount: 2
+                                            page: 1
+                                            perPage: 20
+                                            pageCount: 1
+                                            pageItemsCount: 2
+                                empty:
+                                    summary: No dashboard saved yet
+                                    value:
+                                        data: []
+                                        pagination:
+                                            totalCount: 0
+                                            page: 1
+                                            perPage: 20
+                                            pageCount: 0
+                                            pageItemsCount: 0
+                "403":
+                    description: The caller cannot read dashboards in this environment.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 403
+                                message: "Insufficient permissions to access dashboards."
+
+    /organizations/{orgId}/environments/{envId}/observability/dashboards/{dashboardId}:
+        parameters:
+            - $ref: "#/components/parameters/orgIdParam"
+            - $ref: "#/components/parameters/envIdParam"
+        get:
+            tags:
+                - Dashboards
+            summary: Get a single saved dashboard
+            description: |
+                Returns one dashboard, with filters, time range and widgets restored verbatim. A
+                dashboard id belonging to another environment returns 404 (not 403, not 200), so
+                cross-environment existence cannot be probed.
+            operationId: getObservabilityDashboard
+            parameters:
+                - name: dashboardId
+                  in: path
+                  required: true
+                  description: Unique identifier of the dashboard.
+                  example: d7e246cb-ab02-4da4-8f47-f9fa3e061d6b
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: The saved dashboard.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Dashboard"
+                            examples:
+                                full-dashboard:
+                                    summary: Dashboard with filters and a relative time range
+                                    value:
+                                        id: "d7e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+                                        title: "Performance overview"
+                                        description: "MCP traffic health"
+                                        filters:
+                                            - name: "API_TYPE"
+                                              label: "API Type"
+                                              operator: "EQ"
+                                              value: ["MCP"]
+                                              editable: false
+                                            - name: "HTTP_STATUS"
+                                              label: "Status Code"
+                                              operator: "EQ"
+                                              value: []
+                                              editable: true
+                                        timeRange:
+                                            type: "relative"
+                                            period: "24h"
+                                        widgets: []
+                                        version: 3
+                                        createdAt: 1730000000000
+                                        updatedAt: 1730600000000
+                "403":
+                    description: The caller cannot read dashboards in this environment.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 403
+                                message: "Insufficient permissions to access dashboards."
+                "404":
+                    description: |
+                        No dashboard with this id exists in the context environment — either it
+                        doesn't exist at all, or it belongs to a different environment. Both cases
+                        collapse to this response so cross-environment existence cannot be probed.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 404
+                                message: "Dashboard 'd7e246cb-ab02-4da4-8f47-f9fa3e061d6b' not found"
 
 components:
     securitySchemes:
@@ -2006,6 +2189,109 @@ components:
                     type: array
                     items:
                         $ref: "#/components/schemas/TimeSeriesMetricResult"
+
+        DashboardFilter:
+            type: object
+            description: |
+                A dashboard-definition filter, applied to every widget of the dashboard.
+                `operator` is UPPERCASE; `value` is always an array, even for single-value operators.
+            required: [name, operator, value, editable]
+            properties:
+                name:
+                    type: string
+                    description: Canonical filter name from the shared filter catalog.
+                    example: API_TYPE
+                label:
+                    type: string
+                    description: Human-readable display name, persisted verbatim (not derivable).
+                    example: API Type
+                operator:
+                    $ref: "#/components/schemas/FilterOperator"
+                value:
+                    type: array
+                    description: Filter values. An empty array is the "all values" placeholder.
+                    items:
+                        type: string
+                    example: ["MCP"]
+                editable:
+                    type: boolean
+                    description: Whether the viewer may change the value. `false` locks it.
+
+        DashboardTimeRange:
+            type: object
+            description: |
+                Time window a dashboard opens on. `type` is lowercase to match the frontend's
+                discriminated union. `period` is set for `relative`; `from` / `to` (epoch
+                milliseconds) are set for `absolute`.
+            required: [type]
+            properties:
+                type:
+                    type: string
+                    enum: [relative, absolute]
+                    example: relative
+                period:
+                    type: string
+                    nullable: true
+                    description: Relative period token owned by the frontend, e.g. `24h`, `7d`.
+                    example: 24h
+                from:
+                    type: integer
+                    format: int64
+                    nullable: true
+                    description: Start of the window (epoch milliseconds). Set for `absolute`.
+                to:
+                    type: integer
+                    format: int64
+                    nullable: true
+                    description: End of the window (epoch milliseconds). Set for `absolute`.
+
+        Dashboard:
+            type: object
+            description: |
+                A dashboard saved by a Gamma Observability user. `widgets` is opaque JSON, never
+                parsed by the backend — returned verbatim. `version` is an optimistic-locking
+                counter; nothing enforces it yet but it must round-trip for a future write to use.
+            required: [id, title, filters, widgets, version, createdAt, updatedAt]
+            properties:
+                id:
+                    type: string
+                    example: d7e246cb-ab02-4da4-8f47-f9fa3e061d6b
+                title:
+                    type: string
+                    example: Performance overview
+                description:
+                    type: string
+                    nullable: true
+                filters:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/DashboardFilter"
+                timeRange:
+                    $ref: "#/components/schemas/DashboardTimeRange"
+                widgets:
+                    description: Opaque, returned verbatim. Shape is owned by the frontend.
+                version:
+                    type: integer
+                    example: 3
+                createdAt:
+                    type: integer
+                    format: int64
+                    description: Epoch milliseconds.
+                updatedAt:
+                    type: integer
+                    format: int64
+                    description: Epoch milliseconds.
+
+        DashboardsResponse:
+            type: object
+            required: [data, pagination]
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/Dashboard"
+                pagination:
+                    $ref: "#/components/schemas/Pagination"
 
         Error:
             type: object

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/inmemory/InMemoryDashboardRepository.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/inmemory/InMemoryDashboardRepository.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.inmemory;
+
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.DashboardRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * In-memory {@link DashboardRepository} for domain tests. Filters seeded dashboards on environment
+ * scope just like the real adapter would scope the Mongo/JDBC query, so use-case tests exercise the
+ * environment-isolation contract end-to-end rather than mocking it away.
+ */
+public class InMemoryDashboardRepository implements DashboardRepository {
+
+    private final List<Dashboard> dashboards = new ArrayList<>();
+
+    public void givenDashboard(Dashboard dashboard) {
+        dashboards.add(dashboard);
+    }
+
+    public void reset() {
+        dashboards.clear();
+    }
+
+    @Override
+    public List<Dashboard> findByEnvironmentId(String environmentId) {
+        return dashboards
+            .stream()
+            .filter(d -> Objects.equals(d.environmentId(), environmentId))
+            .toList();
+    }
+
+    @Override
+    public Optional<Dashboard> findByIdAndEnvironmentId(String id, String environmentId) {
+        return dashboards
+            .stream()
+            .filter(d -> Objects.equals(d.id(), id) && Objects.equals(d.environmentId(), environmentId))
+            .findFirst();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/model/DashboardTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/model/DashboardTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.node.NullNode;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DashboardTest {
+
+    @Test
+    void should_reject_blank_id() {
+        assertThatThrownBy(() ->
+            new Dashboard("", "env-1", "title", null, List.of(), null, NullNode.getInstance(), 1, "u", Instant.now(), Instant.now())
+        ).isInstanceOf(InvalidDashboardException.class);
+    }
+
+    @Test
+    void should_reject_blank_environment_id() {
+        assertThatThrownBy(() ->
+            new Dashboard("d-1", " ", "title", null, List.of(), null, NullNode.getInstance(), 1, "u", Instant.now(), Instant.now())
+        ).isInstanceOf(InvalidDashboardException.class);
+    }
+
+    @Test
+    void should_reject_blank_title() {
+        assertThatThrownBy(() ->
+            new Dashboard("d-1", "env-1", "", null, List.of(), null, NullNode.getInstance(), 1, "u", Instant.now(), Instant.now())
+        ).isInstanceOf(InvalidDashboardException.class);
+    }
+
+    @Test
+    void should_default_null_filters_to_empty_list() {
+        var dashboard = new Dashboard(
+            "d-1",
+            "env-1",
+            "title",
+            null,
+            null,
+            null,
+            NullNode.getInstance(),
+            1,
+            "u",
+            Instant.now(),
+            Instant.now()
+        );
+
+        assertThat(dashboard.filters()).isEmpty();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/GetObservabilityDashboardUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/GetObservabilityDashboardUseCaseTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.node.NullNode;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.DashboardNotFoundException;
+import io.gravitee.gamma.rest.core.observability.dashboard.inmemory.InMemoryDashboardRepository;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardFilter;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRange;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRangeType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetObservabilityDashboardUseCaseTest {
+
+    private static final String ENV = "env-1";
+    private static final String OTHER_ENV = "env-2";
+    private static final String DASHBOARD_ID = "dash-1";
+
+    private final InMemoryDashboardRepository dashboardRepository = new InMemoryDashboardRepository();
+    private final GetObservabilityDashboardUseCase useCase = new GetObservabilityDashboardUseCase(dashboardRepository);
+
+    @BeforeEach
+    void reset() {
+        dashboardRepository.reset();
+    }
+
+    @Test
+    void should_return_the_dashboard_with_filters_and_time_range_restored() {
+        dashboardRepository.givenDashboard(
+            new Dashboard(
+                DASHBOARD_ID,
+                ENV,
+                "Performance overview",
+                "desc",
+                List.of(
+                    new DashboardFilter(new FilterCondition("API_TYPE", FilterOperator.EQ, List.of("MCP")), "API Type", false),
+                    new DashboardFilter(new FilterCondition("HTTP_STATUS", FilterOperator.EQ, List.of()), "Status Code", true)
+                ),
+                new TimeRange(TimeRangeType.RELATIVE, "24h", null, null),
+                NullNode.getInstance(),
+                3,
+                "user-1",
+                Instant.parse("2026-06-10T00:00:00Z"),
+                Instant.parse("2026-06-11T00:00:00Z")
+            )
+        );
+
+        var output = useCase.execute(new GetObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID));
+
+        assertThat(output.dashboard().id()).isEqualTo(DASHBOARD_ID);
+        assertThat(output.dashboard().filters()).hasSize(2);
+        assertThat(output.dashboard().filters().get(1).condition().values()).isEmpty();
+        assertThat(output.dashboard().timeRange().type()).isEqualTo(TimeRangeType.RELATIVE);
+        assertThat(output.dashboard().version()).isEqualTo(3);
+    }
+
+    @Test
+    void should_throw_not_found_when_dashboard_does_not_exist() {
+        assertThatThrownBy(() -> useCase.execute(new GetObservabilityDashboardUseCase.Input(ENV, "unknown"))).isInstanceOf(
+            DashboardNotFoundException.class
+        );
+    }
+
+    @Test
+    void should_throw_not_found_when_dashboard_belongs_to_another_environment() {
+        dashboardRepository.givenDashboard(
+            new Dashboard(
+                DASHBOARD_ID,
+                OTHER_ENV,
+                "Performance overview",
+                null,
+                List.of(),
+                null,
+                NullNode.getInstance(),
+                1,
+                "user-1",
+                Instant.parse("2026-06-10T00:00:00Z"),
+                Instant.parse("2026-06-10T00:00:00Z")
+            )
+        );
+
+        assertThatThrownBy(() -> useCase.execute(new GetObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID))).isInstanceOf(
+            DashboardNotFoundException.class
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/ListObservabilityDashboardUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/ListObservabilityDashboardUseCaseTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.node.NullNode;
+import io.gravitee.gamma.rest.core.observability.dashboard.inmemory.InMemoryDashboardRepository;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ListObservabilityDashboardUseCaseTest {
+
+    private static final String ENV = "env-1";
+    private static final String OTHER_ENV = "env-2";
+
+    private final InMemoryDashboardRepository dashboardRepository = new InMemoryDashboardRepository();
+    private final ListObservabilityDashboardUseCase useCase = new ListObservabilityDashboardUseCase(dashboardRepository);
+
+    @BeforeEach
+    void reset() {
+        dashboardRepository.reset();
+    }
+
+    @Test
+    void should_return_every_dashboard_of_the_context_environment_when_it_fits_on_one_page() {
+        dashboardRepository.givenDashboard(dashboard("dash-1", ENV));
+        dashboardRepository.givenDashboard(dashboard("dash-2", ENV));
+        dashboardRepository.givenDashboard(dashboard("dash-3", OTHER_ENV));
+
+        var output = useCase.execute(new ListObservabilityDashboardUseCase.Input(ENV, null, null));
+
+        assertThat(output.dashboards()).extracting(Dashboard::id).containsExactlyInAnyOrder("dash-1", "dash-2");
+        assertThat(output.totalCount()).isEqualTo(2);
+        assertThat(output.page()).isEqualTo(1);
+        assertThat(output.perPage()).isEqualTo(20);
+    }
+
+    @Test
+    void should_return_empty_list_when_no_dashboard_exists_for_the_environment() {
+        var output = useCase.execute(new ListObservabilityDashboardUseCase.Input(ENV, null, null));
+
+        assertThat(output.dashboards()).isEmpty();
+        assertThat(output.totalCount()).isEqualTo(0);
+    }
+
+    @Test
+    void should_slice_by_page_and_perPage() {
+        for (int i = 1; i <= 5; i++) {
+            dashboardRepository.givenDashboard(dashboard("dash-" + i, ENV));
+        }
+
+        var output = useCase.execute(new ListObservabilityDashboardUseCase.Input(ENV, 2, 2));
+
+        assertThat(output.dashboards()).hasSize(2);
+        assertThat(output.totalCount()).isEqualTo(5);
+        assertThat(output.page()).isEqualTo(2);
+        assertThat(output.perPage()).isEqualTo(2);
+    }
+
+    @Test
+    void should_return_empty_page_when_page_is_beyond_the_last_one() {
+        dashboardRepository.givenDashboard(dashboard("dash-1", ENV));
+
+        var output = useCase.execute(new ListObservabilityDashboardUseCase.Input(ENV, 5, 10));
+
+        assertThat(output.dashboards()).isEmpty();
+        assertThat(output.totalCount()).isEqualTo(1);
+    }
+
+    @Test
+    void should_default_invalid_page_and_perPage_to_defaults() {
+        dashboardRepository.givenDashboard(dashboard("dash-1", ENV));
+
+        var output = useCase.execute(new ListObservabilityDashboardUseCase.Input(ENV, 0, -5));
+
+        assertThat(output.page()).isEqualTo(1);
+        assertThat(output.perPage()).isEqualTo(20);
+    }
+
+    @Test
+    void should_cap_perPage_at_the_maximum() {
+        var output = useCase.execute(new ListObservabilityDashboardUseCase.Input(ENV, 1, 1000));
+
+        assertThat(output.perPage()).isEqualTo(100);
+    }
+
+    private static Dashboard dashboard(String id, String environmentId) {
+        return new Dashboard(
+            id,
+            environmentId,
+            "Performance overview",
+            null,
+            List.of(),
+            null,
+            NullNode.getInstance(),
+            1,
+            "user-1",
+            Instant.parse("2026-06-10T00:00:00Z"),
+            Instant.parse("2026-06-10T00:00:00Z")
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapterTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapterTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.repository.management.api.GammaDashboardRepository;
+import io.gravitee.repository.management.model.GammaDashboard;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * The persisted {@link GammaDashboard.Filter} uses {@code field}/lowercase-{@code operator}/
+ * {@code value} while this endpoint's wire format (and the domain {@code FilterCondition} it
+ * composes) uses {@code name}/UPPERCASE-{@code operator}/{@code values} — this test pins the
+ * anticorruption mapping between the two so a future refactor can't silently drop or mis-map a field.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GammaDashboardRepositoryAdapterTest {
+
+    @Mock
+    private GammaDashboardRepository gammaDashboardRepository;
+
+    @Test
+    void should_map_persisted_filter_shape_to_the_domain_filter_condition_shape() throws Exception {
+        GammaDashboard persisted = GammaDashboard.builder()
+            .id("dash-1")
+            .environmentId("env-1")
+            .title("Performance overview")
+            .filters(
+                List.of(
+                    GammaDashboard.Filter.builder()
+                        .field("API_TYPE")
+                        .label("API Type")
+                        .operator("eq")
+                        .value(List.of("MCP"))
+                        .editable(false)
+                        .build()
+                )
+            )
+            .widgets("[]")
+            .version(3)
+            .createdAt(new Date())
+            .updatedAt(new Date())
+            .build();
+        when(gammaDashboardRepository.findByIdAndEnvironmentId("dash-1", "env-1")).thenReturn(Optional.of(persisted));
+
+        Dashboard dashboard = new GammaDashboardRepositoryAdapter(gammaDashboardRepository)
+            .findByIdAndEnvironmentId("dash-1", "env-1")
+            .orElseThrow();
+
+        var filter = dashboard.filters().get(0);
+        assertThat(filter.condition().name()).isEqualTo("API_TYPE");
+        assertThat(filter.condition().operator()).isEqualTo(FilterOperator.EQ);
+        assertThat(filter.condition().values()).containsExactly("MCP");
+        assertThat(filter.label()).isEqualTo("API Type");
+        assertThat(filter.editable()).isFalse();
+    }
+
+    @Test
+    void should_wrap_unsupported_or_missing_persisted_operator_as_a_technical_exception() throws Exception {
+        GammaDashboard persisted = GammaDashboard.builder()
+            .id("dash-1")
+            .environmentId("env-1")
+            .title("Performance overview")
+            .filters(List.of(GammaDashboard.Filter.builder().field("API_TYPE").operator(null).value(List.of("MCP")).build()))
+            .widgets("[]")
+            .version(1)
+            .createdAt(new Date())
+            .updatedAt(new Date())
+            .build();
+        when(gammaDashboardRepository.findByIdAndEnvironmentId("dash-1", "env-1")).thenReturn(Optional.of(persisted));
+
+        assertThatThrownBy(() ->
+            new GammaDashboardRepositoryAdapter(gammaDashboardRepository).findByIdAndEnvironmentId("dash-1", "env-1")
+        ).isInstanceOf(TechnicalDomainException.class);
+    }
+
+    @Test
+    void should_parse_widgets_json_verbatim() throws Exception {
+        GammaDashboard persisted = GammaDashboard.builder()
+            .id("dash-1")
+            .environmentId("env-1")
+            .title("Performance overview")
+            .widgets("[{\"type\":\"metric\"}]")
+            .version(1)
+            .createdAt(new Date())
+            .updatedAt(new Date())
+            .build();
+        when(gammaDashboardRepository.findByIdAndEnvironmentId("dash-1", "env-1")).thenReturn(Optional.of(persisted));
+
+        Dashboard dashboard = new GammaDashboardRepositoryAdapter(gammaDashboardRepository)
+            .findByIdAndEnvironmentId("dash-1", "env-1")
+            .orElseThrow();
+
+        assertThat(dashboard.widgets().isArray()).isTrue();
+        assertThat(dashboard.widgets().get(0).get("type").asText()).isEqualTo("metric");
+    }
+
+    @Test
+    void should_default_widgets_to_null_node_when_not_persisted() throws Exception {
+        GammaDashboard persisted = GammaDashboard.builder()
+            .id("dash-1")
+            .environmentId("env-1")
+            .title("Performance overview")
+            .widgets(null)
+            .version(1)
+            .createdAt(new Date())
+            .updatedAt(new Date())
+            .build();
+        when(gammaDashboardRepository.findByIdAndEnvironmentId("dash-1", "env-1")).thenReturn(Optional.of(persisted));
+
+        Dashboard dashboard = new GammaDashboardRepositoryAdapter(gammaDashboardRepository)
+            .findByIdAndEnvironmentId("dash-1", "env-1")
+            .orElseThrow();
+
+        assertThat(dashboard.widgets().isNull()).isTrue();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResourceTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.dashboards;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.gamma.rest.core.observability.dashboard.inmemory.InMemoryDashboardRepository;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardFilter;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRange;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRangeType;
+import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.DashboardRepository;
+import io.gravitee.gamma.rest.core.observability.dashboard.use_case.GetObservabilityDashboardUseCase;
+import io.gravitee.gamma.rest.core.observability.dashboard.use_case.ListObservabilityDashboardUseCase;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.resource.AbstractResourceTest;
+import io.gravitee.gamma.rest.resources.observability.dashboards.ObservabilityDashboardsResourceTest.DashboardsTestConfiguration;
+import io.gravitee.gamma.rest.spring.ResourceContextConfiguration;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Drives the resources through the <em>real</em> use cases, wired to an in-memory
+ * {@link DashboardRepository}. Only the platform boundaries the resource can't run without
+ * ({@code PermissionService}, {@code EnvironmentService}) stay mocked, via
+ * {@link ResourceContextConfiguration} — so behaviour like environment isolation and pagination is
+ * exercised end-to-end rather than stubbed at the use-case boundary.
+ */
+@ContextConfiguration(classes = { ResourceContextConfiguration.class, DashboardsTestConfiguration.class })
+class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "fake-env";
+    private static final String OTHER_ENVIRONMENT = "other-env";
+    private static final String DASHBOARD_ID = "dash-1";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Inject
+    private InMemoryDashboardRepository dashboardRepository;
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/observability/dashboards";
+    }
+
+    @BeforeEach
+    void prepareEnvironment() {
+        EnvironmentEntity env = new EnvironmentEntity();
+        env.setId(ENVIRONMENT);
+        env.setOrganizationId(ORGANIZATION);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT)).thenReturn(env);
+    }
+
+    @AfterEach
+    void resetRepository() {
+        dashboardRepository.reset();
+    }
+
+    @Nested
+    class ListDashboards {
+
+        @Test
+        void should_return_200_with_data_envelope_and_label_and_uppercase_operator() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget().request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("data")).hasSize(1);
+            JsonNode dto = body.get("data").get(0);
+            assertThat(dto.get("id").asText()).isEqualTo(DASHBOARD_ID);
+            assertThat(dto.get("version").asInt()).isEqualTo(3);
+            assertThat(dto.get("timeRange").get("type").asText()).isEqualTo("relative");
+            JsonNode filter = dto.get("filters").get(0);
+            assertThat(filter.get("name").asText()).isEqualTo("API_TYPE");
+            assertThat(filter.get("label").asText()).isEqualTo("API Type");
+            assertThat(filter.get("operator").asText()).isEqualTo("EQ");
+            assertThat(filter.get("value").get(0).asText()).isEqualTo("MCP");
+            assertThat(filter.get("editable").asBoolean()).isFalse();
+            assertThat(body.get("pagination").get("totalCount").asLong()).isEqualTo(1L);
+            assertThat(body.get("pagination").get("page").asInt()).isEqualTo(1);
+            assertThat(body.get("pagination").get("perPage").asInt()).isEqualTo(20);
+        }
+
+        @Test
+        void should_only_return_dashboards_of_the_context_environment() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+            dashboardRepository.givenDashboard(dashboard("other-dash", OTHER_ENVIRONMENT));
+
+            Response response = rootTarget().request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("data")).hasSize(1);
+            assertThat(body.get("data").get(0).get("id").asText()).isEqualTo(DASHBOARD_ID);
+            assertThat(body.get("pagination").get("totalCount").asLong()).isEqualTo(1L);
+        }
+
+        @Test
+        void should_return_the_requested_page() {
+            for (int i = 1; i <= 5; i++) {
+                dashboardRepository.givenDashboard(dashboard("dash-" + i, ENVIRONMENT));
+            }
+
+            Response response = rootTarget().queryParam("page", 2).queryParam("perPage", 2).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("data")).hasSize(2);
+            assertThat(body.get("data").get(0).get("id").asText()).isEqualTo("dash-3");
+            assertThat(body.get("pagination").get("totalCount").asLong()).isEqualTo(5L);
+            assertThat(body.get("pagination").get("page").asInt()).isEqualTo(2);
+            assertThat(body.get("pagination").get("perPage").asInt()).isEqualTo(2);
+        }
+
+        @Test
+        void should_return_an_empty_page_when_no_dashboard_exists() {
+            Response response = rootTarget().request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("data")).isEmpty();
+            assertThat(body.get("pagination").get("totalCount").asLong()).isZero();
+        }
+
+        @Test
+        void should_return_403_when_caller_cannot_read_dashboards() {
+            when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
+
+            Response response = rootTarget().request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+        }
+    }
+
+    @Nested
+    class GetDashboard {
+
+        @Test
+        void should_return_200_with_the_dashboard_and_its_widgets_verbatim() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("id").asText()).isEqualTo(DASHBOARD_ID);
+            assertThat(body.get("title").asText()).isEqualTo("Performance overview");
+            assertThat(body.get("widgets").get(0).get("type").asText()).isEqualTo("metric");
+            assertThat(body.get("timeRange").get("period").asText()).isEqualTo("24h");
+        }
+
+        @Test
+        void should_return_404_when_dashboard_does_not_exist() {
+            Response response = rootTarget("unknown").request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_404_when_dashboard_belongs_to_another_environment() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, OTHER_ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_when_caller_cannot_read_dashboards() {
+            when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
+
+            Response response = rootTarget(DASHBOARD_ID).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+        }
+    }
+
+    private static Dashboard dashboard(String id, String environmentId) {
+        try {
+            return new Dashboard(
+                id,
+                environmentId,
+                "Performance overview",
+                "desc",
+                List.of(new DashboardFilter(new FilterCondition("API_TYPE", FilterOperator.EQ, List.of("MCP")), "API Type", false)),
+                new TimeRange(TimeRangeType.RELATIVE, "24h", null, null),
+                MAPPER.readTree("[{\"type\":\"metric\"}]"),
+                3,
+                "user-1",
+                Instant.parse("2026-06-10T00:00:00Z"),
+                Instant.parse("2026-06-11T00:00:00Z")
+            );
+        } catch (Exception e) {
+            throw new IllegalStateException("Invalid widgets fixture", e);
+        }
+    }
+
+    @Configuration
+    static class DashboardsTestConfiguration {
+
+        @Bean
+        InMemoryDashboardRepository dashboardRepository() {
+            return new InMemoryDashboardRepository();
+        }
+
+        @Bean
+        ListObservabilityDashboardUseCase listObservabilityDashboardUseCase(DashboardRepository dashboardRepository) {
+            return new ListObservabilityDashboardUseCase(dashboardRepository);
+        }
+
+        @Bean
+        GetObservabilityDashboardUseCase getObservabilityDashboardUseCase(DashboardRepository dashboardRepository) {
+            return new GetObservabilityDashboardUseCase(dashboardRepository);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Serves dashboards saved by Gamma Observability users via two GET endpoints, so a dashboard opens from any machine instead of being tied to one browser's local storage. Read-only — write endpoints land in a later increment (OBS-16/17).

Related: [OBS-15](https://gravitee.atlassian.net/browse/OBS-15) (depends on [OBS-14](https://gravitee.atlassian.net/browse/OBS-14), repository layer, already Done)

## Changes
- New `dashboard` domain under `gravitee-gamma-rest-api` (core model, port, exceptions, use cases) following the module's Hexagonal layout, mirroring the existing tracing/logs/filters domains
- `GammaDashboardRepositoryAdapter` wraps the `GammaDashboardRepository` SPI shipped by OBS-14, with anticorruption mapping between the persisted `field`/lowercase-`operator`/`value` shape and this endpoint's `name`/UPPERCASE-`operator`/`values` wire shape
- Two REST resources (list + single), declarative `@Permissions` on `ENVIRONMENT_DASHBOARD:READ`
- Environment isolation: a dashboard id from another environment returns 404 (not 403), enforced via `findByIdAndEnvironmentId`
- OpenAPI spec extended with the `Dashboards` tag, both paths, and schemas
- Registered in the three mandatory wiring points (`GammaModuleApplication`, `GammaRootResource`, `StandaloneConfiguration`)

### Endpoint summary

| Endpoint | Method | Change | Request example | Response example |
|---|---|---|---|---|
| `/gamma/organizations/{orgId}/environments/{envId}/observability/dashboards` | GET | New | — | `200 { "data": [ { "id", "title", "filters": [...], "timeRange", "widgets", "version", "createdAt", "updatedAt" } ] }` |
| `/gamma/organizations/{orgId}/environments/{envId}/observability/dashboards/{dashboardId}` | GET | New | — | `200 { "id", "title", ... }` / `404` (unknown id or wrong environment) / `403` (missing permission) |

## Test plan
- [x] `mvn test` on `gravitee-gamma-rest-api`: 133 tests, 0 failures, 0 errors
- [x] `mvn prettier:check` clean
- [x] OpenAPI YAML validated (parses, dashboard paths/schemas present)
- [ ] Reviewer: confirm the persisted-to-wire filter mapping (`field`→`name`, lowercase→UPPERCASE `operator`, `value`→`values`, `label` passthrough) reads correctly against a real Mongo/JDBC-backed dashboard once one exists
- [ ] Reviewer: confirm a dashboard id from another environment returns 404, not 403 or 200

## Reviewer notes
- Riskiest part of this diff is the field-mapping in `GammaDashboardRepositoryAdapter.toCore(GammaDashboard.Filter)` — pinned by `GammaDashboardRepositoryAdapterTest`, but worth a close look since the persisted model (OBS-14) and this endpoint's wire format diverge on field names and casing.
- No dashboards can exist yet in any environment (write path is OBS-16), so this PR is effectively unreachable in production until then — safe to merge ahead of it.

[OBS-15]: https://gravitee.atlassian.net/browse/OBS-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OBS-14]: https://gravitee.atlassian.net/browse/OBS-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ