### PR TITLE
fix(reporter): stop dropping reportables with no remote address

### DIFF
--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/java/io/gravitee/apim/reporter/common/formatter/AbstractFormatter.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/src/main/java/io/gravitee/apim/reporter/common/formatter/AbstractFormatter.java
@@ -49,7 +49,8 @@ public abstract class AbstractFormatter<T extends Reportable> implements Formatt
     }
 
     private static String sanitizeRemoteAddress(String remoteAddress) {
-        return InetAddressValidator.getInstance().isValid(remoteAddress) ? remoteAddress : REMOTE_ADDRESS_FALLBACK;
+        // InetAddressValidator.isValid throws on null instead of returning false.
+        return remoteAddress != null && InetAddressValidator.getInstance().isValid(remoteAddress) ? remoteAddress : REMOTE_ADDRESS_FALLBACK;
     }
 
     protected abstract Buffer format0(T data);


### PR DESCRIPTION
`AbstractFormatter.sanitizeRemoteAddress` dereferences the remote address without a null check, so any reportable without one throws an NPE inside the bulk transformer and is dropped silently — no exception surfaces and no document is written.

One-line null guard.
