### PR TITLE
chore(4.12.x): bump gravitee-reactor-native-kafka from 7.0.1 to 7.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
     <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
-    <gravitee-reactor-native-kafka.version>7.0.1</gravitee-reactor-native-kafka.version>
+    <gravitee-reactor-native-kafka.version>7.0.3</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.1.5</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>3.3.5</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.0.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka)** from `7.0.1` to `7.0.3` on branch `4.12.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases) page.