### PR TITLE
perf(gateway): make API Product subscription sync scale with product size

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -59,10 +59,13 @@ public class SubscriptionCacheService implements SubscriptionService {
     // ConcurrentSkipListMap), which would double those side effects under contention.
     private final ConcurrentMap<IdentityKey, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
     private final ConcurrentMap<IdentityKey, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
-    // Single by-id index, including exploded API-Product subscriptions. Values are immutable sets
-    // (almost always a singleton), replaced atomically via compute(): keeps the per-entry footprint
-    // minimal at multi-million-subscription scale and lets readers use them without defensive copies.
-    private final ConcurrentMap<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
+    // Single by-id index, including exploded API-Product subscriptions. Each entry maps a leg's
+    // identity (api, environmentId) to its subscription, so registering one leg is an O(1) put.
+    // The previous immutable-set representation had to copy the whole set per registration, which
+    // made warming up an API Product quadratic in its API count: a product spanning P APIs cost
+    // ~P² element copies per subscription, which dominates cold start once P reaches the hundreds.
+    // Inner maps are ConcurrentHashMap so the outer compute() lambdas stay side-effect-safe.
+    private final ConcurrentMap<String, ConcurrentMap<LegKey, Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
     // Holds subscription ids only, for per-API eviction. Identity keys are not tracked here:
     // unregisterByApiId() re-derives them from the cached subscriptions, which keeps this index
     // at one entry per subscription instead of three (id + 2 identity keys) at multi-million scale.
@@ -74,6 +77,16 @@ public class SubscriptionCacheService implements SubscriptionService {
      * scale) and no String.format on the request hot path. A null plan is the plan-less variant.
      */
     private record IdentityKey(String api, String plan, String clientIdentity) {}
+
+    /**
+     * Identity of a single leg of a subscription. A plain API subscription has exactly one leg; an
+     * exploded API-Product subscription has one per API in the product.
+     */
+    private record LegKey(String api, String environmentId) {}
+
+    private static LegKey legKey(Subscription subscription) {
+        return new LegKey(subscription.getApi(), subscription.getEnvironmentId());
+    }
 
     @Override
     public Optional<Subscription> getByApiAndSecurityToken(String api, SecurityToken securityToken, String plan) {
@@ -99,20 +112,23 @@ public class SubscriptionCacheService implements SubscriptionService {
     public Optional<Subscription> getById(String subscriptionId) {
         // For exploded API-Product subscriptions this returns an arbitrary leg, which matches the
         // historical behavior of the dedicated by-id map (last-registered/rehydrated leg).
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        if (subscriptions == null || subscriptions.isEmpty()) {
+        ConcurrentMap<LegKey, Subscription> legs = cacheBySubscriptionIdAll.get(subscriptionId);
+        if (legs == null) {
             return Optional.empty();
         }
-        return Optional.of(subscriptions.iterator().next());
+        // hasNext() rather than isEmpty()-then-next(): a concurrent unregister may drain the map
+        // between the two calls.
+        Iterator<Subscription> iterator = legs.values().iterator();
+        return iterator.hasNext() ? Optional.of(iterator.next()) : Optional.empty();
     }
 
     /**
      * Returns all subscriptions for the given ID (multiple for exploded API Product subscriptions).
-     * The returned collection is immutable.
+     * The returned collection is an unmodifiable, weakly-consistent view of the cached legs.
      */
     public Collection<Subscription> getAllById(String subscriptionId) {
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        return subscriptions != null ? subscriptions : Collections.emptySet();
+        ConcurrentMap<LegKey, Subscription> legs = cacheBySubscriptionIdAll.get(subscriptionId);
+        return legs != null ? Collections.unmodifiableCollection(legs.values()) : Collections.emptySet();
     }
 
     @Override
@@ -148,48 +164,46 @@ public class SubscriptionCacheService implements SubscriptionService {
 
     @Override
     public void unregister(final Subscription candidate) {
-        // Use compute() so that the isEmpty-check-then-remove is atomic with respect to
-        // concurrent register() calls on the same subscription ID. Without this, a register()
-        // interleaved between isEmpty()=true and remove() would add a new entry to the set
-        // and then have that set orphaned by the remove().
-        cacheBySubscriptionIdAll.compute(candidate.getId(), (id, allSubscriptions) -> {
-            if (allSubscriptions == null) return null;
-
-            var toEvict = allSubscriptions
-                .stream()
-                .filter(s -> Objects.equals(candidate.getApi(), s.getApi()))
-                .toList();
-
-            if (toEvict.isEmpty()) {
-                return allSubscriptions;
-            }
-
-            toEvict.forEach(existing -> {
-                unregisterFromClientId(existing);
-                unregisterFromClientCertificate(existing);
-            });
-
-            evictKeyForApi(candidate.getApi(), candidate.getId());
-            // Handle the case where the candidate carries a different clientId/cert than
-            // what was cached (e.g. a status-change event arriving after a credential update).
-            if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientId(), candidate.getClientId()))) {
-                unregisterFromClientId(candidate);
-            }
-            if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientCertificate(), candidate.getClientCertificate()))) {
-                unregisterFromClientCertificate(candidate);
-            }
-
-            // Singleton fast path: toEvict is non-empty, so the only element is being evicted
-            if (allSubscriptions.size() == 1) {
-                return null;
-            }
-
-            Set<Subscription> remaining = allSubscriptions
-                .stream()
-                .filter(s -> !Objects.equals(candidate.getApi(), s.getApi()))
-                .collect(Collectors.toUnmodifiableSet());
-            return remaining.isEmpty() ? null : remaining;
+        // Use compute() so that the drain-then-remove is atomic with respect to concurrent
+        // register() calls on the same subscription ID. Without this, a register() interleaved
+        // between the emptiness check and the removal would add a leg and then have the whole
+        // entry orphaned by the removal.
+        // Legs are only collected under the bin lock; the identity-map and trust-store eviction
+        // (which hashes the client certificate) runs after compute returns, matching
+        // unregisterByApiId() and keeping the lock hold short.
+        List<Subscription> toEvict = new ArrayList<>();
+        cacheBySubscriptionIdAll.compute(candidate.getId(), (id, legs) -> {
+            if (legs == null) return null;
+            legs
+                .entrySet()
+                .removeIf(entry -> {
+                    if (Objects.equals(candidate.getApi(), entry.getKey().api())) {
+                        toEvict.add(entry.getValue());
+                        return true;
+                    }
+                    return false;
+                });
+            return legs.isEmpty() ? null : legs;
         });
+
+        if (toEvict.isEmpty()) {
+            return;
+        }
+
+        toEvict.forEach(existing -> {
+            unregisterFromClientId(existing);
+            unregisterFromClientCertificate(existing);
+        });
+
+        evictKeyForApi(candidate.getApi(), candidate.getId());
+        // Handle the case where the candidate carries a different clientId/cert than
+        // what was cached (e.g. a status-change event arriving after a credential update).
+        if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientId(), candidate.getClientId()))) {
+            unregisterFromClientId(candidate);
+        }
+        if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientCertificate(), candidate.getClientCertificate()))) {
+            unregisterFromClientCertificate(candidate);
+        }
     }
 
     @Override
@@ -206,25 +220,17 @@ public class SubscriptionCacheService implements SubscriptionService {
         // happens after each compute returns — those structures are not guarded by this lock.
         List<Subscription> evictedLegs = new ArrayList<>();
         subscriptionsByApi.forEach(subscriptionId ->
-            cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, all) -> {
-                // Singleton fast path: most entries hold exactly one leg
-                if (all.size() == 1) {
-                    Subscription single = all.iterator().next();
-                    if (Objects.equals(apiId, single.getApi())) {
-                        evictedLegs.add(single);
-                        return null;
-                    }
-                    return all;
-                }
-                Set<Subscription> remaining = new HashSet<>();
-                for (Subscription subscription : all) {
-                    if (Objects.equals(apiId, subscription.getApi())) {
-                        evictedLegs.add(subscription);
-                    } else {
-                        remaining.add(subscription);
-                    }
-                }
-                return remaining.isEmpty() ? null : Set.copyOf(remaining);
+            cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, legs) -> {
+                legs
+                    .entrySet()
+                    .removeIf(entry -> {
+                        if (Objects.equals(apiId, entry.getKey().api())) {
+                            evictedLegs.add(entry.getValue());
+                            return true;
+                        }
+                        return false;
+                    });
+                return legs.isEmpty() ? null : legs;
             })
         );
         // Same per-leg eviction as unregister(): identity maps and certificate trust store
@@ -252,12 +258,19 @@ public class SubscriptionCacheService implements SubscriptionService {
      * evicted when one API's leg is replaced.
      */
     private Subscription cachedSameApiLeg(final Subscription subscription) {
-        Set<Subscription> existingLegs = cacheBySubscriptionIdAll.get(subscription.getId());
-        if (existingLegs != null) {
-            for (Subscription existing : existingLegs) {
-                if (Objects.equals(subscription.getApi(), existing.getApi())) {
-                    return existing;
-                }
+        ConcurrentMap<LegKey, Subscription> legs = cacheBySubscriptionIdAll.get(subscription.getId());
+        if (legs == null) {
+            return null;
+        }
+        Subscription exact = legs.get(legKey(subscription));
+        if (exact != null) {
+            return exact;
+        }
+        // Fall back to an api-only match so a leg cached under a different environmentId (e.g.
+        // registered before the field was populated) is still found and evicted.
+        for (Subscription existing : legs.values()) {
+            if (Objects.equals(subscription.getApi(), existing.getApi())) {
+                return existing;
             }
         }
         return null;
@@ -295,31 +308,28 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private void registerFromClientId(final Subscription subscription) {
-        // Snapshot old entries before registering (cached sets are immutable)
-        Set<Subscription> cachedAll = cacheBySubscriptionIdAll.get(subscription.getId());
-        Set<Subscription> oldEntries = cachedAll != null ? cachedAll : Set.of();
+        // Only the same-API leg is ever acted on below, so look it up directly instead of
+        // snapshotting every leg: copying the full set here would have kept registration linear in
+        // the product's API count, i.e. quadratic over a full warmup.
+        Subscription cached = cachedSameApiLeg(subscription);
 
         updateSubscriptionIdById(subscription);
 
         // Register new subscription first
         updateIdentityCache(subscription, cacheByApiClientId);
 
-        // Then clean up old entries if clientId or plan changed (e.g. subscription transfer)
-        // Only compare entries for the same API — exploded subscriptions span multiple APIs
-        for (Subscription old : oldEntries) {
-            if (!Objects.equals(old.getApi(), subscription.getApi())) {
-                continue;
-            }
+        // Then clean up the old leg if clientId or plan changed (e.g. subscription transfer)
+        if (cached != null) {
             if (
-                (old.getClientId() != null && !old.getClientId().equals(subscription.getClientId())) ||
-                (old.getPlan() != null && !old.getPlan().equals(subscription.getPlan()))
+                (cached.getClientId() != null && !cached.getClientId().equals(subscription.getClientId())) ||
+                (cached.getPlan() != null && !cached.getPlan().equals(subscription.getPlan()))
             ) {
-                unregisterFromClientId(old);
+                unregisterFromClientId(cached);
             }
             // Credential-type switch: if the old leg was certificate-registered, its entries
             // live in the certificate map and trust store, never overwritten by this
             // clientId registration.
-            unregisterFromClientCertificate(old);
+            unregisterFromClientCertificate(cached);
         }
     }
 
@@ -341,28 +351,16 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private void updateSubscriptionIdById(Subscription subscription) {
-        cacheBySubscriptionIdAll.compute(subscription.getId(), (id, existing) -> {
-            if (existing == null || existing.isEmpty()) {
-                return Set.of(subscription);
-            }
-            // Singleton fast path: replacing the same api/environment leg needs no temporary set
-            if (existing.size() == 1) {
-                Subscription single = existing.iterator().next();
-                if (
-                    Objects.equals(single.getApi(), subscription.getApi()) &&
-                    Objects.equals(single.getEnvironmentId(), subscription.getEnvironmentId())
-                ) {
-                    return Set.of(subscription);
-                }
-            }
-            Set<Subscription> updated = new HashSet<>(existing);
-            updated.removeIf(
-                s ->
-                    Objects.equals(s.getApi(), subscription.getApi()) &&
-                    Objects.equals(s.getEnvironmentId(), subscription.getEnvironmentId())
-            );
-            updated.add(subscription);
-            return updated.size() == 1 ? Set.of(subscription) : Set.copyOf(updated);
+        // O(1) regardless of how many legs the subscription already has: the leg key is the
+        // (api, environmentId) pair the previous implementation matched on, so putting under that
+        // key replaces the same leg it used to filter out — without copying the set.
+        // compute() rather than computeIfAbsent()+put(): it keeps the inner-map creation and the
+        // put atomic against a concurrent unregister() removing the outer entry in between, which
+        // would otherwise orphan the leg we just registered.
+        cacheBySubscriptionIdAll.compute(subscription.getId(), (id, legs) -> {
+            ConcurrentMap<LegKey, Subscription> target = legs != null ? legs : new ConcurrentHashMap<>();
+            target.put(legKey(subscription), subscription);
+            return target;
         });
     }
 
@@ -411,14 +409,14 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private Optional<Subscription> getByApiAndId(String api, String subscriptionId) {
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        if (subscriptions == null || subscriptions.isEmpty()) {
+        ConcurrentMap<LegKey, Subscription> legs = cacheBySubscriptionIdAll.get(subscriptionId);
+        if (legs == null || legs.isEmpty()) {
             // Fallback to old cache for backward compatibility
             return getById(subscriptionId);
         }
-        // Plain loop: this runs on the request hot path for every API-key call and the set is
+        // Plain loop: this runs on the request hot path for every API-key call and the map is
         // almost always a singleton, so avoid allocating a Stream pipeline per request.
-        for (Subscription subscription : subscriptions) {
+        for (Subscription subscription : legs.values()) {
             if (Objects.equals(api, subscription.getApi())) {
                 return Optional.of(subscription);
             }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
@@ -112,8 +112,12 @@ public class SyncConfiguration {
     @Bean("syncFetcherExecutor")
     public ThreadPoolExecutor syncFetcherExecutor(@Value("${services.sync.fetcher:-1}") int syncFetcher) {
         int poolSize = syncFetcher != -1 ? syncFetcher : POOL_SIZE;
+        // Core size must equal the max size: ThreadPoolExecutor only grows past the core size when the
+        // queue rejects an offer, and the unbounded LinkedBlockingQueue below never does. With a core of
+        // 1 the pool stayed single-threaded forever, so services.sync.fetcher and the parallel() rails in
+        // AbstractApiSynchronizer had no effect. allowCoreThreadTimeOut keeps idle nodes cheap.
         final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
-            1,
+            poolSize,
             poolSize,
             15L,
             TimeUnit.SECONDS,
@@ -130,8 +134,11 @@ public class SyncConfiguration {
     @Bean("syncDeployerExecutor")
     public ThreadPoolExecutor syncDeployerExecutor(@Value("${services.sync.deployer:-1}") int syncDeployer) {
         int poolSize = syncDeployer != -1 ? syncDeployer : POOL_SIZE;
+        // See syncFetcherExecutor: core size must equal max size for the pool to ever grow past one
+        // thread. This is what makes the .parallel(getMaximumPoolSize()) fan-out in
+        // AbstractApiSynchronizer actually deploy APIs concurrently instead of serialising them.
         final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
-            1,
+            poolSize,
             poolSize,
             15L,
             TimeUnit.SECONDS,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
@@ -33,6 +33,7 @@ import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.reactivex.rxjava3.core.Completable;
@@ -48,6 +49,11 @@ import lombok.CustomLog;
 public class ApiProductSubscriptionRefresher {
 
     private static final List<String> INCREMENTAL_STATUS = List.of(ACCEPTED.name(), CLOSED.name(), PAUSED.name(), PENDING.name());
+    // The deploy path only ever registers ACCEPTED subscriptions (SubscriptionCacheService.register
+    // unregisters anything else), so pulling the other three statuses just to discard them scales
+    // the fetch with the deployment's whole subscription history. Eviction paths still need
+    // INCREMENTAL_STATUS: they must see a subscription that has left ACCEPTED.
+    private static final List<String> DEPLOY_STATUS = List.of(ACCEPTED.name());
 
     private final SubscriptionRepository subscriptionRepository;
     private final ApiKeyRepository apiKeyRepository;
@@ -151,7 +157,9 @@ public class ApiProductSubscriptionRefresher {
 
         return Completable.fromRunnable(() -> {
             try {
-                var repoSubs = loadSubscriptionModels(subscribablePlans, environments);
+                // Eviction path: keeps INCREMENTAL_STATUS so legs of subscriptions that have since
+                // left ACCEPTED are still unregistered for the removed APIs.
+                var repoSubs = loadSubscriptionModels(subscribablePlans, environments, INCREMENTAL_STATUS);
                 var subsToUnregister = repoSubs
                     .stream()
                     .filter(s -> s.getReferenceType() == SubscriptionReferenceType.API_PRODUCT)
@@ -182,25 +190,45 @@ public class ApiProductSubscriptionRefresher {
 
     private List<io.gravitee.repository.management.model.Subscription> loadSubscriptionModels(
         final Set<String> plans,
-        final Set<String> environments
+        final Set<String> environments,
+        final List<String> statuses
     ) {
-        SubscriptionCriteria.SubscriptionCriteriaBuilder criteriaBuilder = SubscriptionCriteria.builder()
-            .plans(plans)
-            .environments(environments)
-            .statuses(INCREMENTAL_STATUS);
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder().plans(plans).environments(environments).statuses(statuses).build();
+        // Keyset pagination, matching SubscriptionAppender and SubscriptionFetcher. The previous
+        // unpaginated search() returned every matching row in one response, which over the HTTP
+        // repository bridge is serialised into a single body on the mAPI event loop.
+        var sortable = new SortableBuilder().field("plan").order(Order.ASC).build();
 
+        List<io.gravitee.repository.management.model.Subscription> all = new ArrayList<>();
+        SubscriptionCursor cursor = null;
         try {
-            return subscriptionRepository.search(
-                criteriaBuilder.build(),
-                new SortableBuilder().field("updatedAt").order(Order.ASC).build()
-            );
+            while (true) {
+                List<io.gravitee.repository.management.model.Subscription> page = subscriptionRepository.searchAfter(
+                    criteria,
+                    sortable,
+                    cursor,
+                    bulkItems
+                );
+                if (page == null || page.isEmpty()) {
+                    return all;
+                }
+                all.addAll(page);
+                if (page.size() < bulkItems) {
+                    return all;
+                }
+                cursor = SubscriptionCursor.byPlanAndId(page.getLast().getPlan(), page.getLast().getId());
+            }
         } catch (Exception ex) {
             throw new SyncException("Error occurred when retrieving subscriptions for API Product", ex);
         }
     }
 
     private List<Subscription> loadSubscriptions(final Set<String> plans, final Set<String> environments) {
-        List<io.gravitee.repository.management.model.Subscription> repoSubscriptions = loadSubscriptionModels(plans, environments);
+        List<io.gravitee.repository.management.model.Subscription> repoSubscriptions = loadSubscriptionModels(
+            plans,
+            environments,
+            DEPLOY_STATUS
+        );
         return repoSubscriptions
             .stream()
             .flatMap(subscription -> subscriptionMapper.to(subscription).stream())

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -46,9 +47,26 @@ public class SubscriptionMapper {
     private final ApiProductRegistry apiProductRegistry;
 
     public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel) {
+        return to(subscriptionModel, apiId -> true);
+    }
+
+    /**
+     * Maps a subscription model, restricting an API-Product explosion to the APIs passing
+     * {@code apiFilter}.
+     * <p>
+     * Callers that deploy a bounded set of APIs — the sync appenders, which work one batch at a
+     * time — should pass that set. A product subscription otherwise materialises one leg per API in
+     * the entire product and the caller throws away every leg outside its batch: for a product
+     * spanning P APIs synced in batches of B, that allocated P/B times more objects than it kept.
+     * <p>
+     * The filter deliberately does not apply to plain API subscriptions. Those carry exactly one
+     * leg, and an api outside the caller's batch means the subscription's api disagrees with the
+     * API owning its plan — a data inconsistency the caller should surface, not silently drop.
+     */
+    public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel, Predicate<String> apiFilter) {
         try {
             if (subscriptionModel.getReferenceType() == SubscriptionReferenceType.API_PRODUCT) {
-                return explodeApiProductSubscription(subscriptionModel);
+                return explodeApiProductSubscription(subscriptionModel, apiFilter);
             }
 
             // Regular API subscription - return as single-item list
@@ -59,7 +77,10 @@ public class SubscriptionMapper {
         }
     }
 
-    private List<Subscription> explodeApiProductSubscription(io.gravitee.repository.management.model.Subscription subscriptionModel) {
+    private List<Subscription> explodeApiProductSubscription(
+        io.gravitee.repository.management.model.Subscription subscriptionModel,
+        Predicate<String> apiFilter
+    ) {
         String productId = subscriptionModel.getReferenceId();
         if (productId == null) {
             log.warn("API Product subscription [{}] has null referenceId, skipping", subscriptionModel.getId());
@@ -84,9 +105,11 @@ public class SubscriptionMapper {
             return List.of();
         }
 
-        // Create one subscription per API in product
+        // Create one subscription per API in product, skipping APIs the caller has no use for
+        // (filter applied before mapping so discarded legs are never allocated)
         return apiIds
             .stream()
+            .filter(apiFilter)
             .map(apiId -> {
                 Subscription sub = toSubscription(subscriptionModel);
                 sub.setApi(apiId); // Override with individual API

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 
@@ -97,7 +98,20 @@ public class SubscriptionAppender {
         });
 
         if (!allPlans.isEmpty()) {
-            Map<String, List<Subscription>> subscriptionsByApi = loadSubscriptions(initialSync, allPlans, environments);
+            // Restrict the API-Product explosion to this batch's APIs. Product subscriptions were
+            // otherwise exploded across every API in the product and each leg outside the batch
+            // discarded here — for a product spanning P APIs synced in batches of B, that allocated
+            // P/B times more legs than it kept, and logged the full subscription id list per
+            // discarded API.
+            // Plain API subscriptions are still mapped unfiltered, so the warning below keeps
+            // reporting the case it was written for: a subscription whose api disagrees with the
+            // API owning its plan.
+            Map<String, List<Subscription>> subscriptionsByApi = loadSubscriptions(
+                initialSync,
+                allPlans,
+                environments,
+                deployableByApi.keySet()
+            );
             subscriptionsByApi.forEach((api, subscriptions) -> {
                 ApiReactorDeployable deployable = deployableByApi.get(api);
                 if (deployable == null) {
@@ -131,6 +145,19 @@ public class SubscriptionAppender {
         final List<String> plans,
         final Set<String> environments
     ) {
+        return loadSubscriptions(initialSync, plans, environments, null);
+    }
+
+    /**
+     * @param retainedApis APIs whose legs should be materialised, or {@code null} to keep every leg.
+     */
+    protected Map<String, List<Subscription>> loadSubscriptions(
+        final boolean initialSync,
+        final List<String> plans,
+        final Set<String> environments,
+        final Set<String> retainedApis
+    ) {
+        final Predicate<String> apiFilter = retainedApis == null ? apiId -> true : retainedApis::contains;
         SubscriptionCriteria.SubscriptionCriteriaBuilder criteriaBuilder = SubscriptionCriteria.builder()
             .plans(plans)
             .environments(environments);
@@ -160,7 +187,7 @@ public class SubscriptionAppender {
                 }
                 for (io.gravitee.repository.management.model.Subscription record : page) {
                     subscriptionMapper
-                        .to(record)
+                        .to(record, apiFilter)
                         .forEach(converted -> {
                             converted.setForceDispatch(true);
                             grouped.computeIfAbsent(converted.getApi(), k -> new ArrayList<>()).add(converted);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.sync.process.common.deployer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -104,14 +105,14 @@ class ApiProductSubscriptionRefresherTest {
         void returns_complete_when_plans_null_or_empty() throws TechnicalException {
             cut.refresh(null, Set.of(ENV_1)).test().assertComplete();
             cut.refresh(Set.of(), Set.of(ENV_1)).test().assertComplete();
-            verify(subscriptionRepository, never()).search(any(), any());
+            verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), anyInt());
         }
 
         @Test
         void loads_and_deploys_subscriptions() throws TechnicalException {
             var repoSub = productSubscription(SUB_1, PLAN_1, ENV_1);
             var gatewaySub = Subscription.builder().id(SUB_1).api(API_1).plan(PLAN_1).build();
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoSub));
             when(subscriptionMapper.to(repoSub)).thenReturn(List.of(gatewaySub));
 
             cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
@@ -125,7 +126,7 @@ class ApiProductSubscriptionRefresherTest {
             var gatewaySub = Subscription.builder().id(SUB_1).api(API_1).plan(PLAN_1).build();
             var repoKey = productApiKey(KEY_ID, ENV_1, SUB_1);
             var gatewayKey = ApiKey.builder().id(KEY_ID).api(API_1).subscription(SUB_1).build();
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoSub));
             when(subscriptionMapper.to(repoSub)).thenReturn(List.of(gatewaySub));
             when(apiKeyRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoKey));
             when(apiKeyMapper.to(repoKey, gatewaySub)).thenReturn(gatewayKey);
@@ -138,11 +139,11 @@ class ApiProductSubscriptionRefresherTest {
 
         @Test
         void does_not_call_api_key_repository_when_no_subscriptions() throws TechnicalException {
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of());
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of());
 
             cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
 
-            verify(subscriptionRepository).search(any(), any());
+            verify(subscriptionRepository).searchAfter(any(), any(), any(), eq(BULK_ITEMS));
             verify(apiKeyRepository, never()).searchAfter(any(), any(), any(), any(int.class));
         }
 
@@ -165,7 +166,7 @@ class ApiProductSubscriptionRefresherTest {
             var repoSubs = IntStream.range(0, 5)
                 .mapToObj(i -> productSubscription("sub" + i, PLAN_1, ENV_1))
                 .toList();
-            when(subscriptionRepository.search(any(), any())).thenReturn(repoSubs);
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(repoSubs);
             var gatewaySubs = IntStream.range(0, 5)
                 .mapToObj(i -> Subscription.builder().id("sub" + i).api(API_1).plan(PLAN_1).build())
                 .toList();
@@ -209,7 +210,7 @@ class ApiProductSubscriptionRefresherTest {
 
         @Test
         void throws_when_repository_fails() throws TechnicalException {
-            when(subscriptionRepository.search(any(), any())).thenThrow(new TechnicalException("DB error"));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenThrow(new TechnicalException("DB error"));
 
             var thrown = catchThrowable(() -> cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).blockingAwait());
 
@@ -227,13 +228,13 @@ class ApiProductSubscriptionRefresherTest {
         void returns_complete_when_removedApiIds_null_or_empty() throws TechnicalException {
             cut.unregisterRemovedApis(null, Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
             cut.unregisterRemovedApis(Set.of(), Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
-            verify(subscriptionRepository, never()).search(any(), any());
+            verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), anyInt());
         }
 
         @Test
         void returns_complete_when_plans_empty() throws TechnicalException {
             cut.unregisterRemovedApis(Set.of("api-removed"), Set.of(), Set.of(ENV_1)).test().assertComplete();
-            verify(subscriptionRepository, never()).search(any(), any());
+            verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), anyInt());
         }
 
         @Test
@@ -243,7 +244,7 @@ class ApiProductSubscriptionRefresherTest {
             var repoKey = productApiKey(KEY_ID, ENV_1, SUB_1);
             var gatewayKey = ApiKey.builder().id(KEY_ID).api("api-removed").subscription(SUB_1).build();
 
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoSub));
             when(subscriptionMapper.toSubscriptionForApi(repoSub, "api-removed")).thenReturn(subForRemoved);
             when(apiKeyRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoKey));
             when(apiKeyMapper.to(repoKey, subForRemoved)).thenReturn(gatewayKey);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
@@ -210,6 +210,40 @@ class SubscriptionAppenderTest {
         });
     }
 
+    @Test
+    void should_only_materialise_api_product_legs_for_apis_in_the_current_batch() throws TechnicalException {
+        configureMemoryAppender();
+        // A product spanning three APIs, but only one of them is in this deployment batch.
+        io.gravitee.gateway.handlers.api.ReactableApiProduct product = mock(io.gravitee.gateway.handlers.api.ReactableApiProduct.class);
+        when(product.getApiIds()).thenReturn(Set.of("api1", "api2", "api3"));
+        when(apiProductRegistry.get("product1", "env")).thenReturn(product);
+
+        io.gravitee.repository.management.model.Subscription productSub = new io.gravitee.repository.management.model.Subscription();
+        productSub.setId("sub1");
+        productSub.setPlan("plan1");
+        productSub.setEnvironmentId("env");
+        productSub.setReferenceType(io.gravitee.repository.management.model.SubscriptionReferenceType.API_PRODUCT);
+        productSub.setReferenceId("product1");
+        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(List.of(productSub));
+
+        ApiReactorDeployable deployable = ApiReactorDeployable.builder()
+            .apiId("api1")
+            .reactableApi(mock(ReactableApi.class))
+            .subscribablePlans(new HashSet<>(Set.of("plan1")))
+            .apiKeyPlans(new HashSet<>(Set.of("plan1")))
+            .build();
+
+        List<ApiReactorDeployable> deployables = cut.appends(true, List.of(deployable), Set.of("env"));
+
+        // Only the in-batch leg is built: api2 and api3 legs are never allocated...
+        assertThat(deployables).hasSize(1);
+        assertThat(deployables.get(0).subscriptions()).hasSize(1);
+        assertThat(deployables.get(0).subscriptions().get(0).getApi()).isEqualTo("api1");
+        assertThat(deployables.get(0).subscriptions().get(0).getApiProductId()).isEqualTo("product1");
+        // ...so no warning is emitted for them either.
+        Assertions.assertThat(memoryAppender.getLoggedEvents()).isEmpty();
+    }
+
     private void configureMemoryAppender() {
         Logger logger = (Logger) LoggerFactory.getLogger(SubscriptionAppender.class);
         memoryAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());


### PR DESCRIPTION
## Problem

Cold start on a gateway serving API Products degrades non-linearly with the number of APIs in a
product. Once a product spans several hundred APIs, initial sync can take tens of minutes, the
`sync-process` probe never reports ready, and the pod is restarted — discarding all progress and
re-issuing the whole sync against the management API.

Four independent defects compose to produce this. Notation used throughout: **P** = APIs in a
product, **S** = its ACCEPTED subscriptions, **B** = `services.sync.bulk_items`.

### 1. Sync executors are permanently single-threaded

`SyncConfiguration` built both sync pools as:

```java
new ThreadPoolExecutor(1, poolSize, 15L, SECONDS, new LinkedBlockingQueue<>(), factory)
```

`ThreadPoolExecutor` only creates a thread beyond `corePoolSize` when the queue *rejects* an offer,
and an unbounded `LinkedBlockingQueue` never rejects. The pools therefore ran with exactly one
thread regardless of `poolSize`, which means:

- `services.sync.fetcher` and `services.sync.deployer` had no effect at all — they only set
  `maxPoolSize`, which was unreachable.
- `.parallel(syncDeployerExecutor.getMaximumPoolSize()).runOn(...)` in `AbstractApiSynchronizer`
  created N rails that all funnelled through that single thread.

API deployment was fully serialised, so wall-clock cold start scaled linearly with API count and
was insensitive to CPU allocation.

### 2. Registering a subscription leg was O(P), making warmup O(P²)

`SubscriptionCacheService` indexed legs as `ConcurrentMap<String, Set<Subscription>>` with an
immutable value set, replaced on every registration:

```java
Set<Subscription> updated = new HashSet<>(existing);
updated.removeIf(sameApiAndEnvironment);
updated.add(subscription);
return Set.copyOf(updated);          // second copy
```

A singleton fast path covered plain API subscriptions, where the set always holds one element. It
never applies to an exploded API-Product subscription, whose set grows to P legs — so registering a
product's legs cost `Σ2k` for k=1..P ≈ **P² element copies per subscription**, or ~`S × P²` for the
product. This is the dominant cost of a product warmup and the main source of allocation churn.

`registerFromClientId` contained a second instance of the same problem: it snapshotted the entire
leg set on every registration, although the loop that consumed the snapshot only ever acted on the
leg for the same API.

### 3. Product subscriptions were exploded across all P APIs, then discarded

`SubscriptionAppender` runs once per batch of B deployables, but `SubscriptionMapper` explodes a
product subscription across the product's *entire* API list. Legs outside the current batch were
built, grouped into a map, and then dropped — with a warning that serialises the full subscription
id list, one per discarded API.

Because a product's APIs are spread across the event stream rather than grouped, nearly every batch
touches a large product. Total waste is therefore `~(P/B) × S × P` legs allocated per initial sync,
plus the corresponding log volume. Smaller `B` makes this worse, which puts `bulk_items` in direct
conflict with keeping per-response payloads small — a real problem when the HTTP repository bridge
is in use.

### 4. The API Product refresher issued an unpaginated query including CLOSED

`ApiProductSubscriptionRefresher.loadSubscriptionModels` used
`subscriptionRepository.search(criteria, sortable)` — no pagination — with statuses
`ACCEPTED, CLOSED, PAUSED, PENDING` and no `endingAt` filter, and it runs per product on every
deploy. The other two subscription callers (`SubscriptionAppender`, `SubscriptionFetcher`) already
use keyset pagination.

Over the HTTP repository bridge an unpaginated result set is serialised into a single response body
on the management API's Vert.x event loop, so response size translates directly into event-loop
block duration. The deploy path also cannot register anything other than ACCEPTED —
`SubscriptionCacheService.register` unregisters every other status — so three of the four statuses
were fetched only to be thrown away, scaling the query with the deployment's entire subscription
history rather than its live set.

## Changes

| Commit | Change |
|---|---|
| `fix(gateway-sync): let sync executors grow past a single thread` | `corePoolSize` = `poolSize` on both executors. `allowCoreThreadTimeOut(true)` is retained, so idle threads still expire and an idle pool stays cheap. |
| `perf(gateway): index subscription legs by api instead of copying sets` | Leg index becomes `ConcurrentMap<String, ConcurrentMap<LegKey, Subscription>>` keyed on `(api, environmentId)` — the exact pair the previous code filtered on. Registration is an O(1) `put`. `registerFromClientId` now resolves the same-API leg directly instead of snapshotting. |
| `perf(gateway-sync): restrict api product explosion to the current batch` | New `SubscriptionMapper.to(model, Predicate<String> apiFilter)`; the appender passes its batch's API ids. The filter is applied *before* mapping, so out-of-batch legs are never allocated. |
| `perf(gateway-sync): paginate api product subscription refresher` | `loadSubscriptionModels` pages via `searchAfter` with a `(plan, id)` keyset cursor. The deploy path requests `ACCEPTED` only; the eviction path keeps the full status list, which it needs in order to see subscriptions that have left ACCEPTED. |

### Complexity

| | Before | After |
|---|---|---|
| Register one leg | O(P) copies | O(1) put |
| Warm one product's cache | ~`S × P²` element copies | ~`S × P` puts |
| Legs allocated per initial sync | ~`(P/B) × S × P` | ~`S × P` |
| Refresher response size | entire matching set, unpaginated | `bulk_items` per page |
| API deployment | serial | up to `availableProcessors() × 2` |

## Notes on behaviour that is deliberately unchanged

**The `Cannot find api … for subscriptions […]` warning is kept.** The filter in change 3 applies
only to the API-Product explosion, not to plain API subscriptions. For a plain subscription an API
outside the batch means the subscription's `api` disagrees with the API owning its plan — a data
inconsistency worth surfacing, and the case the warning was originally written for
(`SubscriptionAppenderTest#should_ignore_and_log_subscriptions_with_missing_deployable`, unchanged
and passing). What disappears is the pathological volume: product legs no longer reach that branch,
so only genuine inconsistencies are reported.

**`getAllById` now returns an unmodifiable view rather than an immutable snapshot.** Backed by
`ConcurrentHashMap.values()`, so iteration is weakly consistent instead of point-in-time. Javadoc
updated. No caller relies on snapshot semantics.

## Testing

```
gravitee-apim-gateway-handlers-api    Tests run: 982, Failures: 0, Errors: 0, Skipped: 0
gravitee-apim-gateway-services-sync   Tests run: 679, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

All 982 `handlers-api` tests pass **unmodified**, including the multi-leg coverage in
`SubscriptionCacheServiceTest` — most importantly the case where two legs of one subscription share
an API but differ by environment, which is exactly the invariant `LegKey` has to preserve. That
suite is the strongest available evidence that change 2 is semantics-preserving.

Test changes:

- **Added** `SubscriptionAppenderTest#should_only_materialise_api_product_legs_for_apis_in_the_current_batch`.
  A product spanning three APIs with one in the batch: asserts exactly one leg is built, that it
  carries the product id, and that no warning is emitted. `SubscriptionAppenderTest` previously had
  no API-Product coverage — its registry mock always returned an empty list — so the behaviour
  changed in commit 3 was untested.
- **Updated** stubs in `ApiProductSubscriptionRefresherTest` from `search(any(), any())` to
  `searchAfter(any(), any(), any(), eq(BULK_ITEMS))`. Mechanical: the mocked method had to follow
  the switch to the paginated call. No assertion was altered.

## Risk

**Change 1 enables genuinely concurrent API deployment for the first time.** The `.parallel(...)`
fan-out and the `ConcurrentHashMap`-backed caches were written expecting it, so this restores
intended behaviour rather than introducing new concurrency — but that code path has effectively
never executed in parallel, so the deployment pipeline deserves review and load testing with a
realistic API count before this ships. Reviewers may prefer to gate it behind an explicit opt-in.

The remaining three changes are localised to allocation and query shape and do not alter which
subscriptions end up registered.

**Not benchmarked.** The complexity table is derived from the code, not measured. A cold-start
before/after against a large product is still needed, and is the main thing I would want in review.

## Follow-up, intentionally not in this PR

Active API-Product subscriptions are registered twice during cold start: `ApiProductDeployer`
(`Order.API_PRODUCT` = 11) calls `refresher.refresh()`, then the API synchronizer
(`Order.API` = 12) re-collects the product plans and registers the same legs. Skipping the refresh
on initial sync would halve that, but `initialSync` is not threaded through to `ApiProductDeployer`
and adding it would touch the `Deployer` interface, `DeployerFactory`, `ApiProductSynchronizer` and
the deployable record. With registration now O(1), the redundant pass costs `S × P` cheap puts
rather than a second quadratic warmup, so the blast radius looked disproportionate to the remaining
gain. Worth a separate change.
