### PR TITLE
feat: bump gravitee-policy-generate-jwt to 1.9.0-alpha.3

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -66,7 +66,7 @@
     <gravitee-policy-data-logging-masking.version>3.1.3</gravitee-policy-data-logging-masking.version>
     <gravitee-policy-dynamic-routing.version>1.13.0</gravitee-policy-dynamic-routing.version>
     <gravitee-policy-generate-http-signature.version>1.5.1</gravitee-policy-generate-http-signature.version>
-    <gravitee-policy-generate-jwt.version>1.8.0</gravitee-policy-generate-jwt.version>
+    <gravitee-policy-generate-jwt.version>1.9.0-alpha.3</gravitee-policy-generate-jwt.version>
     <gravitee-policy-generate-wssecurity.version>1.0.0</gravitee-policy-generate-wssecurity.version>
     <gravitee-policy-geoip-filtering.version>2.2.2</gravitee-policy-geoip-filtering.version>
     <gravitee-policy-groovy.version>5.0.4</gravitee-policy-groovy.version>


### PR DESCRIPTION
## Purpose

Bump the `gravitee-policy-generate-jwt` dependency version used by this distribution to pick up the latest alpha build.

## Summary of changes

- Bumped `gravitee-policy-generate-jwt.version` in `gravitee-apim-distribution/pom.xml` from `1.8.0` to `1.9.0-alpha.3`. This property is consumed by `gravitee-apim-distribution-standalone/pom.xml` and `gravitee-apim-distribution-integration-tests/pom.xml`, so no other files needed to change.
