### PR TITLE
feat(gamma): added gateway list ui + code skeleton

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -36,6 +36,8 @@ import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { DictionariesPage } from '../pages/DictionariesPage';
 import { DictionaryDetailPage } from '../pages/DictionaryDetailPage';
 import { EntrypointsAndShardingTagsPage } from '../pages/EntrypointsAndShardingTagsPage';
+import { GatewayInstanceDetailStubPage } from '../pages/GatewayInstanceDetailStubPage';
+import { GatewayInstancesPage } from '../pages/GatewayInstancesPage';
 import { GroupsPage } from '../pages/GroupsPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
@@ -86,6 +88,7 @@ function isNavItemVisible(
     canReadMetadata: boolean,
     canReadDictionaries: boolean,
     canAccessUsers: boolean,
+    canReadGateways: boolean,
     canReadEntrypoints: boolean,
     canReadGroups: boolean,
 ): boolean {
@@ -100,6 +103,9 @@ function isNavItemVisible(
     }
     if (itemKey === 'dictionaries') {
         return !permissionsReady || canReadDictionaries;
+    }
+    if (itemKey === 'gateways') {
+        return !permissionsReady || canReadGateways;
     }
     if (itemKey === 'entrypoints-and-sharding-tags') {
         return !permissionsReady || canReadEntrypoints;
@@ -132,6 +138,7 @@ function ModuleLayout() {
     const canReadDictionaries = canReadDictionariesPermission && !isForbiddenApiError(dictionariesQuery.isError, dictionariesQuery.error);
 
     const canAccessUsers = useHasPermission({ anyOf: [...ORGANIZATION_USER_ACCESS_PERMISSIONS] });
+    const canReadGateways = useHasPermission({ anyOf: ['environment-instance-r'] });
     const canReadEntrypoints = useHasPermission({ anyOf: ['environment-entrypoint-r', 'organization-entrypoint-r'] });
     const canReadGroups = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_READ_PERMISSION] });
 
@@ -149,12 +156,13 @@ function ModuleLayout() {
                         canReadMetadata,
                         canReadDictionaries,
                         canAccessUsers,
+                        canReadGateways,
                         canReadEntrypoints,
                         canReadGroups,
                     ),
                 ),
             })).filter(group => group.items.length > 0),
-        [permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers, canReadEntrypoints, canReadGroups],
+        [permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers, canReadGateways, canReadEntrypoints, canReadGroups],
     );
 
     const breadcrumbs = useMemo(
@@ -254,6 +262,28 @@ export function AppRoutes() {
                                     </PermissionPageGuard>
                                 }
                             />
+                        </Route>
+                        <Route path="gateways">
+                            <Route
+                                index
+                                element={
+                                    <PermissionPageGuard permission="environment-instance-r" unauthorizedTo="../applications">
+                                        <GatewayInstancesPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                            <Route
+                                path=":instanceId"
+                                element={
+                                    <PermissionPageGuard permission="environment-instance-r" unauthorizedTo="../../applications">
+                                        <Outlet />
+                                    </PermissionPageGuard>
+                                }
+                            >
+                                <Route index element={<Navigate to="environment" replace />} />
+                                <Route path="environment" element={<GatewayInstanceDetailStubPage />} />
+                                <Route path="monitoring" element={<GatewayInstanceDetailStubPage />} />
+                            </Route>
                         </Route>
                         <Route path="entrypoints-and-sharding-tags" element={<EntrypointsGuard />} />
                         <Route path="security-plan-types" element={<SecurityPlanTypesPage />} />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -14,7 +14,16 @@
  * limitations under the License.
  */
 import type { NavGroup } from '@gravitee/graphene-core';
-import { AppWindowIcon, BookOpenIcon, DatabaseIcon, KeyIcon, RadioIcon, ShieldIcon, UsersIcon } from '@gravitee/graphene-core/icons';
+import {
+    AppWindowIcon,
+    BookOpenIcon,
+    DatabaseIcon,
+    KeyIcon,
+    RadioIcon,
+    ServerIcon,
+    ShieldIcon,
+    UsersIcon,
+} from '@gravitee/graphene-core/icons';
 
 import { ROUTES } from './routes';
 
@@ -40,6 +49,11 @@ export const NAV_GROUPS: NavGroup[] = [
     {
         label: 'Gateways & Infrastructure',
         items: [
+            {
+                key: 'gateways',
+                title: ROUTES.gateways.label,
+                icon: ServerIcon,
+            },
             {
                 key: 'entrypoints-and-sharding-tags',
                 title: ROUTES['entrypoints-and-sharding-tags'].label,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -23,6 +23,7 @@ export const ROUTE_KEYS: readonly string[] = [
     'metadata',
     'dictionaries',
     'security-plan-types',
+    'gateways',
     'entrypoints-and-sharding-tags',
 ];
 export type RouteKey = (typeof ROUTE_KEYS)[number];
@@ -37,6 +38,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     'security-plan-types': { path: 'security-plan-types', label: 'Security Plan Types' },
     metadata: { path: 'metadata', label: 'Metadata' },
     dictionaries: { path: 'dictionaries', label: 'Dictionaries' },
+    gateways: { path: 'gateways', label: 'Gateways' },
     'entrypoints-and-sharding-tags': { path: 'entrypoints-and-sharding-tags', label: 'Entrypoints & Sharding Tags' },
 };
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/components/GatewayInstanceStatusIcon.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/components/GatewayInstanceStatusIcon.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@gravitee/graphene-core';
+import { CircleHelpIcon, CircleStopIcon, PlayIcon } from '@gravitee/graphene-core/icons';
+
+import type { InstanceState } from '../types/instance';
+import { instanceStatusLabel, toInstanceStatusTone } from '../utils/instanceStatus';
+
+export function GatewayInstanceStatusIcon({ state }: Readonly<{ state: InstanceState }>) {
+    const tone = toInstanceStatusTone(state);
+    const label = instanceStatusLabel(state);
+
+    let icon;
+    if (tone === 'running') {
+        icon = <PlayIcon className="size-5 text-success" aria-hidden />;
+    } else if (tone === 'error') {
+        icon = <CircleStopIcon className="size-5 text-destructive" aria-hidden />;
+    } else {
+        icon = <CircleHelpIcon className="size-5 text-muted-foreground" aria-hidden />;
+    }
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <span className="inline-flex" aria-label={label}>
+                    {icon}
+                </span>
+            </TooltipTrigger>
+            <TooltipContent>{label}</TooltipContent>
+        </Tooltip>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/components/GatewayInstancesTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/components/GatewayInstancesTable.spec.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TooltipProvider } from '@gravitee/graphene-core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { GatewayInstancesTable } from './GatewayInstancesTable';
+import type { GatewayInstanceRow } from '../types/instance';
+
+const ROWS: GatewayInstanceRow[] = [
+    {
+        id: 'event-1',
+        hostname: 'apim-gateway',
+        version: '4.12.13',
+        state: 'STARTED',
+        lastHeartbeat: new Date('2026-08-05T13:45:14Z'),
+        os: 'Linux',
+        ip: '172.18.0.3',
+        port: '8082',
+        tenant: '',
+        tags: [],
+    },
+];
+
+describe('GatewayInstancesTable', () => {
+    it('renders the hostname as a link to the environment tab (middle-click / new tab)', () => {
+        render(
+            <MemoryRouter>
+                <TooltipProvider>
+                    <GatewayInstancesTable
+                        rows={ROWS}
+                        isLoading={false}
+                        page={1}
+                        pageSize={10}
+                        totalCount={1}
+                        onPageChange={jest.fn()}
+                        onPageSizeChange={jest.fn()}
+                    />
+                </TooltipProvider>
+            </MemoryRouter>,
+        );
+
+        const link = screen.getByTestId('gateway-instance-name-link');
+        expect(link.getAttribute('href')).toBe('/event-1/environment');
+        expect(link.textContent).toBe('apim-gateway');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/components/GatewayInstancesTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/components/GatewayInstancesTable.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, DataTable, DataTableEmptyState, DateCell, type DataTableProps } from '@gravitee/graphene-core';
+import { ServerIcon } from '@gravitee/graphene-core/icons';
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+
+import { GatewayInstanceStatusIcon } from './GatewayInstanceStatusIcon';
+import type { ColCell } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+import type { GatewayInstanceRow } from '../types/instance';
+
+function buildColumns(): DataTableProps<GatewayInstanceRow>['columns'] {
+    return [
+        {
+            id: 'hostname',
+            accessorKey: 'hostname',
+            header: 'Name',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GatewayInstanceRow>) => (
+                // Classic: hostname is an <a routerLink>; name-only (not full-row) navigation.
+                <Button
+                    asChild
+                    variant="link"
+                    className="h-auto cursor-pointer p-0 text-left font-medium text-foreground hover:underline hover:text-foreground"
+                >
+                    <Link to={`${row.original.id}/environment`} data-testid="gateway-instance-name-link">
+                        {row.original.hostname || '—'}
+                    </Link>
+                </Button>
+            ),
+        },
+        {
+            id: 'version',
+            accessorKey: 'version',
+            header: 'Version',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GatewayInstanceRow>) => <span className="text-sm">{row.original.version || '—'}</span>,
+        },
+        {
+            id: 'state',
+            accessorKey: 'state',
+            header: 'Status',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GatewayInstanceRow>) => <GatewayInstanceStatusIcon state={row.original.state} />,
+        },
+        {
+            id: 'lastHeartbeat',
+            accessorKey: 'lastHeartbeat',
+            header: 'Last Heartbeat',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GatewayInstanceRow>) =>
+                row.original.lastHeartbeat ? (
+                    <DateCell value={row.original.lastHeartbeat} format="absolute" />
+                ) : (
+                    <span className="text-sm text-muted-foreground">—</span>
+                ),
+        },
+        {
+            id: 'os',
+            accessorKey: 'os',
+            header: 'OS',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GatewayInstanceRow>) => <span className="text-sm">{row.original.os || '—'}</span>,
+        },
+        {
+            id: 'ip-port',
+            accessorFn: (row: GatewayInstanceRow) => `${row.ip}:${row.port}`,
+            header: 'IP and Port',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GatewayInstanceRow>) => (
+                <span className="font-mono text-xs">
+                    {row.original.ip || '—'}:{row.original.port || '—'}
+                </span>
+            ),
+        },
+        {
+            id: 'tenant',
+            accessorKey: 'tenant',
+            header: 'Tenant',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GatewayInstanceRow>) => <span className="text-sm">{row.original.tenant || '—'}</span>,
+        },
+        {
+            id: 'tags',
+            accessorFn: (row: GatewayInstanceRow) => row.tags.join(', '),
+            header: 'Sharding Tags',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GatewayInstanceRow>) => (
+                <span className="text-sm">{row.original.tags.length > 0 ? row.original.tags.join(', ') : '—'}</span>
+            ),
+        },
+    ];
+}
+
+export function GatewayInstancesTable({
+    rows,
+    isLoading,
+    page,
+    pageSize,
+    totalCount,
+    onPageChange,
+    onPageSizeChange,
+}: Readonly<{
+    rows: GatewayInstanceRow[];
+    isLoading: boolean;
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    onPageChange: (page: number) => void;
+    onPageSizeChange: (pageSize: number) => void;
+}>) {
+    const columns = useMemo(() => buildColumns(), []);
+
+    return (
+        <DataTable
+            aria-label="Gateways"
+            columns={columns}
+            data={rows}
+            serverSide
+            loading={isLoading}
+            skeletonCount={pageSize}
+            pagination={{
+                page,
+                pageSize,
+                totalCount,
+                pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                onPageChange,
+                onPageSizeChange,
+            }}
+            emptyMessage={
+                <DataTableEmptyState
+                    variant="first-use"
+                    icon={<ServerIcon />}
+                    title="There are no Gateway instances (yet)."
+                    description="Gateway instances appear here once they register a heartbeat with this environment."
+                />
+            }
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/hooks/useGatewayInstanceList.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/hooks/useGatewayInstanceList.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { listGatewayInstances } from '../services/instances';
+import type { GatewayInstanceRow } from '../types/instance';
+import { mapInstanceListItem } from '../utils/mapInstanceListItem';
+import { gatewayInstanceKeys } from '../utils/queryKeys';
+
+/** Classic list has no search; page is 1-based in UI, 0-based for the API. */
+export function useGatewayInstanceList({ page, pageSize }: { page: number; pageSize: number }) {
+    const env = useEnvironment();
+
+    const query = useQuery({
+        queryKey: gatewayInstanceKeys.list(env?.id ?? '', page, pageSize),
+        queryFn: () =>
+            listGatewayInstances(env!.id, {
+                includeStopped: true,
+                from: 0,
+                to: 0,
+                page: Math.max(page - 1, 0),
+                size: pageSize,
+            }),
+        enabled: Boolean(env?.id),
+        // FOUND-33 NFR: heartbeat data refreshed ≤ 30s (classic list has no polling; we refresh on an interval).
+        refetchInterval: 30_000,
+        staleTime: 15_000,
+        placeholderData: keepPreviousData,
+    });
+
+    const rows: GatewayInstanceRow[] = useMemo(() => (query.data?.content ?? []).map(mapInstanceListItem), [query.data?.content]);
+
+    return {
+        ...query,
+        rows,
+        totalCount: query.data?.totalElements ?? 0,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/services/instances.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/services/instances.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getGatewayInstance, getGatewayInstanceMonitoring, listGatewayInstances } from './instances';
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonV1Env: jest.fn(),
+}));
+
+const mockFetch = jest.mocked(apimFetchJsonV1Env);
+
+describe('instances service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFetch.mockResolvedValue({} as never);
+    });
+
+    it('lists instances with classic query defaults', async () => {
+        await listGatewayInstances('env-1', { page: 0, size: 10 });
+        expect(mockFetch).toHaveBeenCalledWith('env-1', '/instances/?includeStopped=true&from=0&to=0&page=0&size=10');
+    });
+
+    it('gets a single instance by event id', async () => {
+        await getGatewayInstance('env-1', 'event-1');
+        expect(mockFetch).toHaveBeenCalledWith('env-1', '/instances/event-1');
+    });
+
+    it('gets monitoring data with event id and gateway id', async () => {
+        await getGatewayInstanceMonitoring('env-1', 'event-1', 'gateway-1');
+        expect(mockFetch).toHaveBeenCalledWith('env-1', '/instances/event-1/monitoring/gateway-1');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/services/instances.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/services/instances.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { Instance, InstanceSearchResult, MonitoringData } from '../types/instance';
+
+/**
+ * Classic: InstanceService.search(includeStopped, from, to, page, size)
+ * GET .../instances/?includeStopped=&from=&to=&page=&size=
+ * `page` is 0-based (classic passes filters.pagination.index - 1).
+ */
+export async function listGatewayInstances(
+    environmentId: string,
+    {
+        includeStopped = true,
+        from = 0,
+        to = 0,
+        page = 0,
+        size = 10,
+    }: {
+        includeStopped?: boolean;
+        from?: number;
+        to?: number;
+        page?: number;
+        size?: number;
+    } = {},
+): Promise<InstanceSearchResult> {
+    const params = new URLSearchParams({
+        includeStopped: String(includeStopped),
+        from: String(from),
+        to: String(to),
+        page: String(page),
+        size: String(size),
+    });
+    return apimFetchJsonV1Env<InstanceSearchResult>(environmentId, `/instances/?${params}`);
+}
+
+/** Classic: InstanceService.get(id) — `id` is the event id from the list. */
+export async function getGatewayInstance(environmentId: string, instanceId: string): Promise<Instance> {
+    return apimFetchJsonV1Env<Instance>(environmentId, `/instances/${encodeURIComponent(instanceId)}`);
+}
+
+/**
+ * Classic: InstanceService.getMonitoringData(id, gatewayId)
+ * `id` = event id (route param); `gatewayId` = Instance.id from the detail payload.
+ */
+export async function getGatewayInstanceMonitoring(environmentId: string, instanceId: string, gatewayId: string): Promise<MonitoringData> {
+    return apimFetchJsonV1Env<MonitoringData>(
+        environmentId,
+        `/instances/${encodeURIComponent(instanceId)}/monitoring/${encodeURIComponent(gatewayId)}`,
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/types/instance.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/types/instance.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Classic: entities/instance/instanceListItem.ts */
+export type InstanceState = 'STARTED' | 'STOPPED' | 'UNKNOWN';
+
+/** Classic: entities/instance/instanceListItem.ts */
+export interface InstanceListItem {
+    event: string;
+    id: string;
+    started_at: number;
+    last_heartbeat_at: number;
+    stopped_at?: number;
+    hostname: string;
+    ip: string;
+    port: string;
+    version: string | null;
+    tags?: string[];
+    tenant?: string;
+    state: InstanceState;
+    operating_system_name?: string;
+}
+
+/** Classic: entities/instance/searchResult.ts */
+export interface InstanceSearchResult {
+    content: InstanceListItem[];
+    pageNumber: number;
+    pageElements: number;
+    totalElements: number;
+}
+
+/** Classic: entities/instance/instance.ts */
+export interface Instance {
+    id: string;
+    event: string;
+    hostname: string;
+    ip: string;
+    port: string;
+    version: string;
+    state: string;
+    started_at: number;
+    last_heartbeat_at: number;
+    stopped_at?: number;
+    operating_system_name?: string;
+    environments?: string[];
+    environments_hrids?: string[];
+    organizations_hrids?: string[];
+    tags?: string[];
+    tenant?: string;
+    systemProperties?: Record<string, string>;
+    plugins?: {
+        id: string;
+        name: string;
+        description: string;
+        version: string;
+        plugin: string;
+        type: string;
+    }[];
+}
+
+/** Classic: entities/instance/monitoringData.ts */
+export interface MonitoringData {
+    cpu: {
+        percent_use: number;
+        load_average: Record<string, number>;
+    };
+    process: {
+        cpu_percent: number;
+        open_file_descriptors: number;
+        max_file_descriptors: number;
+    };
+    jvm: {
+        timestamp: number | Date;
+        uptime_in_millis: number;
+        heap_used_in_bytes: number;
+        heap_used_percent: number;
+        heap_committed_in_bytes: number;
+        heap_max_in_bytes: number;
+        non_heap_used_in_bytes: number;
+        non_heap_committed_in_bytes: number;
+        young_pool_used_in_bytes: number;
+        young_pool_max_in_bytes: number;
+        young_pool_peak_used_in_bytes: number;
+        young_pool_peak_max_in_bytes: number;
+        survivor_pool_used_in_bytes: number;
+        survivor_pool_max_in_bytes: number;
+        survivor_pool_peak_used_in_bytes: number;
+        survivor_pool_peak_max_in_bytes: number;
+        old_pool_used_in_bytes: number;
+        old_pool_max_in_bytes: number;
+        old_pool_peak_used_in_bytes: number;
+        old_pool_peak_max_in_bytes: number;
+    };
+    thread: {
+        count: number;
+        peak_count: number;
+    };
+    gc: {
+        young_collection_count: number;
+        young_collection_time_in_millis: number;
+        old_collection_count: number;
+        old_collection_time_in_millis: number;
+    };
+}
+
+/** Row model for the Gateways list table (classic instance-list TableData). */
+export interface GatewayInstanceRow {
+    /** Route param — classic navigates with `instance.event`. */
+    id: string;
+    hostname: string;
+    version: string;
+    state: InstanceState;
+    lastHeartbeat: Date | null;
+    os: string;
+    ip: string;
+    port: string;
+    tenant: string;
+    tags: string[];
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/utils/instanceStatus.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/utils/instanceStatus.spec.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { instanceStatusLabel, toInstanceStatusTone } from './instanceStatus';
+
+describe('instanceStatus', () => {
+    it('maps classic states to UI tones', () => {
+        expect(toInstanceStatusTone('STARTED')).toBe('running');
+        expect(toInstanceStatusTone('STOPPED')).toBe('error');
+        expect(toInstanceStatusTone('UNKNOWN')).toBe('unknown');
+    });
+
+    it('returns human labels matching classic tooltips', () => {
+        expect(instanceStatusLabel('STARTED')).toBe('Started');
+        expect(instanceStatusLabel('STOPPED')).toBe('Stopped');
+        expect(instanceStatusLabel('UNKNOWN')).toBe('Unknown');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/utils/instanceStatus.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/utils/instanceStatus.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { InstanceState } from '../types/instance';
+
+/** UI tone mapped from classic STARTED / STOPPED / UNKNOWN icons. */
+export type InstanceStatusTone = 'running' | 'error' | 'unknown';
+
+export function toInstanceStatusTone(state: InstanceState | string): InstanceStatusTone {
+    if (state === 'STARTED') return 'running';
+    if (state === 'STOPPED') return 'error';
+    return 'unknown';
+}
+
+export function instanceStatusLabel(state: InstanceState | string): string {
+    if (state === 'STARTED') return 'Started';
+    if (state === 'STOPPED') return 'Stopped';
+    return 'Unknown';
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/utils/mapInstanceListItem.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/utils/mapInstanceListItem.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mapInstanceListItem, shortInstanceVersion } from './mapInstanceListItem';
+import type { InstanceListItem } from '../types/instance';
+
+describe('shortInstanceVersion', () => {
+    it('truncates at the first parenthesis like classic', () => {
+        expect(shortInstanceVersion('4.12.13 (build: 1959495) revision#abc')).toBe('4.12.13');
+    });
+
+    it('returns the version unchanged when there is no build suffix', () => {
+        expect(shortInstanceVersion('4.12.13')).toBe('4.12.13');
+    });
+
+    it('handles null/undefined', () => {
+        expect(shortInstanceVersion(null)).toBe('');
+        expect(shortInstanceVersion(undefined)).toBe('');
+    });
+});
+
+describe('mapInstanceListItem', () => {
+    const base: InstanceListItem = {
+        event: 'event-1',
+        id: 'gateway-1',
+        started_at: 1,
+        last_heartbeat_at: 1_704_000_000_000,
+        hostname: 'apim-gateway',
+        ip: '172.18.0.3',
+        port: '8082',
+        version: '4.12.13 (build: 1)',
+        tags: ['prod', 'eu'],
+        tenant: 'tenant-a',
+        state: 'STARTED',
+        operating_system_name: 'Linux',
+    };
+
+    it('maps classic list fields and uses event id for navigation', () => {
+        const row = mapInstanceListItem(base);
+        expect(row.id).toBe('event-1');
+        expect(row.hostname).toBe('apim-gateway');
+        expect(row.version).toBe('4.12.13');
+        expect(row.state).toBe('STARTED');
+        expect(row.os).toBe('Linux');
+        expect(row.ip).toBe('172.18.0.3');
+        expect(row.port).toBe('8082');
+        expect(row.tenant).toBe('tenant-a');
+        expect(row.tags).toEqual(['prod', 'eu']);
+        expect(row.lastHeartbeat).toEqual(new Date(1_704_000_000_000));
+    });
+
+    it('falls back to instance id when event is missing', () => {
+        const row = mapInstanceListItem({ ...base, event: '' });
+        expect(row.id).toBe('gateway-1');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/utils/mapInstanceListItem.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/utils/mapInstanceListItem.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GatewayInstanceRow, InstanceListItem, InstanceState } from '../types/instance';
+
+/** Classic list truncates version at the first '(' (build/revision suffix). */
+export function shortInstanceVersion(version: string | null | undefined): string {
+    if (!version) return '';
+    if (version.includes('(')) {
+        return version.substring(0, version.indexOf('(')).trim();
+    }
+    return version;
+}
+
+function normalizeState(state: string | undefined): InstanceState {
+    if (state === 'STARTED' || state === 'STOPPED') return state;
+    return 'UNKNOWN';
+}
+
+/** Classic navigates with event id (not gateway instance id); fall back to instance id when event is absent. */
+export function mapInstanceListItem(instance: InstanceListItem): GatewayInstanceRow {
+    return {
+        id: instance.event || instance.id,
+        hostname: instance.hostname ?? '',
+        version: shortInstanceVersion(instance.version),
+        state: normalizeState(instance.state),
+        lastHeartbeat: instance.last_heartbeat_at ? new Date(instance.last_heartbeat_at) : null,
+        os: instance.operating_system_name ?? '',
+        ip: instance.ip ?? '',
+        port: instance.port ?? '',
+        tenant: instance.tenant ?? '',
+        tags: instance.tags ?? [],
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/utils/queryKeys.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const gatewayInstanceKeys = {
+    all: ['gateway-instances'] as const,
+    list: (envId: string, page: number, size: number) => [...gatewayInstanceKeys.all, 'list', envId, page, size] as const,
+    detail: (envId: string, instanceId: string) => [...gatewayInstanceKeys.all, 'detail', envId, instanceId] as const,
+    monitoring: (envId: string, instanceId: string, gatewayId: string) =>
+        [...gatewayInstanceKeys.all, 'monitoring', envId, instanceId, gatewayId] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GatewayInstanceDetailStubPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GatewayInstanceDetailStubPage.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button } from '@gravitee/graphene-core';
+import { ArrowLeftIcon } from '@gravitee/graphene-core/icons';
+import { useNavigate, useParams } from 'react-router-dom';
+
+/**
+ * Placeholder for FOUND-34 / FOUND-35 detail + monitoring tabs.
+ * Keeps list → detail navigation from crashing until those stories land.
+ */
+export function GatewayInstanceDetailStubPage() {
+    const { instanceId } = useParams<{ instanceId: string }>();
+    const navigate = useNavigate();
+
+    return (
+        <div className="space-y-6">
+            <Button type="button" variant="ghost" className="gap-2 px-0" onClick={() => navigate('../..')}>
+                <ArrowLeftIcon className="size-4" aria-hidden />
+                Back to Gateways
+            </Button>
+            <div className="space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">Gateway instance</h1>
+                <p className="text-sm text-muted-foreground font-mono">{instanceId}</p>
+                <p className="text-sm text-muted-foreground pt-2">
+                    Detail (Environment) and Monitoring tabs will be implemented in FOUND-34 and FOUND-35.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GatewayInstancesPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GatewayInstancesPage.spec.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { GatewayInstancesPage } from './GatewayInstancesPage';
+import { useGatewayInstanceList } from '../features/gateway-instances/hooks/useGatewayInstanceList';
+import type { GatewayInstanceRow } from '../features/gateway-instances/types/instance';
+import { ApimApiError } from '../shared/api/apimClient';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: () => ({ id: 'env-1' }),
+}));
+
+jest.mock('../features/gateway-instances/hooks/useGatewayInstanceList');
+
+jest.mock('../features/gateway-instances/components/GatewayInstancesTable', () => ({
+    GatewayInstancesTable: ({
+        rows,
+        onPageChange,
+        onPageSizeChange,
+    }: {
+        rows: GatewayInstanceRow[];
+        onPageChange: (page: number) => void;
+        onPageSizeChange: (size: number) => void;
+    }) => (
+        <div>
+            {rows.map(row => (
+                <span key={row.id}>{row.hostname}</span>
+            ))}
+            <button type="button" onClick={() => onPageChange(2)}>
+                Next page
+            </button>
+            <button type="button" onClick={() => onPageSizeChange(25)}>
+                Page size 25
+            </button>
+        </div>
+    ),
+}));
+
+const mockUseGatewayInstanceList = jest.mocked(useGatewayInstanceList);
+
+const ROWS: GatewayInstanceRow[] = [
+    {
+        id: 'event-1',
+        hostname: 'apim-gateway',
+        version: '4.12.13',
+        state: 'STARTED',
+        lastHeartbeat: new Date('2026-08-05T13:45:14Z'),
+        os: 'Linux',
+        ip: '172.18.0.3',
+        port: '8082',
+        tenant: '',
+        tags: [],
+    },
+];
+
+function renderPage() {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+        <QueryClientProvider client={client}>
+            <MemoryRouter>
+                <GatewayInstancesPage />
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+}
+
+describe('GatewayInstancesPage', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseGatewayInstanceList.mockReturnValue({
+            rows: ROWS,
+            totalCount: 1,
+            isLoading: false,
+            isError: false,
+            error: null,
+        } as ReturnType<typeof useGatewayInstanceList>);
+    });
+
+    it('renders the Gateways heading and rows', () => {
+        renderPage();
+        expect(screen.getByRole('heading', { name: 'Gateways' })).not.toBeNull();
+        expect(screen.getByText('apim-gateway')).not.toBeNull();
+    });
+
+    it('forwards pagination to the list query', () => {
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+        expect(mockUseGatewayInstanceList).toHaveBeenCalledWith(expect.objectContaining({ page: 2 }));
+        fireEvent.click(screen.getByRole('button', { name: 'Page size 25' }));
+        expect(mockUseGatewayInstanceList).toHaveBeenCalledWith(expect.objectContaining({ pageSize: 25, page: 1 }));
+    });
+
+    it('shows an error message when the list query fails', () => {
+        mockUseGatewayInstanceList.mockReturnValue({
+            rows: [],
+            totalCount: 0,
+            isLoading: false,
+            isError: true,
+            error: new Error('boom'),
+        } as ReturnType<typeof useGatewayInstanceList>);
+        renderPage();
+        expect(screen.getByText(/Failed to load gateway instances/i)).not.toBeNull();
+    });
+
+    it('renders nothing while redirecting on forbidden', () => {
+        mockUseGatewayInstanceList.mockReturnValue({
+            rows: [],
+            totalCount: 0,
+            isLoading: false,
+            isError: true,
+            error: new ApimApiError(403, 'Forbidden'),
+        } as ReturnType<typeof useGatewayInstanceList>);
+        const { container } = renderPage();
+        expect(container.textContent).toBe('');
+        expect(screen.queryByRole('heading', { name: 'Gateways' })).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GatewayInstancesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GatewayInstancesPage.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+
+import { GatewayInstancesTable } from '../features/gateway-instances/components/GatewayInstancesTable';
+import { useGatewayInstanceList } from '../features/gateway-instances/hooks/useGatewayInstanceList';
+import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
+import { isForbiddenApiError } from '../shared/utils/apiErrors';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 10;
+
+export function GatewayInstancesPage() {
+    const [page, setPage] = useState(DEFAULT_PAGE);
+    const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+
+    const { rows, totalCount, isLoading, isError, error } = useGatewayInstanceList({ page, pageSize });
+
+    const isForbidden = isForbiddenApiError(isError, error);
+    useForbiddenResourceRedirect({
+        isForbidden,
+        permissionPrefix: 'environment-instance-',
+        redirectTo: '../applications',
+    });
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(DEFAULT_PAGE);
+    }
+
+    if (isForbidden) {
+        return null;
+    }
+
+    if (isError) {
+        return (
+            <div className="space-y-6">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Gateways</h1>
+                </div>
+                <div className="flex items-center justify-center p-8">
+                    <p className="text-sm text-muted-foreground">Failed to load gateway instances. Please refresh and try again.</p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">Gateways</h1>
+            </div>
+            <GatewayInstancesTable
+                rows={rows}
+                isLoading={isLoading}
+                page={page}
+                pageSize={pageSize}
+                totalCount={totalCount}
+                onPageChange={setPage}
+                onPageSizeChange={handlePageSizeChange}
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-33

## Description

Add the Gamma Platform **Gateways** list (env-scoped) with Graphene `DataTable`, status icons, server-side pagination, and 30s refresh. Includes shared instance types/services and a stub detail route for stacked follow-ups (FOUND-34 / FOUND-35).
- Nav + route under Gateways & Infrastructure
- Permission: `environment-instance-r`
- Name link → detail stub (`:instanceId/environment|monitoring`)

## Stack
PR 1/3 — list + skeleton. Detail (FOUND-34) and monitoring (FOUND-35) will stack on top.

## Additional context

[working video] 

https://github.com/user-attachments/assets/4dca6ed0-af6e-4594-a7d1-d5c536ad3970



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>