### PR TITLE
feat: add API product navigation and details models

### DIFF
--- a/gravitee-apim-portal-webui-next/src/entities/api-product/api-product.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api-product/api-product.fixture.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isFunction } from 'lodash';
+
+import { ApiProduct, ApiProductApi } from './api-product';
+
+export function fakeApiProductApi(modifier?: Partial<ApiProductApi> | ((baseApi: ApiProductApi) => ApiProductApi)): ApiProductApi {
+  const base: ApiProductApi = {
+    id: 'api-1',
+    name: 'API 1',
+    version: '1.0.0',
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}
+
+export function fakeApiProduct(modifier?: Partial<ApiProduct> | ((baseApiProduct: ApiProduct) => ApiProduct)): ApiProduct {
+  const base: ApiProduct = {
+    id: '4f6597ca-74b8-4e68-a597-ca74b83e6824',
+    name: 'API Product 1',
+    description: 'API Product description',
+    version: '1.0.0',
+    kind: 'AI_WORKSPACE',
+    navigationItemId: '9d1dfa42-c550-4ca3-9dfa-42c550dca37a',
+    tags: ['AI', 'Workspace'],
+    apis: [fakeApiProductApi()],
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/entities/api-product/api-product.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api-product/api-product.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ApiProductKind = 'AI_WORKSPACE';
+
+export interface ApiProductApi {
+  id: string;
+  name: string;
+  version: string;
+}
+
+export interface ApiProduct {
+  id: string;
+  name: string;
+  description?: string;
+  version: string;
+  kind: ApiProductKind | null;
+  navigationItemId: string;
+  tags: string[];
+  apis: ApiProductApi[];
+}

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.fixture.ts
@@ -15,7 +15,13 @@
  */
 import { isFunction } from 'lodash';
 
-import { PortalNavigationPage, PortalNavigationFolder, PortalNavigationLink, PortalNavigationApi } from './portal-navigation-item';
+import {
+  PortalNavigationPage,
+  PortalNavigationFolder,
+  PortalNavigationLink,
+  PortalNavigationApi,
+  PortalNavigationApiProduct,
+} from './portal-navigation-item';
 
 export function fakePortalNavigationPage(overrides?: Partial<PortalNavigationPage>): PortalNavigationPage {
   const base: PortalNavigationPage = {
@@ -100,6 +106,32 @@ export function fakePortalNavigationApi(overrides?: Partial<PortalNavigationApi>
     apiId: 'api-1',
     published: true,
     rootId: 'nav-api-1',
+  };
+
+  if (isFunction(overrides)) {
+    return overrides(base);
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+export function fakePortalNavigationApiProduct(
+  overrides?: Partial<PortalNavigationApiProduct> | ((baseApiProduct: PortalNavigationApiProduct) => PortalNavigationApiProduct),
+): PortalNavigationApiProduct {
+  const base: PortalNavigationApiProduct = {
+    id: '9d1dfa42-c550-4ca3-9dfa-42c550dca37a',
+    organizationId: 'org-1',
+    environmentId: 'env-1',
+    title: 'API Product 1',
+    type: 'API_PRODUCT',
+    order: 1,
+    area: 'HOMEPAGE',
+    apiProductId: '4f6597ca-74b8-4e68-a597-ca74b83e6824',
+    published: true,
+    rootId: '9d1dfa42-c550-4ca3-9dfa-42c550dca37a',
   };
 
   if (isFunction(overrides)) {

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.ts
@@ -16,7 +16,7 @@
 
 export type PortalArea = 'HOMEPAGE' | 'TOP_NAVBAR';
 
-export type PortalNavigationItemType = 'PAGE' | 'FOLDER' | 'LINK' | 'API';
+export type PortalNavigationItemType = 'PAGE' | 'FOLDER' | 'LINK' | 'API' | 'API_PRODUCT';
 
 export interface BasePortalNavigationItem {
   id: string;
@@ -50,4 +50,14 @@ export interface PortalNavigationApi extends BasePortalNavigationItem {
   apiId: string;
 }
 
-export type PortalNavigationItem = PortalNavigationPage | PortalNavigationFolder | PortalNavigationLink | PortalNavigationApi;
+export interface PortalNavigationApiProduct extends BasePortalNavigationItem {
+  type: 'API_PRODUCT';
+  apiProductId: string;
+}
+
+export type PortalNavigationItem =
+  | PortalNavigationPage
+  | PortalNavigationFolder
+  | PortalNavigationLink
+  | PortalNavigationApi
+  | PortalNavigationApiProduct;

--- a/gravitee-apim-portal-webui-next/src/mocks/portal-navigation-item.mocks.ts
+++ b/gravitee-apim-portal-webui-next/src/mocks/portal-navigation-item.mocks.ts
@@ -16,6 +16,7 @@
 import { PortalNavigationItem } from '../entities/portal-navigation/portal-navigation-item';
 import {
   fakePortalNavigationApi,
+  fakePortalNavigationApiProduct,
   fakePortalNavigationFolder,
   fakePortalNavigationLink,
   fakePortalNavigationPage,
@@ -37,6 +38,8 @@ export const makeItem = (
       return fakePortalNavigationLink({ id, title, order, parentId, rootId: root });
     case 'API':
       return fakePortalNavigationApi({ id, title, order, parentId, rootId: root, apiId: `api-${id}` });
+    case 'API_PRODUCT':
+      return fakePortalNavigationApiProduct({ id, title, order, parentId, rootId: root });
     case 'PAGE':
     default:
       return fakePortalNavigationPage({ id, title, order, parentId, rootId: root });

--- a/gravitee-apim-portal-webui-next/src/services/api-products.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/api-products.service.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ApiProductsService } from './api-products.service';
+import { fakeApiProduct } from '../entities/api-product/api-product.fixture';
+import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
+
+describe('ApiProductsService', () => {
+  let service: ApiProductsService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
+
+    service = TestBed.inject(ApiProductsService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('getById', () => {
+    it('should get API Product details', done => {
+      const apiProduct = fakeApiProduct();
+
+      service.getById(apiProduct.id).subscribe(response => {
+        expect(response).toEqual(apiProduct);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/api-products/${apiProduct.id}`);
+      expect(req.request.method).toEqual('GET');
+      expect(req.request.params.keys()).toHaveLength(0);
+      req.flush(apiProduct);
+    });
+
+    it('should get classic API Product details with a null kind', done => {
+      const apiProduct = fakeApiProduct({ kind: null });
+
+      service.getById(apiProduct.id).subscribe(response => {
+        expect(response.kind).toBeNull();
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/api-products/${apiProduct.id}`);
+      expect(req.request.method).toEqual('GET');
+      req.flush(apiProduct);
+    });
+
+    it('should propagate an API Product not found error', done => {
+      const apiProductId = '4f6597ca-74b8-4e68-a597-ca74b83e6824';
+
+      service.getById(apiProductId).subscribe({
+        next: () => fail(),
+        error: error => {
+          expect(error.status).toEqual(404);
+          done();
+        },
+      });
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/api-products/${apiProductId}`);
+      req.flush({ message: 'API Product not found' }, { status: 404, statusText: 'Not Found' });
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/api-products.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/api-products.service.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ConfigService } from './config.service';
+import { ApiProduct } from '../entities/api-product/api-product';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApiProductsService {
+  private readonly http = inject(HttpClient);
+  private readonly configService = inject(ConfigService);
+
+  getById(apiProductId: string): Observable<ApiProduct> {
+    return this.http.get<ApiProduct>(`${this.configService.baseURL}/api-products/${apiProductId}`);
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
@@ -20,6 +20,7 @@ import { ConfigService } from './config.service';
 import { PortalNavigationItemsService } from './portal-navigation-items.service';
 import { fakeApi } from '../entities/api/api.fixtures';
 import { PortalNavigationItem } from '../entities/portal-navigation/portal-navigation-item';
+import { fakePortalNavigationApiProduct } from '../entities/portal-navigation/portal-navigation-item.fixture';
 import { AppTestingModule } from '../testing/app-testing.module';
 
 describe('PortalNavigationItemsService', () => {
@@ -155,6 +156,29 @@ describe('PortalNavigationItemsService', () => {
     const req = httpMock.expectOne(r => r.method === 'GET' && r.url === `${baseURL}/portal-navigation-items/${id}`);
 
     req.flush(mockItem);
+  });
+
+  it('should preserve API Product navigation items', done => {
+    const apiProductItem = fakePortalNavigationApiProduct({ area: 'HOMEPAGE' });
+
+    service.getNavigationItems('HOMEPAGE').subscribe(items => {
+      expect(items).toEqual([apiProductItem]);
+      expect(items[0]).toMatchObject({
+        type: 'API_PRODUCT',
+        apiProductId: apiProductItem.apiProductId,
+      });
+      done();
+    });
+
+    const req = httpMock.expectOne(
+      r =>
+        r.method === 'GET' &&
+        r.url === `${baseURL}/portal-navigation-items` &&
+        r.params.get('area') === 'HOMEPAGE' &&
+        r.params.get('loadChildren') === 'true',
+    );
+
+    req.flush([apiProductItem]);
   });
 
   it('should search APIs and map to PortalNavigationApisSearchResponse', done => {


### PR DESCRIPTION
## Issue


https://gravitee.atlassian.net/browse/PORTAL-101

## Summary

Add the Portal Next models and service layer required to consume API Product navigation and details from the Portal API.

## Changes

- Extend the Portal navigation item union with `API_PRODUCT` and `apiProductId`.
- Add typed API Product details and included API summary models.
- Add reusable API Product navigation and details fixtures.
- Add `ApiProductsService` to retrieve product details by ID.
- Preserve HTTP errors for handling by future UI components.
- Add focused tests for API Product navigation responses and details retrieval.

## Out of scope

- API Product routing and navigation entries.
- API Product details UI.
- Product documentation rendering.
- Backend or HTTP contract changes.


