### PR TITLE
feat(observability): read authz decisions through the shared logs endpoint

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/MetricsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/MetricsRepository.java
@@ -19,6 +19,8 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.v4.model.LogResponse;
+import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLog;
+import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLogQuery;
 import io.gravitee.repository.log.v4.model.connection.Metrics;
 import io.gravitee.repository.log.v4.model.connection.MetricsQuery;
 import io.gravitee.repository.log.v4.model.connection.NativeApiMetrics;
@@ -44,4 +46,6 @@ public interface MetricsRepository {
         throws AnalyticsException;
 
     LogResponse<NativeApiMetrics> searchNativeApiMetrics(QueryContext queryContext, NativeApiMetricsQuery query) throws AnalyticsException;
+
+    LogResponse<AuthzDecisionLog> searchAuthzDecisionLogs(QueryContext queryContext, AuthzDecisionLogQuery query) throws AnalyticsException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/authz/AuthzDecisionLog.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/authz/AuthzDecisionLog.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.log.v4.model.authz;
+
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * One authorization outcome recorded by the PDP, as stored in the event-metrics data stream under
+ * {@code doc-type: authz}. Unlike a connection log this is not an HTTP exchange — there is no status
+ * code, latency or URI — so it is modelled on its own rather than folded into {@code Metrics}.
+ *
+ * @author GraviteeSource Team
+ */
+@Builder
+public record AuthzDecisionLog(
+    String eventId,
+    Long timestamp,
+    String apiId,
+    String organizationId,
+    String environmentId,
+    String gatewayId,
+    String requestId,
+    String operation,
+    String status,
+    String caller,
+    String targetPdpId,
+    Long policyGeneration,
+    String decision,
+    List<String> matchedPolicyNames,
+    List<String> reasons,
+    String subjectType,
+    String subjectId,
+    String action,
+    String resourceType,
+    String resourceId,
+    String batchId,
+    Integer batchIndex,
+    Integer batchSize,
+    String searchType,
+    Integer resultCount,
+    Long durationNanos
+) {}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/authz/AuthzDecisionLogQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/authz/AuthzDecisionLogQuery.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.log.v4.model.authz;
+
+import java.util.Objects;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@Builder
+public class AuthzDecisionLogQuery {
+
+    public static final int MAX_SIZE = 1_000;
+
+    private Set<String> apiIds;
+    private Long from;
+    private Long to;
+
+    @Builder.Default
+    private int size = 20;
+
+    @Builder.Default
+    private int page = 1;
+
+    public void validate() {
+        Objects.requireNonNull(apiIds, "apiIds");
+        if (apiIds.isEmpty()) {
+            throw new IllegalArgumentException("apiIds must not be empty");
+        }
+        if (page < 1) {
+            throw new IllegalArgumentException("page must be >= 1, was " + page);
+        }
+        if (size < 1) {
+            throw new IllegalArgumentException("size must be >= 1, was " + size);
+        }
+        if (size > MAX_SIZE) {
+            throw new IllegalArgumentException("size must be <= " + MAX_SIZE + ", was " + size);
+        }
+        if (from != null && to != null && from > to) {
+            throw new IllegalArgumentException("from must be <= to, was from=" + from + " to=" + to);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepository.java
@@ -24,6 +24,8 @@ import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepository;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.utils.ClusterUtils;
+import io.gravitee.repository.elasticsearch.v4.log.adapter.authz.SearchAuthzDecisionLogsQueryAdapter;
+import io.gravitee.repository.elasticsearch.v4.log.adapter.authz.SearchAuthzDecisionLogsResponseAdapter;
 import io.gravitee.repository.elasticsearch.v4.log.adapter.connection.SearchConnectionLogErrorKeysQueryAdapter;
 import io.gravitee.repository.elasticsearch.v4.log.adapter.connection.SearchConnectionLogErrorKeysResponseAdapter;
 import io.gravitee.repository.elasticsearch.v4.log.adapter.connection.SearchMetricsQueryAdapter;
@@ -36,6 +38,8 @@ import io.gravitee.repository.elasticsearch.v4.log.adapter.nativeapi.NativeApiMe
 import io.gravitee.repository.elasticsearch.v4.log.adapter.nativeapi.NativeApiMetricsSearchResponseAdapter;
 import io.gravitee.repository.log.v4.api.MetricsRepository;
 import io.gravitee.repository.log.v4.model.LogResponse;
+import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLog;
+import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLogQuery;
 import io.gravitee.repository.log.v4.model.connection.*;
 import io.gravitee.repository.log.v4.model.message.MessageMetrics;
 import io.gravitee.repository.log.v4.model.message.MessageMetricsQuery;
@@ -137,6 +141,22 @@ public class MetricsElasticsearchRepository extends AbstractElasticsearchReposit
         } catch (RuntimeException e) {
             log.error("Failed to search native metrics [apiId={}]", query.getApiId(), e);
             throw new AnalyticsException("Failed to search native metrics for api " + query.getApiId(), e);
+        }
+    }
+
+    @Override
+    public LogResponse<AuthzDecisionLog> searchAuthzDecisionLogs(QueryContext queryContext, AuthzDecisionLogQuery query)
+        throws AnalyticsException {
+        query.validate();
+        var clusters = ClusterUtils.extractClusterIndexPrefixes(configuration);
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.EVENT_METRICS, clusters);
+
+        try {
+            return this.client.search(index, null, SearchAuthzDecisionLogsQueryAdapter.adapt(query))
+                .map(SearchAuthzDecisionLogsResponseAdapter::adapt)
+                .blockingGet();
+        } catch (RuntimeException e) {
+            throw new AnalyticsException("Failed to search authz decision logs for apis " + query.getApiIds(), e);
         }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/AuthzDecisionLogFields.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/AuthzDecisionLogFields.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.log.adapter.authz;
+
+/**
+ * Indexed field names of an {@code AuthzEventMetrics} document, as written by the reporter's
+ * FreeMarker templates. Kept in one place so the query and the response adapter cannot drift.
+ *
+ * @author GraviteeSource Team
+ */
+final class AuthzDecisionLogFields {
+
+    static final String DOC_TYPE = "doc-type";
+    static final String API_ID = "api-id";
+    static final String ORG_ID = "org-id";
+    static final String ENV_ID = "env-id";
+    static final String GW_ID = "gw-id";
+    static final String EVENT_ID = "event-id";
+    static final String REQUEST_ID = "request-id";
+    static final String OPERATION = "operation";
+    static final String STATUS = "status";
+    static final String CALLER = "caller";
+    static final String TARGET_PDP_ID = "target-pdp-id";
+    static final String POLICY_GENERATION = "policy-generation";
+    static final String DECISION = "decision";
+    static final String MATCHED_POLICIES = "matched-policies";
+    static final String MATCHED_POLICY_NAME = "name";
+    static final String REASONS = "reasons";
+    static final String SUBJECT_TYPE = "subject-type";
+    static final String SUBJECT_ID = "subject-id";
+    static final String ACTION = "action";
+    static final String RESOURCE_TYPE = "resource-type";
+    static final String RESOURCE_ID = "resource-id";
+    static final String BATCH_ID = "batch-id";
+    static final String BATCH_INDEX = "batch-index";
+    static final String BATCH_SIZE = "batch-size";
+    static final String SEARCH_TYPE = "search-type";
+    static final String RESULT_COUNT = "result-count";
+    static final String DURATION_NANOS = "duration-nanos";
+
+    private AuthzDecisionLogFields() {}
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/AuthzDecisionLogSourceMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/AuthzDecisionLogSourceMapper.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.log.adapter.authz;
+
+import static io.gravitee.repository.elasticsearch.utils.JsonNodeUtils.asTextOrNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLog;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+final class AuthzDecisionLogSourceMapper {
+
+    private AuthzDecisionLogSourceMapper() {}
+
+    static AuthzDecisionLog from(JsonNode source) {
+        return AuthzDecisionLog.builder()
+            .eventId(asTextOrNull(source.get(AuthzDecisionLogFields.EVENT_ID)))
+            .timestamp(epochMillis(asTextOrNull(source.get("@timestamp"))))
+            .apiId(asTextOrNull(source.get(AuthzDecisionLogFields.API_ID)))
+            .organizationId(asTextOrNull(source.get(AuthzDecisionLogFields.ORG_ID)))
+            .environmentId(asTextOrNull(source.get(AuthzDecisionLogFields.ENV_ID)))
+            .gatewayId(asTextOrNull(source.get(AuthzDecisionLogFields.GW_ID)))
+            .requestId(asTextOrNull(source.get(AuthzDecisionLogFields.REQUEST_ID)))
+            .operation(asTextOrNull(source.get(AuthzDecisionLogFields.OPERATION)))
+            .status(asTextOrNull(source.get(AuthzDecisionLogFields.STATUS)))
+            .caller(asTextOrNull(source.get(AuthzDecisionLogFields.CALLER)))
+            .targetPdpId(asTextOrNull(source.get(AuthzDecisionLogFields.TARGET_PDP_ID)))
+            .policyGeneration(asLongOrNull(source.get(AuthzDecisionLogFields.POLICY_GENERATION)))
+            .decision(asTextOrNull(source.get(AuthzDecisionLogFields.DECISION)))
+            .matchedPolicyNames(matchedPolicyNames(source.get(AuthzDecisionLogFields.MATCHED_POLICIES)))
+            .reasons(asTextList(source.get(AuthzDecisionLogFields.REASONS)))
+            .subjectType(asTextOrNull(source.get(AuthzDecisionLogFields.SUBJECT_TYPE)))
+            .subjectId(asTextOrNull(source.get(AuthzDecisionLogFields.SUBJECT_ID)))
+            .action(asTextOrNull(source.get(AuthzDecisionLogFields.ACTION)))
+            .resourceType(asTextOrNull(source.get(AuthzDecisionLogFields.RESOURCE_TYPE)))
+            .resourceId(asTextOrNull(source.get(AuthzDecisionLogFields.RESOURCE_ID)))
+            .batchId(asTextOrNull(source.get(AuthzDecisionLogFields.BATCH_ID)))
+            .batchIndex(asIntOrNull(source.get(AuthzDecisionLogFields.BATCH_INDEX)))
+            .batchSize(asIntOrNull(source.get(AuthzDecisionLogFields.BATCH_SIZE)))
+            .searchType(asTextOrNull(source.get(AuthzDecisionLogFields.SEARCH_TYPE)))
+            .resultCount(asIntOrNull(source.get(AuthzDecisionLogFields.RESULT_COUNT)))
+            .durationNanos(asLongOrNull(source.get(AuthzDecisionLogFields.DURATION_NANOS)))
+            .build();
+    }
+
+    private static List<String> matchedPolicyNames(JsonNode node) {
+        if (node == null || !node.isArray()) {
+            return List.of();
+        }
+        var names = new ArrayList<String>(node.size());
+        node.forEach(policy -> {
+            var name = asTextOrNull(policy.get(AuthzDecisionLogFields.MATCHED_POLICY_NAME));
+            if (name != null) {
+                names.add(name);
+            }
+        });
+        return names;
+    }
+
+    private static List<String> asTextList(JsonNode node) {
+        if (node == null || !node.isArray()) {
+            return List.of();
+        }
+        var values = new ArrayList<String>(node.size());
+        node.forEach(value -> {
+            if (!value.isNull()) {
+                values.add(value.asText());
+            }
+        });
+        return values;
+    }
+
+    private static Long epochMillis(String timestamp) {
+        if (timestamp == null) {
+            return null;
+        }
+        try {
+            // the reporter writes an offset date-time ("…+02:00"), not a bare instant
+            return OffsetDateTime.parse(timestamp).toInstant().toEpochMilli();
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    private static Long asLongOrNull(JsonNode node) {
+        return node == null || node.isNull() ? null : node.asLong();
+    }
+
+    private static Integer asIntOrNull(JsonNode node) {
+        return node == null || node.isNull() ? null : node.asInt();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsQueryAdapter.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.log.adapter.authz;
+
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Aggs.SORT;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Keys.BOOL;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Keys.FILTER;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Keys.QUERY;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Keys.SIZE;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Keys.TIMESTAMP;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Keys.TRACK_TOTAL_HITS;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Query.GTE;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Query.LTE;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Query.RANGE;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Query.TERM;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Sort.DESC;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Tokens.TERMS;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLogQuery;
+
+/**
+ * @author GraviteeSource Team
+ */
+public final class SearchAuthzDecisionLogsQueryAdapter {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String FROM = "from";
+    private static final String ORDER = "order";
+    private static final String ASC = "asc";
+    private static final String UNMAPPED_TYPE = "unmapped_type";
+    private static final String KEYWORD = "keyword";
+
+    private SearchAuthzDecisionLogsQueryAdapter() {}
+
+    public static String adapt(AuthzDecisionLogQuery query) {
+        ArrayNode filters = MAPPER.createArrayNode();
+        // The event-metrics data stream is shared by every BaseEventMetrics subtype (api, application,
+        // topic, operation, authz), so this term is what makes the result set decisions and nothing else.
+        filters.add(MAPPER.createObjectNode().set(TERM, MAPPER.createObjectNode().put(AuthzDecisionLogFields.DOC_TYPE, "authz")));
+
+        ArrayNode apiIds = MAPPER.createArrayNode();
+        query.getApiIds().forEach(apiIds::add);
+        filters.add(MAPPER.createObjectNode().set(TERMS, MAPPER.createObjectNode().set(AuthzDecisionLogFields.API_ID, apiIds)));
+
+        if (query.getFrom() != null || query.getTo() != null) {
+            ObjectNode bounds = MAPPER.createObjectNode();
+            if (query.getFrom() != null) {
+                bounds.put(GTE, query.getFrom());
+            }
+            if (query.getTo() != null) {
+                bounds.put(LTE, query.getTo());
+            }
+            filters.add(MAPPER.createObjectNode().set(RANGE, MAPPER.createObjectNode().set(TIMESTAMP, bounds)));
+        }
+
+        ObjectNode root = MAPPER.createObjectNode();
+        root.set(QUERY, MAPPER.createObjectNode().set(BOOL, MAPPER.createObjectNode().set(FILTER, filters)));
+        root.put(FROM, (query.getPage() - 1) * query.getSize());
+        root.put(SIZE, query.getSize());
+        root.put(TRACK_TOTAL_HITS, true);
+        // event-id breaks ties: a batch stamps every decision with the same millisecond, and ordering
+        // within a tie is not stable across shards, so paging without it repeats and skips rows.
+        root.set(
+            SORT,
+            MAPPER.createArrayNode()
+                .add(MAPPER.createObjectNode().set(TIMESTAMP, MAPPER.createObjectNode().put(ORDER, DESC)))
+                .add(
+                    MAPPER.createObjectNode().set(
+                        AuthzDecisionLogFields.EVENT_ID,
+                        MAPPER.createObjectNode().put(ORDER, ASC).put(UNMAPPED_TYPE, KEYWORD)
+                    )
+                )
+        );
+
+        return root.toString();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsResponseAdapter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.log.adapter.authz;
+
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.repository.log.v4.model.LogResponse;
+import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLog;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public final class SearchAuthzDecisionLogsResponseAdapter {
+
+    private SearchAuthzDecisionLogsResponseAdapter() {}
+
+    public static LogResponse<AuthzDecisionLog> adapt(SearchResponse response) {
+        var hits = response.getSearchHits();
+        if (hits == null || hits.getHits() == null) {
+            return new LogResponse<>(0, List.of());
+        }
+        var total = hits.getTotal() == null ? 0 : hits.getTotal().getValue();
+        return new LogResponse<>(
+            total,
+            hits
+                .getHits()
+                .stream()
+                .map(hit -> AuthzDecisionLogSourceMapper.from(hit.getSource()))
+                .toList()
+        );
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsQueryAdapterTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.log.adapter.authz;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLogQuery;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SearchAuthzDecisionLogsQueryAdapterTest {
+
+    @Test
+    void builds_a_paginated_query_filtered_by_doc_type_api_ids_and_timestamp_range() {
+        var query = AuthzDecisionLogQuery.builder().apiIds(Set.of("api-1")).from(1000L).to(2000L).page(2).size(10).build();
+
+        var result = SearchAuthzDecisionLogsQueryAdapter.adapt(query);
+
+        assertThatJson(result).isEqualTo(
+            """
+            {
+              "query": {
+                "bool": {
+                  "filter": [
+                    { "term": { "doc-type": "authz" } },
+                    { "terms": { "api-id": ["api-1"] } },
+                    { "range": { "@timestamp": { "gte": 1000, "lte": 2000 } } }
+                  ]
+                }
+              },
+              "from": 10,
+              "size": 10,
+              "track_total_hits": true,
+              "sort": [
+                { "@timestamp": { "order": "desc" } },
+                { "event-id": { "order": "asc", "unmapped_type": "keyword" } }
+              ]
+            }
+            """
+        );
+    }
+
+    @Test
+    void pins_doc_type_so_the_shared_event_metrics_stream_yields_decisions_only() {
+        var query = AuthzDecisionLogQuery.builder().apiIds(Set.of("api-1")).build();
+
+        var result = SearchAuthzDecisionLogsQueryAdapter.adapt(query);
+
+        assertThatJson(result).inPath("$.query.bool.filter[0].term.doc-type").isEqualTo("authz");
+    }
+
+    @Test
+    void breaks_timestamp_ties_on_event_id_so_paging_cannot_repeat_or_skip_a_decision() {
+        var query = AuthzDecisionLogQuery.builder().apiIds(Set.of("api-1")).build();
+
+        var result = SearchAuthzDecisionLogsQueryAdapter.adapt(query);
+
+        assertThatJson(result)
+            .inPath("$.sort[1]")
+            .isEqualTo(
+                """
+                { "event-id": { "order": "asc", "unmapped_type": "keyword" } }
+                """
+            );
+    }
+
+    @Test
+    void omits_the_timestamp_range_when_no_bound_is_given() {
+        var query = AuthzDecisionLogQuery.builder().apiIds(Set.of("api-1")).build();
+
+        var result = SearchAuthzDecisionLogsQueryAdapter.adapt(query);
+
+        assertThatJson(result).inPath("$.query.bool.filter").isArray().hasSize(2);
+        assertThatJson(result).inPath("$.from").isEqualTo(0);
+        assertThatJson(result).inPath("$.size").isEqualTo(20);
+    }
+
+    @Test
+    void keeps_an_open_ended_range_when_only_one_bound_is_given() {
+        var query = AuthzDecisionLogQuery.builder().apiIds(Set.of("api-1")).from(1000L).build();
+
+        var result = SearchAuthzDecisionLogsQueryAdapter.adapt(query);
+
+        assertThatJson(result)
+            .inPath("$.query.bool.filter[2].range.@timestamp")
+            .isEqualTo(
+                """
+                { "gte": 1000 }
+                """
+            );
+    }
+
+    @Test
+    void rejects_a_query_that_would_read_across_every_api() {
+        var query = AuthzDecisionLogQuery.builder().apiIds(Set.of()).build();
+
+        assertThatThrownBy(query::validate).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("apiIds");
+    }
+
+    @Test
+    void rejects_an_inverted_time_range() {
+        var query = AuthzDecisionLogQuery.builder().apiIds(Set.of("api-1")).from(2000L).to(1000L).build();
+
+        assertThatThrownBy(query::validate).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("from must be <= to");
+    }
+
+    @Test
+    void rejects_a_page_larger_than_the_maximum() {
+        var query = AuthzDecisionLogQuery.builder().apiIds(Set.of("api-1")).size(AuthzDecisionLogQuery.MAX_SIZE + 1).build();
+
+        assertThatThrownBy(query::validate).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("size must be <= 1000");
+    }
+
+    @Test
+    void accepts_a_page_at_the_maximum() {
+        var query = AuthzDecisionLogQuery.builder().apiIds(Set.of("api-1")).size(AuthzDecisionLogQuery.MAX_SIZE).build();
+
+        assertThatCode(query::validate).doesNotThrowAnyException();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsResponseAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsResponseAdapterTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.log.adapter.authz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.elasticsearch.model.SearchHit;
+import io.gravitee.elasticsearch.model.SearchHits;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.elasticsearch.model.TotalHits;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SearchAuthzDecisionLogsResponseAdapterTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void returns_an_empty_response_when_the_search_had_no_hits() {
+        var response = SearchAuthzDecisionLogsResponseAdapter.adapt(new SearchResponse());
+
+        assertThat(response.data()).isEmpty();
+        assertThat(response.total()).isZero();
+    }
+
+    @Test
+    @SneakyThrows
+    void carries_identity_request_and_outcome_of_an_evaluation() {
+        var response = responseOf(
+            """
+            {
+              "@timestamp": "2026-08-05T12:03:00.123+02:00",
+              "doc-type": "authz",
+              "event-id": "evt-1",
+              "api-id": "api-1",
+              "org-id": "org-1",
+              "env-id": "env-1",
+              "gw-id": "gateway-1",
+              "request-id": "req-1",
+              "operation": "evaluate",
+              "status": "success",
+              "caller": "pep",
+              "target-pdp-id": "pdp-1",
+              "policy-generation": 7,
+              "decision": "PERMIT",
+              "matched-policies": [
+                { "id": "p1", "name": "allow-readers", "effect": "PERMIT" },
+                { "id": "p2", "name": "allow-admins", "effect": "PERMIT" }
+              ],
+              "reasons": ["Permitted by policy 'allow-readers'"],
+              "subject-type": "User",
+              "subject-id": "alice",
+              "action": "read",
+              "resource-type": "Document",
+              "resource-id": "doc-1",
+              "duration-nanos": 4200
+            }
+            """,
+            3L
+        );
+
+        var result = SearchAuthzDecisionLogsResponseAdapter.adapt(response);
+
+        assertThat(result.total()).isEqualTo(3L);
+        assertThat(result.data()).hasSize(1);
+        var decision = result.data().getFirst();
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(decision.eventId()).isEqualTo("evt-1");
+            soft.assertThat(decision.timestamp()).isEqualTo(1785924180123L);
+            soft.assertThat(decision.apiId()).isEqualTo("api-1");
+            soft.assertThat(decision.organizationId()).isEqualTo("org-1");
+            soft.assertThat(decision.environmentId()).isEqualTo("env-1");
+            soft.assertThat(decision.gatewayId()).isEqualTo("gateway-1");
+            soft.assertThat(decision.requestId()).isEqualTo("req-1");
+            soft.assertThat(decision.operation()).isEqualTo("evaluate");
+            soft.assertThat(decision.status()).isEqualTo("success");
+            soft.assertThat(decision.caller()).isEqualTo("pep");
+            soft.assertThat(decision.targetPdpId()).isEqualTo("pdp-1");
+            soft.assertThat(decision.policyGeneration()).isEqualTo(7L);
+            soft.assertThat(decision.decision()).isEqualTo("PERMIT");
+            soft.assertThat(decision.matchedPolicyNames()).containsExactly("allow-readers", "allow-admins");
+            soft.assertThat(decision.reasons()).containsExactly("Permitted by policy 'allow-readers'");
+            soft.assertThat(decision.subjectType()).isEqualTo("User");
+            soft.assertThat(decision.subjectId()).isEqualTo("alice");
+            soft.assertThat(decision.action()).isEqualTo("read");
+            soft.assertThat(decision.resourceType()).isEqualTo("Document");
+            soft.assertThat(decision.resourceId()).isEqualTo("doc-1");
+            soft.assertThat(decision.durationNanos()).isEqualTo(4200L);
+        });
+    }
+
+    @Test
+    @SneakyThrows
+    void carries_the_batch_position_and_the_search_result_shape() {
+        var response = responseOf(
+            """
+            {
+              "@timestamp": "2026-08-05T10:03:00.000Z",
+              "event-id": "evt-2",
+              "operation": "search",
+              "status": "success",
+              "batch-id": "batch-1",
+              "batch-index": 1,
+              "batch-size": 2,
+              "search-type": "subject",
+              "result-count": 12
+            }
+            """,
+            1L
+        );
+
+        var decision = SearchAuthzDecisionLogsResponseAdapter.adapt(response).data().getFirst();
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(decision.batchId()).isEqualTo("batch-1");
+            soft.assertThat(decision.batchIndex()).isEqualTo(1);
+            soft.assertThat(decision.batchSize()).isEqualTo(2);
+            soft.assertThat(decision.searchType()).isEqualTo("subject");
+            soft.assertThat(decision.resultCount()).isEqualTo(12);
+        });
+    }
+
+    @Test
+    @SneakyThrows
+    void leaves_absent_fields_null_and_absent_lists_empty() {
+        var response = responseOf(
+            """
+            { "event-id": "evt-3" }
+            """,
+            1L
+        );
+
+        var decision = SearchAuthzDecisionLogsResponseAdapter.adapt(response).data().getFirst();
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(decision.timestamp()).isNull();
+            soft.assertThat(decision.decision()).isNull();
+            soft.assertThat(decision.policyGeneration()).isNull();
+            soft.assertThat(decision.batchIndex()).isNull();
+            soft.assertThat(decision.matchedPolicyNames()).isEmpty();
+            soft.assertThat(decision.reasons()).isEmpty();
+        });
+    }
+
+    @Test
+    @SneakyThrows
+    void drops_a_matched_policy_that_carries_no_name_rather_than_reporting_a_null_row() {
+        var response = responseOf(
+            """
+            {
+              "event-id": "evt-4",
+              "matched-policies": [{ "id": "p1" }, { "id": "p2", "name": "allow-admins" }]
+            }
+            """,
+            1L
+        );
+
+        var decision = SearchAuthzDecisionLogsResponseAdapter.adapt(response).data().getFirst();
+
+        assertThat(decision.matchedPolicyNames()).containsExactly("allow-admins");
+    }
+
+    @Test
+    @SneakyThrows
+    void reports_no_timestamp_rather_than_failing_the_page_when_the_stamp_is_unreadable() {
+        var response = responseOf(
+            """
+            { "event-id": "evt-5", "@timestamp": "not-a-date" }
+            """,
+            1L
+        );
+
+        var decision = SearchAuthzDecisionLogsResponseAdapter.adapt(response).data().getFirst();
+
+        assertThat(decision.timestamp()).isNull();
+        assertThat(decision.eventId()).isEqualTo("evt-5");
+    }
+
+    @SneakyThrows
+    private SearchResponse responseOf(String source, long total) {
+        var response = new SearchResponse();
+        var hits = new SearchHits();
+        var hit = new SearchHit();
+        hit.setSource(objectMapper.readTree(source));
+        hits.setHits(List.of(hit));
+        hits.setTotal(new TotalHits(total));
+        response.setSearchHits(hits);
+        return response;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpMetricsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpMetricsRepository.java
@@ -19,6 +19,8 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.v4.api.MetricsRepository;
 import io.gravitee.repository.log.v4.model.LogResponse;
+import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLog;
+import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLogQuery;
 import io.gravitee.repository.log.v4.model.connection.Metrics;
 import io.gravitee.repository.log.v4.model.connection.MetricsQuery;
 import io.gravitee.repository.log.v4.model.connection.NativeApiMetrics;
@@ -54,5 +56,10 @@ public class NoOpMetricsRepository implements MetricsRepository {
     @Override
     public LogResponse<NativeApiMetrics> searchNativeApiMetrics(QueryContext queryContext, NativeApiMetricsQuery query) {
         return new LogResponse<>(0L, new ArrayList<>());
+    }
+
+    @Override
+    public LogResponse<AuthzDecisionLog> searchAuthzDecisionLogs(QueryContext queryContext, AuthzDecisionLogQuery query) {
+        return new LogResponse<>(0, List.of());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/crud_service/AuthzDecisionLogsCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/crud_service/AuthzDecisionLogsCrudService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.log.crud_service;
+
+import io.gravitee.apim.core.log.model.AuthzDecisionLog;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Set;
+
+/**
+ * Reads authorization outcomes from the event-metrics data stream. Separate from
+ * {@link ConnectionLogsCrudService} because a decision is not an HTTP exchange and lives in a
+ * different index.
+ *
+ * @author GraviteeSource Team
+ */
+public interface AuthzDecisionLogsCrudService {
+    SearchLogsResponse<AuthzDecisionLog> searchDecisionLogs(
+        ExecutionContext executionContext,
+        Set<String> apiIds,
+        Long from,
+        Long to,
+        Pageable pageable
+    );
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/model/AuthzDecisionLog.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/model/AuthzDecisionLog.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.log.model;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AuthzDecisionLog(
+    String eventId,
+    Long timestamp,
+    String apiId,
+    String organizationId,
+    String environmentId,
+    String gatewayId,
+    String requestId,
+    String operation,
+    String status,
+    String caller,
+    String targetPdpId,
+    Long policyGeneration,
+    String decision,
+    List<String> matchedPolicyNames,
+    List<String> reasons,
+    String subjectType,
+    String subjectId,
+    String action,
+    String resourceType,
+    String resourceId,
+    String batchId,
+    Integer batchIndex,
+    Integer batchSize,
+    String searchType,
+    Integer resultCount,
+    Long durationNanos
+) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/AuthzDecisionLogsCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/AuthzDecisionLogsCrudServiceImpl.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.log;
+
+import io.gravitee.apim.core.log.crud_service.AuthzDecisionLogsCrudService;
+import io.gravitee.apim.core.log.model.AuthzDecisionLog;
+import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.log.v4.api.MetricsRepository;
+import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLogQuery;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.List;
+import java.util.Set;
+import lombok.CustomLog;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component
+@CustomLog
+class AuthzDecisionLogsCrudServiceImpl implements AuthzDecisionLogsCrudService {
+
+    private final MetricsRepository metricsRepository;
+
+    public AuthzDecisionLogsCrudServiceImpl(@Lazy MetricsRepository metricsRepository) {
+        this.metricsRepository = metricsRepository;
+    }
+
+    @Override
+    public SearchLogsResponse<AuthzDecisionLog> searchDecisionLogs(
+        ExecutionContext executionContext,
+        Set<String> apiIds,
+        Long from,
+        Long to,
+        Pageable pageable
+    ) {
+        if (apiIds == null || apiIds.isEmpty()) {
+            return new SearchLogsResponse<>(0, List.of());
+        }
+        try {
+            var response = metricsRepository.searchAuthzDecisionLogs(
+                new QueryContext(executionContext.getOrganizationId(), executionContext.getEnvironmentId()),
+                AuthzDecisionLogQuery.builder()
+                    .apiIds(apiIds)
+                    .from(from)
+                    .to(to)
+                    .page(pageable.getPageNumber())
+                    .size(pageable.getPageSize())
+                    .build()
+            );
+            return new SearchLogsResponse<>(
+                response.total(),
+                response.data().stream().map(AuthzDecisionLogsCrudServiceImpl::toDomain).toList()
+            );
+        } catch (AnalyticsException e) {
+            log.error("An error occurs while trying to search authz decision logs [apiIds={}]", apiIds, e);
+            throw new TechnicalManagementException("Unable to search authz decision logs", e);
+        }
+    }
+
+    private static AuthzDecisionLog toDomain(io.gravitee.repository.log.v4.model.authz.AuthzDecisionLog decision) {
+        return AuthzDecisionLog.builder()
+            .eventId(decision.eventId())
+            .timestamp(decision.timestamp())
+            .apiId(decision.apiId())
+            .organizationId(decision.organizationId())
+            .environmentId(decision.environmentId())
+            .gatewayId(decision.gatewayId())
+            .requestId(decision.requestId())
+            .operation(decision.operation())
+            .status(decision.status())
+            .caller(decision.caller())
+            .targetPdpId(decision.targetPdpId())
+            .policyGeneration(decision.policyGeneration())
+            .decision(decision.decision())
+            .matchedPolicyNames(decision.matchedPolicyNames())
+            .reasons(decision.reasons())
+            .subjectType(decision.subjectType())
+            .subjectId(decision.subjectId())
+            .action(decision.action())
+            .resourceType(decision.resourceType())
+            .resourceId(decision.resourceId())
+            .batchId(decision.batchId())
+            .batchIndex(decision.batchIndex())
+            .batchSize(decision.batchSize())
+            .searchType(decision.searchType())
+            .resultCount(decision.resultCount())
+            .durationNanos(decision.durationNanos())
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/log/AuthzDecisionLogsCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/log/AuthzDecisionLogsCrudServiceImplTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.log.crud_service.AuthzDecisionLogsCrudService;
+import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.log.v4.api.MetricsRepository;
+import io.gravitee.repository.log.v4.model.LogResponse;
+import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLogQuery;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.List;
+import java.util.Set;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AuthzDecisionLogsCrudServiceImplTest {
+
+    private static final ExecutionContext CONTEXT = new ExecutionContext("org-1", "env-1");
+
+    private MetricsRepository metricsRepository;
+    private AuthzDecisionLogsCrudService service;
+
+    @BeforeEach
+    void setUp() {
+        metricsRepository = mock(MetricsRepository.class);
+        service = new AuthzDecisionLogsCrudServiceImpl(metricsRepository);
+    }
+
+    @Test
+    void does_not_query_the_index_when_no_api_is_in_scope() throws Exception {
+        var response = service.searchDecisionLogs(CONTEXT, Set.of(), null, null, new PageableImpl(1, 20));
+
+        assertThat(response.total()).isZero();
+        assertThat(response.logs()).isEmpty();
+        verify(metricsRepository, never()).searchAuthzDecisionLogs(any(), any());
+    }
+
+    @Test
+    void carries_the_scope_the_range_and_the_page_into_the_query() throws Exception {
+        when(metricsRepository.searchAuthzDecisionLogs(any(), any())).thenReturn(new LogResponse<>(0L, List.of()));
+
+        service.searchDecisionLogs(CONTEXT, Set.of("api-1", "api-2"), 1000L, 2000L, new PageableImpl(3, 50));
+
+        var contextCaptor = ArgumentCaptor.forClass(QueryContext.class);
+        var queryCaptor = ArgumentCaptor.forClass(AuthzDecisionLogQuery.class);
+        verify(metricsRepository).searchAuthzDecisionLogs(contextCaptor.capture(), queryCaptor.capture());
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(contextCaptor.getValue().placeholder()).containsEntry("orgId", "org-1").containsEntry("envId", "env-1");
+            soft.assertThat(queryCaptor.getValue().getApiIds()).containsExactlyInAnyOrder("api-1", "api-2");
+            soft.assertThat(queryCaptor.getValue().getFrom()).isEqualTo(1000L);
+            soft.assertThat(queryCaptor.getValue().getTo()).isEqualTo(2000L);
+            soft.assertThat(queryCaptor.getValue().getPage()).isEqualTo(3);
+            soft.assertThat(queryCaptor.getValue().getSize()).isEqualTo(50);
+        });
+    }
+
+    @Test
+    void maps_the_carrier_record_onto_the_domain_projection() throws Exception {
+        when(metricsRepository.searchAuthzDecisionLogs(any(), any())).thenReturn(
+            new LogResponse<>(
+                9L,
+                List.of(
+                    io.gravitee.repository.log.v4.model.authz.AuthzDecisionLog.builder()
+                        .eventId("evt-1")
+                        .timestamp(1000L)
+                        .apiId("api-1")
+                        .organizationId("org-1")
+                        .environmentId("env-1")
+                        .gatewayId("gateway-1")
+                        .requestId("req-1")
+                        .operation("evaluate")
+                        .status("success")
+                        .caller("pep")
+                        .targetPdpId("pdp-1")
+                        .policyGeneration(7L)
+                        .decision("PERMIT")
+                        .matchedPolicyNames(List.of("allow-readers"))
+                        .reasons(List.of("Permitted by policy 'allow-readers'"))
+                        .subjectType("User")
+                        .subjectId("alice")
+                        .action("read")
+                        .resourceType("Document")
+                        .resourceId("doc-1")
+                        .batchId("batch-1")
+                        .batchIndex(1)
+                        .batchSize(2)
+                        .searchType("subject")
+                        .resultCount(12)
+                        .durationNanos(4200L)
+                        .build()
+                )
+            )
+        );
+
+        var response = service.searchDecisionLogs(CONTEXT, Set.of("api-1"), null, null, new PageableImpl(1, 20));
+
+        assertThat(response.total()).isEqualTo(9L);
+        var decision = response.logs().getFirst();
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(decision.eventId()).isEqualTo("evt-1");
+            soft.assertThat(decision.timestamp()).isEqualTo(1000L);
+            soft.assertThat(decision.apiId()).isEqualTo("api-1");
+            soft.assertThat(decision.organizationId()).isEqualTo("org-1");
+            soft.assertThat(decision.environmentId()).isEqualTo("env-1");
+            soft.assertThat(decision.gatewayId()).isEqualTo("gateway-1");
+            soft.assertThat(decision.requestId()).isEqualTo("req-1");
+            soft.assertThat(decision.operation()).isEqualTo("evaluate");
+            soft.assertThat(decision.status()).isEqualTo("success");
+            soft.assertThat(decision.caller()).isEqualTo("pep");
+            soft.assertThat(decision.targetPdpId()).isEqualTo("pdp-1");
+            soft.assertThat(decision.policyGeneration()).isEqualTo(7L);
+            soft.assertThat(decision.decision()).isEqualTo("PERMIT");
+            soft.assertThat(decision.matchedPolicyNames()).containsExactly("allow-readers");
+            soft.assertThat(decision.reasons()).containsExactly("Permitted by policy 'allow-readers'");
+            soft.assertThat(decision.subjectType()).isEqualTo("User");
+            soft.assertThat(decision.subjectId()).isEqualTo("alice");
+            soft.assertThat(decision.action()).isEqualTo("read");
+            soft.assertThat(decision.resourceType()).isEqualTo("Document");
+            soft.assertThat(decision.resourceId()).isEqualTo("doc-1");
+            soft.assertThat(decision.batchId()).isEqualTo("batch-1");
+            soft.assertThat(decision.batchIndex()).isEqualTo(1);
+            soft.assertThat(decision.batchSize()).isEqualTo(2);
+            soft.assertThat(decision.searchType()).isEqualTo("subject");
+            soft.assertThat(decision.resultCount()).isEqualTo(12);
+            soft.assertThat(decision.durationNanos()).isEqualTo(4200L);
+        });
+    }
+
+    @Test
+    void turns_a_repository_failure_into_a_technical_management_exception() throws Exception {
+        when(metricsRepository.searchAuthzDecisionLogs(any(), any())).thenThrow(new AnalyticsException("index unavailable"));
+
+        assertThatThrownBy(() -> service.searchDecisionLogs(CONTEXT, Set.of("api-1"), null, null, new PageableImpl(1, 20)))
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessageContaining("authz decision logs");
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/ApiType.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/ApiType.java
@@ -38,7 +38,8 @@ public enum ApiType {
     MCP("MCP"),
     A2A("A2A"),
     NATIVE("Kafka (native)"),
-    EDGE("Edge");
+    EDGE("Edge"),
+    AUTHZ("Authz decision");
 
     private final String label;
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/ExtensibleFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/ExtensibleFilters.java
@@ -39,7 +39,11 @@ import java.util.Set;
  */
 public enum ExtensibleFilters {
     // signals = served today (logs + analytics); traces join in a later lot. Cross-cutting on every API kind.
-    API_TYPE("API Type", Set.of(Signal.LOGS, Signal.ANALYTICS), ApiType.ALL);
+    API_TYPE("API Type", Set.of(Signal.LOGS, Signal.ANALYTICS), ApiType.ALL),
+    // Which document contract the rows come from. Every reportable in the event-metrics data stream
+    // answers BaseEventMetrics#getDocumentType, so this is the axis that separates decisions from
+    // request logs — API_TYPE cannot, since a decision is attached to the API it guarded, of any kind.
+    RECORD_TYPE("Record Type", Set.of(Signal.LOGS), ApiType.ALL);
 
     private final String label;
     private final Set<Signal> signals;
@@ -64,6 +68,9 @@ public enum ExtensibleFilters {
         return switch (this) {
             // TODO(GMA-421): remove API kinds here as their owning module becomes a contributor.
             case API_TYPE -> Arrays.stream(ApiType.values())
+                .map(t -> new FilterSpec.EnumValue(t.name(), t.label()))
+                .toList();
+            case RECORD_TYPE -> Arrays.stream(RecordType.values())
                 .map(t -> new FilterSpec.EnumValue(t.name(), t.label()))
                 .toList();
         };

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/RecordType.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/RecordType.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.model;
+
+/**
+ * Which document contract a logs row is read from. Orthogonal to {@link ApiType}: that one narrows
+ * <em>which APIs</em> are in scope, this one selects <em>what kind of record</em> is returned. A
+ * request log and an authorization decision share neither an index nor a shape.
+ *
+ * @author GraviteeSource Team
+ */
+public enum RecordType {
+    REQUEST("Request"),
+    AUTHZ_DECISION("Authz decision");
+
+    private final String label;
+
+    RecordType(String label) {
+        this.label = label;
+    }
+
+    /** Human-readable display label for this record kind. */
+    public String label() {
+        return label;
+    }
+
+    public static RecordType fromNameOrDefault(String value) {
+        if (value == null || value.isBlank()) {
+            return REQUEST;
+        }
+        try {
+            return valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return REQUEST;
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/AuthzDecision.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/AuthzDecision.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.model;
+
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * The authorization outcome carried by a decision row, present only when the search asked for
+ * {@code RECORD_TYPE=AUTHZ_DECISION}. Typed rather than folded into {@code additionalMetrics}: that
+ * map is the extension bag for keys plugins and custom policies attach at runtime, so a known
+ * contract placed there would be invisible to the OpenAPI schema and readable only by convention.
+ */
+@Builder
+public record AuthzDecision(
+    String eventId,
+    String decision,
+    String status,
+    String caller,
+    String operation,
+    String targetPdpId,
+    Long policyGeneration,
+    List<String> matchedPolicyNames,
+    List<String> reasons,
+    String subjectType,
+    String subjectId,
+    String action,
+    String resourceType,
+    String resourceId,
+    String batchId,
+    Integer batchIndex,
+    Integer batchSize,
+    String searchType,
+    Integer resultCount,
+    Long durationNanos
+) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogEntry.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogEntry.java
@@ -65,5 +65,6 @@ public record LogEntry(
     FailureOrigin failureOrigin,
     String clientId,
     String brokerId,
-    Long connectionDurationMs
+    Long connectionDurationMs,
+    AuthzDecision authz
 ) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogsSearchQuery.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogsSearchQuery.java
@@ -16,6 +16,7 @@
 package io.gravitee.gamma.rest.core.observability.logs.model;
 
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.RecordType;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,5 +39,6 @@ public record LogsSearchQuery(
     Long from,
     Long to,
     int page,
-    int perPage
+    int perPage,
+    RecordType recordType
 ) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
@@ -19,7 +19,9 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.gamma.rest.core.observability.filter.domain_service.ObservabilityFilterValidator;
 import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.filter.model.ExtensibleFilters;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.RecordType;
 import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
 import io.gravitee.gamma.rest.core.observability.logs.domain_service.AccessibleApiScopeDomainService;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
@@ -55,7 +57,14 @@ public class SearchObservabilityLogsUseCase {
      * widening this set — the rest of the pipeline (AccessibleApiScope, query building) adjusts
      * automatically.
      */
-    static final Set<ApiType> LOGS_SUPPORTED_API_TYPES = Set.of(ApiType.HTTP_PROXY, ApiType.LLM, ApiType.MCP, ApiType.A2A, ApiType.NATIVE);
+    static final Set<ApiType> LOGS_SUPPORTED_API_TYPES = Set.of(
+        ApiType.HTTP_PROXY,
+        ApiType.LLM,
+        ApiType.MCP,
+        ApiType.A2A,
+        ApiType.NATIVE,
+        ApiType.AUTHZ
+    );
 
     /**
      * Canonical entrypoints applied when no explicit entrypoint filter is set. The HTTP subset
@@ -101,6 +110,15 @@ public class SearchObservabilityLogsUseCase {
         filterValidator.validate(conditions, Signal.LOGS);
         validateTimeRange(input.from, input.to);
 
+        var recordType = extractRecordType(conditions);
+        var effectiveConditions = removeScopeConditions(conditions);
+        if (recordType == RecordType.AUTHZ_DECISION) {
+            rejectConditionsTheDecisionSearchCannotApply(effectiveConditions);
+        } else {
+            // Entrypoints only exist on request documents; injecting them would match nothing on a decision.
+            effectiveConditions = applyDefaultEntrypointScoping(effectiveConditions);
+        }
+
         var accessibleApis = logsDataPort.loadAccessibleApis(input.organizationId, input.environmentId);
 
         var userApiFilter = extractApiFilter(conditions);
@@ -111,8 +129,6 @@ public class SearchObservabilityLogsUseCase {
             return new Output(LogsPage.EMPTY, page, perPage);
         }
 
-        var effectiveConditions = applyDefaultEntrypointScoping(removeScopeConditions(conditions));
-
         var query = LogsSearchQuery.builder()
             .apiIds(scope.apiIds())
             .apisById(scope.apisById())
@@ -121,6 +137,7 @@ public class SearchObservabilityLogsUseCase {
             .to(input.to != null ? input.to.toEpochMilli() : null)
             .page(page)
             .perPage(perPage)
+            .recordType(recordType)
             .build();
 
         var result = logsDataPort.searchLogs(input.organizationId, input.environmentId, query);
@@ -138,6 +155,42 @@ public class SearchObservabilityLogsUseCase {
     private static void validateTimeRange(Instant from, Instant to) {
         if (from != null && to != null && from.isAfter(to)) {
             throw new ValidationDomainException("Invalid time range: 'from' must be before 'to'.");
+        }
+    }
+
+    /**
+     * Which document contract the caller wants. Absent means request logs, so every existing consumer
+     * keeps its behaviour untouched. A multi-valued condition is refused rather than truncated: the two
+     * record kinds live in different indices with different shapes, so asking for both is a second
+     * search, not a wider filter.
+     */
+    private static RecordType extractRecordType(List<FilterCondition> conditions) {
+        var values = conditions
+            .stream()
+            .filter(c -> ExtensibleFilters.RECORD_TYPE.filterName().equals(c.name()))
+            .flatMap(c -> c.values().stream())
+            .distinct()
+            .toList();
+        if (values.size() > 1) {
+            throw new ValidationDomainException(
+                "Filter 'RECORD_TYPE' accepts a single value, was " + values + ". Search one record kind at a time."
+            );
+        }
+        return values.stream().findFirst().map(RecordType::fromNameOrDefault).orElse(RecordType.REQUEST);
+    }
+
+    /**
+     * The decision search is scoped by api and time only, so any other condition would be accepted and
+     * then dropped — indistinguishable, to the caller, from a filter that matched everything.
+     */
+    private static void rejectConditionsTheDecisionSearchCannotApply(List<FilterCondition> conditions) {
+        var unsupported = conditions.stream().map(FilterCondition::name).distinct().sorted().toList();
+        if (!unsupported.isEmpty()) {
+            throw new ValidationDomainException(
+                "Filters " +
+                    unsupported +
+                    " do not apply to RECORD_TYPE=AUTHZ_DECISION. Only API, API_TYPE and the time range are supported."
+            );
         }
     }
 
@@ -178,7 +231,9 @@ public class SearchObservabilityLogsUseCase {
     private static List<FilterCondition> removeScopeConditions(List<FilterCondition> conditions) {
         return conditions
             .stream()
-            .filter(c -> !"API".equals(c.name()) && !"API_TYPE".equals(c.name()))
+            .filter(
+                c -> !"API".equals(c.name()) && !"API_TYPE".equals(c.name()) && !ExtensibleFilters.RECORD_TYPE.filterName().equals(c.name())
+            )
             .toList();
     }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
@@ -22,7 +22,9 @@ import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.gateway.model.BaseInstance;
 import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
+import io.gravitee.apim.core.log.crud_service.AuthzDecisionLogsCrudService;
 import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
+import io.gravitee.apim.core.log.model.AuthzDecisionLog;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
@@ -33,8 +35,10 @@ import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObs
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import io.gravitee.gamma.rest.core.observability.filter.model.RecordType;
 import io.gravitee.gamma.rest.core.observability.filter.model.StaticFilters;
 import io.gravitee.gamma.rest.core.observability.logs.model.ApiReference;
+import io.gravitee.gamma.rest.core.observability.logs.model.AuthzDecision;
 import io.gravitee.gamma.rest.core.observability.logs.model.HttpPayload;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogDetail;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
@@ -63,6 +67,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -94,6 +99,7 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
     private static final int HTTP_STATUS_MAX = HTTP_STATUS_RANGE.max().intValue();
 
     private final ConnectionLogsCrudService connectionLogsCrudService;
+    private final AuthzDecisionLogsCrudService authzDecisionLogsCrudService;
     private final AnalyticsQueryService analyticsQueryService;
     private final UserContextLoader userContextLoader;
     private final PlanCrudService planCrudService;
@@ -118,6 +124,10 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
     public LogsPage searchLogs(String organizationId, String environmentId, LogsSearchQuery query) {
         var executionContext = new ExecutionContext(organizationId, environmentId);
         var pageable = new PageableImpl(query.page(), query.perPage());
+
+        if (query.recordType() == RecordType.AUTHZ_DECISION) {
+            return searchDecisionLogs(executionContext, query, pageable);
+        }
 
         var searchFilters = buildSearchFilters(query);
         var result = connectionLogsCrudService.searchApiConnectionLogs(
@@ -387,6 +397,52 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
         builder.responseTimeRanges(responseTimeRanges);
 
         return builder.build();
+    }
+
+    private LogsPage searchDecisionLogs(ExecutionContext executionContext, LogsSearchQuery query, PageableImpl pageable) {
+        var result = authzDecisionLogsCrudService.searchDecisionLogs(executionContext, query.apiIds(), query.from(), query.to(), pageable);
+        var entries = result
+            .logs()
+            .stream()
+            .map(decision -> mapDecisionToLogEntry(decision, query.apisById()))
+            .toList();
+        return new LogsPage(entries, result.total());
+    }
+
+    private LogEntry mapDecisionToLogEntry(AuthzDecisionLog decision, Map<String, ApiReference> apisById) {
+        var apiRef = apisById != null ? apisById.get(decision.apiId()) : null;
+        return LogEntry.builder()
+            .apiId(decision.apiId())
+            .apiName(apiRef != null ? apiRef.name() : null)
+            .apiType(apiRef != null ? apiRef.apiType() : null)
+            .timestamp(decision.timestamp() == null ? null : Instant.ofEpochMilli(decision.timestamp()))
+            .requestId(decision.requestId())
+            .gateway(decision.gatewayId())
+            .authz(
+                AuthzDecision.builder()
+                    .eventId(decision.eventId())
+                    .decision(decision.decision())
+                    .status(decision.status())
+                    .caller(decision.caller())
+                    .operation(decision.operation())
+                    .targetPdpId(decision.targetPdpId())
+                    .policyGeneration(decision.policyGeneration())
+                    .matchedPolicyNames(decision.matchedPolicyNames())
+                    .reasons(decision.reasons())
+                    .subjectType(decision.subjectType())
+                    .subjectId(decision.subjectId())
+                    .action(decision.action())
+                    .resourceType(decision.resourceType())
+                    .resourceId(decision.resourceId())
+                    .batchId(decision.batchId())
+                    .batchIndex(decision.batchIndex())
+                    .batchSize(decision.batchSize())
+                    .searchType(decision.searchType())
+                    .resultCount(decision.resultCount())
+                    .durationNanos(decision.durationNanos())
+                    .build()
+            )
+            .build();
     }
 
     private LogEntry mapToLogEntry(BaseConnectionLog log, Map<String, ApiReference> apisById) {
@@ -671,7 +727,7 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
             case A2A_PROXY -> io.gravitee.gamma.rest.core.observability.filter.model.ApiType.A2A;
             case NATIVE -> io.gravitee.gamma.rest.core.observability.filter.model.ApiType.NATIVE;
             case EDGE -> io.gravitee.gamma.rest.core.observability.filter.model.ApiType.EDGE;
-            case AUTHZ -> null; // No Gamma observability equivalent — AUTHZ APIs are excluded from logs scope
+            case AUTHZ -> io.gravitee.gamma.rest.core.observability.filter.model.ApiType.AUTHZ;
         };
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaLogsConfiguration.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaLogsConfiguration.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
 import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
+import io.gravitee.apim.core.log.crud_service.AuthzDecisionLogsCrudService;
 import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
@@ -50,6 +51,7 @@ public class GammaLogsConfiguration {
     @Bean
     public ObservabilityLogsDataPort observabilityLogsDataPort(
         ConnectionLogsCrudService connectionLogsCrudService,
+        AuthzDecisionLogsCrudService authzDecisionLogsCrudService,
         AnalyticsQueryService analyticsQueryService,
         UserContextLoader userContextLoader,
         PlanCrudService planCrudService,
@@ -59,6 +61,7 @@ public class GammaLogsConfiguration {
     ) {
         return new ObservabilityLogsDataPortAdapter(
             connectionLogsCrudService,
+            authzDecisionLogsCrudService,
             analyticsQueryService,
             userContextLoader,
             planCrudService,

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/LogEntryDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/LogEntryDto.java
@@ -16,6 +16,7 @@
 package io.gravitee.gamma.rest.resources.observability.logs.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.gravitee.gamma.rest.core.observability.logs.model.AuthzDecision;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogEntryWarning;
 import java.util.List;
@@ -70,12 +71,62 @@ public record LogEntryDto(
     String failureOrigin,
     String clientId,
     String brokerId,
-    Long connectionDurationMs
+    Long connectionDurationMs,
+    AuthzDecisionDto authz
 ) {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record WarningDto(String componentType, String componentName, String key, String message) {
         public static WarningDto from(LogEntryWarning w) {
             return new WarningDto(w.componentType(), w.componentName(), w.key(), w.message());
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record AuthzDecisionDto(
+        String eventId,
+        String decision,
+        String status,
+        String caller,
+        String operation,
+        String targetPdpId,
+        Long policyGeneration,
+        List<String> matchedPolicyNames,
+        List<String> reasons,
+        String subjectType,
+        String subjectId,
+        String action,
+        String resourceType,
+        String resourceId,
+        String batchId,
+        Integer batchIndex,
+        Integer batchSize,
+        String searchType,
+        Integer resultCount,
+        Long durationNanos
+    ) {
+        public static AuthzDecisionDto from(AuthzDecision authz) {
+            return new AuthzDecisionDto(
+                authz.eventId(),
+                authz.decision(),
+                authz.status(),
+                authz.caller(),
+                authz.operation(),
+                authz.targetPdpId(),
+                authz.policyGeneration(),
+                authz.matchedPolicyNames(),
+                authz.reasons(),
+                authz.subjectType(),
+                authz.subjectId(),
+                authz.action(),
+                authz.resourceType(),
+                authz.resourceId(),
+                authz.batchId(),
+                authz.batchIndex(),
+                authz.batchSize(),
+                authz.searchType(),
+                authz.resultCount(),
+                authz.durationNanos()
+            );
         }
     }
 
@@ -115,7 +166,8 @@ public record LogEntryDto(
             entry.failureOrigin() != null ? entry.failureOrigin().name() : null,
             entry.clientId(),
             entry.brokerId(),
-            entry.connectionDurationMs()
+            entry.connectionDurationMs(),
+            entry.authz() != null ? AuthzDecisionDto.from(entry.authz()) : null
         );
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -536,10 +536,22 @@ paths:
                 are rejected with 400. Use `GET /observability/filters/definition?signal=LOGS` to
                 discover valid filters.
 
+                **Record kind**: the `RECORD_TYPE` filter selects which document contract the rows
+                are read from — `REQUEST` (the default when the filter is absent) or
+                `AUTHZ_DECISION`. Decisions are read from a different index with a different shape,
+                so the two cannot be mixed: a multi-valued `RECORD_TYPE` is rejected with 400 rather
+                than resolved to one of them. Decision rows carry the `authz` object and omit the
+                request-shaped fields; request rows carry neither.
+
+                The decision search is scoped by API and time range only. Any other condition sent
+                alongside `RECORD_TYPE=AUTHZ_DECISION` is rejected with 400 rather than accepted and
+                ignored, so an applied filter is never indistinguishable from an unfiltered result.
+
                 **Default entrypoint scoping**: when no explicit `ENTRYPOINT` filter is supplied,
                 the server injects the canonical HTTP entrypoints (`http-get`, `http-post`,
                 `http-proxy`, `llm-proxy`, `mcp-proxy`) so log table totals match the analytics
-                dashboard for the same time range.
+                dashboard for the same time range. Skipped for decision rows, which carry no
+                entrypoint.
 
                 **Enrichment**: each log entry is enriched server-side with display names for API,
                 plan, application, gateway hostname, and API product. Use the `resolve` endpoint
@@ -1831,6 +1843,88 @@ components:
                     type: string
                     description: Display name of the API product (enriched server-side). Returns `"Standalone API"` when the API has no product.
                     example: "Standalone API"
+                authz:
+                    $ref: "#/components/schemas/AuthzDecision"
+
+        AuthzDecision:
+            type: object
+            description: |
+                The authorization outcome carried by a decision row. Present only on rows returned for
+                `RECORD_TYPE=AUTHZ_DECISION`, and absent entirely on request logs. A decision is not an
+                HTTP exchange, so the request-shaped fields of `LogEntry` (`method`, `status`, `uri`,
+                `gatewayResponseTime`) are absent on these rows.
+            properties:
+                eventId:
+                    type: string
+                    description: Identifier of the decision event, unique per evaluated decision.
+                decision:
+                    type: string
+                    description: The authorization outcome the PDP returned.
+                    example: "PERMIT"
+                status:
+                    type: string
+                    description: Whether the evaluation itself completed, independently of its outcome.
+                    example: "success"
+                caller:
+                    type: string
+                    description: Which component asked for the decision.
+                    example: "pep"
+                operation:
+                    type: string
+                    description: The kind of call made to the PDP.
+                    example: "evaluate"
+                targetPdpId:
+                    type: string
+                    description: Identifier of the PDP that evaluated the request.
+                policyGeneration:
+                    type: integer
+                    format: int64
+                    description: Generation of the policy set the decision was evaluated against.
+                matchedPolicyNames:
+                    type: array
+                    description: Names of the policies that matched during evaluation.
+                    items:
+                        type: string
+                reasons:
+                    type: array
+                    description: Diagnostics explaining the outcome.
+                    items:
+                        type: string
+                subjectType:
+                    type: string
+                    description: Entity type of the principal the decision was taken for.
+                subjectId:
+                    type: string
+                    description: Identifier of the principal the decision was taken for.
+                action:
+                    type: string
+                    description: The action the principal attempted.
+                resourceType:
+                    type: string
+                    description: Entity type of the resource the action targeted.
+                resourceId:
+                    type: string
+                    description: Identifier of the resource the action targeted.
+                batchId:
+                    type: string
+                    description: Identifier shared by every decision of one batch evaluation.
+                batchIndex:
+                    type: integer
+                    description: Position of this decision within its batch.
+                batchSize:
+                    type: integer
+                    description: Number of decisions in the batch.
+                searchType:
+                    type: string
+                    description: Which search the PDP ran, for search records rather than evaluations.
+                resultCount:
+                    type: integer
+                    description: Number of results a search record returned.
+                durationNanos:
+                    type: integer
+                    format: int64
+                    description: Time the PDP spent evaluating, in nanoseconds.
+                    example: 431000
 
         LogEntryWarning:
             type: object

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/SpiFilterRegistryTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/SpiFilterRegistryTest.java
@@ -182,7 +182,8 @@ class SpiFilterRegistryTest {
                 "TRANSACTION_ID",
                 "NATIVE_CONNECTION_STATUS",
                 "FAILURE_ORIGIN",
-                "API_TYPE"
+                "API_TYPE",
+                "RECORD_TYPE"
             );
     }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCaseTest.java
@@ -42,7 +42,7 @@ class GetObservabilityFilterValuesUseCaseTest {
     void should_return_enum_values_with_labels_for_an_enum_filter() {
         var output = useCase.execute(new GetObservabilityFilterValuesUseCase.Input("API_TYPE", null, null, null, null, null));
 
-        assertThat(output.values().totalElements()).isEqualTo(7L);
+        assertThat(output.values().totalElements()).isEqualTo(8L);
         assertThat(output.values().data())
             .extracting(FilterValue::value, FilterValue::label)
             .contains(
@@ -67,7 +67,7 @@ class GetObservabilityFilterValuesUseCaseTest {
 
         assertThat(firstPage.values().data()).hasSize(2);
         assertThat(secondPage.values().data()).hasSize(2);
-        assertThat(firstPage.values().totalElements()).isEqualTo(7L);
+        assertThat(firstPage.values().totalElements()).isEqualTo(8L);
         assertThat(firstPage.values().data()).isNotEqualTo(secondPage.values().data());
     }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCaseTest.java
@@ -31,6 +31,7 @@ import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterType;
+import io.gravitee.gamma.rest.core.observability.filter.model.RecordType;
 import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
 import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
 import io.gravitee.gamma.rest.core.observability.logs.domain_service.AccessibleApiScopeDomainService;
@@ -126,9 +127,97 @@ class SearchObservabilityLogsUseCaseTest {
                     null,
                     Set.of(Signal.ANALYTICS),
                     io.gravitee.gamma.rest.core.observability.filter.model.ApiType.ALL
+                ),
+                new FilterSpec(
+                    "RECORD_TYPE",
+                    "Record Type",
+                    FilterType.ENUM,
+                    List.of(FilterOperator.EQ, FilterOperator.IN),
+                    List.of(new FilterSpec.EnumValue("REQUEST", "Request"), new FilterSpec.EnumValue("AUTHZ_DECISION", "Authz decision")),
+                    null,
+                    Set.of(Signal.LOGS),
+                    io.gravitee.gamma.rest.core.observability.filter.model.ApiType.ALL
                 )
             )
         );
+    }
+
+    @Nested
+    class DecisionRecordType {
+
+        @Test
+        void should_refuse_a_condition_the_decision_search_cannot_apply() {
+            assertThatThrownBy(() ->
+                useCase.execute(
+                    new SearchObservabilityLogsUseCase.Input(
+                        ORG_ID,
+                        ENV_ID,
+                        List.of(
+                            new FilterCondition("RECORD_TYPE", FilterOperator.EQ, List.of("AUTHZ_DECISION")),
+                            new FilterCondition("APPLICATION", FilterOperator.EQ, List.of("app-1"))
+                        ),
+                        null,
+                        null,
+                        1,
+                        20
+                    )
+                )
+            )
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("APPLICATION")
+                .hasMessageContaining("AUTHZ_DECISION");
+
+            verifyNoInteractions(logsDataPort);
+        }
+
+        @Test
+        void should_refuse_a_multi_valued_record_type_rather_than_truncating_it() {
+            assertThatThrownBy(() ->
+                useCase.execute(
+                    new SearchObservabilityLogsUseCase.Input(
+                        ORG_ID,
+                        ENV_ID,
+                        List.of(new FilterCondition("RECORD_TYPE", FilterOperator.IN, List.of("REQUEST", "AUTHZ_DECISION"))),
+                        null,
+                        null,
+                        1,
+                        20
+                    )
+                )
+            )
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("single value");
+
+            verifyNoInteractions(logsDataPort);
+        }
+
+        @Test
+        void should_accept_api_scope_conditions_alongside_the_record_type() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API One", ApiType.HTTP_PROXY))
+            );
+            when(logsDataPort.searchLogs(any(), any(), any())).thenReturn(new LogsPage(List.of(), 0));
+
+            useCase.execute(
+                new SearchObservabilityLogsUseCase.Input(
+                    ORG_ID,
+                    ENV_ID,
+                    List.of(
+                        new FilterCondition("RECORD_TYPE", FilterOperator.EQ, List.of("AUTHZ_DECISION")),
+                        new FilterCondition("API", FilterOperator.EQ, List.of("api-1"))
+                    ),
+                    null,
+                    null,
+                    1,
+                    20
+                )
+            );
+
+            var captor = ArgumentCaptor.forClass(LogsSearchQuery.class);
+            verify(logsDataPort).searchLogs(any(), any(), captor.capture());
+            assertThat(captor.getValue().recordType()).isEqualTo(RecordType.AUTHZ_DECISION);
+            assertThat(captor.getValue().conditions()).isEmpty();
+        }
     }
 
     @Nested

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
@@ -27,19 +27,23 @@ import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
+import io.gravitee.apim.core.log.crud_service.AuthzDecisionLogsCrudService;
 import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
+import io.gravitee.apim.core.log.model.AuthzDecisionLog;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.filter.model.RecordType;
 import io.gravitee.gamma.rest.core.observability.logs.model.ApiReference;
 import io.gravitee.gamma.rest.core.observability.logs.model.FailureOrigin;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
 import io.gravitee.rest.api.model.analytics.SearchLogsFilters;
 import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
 import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -62,6 +66,9 @@ class ObservabilityLogsDataPortAdapterTest {
 
     @Mock
     private ConnectionLogsCrudService connectionLogsCrudService;
+
+    @Mock
+    private AuthzDecisionLogsCrudService authzDecisionLogsCrudService;
 
     @Mock
     private AnalyticsQueryService analyticsQueryService;
@@ -87,6 +94,7 @@ class ObservabilityLogsDataPortAdapterTest {
     void setUp() {
         adapter = new ObservabilityLogsDataPortAdapter(
             connectionLogsCrudService,
+            authzDecisionLogsCrudService,
             analyticsQueryService,
             userContextLoader,
             planCrudService,
@@ -609,5 +617,81 @@ class ObservabilityLogsDataPortAdapterTest {
         var captor = ArgumentCaptor.forClass(SearchLogsFilters.class);
         verify(connectionLogsCrudService).searchApiConnectionLogs(any(), captor.capture(), any(), any());
         return captor.getValue();
+    }
+
+    @Nested
+    class AuthzDecisions {
+
+        @Test
+        void should_read_decisions_instead_of_connection_logs() {
+            when(authzDecisionLogsCrudService.searchDecisionLogs(any(), any(), any(), any(), any())).thenReturn(
+                new SearchLogsResponse<>(
+                    3,
+                    List.of(
+                        AuthzDecisionLog.builder()
+                            .eventId("evt-1")
+                            .apiId("api-1")
+                            .timestamp(1_000L)
+                            .requestId("req-1")
+                            .gatewayId("gateway-1")
+                            .operation("evaluate")
+                            .status("success")
+                            .caller("pep")
+                            .decision("PERMIT")
+                            .matchedPolicyNames(List.of("allow-readers"))
+                            .subjectId("alice")
+                            .durationNanos(4_200L)
+                            .build()
+                    )
+                )
+            );
+
+            var page = adapter.searchLogs(ORG, ENV, decisionQuery());
+
+            assertThat(page.totalCount()).isEqualTo(3);
+            var entry = page.data().getFirst();
+            assertThat(entry.apiName()).isEqualTo("API 1");
+            assertThat(entry.timestamp()).isEqualTo(Instant.ofEpochMilli(1_000L));
+            assertThat(entry.authz())
+                .isNotNull()
+                .satisfies(authz -> {
+                    assertThat(authz.decision()).isEqualTo("PERMIT");
+                    assertThat(authz.caller()).isEqualTo("pep");
+                    assertThat(authz.operation()).isEqualTo("evaluate");
+                    assertThat(authz.eventId()).isEqualTo("evt-1");
+                    assertThat(authz.status()).isEqualTo("success");
+                    assertThat(authz.subjectId()).isEqualTo("alice");
+                    assertThat(authz.durationNanos()).isEqualTo(4_200L);
+                    assertThat(authz.matchedPolicyNames()).containsExactly("allow-readers");
+                });
+            assertThat(entry.additionalMetrics()).isNull();
+            verifyNoInteractions(connectionLogsCrudService);
+        }
+
+        @Test
+        void should_leave_absent_decision_details_null() {
+            when(authzDecisionLogsCrudService.searchDecisionLogs(any(), any(), any(), any(), any())).thenReturn(
+                new SearchLogsResponse<>(1, List.of(AuthzDecisionLog.builder().eventId("evt-1").apiId("api-1").build()))
+            );
+
+            var entry = adapter.searchLogs(ORG, ENV, decisionQuery()).data().getFirst();
+
+            assertThat(entry.timestamp()).isNull();
+            assertThat(entry.authz().eventId()).isEqualTo("evt-1");
+            assertThat(entry.authz().decision()).isNull();
+            assertThat(entry.authz().subjectId()).isNull();
+            assertThat(entry.authz().batchIndex()).isNull();
+        }
+
+        private LogsSearchQuery decisionQuery() {
+            return LogsSearchQuery.builder()
+                .apiIds(Set.of("api-1"))
+                .apisById(Map.of("api-1", new ApiReference("API 1", "HTTP_PROXY")))
+                .conditions(List.of())
+                .page(1)
+                .perPage(20)
+                .recordType(RecordType.AUTHZ_DECISION)
+                .build();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Authorization decisions have been written to Elasticsearch for a while, but nothing could read them
back as documents. This serves them through the existing `POST /observability/logs/search`, so the
console reads decisions with the same `@gravitee/gamma-lib-observability` every other Gamma module
already uses. No new REST resource and no new signal: a decision is another record kind on the logs
signal, selected by one new filter.

## Why a new read is needed

Decisions are stored as `AuthzEventMetrics` in the `gravitee-event-metrics` data stream. Nothing read
documents from that index: `MetricsRepository` and `LogRepository` only touch `v4-metrics` /
`request` / `v4-log`, and the one `AnalyticsRepository` method that reaches event-metrics returns a
histogram. This adds the document-level query and plugs it in behind the endpoint that already
exists.

## Selecting decisions

A new cross-cutting `RECORD_TYPE` filter (`REQUEST` / `AUTHZ_DECISION`), not `API_TYPE`.

`API_TYPE` narrows **which APIs** are in scope. A decision is attached to the API it guarded — usually
a plain HTTP proxy — so scoping by it would silently drop every decision made in front of one. The
two filters compose: `RECORD_TYPE=AUTHZ_DECISION` + `API_TYPE=HTTP_PROXY` answers "decisions on my
HTTP proxies".

`doc-type: authz` is pinned in the query itself rather than derived from the filter. The data stream
is shared by all five `BaseEventMetrics` subtypes, so without it the result set would mix in api,
application, topic and operation events.

## Changes

**Repository**
- `MetricsRepository` gains `searchAuthzDecisionLogs`. `AuthzDecisionLogQuery` carries the api scope,
  time range and paging, and validates itself before a request is built — including an upper bound on
  page size (`MAX_SIZE = 1000`).
- Elasticsearch side: `SearchAuthzDecisionLogsQueryAdapter` builds the search and pins the doc type,
  `AuthzDecisionLogSourceMapper` and `SearchAuthzDecisionLogsResponseAdapter` read the flat
  `AuthzEventMetrics` source, `AuthzDecisionLogFields` names the fields in one place.
- The sort is `@timestamp desc, event-id asc`. A decision batch stamps every row with the same
  millisecond and tie order is not stable across shards, so paging on the timestamp alone repeats and
  skips rows.
- `NoOpMetricsRepository` gets the empty implementation.

**Core**
- `AuthzDecisionLogsCrudService` port over a core-owned `AuthzDecisionLog` record, returning
  `SearchLogsResponse` exactly as `ConnectionLogsCrudService` does. The infra implementation maps the
  repository record onto it: `io.gravitee.repository` is not on the `CoreRulesTest` allow-list for
  `io.gravitee.apim.core`.

**Gamma REST**
- `RECORD_TYPE` joins the extensible filter catalog on the `LOGS` signal only. Absent means `REQUEST`,
  so every existing caller keeps its behaviour.
- `ApiType` gains `AUTHZ`, and `toGammaApiType` stops mapping `AUTHZ -> null`. That mapping dropped
  the PDP's own API out of the accessible set, which made its decisions unreachable no matter what
  filter was sent.
- Default entrypoint injection is skipped when the record type is a decision. A decision document
  carries no entrypoint, so the injected terms would match nothing.
- The decision itself rides in a typed `authz` object on `LogEntry` / `LogEntryDto`, not in
  `additionalMetrics`. That map is the extension bag for keys plugins attach at runtime, so a known
  contract placed there would be invisible to the schema and readable only by convention — the same
  reason the native Kafka fields were hoisted out of it. All twenty fields are described in
  `openapi-observability.yaml`, which this PR previously did not touch at all.
- The decision search is scoped by api and time only, so any other condition is **refused** rather
  than accepted and dropped. A silently ignored filter is indistinguishable, to the caller, from one
  that matched everything. A multi-valued `RECORD_TYPE` is refused for the same reason instead of
  resolving to its first value.

## API surface

| Endpoint | Method | Change | Request | Response |
|---|---|---|---|---|
| `/environments/{envId}/observability/logs/search` | `POST` | Accepts the new `RECORD_TYPE` filter (`EQ` / `IN`, values `REQUEST` and `AUTHZ_DECISION`). Omitted, the request behaves exactly as before. | `{"filters":[{"name":"RECORD_TYPE","operator":"EQ","value":"AUTHZ_DECISION"}]}` | `200` — decision rows instead of request logs; previously there was no way to ask for them |
| `/environments/{envId}/observability/logs/search` | `POST` | `LogEntryDto` gains a typed `authz` object (20 fields, new `AuthzDecision` schema). `@JsonInclude(NON_NULL)` throughout, so request rows serialise byte for byte as before. | unchanged | `{ "authz": { "decision": "DENY", "subjectId": "alice", "batchIndex": 2, … } }` on decision rows only |
| `/environments/{envId}/observability/logs/search` | `POST` | **Refusal**: any condition other than `API` / `API_TYPE` sent with `RECORD_TYPE=AUTHZ_DECISION`, and any multi-valued `RECORD_TYPE`. | `{"filters":[{"name":"RECORD_TYPE","operator":"EQ","value":"AUTHZ_DECISION"},{"name":"REQUEST_ID","operator":"EQ","value":"req-1"}]}` | `400` — the decision search cannot apply it, so it is refused rather than ignored |
| `/environments/{envId}/observability/filters/definition` | `GET` | Catalog gains a `RECORD_TYPE` entry, advertised for `LOGS` only, with both enum values. `API_TYPE` gains `AUTHZ` among its values. | `?signal=LOGS` | one additional `FilterSpec`; existing entries unchanged apart from the added `API_TYPE` value |

No breaking change for request logs: `RECORD_TYPE` is a new optional filter that defaults to the
previous behaviour, `authz` is absent on request rows, and `AUTHZ` widens an existing enum rather
than altering it. The refusals only reach requests that could not have worked before — they were
accepted and then dropped.

**Companion change**: the console reads the new shape in
[gravitee-gamma-module-authz@2b61c71](https://github.com/gravitee-io/gravitee-gamma-module-authz/commit/2b61c71)
(branch `authz-decisions-logs`). The unpacking lives in one adapter, so no column changed.

## Test plan

- [ ] On *Observability → Logs*, open **Add filter**: a **Record Type** entry is offered, with
      **Request** and **Authz decision** as values.
- [ ] Search with no `RECORD_TYPE` filter: the result is request logs, unchanged from before this PR.
- [ ] Apply **Record Type = Authz decision**: decision rows come back, carrying decision, caller and
      operation. Request logs are gone from the result, not merely reordered.
- [ ] Check a batch: rows from one batch share a timestamp and each carries its own index. Page
      forward and back through a batch — no row repeats and none is skipped.
- [ ] Apply **Record Type = Authz decision** together with **API Type = HTTP Proxy**: the two compose,
      returning decisions taken in front of HTTP proxies only.
- [ ] The PDP's own API appears in the API scope selector. Before this change it was filtered out and
      its decisions were unreachable.
- [ ] On *Observability → Overview* (analytics signal), **Record Type** is not offered.
- [ ] Send `RECORD_TYPE=AUTHZ_DECISION` together with `REQUEST_ID` over the API: `400`, naming the
      filter that does not apply. Before this change the call returned every decision in scope.
- [ ] Regression: the tracing and dashboards screens still load and filter as before.

### Edge cases to check
- A `RECORD_TYPE` value that matches nothing must return zero rows rather than falling back to the
  unfiltered set — that is the difference between an applied filter and an ignored one.
- A decision row has no entrypoint, method, status or latency. The table must render it without those
  columns rather than showing empty or zeroed cells.

## Reviewer notes

**What changed after review.** The first version of this branch accepted conditions the decision
search cannot apply and dropped them on the floor: 21 of the 24 filters declared for the `LOGS`
signal reached the query object and were never read, so a request combining `RECORD_TYPE` with any
of them returned the unfiltered set with no error. Those are now refused, as is a multi-valued
`RECORD_TYPE` that used to resolve to its first value. An unknown `RECORD_TYPE` value was already a
400 before reaching this code — `ObservabilityFilterValidator.validateEnumValues` rejects any value
the catalog does not advertise, which is verified by the new use-case tests.

**`blockingGet` in the repository is not an oversight.** `MetricsRepository` is synchronous — it
returns `LogResponse<T>`, not `Single<LogResponse<T>>` — so the chain out of `client.search` has to be
collapsed in the implementation, which is what all nine reads in that package do. The management API
runs on Jetty (`JettyEmbeddedContainer` with `JettyQueuedThreadPool`), thread per request, so the cost
is one pooled thread held for one query rather than a stalled event loop. Making it reactive means
changing the SPI signature and both implementations, which belongs in its own change.

**Page size is bounded, deep paging is not.** `AuthzDecisionLogQuery.validate()` now refuses a size
above 1000. That guards the SPI contract rather than a reachable hole, since
`SearchObservabilityLogsUseCase` already clamps `perPage` to 100. The dimension that is genuinely
unbounded is `page`: `resolvePage` accepts any positive value and every adapter in this family builds
`from = (page - 1) * size`, so a large enough page number lands past Elasticsearch's
`index.max_result_window`. That predates this PR and applies equally to connection logs, message logs
and metrics — capping it belongs in a change across the whole family.

## Verification

**Live**, on a local stack: decisions from all three producers (PEP policy, AuthZEN policy, authz
reactor) render in the console's decisions table, including batch rows with their index and search
records.

**Automated**, run on this branch before pushing: the whole `gravitee-gamma-rest-api` module (276,
zero failures, prettier-java check included), of which `SearchObservabilityLogsUseCaseTest` (22,
three new for the refusals), `ObservabilityLogsDataPortAdapterTest` (40) and `LogsResourceTest` (10)
cover this path; plus `SearchAuthzDecisionLogsQueryAdapterTest` (9),
`SearchAuthzDecisionLogsResponseAdapterTest` (6), `AuthzDecisionLogsCrudServiceImplTest` (4) and the
ArchUnit `CoreRulesTest` in both rest-api-service and gamma-rest-api. Console side: 1,179 tests,
four of them new for the `authz` unpacking, which had no coverage before. Full suites run on CI.

The `authz` schema was checked by parsing the OpenAPI document rather than by eye: 20 properties,
matching the record field for field, referenced from `LogEntry` and absent from `LogDetail`, which
does not serve decisions.
