### PR TITLE
feat(gamma): add group detail page and redirect to it on create

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/package.json
@@ -5,7 +5,7 @@
         "@gravitee/gamma-lib-observability": "1.39.1",
         "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/graphene-charts": "3.8.0",
-        "@gravitee/graphene-core": "3.8.0",
+        "@gravitee/graphene-core": "3.9.0",
         "@gravitee/graphene-policy-studio": "3.8.0",
         "@tanstack/react-query": "5.100.14",
         "react": "19.2.6",

--- a/gravitee-gamma/gravitee-gamma-module-platform/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-platform/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "dependencies": {
         "@gravitee/gamma-modules-sdk": "1.2.0",
-        "@gravitee/graphene-core": "3.8.0",
+        "@gravitee/graphene-core": "3.9.0",
         "@tanstack/react-query": "5.100.14",
         "react": "19.2.6",
         "react-dom": "19.2.6",

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -82,6 +82,10 @@ jest.mock('../pages/GroupsPage', () => ({
     GroupsPage: () => <div data-testid="groups-page" />,
 }));
 
+jest.mock('../pages/GroupDetailPage', () => ({
+    GroupDetailPage: () => <div data-testid="group-detail-page" />,
+}));
+
 jest.mock('../pages/RegisterApplicationPage', () => ({
     RegisterApplicationPage: () => <div data-testid="register-application-page" />,
 }));
@@ -144,7 +148,7 @@ describe('AppRoutes', () => {
         expect(screen.getByTestId('users-page')).not.toBeNull();
     });
 
-    it('routes to the User Groups page under the platform module', () => {
+    it('routes to the Groups page under the platform module', () => {
         render(
             <MemoryRouter initialEntries={['/user-groups']}>
                 <AppRoutes />
@@ -154,13 +158,23 @@ describe('AppRoutes', () => {
         expect(screen.getByTestId('groups-page')).not.toBeNull();
     });
 
-    it('shows the User Groups nav item when the user has read permission', () => {
+    it('routes to the Group detail page under the platform module', () => {
+        render(
+            <MemoryRouter initialEntries={['/user-groups/group-1']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('group-detail-page')).not.toBeNull();
+    });
+
+    it('shows the Groups nav item when the user has read permission', () => {
         renderPlatform();
 
         expect(visibleNavKeys()).toContain('user-groups');
     });
 
-    it('hides the User Groups nav item when the user lacks environment-group-r', () => {
+    it('hides the Groups nav item when the user lacks environment-group-r', () => {
         mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-group-r'));
 
         renderPlatform();

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -36,6 +36,7 @@ import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { DictionariesPage } from '../pages/DictionariesPage';
 import { DictionaryDetailPage } from '../pages/DictionaryDetailPage';
 import { EntrypointsAndShardingTagsPage } from '../pages/EntrypointsAndShardingTagsPage';
+import { GroupDetailPage } from '../pages/GroupDetailPage';
 import { GroupsPage } from '../pages/GroupsPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
@@ -213,14 +214,24 @@ export function AppRoutes() {
                                 }
                             />
                         </Route>
-                        <Route
-                            path="user-groups"
-                            element={
-                                <PermissionPageGuard permission={ENVIRONMENT_GROUP_READ_PERMISSION}>
-                                    <GroupsPage />
-                                </PermissionPageGuard>
-                            }
-                        />
+                        <Route path="user-groups">
+                            <Route
+                                index
+                                element={
+                                    <PermissionPageGuard permission={ENVIRONMENT_GROUP_READ_PERMISSION} unauthorizedTo="../applications">
+                                        <GroupsPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                            <Route
+                                path=":groupId"
+                                element={
+                                    <PermissionPageGuard permission={ENVIRONMENT_GROUP_READ_PERMISSION} unauthorizedTo="../../applications">
+                                        <GroupDetailPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                        </Route>
                         <Route
                             path="metadata"
                             element={

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -40,6 +40,7 @@ import { EntrypointsAndShardingTagsPage } from '../pages/EntrypointsAndShardingT
 import { GatewayInstanceEnvironmentPage } from '../pages/GatewayInstanceEnvironmentPage';
 import { GatewayInstanceMonitoringStubPage } from '../pages/GatewayInstanceMonitoringStubPage';
 import { GatewayInstancesPage } from '../pages/GatewayInstancesPage';
+import { GroupDetailPage } from '../pages/GroupDetailPage';
 import { GroupsPage } from '../pages/GroupsPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
@@ -223,14 +224,24 @@ export function AppRoutes() {
                                 }
                             />
                         </Route>
-                        <Route
-                            path="user-groups"
-                            element={
-                                <PermissionPageGuard permission={ENVIRONMENT_GROUP_READ_PERMISSION}>
-                                    <GroupsPage />
-                                </PermissionPageGuard>
-                            }
-                        />
+                        <Route path="user-groups">
+                            <Route
+                                index
+                                element={
+                                    <PermissionPageGuard permission={ENVIRONMENT_GROUP_READ_PERMISSION} unauthorizedTo="../applications">
+                                        <GroupsPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                            <Route
+                                path=":groupId"
+                                element={
+                                    <PermissionPageGuard permission={ENVIRONMENT_GROUP_READ_PERMISSION} unauthorizedTo="../../applications">
+                                        <GroupDetailPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                        </Route>
                         <Route
                             path="metadata"
                             element={

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -13,20 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { UsersIcon } from '@gravitee/graphene-core/icons';
+import { GroupIcon, UsersIcon } from '@gravitee/graphene-core/icons';
 
 import { NAV_GROUPS } from './navigation';
 import { PLATFORM_ROUTE_CONFIG, ROUTES } from './routes';
 
 describe('platform navigation config', () => {
-    it('registers Users and User Groups under Identity & Access', () => {
+    it('registers Users and Groups under Identity & Access', () => {
         const identityGroup = NAV_GROUPS.find(group => group.label === 'Identity & Access');
         expect(identityGroup).toBeDefined();
         expect(identityGroup?.items.map(item => item.key)).toEqual(['users', 'user-groups']);
         expect(identityGroup?.items[0]?.title).toBe('Users');
         expect(identityGroup?.items[0]?.icon).toBe(UsersIcon);
-        expect(identityGroup?.items[1]?.title).toBe('User Groups');
-        expect(identityGroup?.items[1]?.icon).toBeUndefined();
+        expect(identityGroup?.items[1]?.title).toBe('Groups');
+        expect(identityGroup?.items[1]?.icon).toBe(GroupIcon);
     });
 
     it('declares the users route in platform routing config', () => {
@@ -36,6 +36,6 @@ describe('platform navigation config', () => {
 
     it('declares the user-groups route in platform routing config', () => {
         expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('user-groups');
-        expect(ROUTES['user-groups']).toEqual({ path: 'user-groups', label: 'User Groups' });
+        expect(ROUTES['user-groups']).toEqual({ path: 'user-groups', label: 'Groups' });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -19,13 +19,13 @@ import { NAV_GROUPS } from './navigation';
 import { PLATFORM_ROUTE_CONFIG, ROUTES } from './routes';
 
 describe('platform navigation config', () => {
-    it('registers Users and User Groups under Identity & Access', () => {
+    it('registers Users and Groups under Identity & Access', () => {
         const identityGroup = NAV_GROUPS.find(group => group.label === 'Identity & Access');
         expect(identityGroup).toBeDefined();
         expect(identityGroup?.items.map(item => item.key)).toEqual(['users', 'user-groups']);
         expect(identityGroup?.items[0]?.title).toBe('Users');
         expect(identityGroup?.items[0]?.icon).toBe(UsersIcon);
-        expect(identityGroup?.items[1]?.title).toBe('User Groups');
+        expect(identityGroup?.items[1]?.title).toBe('Groups');
         expect(identityGroup?.items[1]?.icon).toBeUndefined();
     });
 
@@ -36,6 +36,6 @@ describe('platform navigation config', () => {
 
     it('declares the user-groups route in platform routing config', () => {
         expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('user-groups');
-        expect(ROUTES['user-groups']).toEqual({ path: 'user-groups', label: 'User Groups' });
+        expect(ROUTES['user-groups']).toEqual({ path: 'user-groups', label: 'Groups' });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -18,6 +18,7 @@ import {
     AppWindowIcon,
     BookOpenIcon,
     DatabaseIcon,
+    GroupIcon,
     KeyIcon,
     RadioIcon,
     ServerIcon,
@@ -36,7 +37,7 @@ export const NAV_GROUPS: NavGroup[] = [
         label: 'Identity & Access',
         items: [
             { key: 'users', title: ROUTES.users.label, icon: UsersIcon },
-            { key: 'user-groups', title: ROUTES['user-groups'].label },
+            { key: 'user-groups', title: ROUTES['user-groups'].label, icon: GroupIcon },
         ],
     },
     {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -32,7 +32,7 @@ const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
 export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: string }> = {
     applications: { path: 'applications', label: 'Applications' },
     users: { path: 'users', label: 'Users' },
-    'user-groups': { path: 'user-groups', label: 'User Groups' },
+    'user-groups': { path: 'user-groups', label: 'Groups' },
     'access-management': { path: 'access-management', label: 'Access Management' },
     'security-plan-types': { path: 'security-plan-types', label: 'Security Plan Types' },
     metadata: { path: 'metadata', label: 'Metadata' },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -33,7 +33,7 @@ const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
 export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: string }> = {
     applications: { path: 'applications', label: 'Applications' },
     users: { path: 'users', label: 'Users' },
-    'user-groups': { path: 'user-groups', label: 'User Groups' },
+    'user-groups': { path: 'user-groups', label: 'Groups' },
     'access-management': { path: 'access-management', label: 'Access Management' },
     'security-plan-types': { path: 'security-plan-types', label: 'Security Plan Types' },
     metadata: { path: 'metadata', label: 'Metadata' },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.spec.tsx
@@ -30,7 +30,7 @@ describe('GroupDeleteSheet', () => {
             const onConfirm = jest.fn();
             render(<GroupDeleteSheet open group={GROUP} onClose={jest.fn()} onConfirm={onConfirm} isDeleting={false} />);
 
-            expect(screen.queryByRole('heading', { name: 'Delete Group' })).not.toBeNull();
+            expect(screen.queryByRole('heading', { name: 'Delete group' })).not.toBeNull();
             expect(screen.getByRole('button', { name: 'Delete' })).not.toBeNull();
 
             fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
@@ -57,7 +57,7 @@ describe('GroupDeleteSheet', () => {
                 <GroupDeleteSheet open group={{ ...GROUP, ...override }} onClose={jest.fn()} onConfirm={onConfirm} isDeleting={false} />,
             );
 
-            expect(screen.queryByRole('heading', { name: 'Delete group?' })).not.toBeNull();
+            expect(screen.queryByRole('heading', { name: 'Delete group' })).not.toBeNull();
             expect(screen.queryByText(/cannot be deleted while it still has a primary owner membership/i)).not.toBeNull();
             expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();
             expect(onConfirm).not.toHaveBeenCalled();

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.spec.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupDeleteSheet } from './GroupDeleteSheet';
+import type { Group } from '../types/group';
+
+const GROUP: Group = { id: 'group-1', name: 'API Team' };
+
+describe('GroupDeleteSheet', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('deletable group', () => {
+        it('asks for confirmation and calls onConfirm', () => {
+            const onConfirm = jest.fn();
+            render(<GroupDeleteSheet open group={GROUP} onClose={jest.fn()} onConfirm={onConfirm} isDeleting={false} />);
+
+            expect(screen.queryByRole('heading', { name: 'Delete group' })).not.toBeNull();
+            expect(screen.getByRole('button', { name: 'Delete' })).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+            expect(onConfirm).toHaveBeenCalled();
+        });
+
+        it('calls onClose when Cancel is clicked', () => {
+            const onClose = jest.fn();
+            render(<GroupDeleteSheet open group={GROUP} onClose={onClose} onConfirm={jest.fn()} isDeleting={false} />);
+
+            fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+            expect(onClose).toHaveBeenCalled();
+        });
+    });
+
+    describe('primary-owner group (blocked)', () => {
+        it.each([
+            ['primary_owner is true', { primary_owner: true }],
+            ['apiPrimaryOwner is set', { apiPrimaryOwner: 'user-1' }],
+            ['apiProductPrimaryOwner is set', { apiProductPrimaryOwner: 'user-1' }],
+        ])('shows why the group cannot be deleted, with no Delete button, when %s', (_label, override) => {
+            const onConfirm = jest.fn();
+            render(
+                <GroupDeleteSheet open group={{ ...GROUP, ...override }} onClose={jest.fn()} onConfirm={onConfirm} isDeleting={false} />,
+            );
+
+            expect(screen.queryByRole('heading', { name: 'Delete group' })).not.toBeNull();
+            expect(screen.queryByText(/cannot be deleted while it still has a primary owner membership/i)).not.toBeNull();
+            expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();
+            expect(onConfirm).not.toHaveBeenCalled();
+        });
+
+        it('still lets the user cancel out of the blocked dialog', () => {
+            const onClose = jest.fn();
+            render(
+                <GroupDeleteSheet
+                    open
+                    group={{ ...GROUP, primary_owner: true }}
+                    onClose={onClose}
+                    onConfirm={jest.fn()}
+                    isDeleting={false}
+                />,
+            );
+
+            fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+            expect(onClose).toHaveBeenCalled();
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.spec.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupDeleteSheet } from './GroupDeleteSheet';
+import type { Group } from '../types/group';
+
+const GROUP: Group = { id: 'group-1', name: 'API Team' };
+
+describe('GroupDeleteSheet', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('deletable group', () => {
+        it('asks for confirmation and calls onConfirm', () => {
+            const onConfirm = jest.fn();
+            render(<GroupDeleteSheet open group={GROUP} onClose={jest.fn()} onConfirm={onConfirm} isDeleting={false} />);
+
+            expect(screen.queryByRole('heading', { name: 'Delete Group' })).not.toBeNull();
+            expect(screen.getByRole('button', { name: 'Delete' })).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+            expect(onConfirm).toHaveBeenCalled();
+        });
+
+        it('calls onClose when Cancel is clicked', () => {
+            const onClose = jest.fn();
+            render(<GroupDeleteSheet open group={GROUP} onClose={onClose} onConfirm={jest.fn()} isDeleting={false} />);
+
+            fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+            expect(onClose).toHaveBeenCalled();
+        });
+    });
+
+    describe('primary-owner group (blocked)', () => {
+        it.each([
+            ['primary_owner is true', { primary_owner: true }],
+            ['apiPrimaryOwner is set', { apiPrimaryOwner: 'user-1' }],
+            ['apiProductPrimaryOwner is set', { apiProductPrimaryOwner: 'user-1' }],
+        ])('shows why the group cannot be deleted, with no Delete button, when %s', (_label, override) => {
+            const onConfirm = jest.fn();
+            render(
+                <GroupDeleteSheet open group={{ ...GROUP, ...override }} onClose={jest.fn()} onConfirm={onConfirm} isDeleting={false} />,
+            );
+
+            expect(screen.queryByRole('heading', { name: 'Delete group?' })).not.toBeNull();
+            expect(screen.queryByText(/cannot be deleted while it still has a primary owner membership/i)).not.toBeNull();
+            expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();
+            expect(onConfirm).not.toHaveBeenCalled();
+        });
+
+        it('still lets the user cancel out of the blocked dialog', () => {
+            const onClose = jest.fn();
+            render(
+                <GroupDeleteSheet
+                    open
+                    group={{ ...GROUP, primary_owner: true }}
+                    onClose={onClose}
+                    onConfirm={jest.fn()}
+                    isDeleting={false}
+                />,
+            );
+
+            fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+            expect(onClose).toHaveBeenCalled();
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.tsx
@@ -15,8 +15,10 @@
  */
 
 import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+import { TriangleAlertIcon } from '@gravitee/graphene-core/icons';
 
 import type { Group } from '../types/group';
+import { isPrimaryOwnerGroup } from '../utils/groupPermissions';
 
 export function GroupDeleteSheet({
     open,
@@ -31,23 +33,42 @@ export function GroupDeleteSheet({
     onConfirm: () => void;
     isDeleting: boolean;
 }>) {
+    // Delete is always offered (classic doesn't hide it either) — a primary-owner group is rejected by the
+    // backend with StillPrimaryOwnerException regardless, so surface that as soon as the dialog opens
+    // instead of letting the user hit an API error after confirming.
+    const blocked = group ? isPrimaryOwnerGroup(group) : false;
+
     return (
         <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
             <DialogContent className="max-w-sm">
                 <DialogHeader>
-                    <DialogTitle>Delete Group</DialogTitle>
+                    <DialogTitle className={blocked ? 'flex items-center gap-2' : undefined}>
+                        {blocked && <TriangleAlertIcon className="size-5 text-destructive" aria-hidden />}
+                        Delete group
+                    </DialogTitle>
                     <DialogDescription>
-                        Are you sure you want to delete <span className="font-medium text-foreground">{group?.name}</span>? Members will
-                        lose any access granted through this group.
+                        {blocked ? (
+                            <>
+                                <span className="font-medium text-foreground">{group?.name}</span> cannot be deleted while it still has a
+                                primary owner membership. Reassign or remove the primary owner first.
+                            </>
+                        ) : (
+                            <>
+                                Are you sure you want to delete <span className="font-medium text-foreground">{group?.name}</span>? Members
+                                will lose any access granted through this group.
+                            </>
+                        )}
                     </DialogDescription>
                 </DialogHeader>
                 <DialogFooter className="border-t px-6 py-4 gap-2">
                     <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
                         Cancel
                     </Button>
-                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || !group}>
-                        {isDeleting ? 'Deleting…' : 'Delete'}
-                    </Button>
+                    {!blocked && (
+                        <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || !group}>
+                            {isDeleting ? 'Deleting…' : 'Delete'}
+                        </Button>
+                    )}
                 </DialogFooter>
             </DialogContent>
         </Dialog>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.tsx
@@ -38,47 +38,37 @@ export function GroupDeleteSheet({
     // instead of letting the user hit an API error after confirming.
     const blocked = group ? isPrimaryOwnerGroup(group) : false;
 
-    if (blocked) {
-        return (
-            <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
-                <DialogContent className="max-w-sm">
-                    <DialogHeader>
-                        <DialogTitle className="flex items-center gap-2">
-                            <TriangleAlertIcon className="size-5 text-destructive" aria-hidden />
-                            Delete group?
-                        </DialogTitle>
-                        <DialogDescription>
-                            <span className="font-medium text-foreground">{group?.name}</span> cannot be deleted while it still has a
-                            primary owner membership. Reassign or remove the primary owner first.
-                        </DialogDescription>
-                    </DialogHeader>
-                    <DialogFooter className="border-t px-6 py-4 gap-2">
-                        <Button type="button" variant="outline" onClick={onClose}>
-                            Cancel
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-            </Dialog>
-        );
-    }
-
     return (
         <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
             <DialogContent className="max-w-sm">
                 <DialogHeader>
-                    <DialogTitle>Delete Group</DialogTitle>
+                    <DialogTitle className={blocked ? 'flex items-center gap-2' : undefined}>
+                        {blocked && <TriangleAlertIcon className="size-5 text-destructive" aria-hidden />}
+                        Delete group
+                    </DialogTitle>
                     <DialogDescription>
-                        Are you sure you want to delete <span className="font-medium text-foreground">{group?.name}</span>? Members will
-                        lose any access granted through this group.
+                        {blocked ? (
+                            <>
+                                <span className="font-medium text-foreground">{group?.name}</span> cannot be deleted while it still has a
+                                primary owner membership. Reassign or remove the primary owner first.
+                            </>
+                        ) : (
+                            <>
+                                Are you sure you want to delete <span className="font-medium text-foreground">{group?.name}</span>? Members
+                                will lose any access granted through this group.
+                            </>
+                        )}
                     </DialogDescription>
                 </DialogHeader>
                 <DialogFooter className="border-t px-6 py-4 gap-2">
                     <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
                         Cancel
                     </Button>
-                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || !group}>
-                        {isDeleting ? 'Deleting…' : 'Delete'}
-                    </Button>
+                    {!blocked && (
+                        <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || !group}>
+                            {isDeleting ? 'Deleting…' : 'Delete'}
+                        </Button>
+                    )}
                 </DialogFooter>
             </DialogContent>
         </Dialog>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupDeleteSheet.tsx
@@ -15,8 +15,10 @@
  */
 
 import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+import { TriangleAlertIcon } from '@gravitee/graphene-core/icons';
 
 import type { Group } from '../types/group';
+import { isPrimaryOwnerGroup } from '../utils/groupPermissions';
 
 export function GroupDeleteSheet({
     open,
@@ -31,6 +33,35 @@ export function GroupDeleteSheet({
     onConfirm: () => void;
     isDeleting: boolean;
 }>) {
+    // Delete is always offered (classic doesn't hide it either) — a primary-owner group is rejected by the
+    // backend with StillPrimaryOwnerException regardless, so surface that as soon as the dialog opens
+    // instead of letting the user hit an API error after confirming.
+    const blocked = group ? isPrimaryOwnerGroup(group) : false;
+
+    if (blocked) {
+        return (
+            <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+                <DialogContent className="max-w-sm">
+                    <DialogHeader>
+                        <DialogTitle className="flex items-center gap-2">
+                            <TriangleAlertIcon className="size-5 text-destructive" aria-hidden />
+                            Delete group?
+                        </DialogTitle>
+                        <DialogDescription>
+                            <span className="font-medium text-foreground">{group?.name}</span> cannot be deleted while it still has a
+                            primary owner membership. Reassign or remove the primary owner first.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter className="border-t px-6 py-4 gap-2">
+                        <Button type="button" variant="outline" onClick={onClose}>
+                            Cancel
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        );
+    }
+
     return (
         <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
             <DialogContent className="max-w-sm">

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.spec.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupMembersTable } from './GroupMembersTable';
+import type { GroupMember } from '../types/group';
+
+const RAVI: GroupMember = {
+    id: 'user-1',
+    displayName: 'Ravi Patel',
+    roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', GROUP: 'ADMIN' },
+};
+
+const MIA: GroupMember = {
+    id: 'user-2',
+    displayName: 'Mia Chen',
+    roles: { API: 'OWNER', APPLICATION: 'USER' },
+};
+
+function renderTable(overrides: Partial<React.ComponentProps<typeof GroupMembersTable>> = {}) {
+    return render(<GroupMembersTable members={[RAVI, MIA]} loading={false} {...overrides} />);
+}
+
+describe('GroupMembersTable', () => {
+    it('renders each member’s roles across the API, API product, Application, Integration, and Cluster columns', () => {
+        renderTable();
+
+        const raviRow = screen.getByText('Ravi Patel').closest('tr')!;
+        expect(raviRow.textContent).toContain('PRIMARY_OWNER');
+        expect(raviRow.textContent).toContain('OWNER');
+
+        const miaRow = screen.getByText('Mia Chen').closest('tr')!;
+        expect(miaRow.textContent).toContain('USER');
+    });
+
+    it('shows a Group admin badge for members with the GROUP/ADMIN role', () => {
+        renderTable();
+        expect(screen.getByText('Ravi Patel').closest('tr')!.textContent).toContain('Group admin');
+        expect(screen.getByText('Mia Chen').closest('tr')!.textContent).not.toContain('Group admin');
+    });
+
+    it('filters members by name client-side', () => {
+        renderTable();
+        fireEvent.change(screen.getByPlaceholderText('Search members…'), { target: { value: 'mia' } });
+        expect(screen.queryByText('Ravi Patel')).toBeNull();
+        expect(screen.queryByText('Mia Chen')).not.toBeNull();
+    });
+
+    it('shows a first-use empty state with no members', () => {
+        renderTable({ members: [] });
+        expect(screen.queryByText('No members yet')).not.toBeNull();
+    });
+
+    it('shows a no-results empty state when the search matches nothing', () => {
+        renderTable();
+        fireEvent.change(screen.getByPlaceholderText('Search members…'), { target: { value: 'nobody' } });
+        expect(screen.queryByText('No members match your search')).not.toBeNull();
+    });
+
+    it('does not throw when a member is missing displayName', () => {
+        const noName = { id: 'user-3', roles: {} } as unknown as GroupMember;
+        expect(() => renderTable({ members: [RAVI, noName] })).not.toThrow();
+        expect(() => fireEvent.change(screen.getByPlaceholderText('Search members…'), { target: { value: 'ravi' } })).not.toThrow();
+        expect(screen.queryByText('Ravi Patel')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.spec.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupMembersTable } from './GroupMembersTable';
+import type { GroupMember } from '../types/group';
+
+const RAVI: GroupMember = {
+    id: 'user-1',
+    displayName: 'Ravi Patel',
+    roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', GROUP: 'ADMIN' },
+};
+
+const MIA: GroupMember = {
+    id: 'user-2',
+    displayName: 'Mia Chen',
+    roles: { API: 'OWNER', APPLICATION: 'USER' },
+};
+
+function renderTable(overrides: Partial<React.ComponentProps<typeof GroupMembersTable>> = {}) {
+    return render(<GroupMembersTable members={[RAVI, MIA]} loading={false} {...overrides} />);
+}
+
+describe('GroupMembersTable', () => {
+    it('renders each member’s roles across the API, API product, Application, Integration, and Cluster columns', () => {
+        renderTable();
+
+        const raviRow = screen.getByText('Ravi Patel').closest('tr')!;
+        expect(raviRow.textContent).toContain('PRIMARY_OWNER');
+        expect(raviRow.textContent).toContain('OWNER');
+
+        const miaRow = screen.getByText('Mia Chen').closest('tr')!;
+        expect(miaRow.textContent).toContain('USER');
+    });
+
+    it('shows a Group admin badge for members with the GROUP/ADMIN role', () => {
+        renderTable();
+        expect(screen.getByText('Ravi Patel').closest('tr')!.textContent).toContain('Group admin');
+        expect(screen.getByText('Mia Chen').closest('tr')!.textContent).not.toContain('Group admin');
+    });
+
+    it('filters members by name client-side', () => {
+        renderTable();
+        fireEvent.change(screen.getByPlaceholderText('Search members…'), { target: { value: 'mia' } });
+        expect(screen.queryByText('Ravi Patel')).toBeNull();
+        expect(screen.queryByText('Mia Chen')).not.toBeNull();
+    });
+
+    it('shows a first-use empty state with no members', () => {
+        renderTable({ members: [] });
+        expect(screen.queryByText('No members yet')).not.toBeNull();
+    });
+
+    it('shows a no-results empty state when the search matches nothing', () => {
+        renderTable();
+        fireEvent.change(screen.getByPlaceholderText('Search members…'), { target: { value: 'nobody' } });
+        expect(screen.queryByText('No members match your search')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Badge,
+    Button,
+    DataTable,
+    DataTableColumnHeader,
+    DataTableEmptyState,
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { SearchIcon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+import type { GroupMember } from '../types/group';
+
+const PAGE_SIZE = 10;
+
+function roleCell(member: GroupMember, scope: 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER') {
+    const role = member.roles?.[scope];
+    return <span className="text-sm text-muted-foreground">{role ?? '—'}</span>;
+}
+
+function buildColumns(): DataTableProps<GroupMember>['columns'] {
+    return [
+        {
+            id: 'member',
+            accessorKey: 'displayName',
+            header: ({ column }: ColHeader<GroupMember>) => <DataTableColumnHeader column={column} title="Member" />,
+            cell: ({ row }: ColCell<GroupMember>) => (
+                <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{row.original.displayName}</span>
+                    {row.original.roles?.GROUP === 'ADMIN' && (
+                        <Badge variant="default" className="text-xs font-normal">
+                            Group admin
+                        </Badge>
+                    )}
+                </div>
+            ),
+        },
+        {
+            id: 'api',
+            header: 'API',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupMember>) => roleCell(row.original, 'API'),
+        },
+        {
+            id: 'apiProduct',
+            header: 'API product',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupMember>) => roleCell(row.original, 'API_PRODUCT'),
+        },
+        {
+            id: 'application',
+            header: 'Application',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupMember>) => roleCell(row.original, 'APPLICATION'),
+        },
+        {
+            id: 'integration',
+            header: 'Integration',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupMember>) => roleCell(row.original, 'INTEGRATION'),
+        },
+        {
+            id: 'cluster',
+            header: 'Cluster',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupMember>) => roleCell(row.original, 'CLUSTER'),
+        },
+    ];
+}
+
+function paginate(items: GroupMember[], page: number, pageSize: number): GroupMember[] {
+    const start = (page - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+}
+
+interface GroupMembersTableProps {
+    readonly members: GroupMember[];
+    readonly loading: boolean;
+}
+
+// Member management (add/invite/edit roles/remove) is added on top of this read-only view in a
+// follow-up PR (FOUND-106/FOUND-107) — this component intentionally has no action column yet.
+export function GroupMembersTable({ members, loading }: GroupMembersTableProps) {
+    const [search, setSearch] = useState('');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(PAGE_SIZE);
+
+    const filtered = useMemo(() => {
+        const query = search.trim().toLowerCase();
+        return query ? members.filter(member => (member.displayName ?? '').toLowerCase().includes(query)) : members;
+    }, [members, search]);
+
+    const totalCount = filtered.length;
+    const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1;
+    const pageData = useMemo(() => paginate(filtered, page, pageSize), [filtered, page, pageSize]);
+    const columns = useMemo(() => buildColumns(), []);
+
+    useEffect(() => {
+        if (page > totalPages) setPage(totalPages);
+    }, [page, totalPages]);
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    return (
+        <DataTable
+            aria-label="Members"
+            columns={columns}
+            data={pageData}
+            loading={loading}
+            skeletonCount={pageSize}
+            // Pagination is actually client-side (paginate() above already slices `data` down to the
+            // current page) — `serverSide` here just tells DataTable not to re-paginate what we hand it,
+            // since the `pagination` prop below drives the page controls off our own state instead.
+            serverSide
+            pagination={{
+                page,
+                pageSize,
+                totalCount,
+                pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                onPageChange: setPage,
+                onPageSizeChange: handlePageSizeChange,
+            }}
+            emptyMessage={
+                search ? (
+                    <DataTableEmptyState
+                        variant="no-results"
+                        icon={<SearchIcon className="size-8" aria-hidden />}
+                        title="No members match your search"
+                        description="Try adjusting your search terms."
+                        action={
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => {
+                                    handleSearchChange('');
+                                }}
+                            >
+                                Clear search
+                            </Button>
+                        }
+                    />
+                ) : (
+                    <DataTableEmptyState
+                        variant="first-use"
+                        icon={<UsersRoundIcon className="size-8" aria-hidden />}
+                        title="No members yet"
+                        description="Add users to this group to get started."
+                    />
+                )
+            }
+            toolbar={
+                <div className="w-64">
+                    <InputGroup>
+                        <InputGroupAddon align="inline-start">
+                            <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                        </InputGroupAddon>
+                        <InputGroupInput placeholder="Search members…" value={search} onChange={e => handleSearchChange(e.target.value)} />
+                    </InputGroup>
+                </div>
+            }
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
@@ -112,7 +112,7 @@ export function GroupMembersTable({ members, loading }: GroupMembersTableProps) 
     }, [members, search]);
 
     const totalCount = filtered.length;
-    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+    const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1;
     const pageData = useMemo(() => paginate(filtered, page, pageSize), [filtered, page, pageSize]);
     const columns = useMemo(() => buildColumns(), []);
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Badge,
+    Button,
+    DataTable,
+    DataTableColumnHeader,
+    DataTableEmptyState,
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { SearchIcon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+import type { GroupMember } from '../types/group';
+
+const PAGE_SIZE = 10;
+
+function roleCell(member: GroupMember, scope: 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER') {
+    const role = member.roles?.[scope];
+    return <span className="text-sm text-muted-foreground">{role ?? '—'}</span>;
+}
+
+function buildColumns(): DataTableProps<GroupMember>['columns'] {
+    return [
+        {
+            id: 'member',
+            accessorKey: 'displayName',
+            header: ({ column }: ColHeader<GroupMember>) => <DataTableColumnHeader column={column} title="Member" />,
+            cell: ({ row }: ColCell<GroupMember>) => (
+                <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{row.original.displayName}</span>
+                    {row.original.roles?.GROUP === 'ADMIN' && (
+                        <Badge variant="default" className="text-xs font-normal">
+                            Group admin
+                        </Badge>
+                    )}
+                </div>
+            ),
+        },
+        {
+            id: 'api',
+            header: 'API',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupMember>) => roleCell(row.original, 'API'),
+        },
+        {
+            id: 'apiProduct',
+            header: 'API product',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupMember>) => roleCell(row.original, 'API_PRODUCT'),
+        },
+        {
+            id: 'application',
+            header: 'Application',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupMember>) => roleCell(row.original, 'APPLICATION'),
+        },
+        {
+            id: 'integration',
+            header: 'Integration',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupMember>) => roleCell(row.original, 'INTEGRATION'),
+        },
+        {
+            id: 'cluster',
+            header: 'Cluster',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupMember>) => roleCell(row.original, 'CLUSTER'),
+        },
+    ];
+}
+
+function paginate(items: GroupMember[], page: number, pageSize: number): GroupMember[] {
+    const start = (page - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+}
+
+interface GroupMembersTableProps {
+    readonly members: GroupMember[];
+    readonly loading: boolean;
+}
+
+// Member management (add/invite/edit roles/remove) is added on top of this read-only view in a
+// follow-up PR (FOUND-106/FOUND-107) — this component intentionally has no action column yet.
+export function GroupMembersTable({ members, loading }: GroupMembersTableProps) {
+    const [search, setSearch] = useState('');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(PAGE_SIZE);
+
+    const filtered = useMemo(() => {
+        const query = search.trim().toLowerCase();
+        return query ? members.filter(member => member.displayName.toLowerCase().includes(query)) : members;
+    }, [members, search]);
+
+    const totalCount = filtered.length;
+    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+    const pageData = useMemo(() => paginate(filtered, page, pageSize), [filtered, page, pageSize]);
+    const columns = useMemo(() => buildColumns(), []);
+
+    useEffect(() => {
+        if (page > totalPages) setPage(totalPages);
+    }, [page, totalPages]);
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    return (
+        <DataTable
+            aria-label="Members"
+            columns={columns}
+            data={pageData}
+            loading={loading}
+            skeletonCount={pageSize}
+            serverSide
+            pagination={{
+                page,
+                pageSize,
+                totalCount,
+                pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                onPageChange: setPage,
+                onPageSizeChange: handlePageSizeChange,
+            }}
+            emptyMessage={
+                search ? (
+                    <DataTableEmptyState
+                        variant="no-results"
+                        icon={<SearchIcon className="size-8" aria-hidden />}
+                        title="No members match your search"
+                        description="Try adjusting your search terms."
+                        action={
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => {
+                                    handleSearchChange('');
+                                }}
+                            >
+                                Clear search
+                            </Button>
+                        }
+                    />
+                ) : (
+                    <DataTableEmptyState
+                        variant="first-use"
+                        icon={<UsersRoundIcon className="size-8" aria-hidden />}
+                        title="No members yet"
+                        description="Add users to this group to get started."
+                    />
+                )
+            }
+            toolbar={
+                <div className="w-64">
+                    <InputGroup>
+                        <InputGroupAddon align="inline-start">
+                            <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                        </InputGroupAddon>
+                        <InputGroupInput placeholder="Search members…" value={search} onChange={e => handleSearchChange(e.target.value)} />
+                    </InputGroup>
+                </div>
+            }
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembershipTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembershipTable.spec.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupMembershipTable } from './GroupMembershipTable';
+import type { GroupMembershipItem } from '../types/group';
+
+const BILLING_API: GroupMembershipItem = { id: 'api-1', name: 'Billing API', version: '1.0' };
+const CATALOG_API: GroupMembershipItem = { id: 'api-2', name: 'Catalog API', version: '2.1' };
+const MOBILE_APP: GroupMembershipItem = { id: 'app-1', name: 'Mobile App' };
+
+function renderTable(overrides: Partial<React.ComponentProps<typeof GroupMembershipTable>> = {}) {
+    return render(
+        <GroupMembershipTable
+            items={[BILLING_API, CATALOG_API]}
+            loading={false}
+            ariaLabel="APIs"
+            searchPlaceholder="Search APIs…"
+            emptyTitle="No dependent APIs to display"
+            emptyDescription="APIs associated with this group will appear here."
+            {...overrides}
+        />,
+    );
+}
+
+describe('GroupMembershipTable', () => {
+    it('renders each item’s name and version', () => {
+        renderTable();
+
+        expect(screen.getByText('Billing API').closest('tr')!.textContent).toContain('1.0');
+        expect(screen.getByText('Catalog API').closest('tr')!.textContent).toContain('2.1');
+    });
+
+    it('omits the Version column when showVersionColumn is false — Applications have no version', () => {
+        renderTable({ items: [MOBILE_APP], showVersionColumn: false });
+
+        expect(screen.queryByText('Version')).toBeNull();
+        expect(screen.getByText('Mobile App')).not.toBeNull();
+    });
+
+    it('filters items by name client-side', () => {
+        renderTable();
+        fireEvent.change(screen.getByPlaceholderText('Search APIs…'), { target: { value: 'billing' } });
+        expect(screen.queryByText('Catalog API')).toBeNull();
+        expect(screen.queryByText('Billing API')).not.toBeNull();
+    });
+
+    it('paginates client-side once items exceed the page size', () => {
+        const items = Array.from({ length: 12 }, (_, i) => ({ id: `api-${i}`, name: `API ${i}` }));
+        renderTable({ items });
+
+        expect(screen.queryByText('API 0')).not.toBeNull();
+        expect(screen.queryByText('API 11')).toBeNull();
+    });
+
+    it('shows a first-use empty state with no items', () => {
+        renderTable({ items: [] });
+        expect(screen.queryByText('No dependent APIs to display')).not.toBeNull();
+    });
+
+    it('shows a no-results empty state when the search matches nothing', () => {
+        renderTable();
+        fireEvent.change(screen.getByPlaceholderText('Search APIs…'), { target: { value: 'nobody' } });
+        expect(screen.queryByText('No results match your search')).not.toBeNull();
+    });
+
+    it('clears the search from the no-results empty state', () => {
+        renderTable();
+        fireEvent.change(screen.getByPlaceholderText('Search APIs…'), { target: { value: 'nobody' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+        expect(screen.getByText('Billing API')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembershipTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembershipTable.tsx
@@ -15,6 +15,7 @@
  */
 
 import {
+    Button,
     DataTable,
     DataTableColumnHeader,
     DataTableEmptyState,
@@ -32,23 +33,27 @@ import type { GroupMembershipItem } from '../types/group';
 
 const PAGE_SIZE = 10;
 
-function buildColumns(): DataTableProps<GroupMembershipItem>['columns'] {
-    return [
+function buildColumns(showVersionColumn: boolean): DataTableProps<GroupMembershipItem>['columns'] {
+    const columns: DataTableProps<GroupMembershipItem>['columns'] = [
         {
             id: 'name',
             accessorKey: 'name',
             header: ({ column }: ColHeader<GroupMembershipItem>) => <DataTableColumnHeader column={column} title="Name" />,
             cell: ({ row }: ColCell<GroupMembershipItem>) => <span className="text-sm font-medium">{row.original.name}</span>,
         },
-        {
+    ];
+    // Applications don't have a version — showing an always-"—" column there is just noise.
+    if (showVersionColumn) {
+        columns.push({
             id: 'version',
             header: 'Version',
             enableSorting: false,
             cell: ({ row }: ColCell<GroupMembershipItem>) => (
                 <span className="text-sm text-muted-foreground">{row.original.version ?? '—'}</span>
             ),
-        },
-    ];
+        });
+    }
+    return columns;
 }
 
 function paginate(items: GroupMembershipItem[], page: number, pageSize: number): GroupMembershipItem[] {
@@ -61,8 +66,12 @@ interface GroupMembershipTableProps {
     readonly loading: boolean;
     readonly ariaLabel: string;
     readonly searchPlaceholder: string;
+    /** Shown when there are no items at all (never associated) — distinct from the search "no results"
+     *  state below, mirroring GroupMembersTable's branching. */
     readonly emptyTitle: string;
     readonly emptyDescription: string;
+    /** Applications have no version — omit the column entirely rather than showing an always-"—" one. */
+    readonly showVersionColumn?: boolean;
 }
 
 export function GroupMembershipTable({
@@ -72,6 +81,7 @@ export function GroupMembershipTable({
     searchPlaceholder,
     emptyTitle,
     emptyDescription,
+    showVersionColumn = true,
 }: GroupMembershipTableProps) {
     const [search, setSearch] = useState('');
     const [page, setPage] = useState(1);
@@ -83,9 +93,9 @@ export function GroupMembershipTable({
     }, [items, search]);
 
     const totalCount = filtered.length;
-    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+    const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1;
     const pageData = useMemo(() => paginate(filtered, page, pageSize), [filtered, page, pageSize]);
-    const columns = useMemo(() => buildColumns(), []);
+    const columns = useMemo(() => buildColumns(showVersionColumn), [showVersionColumn]);
 
     useEffect(() => {
         if (page > totalPages) setPage(totalPages);
@@ -108,6 +118,9 @@ export function GroupMembershipTable({
             data={pageData}
             loading={loading}
             skeletonCount={pageSize}
+            // Pagination is actually client-side (paginate() above already slices `data` down to the
+            // current page) — `serverSide` here just tells DataTable not to re-paginate what we hand it,
+            // since the `pagination` prop below drives the page controls off our own state instead.
             serverSide
             pagination={{
                 page,
@@ -118,12 +131,26 @@ export function GroupMembershipTable({
                 onPageSizeChange: handlePageSizeChange,
             }}
             emptyMessage={
-                <DataTableEmptyState
-                    variant="no-results"
-                    icon={<SearchIcon className="size-8" aria-hidden />}
-                    title={emptyTitle}
-                    description={emptyDescription}
-                />
+                search ? (
+                    <DataTableEmptyState
+                        variant="no-results"
+                        icon={<SearchIcon className="size-8" aria-hidden />}
+                        title="No results match your search"
+                        description="Try adjusting your search terms."
+                        action={
+                            <Button size="sm" variant="outline" onClick={() => handleSearchChange('')}>
+                                Clear search
+                            </Button>
+                        }
+                    />
+                ) : (
+                    <DataTableEmptyState
+                        variant="first-use"
+                        icon={<SearchIcon className="size-8" aria-hidden />}
+                        title={emptyTitle}
+                        description={emptyDescription}
+                    />
+                )
             }
             toolbar={
                 <div className="w-64">

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembershipTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembershipTable.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    DataTable,
+    DataTableColumnHeader,
+    DataTableEmptyState,
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { SearchIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+import type { GroupMembershipItem } from '../types/group';
+
+const PAGE_SIZE = 10;
+
+function buildColumns(showVersionColumn: boolean): DataTableProps<GroupMembershipItem>['columns'] {
+    const columns: DataTableProps<GroupMembershipItem>['columns'] = [
+        {
+            id: 'name',
+            accessorKey: 'name',
+            header: ({ column }: ColHeader<GroupMembershipItem>) => <DataTableColumnHeader column={column} title="Name" />,
+            cell: ({ row }: ColCell<GroupMembershipItem>) => <span className="text-sm font-medium">{row.original.name}</span>,
+        },
+    ];
+    // Applications don't have a version — showing an always-"—" column there is just noise.
+    if (showVersionColumn) {
+        columns.push({
+            id: 'version',
+            header: 'Version',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupMembershipItem>) => (
+                <span className="text-sm text-muted-foreground">{row.original.version ?? '—'}</span>
+            ),
+        });
+    }
+    return columns;
+}
+
+function paginate(items: GroupMembershipItem[], page: number, pageSize: number): GroupMembershipItem[] {
+    const start = (page - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+}
+
+interface GroupMembershipTableProps {
+    readonly items: GroupMembershipItem[];
+    readonly loading: boolean;
+    readonly ariaLabel: string;
+    readonly searchPlaceholder: string;
+    /** Shown when there are no items at all (never associated) — distinct from the search "no results"
+     *  state below, mirroring GroupMembersTable's branching. */
+    readonly emptyTitle: string;
+    readonly emptyDescription: string;
+    /** Applications have no version — omit the column entirely rather than showing an always-"—" one. */
+    readonly showVersionColumn?: boolean;
+}
+
+export function GroupMembershipTable({
+    items,
+    loading,
+    ariaLabel,
+    searchPlaceholder,
+    emptyTitle,
+    emptyDescription,
+    showVersionColumn = true,
+}: GroupMembershipTableProps) {
+    const [search, setSearch] = useState('');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(PAGE_SIZE);
+
+    const filtered = useMemo(() => {
+        const query = search.trim().toLowerCase();
+        return query ? items.filter(item => item.name.toLowerCase().includes(query)) : items;
+    }, [items, search]);
+
+    const totalCount = filtered.length;
+    const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1;
+    const pageData = useMemo(() => paginate(filtered, page, pageSize), [filtered, page, pageSize]);
+    const columns = useMemo(() => buildColumns(showVersionColumn), [showVersionColumn]);
+
+    useEffect(() => {
+        if (page > totalPages) setPage(totalPages);
+    }, [page, totalPages]);
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    return (
+        <DataTable
+            aria-label={ariaLabel}
+            columns={columns}
+            data={pageData}
+            loading={loading}
+            skeletonCount={pageSize}
+            // Pagination is actually client-side (paginate() above already slices `data` down to the
+            // current page) — `serverSide` here just tells DataTable not to re-paginate what we hand it,
+            // since the `pagination` prop below drives the page controls off our own state instead.
+            serverSide
+            pagination={{
+                page,
+                pageSize,
+                totalCount,
+                pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                onPageChange: setPage,
+                onPageSizeChange: handlePageSizeChange,
+            }}
+            emptyMessage={
+                search ? (
+                    <DataTableEmptyState
+                        variant="no-results"
+                        icon={<SearchIcon className="size-8" aria-hidden />}
+                        title="No results match your search"
+                        description="Try adjusting your search terms."
+                        action={
+                            <Button size="sm" variant="outline" onClick={() => handleSearchChange('')}>
+                                Clear search
+                            </Button>
+                        }
+                    />
+                ) : (
+                    <DataTableEmptyState
+                        variant="first-use"
+                        icon={<SearchIcon className="size-8" aria-hidden />}
+                        title={emptyTitle}
+                        description={emptyDescription}
+                    />
+                )
+            }
+            toolbar={
+                <div className="w-64">
+                    <InputGroup>
+                        <InputGroupAddon align="inline-start">
+                            <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                        </InputGroupAddon>
+                        <InputGroupInput
+                            placeholder={searchPlaceholder}
+                            value={search}
+                            onChange={e => handleSearchChange(e.target.value)}
+                        />
+                    </InputGroup>
+                </div>
+            }
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembershipTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembershipTable.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    DataTable,
+    DataTableColumnHeader,
+    DataTableEmptyState,
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { SearchIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+import type { GroupMembershipItem } from '../types/group';
+
+const PAGE_SIZE = 10;
+
+function buildColumns(): DataTableProps<GroupMembershipItem>['columns'] {
+    return [
+        {
+            id: 'name',
+            accessorKey: 'name',
+            header: ({ column }: ColHeader<GroupMembershipItem>) => <DataTableColumnHeader column={column} title="Name" />,
+            cell: ({ row }: ColCell<GroupMembershipItem>) => <span className="text-sm font-medium">{row.original.name}</span>,
+        },
+        {
+            id: 'version',
+            header: 'Version',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupMembershipItem>) => (
+                <span className="text-sm text-muted-foreground">{row.original.version ?? '—'}</span>
+            ),
+        },
+    ];
+}
+
+function paginate(items: GroupMembershipItem[], page: number, pageSize: number): GroupMembershipItem[] {
+    const start = (page - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+}
+
+interface GroupMembershipTableProps {
+    readonly items: GroupMembershipItem[];
+    readonly loading: boolean;
+    readonly ariaLabel: string;
+    readonly searchPlaceholder: string;
+    readonly emptyTitle: string;
+    readonly emptyDescription: string;
+}
+
+export function GroupMembershipTable({
+    items,
+    loading,
+    ariaLabel,
+    searchPlaceholder,
+    emptyTitle,
+    emptyDescription,
+}: GroupMembershipTableProps) {
+    const [search, setSearch] = useState('');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(PAGE_SIZE);
+
+    const filtered = useMemo(() => {
+        const query = search.trim().toLowerCase();
+        return query ? items.filter(item => item.name.toLowerCase().includes(query)) : items;
+    }, [items, search]);
+
+    const totalCount = filtered.length;
+    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+    const pageData = useMemo(() => paginate(filtered, page, pageSize), [filtered, page, pageSize]);
+    const columns = useMemo(() => buildColumns(), []);
+
+    useEffect(() => {
+        if (page > totalPages) setPage(totalPages);
+    }, [page, totalPages]);
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    return (
+        <DataTable
+            aria-label={ariaLabel}
+            columns={columns}
+            data={pageData}
+            loading={loading}
+            skeletonCount={pageSize}
+            serverSide
+            pagination={{
+                page,
+                pageSize,
+                totalCount,
+                pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                onPageChange: setPage,
+                onPageSizeChange: handlePageSizeChange,
+            }}
+            emptyMessage={
+                <DataTableEmptyState
+                    variant="no-results"
+                    icon={<SearchIcon className="size-8" aria-hidden />}
+                    title={emptyTitle}
+                    description={emptyDescription}
+                />
+            }
+            toolbar={
+                <div className="w-64">
+                    <InputGroup>
+                        <InputGroupAddon align="inline-start">
+                            <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                        </InputGroupAddon>
+                        <InputGroupInput
+                            placeholder={searchPlaceholder}
+                            value={search}
+                            onChange={e => handleSearchChange(e.target.value)}
+                        />
+                    </InputGroup>
+                </div>
+            }
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.spec.tsx
@@ -15,9 +15,17 @@
  */
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useNavigate } from 'react-router-dom';
 
 import { GroupsTable } from './GroupsTable';
 import type { Group } from '../types/group';
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: jest.fn(),
+}));
+
+const mockUseNavigate = jest.mocked(useNavigate);
 
 const GROUP: Group = { id: 'group-1', name: 'Support Team', created_at: 1700000000000 };
 
@@ -44,8 +52,22 @@ function renderTable(overrides: Partial<React.ComponentProps<typeof GroupsTable>
 }
 
 describe('GroupsTable', () => {
+    beforeEach(() => {
+        mockUseNavigate.mockReturnValue(jest.fn());
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
+    });
+
+    it('navigates to the group detail page when clicking the name', () => {
+        const navigate = jest.fn();
+        mockUseNavigate.mockReturnValue(navigate);
+
+        renderTable();
+        fireEvent.click(screen.getByRole('button', { name: 'Support Team' }));
+
+        expect(navigate).toHaveBeenCalledWith('group-1');
     });
 
     describe('Primary owner badge', () => {
@@ -65,17 +87,20 @@ describe('GroupsTable', () => {
     });
 
     describe('row-level action gating', () => {
-        it('hides Edit/Delete entirely when manageable is false, even with global permissions', () => {
+        it('does not gate Edit/Delete on manageable — classic only uses it for member invitations', async () => {
+            const user = userEvent.setup();
             renderTable({ groups: [{ ...GROUP, manageable: false }], canEdit: true, canDelete: true });
-            expect(screen.queryByRole('button', { name: 'Group actions' })).toBeNull();
+            await user.click(screen.getByRole('button', { name: 'Group actions' }));
+            expect(await screen.findByRole('menuitem', { name: /^Edit$/ })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: /^Delete$/ })).not.toBeNull();
         });
 
-        it('disables Delete (but keeps Edit) for a primary-owner group', async () => {
+        it('still shows Delete for a primary-owner group — GroupDeleteSheet explains why it is blocked, not this menu', async () => {
             const user = userEvent.setup();
             renderTable({ groups: [{ ...GROUP, primary_owner: true }], canEdit: true, canDelete: true });
             await user.click(screen.getByRole('button', { name: 'Group actions' }));
             expect(await screen.findByRole('menuitem', { name: /^Edit$/ })).not.toBeNull();
-            expect(screen.queryByRole('menuitem', { name: /^Delete$/ })).toBeNull();
+            expect(screen.queryByRole('menuitem', { name: /^Delete$/ })).not.toBeNull();
         });
 
         it('allows Delete for a non-primary-owner, manageable group', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.spec.tsx
@@ -15,59 +15,45 @@
  */
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useNavigate } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
 import { GroupsTable } from './GroupsTable';
 import type { Group } from '../types/group';
-
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useNavigate: jest.fn(),
-}));
-
-const mockUseNavigate = jest.mocked(useNavigate);
 
 const GROUP: Group = { id: 'group-1', name: 'Support Team', created_at: 1700000000000 };
 
 function renderTable(overrides: Partial<React.ComponentProps<typeof GroupsTable>> = {}) {
     return render(
-        <GroupsTable
-            groups={[GROUP]}
-            totalCount={1}
-            loading={false}
-            isFirstUse={false}
-            search=""
-            page={1}
-            pageSize={10}
-            canEdit={false}
-            canDelete={false}
-            onSearchChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onPageSizeChange={jest.fn()}
-            onEdit={jest.fn()}
-            onDelete={jest.fn()}
-            {...overrides}
-        />,
+        <MemoryRouter>
+            <GroupsTable
+                groups={[GROUP]}
+                totalCount={1}
+                loading={false}
+                isFirstUse={false}
+                search=""
+                page={1}
+                pageSize={10}
+                canEdit={false}
+                canDelete={false}
+                onSearchChange={jest.fn()}
+                onPageChange={jest.fn()}
+                onPageSizeChange={jest.fn()}
+                onEdit={jest.fn()}
+                onDelete={jest.fn()}
+                {...overrides}
+            />
+        </MemoryRouter>,
     );
 }
 
 describe('GroupsTable', () => {
-    beforeEach(() => {
-        mockUseNavigate.mockReturnValue(jest.fn());
-    });
-
     afterEach(() => {
         jest.clearAllMocks();
     });
 
-    it('navigates to the group detail page when clicking the name', () => {
-        const navigate = jest.fn();
-        mockUseNavigate.mockReturnValue(navigate);
-
+    it('renders the name as a real link to the group detail page — supports open-in-new-tab/middle-click', () => {
         renderTable();
-        fireEvent.click(screen.getByRole('button', { name: 'Support Team' }));
-
-        expect(navigate).toHaveBeenCalledWith('group-1');
+        expect(screen.getByRole('link', { name: 'Support Team' }).getAttribute('href')).toBe('/group-1');
     });
 
     describe('Primary owner badge', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.spec.tsx
@@ -15,6 +15,7 @@
  */
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 
 import { GroupsTable } from './GroupsTable';
 import type { Group } from '../types/group';
@@ -23,29 +24,36 @@ const GROUP: Group = { id: 'group-1', name: 'Support Team', created_at: 17000000
 
 function renderTable(overrides: Partial<React.ComponentProps<typeof GroupsTable>> = {}) {
     return render(
-        <GroupsTable
-            groups={[GROUP]}
-            totalCount={1}
-            loading={false}
-            isFirstUse={false}
-            search=""
-            page={1}
-            pageSize={10}
-            canEdit={false}
-            canDelete={false}
-            onSearchChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onPageSizeChange={jest.fn()}
-            onEdit={jest.fn()}
-            onDelete={jest.fn()}
-            {...overrides}
-        />,
+        <MemoryRouter>
+            <GroupsTable
+                groups={[GROUP]}
+                totalCount={1}
+                loading={false}
+                isFirstUse={false}
+                search=""
+                page={1}
+                pageSize={10}
+                canEdit={false}
+                canDelete={false}
+                onSearchChange={jest.fn()}
+                onPageChange={jest.fn()}
+                onPageSizeChange={jest.fn()}
+                onEdit={jest.fn()}
+                onDelete={jest.fn()}
+                {...overrides}
+            />
+        </MemoryRouter>,
     );
 }
 
 describe('GroupsTable', () => {
     afterEach(() => {
         jest.clearAllMocks();
+    });
+
+    it('renders the name as a real link to the group detail page — supports open-in-new-tab/middle-click', () => {
+        renderTable();
+        expect(screen.getByRole('link', { name: 'Support Team' }).getAttribute('href')).toBe('/group-1');
     });
 
     describe('Primary owner badge', () => {
@@ -65,17 +73,20 @@ describe('GroupsTable', () => {
     });
 
     describe('row-level action gating', () => {
-        it('hides Edit/Delete entirely when manageable is false, even with global permissions', () => {
+        it('does not gate Edit/Delete on manageable — classic only uses it for member invitations', async () => {
+            const user = userEvent.setup();
             renderTable({ groups: [{ ...GROUP, manageable: false }], canEdit: true, canDelete: true });
-            expect(screen.queryByRole('button', { name: 'Group actions' })).toBeNull();
+            await user.click(screen.getByRole('button', { name: 'Group actions' }));
+            expect(await screen.findByRole('menuitem', { name: /^Edit$/ })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: /^Delete$/ })).not.toBeNull();
         });
 
-        it('disables Delete (but keeps Edit) for a primary-owner group', async () => {
+        it('still shows Delete for a primary-owner group — GroupDeleteSheet explains why it is blocked, not this menu', async () => {
             const user = userEvent.setup();
             renderTable({ groups: [{ ...GROUP, primary_owner: true }], canEdit: true, canDelete: true });
             await user.click(screen.getByRole('button', { name: 'Group actions' }));
             expect(await screen.findByRole('menuitem', { name: /^Edit$/ })).not.toBeNull();
-            expect(screen.queryByRole('menuitem', { name: /^Delete$/ })).toBeNull();
+            expect(screen.queryByRole('menuitem', { name: /^Delete$/ })).not.toBeNull();
         });
 
         it('allows Delete for a non-primary-owner, manageable group', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.tsx
@@ -33,22 +33,22 @@ import {
 } from '@gravitee/graphene-core';
 import { MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
 import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
 import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
 import type { Group } from '../types/group';
+import { hasEventRule } from '../utils/groupPayload';
 import { isPrimaryOwnerGroup } from '../utils/groupPermissions';
 
-function hasEventRule(group: Group, event: 'API_CREATE' | 'APPLICATION_CREATE' | 'API_PRODUCT_CREATE'): boolean {
-    return (group.event_rules ?? []).some(rule => rule.event === event);
-}
-
 function buildColumns({
+    navigate,
     canEdit,
     canDelete,
     onEdit,
     onDelete,
 }: {
+    navigate: ReturnType<typeof useNavigate>;
     canEdit: boolean;
     canDelete: boolean;
     onEdit: (group: Group) => void;
@@ -61,7 +61,14 @@ function buildColumns({
             header: ({ column }: ColHeader<Group>) => <DataTableColumnHeader column={column} title="Name" />,
             cell: ({ row }: ColCell<Group>) => (
                 <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-medium">{row.original.name}</span>
+                    <Button
+                        type="button"
+                        variant="link"
+                        className="h-auto p-0 text-left text-sm font-medium text-foreground hover:underline hover:text-foreground"
+                        onClick={() => navigate(row.original.id)}
+                    >
+                        {row.original.name}
+                    </Button>
                     {isPrimaryOwnerGroup(row.original) && (
                         <Badge variant="default" className="text-xs font-normal">
                             Primary owner
@@ -106,14 +113,13 @@ function buildColumns({
             enableSorting: false,
             enableHiding: false,
             cell: ({ row }: ColCell<Group>) => {
-                // Mirrors classic Console's group.component.ts: a group with manageable === false can't be
-                // edited/deleted by the current user even if they hold the global environment-group-u/d
-                // permission, and a primary-owner group can never be deleted (backend rejects with
-                // StillPrimaryOwnerException regardless). Absent manageable (undefined) means the backend
-                // didn't send the flag — default to allowed.
-                const manageable = row.original.manageable ?? true;
-                const canEditRow = canEdit && manageable;
-                const canDeleteRow = canDelete && manageable && !isPrimaryOwnerGroup(row.original);
+                // Delete stays visible even for a primary-owner group — classic doesn't hide it either.
+                // GroupDeleteSheet checks isPrimaryOwnerGroup itself and shows why deletion is blocked
+                // instead of a confirm button, so the user finds out without a failed API call.
+                // `manageable` is NOT part of classic's edit/delete gating — classic only uses it to gate
+                // member invitations — so it's deliberately not checked here either.
+                const canEditRow = canEdit;
+                const canDeleteRow = canDelete;
                 if (!canEditRow && !canDeleteRow) return null;
                 return (
                     <div className="flex justify-end">
@@ -183,7 +189,11 @@ export function GroupsTable({
     onDelete,
     onCreateGroup,
 }: GroupsTableProps) {
-    const columns = useMemo(() => buildColumns({ canEdit, canDelete, onEdit, onDelete }), [canEdit, canDelete, onEdit, onDelete]);
+    const navigate = useNavigate();
+    const columns = useMemo(
+        () => buildColumns({ navigate, canEdit, canDelete, onEdit, onDelete }),
+        [navigate, canEdit, canDelete, onEdit, onDelete],
+    );
 
     if (isFirstUse) {
         return (

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.tsx
@@ -33,15 +33,13 @@ import {
 } from '@gravitee/graphene-core';
 import { MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
 import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
 
 import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
 import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
 import type { Group } from '../types/group';
+import { hasEventRule } from '../utils/groupPayload';
 import { isPrimaryOwnerGroup } from '../utils/groupPermissions';
-
-function hasEventRule(group: Group, event: 'API_CREATE' | 'APPLICATION_CREATE' | 'API_PRODUCT_CREATE'): boolean {
-    return (group.event_rules ?? []).some(rule => rule.event === event);
-}
 
 function buildColumns({
     canEdit,
@@ -61,7 +59,11 @@ function buildColumns({
             header: ({ column }: ColHeader<Group>) => <DataTableColumnHeader column={column} title="Name" />,
             cell: ({ row }: ColCell<Group>) => (
                 <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-medium">{row.original.name}</span>
+                    {/* A real Link (not onClick + navigate()) so open-in-new-tab/middle-click work — matches
+                        UsersTable's name column. */}
+                    <Button asChild variant="link" className="h-auto p-0 text-left text-sm font-medium text-foreground hover:underline">
+                        <Link to={row.original.id}>{row.original.name}</Link>
+                    </Button>
                     {isPrimaryOwnerGroup(row.original) && (
                         <Badge variant="default" className="text-xs font-normal">
                             Primary owner
@@ -106,14 +108,14 @@ function buildColumns({
             enableSorting: false,
             enableHiding: false,
             cell: ({ row }: ColCell<Group>) => {
-                // Mirrors classic Console's group.component.ts: a group with manageable === false can't be
-                // edited/deleted by the current user even if they hold the global environment-group-u/d
-                // permission, and a primary-owner group can never be deleted (backend rejects with
-                // StillPrimaryOwnerException regardless). Absent manageable (undefined) means the backend
-                // didn't send the flag — default to allowed.
-                const manageable = row.original.manageable ?? true;
-                const canEditRow = canEdit && manageable;
-                const canDeleteRow = canDelete && manageable && !isPrimaryOwnerGroup(row.original);
+                // Intentional, not a regression: `manageable`/primary-owner gating was verified against
+                // classic Console's actual group.component.ts (canInviteMember() is the only place
+                // `manageable` is read there — it never gates edit/delete), so it's deliberately not
+                // checked here either. Delete stays visible even for a primary-owner group for the same
+                // reason — classic doesn't hide it — and GroupDeleteSheet checks isPrimaryOwnerGroup
+                // itself, showing why deletion is blocked instead of a confirm button that would 400.
+                const canEditRow = canEdit;
+                const canDeleteRow = canDelete;
                 if (!canEditRow && !canDeleteRow) return null;
                 return (
                     <div className="flex justify-end">

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsTable.tsx
@@ -33,7 +33,7 @@ import {
 } from '@gravitee/graphene-core';
 import { MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
 import { useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
 import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
@@ -42,13 +42,11 @@ import { hasEventRule } from '../utils/groupPayload';
 import { isPrimaryOwnerGroup } from '../utils/groupPermissions';
 
 function buildColumns({
-    navigate,
     canEdit,
     canDelete,
     onEdit,
     onDelete,
 }: {
-    navigate: ReturnType<typeof useNavigate>;
     canEdit: boolean;
     canDelete: boolean;
     onEdit: (group: Group) => void;
@@ -61,13 +59,10 @@ function buildColumns({
             header: ({ column }: ColHeader<Group>) => <DataTableColumnHeader column={column} title="Name" />,
             cell: ({ row }: ColCell<Group>) => (
                 <div className="flex flex-wrap items-center gap-2">
-                    <Button
-                        type="button"
-                        variant="link"
-                        className="h-auto p-0 text-left text-sm font-medium text-foreground hover:underline hover:text-foreground"
-                        onClick={() => navigate(row.original.id)}
-                    >
-                        {row.original.name}
+                    {/* A real Link (not onClick + navigate()) so open-in-new-tab/middle-click work — matches
+                        UsersTable's name column. */}
+                    <Button asChild variant="link" className="h-auto p-0 text-left text-sm font-medium text-foreground hover:underline">
+                        <Link to={row.original.id}>{row.original.name}</Link>
                     </Button>
                     {isPrimaryOwnerGroup(row.original) && (
                         <Badge variant="default" className="text-xs font-normal">
@@ -113,11 +108,12 @@ function buildColumns({
             enableSorting: false,
             enableHiding: false,
             cell: ({ row }: ColCell<Group>) => {
-                // Delete stays visible even for a primary-owner group — classic doesn't hide it either.
-                // GroupDeleteSheet checks isPrimaryOwnerGroup itself and shows why deletion is blocked
-                // instead of a confirm button, so the user finds out without a failed API call.
-                // `manageable` is NOT part of classic's edit/delete gating — classic only uses it to gate
-                // member invitations — so it's deliberately not checked here either.
+                // Intentional, not a regression: `manageable`/primary-owner gating was verified against
+                // classic Console's actual group.component.ts (canInviteMember() is the only place
+                // `manageable` is read there — it never gates edit/delete), so it's deliberately not
+                // checked here either. Delete stays visible even for a primary-owner group for the same
+                // reason — classic doesn't hide it — and GroupDeleteSheet checks isPrimaryOwnerGroup
+                // itself, showing why deletion is blocked instead of a confirm button that would 400.
                 const canEditRow = canEdit;
                 const canDeleteRow = canDelete;
                 if (!canEditRow && !canDeleteRow) return null;
@@ -189,11 +185,7 @@ export function GroupsTable({
     onDelete,
     onCreateGroup,
 }: GroupsTableProps) {
-    const navigate = useNavigate();
-    const columns = useMemo(
-        () => buildColumns({ navigate, canEdit, canDelete, onEdit, onDelete }),
-        [navigate, canEdit, canDelete, onEdit, onDelete],
-    );
+    const columns = useMemo(() => buildColumns({ canEdit, canDelete, onEdit, onDelete }), [canEdit, canDelete, onEdit, onDelete]);
 
     if (isFirstUse) {
         return (

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupDetail.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupDetail.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { getGroup, listGroupMembers, listGroupMemberships } from '../services/groups';
+import type { GroupMembershipType } from '../types/group';
+import { groupKeys } from '../utils/queryKeys';
+
+export function useGroupDetail(groupId: string | undefined) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: groupKeys.detail(env?.id ?? '', groupId ?? ''),
+        queryFn: () => getGroup(env!.id, groupId!),
+        enabled: Boolean(env && groupId),
+    });
+}
+
+export function useGroupMembers(groupId: string | undefined) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: groupKeys.members(env?.id ?? '', groupId ?? ''),
+        queryFn: () => listGroupMembers(env!.id, groupId!),
+        enabled: Boolean(env && groupId),
+    });
+}
+
+function useGroupMemberships(groupId: string | undefined, type: GroupMembershipType) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: groupKeys.memberships(env?.id ?? '', groupId ?? '', type),
+        queryFn: () => listGroupMemberships(env!.id, groupId!, type),
+        enabled: Boolean(env && groupId),
+    });
+}
+
+export function useGroupApis(groupId: string | undefined) {
+    return useGroupMemberships(groupId, 'api');
+}
+
+export function useGroupApplications(groupId: string | undefined) {
+    return useGroupMemberships(groupId, 'application');
+}
+
+export function useGroupApiProducts(groupId: string | undefined) {
+    return useGroupMemberships(groupId, 'api_product');
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
@@ -15,7 +15,16 @@
  */
 
 import { apimFetchJsonOrg, apimFetchJsonV1Env } from '../../../shared/api/apimClient';
-import type { Group, GroupRole, GroupsPagedResponse, NewGroupPayload, UpdateGroupPayload } from '../types/group';
+import type {
+    Group,
+    GroupMember,
+    GroupMembershipItem,
+    GroupMembershipType,
+    GroupRole,
+    GroupsPagedResponse,
+    NewGroupPayload,
+    UpdateGroupPayload,
+} from '../types/group';
 
 export async function listGroupsPaged(
     environmentId: string,
@@ -29,6 +38,28 @@ export async function listGroupsPaged(
         searchParams.set('query', query);
     }
     return apimFetchJsonV1Env<GroupsPagedResponse>(environmentId, `/configuration/groups/_paged?${searchParams.toString()}`);
+}
+
+export async function getGroup(environmentId: string, groupId: string): Promise<Group> {
+    return apimFetchJsonV1Env<Group>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}`);
+}
+
+/** Unpaged, like classic Console's own group.component.ts — search and pagination for members happens
+ *  client-side (the `_paged` endpoint has no server-side search param to filter by). */
+export async function listGroupMembers(environmentId: string, groupId: string): Promise<GroupMember[]> {
+    return apimFetchJsonV1Env<GroupMember[]>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}/members`);
+}
+
+export async function listGroupMemberships(
+    environmentId: string,
+    groupId: string,
+    type: GroupMembershipType,
+): Promise<GroupMembershipItem[]> {
+    const items = await apimFetchJsonV1Env<GroupMembershipItem[] | undefined>(
+        environmentId,
+        `/configuration/groups/${encodeURIComponent(groupId)}/memberships?type=${type}`,
+    );
+    return items ?? [];
 }
 
 export async function createGroup(environmentId: string, data: NewGroupPayload): Promise<Group> {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
@@ -15,7 +15,16 @@
  */
 
 import { apimFetchJsonOrg, apimFetchJsonV1Env } from '../../../shared/api/apimClient';
-import type { Group, GroupRole, GroupsPagedResponse, NewGroupPayload, UpdateGroupPayload } from '../types/group';
+import type {
+    Group,
+    GroupMember,
+    GroupMembershipItem,
+    GroupMembershipType,
+    GroupRole,
+    GroupsPagedResponse,
+    NewGroupPayload,
+    UpdateGroupPayload,
+} from '../types/group';
 
 export async function listGroupsPaged(
     environmentId: string,
@@ -29,6 +38,29 @@ export async function listGroupsPaged(
         searchParams.set('query', query);
     }
     return apimFetchJsonV1Env<GroupsPagedResponse>(environmentId, `/configuration/groups/_paged?${searchParams.toString()}`);
+}
+
+export async function getGroup(environmentId: string, groupId: string): Promise<Group> {
+    return apimFetchJsonV1Env<Group>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}`);
+}
+
+/** Unpaged, like classic Console's own group.component.ts — the `_paged` endpoint has no server-side
+ *  search param to filter by, so search/pagination happens client-side. This means very large groups
+ *  fetch their full member list in one call; accepted as a known scale limitation for classic parity. */
+export async function listGroupMembers(environmentId: string, groupId: string): Promise<GroupMember[]> {
+    return apimFetchJsonV1Env<GroupMember[]>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}/members`);
+}
+
+export async function listGroupMemberships(
+    environmentId: string,
+    groupId: string,
+    type: GroupMembershipType,
+): Promise<GroupMembershipItem[]> {
+    const items = await apimFetchJsonV1Env<GroupMembershipItem[] | undefined>(
+        environmentId,
+        `/configuration/groups/${encodeURIComponent(groupId)}/memberships?type=${type}`,
+    );
+    return items ?? [];
 }
 
 export async function createGroup(environmentId: string, data: NewGroupPayload): Promise<Group> {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/types/group.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/types/group.ts
@@ -100,3 +100,22 @@ export interface GroupRole {
     system?: boolean;
     default?: boolean;
 }
+
+/** v1 `GroupMemberEntity` (GET .../configuration/groups/{id}/members...). */
+export interface GroupMember {
+    id: string;
+    displayName: string;
+    roles?: Record<string, string>;
+    created_at?: number;
+    updated_at?: number;
+}
+
+export type GroupMembershipType = 'api' | 'application' | 'api_product';
+
+/** Minimal shape shared by ApiEntity / ApplicationEntity / ApiProductEntity for group-association lists
+ *  (GET .../configuration/groups/{id}/memberships?type=api|application|api_product). */
+export interface GroupMembershipItem {
+    id: string;
+    name: string;
+    version?: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPayload.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPayload.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import type { GroupEventRule } from '../types/group';
+import type { Group, GroupEventRule, GroupEventName } from '../types/group';
+
+/** Shared by the groups list and detail page for the "Auto APIs/API Products/Applications" badges. */
+export function hasEventRule(group: Group, event: GroupEventName): boolean {
+    return (group.event_rules ?? []).some(rule => rule.event === event);
+}
 
 /** Rebuilds the full event-rules list from the three toggles the UI manages. */
 export function buildEventRules(events: { apiCreate: boolean; applicationCreate: boolean; apiProductCreate: boolean }): GroupEventRule[] {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/queryKeys.ts
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
+import type { GroupMembershipType } from '../types/group';
+
 export const groupKeys = {
     all: ['environment-groups'] as const,
     list: (envId: string, query: string, page: number, size: number) => [...groupKeys.all, 'list', envId, query, page, size] as const,
+    detail: (envId: string, groupId: string) => [...groupKeys.all, 'detail', envId, groupId] as const,
+    members: (envId: string, groupId: string) => [...groupKeys.all, 'members', envId, groupId] as const,
+    memberships: (envId: string, groupId: string, type: GroupMembershipType) =>
+        [...groupKeys.all, 'memberships', envId, groupId, type] as const,
     roles: (scope: 'API' | 'APPLICATION' | 'API_PRODUCT') => [...groupKeys.all, 'roles', scope] as const,
     apiRoles: () => groupKeys.roles('API'),
     applicationRoles: () => groupKeys.roles('APPLICATION'),

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
@@ -69,14 +69,19 @@ describe('GroupDetailPage', () => {
         mockUseGroupMembers.mockReturnValue({
             data: [{ id: 'member-1', displayName: 'Anna Schmidt', roles: {} }],
             isLoading: false,
+            isError: false,
         } as ReturnType<typeof useGroupMembers>);
-        mockUseGroupApis.mockReturnValue({ data: [{ id: 'api-1', name: 'Billing API', version: '1.0' }], isLoading: false } as ReturnType<
-            typeof useGroupApis
-        >);
-        mockUseGroupApplications.mockReturnValue({ data: [{ id: 'app-1', name: 'Mobile App' }], isLoading: false } as ReturnType<
-            typeof useGroupApplications
-        >);
-        mockUseGroupApiProducts.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupApiProducts>);
+        mockUseGroupApis.mockReturnValue({
+            data: [{ id: 'api-1', name: 'Billing API', version: '1.0' }],
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useGroupApis>);
+        mockUseGroupApplications.mockReturnValue({
+            data: [{ id: 'app-1', name: 'Mobile App' }],
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useGroupApplications>);
+        mockUseGroupApiProducts.mockReturnValue({ data: [], isLoading: false, isError: false } as ReturnType<typeof useGroupApiProducts>);
     });
 
     afterEach(() => {
@@ -112,6 +117,75 @@ describe('GroupDetailPage', () => {
 
         expect(screen.queryByRole('button', { name: /Edit/i })).toBeNull();
         expect(screen.queryByRole('button', { name: /Delete/i })).toBeNull();
+    });
+
+    describe('created/updated metadata', () => {
+        it('shows only Created when there is no distinct updated_at', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, created_at: 1700000000000 },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.getByText(/^Created/)).not.toBeNull();
+            expect(screen.queryByText(/Updated/)).toBeNull();
+        });
+
+        it('shows Created and Updated when updated_at differs from created_at', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, created_at: 1700000000000, updated_at: 1700003600000 },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.getByText(/Updated/)).not.toBeNull();
+        });
+
+        it('renders no created/updated line when created_at is absent', () => {
+            renderPage();
+
+            expect(screen.queryByText(/^Created/)).toBeNull();
+        });
+    });
+
+    describe('per-section errors', () => {
+        it('shows a section error instead of the members table when members fail to load', () => {
+            mockUseGroupMembers.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<typeof useGroupMembers>);
+            renderPage();
+
+            expect(screen.getByText('Failed to load members. Please refresh and try again.')).not.toBeNull();
+            expect(screen.queryByTestId('members-table')).toBeNull();
+        });
+
+        it('shows a section error instead of the APIs table when APIs fail to load', () => {
+            mockUseGroupApis.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<typeof useGroupApis>);
+            renderPage();
+
+            expect(screen.getByText('Failed to load associated APIs. Please refresh and try again.')).not.toBeNull();
+            expect(screen.queryByTestId('membership-table-APIs')).toBeNull();
+        });
+
+        it('shows a section error instead of the API Products table when API Products fail to load', () => {
+            mockUseGroupApiProducts.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<
+                typeof useGroupApiProducts
+            >);
+            renderPage();
+
+            expect(screen.getByText('Failed to load associated API Products. Please refresh and try again.')).not.toBeNull();
+            expect(screen.queryByTestId('membership-table-API Products')).toBeNull();
+        });
+
+        it('shows a section error instead of the Applications table when Applications fail to load', () => {
+            mockUseGroupApplications.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<
+                typeof useGroupApplications
+            >);
+            renderPage();
+
+            expect(screen.getByText('Failed to load associated applications. Please refresh and try again.')).not.toBeNull();
+            expect(screen.queryByTestId('membership-table-Applications')).toBeNull();
+        });
     });
 
     describe('settings section', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
@@ -114,6 +114,45 @@ describe('GroupDetailPage', () => {
         expect(screen.queryByRole('button', { name: /Delete/i })).toBeNull();
     });
 
+    describe('settings section', () => {
+        it('shows default roles, lock flags, and invitation settings read-only', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: {
+                    ...GROUP,
+                    roles: { API: 'OWNER', API_PRODUCT: 'USER', APPLICATION: 'USER' },
+                    lock_api_role: true,
+                    lock_api_product_role: false,
+                    lock_application_role: false,
+                    max_invitation: 25,
+                    system_invitation: true,
+                    email_invitation: false,
+                    disable_membership_notifications: true,
+                },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.getByText('OWNER')).not.toBeNull();
+            expect(screen.getByText('25')).not.toBeNull();
+            expect(screen.getAllByText('Allowed')).toHaveLength(1);
+            expect(screen.getAllByText('Not allowed')).toHaveLength(1);
+            // Two "Yes"/"No" pairs: lock_api_product_role=false, lock_application_role=false,
+            // disable_membership_notifications=true (→ Notify = No) all render 'No'; lock_api_role=true
+            // renders 'Yes' alongside them, so assert via the labels instead of raw Yes/No counts.
+            expect(screen.getByText('Lock API role').nextSibling?.textContent).toBe('Yes');
+            expect(screen.getByText('Lock API product role').nextSibling?.textContent).toBe('No');
+            expect(screen.getByText('Notify on new members').nextSibling?.textContent).toBe('No');
+        });
+
+        it('falls back to "Not set"/"Unlimited" when roles and max members are absent', () => {
+            renderPage();
+
+            expect(screen.getAllByText('Not set')).toHaveLength(3);
+            expect(screen.getByText('Unlimited')).not.toBeNull();
+        });
+    });
+
     describe('header badges', () => {
         // Unlike the list, the detail page never shows a "Primary owner" badge — that's summary info for
         // the list view; here it's already conveyed per-member in the Members table's role columns.

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { GroupDetailPage } from './GroupDetailPage';
+import {
+    useGroupApis,
+    useGroupApplications,
+    useGroupApiProducts,
+    useGroupDetail,
+    useGroupMembers,
+} from '../features/groups/hooks/useGroupDetail';
+import type { Group, GroupMembershipItem } from '../features/groups/types/group';
+
+jest.mock('../features/groups/hooks/useGroupDetail');
+
+// Stub the nested DataTable-backed components to avoid jsdom/Radix DataTable complexity;
+// exposes the fetched rows as plain text so orchestration (what data flows in) stays covered.
+// GroupMembersTable's own spec covers its columns/search internals.
+jest.mock('../features/groups/components/GroupMembersTable', () => ({
+    GroupMembersTable: ({ members }: { members: { id: string; displayName: string }[] }) => (
+        <div data-testid="members-table">{members.map(m => m.displayName).join(', ')}</div>
+    ),
+}));
+jest.mock('../features/groups/components/GroupMembershipTable', () => ({
+    GroupMembershipTable: ({ items, ariaLabel }: { items: GroupMembershipItem[]; ariaLabel: string }) => (
+        <div data-testid={`membership-table-${ariaLabel}`}>{items.map(i => i.name).join(', ')}</div>
+    ),
+}));
+
+const mockUseGroupDetail = jest.mocked(useGroupDetail);
+const mockUseGroupMembers = jest.mocked(useGroupMembers);
+const mockUseGroupApis = jest.mocked(useGroupApis);
+const mockUseGroupApplications = jest.mocked(useGroupApplications);
+const mockUseGroupApiProducts = jest.mocked(useGroupApiProducts);
+
+const GROUP: Group = { id: 'group-1', name: 'Support Team', event_rules: [{ event: 'API_CREATE' }] };
+
+function renderPage(initialGroupId = 'group-1') {
+    return render(
+        <MemoryRouter initialEntries={[`/user-groups/${initialGroupId}`]}>
+            <Routes>
+                <Route path="/user-groups">
+                    <Route index element={<div>Groups List</div>} />
+                    <Route path=":groupId" element={<GroupDetailPage />} />
+                </Route>
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('GroupDetailPage', () => {
+    beforeEach(() => {
+        mockUseGroupDetail.mockReturnValue({ data: GROUP, isLoading: false, isError: false } as ReturnType<typeof useGroupDetail>);
+        mockUseGroupMembers.mockReturnValue({
+            data: [{ id: 'member-1', displayName: 'Anna Schmidt', roles: {} }],
+            isLoading: false,
+        } as ReturnType<typeof useGroupMembers>);
+        mockUseGroupApis.mockReturnValue({ data: [{ id: 'api-1', name: 'Billing API', version: '1.0' }], isLoading: false } as ReturnType<
+            typeof useGroupApis
+        >);
+        mockUseGroupApplications.mockReturnValue({ data: [{ id: 'app-1', name: 'Mobile App' }], isLoading: false } as ReturnType<
+            typeof useGroupApplications
+        >);
+        mockUseGroupApiProducts.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupApiProducts>);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders the group name and dependent sections', () => {
+        renderPage();
+
+        expect(screen.queryByRole('heading', { name: 'Support Team' })).not.toBeNull();
+        expect(screen.getByTestId('members-table').textContent).toContain('Anna Schmidt');
+        expect(screen.getByTestId('membership-table-APIs').textContent).toContain('Billing API');
+        expect(screen.getByTestId('membership-table-Applications').textContent).toContain('Mobile App');
+    });
+
+    it('navigates back to the groups list', () => {
+        renderPage();
+
+        fireEvent.click(screen.getByRole('link', { name: /Back to groups/i }));
+
+        expect(screen.queryByText('Groups List')).not.toBeNull();
+    });
+
+    it('shows a not-found message when the group fails to load', () => {
+        mockUseGroupDetail.mockReturnValue({ data: undefined, isLoading: false, isError: true } as ReturnType<typeof useGroupDetail>);
+        renderPage();
+
+        expect(screen.queryByText('Group not found or failed to load.')).not.toBeNull();
+    });
+
+    it('has no Edit or Delete action — classic only allows those from the list', () => {
+        renderPage();
+
+        expect(screen.queryByRole('button', { name: /Edit/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /Delete/i })).toBeNull();
+    });
+
+    describe('header badges', () => {
+        // Unlike the list, the detail page never shows a "Primary owner" badge — that's summary info for
+        // the list view; here it's already conveyed per-member in the Members table's role columns.
+        it.each([
+            ['primary_owner is true', { primary_owner: true }],
+            ['apiPrimaryOwner is set', { apiPrimaryOwner: 'user-1' }],
+            ['apiProductPrimaryOwner is set', { apiProductPrimaryOwner: 'user-1' }],
+        ])('never shows a Primary owner badge, even when %s', (_label, override) => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, ...override },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByText('Primary owner')).toBeNull();
+        });
+
+        it('shows Auto APIs/API Products/Applications badges based on event rules', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: {
+                    ...GROUP,
+                    event_rules: [{ event: 'API_CREATE' }, { event: 'API_PRODUCT_CREATE' }, { event: 'APPLICATION_CREATE' }],
+                },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByText('Auto APIs')).not.toBeNull();
+            expect(screen.queryByText('Auto API Products')).not.toBeNull();
+            expect(screen.queryByText('Auto Applications')).not.toBeNull();
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
@@ -1,0 +1,394 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { GroupDetailPage } from './GroupDetailPage';
+import {
+    useGroupApis,
+    useGroupApplications,
+    useGroupApiProducts,
+    useGroupDetail,
+    useGroupMembers,
+} from '../features/groups/hooks/useGroupDetail';
+import { useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
+import { useGroupApiProductRoles, useGroupApiRoles, useGroupApplicationRoles } from '../features/groups/hooks/useGroupRoles';
+import type { Group, GroupMembershipItem } from '../features/groups/types/group';
+import { notify } from '../shared/notify';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+jest.mock('../features/groups/hooks/useGroupDetail');
+jest.mock('../features/groups/hooks/useGroupRoles');
+jest.mock('../features/groups/hooks/useGroupMutations');
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+
+// Stub the nested DataTable-backed components to avoid jsdom/Radix DataTable complexity;
+// exposes the fetched rows as plain text so orchestration (what data flows in) stays covered.
+// GroupMembersTable's own spec covers its columns/search internals.
+jest.mock('../features/groups/components/GroupMembersTable', () => ({
+    GroupMembersTable: ({ members }: { members: { id: string; displayName: string }[] }) => (
+        <div data-testid="members-table">{members.map(m => m.displayName).join(', ')}</div>
+    ),
+}));
+jest.mock('../features/groups/components/GroupMembershipTable', () => ({
+    GroupMembershipTable: ({ items, ariaLabel }: { items: GroupMembershipItem[]; ariaLabel: string }) => (
+        <div data-testid={`membership-table-${ariaLabel}`}>{items.map(i => i.name).join(', ')}</div>
+    ),
+}));
+
+// Radix Switch (rendered inside the real GroupSheet, mounted unconditionally so Edit can open it) measures
+// its thumb via ResizeObserver, which jsdom lacks.
+beforeAll(() => {
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as typeof ResizeObserver;
+});
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseGroupDetail = jest.mocked(useGroupDetail);
+const mockUseGroupMembers = jest.mocked(useGroupMembers);
+const mockUseGroupApis = jest.mocked(useGroupApis);
+const mockUseGroupApplications = jest.mocked(useGroupApplications);
+const mockUseGroupApiProducts = jest.mocked(useGroupApiProducts);
+const mockUseGroupApiRoles = jest.mocked(useGroupApiRoles);
+const mockUseGroupApplicationRoles = jest.mocked(useGroupApplicationRoles);
+const mockUseGroupApiProductRoles = jest.mocked(useGroupApiProductRoles);
+const mockUseUpdateGroup = jest.mocked(useUpdateGroup);
+const mockUseDeleteGroup = jest.mocked(useDeleteGroup);
+
+const GROUP: Group = { id: 'group-1', name: 'Support Team', event_rules: [{ event: 'API_CREATE' }] };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeMutation(mutateAsync = jest.fn()): any {
+    return { mutateAsync, isPending: false };
+}
+
+function renderPage(initialGroupId = 'group-1') {
+    return render(
+        <MemoryRouter initialEntries={[`/user-groups/${initialGroupId}`]}>
+            <Routes>
+                <Route path="/user-groups">
+                    <Route index element={<div>Groups List</div>} />
+                    <Route path=":groupId" element={<GroupDetailPage />} />
+                </Route>
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('GroupDetailPage', () => {
+    beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseGroupDetail.mockReturnValue({ data: GROUP, isLoading: false, isError: false } as ReturnType<typeof useGroupDetail>);
+        mockUseGroupMembers.mockReturnValue({
+            data: [{ id: 'member-1', displayName: 'Anna Schmidt', roles: {} }],
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useGroupMembers>);
+        mockUseGroupApis.mockReturnValue({
+            data: [{ id: 'api-1', name: 'Billing API', version: '1.0' }],
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useGroupApis>);
+        mockUseGroupApplications.mockReturnValue({
+            data: [{ id: 'app-1', name: 'Mobile App' }],
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useGroupApplications>);
+        mockUseGroupApiProducts.mockReturnValue({ data: [], isLoading: false, isError: false } as ReturnType<typeof useGroupApiProducts>);
+        mockUseGroupApiRoles.mockReturnValue({ data: [{ name: 'USER', scope: 'API', default: true }], isLoading: false } as ReturnType<
+            typeof useGroupApiRoles
+        >);
+        mockUseGroupApplicationRoles.mockReturnValue({
+            data: [{ name: 'USER', scope: 'APPLICATION', default: true }],
+            isLoading: false,
+        } as ReturnType<typeof useGroupApplicationRoles>);
+        mockUseGroupApiProductRoles.mockReturnValue({
+            data: [{ name: 'USER', scope: 'API_PRODUCT', default: true }],
+            isLoading: false,
+        } as ReturnType<typeof useGroupApiProductRoles>);
+        mockUseUpdateGroup.mockReturnValue(makeMutation());
+        mockUseDeleteGroup.mockReturnValue(makeMutation());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders the group name and dependent sections', () => {
+        renderPage();
+
+        expect(screen.queryByRole('heading', { name: 'Support Team' })).not.toBeNull();
+        expect(screen.getByTestId('members-table').textContent).toContain('Anna Schmidt');
+        expect(screen.getByTestId('membership-table-APIs').textContent).toContain('Billing API');
+        expect(screen.getByTestId('membership-table-Applications').textContent).toContain('Mobile App');
+    });
+
+    it('navigates back to the groups list', () => {
+        renderPage();
+
+        fireEvent.click(screen.getByRole('link', { name: /Back to groups/i }));
+
+        expect(screen.queryByText('Groups List')).not.toBeNull();
+    });
+
+    it('shows a not-found message when the group fails to load', () => {
+        mockUseGroupDetail.mockReturnValue({ data: undefined, isLoading: false, isError: true } as ReturnType<typeof useGroupDetail>);
+        renderPage();
+
+        expect(screen.queryByText('Group not found or failed to load.')).not.toBeNull();
+    });
+
+    describe('edit and delete actions', () => {
+        it('shows Edit group and Delete when the user has permission', () => {
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: 'Edit group' })).not.toBeNull();
+            expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeNull();
+        });
+
+        it('hides Edit group and Delete without permission', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: 'Edit group' })).toBeNull();
+            expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();
+        });
+
+        it('opens the edit sheet, submits, and shows a success toast', async () => {
+            const mutateAsync = jest.fn().mockResolvedValue({});
+            mockUseUpdateGroup.mockReturnValue(makeMutation(mutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit group' }));
+            expect(screen.getByRole('heading', { name: 'Edit group' })).not.toBeNull();
+
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Support Team v2' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            await waitFor(() =>
+                expect(mutateAsync).toHaveBeenCalledWith(
+                    expect.objectContaining({ groupId: 'group-1', data: expect.objectContaining({ name: 'Support Team v2' }) }),
+                ),
+            );
+            expect(notify.success).toHaveBeenCalledWith('Group updated successfully');
+        });
+
+        it('shows an error toast when updating fails', async () => {
+            const error = new Error('update failed');
+            mockUseUpdateGroup.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit group' }));
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Support Team v2' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to update group'));
+        });
+
+        it('opens the delete sheet, confirms, and navigates back to the groups list', async () => {
+            const mutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseDeleteGroup.mockReturnValue(makeMutation(mutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+            expect(screen.getByRole('heading', { name: 'Delete group' })).not.toBeNull();
+
+            // Radix's Dialog marks the rest of the page aria-hidden while open, so the header trigger
+            // drops out of the accessibility tree here — only the dialog's own "Delete" is queryable.
+            fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+            await waitFor(() => expect(mutateAsync).toHaveBeenCalledWith('group-1'));
+            expect(notify.success).toHaveBeenCalledWith('Group deleted successfully');
+            await waitFor(() => expect(screen.queryByText('Groups List')).not.toBeNull());
+        });
+
+        it('shows an error toast when deleting fails', async () => {
+            const error = new Error('delete failed');
+            mockUseDeleteGroup.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to delete group'));
+        });
+    });
+
+    describe('created/updated metadata', () => {
+        it('shows only Created when there is no distinct updated_at', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, created_at: 1700000000000 },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.getByText(/^Created/)).not.toBeNull();
+            expect(screen.queryByText(/Updated/)).toBeNull();
+        });
+
+        it('shows Created and Updated when updated_at differs from created_at', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, created_at: 1700000000000, updated_at: 1700003600000 },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.getByText(/Updated/)).not.toBeNull();
+        });
+
+        it('renders no created/updated line when created_at is absent', () => {
+            renderPage();
+
+            expect(screen.queryByText(/^Created/)).toBeNull();
+        });
+    });
+
+    describe('per-section errors', () => {
+        it('shows a section error instead of the members table when members fail to load', () => {
+            mockUseGroupMembers.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<typeof useGroupMembers>);
+            renderPage();
+
+            expect(screen.getByText('Failed to load members. Please refresh and try again.')).not.toBeNull();
+            expect(screen.queryByTestId('members-table')).toBeNull();
+        });
+
+        it('shows a section error instead of the APIs table when APIs fail to load', () => {
+            mockUseGroupApis.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<typeof useGroupApis>);
+            renderPage();
+
+            expect(screen.getByText('Failed to load associated APIs. Please refresh and try again.')).not.toBeNull();
+            expect(screen.queryByTestId('membership-table-APIs')).toBeNull();
+        });
+
+        it('shows a section error instead of the API Products table when API Products fail to load', () => {
+            mockUseGroupApiProducts.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<
+                typeof useGroupApiProducts
+            >);
+            renderPage();
+
+            expect(screen.getByText('Failed to load associated API Products. Please refresh and try again.')).not.toBeNull();
+            expect(screen.queryByTestId('membership-table-API Products')).toBeNull();
+        });
+
+        it('shows a section error instead of the Applications table when Applications fail to load', () => {
+            mockUseGroupApplications.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<
+                typeof useGroupApplications
+            >);
+            renderPage();
+
+            expect(screen.getByText('Failed to load associated applications. Please refresh and try again.')).not.toBeNull();
+            expect(screen.queryByTestId('membership-table-Applications')).toBeNull();
+        });
+    });
+
+    describe('Settings section', () => {
+        it('shows placeholders when no roles, limit, or invitation methods are configured', () => {
+            renderPage();
+
+            expect(screen.getByText('Max members').nextElementSibling?.textContent).toBe('Unlimited');
+            expect(screen.getByText('Invitation methods').nextElementSibling?.textContent).toBe('None');
+            expect(screen.getByText('Default API role').nextElementSibling?.textContent).toBe('—');
+        });
+
+        it('shows the configured default roles with a lock indicator for locked scopes', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: {
+                    ...GROUP,
+                    roles: { API: 'OWNER', API_PRODUCT: 'USER', APPLICATION: 'USER' },
+                    lock_api_role: true,
+                },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            const apiRoleValue = screen.getByText('Default API role').nextElementSibling;
+            expect(apiRoleValue?.textContent).toContain('OWNER');
+            expect(apiRoleValue?.querySelector('[aria-label="Locked"]')).not.toBeNull();
+
+            const applicationRoleValue = screen.getByText('Default application role').nextElementSibling;
+            expect(applicationRoleValue?.querySelector('[aria-label="Locked"]')).toBeNull();
+        });
+
+        it('shows the configured max member limit', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, max_invitation: 25 },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.getByText('Max members').nextElementSibling?.textContent).toBe('25');
+        });
+
+        it('shows badges for each enabled invitation method', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, system_invitation: true, email_invitation: true },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByText('User search')).not.toBeNull();
+            expect(screen.queryByText('Email invitation')).not.toBeNull();
+        });
+    });
+
+    describe('header badges', () => {
+        // Unlike the list, the detail page never shows a "Primary owner" badge — that's summary info for
+        // the list view; here it's already conveyed per-member in the Members table's role columns.
+        it.each([
+            ['primary_owner is true', { primary_owner: true }],
+            ['apiPrimaryOwner is set', { apiPrimaryOwner: 'user-1' }],
+            ['apiProductPrimaryOwner is set', { apiProductPrimaryOwner: 'user-1' }],
+        ])('never shows a Primary owner badge, even when %s', (_label, override) => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, ...override },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByText('Primary owner')).toBeNull();
+        });
+
+        it('shows Auto APIs/API Products/Applications badges based on event rules', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: {
+                    ...GROUP,
+                    event_rules: [{ event: 'API_CREATE' }, { event: 'API_PRODUCT_CREATE' }, { event: 'APPLICATION_CREATE' }],
+                },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByText('Auto APIs')).not.toBeNull();
+            expect(screen.queryByText('Auto API Products')).not.toBeNull();
+            expect(screen.queryByText('Auto Applications')).not.toBeNull();
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { Badge, Button, Skeleton } from '@gravitee/graphene-core';
-import { ArrowLeftIcon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
+import { Badge, Button, DateCell, Skeleton } from '@gravitee/graphene-core';
+import { ArrowLeftIcon, TriangleAlertIcon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { GroupMembershipTable } from '../features/groups/components/GroupMembershipTable';
@@ -29,6 +29,15 @@ import {
 } from '../features/groups/hooks/useGroupDetail';
 import { hasEventRule } from '../features/groups/utils/groupPayload';
 
+function SectionError({ message }: Readonly<{ message: string }>) {
+    return (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive">
+            <TriangleAlertIcon className="size-4 shrink-0" aria-hidden />
+            {message}
+        </div>
+    );
+}
+
 // Classic Console's group.component.ts has no delete action on this screen at all — a group can only be
 // deleted from the list (groups.component.ts). Editing group settings (name, default roles, invitation
 // rules) also only happens from the list's Edit action, not this page — the detail page is read-only.
@@ -39,10 +48,10 @@ export function GroupDetailPage() {
     const navigate = useNavigate();
 
     const { data: group, isLoading, isError } = useGroupDetail(groupId);
-    const { data: members = [], isLoading: membersLoading } = useGroupMembers(groupId);
-    const { data: apis = [], isLoading: apisLoading } = useGroupApis(groupId);
-    const { data: applications = [], isLoading: applicationsLoading } = useGroupApplications(groupId);
-    const { data: apiProducts = [], isLoading: apiProductsLoading } = useGroupApiProducts(groupId);
+    const { data: members = [], isLoading: membersLoading, isError: membersError } = useGroupMembers(groupId);
+    const { data: apis = [], isLoading: apisLoading, isError: apisError } = useGroupApis(groupId);
+    const { data: applications = [], isLoading: applicationsLoading, isError: applicationsError } = useGroupApplications(groupId);
+    const { data: apiProducts = [], isLoading: apiProductsLoading, isError: apiProductsError } = useGroupApiProducts(groupId);
 
     if (isLoading) {
         return (
@@ -100,7 +109,17 @@ export function GroupDetailPage() {
                                     </Badge>
                                 )}
                             </div>
-                            <p className="text-sm text-muted-foreground">No description provided.</p>
+                            {group.created_at && (
+                                <p className="text-sm text-muted-foreground">
+                                    Created <DateCell value={new Date(group.created_at)} format="absolute" />
+                                    {group.updated_at && group.updated_at !== group.created_at && (
+                                        <>
+                                            {' '}
+                                            · Updated <DateCell value={new Date(group.updated_at)} format="absolute" />
+                                        </>
+                                    )}
+                                </p>
+                            )}
                         </div>
                     </div>
                 </div>
@@ -157,43 +176,60 @@ export function GroupDetailPage() {
                     <h2 className="text-base font-semibold">Members</h2>
                     <p className="text-sm text-muted-foreground">Direct members of this group and their scoped roles.</p>
                 </div>
-                <GroupMembersTable members={members} loading={membersLoading} />
+                {membersError ? (
+                    <SectionError message="Failed to load members. Please refresh and try again." />
+                ) : (
+                    <GroupMembersTable members={members} loading={membersLoading} />
+                )}
             </section>
 
             <section className="space-y-4 rounded-xl border bg-card p-5">
                 <h2 className="text-base font-semibold">APIs</h2>
-                <GroupMembershipTable
-                    items={apis}
-                    loading={apisLoading}
-                    ariaLabel="APIs"
-                    searchPlaceholder="Search APIs…"
-                    emptyTitle="No dependent APIs to display"
-                    emptyDescription="APIs associated with this group will appear here."
-                />
+                {apisError ? (
+                    <SectionError message="Failed to load associated APIs. Please refresh and try again." />
+                ) : (
+                    <GroupMembershipTable
+                        items={apis}
+                        loading={apisLoading}
+                        ariaLabel="APIs"
+                        searchPlaceholder="Search APIs…"
+                        emptyTitle="No dependent APIs to display"
+                        emptyDescription="APIs associated with this group will appear here."
+                    />
+                )}
             </section>
 
             <section className="space-y-4 rounded-xl border bg-card p-5">
                 <h2 className="text-base font-semibold">API Products</h2>
-                <GroupMembershipTable
-                    items={apiProducts}
-                    loading={apiProductsLoading}
-                    ariaLabel="API Products"
-                    searchPlaceholder="Search API Products…"
-                    emptyTitle="No dependent API Products to display"
-                    emptyDescription="API Products associated with this group will appear here."
-                />
+                {apiProductsError ? (
+                    <SectionError message="Failed to load associated API Products. Please refresh and try again." />
+                ) : (
+                    <GroupMembershipTable
+                        items={apiProducts}
+                        loading={apiProductsLoading}
+                        ariaLabel="API Products"
+                        searchPlaceholder="Search API Products…"
+                        emptyTitle="No dependent API Products to display"
+                        emptyDescription="API Products associated with this group will appear here."
+                    />
+                )}
             </section>
 
             <section className="space-y-4 rounded-xl border bg-card p-5">
                 <h2 className="text-base font-semibold">Applications</h2>
-                <GroupMembershipTable
-                    items={applications}
-                    loading={applicationsLoading}
-                    ariaLabel="Applications"
-                    searchPlaceholder="Search Applications…"
-                    emptyTitle="No dependent applications to display"
-                    emptyDescription="Applications associated with this group will appear here."
-                />
+                {applicationsError ? (
+                    <SectionError message="Failed to load associated applications. Please refresh and try again." />
+                ) : (
+                    <GroupMembershipTable
+                        items={applications}
+                        loading={applicationsLoading}
+                        ariaLabel="Applications"
+                        searchPlaceholder="Search Applications…"
+                        emptyTitle="No dependent applications to display"
+                        emptyDescription="Applications associated with this group will appear here."
+                        showVersionColumn={false}
+                    />
+                )}
             </section>
         </div>
     );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -107,6 +107,52 @@ export function GroupDetailPage() {
             </section>
 
             <section className="space-y-4 rounded-xl border bg-card p-5">
+                <h2 className="text-base font-semibold">Settings</h2>
+                <dl className="grid grid-cols-2 gap-x-6 gap-y-4 sm:grid-cols-3">
+                    <div>
+                        <dt className="text-sm text-muted-foreground">Default API role</dt>
+                        <dd className="text-sm font-medium">{group.roles?.API ?? 'Not set'}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-sm text-muted-foreground">Default API product role</dt>
+                        <dd className="text-sm font-medium">{group.roles?.API_PRODUCT ?? 'Not set'}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-sm text-muted-foreground">Default application role</dt>
+                        <dd className="text-sm font-medium">{group.roles?.APPLICATION ?? 'Not set'}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-sm text-muted-foreground">Lock API role</dt>
+                        <dd className="text-sm font-medium">{group.lock_api_role ? 'Yes' : 'No'}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-sm text-muted-foreground">Lock API product role</dt>
+                        <dd className="text-sm font-medium">{group.lock_api_product_role ? 'Yes' : 'No'}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-sm text-muted-foreground">Lock application role</dt>
+                        <dd className="text-sm font-medium">{group.lock_application_role ? 'Yes' : 'No'}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-sm text-muted-foreground">Maximum members</dt>
+                        <dd className="text-sm font-medium">{group.max_invitation ?? 'Unlimited'}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-sm text-muted-foreground">Invitation via search</dt>
+                        <dd className="text-sm font-medium">{group.system_invitation ? 'Allowed' : 'Not allowed'}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-sm text-muted-foreground">Invitation via email</dt>
+                        <dd className="text-sm font-medium">{group.email_invitation ? 'Allowed' : 'Not allowed'}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-sm text-muted-foreground">Notify on new members</dt>
+                        <dd className="text-sm font-medium">{group.disable_membership_notifications ? 'No' : 'Yes'}</dd>
+                    </div>
+                </dl>
+            </section>
+
+            <section className="space-y-4 rounded-xl border bg-card p-5">
                 <div>
                     <h2 className="text-base font-semibold">Members</h2>
                     <p className="text-sm text-muted-foreground">Direct members of this group and their scoped roles.</p>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Badge, Button, Skeleton } from '@gravitee/graphene-core';
+import { ArrowLeftIcon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { GroupMembershipTable } from '../features/groups/components/GroupMembershipTable';
+import { GroupMembersTable } from '../features/groups/components/GroupMembersTable';
+import {
+    useGroupApis,
+    useGroupApplications,
+    useGroupApiProducts,
+    useGroupDetail,
+    useGroupMembers,
+} from '../features/groups/hooks/useGroupDetail';
+import { hasEventRule } from '../features/groups/utils/groupPayload';
+
+// Classic Console's group.component.ts has no delete action on this screen at all — a group can only be
+// deleted from the list (groups.component.ts). Editing group settings (name, default roles, invitation
+// rules) also only happens from the list's Edit action, not this page — the detail page is read-only.
+// Member management (add/invite/edit roles/remove) is added on top of this read-only view in a
+// follow-up PR (FOUND-106/FOUND-107).
+export function GroupDetailPage() {
+    const { groupId } = useParams<{ groupId: string }>();
+    const navigate = useNavigate();
+
+    const { data: group, isLoading, isError } = useGroupDetail(groupId);
+    const { data: members = [], isLoading: membersLoading } = useGroupMembers(groupId);
+    const { data: apis = [], isLoading: apisLoading } = useGroupApis(groupId);
+    const { data: applications = [], isLoading: applicationsLoading } = useGroupApplications(groupId);
+    const { data: apiProducts = [], isLoading: apiProductsLoading } = useGroupApiProducts(groupId);
+
+    if (isLoading) {
+        return (
+            <div className="space-y-4">
+                <Skeleton className="h-8 w-32" />
+                <Skeleton className="h-32 w-full rounded-xl" />
+                <Skeleton className="h-56 w-full rounded-xl" />
+            </div>
+        );
+    }
+
+    if (isError || !group) {
+        return (
+            <div className="space-y-4">
+                <Button type="button" variant="ghost" className="gap-1.5 px-0" onClick={() => navigate('..')}>
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                    Back to groups
+                </Button>
+                <p className="text-sm text-muted-foreground">Group not found or failed to load.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <Button type="button" variant="ghost" className="gap-1.5 px-0 text-muted-foreground" asChild>
+                <Link to="..">
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                    Back to groups
+                </Link>
+            </Button>
+
+            <section className="rounded-xl border bg-card p-5">
+                <div className="flex items-start justify-between gap-4">
+                    <div className="flex min-w-0 items-start gap-3">
+                        <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-700">
+                            <UsersRoundIcon className="size-5" aria-hidden />
+                        </div>
+                        <div className="min-w-0 space-y-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                                <h1 className="text-xl font-semibold tracking-tight">{group.name}</h1>
+                                {hasEventRule(group, 'API_CREATE') && (
+                                    <Badge variant="default" className="text-xs font-normal">
+                                        Auto APIs
+                                    </Badge>
+                                )}
+                                {hasEventRule(group, 'API_PRODUCT_CREATE') && (
+                                    <Badge variant="default" className="text-xs font-normal">
+                                        Auto API Products
+                                    </Badge>
+                                )}
+                                {hasEventRule(group, 'APPLICATION_CREATE') && (
+                                    <Badge variant="default" className="text-xs font-normal">
+                                        Auto Applications
+                                    </Badge>
+                                )}
+                            </div>
+                            <p className="text-sm text-muted-foreground">No description provided.</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section className="space-y-4 rounded-xl border bg-card p-5">
+                <div>
+                    <h2 className="text-base font-semibold">Members</h2>
+                    <p className="text-sm text-muted-foreground">Direct members of this group and their scoped roles.</p>
+                </div>
+                <GroupMembersTable members={members} loading={membersLoading} />
+            </section>
+
+            <section className="space-y-4 rounded-xl border bg-card p-5">
+                <h2 className="text-base font-semibold">APIs</h2>
+                <GroupMembershipTable
+                    items={apis}
+                    loading={apisLoading}
+                    ariaLabel="APIs"
+                    searchPlaceholder="Search APIs…"
+                    emptyTitle="No dependent APIs to display"
+                    emptyDescription="APIs associated with this group will appear here."
+                />
+            </section>
+
+            <section className="space-y-4 rounded-xl border bg-card p-5">
+                <h2 className="text-base font-semibold">API Products</h2>
+                <GroupMembershipTable
+                    items={apiProducts}
+                    loading={apiProductsLoading}
+                    ariaLabel="API Products"
+                    searchPlaceholder="Search API Products…"
+                    emptyTitle="No dependent API Products to display"
+                    emptyDescription="API Products associated with this group will appear here."
+                />
+            </section>
+
+            <section className="space-y-4 rounded-xl border bg-card p-5">
+                <h2 className="text-base font-semibold">Applications</h2>
+                <GroupMembershipTable
+                    items={applications}
+                    loading={applicationsLoading}
+                    ariaLabel="Applications"
+                    searchPlaceholder="Search Applications…"
+                    emptyTitle="No dependent applications to display"
+                    emptyDescription="Applications associated with this group will appear here."
+                />
+            </section>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -1,0 +1,355 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Badge, Button, DateCell, Skeleton } from '@gravitee/graphene-core';
+import {
+    ArrowLeftIcon,
+    LockIcon,
+    MailIcon,
+    PencilIcon,
+    SearchIcon,
+    Trash2Icon,
+    TriangleAlertIcon,
+    UsersRoundIcon,
+} from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { GroupDeleteSheet } from '../features/groups/components/GroupDeleteSheet';
+import { GroupMembershipTable } from '../features/groups/components/GroupMembershipTable';
+import { GroupMembersTable } from '../features/groups/components/GroupMembersTable';
+import { GroupSheet, type GroupFormValues } from '../features/groups/components/GroupSheet';
+import {
+    useGroupApis,
+    useGroupApplications,
+    useGroupApiProducts,
+    useGroupDetail,
+    useGroupMembers,
+} from '../features/groups/hooks/useGroupDetail';
+import { useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
+import { useGroupApiProductRoles, useGroupApiRoles, useGroupApplicationRoles } from '../features/groups/hooks/useGroupRoles';
+import { buildEventRules, buildRolesMap, hasEventRule, parseMaxInvitation } from '../features/groups/utils/groupPayload';
+import { ENVIRONMENT_GROUP_DELETE_PERMISSION, ENVIRONMENT_GROUP_UPDATE_PERMISSION } from '../features/groups/utils/groupPermissions';
+import { notify } from '../shared/notify';
+
+function SectionError({ message }: Readonly<{ message: string }>) {
+    return (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive">
+            <TriangleAlertIcon className="size-4 shrink-0" aria-hidden />
+            {message}
+        </div>
+    );
+}
+
+export function GroupDetailPage() {
+    const { groupId } = useParams<{ groupId: string }>();
+    const navigate = useNavigate();
+    const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_UPDATE_PERMISSION] });
+    const canDelete = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_DELETE_PERMISSION] });
+
+    const [editOpen, setEditOpen] = useState(false);
+    const [deleteOpen, setDeleteOpen] = useState(false);
+
+    const { data: group, isLoading, isError } = useGroupDetail(groupId);
+    const { data: members = [], isLoading: membersLoading, isError: membersError } = useGroupMembers(groupId);
+    const { data: apis = [], isLoading: apisLoading, isError: apisError } = useGroupApis(groupId);
+    const { data: applications = [], isLoading: applicationsLoading, isError: applicationsError } = useGroupApplications(groupId);
+    const { data: apiProducts = [], isLoading: apiProductsLoading, isError: apiProductsError } = useGroupApiProducts(groupId);
+    const { data: apiRoles = [], isLoading: apiRolesLoading } = useGroupApiRoles();
+    const { data: applicationRoles = [], isLoading: applicationRolesLoading } = useGroupApplicationRoles();
+    const { data: apiProductRoles = [], isLoading: apiProductRolesLoading } = useGroupApiProductRoles();
+
+    const updateMutation = useUpdateGroup();
+    const deleteMutation = useDeleteGroup();
+
+    async function handleUpdate(values: GroupFormValues) {
+        if (!group) return;
+        try {
+            await updateMutation.mutateAsync({
+                groupId: group.id,
+                data: {
+                    name: values.name,
+                    lock_api_role: values.lockApiRole,
+                    lock_api_product_role: values.lockApiProductRole,
+                    lock_application_role: values.lockApplicationRole,
+                    event_rules: buildEventRules({
+                        apiCreate: values.defaultGroupForNewApis,
+                        applicationCreate: values.defaultGroupForNewApplications,
+                        apiProductCreate: values.defaultGroupForNewApiProducts,
+                    }),
+                    roles: buildRolesMap(group.roles, values.apiRole, values.applicationRole, values.apiProductRole),
+                    max_invitation: parseMaxInvitation(values.maxInvitation),
+                    system_invitation: values.systemInvitation,
+                    email_invitation: values.emailInvitation,
+                    disable_membership_notifications: !values.notifyOnMemberAdded,
+                },
+            });
+            notify.success('Group updated successfully');
+            setEditOpen(false);
+        } catch (error) {
+            notify.error(error, 'Failed to update group');
+        }
+    }
+
+    async function handleDelete() {
+        if (!group) return;
+        try {
+            await deleteMutation.mutateAsync(group.id);
+            notify.success('Group deleted successfully');
+            setDeleteOpen(false);
+            navigate('..');
+        } catch (error) {
+            notify.error(error, 'Failed to delete group');
+        }
+    }
+
+    if (isLoading) {
+        return (
+            <div className="space-y-4">
+                <Skeleton className="h-8 w-32" />
+                <Skeleton className="h-32 w-full rounded-xl" />
+                <Skeleton className="h-56 w-full rounded-xl" />
+            </div>
+        );
+    }
+
+    if (isError || !group) {
+        return (
+            <div className="space-y-4">
+                <Button type="button" variant="ghost" className="gap-1.5 px-0" asChild>
+                    <Link to="..">
+                        <ArrowLeftIcon className="size-4" aria-hidden />
+                        Back to groups
+                    </Link>
+                </Button>
+                <p className="text-sm text-muted-foreground">Group not found or failed to load.</p>
+            </div>
+        );
+    }
+
+    return (
+        <>
+            <div className="space-y-6">
+                <Button type="button" variant="ghost" className="gap-1.5 px-0 text-muted-foreground" asChild>
+                    <Link to="..">
+                        <ArrowLeftIcon className="size-4" aria-hidden />
+                        Back to groups
+                    </Link>
+                </Button>
+
+                <section className="rounded-xl border bg-card p-5">
+                    <div className="flex items-start justify-between gap-4">
+                        <div className="flex min-w-0 items-start gap-3">
+                            <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-700">
+                                <UsersRoundIcon className="size-5" aria-hidden />
+                            </div>
+                            <div className="min-w-0 space-y-1">
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <h1 className="text-xl font-semibold tracking-tight">{group.name}</h1>
+                                    {hasEventRule(group, 'API_CREATE') && (
+                                        <Badge variant="default" className="text-xs font-normal">
+                                            Auto APIs
+                                        </Badge>
+                                    )}
+                                    {hasEventRule(group, 'API_PRODUCT_CREATE') && (
+                                        <Badge variant="default" className="text-xs font-normal">
+                                            Auto API Products
+                                        </Badge>
+                                    )}
+                                    {hasEventRule(group, 'APPLICATION_CREATE') && (
+                                        <Badge variant="default" className="text-xs font-normal">
+                                            Auto Applications
+                                        </Badge>
+                                    )}
+                                </div>
+                                {group.created_at && (
+                                    <p className="text-sm text-muted-foreground">
+                                        Created <DateCell value={new Date(group.created_at)} format="absolute" />
+                                        {group.updated_at && group.updated_at !== group.created_at && (
+                                            <>
+                                                {' '}
+                                                · Updated <DateCell value={new Date(group.updated_at)} format="absolute" />
+                                            </>
+                                        )}
+                                    </p>
+                                )}
+                            </div>
+                        </div>
+                        {(canEdit || canDelete) && (
+                            <div className="flex shrink-0 items-center gap-2">
+                                {canEdit && (
+                                    <Button type="button" variant="outline" size="sm" className="gap-1.5" onClick={() => setEditOpen(true)}>
+                                        <PencilIcon className="size-4" aria-hidden />
+                                        Edit group
+                                    </Button>
+                                )}
+                                {canDelete && (
+                                    <Button
+                                        type="button"
+                                        variant="destructive"
+                                        size="sm"
+                                        className="gap-1.5"
+                                        onClick={() => setDeleteOpen(true)}
+                                    >
+                                        <Trash2Icon className="size-4" aria-hidden />
+                                        Delete
+                                    </Button>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                </section>
+
+                <section className="space-y-4 rounded-xl border bg-card p-5">
+                    <div>
+                        <h2 className="text-base font-semibold">Settings</h2>
+                        <p className="text-sm text-muted-foreground">
+                            Default roles, member limits, and invitation methods for this group.
+                        </p>
+                    </div>
+                    <dl className="grid grid-cols-2 gap-x-6 gap-y-4 sm:grid-cols-3">
+                        <div>
+                            <dt className="text-xs font-medium text-muted-foreground">Default API role</dt>
+                            <dd className="flex items-center gap-1.5 text-sm">
+                                {group.roles?.API ?? '—'}
+                                {group.lock_api_role && <LockIcon className="size-3.5 text-muted-foreground" aria-label="Locked" />}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt className="text-xs font-medium text-muted-foreground">Default API product role</dt>
+                            <dd className="flex items-center gap-1.5 text-sm">
+                                {group.roles?.API_PRODUCT ?? '—'}
+                                {group.lock_api_product_role && <LockIcon className="size-3.5 text-muted-foreground" aria-label="Locked" />}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt className="text-xs font-medium text-muted-foreground">Default application role</dt>
+                            <dd className="flex items-center gap-1.5 text-sm">
+                                {group.roles?.APPLICATION ?? '—'}
+                                {group.lock_application_role && <LockIcon className="size-3.5 text-muted-foreground" aria-label="Locked" />}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt className="text-xs font-medium text-muted-foreground">Max members</dt>
+                            <dd className="text-sm">{typeof group.max_invitation === 'number' ? group.max_invitation : 'Unlimited'}</dd>
+                        </div>
+                        <div className="col-span-2 sm:col-span-2">
+                            <dt className="text-xs font-medium text-muted-foreground">Invitation methods</dt>
+                            <dd className="flex flex-wrap items-center gap-1.5 text-sm">
+                                {group.system_invitation && (
+                                    <Badge variant="default" className="gap-1 text-xs font-normal">
+                                        <SearchIcon className="size-3" aria-hidden />
+                                        User search
+                                    </Badge>
+                                )}
+                                {group.email_invitation && (
+                                    <Badge variant="default" className="gap-1 text-xs font-normal">
+                                        <MailIcon className="size-3" aria-hidden />
+                                        Email invitation
+                                    </Badge>
+                                )}
+                                {!group.system_invitation && !group.email_invitation && <span className="text-muted-foreground">None</span>}
+                            </dd>
+                        </div>
+                    </dl>
+                </section>
+
+                <section className="space-y-4 rounded-xl border bg-card p-5">
+                    <div>
+                        <h2 className="text-base font-semibold">Members</h2>
+                        <p className="text-sm text-muted-foreground">Direct members of this group and their scoped roles.</p>
+                    </div>
+                    {membersError ? (
+                        <SectionError message="Failed to load members. Please refresh and try again." />
+                    ) : (
+                        <GroupMembersTable members={members} loading={membersLoading} />
+                    )}
+                </section>
+
+                <section className="space-y-4 rounded-xl border bg-card p-5">
+                    <h2 className="text-base font-semibold">APIs</h2>
+                    {apisError ? (
+                        <SectionError message="Failed to load associated APIs. Please refresh and try again." />
+                    ) : (
+                        <GroupMembershipTable
+                            items={apis}
+                            loading={apisLoading}
+                            ariaLabel="APIs"
+                            searchPlaceholder="Search APIs…"
+                            emptyTitle="No dependent APIs to display"
+                            emptyDescription="APIs associated with this group will appear here."
+                        />
+                    )}
+                </section>
+
+                <section className="space-y-4 rounded-xl border bg-card p-5">
+                    <h2 className="text-base font-semibold">API Products</h2>
+                    {apiProductsError ? (
+                        <SectionError message="Failed to load associated API Products. Please refresh and try again." />
+                    ) : (
+                        <GroupMembershipTable
+                            items={apiProducts}
+                            loading={apiProductsLoading}
+                            ariaLabel="API Products"
+                            searchPlaceholder="Search API Products…"
+                            emptyTitle="No dependent API Products to display"
+                            emptyDescription="API Products associated with this group will appear here."
+                        />
+                    )}
+                </section>
+
+                <section className="space-y-4 rounded-xl border bg-card p-5">
+                    <h2 className="text-base font-semibold">Applications</h2>
+                    {applicationsError ? (
+                        <SectionError message="Failed to load associated applications. Please refresh and try again." />
+                    ) : (
+                        <GroupMembershipTable
+                            items={applications}
+                            loading={applicationsLoading}
+                            ariaLabel="Applications"
+                            searchPlaceholder="Search Applications…"
+                            emptyTitle="No dependent applications to display"
+                            emptyDescription="Applications associated with this group will appear here."
+                            showVersionColumn={false}
+                        />
+                    )}
+                </section>
+            </div>
+
+            <GroupSheet
+                open={editOpen}
+                mode="edit"
+                group={group}
+                apiRoles={apiRoles}
+                applicationRoles={applicationRoles}
+                apiProductRoles={apiProductRoles}
+                rolesLoading={apiRolesLoading || applicationRolesLoading || apiProductRolesLoading}
+                onClose={() => setEditOpen(false)}
+                onSubmit={handleUpdate}
+                isSaving={updateMutation.isPending}
+            />
+
+            <GroupDeleteSheet
+                open={deleteOpen}
+                group={group}
+                onClose={() => setDeleteOpen(false)}
+                onConfirm={handleDelete}
+                isDeleting={deleteMutation.isPending}
+            />
+        </>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
@@ -318,7 +318,7 @@ describe('GroupsPage', () => {
             renderPage();
 
             fireEvent.click(screen.getByRole('button', { name: 'Delete Support Team' }));
-            expect(screen.queryByRole('heading', { name: 'Delete Group' })).not.toBeNull();
+            expect(screen.queryByRole('heading', { name: 'Delete group' })).not.toBeNull();
 
             fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
@@ -251,7 +251,7 @@ describe('GroupsPage', () => {
             await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to create group'));
         });
 
-        it('closes the sheet and warns (not errors) when the group was created but the role update fails', async () => {
+        it('closes the sheet, warns (not errors), and still navigates to the group when the role update fails', async () => {
             const createMutateAsync = jest.fn().mockResolvedValue({
                 id: 'new-group-id',
                 name: 'My Group',
@@ -262,6 +262,8 @@ describe('GroupsPage', () => {
                 roles: {},
             });
             const updateMutateAsync = jest.fn().mockRejectedValue(new Error('role update failed'));
+            const navigate = jest.fn();
+            mockUseNavigate.mockReturnValue(navigate);
             mockUseCreateGroup.mockReturnValue(makeMutation(createMutateAsync));
             mockUseUpdateGroup.mockReturnValue(makeMutation(updateMutateAsync));
 
@@ -276,6 +278,7 @@ describe('GroupsPage', () => {
             );
             expect(notify.error).not.toHaveBeenCalled();
             expect(notify.success).not.toHaveBeenCalled();
+            expect(navigate).toHaveBeenCalledWith('new-group-id');
             await waitFor(() => expect(screen.queryByRole('heading', { name: 'Create group' })).toBeNull());
         });
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
@@ -15,6 +15,7 @@
  */
 import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useNavigate } from 'react-router-dom';
 
 import { GroupsPage } from './GroupsPage';
 import { useCreateGroup, useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
@@ -25,6 +26,10 @@ import { notify } from '../shared/notify';
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasPermission: jest.fn(),
+}));
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: jest.fn(),
 }));
 jest.mock('../features/groups/hooks/useGroups');
 jest.mock('../features/groups/hooks/useGroupRoles');
@@ -93,6 +98,7 @@ beforeAll(() => {
 });
 
 const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseNavigate = jest.mocked(useNavigate);
 const mockUseGroupsPaged = jest.mocked(useGroupsPaged);
 const mockUseGroupApiRoles = jest.mocked(useGroupApiRoles);
 const mockUseGroupApplicationRoles = jest.mocked(useGroupApplicationRoles);
@@ -126,6 +132,7 @@ function renderPage() {
 describe('GroupsPage', () => {
     beforeEach(() => {
         mockUseHasPermission.mockReturnValue(true);
+        mockUseNavigate.mockReturnValue(jest.fn());
         mockUseGroupsPaged.mockReturnValue(makeGroupsResult());
         mockUseGroupApiRoles.mockReturnValue({ data: [{ name: 'USER', scope: 'API', default: true }], isLoading: false } as ReturnType<
             typeof useGroupApiRoles
@@ -150,7 +157,7 @@ describe('GroupsPage', () => {
     describe('page header', () => {
         it('renders the page title', () => {
             renderPage();
-            expect(screen.queryByRole('heading', { name: 'User Groups' })).not.toBeNull();
+            expect(screen.queryByRole('heading', { name: 'Groups' })).not.toBeNull();
         });
 
         it('shows the Create Group button when user can create', () => {
@@ -188,7 +195,7 @@ describe('GroupsPage', () => {
     });
 
     describe('create flow', () => {
-        it('creates the group, then follows up with a role update, and shows a success toast', async () => {
+        it('creates the group, then follows up with a role update, shows a success toast, and navigates to the group detail page', async () => {
             const createMutateAsync = jest.fn().mockResolvedValue({
                 id: 'new-group-id',
                 name: 'My Group',
@@ -199,6 +206,8 @@ describe('GroupsPage', () => {
                 roles: {},
             });
             const updateMutateAsync = jest.fn().mockResolvedValue({});
+            const navigate = jest.fn();
+            mockUseNavigate.mockReturnValue(navigate);
             mockUseCreateGroup.mockReturnValue(makeMutation(createMutateAsync));
             mockUseUpdateGroup.mockReturnValue(makeMutation(updateMutateAsync));
 
@@ -227,6 +236,7 @@ describe('GroupsPage', () => {
                 });
             });
             expect(notify.success).toHaveBeenCalledWith('Group created successfully');
+            expect(navigate).toHaveBeenCalledWith('new-group-id');
         });
 
         it('shows an error toast when create fails', async () => {
@@ -241,7 +251,7 @@ describe('GroupsPage', () => {
             await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to create group'));
         });
 
-        it('closes the sheet and warns (not errors) when the group was created but the role update fails', async () => {
+        it('closes the sheet, warns (not errors), and still navigates to the group when the role update fails', async () => {
             const createMutateAsync = jest.fn().mockResolvedValue({
                 id: 'new-group-id',
                 name: 'My Group',
@@ -252,6 +262,8 @@ describe('GroupsPage', () => {
                 roles: {},
             });
             const updateMutateAsync = jest.fn().mockRejectedValue(new Error('role update failed'));
+            const navigate = jest.fn();
+            mockUseNavigate.mockReturnValue(navigate);
             mockUseCreateGroup.mockReturnValue(makeMutation(createMutateAsync));
             mockUseUpdateGroup.mockReturnValue(makeMutation(updateMutateAsync));
 
@@ -266,6 +278,7 @@ describe('GroupsPage', () => {
             );
             expect(notify.error).not.toHaveBeenCalled();
             expect(notify.success).not.toHaveBeenCalled();
+            expect(navigate).toHaveBeenCalledWith('new-group-id');
             await waitFor(() => expect(screen.queryByRole('heading', { name: 'Create group' })).toBeNull());
         });
     });
@@ -308,7 +321,7 @@ describe('GroupsPage', () => {
             renderPage();
 
             fireEvent.click(screen.getByRole('button', { name: 'Delete Support Team' }));
-            expect(screen.queryByRole('heading', { name: 'Delete Group' })).not.toBeNull();
+            expect(screen.queryByRole('heading', { name: 'Delete group' })).not.toBeNull();
 
             fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
@@ -15,6 +15,7 @@
  */
 import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useNavigate } from 'react-router-dom';
 
 import { GroupsPage } from './GroupsPage';
 import { useCreateGroup, useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
@@ -25,6 +26,10 @@ import { notify } from '../shared/notify';
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasPermission: jest.fn(),
+}));
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: jest.fn(),
 }));
 jest.mock('../features/groups/hooks/useGroups');
 jest.mock('../features/groups/hooks/useGroupRoles');
@@ -93,6 +98,7 @@ beforeAll(() => {
 });
 
 const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseNavigate = jest.mocked(useNavigate);
 const mockUseGroupsPaged = jest.mocked(useGroupsPaged);
 const mockUseGroupApiRoles = jest.mocked(useGroupApiRoles);
 const mockUseGroupApplicationRoles = jest.mocked(useGroupApplicationRoles);
@@ -126,6 +132,7 @@ function renderPage() {
 describe('GroupsPage', () => {
     beforeEach(() => {
         mockUseHasPermission.mockReturnValue(true);
+        mockUseNavigate.mockReturnValue(jest.fn());
         mockUseGroupsPaged.mockReturnValue(makeGroupsResult());
         mockUseGroupApiRoles.mockReturnValue({ data: [{ name: 'USER', scope: 'API', default: true }], isLoading: false } as ReturnType<
             typeof useGroupApiRoles
@@ -150,7 +157,7 @@ describe('GroupsPage', () => {
     describe('page header', () => {
         it('renders the page title', () => {
             renderPage();
-            expect(screen.queryByRole('heading', { name: 'User Groups' })).not.toBeNull();
+            expect(screen.queryByRole('heading', { name: 'Groups' })).not.toBeNull();
         });
 
         it('shows the Create Group button when user can create', () => {
@@ -188,7 +195,7 @@ describe('GroupsPage', () => {
     });
 
     describe('create flow', () => {
-        it('creates the group, then follows up with a role update, and shows a success toast', async () => {
+        it('creates the group, then follows up with a role update, shows a success toast, and navigates to the group detail page', async () => {
             const createMutateAsync = jest.fn().mockResolvedValue({
                 id: 'new-group-id',
                 name: 'My Group',
@@ -199,6 +206,8 @@ describe('GroupsPage', () => {
                 roles: {},
             });
             const updateMutateAsync = jest.fn().mockResolvedValue({});
+            const navigate = jest.fn();
+            mockUseNavigate.mockReturnValue(navigate);
             mockUseCreateGroup.mockReturnValue(makeMutation(createMutateAsync));
             mockUseUpdateGroup.mockReturnValue(makeMutation(updateMutateAsync));
 
@@ -227,6 +236,7 @@ describe('GroupsPage', () => {
                 });
             });
             expect(notify.success).toHaveBeenCalledWith('Group created successfully');
+            expect(navigate).toHaveBeenCalledWith('new-group-id');
         });
 
         it('shows an error toast when create fails', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.tsx
@@ -18,6 +18,7 @@ import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { Button } from '@gravitee/graphene-core';
 import { PlusIcon } from '@gravitee/graphene-core/icons';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { GroupDeleteSheet } from '../features/groups/components/GroupDeleteSheet';
 import { GroupSheet, type GroupFormValues } from '../features/groups/components/GroupSheet';
@@ -38,6 +39,7 @@ import { notify } from '../shared/notify';
 type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'edit'; group: Group } | { type: 'delete'; group: Group };
 
 export function GroupsPage() {
+    const navigate = useNavigate();
     const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_CREATE_PERMISSION] });
     const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_UPDATE_PERMISSION] });
     const canDelete = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_DELETE_PERMISSION] });
@@ -122,13 +124,15 @@ export function GroupsPage() {
                     disable_membership_notifications: created.disable_membership_notifications ?? !values.notifyOnMemberAdded,
                 };
                 await updateMutation.mutateAsync({ groupId: created.id, data: rolesUpdate });
+                notify.success('Group created successfully');
             } catch {
                 notify.warning(`Group "${created.name}" was created, but default roles could not be applied. Edit the group to set them.`);
-                return;
             }
+        } else {
+            notify.success('Group created successfully');
         }
 
-        notify.success('Group created successfully');
+        navigate(created.id);
     }
 
     async function handleUpdate(values: GroupFormValues) {
@@ -184,7 +188,7 @@ export function GroupsPage() {
         <div className="space-y-6">
             <div className="flex items-start justify-between gap-4">
                 <div className="space-y-1">
-                    <h1 className="text-2xl font-semibold tracking-tight">User Groups</h1>
+                    <h1 className="text-2xl font-semibold tracking-tight">Groups</h1>
                     <p className="text-sm text-muted-foreground">
                         Organize users into groups to share default roles and simplify access management.
                     </p>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.tsx
@@ -124,13 +124,14 @@ export function GroupsPage() {
                     disable_membership_notifications: created.disable_membership_notifications ?? !values.notifyOnMemberAdded,
                 };
                 await updateMutation.mutateAsync({ groupId: created.id, data: rolesUpdate });
+                notify.success('Group created successfully');
             } catch {
                 notify.warning(`Group "${created.name}" was created, but default roles could not be applied. Edit the group to set them.`);
-                return;
             }
+        } else {
+            notify.success('Group created successfully');
         }
 
-        notify.success('Group created successfully');
         navigate(created.id);
     }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.tsx
@@ -18,6 +18,7 @@ import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { Button } from '@gravitee/graphene-core';
 import { PlusIcon } from '@gravitee/graphene-core/icons';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { GroupDeleteSheet } from '../features/groups/components/GroupDeleteSheet';
 import { GroupSheet, type GroupFormValues } from '../features/groups/components/GroupSheet';
@@ -38,6 +39,7 @@ import { notify } from '../shared/notify';
 type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'edit'; group: Group } | { type: 'delete'; group: Group };
 
 export function GroupsPage() {
+    const navigate = useNavigate();
     const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_CREATE_PERMISSION] });
     const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_UPDATE_PERMISSION] });
     const canDelete = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_DELETE_PERMISSION] });
@@ -129,6 +131,7 @@ export function GroupsPage() {
         }
 
         notify.success('Group created successfully');
+        navigate(created.id);
     }
 
     async function handleUpdate(values: GroupFormValues) {
@@ -184,7 +187,7 @@ export function GroupsPage() {
         <div className="space-y-6">
             <div className="flex items-start justify-between gap-4">
                 <div className="space-y-1">
-                    <h1 className="text-2xl font-semibold tracking-tight">User Groups</h1>
+                    <h1 className="text-2xl font-semibold tracking-tight">Groups</h1>
                     <p className="text-sm text-muted-foreground">
                         Organize users into groups to share default roles and simplify access management.
                     </p>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@fontsource/roboto": "5.2.5",
         "@gravitee/gamma-lib-observability": "1.39.1",
         "@gravitee/graphene-charts": "3.8.0",
-        "@gravitee/graphene-core": "3.8.0",
+        "@gravitee/graphene-core": "3.9.0",
         "@gravitee/graphene-policy-studio": "3.8.0",
         "@gravitee/ui-analytics": "17.8.0",
         "@gravitee/ui-components": "4.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4628,9 +4628,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/graphene-core@npm:3.8.0":
-  version: 3.8.0
-  resolution: "@gravitee/graphene-core@npm:3.8.0"
+"@gravitee/graphene-core@npm:3.9.0":
+  version: 3.9.0
+  resolution: "@gravitee/graphene-core@npm:3.9.0"
   dependencies:
     "@base-ui/react": "npm:1.4.1"
     "@types/json-schema": "npm:7.0.15"
@@ -4697,7 +4697,7 @@ __metadata:
       optional: true
   bin:
     graphene-sync-ai-rules: scripts/sync-ai-rules.mjs
-  checksum: 10c0/e7e0f7ffe533d3d5b646d737940b74c2a94fdc29b5a1ecccdc9755ac636e96d6893e8af0fa6f558fbb554a618a9442a0706ebd3b087561c1d528380930a74e93
+  checksum: 10c0/dad4c18396e6a98046d3623b069b192cd38a7743c4ec4ab4c4a6a8c19eef54fcd2750c450d9b3c66477be82d80cf938255d3663a81194ffd31b92aaa75880fd8
   languageName: node
   linkType: hard
 
@@ -21522,7 +21522,7 @@ __metadata:
     "@gravitee/gamma-lib-observability": "npm:1.39.1"
     "@gravitee/gamma-modules-sdk": "npm:1.2.0"
     "@gravitee/graphene-charts": "npm:3.8.0"
-    "@gravitee/graphene-core": "npm:3.8.0"
+    "@gravitee/graphene-core": "npm:3.9.0"
     "@gravitee/graphene-policy-studio": "npm:3.8.0"
     "@gravitee/ui-analytics": "npm:17.8.0"
     "@gravitee/ui-components": "npm:4.5.2"


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/FOUND-103
https://gravitee.atlassian.net/browse/FOUND-104
https://gravitee.atlassian.net/browse/FOUND-105
https://gravitee.atlassian.net/browse/FOUND-110

Note: this branch is named/opened against FOUND-102 (Create User Group), but that story already shipped in an earlier PR (`GroupSheet`'s create flow was merged separately). This PR is actually the detail-page follow-up — updated the ticket references above to match what's really in the diff.

- **New `GroupDetailPage`**, routed at `/user-groups/:groupId` (FOUND-103 — View Group Details). Shows:
  - **Settings section** (FOUND-103): default roles per scope with lock indicators, max members, invitation methods — read-only. [`GroupDetailPage.tsx#L217-L269`](https://github.com/gravitee-io/gravitee-api-management/blob/FOUND-102-Create-User-Group/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx#L217-L269), tested in [`GroupDetailPage.spec.tsx#L307-L358`](https://github.com/gravitee-io/gravitee-api-management/blob/FOUND-102-Create-User-Group/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx#L307-L358).
  - **Members table** (FOUND-105 — List Group Members): read-only in this PR, no add/edit/remove yet. Member count follows classic's own pattern — conveyed via the table's pagination range, not a header count (see [`GroupMembersTable.tsx#L144-L151`](https://github.com/gravitee-io/gravitee-api-management/blob/FOUND-102-Create-User-Group/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx#L144-L151), matching `group.component.html`'s `mat-paginator`).
  - Three membership tables (APIs / API Products / Applications currently associated with the group), each with its own search + pagination — read-only display; associating new items is FOUND-108, in a later PR.
- **Edit group** (FOUND-104 — Edit User Group): opens `GroupSheet` in edit mode from the detail page header.
- **Delete group** (FOUND-110 — Delete User Group): `GroupDeleteSheet`, with primary-owner-group detection *before* confirm so the user sees why deletion is blocked instead of hitting a backend `StillPrimaryOwnerException` after confirming.
- **Groups list → detail navigation**: group name in `GroupsTable` is now a clickable link instead of static text.
- **"Create Group" now redirects** to the new detail page on success, instead of just closing the sheet.
- **Label rename**: nav item / page heading changed from "User Groups" to "Groups". The route path (`user-groups`) and permission key are intentionally unchanged — this is a display-only rename.
- **Bug fix along the way**: group row edit/delete actions were incorrectly gated by the `manageable` flag — classic Console only uses `manageable` to gate member invitations, not edit/delete. Corrected to match.

## Testing

- `GroupDetailPage.spec.tsx` — Settings section (placeholders, locked-role indicator, max members, invitation badges), created/updated metadata, per-section error states, edit/delete flows.
- `GroupMembersTable.spec.tsx` — columns, search, pagination.
- Doc comments added on `GroupMembersTable.tsx#L140-L143` (why `serverSide` is used despite client-side pagination) and `groups.ts#L47-L49` (unpaged members call is an accepted, documented scale trade-off for classic parity).

## Out of scope (comes in later PRs in the stack)

- Add/invite/edit/remove members — FOUND-106/FOUND-107 — `#19018`
- Bulk-associate group with existing APIs/Products/Applications — FOUND-108 — `#19019`
- Manage group invitations — FOUND-109
- Org-wide, cross-environment group list — FOUND-111 — `#19020`
