### PR TITLE
feat: handle API Product API creation failures

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.html
@@ -21,7 +21,7 @@
   <mat-dialog-content class="mat-elevation-z0">
     <div class="api-search-description-box">
       <div class="selected-panel__title">APIs</div>
-      <div class="api-search-description">Pick the unpublished APIs you want to add to your navigation menu.</div>
+      <div class="api-search-description" data-testid="api-picker-description">{{ description }}</div>
     </div>
 
     <gio-table-wrapper [searchLabel]="'Search'" [length]="total" [filters]="filters" (filtersChange)="onFiltersChanged($event)">

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.spec.ts
@@ -108,6 +108,19 @@ describe('ApiSectionEditorDialogComponent', () => {
     });
   }
 
+  function expectApiProductApisRequest(apiProductId: string, options: { page?: number; perPage?: number; query?: string } = {}) {
+    const { page = 1, perPage = 10, query } = options;
+    return httpTestingController.expectOne(request => {
+      if (request.method !== 'GET' || request.url !== `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${apiProductId}/apis`) {
+        return false;
+      }
+      if (request.params.get('page') !== page.toString() || request.params.get('perPage') !== perPage.toString()) {
+        return false;
+      }
+      return query === undefined ? !request.params.has('query') : request.params.get('query') === query;
+    });
+  }
+
   it('should not allow submit when no api is selected', fakeAsync(() => {
     component.clicked();
     fixture.detectChanges();
@@ -151,6 +164,123 @@ describe('ApiSectionEditorDialogComponent', () => {
     expect(Array.isArray(component.dialogValue?.apiIds)).toEqual(true);
     expect(component.dialogValue?.apiIds?.length).toBeGreaterThan(1);
     expect(component.dialogValue?.apiId).toEqual(component.dialogValue?.apiIds?.[0]);
+  }));
+
+  it('should load APIs from the owning API Product and display the product-specific description', fakeAsync(async () => {
+    component.clicked({
+      apiProductContext: { navigationItemId: 'api-product-navigation-item', apiProductId: 'api-product-id' },
+    });
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductApisRequest('api-product-id').flush({
+      data: [fakeApiV2({ id: 'product-api', name: 'Product API' })],
+      pagination: { totalCount: 1 },
+    });
+    fixture.detectChanges();
+    tick();
+
+    const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+    expect(await dialog.getDescription()).toBe('Pick the APIs included in this API Product that you want to add to its navigation.');
+
+    const checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' }));
+    expect(checkboxes).toHaveLength(1);
+    expect(await (await checkboxes[0].host()).getAttribute('data-testid')).toBe('api-picker-checkbox-product-api');
+  }));
+
+  it('should forward product search and pagination to the API Product APIs endpoint', fakeAsync(async () => {
+    component.clicked({
+      apiProductContext: { navigationItemId: 'api-product-navigation-item', apiProductId: 'api-product-id' },
+    });
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductApisRequest('api-product-id').flush({
+      data: [fakeApiV2({ id: 'first-api', name: 'First API' })],
+      pagination: { totalCount: 20 },
+    });
+    fixture.detectChanges();
+    tick();
+
+    const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+    await dialog.goToNextPage();
+    tick(450);
+    expectApiProductApisRequest('api-product-id', { page: 2 }).flush({
+      data: [fakeApiV2({ id: 'second-page-api', name: 'Second page API' })],
+      pagination: { totalCount: 20 },
+    });
+    fixture.detectChanges();
+    tick();
+
+    await dialog.setSearchValue('Orders');
+    tick(450);
+    expectApiProductApisRequest('api-product-id', { query: 'Orders' }).flush({
+      data: [fakeApiV2({ id: 'orders-api', name: 'Orders API' })],
+      pagination: { totalCount: 1 },
+    });
+    fixture.detectChanges();
+    tick();
+  }));
+
+  it('should preserve selected product APIs while searching', fakeAsync(async () => {
+    component.clicked({
+      apiProductContext: { navigationItemId: 'api-product-navigation-item', apiProductId: 'api-product-id' },
+    });
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductApisRequest('api-product-id').flush({
+      data: [fakeApiV2({ id: 'first-api', name: 'First API' })],
+      pagination: { totalCount: 2 },
+    });
+    fixture.detectChanges();
+    tick();
+
+    let checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' }));
+    await checkboxes[0].check();
+
+    const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+    await dialog.setSearchValue('Second');
+    tick(450);
+    expectApiProductApisRequest('api-product-id', { query: 'Second' }).flush({
+      data: [fakeApiV2({ id: 'second-api', name: 'Second API' })],
+      pagination: { totalCount: 1 },
+    });
+    fixture.detectChanges();
+    tick();
+
+    checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' }));
+    await checkboxes[0].check();
+    await dialog.clickSubmitButton();
+    tick();
+
+    expect(component.dialogValue?.apiIds).toEqual(['first-api', 'second-api']);
+  }));
+
+  it('should not fall back to the environment API search when loading product APIs fails', fakeAsync(() => {
+    component.clicked({
+      apiProductContext: { navigationItemId: 'api-product-navigation-item', apiProductId: 'api-product-id' },
+    });
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiProductApisRequest('api-product-id').flush('Server error', { status: 500, statusText: 'Internal Server Error' });
+    tick();
+
+    httpTestingController.expectNone(request => request.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search`);
+  }));
+
+  it('should preserve the standalone dialog description and environment API search', fakeAsync(async () => {
+    component.clicked();
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiSearchResponse();
+    fixture.detectChanges();
+    tick();
+
+    const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+    expect(await dialog.getDescription()).toBe('Pick the unpublished APIs you want to add to your navigation menu.');
   }));
 
   it('should hide checkbox, show "Already added" label and grey out row for already-added API', fakeAsync(async () => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.ts
@@ -28,10 +28,11 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTableModule } from '@angular/material/table';
 import { isEqual } from 'lodash';
-import { Observable, Subject, of, BehaviorSubject } from 'rxjs';
-import { catchError, debounceTime, distinctUntilChanged, map, startWith, switchMap, tap } from 'rxjs/operators';
+import { Observable, of, BehaviorSubject } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
 
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 import { Api, ApiV2, ApiV4, PortalNavigationItem, PortalVisibility, ApisResponse } from '../../../entities/management-api-v2';
 import { getApiAccess } from '../../../shared/utils';
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
@@ -104,12 +105,16 @@ type ApiSectionForm = FormGroup<ApiSectionFormControls>;
 })
 export class ApiSectionEditorDialogComponent implements OnInit {
   private readonly apiService = inject(ApiV2Service);
+  private readonly apiProductService = inject(ApiProductV2Service);
   private readonly dialogData = inject<ApiSectionEditorDialogData>(MAT_DIALOG_DATA);
 
   form!: ApiSectionForm;
   public initialFormValues: ApiSectionFormValues;
 
   public title = 'Add APIs';
+  readonly description = this.dialogData.apiProductContext
+    ? 'Pick the APIs included in this API Product that you want to add to its navigation.'
+    : 'Pick the unpublished APIs you want to add to your navigation menu.';
 
   displayedColumns = ['select', 'name', 'path', 'labels'];
 
@@ -122,7 +127,6 @@ export class ApiSectionEditorDialogComponent implements OnInit {
   isLoading = true;
 
   private readonly filters$ = new BehaviorSubject<GioTableWrapperFilters>(this.filters);
-  private readonly refresh$ = new Subject<void>();
 
   private selectedOrderedApis = signal<SelectedApi[]>([]);
   selectedCount = computed(() => this.selectedOrderedApis().length);
@@ -173,20 +177,16 @@ export class ApiSectionEditorDialogComponent implements OnInit {
     this.rows$ = this.filters$.pipe(
       debounceTime(100),
       distinctUntilChanged(isEqual),
+      tap(() => (this.isLoading = true)),
       switchMap(filters =>
-        this.refresh$.pipe(
-          startWith(undefined),
-          tap(() => (this.isLoading = true)),
-          switchMap(() =>
-            this.apiService.search({ query: filters.searchTerm }, undefined, filters.pagination.index, filters.pagination.size, false),
-          ),
+        this.searchApis(filters).pipe(
           catchError((): Observable<ApisResponse> => {
             this.total = 0;
             return of({ data: [], pagination: undefined, links: undefined });
           }),
-          tap(() => (this.isLoading = false)),
         ),
       ),
+      tap(() => (this.isLoading = false)),
       tap(resp => {
         this.total = resp.pagination?.totalCount ?? 0;
       }),
@@ -225,7 +225,6 @@ export class ApiSectionEditorDialogComponent implements OnInit {
   onFiltersChanged(filters: GioTableWrapperFilters): void {
     this.filters = { ...this.filters, ...filters };
     this.filters$.next(this.filters);
-    this.refresh$.next();
   }
 
   isChecked(apiId: string): boolean {
@@ -293,5 +292,14 @@ export class ApiSectionEditorDialogComponent implements OnInit {
 
   private isApiV2OrV4(api: Api): api is ApiV2 | ApiV4 {
     return api.definitionVersion === 'V2' || api.definitionVersion === 'V4';
+  }
+
+  private searchApis(filters: GioTableWrapperFilters): Observable<ApisResponse> {
+    const apiProductId = this.dialogData.apiProductContext?.apiProductId;
+    if (apiProductId) {
+      return this.apiProductService.getApis(apiProductId, filters.pagination.index, filters.pagination.size, filters.searchTerm);
+    }
+
+    return this.apiService.search({ query: filters.searchTerm }, undefined, filters.pagination.index, filters.pagination.size, false);
   }
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.harness.ts
@@ -18,6 +18,8 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { DivHarness, SpanHarness } from '@gravitee/ui-particles-angular/testing';
 
+import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
+
 export class ApiSectionEditorDialogHarness extends ComponentHarness {
   static hostSelector = 'api-section-editor-dialog';
 
@@ -25,6 +27,8 @@ export class ApiSectionEditorDialogHarness extends ComponentHarness {
   private locateSubmitButton = this.locatorFor(MatButtonHarness.with({ text: /Add|Save/ }));
   private locateFormTitle = this.locatorFor(DivHarness.with({ selector: '[mat-dialog-title]' }));
   private locateAuthenticationToggle = this.locatorFor(MatSlideToggleHarness);
+  private locateDescription = this.locatorFor(DivHarness.with({ selector: '[data-testid="api-picker-description"]' }));
+  private locateTableWrapper = this.locatorFor(GioTableWrapperHarness);
   private locateAlreadyAddedLabels = this.locatorForAll(SpanHarness.with({ selector: '[data-testid^="api-picker-already-added-"]' }));
 
   async clickCancelButton(): Promise<void> {
@@ -45,6 +49,19 @@ export class ApiSectionEditorDialogHarness extends ComponentHarness {
   async getDialogTitle(): Promise<string> {
     const titleElement = await this.locateFormTitle();
     return titleElement.getText();
+  }
+
+  async getDescription(): Promise<string> {
+    return (await this.locateDescription()).getText();
+  }
+
+  async setSearchValue(value: string): Promise<void> {
+    return (await this.locateTableWrapper()).setSearchValue(value);
+  }
+
+  async goToNextPage(): Promise<void> {
+    const paginator = await (await this.locateTableWrapper()).getPaginator();
+    await paginator?.goToNextPage();
   }
 
   async getAuthenticationToggle(): Promise<MatSlideToggleHarness> {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -3051,6 +3051,25 @@ describe('PortalNavigationItemsComponent', () => {
     fixture.detectChanges();
   }
 
+  function expectApiProductApisResponse(apiProductId: string, apiIds: string[]) {
+    const req = httpTestingController.expectOne(request => {
+      return (
+        request.method === 'GET' &&
+        request.url === `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${apiProductId}/apis` &&
+        request.params.get('page') === '1' &&
+        request.params.get('perPage') === '10' &&
+        !request.params.has('query')
+      );
+    });
+
+    req.flush({
+      data: apiIds.map(id => ({ id, name: id })),
+      pagination: { totalCount: apiIds.length },
+    });
+
+    fixture.detectChanges();
+  }
+
   function expectApiProductSearchResponse(apiProducts: ApiProduct[]) {
     const req = httpTestingController.expectOne(request => {
       return (
@@ -3116,8 +3135,11 @@ describe('PortalNavigationItemsComponent', () => {
   }
 
   function flushPendingLinkedApiProductRequests() {
+    const apiProductsUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/`;
     const requests = httpTestingController.match(request => {
-      return request.method === 'GET' && request.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/`);
+      return (
+        request.method === 'GET' && request.url.startsWith(apiProductsUrl) && !request.url.substring(apiProductsUrl.length).includes('/')
+      );
     });
 
     requests
@@ -3351,7 +3373,7 @@ describe('PortalNavigationItemsComponent', () => {
   });
 
   describe('API Product context passed to API section dialog', () => {
-    async function openApiSectionDialog(parentItem: PortalNavigationItem): Promise<SpyInstance> {
+    async function openApiSectionDialog(parentItem: PortalNavigationItem, apiProductId?: string): Promise<SpyInstance> {
       const openSpy = jest.spyOn(TestBed.inject(MatDialog), 'open');
       const parentNode: SectionNode = {
         id: parentItem.id,
@@ -3362,9 +3384,14 @@ describe('PortalNavigationItemsComponent', () => {
 
       component.onNodeMenuAction({ action: 'create', itemType: 'API', node: parentNode });
       fixture.detectChanges();
+      flushPendingLinkedApiSearchRequests();
       flushPendingLinkedApiProductRequests();
       await fixture.whenStable();
-      expectApiSearchResponse([]);
+      if (apiProductId) {
+        expectApiProductApisResponse(apiProductId, []);
+      } else {
+        expectApiSearchResponse([]);
+      }
 
       return openSpy;
     }
@@ -3379,7 +3406,7 @@ describe('PortalNavigationItemsComponent', () => {
       });
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct] }));
 
-      const openSpy = await openApiSectionDialog(apiProduct);
+      const openSpy = await openApiSectionDialog(apiProduct, apiProduct.apiProductId);
 
       expect(openSpy).toHaveBeenCalledWith(
         expect.anything(),
@@ -3416,7 +3443,7 @@ describe('PortalNavigationItemsComponent', () => {
         fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct, firstNestedFolder, secondNestedFolder] }),
       );
 
-      const openSpy = await openApiSectionDialog(secondNestedFolder);
+      const openSpy = await openApiSectionDialog(secondNestedFolder, apiProduct.apiProductId);
 
       expect(openSpy).toHaveBeenCalledWith(
         expect.anything(),
@@ -3456,6 +3483,75 @@ describe('PortalNavigationItemsComponent', () => {
         expect.anything(),
         expect.objectContaining({
           data: expect.objectContaining({ apiProductContext: undefined }),
+        }),
+      );
+    });
+
+    it('should only pass API ids from the current API Product subtree', async () => {
+      const rootFolder = fakePortalNavigationFolder({ id: 'root-folder', title: 'Root folder' });
+      const firstApiProduct = fakePortalNavigationApiProduct({
+        id: 'first-product-navigation-item',
+        apiProductId: 'first-api-product-id',
+        title: 'First API Product',
+        parentId: rootFolder.id,
+      });
+      const nestedFolder = fakePortalNavigationFolder({
+        id: 'nested-folder',
+        title: 'Nested folder',
+        parentId: firstApiProduct.id,
+      });
+      const directApi = fakePortalNavigationApi({ id: 'direct-api-item', apiId: 'direct-api', parentId: firstApiProduct.id });
+      const nestedApi = fakePortalNavigationApi({ id: 'nested-api-item', apiId: 'nested-api', parentId: nestedFolder.id });
+      const secondApiProduct = fakePortalNavigationApiProduct({
+        id: 'second-product-navigation-item',
+        apiProductId: 'second-api-product-id',
+        title: 'Second API Product',
+        parentId: rootFolder.id,
+      });
+      const otherProductApi = fakePortalNavigationApi({
+        id: 'other-product-api-item',
+        apiId: 'other-product-api',
+        parentId: secondApiProduct.id,
+      });
+      const standaloneApi = fakePortalNavigationApi({ id: 'standalone-api-item', apiId: 'standalone-api', parentId: rootFolder.id });
+      await expectGetNavigationItems(
+        fakePortalNavigationItemsResponse({
+          items: [rootFolder, firstApiProduct, nestedFolder, directApi, nestedApi, secondApiProduct, otherProductApi, standaloneApi],
+        }),
+      );
+
+      const openSpy = await openApiSectionDialog(nestedFolder, firstApiProduct.apiProductId);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            existingApiIds: ['direct-api', 'nested-api'],
+          }),
+        }),
+      );
+    });
+
+    it('should not treat APIs from an API Product subtree as already added in standalone context', async () => {
+      const rootFolder = fakePortalNavigationFolder({ id: 'root-folder', title: 'Root folder' });
+      const apiProduct = fakePortalNavigationApiProduct({
+        id: 'product-navigation-item',
+        apiProductId: 'api-product-id',
+        title: 'API Product',
+        parentId: rootFolder.id,
+      });
+      const productApi = fakePortalNavigationApi({ id: 'product-api-item', apiId: 'product-api', parentId: apiProduct.id });
+      const standaloneApi = fakePortalNavigationApi({ id: 'standalone-api-item', apiId: 'standalone-api', parentId: rootFolder.id });
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct, productApi, standaloneApi] }));
+
+      const openSpy = await openApiSectionDialog(rootFolder);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            existingApiIds: ['standalone-api'],
+          }),
         }),
       );
     });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -25,7 +25,7 @@ import { Router } from '@angular/router';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { GioConfirmAndValidateDialogHarness, GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
-import { Observable, of, ReplaySubject } from 'rxjs';
+import { Observable, of, ReplaySubject, throwError } from 'rxjs';
 
 import SpyInstance = jest.SpyInstance;
 
@@ -69,6 +69,7 @@ import {
 import { SectionNode } from '../components/flat-tree/flat-tree.component';
 import { SnackBarService } from '../../services-ngx/snack-bar.service';
 import { PortalPageContentService } from '../../services-ngx/portal-page-content.service';
+import { PortalNavigationItemService } from '../../services-ngx/portal-navigation-item.service';
 import { ApiProduct } from '../../entities/management-api-v2/api-product';
 
 type PortalNavigationItemsComponentPrivateMethods = {
@@ -2827,6 +2828,162 @@ describe('PortalNavigationItemsComponent', () => {
       expect(document.body.textContent).toContain('Failed to create default API pages');
       expect(routerSpy).toHaveBeenCalledWith(['.'], expect.objectContaining({ queryParams: { navId: createdApis[1].id } }));
     });
+  });
+
+  describe('creating API navigation items in an API Product context', () => {
+    const rootFolder = fakePortalNavigationFolder({ id: 'root-folder', title: 'Root folder' });
+    const apiProduct = fakePortalNavigationApiProduct({
+      id: 'product-navigation-item',
+      apiProductId: 'api-product-id',
+      title: 'API Product',
+      parentId: rootFolder.id,
+    });
+    const nestedFolder = fakePortalNavigationFolder({
+      id: 'nested-folder',
+      title: 'Nested folder',
+      parentId: apiProduct.id,
+    });
+
+    beforeEach(async () => {
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct, nestedFolder] }));
+    });
+
+    it('should create multiple APIs below a nested product folder using the shared ordered pipeline', async () => {
+      const apiIds = ['api-1', 'api-2'];
+      const createdApis = [
+        fakePortalNavigationApi({
+          id: 'nav-api-1',
+          apiId: apiIds[0],
+          title: apiIds[0],
+          parentId: nestedFolder.id,
+          visibility: 'PRIVATE',
+        }),
+        fakePortalNavigationApi({
+          id: 'nav-api-2',
+          apiId: apiIds[1],
+          title: apiIds[1],
+          parentId: nestedFolder.id,
+          visibility: 'PRIVATE',
+        }),
+      ];
+      const dialog = await openApiDialog(apiIds);
+      await dialog.toggleAuthentication();
+
+      await dialog.clickSubmitButton();
+
+      expectCreateNavigationItemsInBulk(
+        apiIds.map(apiId => ({
+          title: '',
+          type: 'API',
+          area: 'TOP_NAVBAR',
+          parentId: nestedFolder.id,
+          visibility: 'PRIVATE',
+          apiId,
+        })),
+        fakePortalNavigationItemsResponse({ items: createdApis }),
+      );
+      expectSeedDefaultPages(createdApis.map(api => api.id));
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct, nestedFolder, ...createdApis] }));
+      flushPendingLinkedApiSearchRequests();
+      flushPendingLinkedApiProductRequests();
+
+      expect(routerSpy).toHaveBeenCalledWith(['.'], expect.objectContaining({ queryParams: { navId: createdApis[1].id } }));
+    });
+
+    it.each([
+      {
+        description: 'stale API Product membership',
+        status: 400,
+        statusText: 'Bad Request',
+        backendMessage: 'API api-2 no longer belongs to API Product api-product-id',
+      },
+      {
+        description: 'a contextual duplicate',
+        status: 409,
+        statusText: 'Conflict',
+        backendMessage: 'API api-2 already exists in this API Product navigation',
+      },
+    ])('should preserve the backend HTTP error and refresh retained items for $description', async errorResponse => {
+      const apiIds = ['api-1', 'api-2'];
+      const retainedApi = fakePortalNavigationApi({
+        id: 'retained-api-navigation-item',
+        apiId: apiIds[0],
+        title: apiIds[0],
+        parentId: nestedFolder.id,
+      });
+      const errorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+      const dialog = await openApiDialog(apiIds);
+
+      await dialog.clickSubmitButton();
+
+      const request = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/_bulk`,
+      });
+      expect(request.request.body).toEqual({
+        items: apiIds.map(apiId => ({
+          title: '',
+          type: 'API',
+          area: 'TOP_NAVBAR',
+          parentId: nestedFolder.id,
+          visibility: 'PUBLIC',
+          apiId,
+        })),
+      });
+      request.flush({ message: errorResponse.backendMessage }, { status: errorResponse.status, statusText: errorResponse.statusText });
+
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct, nestedFolder, retainedApi] }));
+      flushPendingLinkedApiSearchRequests();
+      flushPendingLinkedApiProductRequests();
+
+      expect(errorSpy).not.toHaveBeenCalledWith('Failed to create API navigation items');
+      httpTestingController.expectNone(request => request.method === 'DELETE');
+    });
+
+    it('should show the generic fallback and refresh the tree for a non-HTTP failure', async () => {
+      const apiIds = ['api-1'];
+      const errorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+      const dialog = await openApiDialog(apiIds);
+      const bulkCreateSpy = jest
+        .spyOn(TestBed.inject(PortalNavigationItemService), 'createNavigationItemsInBulk')
+        .mockReturnValueOnce(throwError(() => new Error('Unexpected local failure')));
+
+      await dialog.clickSubmitButton();
+
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [rootFolder, apiProduct, nestedFolder] }));
+
+      expect(errorSpy).toHaveBeenCalledWith('Failed to create API navigation items');
+      httpTestingController.expectNone({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/_bulk`,
+      });
+      bulkCreateSpy.mockRestore();
+    });
+
+    async function openApiDialog(apiIds: string[]): Promise<ApiSectionEditorDialogHarness> {
+      component.onNodeMenuAction({
+        action: 'create',
+        itemType: 'API',
+        node: fakeSectionNode({
+          id: nestedFolder.id,
+          label: nestedFolder.title,
+          type: nestedFolder.type,
+          data: nestedFolder,
+        }),
+      });
+      fixture.detectChanges();
+      flushPendingLinkedApiSearchRequests();
+      flushPendingLinkedApiProductRequests();
+      await fixture.whenStable();
+      expectApiProductApisResponse(apiProduct.apiProductId, apiIds);
+
+      const checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' }));
+      for (const checkbox of checkboxes) {
+        await checkbox.check();
+      }
+
+      return rootLoader.getHarness(ApiSectionEditorDialogHarness);
+    }
   });
 
   describe('creating API Product navigation items in bulk', () => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -362,7 +362,9 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
       .afterClosed()
       .pipe(
         filter(result => !!result),
-        switchMap(result => this.createApisInOrder(existingItem?.id, result.apiIds ?? [], result.visibility ?? 'PUBLIC')),
+        switchMap(result =>
+          this.createApisInOrder(existingItem?.id, result.apiIds ?? [], result.visibility ?? 'PUBLIC', apiProductContext !== undefined),
+        ),
         map(id => id ?? existingItem?.id ?? null),
         tap(id => {
           this.refreshMenuList.next(1);
@@ -523,6 +525,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     parentId: string | undefined,
     apiIds: string[],
     visibility: PortalVisibility = 'PUBLIC',
+    preserveHttpErrorMessage = false,
   ): Observable<string | null> {
     if (!parentId) {
       this.snackBarService.error('Select a folder before adding APIs');
@@ -566,8 +569,10 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         }
         return null;
       }),
-      catchError(() => {
-        this.snackBarService.error('Failed to create API navigation items');
+      catchError(error => {
+        if (!(preserveHttpErrorMessage && error instanceof HttpErrorResponse)) {
+          this.snackBarService.error('Failed to create API navigation items');
+        }
         return of(null);
       }),
     );

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -354,7 +354,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         width: GIO_DIALOG_WIDTH.LARGE,
         data: {
           mode: 'create',
-          existingApiIds: this.extractApiIdsFromNavigationItems(),
+          existingApiIds: this.extractApiIdsFromNavigationContext(apiProductContext),
           parentItem: existingItem,
           apiProductContext,
         },
@@ -994,10 +994,19 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     );
   }
 
-  private extractApiIdsFromNavigationItems(): string[] {
-    return this.menuLinks()
-      .filter(i => i.type === 'API')
-      .map(i => i.apiId);
+  private extractApiIdsFromNavigationContext(apiProductContext?: ApiProductNavigationContext): string[] {
+    const navigationItems = this.menuLinks();
+    const itemsById = new Map(navigationItems.map(item => [item.id, item]));
+
+    return navigationItems
+      .filter(item => item.type === 'API')
+      .filter(item => {
+        const itemApiProductContext = this.findApiProductNavigationContext(item, itemsById);
+        return apiProductContext
+          ? itemApiProductContext?.navigationItemId === apiProductContext.navigationItemId
+          : itemApiProductContext === undefined;
+      })
+      .map(item => item.apiId);
   }
 
   private extractApiProductIdsFromNavigationItems(): string[] {
@@ -1006,8 +1015,10 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
       .map(item => item.apiProductId);
   }
 
-  private findApiProductNavigationContext(item: PortalNavigationItem): ApiProductNavigationContext | undefined {
-    const itemsById = new Map(this.menuLinks().map(menuItem => [menuItem.id, menuItem]));
+  private findApiProductNavigationContext(
+    item: PortalNavigationItem,
+    itemsById = new Map(this.menuLinks().map(menuItem => [menuItem.id, menuItem])),
+  ): ApiProductNavigationContext | undefined {
     const visitedItemIds = new Set<string>();
     let currentItem: PortalNavigationItem | undefined = item;
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-100

## Description

Improve error handling when adding APIs within an API Product navigation context.

- Preserve backend validation messages for HTTP errors.
- Refresh the navigation tree after a failed bulk request so partially created items remain visible.
- Keep the generic fallback message for non-HTTP errors.
- Do not roll back API navigation items retained by the backend.
- Keep the standalone Add API flow unchanged.

## Tests

- Added coverage for successful multi-API creation.
- Added coverage for partial failures caused by stale API Product membership and duplicate navigation items.
- Added coverage for non-HTTP error fallback.


