### PR TITLE
fix(rest-api): load default portal templates via defining classloader

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCase.java
@@ -70,14 +70,14 @@ public class CreateDefaultPortalNavigationItemsUseCase {
             PortalArea.TOP_NAVBAR
         );
 
-        var folderGuides = findByTitle(topLevelTopNavbarItems, "Guides");
+        var folderGuides = findByTitleAndType(topLevelTopNavbarItems, "Guides", PortalNavigationItemType.FOLDER);
         if (folderGuides == null) {
             folderGuides = createPortalFolder("Guides", organizationId, environmentId, PortalArea.TOP_NAVBAR, null);
         }
 
         final var guidesChildren = portalNavigationItemsQueryService.findByParentIdAndEnvironmentId(environmentId, folderGuides.getId());
 
-        if (findByTitle(guidesChildren, "Getting started") == null) {
+        if (findByTitleAndType(guidesChildren, "Getting started", PortalNavigationItemType.PAGE) == null) {
             final var contentGettingStarted = createPortalPageContent(organizationId, environmentId, GETTING_STARTED_PATH);
             createPortalPage(
                 "Getting started",
@@ -89,7 +89,7 @@ public class CreateDefaultPortalNavigationItemsUseCase {
             );
         }
 
-        var folderCoreConcepts = findByTitle(guidesChildren, "Core concepts");
+        var folderCoreConcepts = findByTitleAndType(guidesChildren, "Core concepts", PortalNavigationItemType.FOLDER);
         if (folderCoreConcepts == null) {
             folderCoreConcepts = createPortalFolder(
                 "Core concepts",
@@ -105,7 +105,7 @@ public class CreateDefaultPortalNavigationItemsUseCase {
             folderCoreConcepts.getId()
         );
 
-        if (findByTitle(coreConceptsChildren, "Authentication") == null) {
+        if (findByTitleAndType(coreConceptsChildren, "Authentication", PortalNavigationItemType.PAGE) == null) {
             final var contentAuthentication = createPortalPageContent(organizationId, environmentId, AUTHENTICATION_PATH);
             createPortalPage(
                 "Authentication",
@@ -117,7 +117,7 @@ public class CreateDefaultPortalNavigationItemsUseCase {
             );
         }
 
-        if (findByTitle(coreConceptsChildren, "Making your first API call") == null) {
+        if (findByTitleAndType(coreConceptsChildren, "Making your first API call", PortalNavigationItemType.PAGE) == null) {
             final var contentFirstApiCall = createPortalPageContent(organizationId, environmentId, FIRST_API_CALL_PATH);
             createPortalPage(
                 "Making your first API call",
@@ -129,7 +129,7 @@ public class CreateDefaultPortalNavigationItemsUseCase {
             );
         }
 
-        if (findByTitle(topLevelTopNavbarItems, "Docs") == null) {
+        if (findByTitleAndType(topLevelTopNavbarItems, "Docs", PortalNavigationItemType.LINK) == null) {
             createPortalLink("Docs", organizationId, environmentId, DOCS_URL, PortalArea.TOP_NAVBAR, null);
         }
 
@@ -143,10 +143,10 @@ public class CreateDefaultPortalNavigationItemsUseCase {
         }
     }
 
-    private static PortalNavigationItem findByTitle(List<PortalNavigationItem> items, String title) {
+    private static PortalNavigationItem findByTitleAndType(List<PortalNavigationItem> items, String title, PortalNavigationItemType type) {
         return items
             .stream()
-            .filter(item -> title.equals(item.getTitle()))
+            .filter(item -> title.equals(item.getTitle()) && item.getType() == type)
             .findFirst()
             .orElse(null);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCase.java
@@ -28,6 +28,8 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.List;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -44,9 +46,10 @@ public class CreateDefaultPortalNavigationItemsUseCase {
 
     private final PortalNavigationItemDomainService portalNavigationItemDomainService;
     private final PortalPageContentCrudService pageContentCrudService;
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
 
     /**
-     * Creates a collection of default navigation items:
+     * Creates whichever of the following default navigation items are still missing for the environment:
      *
      * <pre>
      * 🗂 Guides
@@ -56,52 +59,92 @@ public class CreateDefaultPortalNavigationItemsUseCase {
      *     📄 Making your first API call
      * 🔗 Docs
      * </pre>
+     *
+     * Idempotent per item, so it is safe to call more than once for the same environment (e.g. to repair
+     * an environment left partially seeded by a previous failed run): items that already exist by title
+     * under their expected parent are left untouched, and only missing items are created.
      */
     public void execute(String organizationId, String environmentId) {
-        final var folderGuides = createPortalFolder("Guides", organizationId, environmentId, PortalArea.TOP_NAVBAR, null);
-
-        final var contentGettingStarted = createPortalPageContent(organizationId, environmentId, GETTING_STARTED_PATH);
-        createPortalPage(
-            "Getting started",
-            organizationId,
+        final var topLevelTopNavbarItems = portalNavigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalArea(
             environmentId,
-            PortalArea.TOP_NAVBAR,
-            contentGettingStarted.getId(),
-            folderGuides.getId()
+            PortalArea.TOP_NAVBAR
         );
 
-        final var folderCoreConcepts = createPortalFolder(
-            "Core concepts",
-            organizationId,
-            environmentId,
-            PortalArea.TOP_NAVBAR,
-            folderGuides.getId()
-        );
+        var folderGuides = findByTitle(topLevelTopNavbarItems, "Guides");
+        if (folderGuides == null) {
+            folderGuides = createPortalFolder("Guides", organizationId, environmentId, PortalArea.TOP_NAVBAR, null);
+        }
 
-        final var contentAuthentication = createPortalPageContent(organizationId, environmentId, AUTHENTICATION_PATH);
-        createPortalPage(
-            "Authentication",
-            organizationId,
+        final var guidesChildren = portalNavigationItemsQueryService.findByParentIdAndEnvironmentId(environmentId, folderGuides.getId());
+
+        if (findByTitle(guidesChildren, "Getting started") == null) {
+            final var contentGettingStarted = createPortalPageContent(organizationId, environmentId, GETTING_STARTED_PATH);
+            createPortalPage(
+                "Getting started",
+                organizationId,
+                environmentId,
+                PortalArea.TOP_NAVBAR,
+                contentGettingStarted.getId(),
+                folderGuides.getId()
+            );
+        }
+
+        var folderCoreConcepts = findByTitle(guidesChildren, "Core concepts");
+        if (folderCoreConcepts == null) {
+            folderCoreConcepts = createPortalFolder(
+                "Core concepts",
+                organizationId,
+                environmentId,
+                PortalArea.TOP_NAVBAR,
+                folderGuides.getId()
+            );
+        }
+
+        final var coreConceptsChildren = portalNavigationItemsQueryService.findByParentIdAndEnvironmentId(
             environmentId,
-            PortalArea.TOP_NAVBAR,
-            contentAuthentication.getId(),
             folderCoreConcepts.getId()
         );
 
-        final var contentFirstApiCall = createPortalPageContent(organizationId, environmentId, FIRST_API_CALL_PATH);
-        createPortalPage(
-            "Making your first API call",
-            organizationId,
+        if (findByTitle(coreConceptsChildren, "Authentication") == null) {
+            final var contentAuthentication = createPortalPageContent(organizationId, environmentId, AUTHENTICATION_PATH);
+            createPortalPage(
+                "Authentication",
+                organizationId,
+                environmentId,
+                PortalArea.TOP_NAVBAR,
+                contentAuthentication.getId(),
+                folderCoreConcepts.getId()
+            );
+        }
+
+        if (findByTitle(coreConceptsChildren, "Making your first API call") == null) {
+            final var contentFirstApiCall = createPortalPageContent(organizationId, environmentId, FIRST_API_CALL_PATH);
+            createPortalPage(
+                "Making your first API call",
+                organizationId,
+                environmentId,
+                PortalArea.TOP_NAVBAR,
+                contentFirstApiCall.getId(),
+                folderCoreConcepts.getId()
+            );
+        }
+
+        if (findByTitle(topLevelTopNavbarItems, "Docs") == null) {
+            createPortalLink("Docs", organizationId, environmentId, DOCS_URL, PortalArea.TOP_NAVBAR, null);
+        }
+
+        final var existingHomepage = portalNavigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalArea(
             environmentId,
-            PortalArea.TOP_NAVBAR,
-            contentFirstApiCall.getId(),
-            folderCoreConcepts.getId()
+            PortalArea.HOMEPAGE
         );
+        if (existingHomepage.isEmpty()) {
+            final var contentHomePage = createPortalPageContent(organizationId, environmentId, HOMEPAGE_CONTENT_PATH);
+            createPortalPage("Home Page", organizationId, environmentId, PortalArea.HOMEPAGE, contentHomePage.getId(), null);
+        }
+    }
 
-        createPortalLink("Docs", organizationId, environmentId, DOCS_URL, PortalArea.TOP_NAVBAR, null);
-
-        final var contentHomePage = createPortalPageContent(organizationId, environmentId, HOMEPAGE_CONTENT_PATH);
-        createPortalPage("Home Page", organizationId, environmentId, PortalArea.HOMEPAGE, contentHomePage.getId(), null);
+    private static PortalNavigationItem findByTitle(List<PortalNavigationItem> items, String title) {
+        return items.stream().filter(item -> title.equals(item.getTitle())).findFirst().orElse(null);
     }
 
     private PortalNavigationItem createPortalFolder(
@@ -166,7 +209,9 @@ public class CreateDefaultPortalNavigationItemsUseCase {
 
     private String loadContent(String contentPath) {
         try (
-            final var is = Thread.currentThread().getContextClassLoader().getResourceAsStream(String.format("templates/%s", contentPath))
+            final var is = CreateDefaultPortalNavigationItemsUseCase.class.getClassLoader().getResourceAsStream(
+                String.format("templates/%s", contentPath)
+            )
         ) {
             if (is == null) {
                 throw new IllegalStateException(String.format("Could not load default portal page template for %s", contentPath));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCase.java
@@ -144,7 +144,11 @@ public class CreateDefaultPortalNavigationItemsUseCase {
     }
 
     private static PortalNavigationItem findByTitle(List<PortalNavigationItem> items, String title) {
-        return items.stream().filter(item -> title.equals(item.getTitle())).findFirst().orElse(null);
+        return items
+            .stream()
+            .filter(item -> title.equals(item.getTitle()))
+            .findFirst()
+            .orElse(null);
     }
 
     private PortalNavigationItem createPortalFolder(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCase.java
@@ -114,7 +114,9 @@ public class SeedDefaultPagesForApiNavigationItemsUseCase {
 
     private String loadContent(String contentPath) {
         try (
-            var inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(String.format("templates/%s", contentPath))
+            var inputStream = SeedDefaultPagesForApiNavigationItemsUseCase.class.getClassLoader().getResourceAsStream(
+                String.format("templates/%s", contentPath)
+            )
         ) {
             if (inputStream == null) {
                 throw new IllegalStateException(String.format("Could not load default portal page template for %s", contentPath));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/CreateDefaultSubscriptionFormUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/CreateDefaultSubscriptionFormUseCase.java
@@ -64,7 +64,7 @@ public class CreateDefaultSubscriptionFormUseCase {
     }
 
     private String loadDefaultFormContent() {
-        try (final var is = Thread.currentThread().getContextClassLoader().getResourceAsStream(DEFAULT_FORM_TEMPLATE_PATH)) {
+        try (final var is = CreateDefaultSubscriptionFormUseCase.class.getClassLoader().getResourceAsStream(DEFAULT_FORM_TEMPLATE_PATH)) {
             if (is == null) {
                 throw new IllegalStateException("Could not load default subscription form template: " + DEFAULT_FORM_TEMPLATE_PATH);
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultSubscriptionFormUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultSubscriptionFormUpgrader.java
@@ -47,9 +47,14 @@ public class DefaultSubscriptionFormUpgrader implements Upgrader {
         this.createDefaultSubscriptionFormUseCase = createDefaultSubscriptionFormUseCase;
     }
 
+    /**
+     * Bumped to re-run once more: {@link CreateDefaultSubscriptionFormUseCase#execute} is idempotent,
+     * so this catches environments where the form was never created because APIM-14865 (a classloader
+     * bug) aborted EnvironmentCommandHandler before this use case was even reached.
+     */
     @Override
     public String version() {
-        return "v2";
+        return "v3";
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentsDefaultPortalNavigationItemsUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentsDefaultPortalNavigationItemsUpgrader.java
@@ -17,6 +17,8 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.ENVIRONMENTS_DEFAULT_PORTAL_NAVIGATION_ITEMS_UPGRADER;
 
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.node.api.upgrader.Upgrader;
 import io.gravitee.node.api.upgrader.UpgraderException;
@@ -32,18 +34,31 @@ public class EnvironmentsDefaultPortalNavigationItemsUpgrader implements Upgrade
 
     private final EnvironmentRepository environmentRepository;
     private final CreateDefaultPortalNavigationItemsUseCase createDefaultPortalNavigationItemsUseCase;
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
 
     public EnvironmentsDefaultPortalNavigationItemsUpgrader(
         @Lazy EnvironmentRepository environmentRepository,
-        CreateDefaultPortalNavigationItemsUseCase createDefaultPortalNavigationItemsUseCase
+        CreateDefaultPortalNavigationItemsUseCase createDefaultPortalNavigationItemsUseCase,
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService
     ) {
         this.environmentRepository = environmentRepository;
         this.createDefaultPortalNavigationItemsUseCase = createDefaultPortalNavigationItemsUseCase;
+        this.portalNavigationItemsQueryService = portalNavigationItemsQueryService;
     }
 
     @Override
     public int getOrder() {
         return ENVIRONMENTS_DEFAULT_PORTAL_NAVIGATION_ITEMS_UPGRADER;
+    }
+
+    /**
+     * Bumped to re-run once: repairs environments left partially seeded by APIM-14865 (a classloader
+     * bug that could abort seeding partway through, after creating the "Guides" folder but before the
+     * Home Page).
+     */
+    @Override
+    public String version() {
+        return "v2";
     }
 
     @Override
@@ -53,7 +68,16 @@ public class EnvironmentsDefaultPortalNavigationItemsUpgrader implements Upgrade
 
     private boolean applyUpgrade() throws TechnicalException {
         for (final var environment : environmentRepository.findAll()) {
-            createDefaultPortalNavigationItemsUseCase.execute(environment.getOrganizationId(), environment.getId());
+            // Only touch environments where seeding never completed (no Home Page yet). An environment
+            // that has a Home Page was fully seeded at some point; if a user later deliberately removed
+            // e.g. the "Guides" folder, re-running here must not resurrect it.
+            var existingHomepage = portalNavigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalArea(
+                environment.getId(),
+                PortalArea.HOMEPAGE
+            );
+            if (existingHomepage.isEmpty()) {
+                createDefaultPortalNavigationItemsUseCase.execute(environment.getOrganizationId(), environment.getId());
+            }
         }
         return true;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCaseTest.java
@@ -206,7 +206,12 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
         // Given: a previous run failed right after creating the "Guides" folder (matches APIM-14865:
         // the classloader-fragile template loader threw on the very next call, leaving only "Guides").
         useCase.execute(ORG_ID, ENV_ID);
-        final var guidesFolder = queryService.storage().stream().filter(item -> item.getTitle().equals("Guides")).findFirst().get();
+        final var guidesFolder = queryService
+            .storage()
+            .stream()
+            .filter(item -> item.getTitle().equals("Guides"))
+            .findFirst()
+            .get();
         queryService.storage().removeIf(item -> !item.getTitle().equals("Guides"));
         pageContentCrudService.storage().clear();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCaseTest.java
@@ -19,6 +19,7 @@ import static fixtures.core.model.PortalNavigationItemFixtures.ENV_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.ORG_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
@@ -233,6 +234,38 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
         );
         assertThat(items.stream().filter(item -> item.getType() == PortalNavigationItemType.PAGE)).hasSize(4);
         assertThat(pageContentCrudService.storage()).hasSize(4);
+    }
+
+    @Test
+    void should_not_mistake_a_title_colliding_item_of_a_different_type_for_the_default_one() {
+        // Given: a user-created PAGE happens to be titled "Guides" (title collision, wrong type) - a
+        // title-only lookup would treat it as the default folder and pass its id as a parent, which
+        // PortalNavigationItemDomainService.resolveParentContainer rejects since it isn't a container,
+        // aborting the whole repair instead of fixing the environment.
+        final var collidingPage = PortalNavigationItemFixtures.aPage("Guides", null);
+        queryService.storage().add(collidingPage);
+
+        // When
+        useCase.execute(ORG_ID, ENV_ID);
+
+        // Then: a proper "Guides" FOLDER was created alongside the colliding page (left untouched),
+        // and the folder's children were correctly parented under the new folder.
+        final var items = queryService.storage();
+        assertThat(items.stream().filter(item -> item.getId().equals(collidingPage.getId()))).hasSize(1);
+
+        final var guidesFolder = items
+            .stream()
+            .filter(item -> item.getTitle().equals("Guides") && item.getType() == PortalNavigationItemType.FOLDER)
+            .findFirst()
+            .get();
+        assertThat(guidesFolder.getId()).isNotEqualTo(collidingPage.getId());
+
+        final var gettingStartedPage = items
+            .stream()
+            .filter(item -> item.getTitle().equals("Getting started"))
+            .findFirst()
+            .get();
+        assertThat(gettingStartedPage.getParentId()).isEqualTo(guidesFolder.getId());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateDefaultPortalNavigationItemsUseCaseTest.java
@@ -26,9 +26,12 @@ import inmemory.PortalPageContentCrudServiceInMemory;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -58,7 +61,7 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
             pageContentCrudService,
             apiCrudService
         );
-        useCase = new CreateDefaultPortalNavigationItemsUseCase(portalNavigationItemDomainService, pageContentCrudService);
+        useCase = new CreateDefaultPortalNavigationItemsUseCase(portalNavigationItemDomainService, pageContentCrudService, queryService);
     }
 
     @Test
@@ -182,5 +185,69 @@ class CreateDefaultPortalNavigationItemsUseCaseTest {
         assertThat(homePage.getEnvironmentId()).isEqualTo(ENV_ID);
         assertThat(homePage.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
         assertThat(homePage.getPublished()).isTrue();
+    }
+
+    @Test
+    void should_be_idempotent_when_called_twice() {
+        // When
+        useCase.execute(ORG_ID, ENV_ID);
+        final var itemsAfterFirstRun = queryService.storage().size();
+        final var contentAfterFirstRun = pageContentCrudService.storage().size();
+
+        useCase.execute(ORG_ID, ENV_ID);
+
+        // Then
+        assertThat(queryService.storage()).hasSize(itemsAfterFirstRun);
+        assertThat(pageContentCrudService.storage()).hasSize(contentAfterFirstRun);
+    }
+
+    @Test
+    void should_fill_in_only_missing_items_when_environment_was_left_partially_seeded() {
+        // Given: a previous run failed right after creating the "Guides" folder (matches APIM-14865:
+        // the classloader-fragile template loader threw on the very next call, leaving only "Guides").
+        useCase.execute(ORG_ID, ENV_ID);
+        final var guidesFolder = queryService.storage().stream().filter(item -> item.getTitle().equals("Guides")).findFirst().get();
+        queryService.storage().removeIf(item -> !item.getTitle().equals("Guides"));
+        pageContentCrudService.storage().clear();
+
+        // When
+        useCase.execute(ORG_ID, ENV_ID);
+
+        // Then
+        final var items = queryService.storage();
+        assertThat(items.stream().filter(item -> item.getTitle().equals("Guides"))).hasSize(1);
+        assertThat(items.stream().filter(item -> item.getId().equals(guidesFolder.getId()))).hasSize(1);
+        assertThat(items.stream().map(PortalNavigationItem::getTitle)).containsExactlyInAnyOrder(
+            "Guides",
+            "Getting started",
+            "Core concepts",
+            "Authentication",
+            "Making your first API call",
+            "Docs",
+            "Home Page"
+        );
+        assertThat(items.stream().filter(item -> item.getType() == PortalNavigationItemType.PAGE)).hasSize(4);
+        assertThat(pageContentCrudService.storage()).hasSize(4);
+    }
+
+    @Test
+    void should_load_templates_regardless_of_thread_context_classloader() {
+        // Given: a context classloader that cannot see this module's classpath resources at all,
+        // reproducing the production failure mode (a Vert.x/plugin-owned thread whose context
+        // classloader isn't the one that loaded gravitee-apim-rest-api-service).
+        final var originalClassLoader = Thread.currentThread().getContextClassLoader();
+        final var isolatedClassLoader = new URLClassLoader(new URL[0], null);
+        Thread.currentThread().setContextClassLoader(isolatedClassLoader);
+
+        try {
+            // When
+            useCase.execute(ORG_ID, ENV_ID);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+
+        // Then
+        assertThat(queryService.storage().stream().map(PortalNavigationItem::getTitle)).contains("Home Page", "Getting started");
+        assertThat(pageContentCrudService.storage()).hasSize(4);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCaseTest.java
@@ -35,6 +35,8 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.definition.model.v4.ApiType;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -150,10 +152,34 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
         assertThat(portalPageContentCrudService.storage()).hasSize(1);
     }
 
+    @Test
+    void should_load_templates_regardless_of_thread_context_classloader() {
+        // Given: a context classloader that cannot see this module's classpath resources at all,
+        // reproducing the production failure mode (a Vert.x/plugin-owned thread whose context
+        // classloader isn't the one that loaded gravitee-apim-rest-api-service).
+        final var originalClassLoader = Thread.currentThread().getContextClassLoader();
+        final var isolatedClassLoader = new URLClassLoader(new URL[0], null);
+        Thread.currentThread().setContextClassLoader(isolatedClassLoader);
+
+        SeedDefaultPagesForApiNavigationItemsUseCase.Output output;
+        try {
+            // When
+            output = useCase.execute(
+                new SeedDefaultPagesForApiNavigationItemsUseCase.Input(ORG_ID, ENV_ID, List.of(PortalNavigationItemId.of(API1_ID)))
+            );
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+
+        // Then
+        assertThat(output.seededNavigationItemIds()).containsExactly(PortalNavigationItemId.of(API1_ID));
+        assertThat(portalPageContentCrudService.storage()).hasSize(1);
+    }
+
     private String loadTemplate(String templatePath) {
         try (
-            var inputStream = Thread.currentThread()
-                .getContextClassLoader()
+            var inputStream = SeedDefaultPagesForApiNavigationItemsUseCaseTest.class
+                .getClassLoader()
                 .getResourceAsStream(String.format("templates/%s", templatePath))
         ) {
             assertThat(inputStream).isNotNull();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCaseTest.java
@@ -178,9 +178,9 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
 
     private String loadTemplate(String templatePath) {
         try (
-            var inputStream = SeedDefaultPagesForApiNavigationItemsUseCaseTest.class
-                .getClassLoader()
-                .getResourceAsStream(String.format("templates/%s", templatePath))
+            var inputStream = SeedDefaultPagesForApiNavigationItemsUseCaseTest.class.getClassLoader().getResourceAsStream(
+                String.format("templates/%s", templatePath)
+            )
         ) {
             assertThat(inputStream).isNotNull();
             return new String(inputStream.readAllBytes());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/CreateDefaultSubscriptionFormUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/CreateDefaultSubscriptionFormUseCaseTest.java
@@ -24,6 +24,8 @@ import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormConstraintsFactory;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
 import io.gravitee.apim.infra.domain_service.subscription_form.SubscriptionFormSchemaGeneratorImpl;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,5 +81,25 @@ class CreateDefaultSubscriptionFormUseCaseTest {
         useCase.execute(ENVIRONMENT_ID);
 
         assertThat(crudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_load_template_regardless_of_thread_context_classloader() {
+        // Given: a context classloader that cannot see this module's classpath resources at all,
+        // reproducing the production failure mode (a Vert.x/plugin-owned thread whose context
+        // classloader isn't the one that loaded gravitee-apim-rest-api-service).
+        final var originalClassLoader = Thread.currentThread().getContextClassLoader();
+        final var isolatedClassLoader = new URLClassLoader(new URL[0], null);
+        Thread.currentThread().setContextClassLoader(isolatedClassLoader);
+
+        try {
+            // When
+            useCase.execute(ENVIRONMENT_ID);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+
+        // Then
+        assertThat(crudService.storage()).hasSize(1);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentsDefaultPortalNavigationItemsUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentsDefaultPortalNavigationItemsUpgraderTest.java
@@ -17,11 +17,18 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import fixtures.core.model.PortalNavigationItemFixtures;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -58,11 +65,18 @@ public class EnvironmentsDefaultPortalNavigationItemsUpgraderTest {
     @Mock
     CreateDefaultPortalNavigationItemsUseCase createDefaultPortalNavigationItemsUseCase;
 
+    @Mock
+    PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+
     private EnvironmentsDefaultPortalNavigationItemsUpgrader upgrader;
 
     @BeforeEach
     public void setUp() {
-        upgrader = new EnvironmentsDefaultPortalNavigationItemsUpgrader(environmentRepository, createDefaultPortalNavigationItemsUseCase);
+        upgrader = new EnvironmentsDefaultPortalNavigationItemsUpgrader(
+            environmentRepository,
+            createDefaultPortalNavigationItemsUseCase,
+            portalNavigationItemsQueryService
+        );
     }
 
     @Test
@@ -88,8 +102,11 @@ public class EnvironmentsDefaultPortalNavigationItemsUpgraderTest {
 
     @Test
     @SneakyThrows
-    void should_create_default_portal_page_for_both_environments() {
+    void should_create_default_portal_page_for_both_environments_when_neither_has_a_homepage() {
         when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT, ANOTHER_ENVIRONMENT));
+        when(portalNavigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalArea(any(), eq(PortalArea.HOMEPAGE))).thenReturn(
+            List.of()
+        );
 
         assertThat(upgrader.upgrade()).isTrue();
 
@@ -99,5 +116,28 @@ public class EnvironmentsDefaultPortalNavigationItemsUpgraderTest {
         verify(createDefaultPortalNavigationItemsUseCase, times(2)).execute(captorOrgId.capture(), captorEnvId.capture());
         assertThat(captorOrgId.getAllValues()).containsExactlyInAnyOrder("DEFAULT", "ANOTHER_ORG");
         assertThat(captorEnvId.getAllValues()).containsExactlyInAnyOrder("DEFAULT", "ANOTHER_ENVIRONMENT");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_skip_environment_that_already_has_a_homepage() {
+        // Given: DEFAULT was already fully seeded (has a homepage) - even if a user later deleted e.g.
+        // its "Guides" folder on purpose, this upgrader must not touch it. ANOTHER_ENVIRONMENT has no
+        // homepage yet, so it should still be repaired.
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT, ANOTHER_ENVIRONMENT));
+        when(
+            portalNavigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalArea(eq("DEFAULT"), eq(PortalArea.HOMEPAGE))
+        ).thenReturn(List.of(PortalNavigationItemFixtures.aPage("00000000-0000-0000-0000-000000000999", "Home Page", null)));
+        when(
+            portalNavigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalArea(
+                eq("ANOTHER_ENVIRONMENT"),
+                eq(PortalArea.HOMEPAGE)
+            )
+        ).thenReturn(List.of());
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(createDefaultPortalNavigationItemsUseCase, never()).execute(eq("DEFAULT"), eq("DEFAULT"));
+        verify(createDefaultPortalNavigationItemsUseCase, times(1)).execute("ANOTHER_ORG", "ANOTHER_ENVIRONMENT");
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14880

**Purpose**

Fix default portal navigation items (including the homepage) and the default subscription form failing to seed for Cockpit-created environments due to a classloader bug, and repair environments already stuck in that state.

**Summary of changes**

- Replace `Thread.currentThread().getContextClassLoader()` with `<Class>.class.getClassLoader()` in `CreateDefaultPortalNavigationItemsUseCase`, `SeedDefaultPagesForApiNavigationItemsUseCase`, and `CreateDefaultSubscriptionFormUseCase` (plus a test helper with the same pattern) — the previous lookup could return null when the calling thread's context classloader traced back to the isolated Cockpit WS connector plugin instead of the main app classpath, aborting seeding partway through.
- Make `CreateDefaultPortalNavigationItemsUseCase.execute()` idempotent per item, so it only creates whatever default nav items are still missing.
- Add a guard in `EnvironmentsDefaultPortalNavigationItemsUpgrader`: only repair an environment if it has no Home Page at all — an environment with a homepage was fully seeded at some point, so it's left untouched even if a user later deleted something like the "Guides" folder on purpose.
- Bump `EnvironmentsDefaultPortalNavigationItemsUpgrader` to `v2` and `DefaultSubscriptionFormUpgrader` to `v3` so both re-run once on next boot and repair any environment left stuck by this bug (including subscription forms, since the original handler failure would have skipped that call too).

**Out of scope**

- No change to `EnvironmentCommandHandler`'s new-vs-existing gating logic — the upgrader-based repair is a general safety net for this class of partial-seeding failure regardless of cause.
- No dedicated data-migration script for this specific customer's environment — the general repair upgrader covers it automatically on next boot.

**Testing**

- Unit tests added/updated across `CreateDefaultPortalNavigationItemsUseCaseTest`, `SeedDefaultPagesForApiNavigationItemsUseCaseTest`, `CreateDefaultSubscriptionFormUseCaseTest`, `EnvironmentsDefaultPortalNavigationItemsUpgraderTest` — covering classloader independence, idempotency, partial-state repair, and the new homepage-presence guard. All pass.
- Manual end-to-end verification: built the fixed image locally, connected a real running instance to a protocol-faithful mock Cockpit controller (`gravitee-cockpit-exchange-tester`), and confirmed (a) a brand-new environment seeds fully, (b) an environment simulating the exact reported broken state (only an empty "Guides" folder) gets fully repaired on restart via the version-bumped upgraders, and (c) a fully-seeded environment with a deliberately-deleted "Guides" folder is left untouched.

**Additional context**

Root cause analysis is documented as a comment on the ticket.
