### PR TITLE
chore(4.11.x): bump gravitee-reactor-native-kafka from 6.3.2 to 6.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.1.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>10.0.1</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>6.3.2</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>6.3.3</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>2.2.1</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>2.11.3</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.2</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka)** from `6.3.2` to `6.3.3` on branch `4.11.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases) page.

## Jira

[ESM-121](https://gravitee.atlassian.net/browse/ESM-121)

[ESM-121]: https://gravitee.atlassian.net/browse/ESM-121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ