### PR TITLE
chore(4.10.x): bump gravitee-reactor-native-kafka from 5.0.4 to 5.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.0.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>9.0.1</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>5.0.4</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>5.0.5</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.2.0</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>1.4.3</gravitee-reactor-llm-proxy.version>
         <gravitee-apim-repository-bridge.version>7.1.1</gravitee-apim-repository-bridge.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka)** from `5.0.4` to `5.0.5` on branch `4.10.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases) page.