### PR TITLE
feat: add unified API and API Product catalog search

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApiProductMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApiProductMapper.java
@@ -19,6 +19,8 @@ import io.gravitee.apim.core.api_product.model.ApiProductKind;
 import io.gravitee.apim.core.api_product.model.PortalApiProductDetails.ApiSummary;
 import io.gravitee.rest.api.portal.rest.model.PortalApiProductApi;
 import io.gravitee.rest.api.portal.rest.model.PortalApiProductDetails;
+import io.gravitee.rest.api.portal.rest.model.PortalCatalogApiProductSummary;
+import java.util.List;
 import java.util.UUID;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
@@ -30,6 +32,12 @@ public interface ApiProductMapper {
     PortalApiProductDetails map(io.gravitee.apim.core.api_product.model.PortalApiProductDetails apiProduct);
 
     PortalApiProductApi map(ApiSummary api);
+
+    List<PortalCatalogApiProductSummary> map(List<io.gravitee.apim.core.portal_page.model.PortalCatalogApiProductSummary> apiProducts);
+
+    PortalCatalogApiProductSummary map(io.gravitee.apim.core.portal_page.model.PortalCatalogApiProductSummary apiProduct);
+
+    PortalApiProductApi map(io.gravitee.apim.core.portal_page.model.PortalCatalogApiProductSummary.ApiSummary api);
 
     default UUID map(String value) {
         return value == null ? null : UUID.fromString(value);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -162,6 +162,7 @@ public interface PortalNavigationItemMapper {
             .map(i ->
                 switch (i) {
                     case API -> io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude.API;
+                    case API_PRODUCT -> io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude.API_PRODUCT;
                 }
             )
             .collect(Collectors.toSet());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
@@ -20,13 +20,16 @@ import static io.gravitee.rest.api.service.common.GraviteeContext.getExecutionCo
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.use_case.GetVisiblePortalCatalogItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetVisiblePortalNavigationApisUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.portal.rest.mapper.ApiMapper;
+import io.gravitee.rest.api.portal.rest.mapper.ApiProductMapper;
 import io.gravitee.rest.api.portal.rest.mapper.PortalNavigationItemMapper;
 import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
+import io.gravitee.rest.api.portal.rest.model.Links;
 import io.gravitee.rest.api.portal.rest.model.PortalArea;
 import io.gravitee.rest.api.portal.rest.model.PortalNavigationItemsSearchResponse;
 import io.gravitee.rest.api.portal.rest.model.PortalNavigationSearchInclude;
@@ -34,6 +37,7 @@ import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
@@ -62,9 +66,13 @@ public class PortalNavigationItemsResource extends AbstractResource {
     private GetVisiblePortalNavigationApisUseCase getVisiblePortalNavigationApisUseCase;
 
     @Inject
+    private GetVisiblePortalCatalogItemsUseCase getVisiblePortalCatalogItemsUseCase;
+
+    @Inject
     private ApiMapper apiMapper;
 
     private final PortalNavigationItemMapper portalNavigationItemMapper = PortalNavigationItemMapper.INSTANCE;
+    private final ApiProductMapper apiProductMapper = ApiProductMapper.INSTANCE;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -94,6 +102,9 @@ public class PortalNavigationItemsResource extends AbstractResource {
         @QueryParam("include") Set<String> include,
         @BeanParam PaginationParam paginationParam
     ) {
+        if ("catalog".equalsIgnoreCase(type)) {
+            return searchPortalCatalog(query, include, paginationParam);
+        }
         if (!"api".equalsIgnoreCase(type)) {
             return Response.status(Response.Status.BAD_REQUEST).entity(new ErrorResponse()).build();
         }
@@ -119,7 +130,7 @@ public class PortalNavigationItemsResource extends AbstractResource {
         var responseBody = new PortalNavigationItemsSearchResponse()
             .data(pageItems)
             .metadata(buildSearchMetadata(paginationParam, page.getTotalElements(), pageItems.size()))
-            .links(computePaginatedLinks(paginationParam.getPage(), paginationParam.getSize(), (int) page.getTotalElements()));
+            .links(buildSearchLinks(paginationParam, page.getTotalElements()));
 
         if (!includedApis.isEmpty()) {
             responseBody.apis(includedApis);
@@ -128,10 +139,49 @@ public class PortalNavigationItemsResource extends AbstractResource {
         return Response.ok(responseBody).build();
     }
 
+    private Response searchPortalCatalog(String query, Set<String> include, PaginationParam paginationParam) {
+        Set<io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude> coreIncludes = parseIncludes(include);
+        var executionContext = getExecutionContext();
+        var output = getVisiblePortalCatalogItemsUseCase.execute(
+            new GetVisiblePortalCatalogItemsUseCase.Input(
+                executionContext.getEnvironmentId(),
+                executionContext.getOrganizationId(),
+                PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull()),
+                new PageableImpl(paginationParam.getPage(), paginationParam.getSize()),
+                Optional.ofNullable(query),
+                coreIncludes
+            )
+        );
+
+        var page = output.items();
+        List<io.gravitee.rest.api.portal.rest.model.PortalNavigationItem> pageItems = portalNavigationItemMapper.map(page.getContent());
+        List<io.gravitee.rest.api.portal.rest.model.Api> includedApis = loadIncludedApiEntities(executionContext, output.includedApis());
+
+        var responseBody = new PortalNavigationItemsSearchResponse()
+            .data(pageItems)
+            .metadata(buildSearchMetadata(paginationParam, page.getTotalElements(), pageItems.size()))
+            .links(buildSearchLinks(paginationParam, page.getTotalElements()));
+
+        if (!includedApis.isEmpty()) {
+            responseBody.apis(includedApis);
+        }
+        if (!output.includedApiProducts().isEmpty()) {
+            responseBody.apiProducts(apiProductMapper.map(output.includedApiProducts()));
+        }
+
+        return Response.ok(responseBody).build();
+    }
+
     private Map<String, Map<String, Object>> buildSearchMetadata(PaginationParam paginationParam, long totalElements, int dataTotal) {
-        int pageNumber = paginationParam.getPage();
+        boolean hasPagination = paginationParam.hasPagination();
+        int pageNumber = hasPagination ? paginationParam.getPage() : 1;
         int pageSize = paginationParam.getSize();
-        int totalPages = pageSize > 0 ? (int) Math.ceil((double) totalElements / pageSize) : 0;
+        int totalPages;
+        if (!hasPagination) {
+            totalPages = totalElements > 0 ? 1 : 0;
+        } else {
+            totalPages = pageSize > 0 ? (int) Math.ceil((double) totalElements / pageSize) : 0;
+        }
         int startIndex = pageSize > 0 ? (pageNumber - 1) * pageSize : 0;
         int lastIndex = pageSize > 0 ? (int) Math.min((long) startIndex + pageSize, totalElements) : (int) totalElements;
 
@@ -149,11 +199,23 @@ public class PortalNavigationItemsResource extends AbstractResource {
         return metadata;
     }
 
+    private Links buildSearchLinks(PaginationParam paginationParam, long totalElements) {
+        if (paginationParam.hasPagination()) {
+            return computePaginatedLinks(paginationParam.getPage(), paginationParam.getSize(), (int) totalElements);
+        }
+        int unpaginatedSize = (int) totalElements;
+        return computePaginatedLinks(1, unpaginatedSize, unpaginatedSize);
+    }
+
     private Set<io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude> parseIncludes(Set<String> include) {
-        Set<PortalNavigationSearchInclude> restIncludes = include == null
-            ? Set.of()
-            : include.stream().map(PortalNavigationSearchInclude::fromValue).collect(Collectors.toSet());
-        return portalNavigationItemMapper.map(restIncludes);
+        try {
+            Set<PortalNavigationSearchInclude> restIncludes = include == null
+                ? Set.of()
+                : include.stream().map(PortalNavigationSearchInclude::fromValue).collect(Collectors.toSet());
+            return portalNavigationItemMapper.map(restIncludes);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Unsupported include value: " + include, e);
+        }
     }
 
     private List<io.gravitee.rest.api.portal.rest.model.PortalNavigationItem> mapPageItems(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -3965,6 +3965,7 @@ paths:
                       type: string
                       enum:
                           - api
+                          - catalog
                 - name: include
                   in: query
                   required: false
@@ -4686,6 +4687,11 @@ components:
                     type: array
                     items:
                         $ref: "#/components/schemas/Api"
+                apiProducts:
+                    type: array
+                    description: API Product summaries referenced by API Product navigation items in the returned page.
+                    items:
+                        $ref: "#/components/schemas/PortalCatalogApiProductSummary"
                 links:
                     $ref: "#/components/schemas/Links"
         SubscriptionForm:
@@ -5319,6 +5325,39 @@ components:
                 version:
                     type: string
                     description: Version of the API.
+
+        PortalCatalogApiProductSummary:
+            type: object
+            description: Consumer-safe summary of an API Product returned by the Portal Catalog.
+            required:
+                - id
+                - name
+                - version
+                - navigationItemId
+                - apis
+            properties:
+                id:
+                    type: string
+                    format: uuid
+                    description: Unique identifier of the API Product.
+                name:
+                    type: string
+                    description: Name of the API Product.
+                description:
+                    type: string
+                    description: Description of the API Product.
+                version:
+                    type: string
+                    description: Version of the API Product.
+                navigationItemId:
+                    type: string
+                    format: uuid
+                    description: Identifier of the Portal navigation item exposing the API Product.
+                apis:
+                    type: array
+                    description: APIs included in the API Product and accessible to the current user.
+                    items:
+                        $ref: "#/components/schemas/PortalApiProductApi"
 
         DefinitionVersion:
             type: string
@@ -8230,6 +8269,7 @@ components:
             type: string
             enum:
                 - api
+                - api_product
         BasePortalNavigationItem:
             type: object
             description: Base portal navigation item

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApiProductMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApiProductMapperTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.core.api_product.model.ApiProductKind;
 import io.gravitee.apim.core.api_product.model.PortalApiProductDetails;
+import io.gravitee.apim.core.portal_page.model.PortalCatalogApiProductSummary;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,33 @@ class ApiProductMapperTest {
         assertThat(result.getKind()).isEqualTo(io.gravitee.rest.api.portal.rest.model.PortalApiProductDetails.KindEnum.AI_WORKSPACE);
         assertThat(result.getNavigationItemId()).isEqualTo(NAVIGATION_ITEM_ID);
         assertThat(result.getTags()).containsExactly("ai");
+        assertThat(result.getApis())
+            .singleElement()
+            .satisfies(api -> {
+                assertThat(api.getId()).isEqualTo("api-id");
+                assertThat(api.getName()).isEqualTo("API");
+                assertThat(api.getVersion()).isEqualTo("2.0.0");
+            });
+    }
+
+    @Test
+    void should_map_catalog_api_product_summary() {
+        var source = new PortalCatalogApiProductSummary(
+            API_PRODUCT_ID.toString(),
+            "AI Workspace",
+            "Description",
+            "1.0.0",
+            NAVIGATION_ITEM_ID.toString(),
+            List.of(new PortalCatalogApiProductSummary.ApiSummary("api-id", "API", "2.0.0"))
+        );
+
+        var result = ApiProductMapper.INSTANCE.map(source);
+
+        assertThat(result.getId()).isEqualTo(API_PRODUCT_ID);
+        assertThat(result.getName()).isEqualTo("AI Workspace");
+        assertThat(result.getDescription()).isEqualTo("Description");
+        assertThat(result.getVersion()).isEqualTo("1.0.0");
+        assertThat(result.getNavigationItemId()).isEqualTo(NAVIGATION_ITEM_ID);
         assertThat(result.getApis())
             .singleElement()
             .satisfies(api -> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceNotAuthenticatedTest.java
@@ -17,13 +17,20 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +46,9 @@ public class PortalNavigationItemsResourceNotAuthenticatedTest extends AbstractR
 
     @Autowired
     private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
+
+    @Autowired
+    private ApiProductQueryServiceInMemory apiProductQueryService;
 
     @Override
     protected String contextPath() {
@@ -59,6 +69,7 @@ public class PortalNavigationItemsResourceNotAuthenticatedTest extends AbstractR
     public void tearDown() {
         GraviteeContext.cleanContext();
         portalNavigationItemsQueryService.reset();
+        apiProductQueryService.reset();
     }
 
     @Test
@@ -94,5 +105,42 @@ public class PortalNavigationItemsResourceNotAuthenticatedTest extends AbstractR
             new jakarta.ws.rs.core.GenericType<List<io.gravitee.rest.api.portal.rest.model.PortalNavigationItem>>() {}
         );
         assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void should_not_return_private_api_product_in_catalog_search() {
+        var apiProductId = "00000000-0000-0000-0000-000000000101";
+        var item = PortalNavigationApiProduct.builder()
+            .id(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000102"))
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Private Product")
+            .segment("private-product")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .apiProductId(apiProductId)
+            .published(true)
+            .visibility(PortalVisibility.PRIVATE)
+            .build();
+        portalNavigationItemsQueryService.initWith(List.of(item));
+        apiProductQueryService.initWith(
+            List.of(
+                ApiProduct.builder()
+                    .id(apiProductId)
+                    .environmentId(ENV_ID)
+                    .name("Private Product")
+                    .version("1.0.0")
+                    .apiIds(Set.of())
+                    .build()
+            )
+        );
+
+        Response response = target("/_search").queryParam("type", "catalog").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        @SuppressWarnings("unchecked")
+        var data = (List<Object>) result.get("data");
+        assertThat(data).isEmpty();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceTest.java
@@ -21,8 +21,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import inmemory.ApiPortalSearchQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
@@ -58,6 +60,9 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
     @Autowired
     private ApiPortalSearchQueryServiceInMemory apiPortalSearchQueryService;
 
+    @Autowired
+    private ApiProductQueryServiceInMemory apiProductQueryService;
+
     @Override
     protected String contextPath() {
         return "portal-navigation-items";
@@ -76,6 +81,7 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
         GraviteeContext.cleanContext();
         portalNavigationItemsQueryService.reset();
         apiPortalSearchQueryService.reset();
+        apiProductQueryService.reset();
     }
 
     @Test
@@ -257,6 +263,20 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
     }
 
     @Test
+    void should_return_400_when_catalog_include_is_unsupported() {
+        Response response = target("/_search").queryParam("type", "catalog").queryParam("include", "unsupported").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void should_return_400_when_api_include_is_unsupported() {
+        Response response = target("/_search").queryParam("type", "api").queryParam("include", "unsupported").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
     void should_return_paginated_api_navigation_items() {
         // Given
         var apiItem = PortalNavigationApi.builder()
@@ -370,6 +390,106 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
         @SuppressWarnings("unchecked")
         var apis = (List<Object>) result.get("apis");
         assertThat(apis).hasSize(1);
+    }
+
+    @Test
+    void should_return_api_product_summary_in_catalog_search() {
+        var apiProductId = UUID.fromString("00000000-0000-0000-0000-000000000101");
+        var navigationItemId = PortalNavigationItemId.of("00000000-0000-0000-0000-000000000102");
+        var apiProductItem = PortalNavigationFixtures.apiProduct(navigationItemId, "Payments Product", PortalArea.TOP_NAVBAR, apiProductId);
+        apiProductItem.setEnvironmentId(ENV_ID);
+        portalNavigationItemsQueryService.initWith(List.of(apiProductItem));
+        apiProductQueryService.initWith(
+            List.of(
+                ApiProduct.builder()
+                    .id(apiProductId.toString())
+                    .environmentId(ENV_ID)
+                    .name("Payments Product")
+                    .description("Payment APIs")
+                    .version("1.0.0")
+                    .apiIds(Set.of())
+                    .build()
+            )
+        );
+
+        Response response = target("/_search").queryParam("type", "catalog").queryParam("include", "api_product").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        @SuppressWarnings("unchecked")
+        var data = (List<Object>) result.get("data");
+        assertThat(data).hasSize(1);
+        @SuppressWarnings("unchecked")
+        var apiProducts = (List<Map<String, Object>>) result.get("apiProducts");
+        assertThat(apiProducts)
+            .singleElement()
+            .satisfies(apiProduct -> {
+                assertThat(apiProduct).containsEntry("id", apiProductId.toString());
+                assertThat(apiProduct).containsEntry("name", "Payments Product");
+                assertThat(apiProduct).containsEntry("navigationItemId", navigationItemId.json());
+                assertThat(apiProduct).containsEntry("apis", List.of());
+            });
+    }
+
+    @Test
+    void should_return_all_catalog_items_with_unpaginated_metadata_and_links() {
+        var firstApiProductId = UUID.fromString("00000000-0000-0000-0000-000000000201");
+        var secondApiProductId = UUID.fromString("00000000-0000-0000-0000-000000000202");
+        var firstNavigationItem = PortalNavigationFixtures.apiProduct(
+            PortalNavigationItemId.of("00000000-0000-0000-0000-000000000203"),
+            "Zebra Product",
+            PortalArea.TOP_NAVBAR,
+            firstApiProductId
+        );
+        var secondNavigationItem = PortalNavigationFixtures.apiProduct(
+            PortalNavigationItemId.of("00000000-0000-0000-0000-000000000204"),
+            "Apple Product",
+            PortalArea.TOP_NAVBAR,
+            secondApiProductId
+        );
+        firstNavigationItem.setEnvironmentId(ENV_ID);
+        secondNavigationItem.setEnvironmentId(ENV_ID);
+        portalNavigationItemsQueryService.initWith(List.of(firstNavigationItem, secondNavigationItem));
+        apiProductQueryService.initWith(
+            List.of(
+                ApiProduct.builder()
+                    .id(firstApiProductId.toString())
+                    .environmentId(ENV_ID)
+                    .name("Zebra Product")
+                    .version("1.0.0")
+                    .apiIds(Set.of())
+                    .build(),
+                ApiProduct.builder()
+                    .id(secondApiProductId.toString())
+                    .environmentId(ENV_ID)
+                    .name("Apple Product")
+                    .version("1.0.0")
+                    .apiIds(Set.of())
+                    .build()
+            )
+        );
+
+        Response response = target("/_search").queryParam("type", "catalog").queryParam("size", -1).request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        @SuppressWarnings("unchecked")
+        var data = (List<Object>) result.get("data");
+        assertThat(data).hasSize(2);
+        @SuppressWarnings("unchecked")
+        var metadata = (Map<String, Object>) result.get("metadata");
+        @SuppressWarnings("unchecked")
+        var pagination = (Map<String, Object>) metadata.get("pagination");
+        assertThat(pagination)
+            .containsEntry("total", 2)
+            .containsEntry("size", -1)
+            .containsEntry("current_page", 1)
+            .containsEntry("total_pages", 1)
+            .containsEntry("first", 1)
+            .containsEntry("last", 2);
+        @SuppressWarnings("unchecked")
+        var links = (Map<String, Object>) result.get("links");
+        assertThat(links).containsKey("self");
     }
 
     private String getIdFromItem(io.gravitee.rest.api.portal.rest.model.PortalNavigationItem item) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -151,6 +151,7 @@ import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomain
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.CheckTypoToleranceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransformer;
+import io.gravitee.apim.core.portal_page.domain_service.PortalCatalogNavigationVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
@@ -163,6 +164,7 @@ import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTempla
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
+import io.gravitee.apim.core.portal_page.use_case.GetVisiblePortalCatalogItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetVisiblePortalNavigationApisUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalNavigationItemUseCase;
@@ -1367,6 +1369,13 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public PortalCatalogNavigationVisibilityDomainService portalCatalogNavigationVisibilityDomainService(
+        PortalNavigationApiProductVisibilityDomainService portalNavigationApiProductVisibilityDomainService
+    ) {
+        return new PortalCatalogNavigationVisibilityDomainService(portalNavigationApiProductVisibilityDomainService);
+    }
+
+    @Bean
     public CheckTypoToleranceDomainService checkTypoToleranceDomainService(ParametersQueryServiceInMemory parametersQueryService) {
         return new CheckTypoToleranceDomainService(parametersQueryService);
     }
@@ -1380,6 +1389,29 @@ public class ResourceContextConfiguration {
         return new GetVisiblePortalNavigationApisUseCase(
             portalNavigationApiVisibilityDomainService,
             apiPortalSearchQueryService,
+            checkTypoToleranceDomainService
+        );
+    }
+
+    @Bean
+    public GetVisiblePortalCatalogItemsUseCase getVisiblePortalCatalogItemsUseCase(
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService,
+        PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService,
+        PortalNavigationApiProductVisibilityDomainService portalNavigationApiProductVisibilityDomainService,
+        PortalCatalogNavigationVisibilityDomainService portalCatalogNavigationVisibilityDomainService,
+        ApiPortalSearchQueryServiceInMemory apiPortalSearchQueryService,
+        ApiQueryService apiQueryService,
+        ApiProductQueryService apiProductQueryService,
+        CheckTypoToleranceDomainService checkTypoToleranceDomainService
+    ) {
+        return new GetVisiblePortalCatalogItemsUseCase(
+            portalNavigationItemsQueryService,
+            portalNavigationApiVisibilityDomainService,
+            portalNavigationApiProductVisibilityDomainService,
+            portalCatalogNavigationVisibilityDomainService,
+            apiPortalSearchQueryService,
+            apiQueryService,
+            apiProductQueryService,
             checkTypoToleranceDomainService
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalCatalogNavigationVisibilityDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalCatalogNavigationVisibilityDomainService.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class PortalCatalogNavigationVisibilityDomainService {
+
+    private final PortalNavigationApiProductVisibilityDomainService apiProductVisibilityDomainService;
+
+    public <T extends PortalNavigationItem> List<T> filterVisibleItems(
+        List<T> items,
+        Map<PortalNavigationItemId, PortalNavigationItem> itemsById,
+        PortalNavigationItemViewerContext viewerContext,
+        Set<PortalNavigationItemId> accessibleApiNavigationItemIds,
+        Set<String> accessibleApiProductIds
+    ) {
+        return items
+            .stream()
+            .filter(
+                item ->
+                    !isHidden(item, viewerContext, accessibleApiNavigationItemIds, accessibleApiProductIds) &&
+                    !hasHiddenAncestor(item, itemsById, viewerContext, accessibleApiNavigationItemIds, accessibleApiProductIds)
+            )
+            .toList();
+    }
+
+    private boolean hasHiddenAncestor(
+        PortalNavigationItem item,
+        Map<PortalNavigationItemId, PortalNavigationItem> itemsById,
+        PortalNavigationItemViewerContext viewerContext,
+        Set<PortalNavigationItemId> accessibleApiNavigationItemIds,
+        Set<String> accessibleApiProductIds
+    ) {
+        Set<PortalNavigationItemId> visited = new HashSet<>();
+        PortalNavigationItem current = item;
+        while (current != null && current.getParentId() != null && visited.add(current.getId())) {
+            current = itemsById.get(current.getParentId());
+            if (current != null && isHidden(current, viewerContext, accessibleApiNavigationItemIds, accessibleApiProductIds)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isHidden(
+        PortalNavigationItem item,
+        PortalNavigationItemViewerContext viewerContext,
+        Set<PortalNavigationItemId> accessibleApiNavigationItemIds,
+        Set<String> accessibleApiProductIds
+    ) {
+        if (viewerContext.shouldNotShow(item)) {
+            return true;
+        }
+        if (item instanceof PortalNavigationApi) {
+            return !accessibleApiNavigationItemIds.contains(item.getId());
+        }
+        if (item instanceof PortalNavigationApiProduct apiProduct) {
+            return apiProductVisibilityDomainService.isApiProductItemHidden(apiProduct, viewerContext, accessibleApiProductIds);
+        }
+        return false;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalCatalogApiProductSummary.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalCatalogApiProductSummary.java
@@ -15,7 +15,19 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
-public enum PortalNavigationSearchInclude {
-    API,
-    API_PRODUCT,
+import java.util.List;
+
+public record PortalCatalogApiProductSummary(
+    String id,
+    String name,
+    String description,
+    String version,
+    String navigationItemId,
+    List<ApiSummary> apis
+) {
+    public PortalCatalogApiProductSummary {
+        apis = apis == null ? List.of() : List.copyOf(apis);
+    }
+
+    public record ApiSummary(String id, String name, String version) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCase.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiFieldFilter;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.apim.core.api.query_service.ApiPortalSearchQueryService;
+import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.portal_page.domain_service.CheckTypoToleranceDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalCatalogNavigationVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalCatalogApiProductSummary;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetVisiblePortalCatalogItemsUseCase {
+
+    private static final Comparator<String> NULL_SAFE_STRING_COMPARATOR = Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER);
+    private static final Comparator<CatalogEntry> CATALOG_ENTRY_COMPARATOR = Comparator.comparing(
+        CatalogEntry::name,
+        NULL_SAFE_STRING_COMPARATOR
+    )
+        .thenComparing(entry -> entry.item().getType().name())
+        .thenComparing(entry -> entry.item().getId().json());
+    private static final Comparator<Api> API_COMPARATOR = Comparator.comparing(Api::getName, NULL_SAFE_STRING_COMPARATOR)
+        .thenComparing(Api::getVersion, NULL_SAFE_STRING_COMPARATOR)
+        .thenComparing(Api::getId, NULL_SAFE_STRING_COMPARATOR);
+    private static final ApiFieldFilter API_FIELD_FILTER = ApiFieldFilter.builder().definitionExcluded(true).pictureExcluded(true).build();
+
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
+    private final PortalNavigationApiProductVisibilityDomainService apiProductVisibilityDomainService;
+    private final PortalCatalogNavigationVisibilityDomainService catalogNavigationVisibilityDomainService;
+    private final ApiPortalSearchQueryService apiPortalSearchQueryService;
+    private final ApiQueryService apiQueryService;
+    private final ApiProductQueryService apiProductQueryService;
+    private final CheckTypoToleranceDomainService checkTypoToleranceDomainService;
+
+    public Output execute(Input input) {
+        List<PortalNavigationItem> navigationItems = portalNavigationItemsQueryService.search(
+            PortalNavigationItemQueryCriteria.builder().environmentId(input.environmentId()).build()
+        );
+        Map<PortalNavigationItemId, PortalNavigationItem> navigationItemsById = navigationItems
+            .stream()
+            .collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity(), (first, ignored) -> first));
+        List<PortalNavigationApi> accessibleApis = input
+            .viewerContext()
+            .userId()
+            .map(userId -> apiVisibilityDomainService.resolveVisibleItems(input.environmentId(), userId))
+            .orElseGet(() -> apiVisibilityDomainService.resolveVisibleItems(input.environmentId()));
+        Set<PortalNavigationItemId> accessibleApiNavigationItemIds = accessibleApis
+            .stream()
+            .map(PortalNavigationItem::getId)
+            .collect(Collectors.toSet());
+        Set<String> accessibleApiProductIds = apiProductVisibilityDomainService.resolveAccessibleApiProductIds(
+            input.environmentId(),
+            input.viewerContext()
+        );
+
+        List<PortalNavigationApi> visibleApis = catalogNavigationVisibilityDomainService.filterVisibleItems(
+            accessibleApis,
+            navigationItemsById,
+            input.viewerContext(),
+            accessibleApiNavigationItemIds,
+            accessibleApiProductIds
+        );
+        List<PortalNavigationApiProduct> visibleApiProducts = findVisibleApiProducts(
+            navigationItems,
+            input,
+            navigationItemsById,
+            accessibleApiNavigationItemIds,
+            accessibleApiProductIds
+        );
+
+        Optional<String> query = input
+            .query()
+            .filter(value -> !value.isBlank())
+            .map(String::trim);
+        Map<String, Api> matchingApisById = findMatchingApis(input, visibleApis, query)
+            .stream()
+            .collect(Collectors.toMap(Api::getId, Function.identity(), (first, ignored) -> first));
+        Map<String, ApiProduct> visibleApiProductsById = loadApiProducts(input.environmentId(), visibleApiProducts);
+
+        List<CatalogEntry> entries = createEntries(visibleApis, visibleApiProducts, matchingApisById, visibleApiProductsById, query)
+            .stream()
+            .sorted(CATALOG_ENTRY_COMPARATOR)
+            .toList();
+        List<CatalogEntry> pageEntries = paginate(entries, input.pageable());
+        List<PortalNavigationItem> pageItems = pageEntries.stream().map(CatalogEntry::item).toList();
+        Page<PortalNavigationItem> page = new Page<>(pageItems, input.pageable().getPageNumber(), pageItems.size(), entries.size());
+
+        List<Api> includedApis = resolveIncludedApis(input, pageEntries, matchingApisById);
+        List<PortalCatalogApiProductSummary> includedApiProducts = resolveIncludedApiProducts(
+            input,
+            pageEntries,
+            visibleApiProductsById,
+            visibleApis
+        );
+
+        return new Output(page, includedApis, includedApiProducts);
+    }
+
+    private List<PortalNavigationApiProduct> findVisibleApiProducts(
+        List<PortalNavigationItem> navigationItems,
+        Input input,
+        Map<PortalNavigationItemId, PortalNavigationItem> navigationItemsById,
+        Set<PortalNavigationItemId> accessibleApiNavigationItemIds,
+        Set<String> accessibleApiProductIds
+    ) {
+        List<PortalNavigationApiProduct> apiProductItems = navigationItems
+            .stream()
+            .filter(PortalNavigationApiProduct.class::isInstance)
+            .map(PortalNavigationApiProduct.class::cast)
+            .filter(item -> Boolean.TRUE.equals(item.getPublished()))
+            .toList();
+        return catalogNavigationVisibilityDomainService.filterVisibleItems(
+            apiProductItems,
+            navigationItemsById,
+            input.viewerContext(),
+            accessibleApiNavigationItemIds,
+            accessibleApiProductIds
+        );
+    }
+
+    private List<Api> findMatchingApis(Input input, List<PortalNavigationApi> visibleApis, Optional<String> query) {
+        Set<String> visibleApiIds = visibleApis.stream().map(PortalNavigationApi::getApiId).collect(Collectors.toSet());
+        if (visibleApiIds.isEmpty()) {
+            return List.of();
+        }
+        if (query.isPresent()) {
+            return apiPortalSearchQueryService.search(
+                input.environmentId(),
+                input.organizationId(),
+                query.get(),
+                visibleApiIds,
+                checkTypoToleranceDomainService.isEnabled(input.environmentId(), input.organizationId())
+            );
+        }
+        return loadApis(input.environmentId(), visibleApiIds);
+    }
+
+    private Map<String, ApiProduct> loadApiProducts(String environmentId, List<PortalNavigationApiProduct> items) {
+        Set<String> ids = items.stream().map(PortalNavigationApiProduct::getApiProductId).collect(Collectors.toSet());
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        return apiProductQueryService
+            .findByEnvironmentIdAndIdIn(environmentId, ids)
+            .stream()
+            .collect(Collectors.toMap(ApiProduct::getId, Function.identity(), (first, ignored) -> first));
+    }
+
+    private List<CatalogEntry> createEntries(
+        List<PortalNavigationApi> visibleApis,
+        List<PortalNavigationApiProduct> visibleApiProducts,
+        Map<String, Api> matchingApisById,
+        Map<String, ApiProduct> visibleApiProductsById,
+        Optional<String> query
+    ) {
+        List<CatalogEntry> apiEntries = visibleApis
+            .stream()
+            .filter(item -> matchingApisById.containsKey(item.getApiId()))
+            .map(item -> new CatalogEntry(item, matchingApisById.get(item.getApiId()).getName()))
+            .toList();
+        List<CatalogEntry> productEntries = visibleApiProducts
+            .stream()
+            .filter(item -> visibleApiProductsById.containsKey(item.getApiProductId()))
+            .filter(item -> matchesQuery(visibleApiProductsById.get(item.getApiProductId()).getName(), query))
+            .map(item -> new CatalogEntry(item, visibleApiProductsById.get(item.getApiProductId()).getName()))
+            .toList();
+
+        return java.util.stream.Stream.concat(apiEntries.stream(), productEntries.stream()).toList();
+    }
+
+    private boolean matchesQuery(String name, Optional<String> query) {
+        return query.isEmpty() || (name != null && name.toLowerCase(Locale.ROOT).contains(query.get().toLowerCase(Locale.ROOT)));
+    }
+
+    private List<CatalogEntry> paginate(List<CatalogEntry> entries, Pageable pageable) {
+        if (pageable.getPageSize() == -1) {
+            return entries;
+        }
+        long skip = (long) (pageable.getPageNumber() - 1) * pageable.getPageSize();
+        return entries.stream().skip(skip).limit(pageable.getPageSize()).toList();
+    }
+
+    private List<Api> resolveIncludedApis(Input input, List<CatalogEntry> pageEntries, Map<String, Api> matchingApisById) {
+        if (!input.includes().contains(PortalNavigationSearchInclude.API)) {
+            return List.of();
+        }
+        Map<String, Api> includedApisById = new LinkedHashMap<>();
+        pageEntries
+            .stream()
+            .map(CatalogEntry::item)
+            .filter(PortalNavigationApi.class::isInstance)
+            .map(PortalNavigationApi.class::cast)
+            .map(PortalNavigationApi::getApiId)
+            .map(matchingApisById::get)
+            .filter(java.util.Objects::nonNull)
+            .forEach(api -> includedApisById.putIfAbsent(api.getId(), api));
+        return List.copyOf(includedApisById.values());
+    }
+
+    private List<PortalCatalogApiProductSummary> resolveIncludedApiProducts(
+        Input input,
+        List<CatalogEntry> pageEntries,
+        Map<String, ApiProduct> apiProductsById,
+        List<PortalNavigationApi> visibleApis
+    ) {
+        if (!input.includes().contains(PortalNavigationSearchInclude.API_PRODUCT)) {
+            return List.of();
+        }
+        List<PortalNavigationApiProduct> pageApiProducts = pageEntries
+            .stream()
+            .map(CatalogEntry::item)
+            .filter(PortalNavigationApiProduct.class::isInstance)
+            .map(PortalNavigationApiProduct.class::cast)
+            .toList();
+        Set<String> visibleApiIds = visibleApis.stream().map(PortalNavigationApi::getApiId).collect(Collectors.toSet());
+        Set<String> includedApiIds = pageApiProducts
+            .stream()
+            .map(item -> apiProductsById.get(item.getApiProductId()))
+            .filter(java.util.Objects::nonNull)
+            .map(ApiProduct::getApiIds)
+            .filter(java.util.Objects::nonNull)
+            .flatMap(Set::stream)
+            .filter(visibleApiIds::contains)
+            .collect(Collectors.toSet());
+        Map<String, Api> includedApisById = loadApis(input.environmentId(), includedApiIds)
+            .stream()
+            .collect(Collectors.toMap(Api::getId, Function.identity(), (first, ignored) -> first));
+
+        return pageApiProducts
+            .stream()
+            .map(item -> toSummary(item, apiProductsById.get(item.getApiProductId()), includedApisById))
+            .filter(java.util.Objects::nonNull)
+            .toList();
+    }
+
+    private PortalCatalogApiProductSummary toSummary(
+        PortalNavigationApiProduct item,
+        ApiProduct apiProduct,
+        Map<String, Api> includedApisById
+    ) {
+        if (apiProduct == null) {
+            return null;
+        }
+        List<PortalCatalogApiProductSummary.ApiSummary> apiSummaries = Optional.ofNullable(apiProduct.getApiIds())
+            .orElse(Set.of())
+            .stream()
+            .map(includedApisById::get)
+            .filter(java.util.Objects::nonNull)
+            .sorted(API_COMPARATOR)
+            .map(api -> new PortalCatalogApiProductSummary.ApiSummary(api.getId(), api.getName(), api.getVersion()))
+            .toList();
+        return new PortalCatalogApiProductSummary(
+            apiProduct.getId(),
+            apiProduct.getName(),
+            apiProduct.getDescription(),
+            apiProduct.getVersion(),
+            item.getId().json(),
+            apiSummaries
+        );
+    }
+
+    private List<Api> loadApis(String environmentId, Set<String> apiIds) {
+        if (apiIds.isEmpty()) {
+            return List.of();
+        }
+        return apiQueryService
+            .search(ApiSearchCriteria.builder().environmentId(environmentId).ids(List.copyOf(apiIds)).build(), null, API_FIELD_FILTER)
+            .toList();
+    }
+
+    public record Input(
+        String environmentId,
+        String organizationId,
+        PortalNavigationItemViewerContext viewerContext,
+        Pageable pageable,
+        Optional<String> query,
+        Set<PortalNavigationSearchInclude> includes
+    ) {}
+
+    public record Output(
+        Page<PortalNavigationItem> items,
+        List<Api> includedApis,
+        List<PortalCatalogApiProductSummary> includedApiProducts
+    ) {}
+
+    private record CatalogEntry(PortalNavigationItem item, String name) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCase.java
@@ -66,8 +66,13 @@ public class GetVisiblePortalNavigationApisUseCase {
                 .toList();
         }
 
-        int skip = (input.pageable().getPageNumber() - 1) * input.pageable().getPageSize();
-        List<PortalNavigationApi> pageItems = filtered.stream().skip(skip).limit(input.pageable().getPageSize()).toList();
+        List<PortalNavigationApi> pageItems;
+        if (input.pageable().getPageSize() == -1) {
+            pageItems = filtered;
+        } else {
+            int skip = (input.pageable().getPageNumber() - 1) * input.pageable().getPageSize();
+            pageItems = filtered.stream().skip(skip).limit(input.pageable().getPageSize()).toList();
+        }
         Page<PortalNavigationApi> page = new Page<>(pageItems, input.pageable().getPageNumber(), pageItems.size(), filtered.size());
 
         List<Api> includedApis = resolveIncludedApis(input, searchedApis, pageItems);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalCatalogNavigationVisibilityDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalCatalogNavigationVisibilityDomainServiceTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalCatalogNavigationVisibilityDomainServiceTest {
+
+    private static final String ENV_ID = "env-id";
+    private static final String ORG_ID = "org-id";
+    private static final PortalNavigationItemViewerContext VIEWER_CONTEXT = PortalNavigationItemViewerContext.forPortal("user-id");
+
+    private PortalCatalogNavigationVisibilityDomainService service;
+
+    @BeforeEach
+    void set_up() {
+        var apiProductVisibilityDomainService = new PortalNavigationApiProductVisibilityDomainService(
+            new PortalNavigationItemsQueryServiceInMemory(),
+            new ApiProductAccessibleIdsDomainService(new ApiProductQueryServiceInMemory(), new MembershipQueryServiceInMemory())
+        );
+        service = new PortalCatalogNavigationVisibilityDomainService(apiProductVisibilityDomainService);
+    }
+
+    @Test
+    void should_filter_api_and_api_product_below_the_same_hidden_parent() {
+        var parent = folder("hidden-parent", null);
+        parent.setPublished(false);
+        var api = api("api-item", parent.getId(), PortalVisibility.PUBLIC);
+        var apiProduct = apiProduct("api-product-item", parent.getId(), PortalVisibility.PUBLIC);
+        var items = List.<PortalNavigationItem>of(parent, api, apiProduct);
+
+        var result = filter(List.of(api, apiProduct), items, Set.of(api.getId()), Set.of());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_filter_an_item_below_a_hidden_multi_level_ancestor() {
+        var hiddenParent = folder("hidden-parent", null);
+        hiddenParent.setPublished(false);
+        var visibleParent = folder("visible-parent", hiddenParent.getId());
+        var apiProduct = apiProduct("api-product-item", visibleParent.getId(), PortalVisibility.PUBLIC);
+        var items = List.<PortalNavigationItem>of(hiddenParent, visibleParent, apiProduct);
+
+        var result = filter(List.of(apiProduct), items, Set.of(), Set.of());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_keep_an_item_when_its_parent_is_missing() {
+        var apiProduct = apiProduct("api-product-item", PortalNavigationItemId.random(), PortalVisibility.PUBLIC);
+
+        var result = filter(List.of(apiProduct), List.of(apiProduct), Set.of(), Set.of());
+
+        assertThat(result).containsExactly(apiProduct);
+    }
+
+    @Test
+    void should_stop_traversal_when_ancestors_form_a_cycle() {
+        var firstParentId = PortalNavigationItemId.random();
+        var secondParentId = PortalNavigationItemId.random();
+        var firstParent = folder(firstParentId, secondParentId);
+        var secondParent = folder(secondParentId, firstParentId);
+        var apiProduct = apiProduct("api-product-item", firstParentId, PortalVisibility.PUBLIC);
+        var items = List.<PortalNavigationItem>of(firstParent, secondParent, apiProduct);
+
+        var result = filter(List.of(apiProduct), items, Set.of(), Set.of());
+
+        assertThat(result).containsExactly(apiProduct);
+    }
+
+    @Test
+    void should_apply_type_specific_visibility_to_apis_and_api_products() {
+        var api = api("api-item", null, PortalVisibility.PRIVATE);
+        var apiProduct = apiProduct("api-product-item", null, PortalVisibility.PRIVATE);
+        var items = List.<PortalNavigationItem>of(api, apiProduct);
+
+        var hidden = filter(List.of(api, apiProduct), items, Set.of(), Set.of());
+        var visible = filter(List.of(api, apiProduct), items, Set.of(api.getId()), Set.of(apiProduct.getApiProductId()));
+
+        assertThat(hidden).isEmpty();
+        assertThat(visible).containsExactly(api, apiProduct);
+    }
+
+    private <T extends PortalNavigationItem> List<T> filter(
+        List<T> candidates,
+        List<PortalNavigationItem> allItems,
+        Set<PortalNavigationItemId> accessibleApiNavigationItemIds,
+        Set<String> accessibleApiProductIds
+    ) {
+        Map<PortalNavigationItemId, PortalNavigationItem> itemsById = allItems
+            .stream()
+            .collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity()));
+        return service.filterVisibleItems(candidates, itemsById, VIEWER_CONTEXT, accessibleApiNavigationItemIds, accessibleApiProductIds);
+    }
+
+    private PortalNavigationFolder folder(String id, PortalNavigationItemId parentId) {
+        return folder(navigationItemId(id), parentId);
+    }
+
+    private PortalNavigationFolder folder(PortalNavigationItemId id, PortalNavigationItemId parentId) {
+        return PortalNavigationFolder.builder()
+            .id(id)
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title(id.json())
+            .segment(id.json())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .parentId(parentId)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    private PortalNavigationApi api(String id, PortalNavigationItemId parentId, PortalVisibility visibility) {
+        return PortalNavigationApi.builder()
+            .id(navigationItemId(id))
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title(id)
+            .segment(id)
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .parentId(parentId)
+            .apiId(id)
+            .published(true)
+            .visibility(visibility)
+            .build();
+    }
+
+    private PortalNavigationApiProduct apiProduct(String id, PortalNavigationItemId parentId, PortalVisibility visibility) {
+        return PortalNavigationApiProduct.builder()
+            .id(navigationItemId(id))
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title(id)
+            .segment(id)
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .parentId(parentId)
+            .apiProductId(id)
+            .published(true)
+            .visibility(visibility)
+            .build();
+    }
+
+    private PortalNavigationItemId navigationItemId(String value) {
+        return PortalNavigationItemId.of(UUID.nameUUIDFromBytes(value.getBytes(StandardCharsets.UTF_8)).toString());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCaseTest.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ApiPortalSearchQueryServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.ParametersQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.CheckTypoToleranceDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalCatalogNavigationVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetVisiblePortalCatalogItemsUseCaseTest {
+
+    private static final String ENV_ID = "env-id";
+    private static final String ORG_ID = "org-id";
+
+    private GetVisiblePortalCatalogItemsUseCase useCase;
+    private CountingPortalNavigationItemsQueryService navigationItemsQueryService;
+    private ApiPortalSearchQueryServiceInMemory apiPortalSearchQueryService;
+    private ApiQueryServiceInMemory apiQueryService;
+    private ApiProductQueryServiceInMemory apiProductQueryService;
+
+    @BeforeEach
+    void set_up() {
+        navigationItemsQueryService = new CountingPortalNavigationItemsQueryService();
+        apiPortalSearchQueryService = new ApiPortalSearchQueryServiceInMemory();
+        apiQueryService = new ApiQueryServiceInMemory();
+        apiProductQueryService = new ApiProductQueryServiceInMemory();
+        var membershipQueryService = new MembershipQueryServiceInMemory();
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            new SubscriptionQueryServiceInMemory(),
+            apiQueryService
+        );
+        var apiVisibilityDomainService = new PortalNavigationApiVisibilityDomainService(
+            navigationItemsQueryService,
+            apiMembershipDomainService
+        );
+        var apiProductVisibilityDomainService = new PortalNavigationApiProductVisibilityDomainService(
+            navigationItemsQueryService,
+            new ApiProductAccessibleIdsDomainService(apiProductQueryService, membershipQueryService)
+        );
+        var catalogNavigationVisibilityDomainService = new PortalCatalogNavigationVisibilityDomainService(
+            apiProductVisibilityDomainService
+        );
+        useCase = new GetVisiblePortalCatalogItemsUseCase(
+            navigationItemsQueryService,
+            apiVisibilityDomainService,
+            apiProductVisibilityDomainService,
+            catalogNavigationVisibilityDomainService,
+            apiPortalSearchQueryService,
+            apiQueryService,
+            apiProductQueryService,
+            new CheckTypoToleranceDomainService(new ParametersQueryServiceInMemory())
+        );
+    }
+
+    @Test
+    void should_return_api_and_api_product_in_one_deterministic_page() {
+        var folder = folder("folder-id", "Catalog", null);
+        var apiItem = apiItem("api-item-id", "api-id", folder.getId(), PortalVisibility.PUBLIC);
+        var apiProductItem = apiProductItem("product-item-id", "product-id", null, PortalVisibility.PUBLIC);
+        navigationItemsQueryService.initWith(List.of(folder, apiItem, apiProductItem));
+        initApis(List.of(api("api-id", "Zebra API", "1.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Apple Product", Set.of())));
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(), 1, 10));
+
+        assertThat(output.items().getTotalElements()).isEqualTo(2);
+        assertThat(output.items().getContent())
+            .extracting(PortalNavigationItem::getType)
+            .containsExactly(PortalNavigationItemType.API_PRODUCT, PortalNavigationItemType.API);
+        assertThat(output.includedApis()).isEmpty();
+        assertThat(output.includedApiProducts()).isEmpty();
+    }
+
+    @Test
+    void should_resolve_ancestors_with_a_bounded_number_of_queries() {
+        var apiFolder = folder("api-folder-id", "APIs", null);
+        var productFolder = folder("product-folder-id", "Products", null);
+        var apiItem = apiItem("api-item-id", "api-id", apiFolder.getId(), PortalVisibility.PUBLIC);
+        var apiProductItem = apiProductItem("product-item-id", "product-id", productFolder.getId(), PortalVisibility.PUBLIC);
+        navigationItemsQueryService.initWith(List.of(apiFolder, productFolder, apiItem, apiProductItem));
+        initApis(List.of(api("api-id", "API", "1.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Product", Set.of())));
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(), 1, 10));
+
+        assertThat(output.items().getContent()).hasSize(2);
+        assertThat(navigationItemsQueryService.searchCalls).isEqualTo(2);
+        assertThat(navigationItemsQueryService.singleItemLookupCalls).isZero();
+    }
+
+    @Test
+    void should_match_api_and_api_product_names() {
+        var folder = folder("folder-id", "Catalog", null);
+        var apiItem = apiItem("api-item-id", "api-id", folder.getId(), PortalVisibility.PUBLIC);
+        var apiProductItem = apiProductItem("product-item-id", "product-id", null, PortalVisibility.PUBLIC);
+        navigationItemsQueryService.initWith(List.of(folder, apiItem, apiProductItem));
+        initApis(List.of(api("api-id", "Payments API", "1.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Payments Suite", Set.of())));
+
+        var output = useCase.execute(input(Optional.of("payments"), Set.of(), 1, 10));
+
+        assertThat(output.items().getContent())
+            .extracting(PortalNavigationItem::getType)
+            .containsExactly(PortalNavigationItemType.API, PortalNavigationItemType.API_PRODUCT);
+    }
+
+    @Test
+    void should_paginate_the_combined_result_after_sorting() {
+        var folder = folder("folder-id", "Catalog", null);
+        var apiItem = apiItem("api-item-id", "api-id", folder.getId(), PortalVisibility.PUBLIC);
+        var apiProductItem = apiProductItem("product-item-id", "product-id", null, PortalVisibility.PUBLIC);
+        navigationItemsQueryService.initWith(List.of(folder, apiItem, apiProductItem));
+        initApis(List.of(api("api-id", "Zebra API", "1.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Apple Product", Set.of())));
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(), 1, 1));
+
+        assertThat(output.items().getTotalElements()).isEqualTo(2);
+        assertThat(output.items().getContent())
+            .singleElement()
+            .extracting(PortalNavigationItem::getType)
+            .isEqualTo(PortalNavigationItemType.API_PRODUCT);
+    }
+
+    @Test
+    void should_return_all_sorted_entries_when_pagination_is_disabled() {
+        var folder = folder("folder-id", "Catalog", null);
+        var apiItem = apiItem("api-item-id", "api-id", folder.getId(), PortalVisibility.PUBLIC);
+        var firstProductItem = apiProductItem("first-product-item-id", "first-product-id", null, PortalVisibility.PUBLIC);
+        var secondProductItem = apiProductItem("second-product-item-id", "second-product-id", null, PortalVisibility.PUBLIC);
+        navigationItemsQueryService.initWith(List.of(folder, apiItem, firstProductItem, secondProductItem));
+        initApis(List.of(api("api-id", "Zebra API", "1.0.0")));
+        apiProductQueryService.initWith(
+            List.of(apiProduct("first-product-id", "Apple Product", Set.of()), apiProduct("second-product-id", "Middle Product", Set.of()))
+        );
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(), 1, -1));
+
+        assertThat(output.items().getContent())
+            .extracting(PortalNavigationItem::getId)
+            .containsExactly(firstProductItem.getId(), secondProductItem.getId(), apiItem.getId());
+        assertThat(output.items().getTotalElements()).isEqualTo(3);
+    }
+
+    @Test
+    void should_return_an_empty_result_when_pagination_is_disabled() {
+        var output = useCase.execute(input(Optional.empty(), Set.of(), 1, -1));
+
+        assertThat(output.items().getContent()).isEmpty();
+        assertThat(output.items().getTotalElements()).isZero();
+    }
+
+    @Test
+    void should_include_only_visible_apis_in_api_product_summary() {
+        var productItem = apiProductItem("product-item-id", "product-id", null, PortalVisibility.PUBLIC);
+        var publicApiItem = apiItem("public-api-item-id", "public-api-id", productItem.getId(), PortalVisibility.PUBLIC);
+        var privateApiItem = apiItem("private-api-item-id", "private-api-id", productItem.getId(), PortalVisibility.PRIVATE);
+        navigationItemsQueryService.initWith(List.of(productItem, publicApiItem, privateApiItem));
+        initApis(List.of(api("public-api-id", "Public API", "1.0.0"), api("private-api-id", "Private API", "2.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Product", Set.of("public-api-id", "private-api-id"))));
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(PortalNavigationSearchInclude.API_PRODUCT), 1, 10));
+
+        assertThat(output.includedApiProducts())
+            .singleElement()
+            .satisfies(summary -> {
+                assertThat(summary.id()).isEqualTo("product-id");
+                assertThat(summary.navigationItemId()).isEqualTo(productItem.getId().json());
+                assertThat(summary.apis())
+                    .singleElement()
+                    .satisfies(api -> {
+                        assertThat(api.id()).isEqualTo("public-api-id");
+                        assertThat(api.name()).isEqualTo("Public API");
+                    });
+            });
+    }
+
+    @Test
+    void should_not_return_items_below_a_hidden_api_product() {
+        var productItem = apiProductItem("product-item-id", "product-id", null, PortalVisibility.PRIVATE);
+        var apiItem = apiItem("api-item-id", "api-id", productItem.getId(), PortalVisibility.PUBLIC);
+        navigationItemsQueryService.initWith(List.of(productItem, apiItem));
+        initApis(List.of(api("api-id", "API", "1.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Product", Set.of("api-id"))));
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(), 1, 10));
+
+        assertThat(output.items().getContent()).isEmpty();
+        assertThat(output.items().getTotalElements()).isZero();
+    }
+
+    @Test
+    void should_not_return_api_product_below_an_unpublished_parent() {
+        var folder = folder("folder-id", "Hidden", null);
+        folder.setPublished(false);
+        var apiProductItem = apiProductItem("product-item-id", "product-id", folder.getId(), PortalVisibility.PUBLIC);
+        navigationItemsQueryService.initWith(List.of(folder, apiProductItem));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Product", Set.of())));
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(), 1, 10));
+
+        assertThat(output.items().getContent()).isEmpty();
+    }
+
+    private GetVisiblePortalCatalogItemsUseCase.Input input(
+        Optional<String> query,
+        Set<PortalNavigationSearchInclude> includes,
+        int page,
+        int size
+    ) {
+        return new GetVisiblePortalCatalogItemsUseCase.Input(
+            ENV_ID,
+            ORG_ID,
+            PortalNavigationItemViewerContext.forPortal((String) null),
+            new PageableImpl(page, size),
+            query,
+            includes
+        );
+    }
+
+    private void initApis(List<Api> apis) {
+        apiPortalSearchQueryService.initWith(apis);
+        apiQueryService.initWith(apis);
+    }
+
+    private Api api(String id, String name, String version) {
+        return Api.builder().id(id).environmentId(ENV_ID).name(name).version(version).build();
+    }
+
+    private ApiProduct apiProduct(String id, String name, Set<String> apiIds) {
+        return ApiProduct.builder()
+            .id(id)
+            .environmentId(ENV_ID)
+            .name(name)
+            .description("Description")
+            .version("1.0.0")
+            .apiIds(apiIds)
+            .build();
+    }
+
+    private PortalNavigationFolder folder(String id, String title, PortalNavigationItemId parentId) {
+        return PortalNavigationFolder.builder()
+            .id(navigationItemId(id))
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title(title)
+            .segment(PortalNavigationItem.slugify(title).value())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .parentId(parentId)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    private PortalNavigationApi apiItem(String id, String apiId, PortalNavigationItemId parentId, PortalVisibility visibility) {
+        return PortalNavigationApi.builder()
+            .id(navigationItemId(id))
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title(apiId)
+            .segment(apiId)
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .parentId(parentId)
+            .apiId(apiId)
+            .published(true)
+            .visibility(visibility)
+            .build();
+    }
+
+    private PortalNavigationApiProduct apiProductItem(
+        String id,
+        String apiProductId,
+        PortalNavigationItemId parentId,
+        PortalVisibility visibility
+    ) {
+        return PortalNavigationApiProduct.builder()
+            .id(navigationItemId(id))
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title(apiProductId)
+            .segment(apiProductId)
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .parentId(parentId)
+            .apiProductId(apiProductId)
+            .published(true)
+            .visibility(visibility)
+            .build();
+    }
+
+    private PortalNavigationItemId navigationItemId(String value) {
+        return PortalNavigationItemId.of(UUID.nameUUIDFromBytes(value.getBytes(StandardCharsets.UTF_8)).toString());
+    }
+
+    private static class CountingPortalNavigationItemsQueryService extends PortalNavigationItemsQueryServiceInMemory {
+
+        private int searchCalls;
+        private int singleItemLookupCalls;
+
+        @Override
+        public List<PortalNavigationItem> search(PortalNavigationItemQueryCriteria criteria) {
+            searchCalls++;
+            return super.search(criteria);
+        }
+
+        @Override
+        public PortalNavigationItem findByIdAndEnvironmentId(String environmentId, PortalNavigationItemId id) {
+            singleItemLookupCalls++;
+            return super.findByIdAndEnvironmentId(environmentId, id);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
@@ -180,6 +180,31 @@ class GetVisiblePortalNavigationApisUseCaseTest {
     }
 
     @Test
+    void returns_all_items_when_pagination_is_disabled() {
+        navQueryService.initWith(
+            List.of(
+                publishedApiNavItem("api-a", PortalVisibility.PUBLIC),
+                publishedApiNavItem("api-b", PortalVisibility.PUBLIC),
+                publishedApiNavItem("api-c", PortalVisibility.PUBLIC)
+            )
+        );
+
+        var result = useCase.execute(
+            new GetVisiblePortalNavigationApisUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                Optional.empty(),
+                new PageableImpl(1, -1),
+                Optional.empty(),
+                Set.of()
+            )
+        );
+
+        assertThat(result.apis().getContent()).extracting(PortalNavigationApi::getApiId).containsExactly("api-a", "api-b", "api-c");
+        assertThat(result.apis().getTotalElements()).isEqualTo(3);
+    }
+
+    @Test
     void returns_correct_total_count() {
         navQueryService.initWith(
             List.of(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-102

## Summary

Add a unified Portal Catalog search returning visible APIs and API Products in a single paginated result.

## Changes

- Add `type=catalog` to `GET /portal-navigation-items/_search`.
- Add support for `include=api_product`.
- Return page-scoped API Product summaries with their visible APIs.
- Apply consumer visibility and hidden-ancestor filtering.
- Search by API and API Product names.
- Apply deterministic ordering and combined pagination.
- Resolve products and included APIs in bulk.
- Preserve the existing `type=api` behavior.

