### PR TITLE
fix(gateway): optimize API product subscription sync

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployer.java
@@ -42,6 +42,16 @@ public class ApiProductDeployer implements Deployer<ApiProductReactorDeployable>
 
     @Override
     public Completable deploy(ApiProductReactorDeployable deployable) {
+        return deploy(deployable, true);
+    }
+
+    /**
+     * Deploys an API Product and optionally refreshes its subscriptions. During an initial sync,
+     * subscriptions are appended while APIs are deployed immediately after API Products, so doing
+     * the refresh here would build and register the complete product-subscription Cartesian product
+     * twice.
+     */
+    public Completable deploy(ApiProductReactorDeployable deployable, boolean refreshSubscriptions) {
         ReactableApiProduct reactableApiProduct = deployable.reactableApiProduct();
         String apiProductId = deployable.apiProductId();
 
@@ -68,7 +78,7 @@ public class ApiProductDeployer implements Deployer<ApiProductReactorDeployable>
             }
         }
         doBeforeEmit = doBeforeEmit.andThen(Completable.fromRunnable(() -> registerApiProductPlans(deployable)));
-        if (newApiIds != null && !newApiIds.isEmpty()) {
+        if (refreshSubscriptions && !newApiIds.isEmpty()) {
             doBeforeEmit = doBeforeEmit.andThen(
                 subscriptionRefresher.refresh(deployable.subscribablePlans(), Set.of(reactableApiProduct.getEnvironmentId()))
             );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -46,20 +46,35 @@ public class SubscriptionMapper {
     private final ApiProductRegistry apiProductRegistry;
 
     public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel) {
+        return to(subscriptionModel, null);
+    }
+
+    /**
+     * Maps a repository subscription only for the requested APIs. This prevents an API Product
+     * subscription from being expanded to every API in the product when an API synchronizer is
+     * currently processing only a small batch of those APIs.
+     *
+     * @param subscriptionModel the repository subscription
+     * @param targetApiIds APIs to map, or {@code null} to map every API
+     */
+    public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel, Set<String> targetApiIds) {
         try {
             if (subscriptionModel.getReferenceType() == SubscriptionReferenceType.API_PRODUCT) {
-                return explodeApiProductSubscription(subscriptionModel);
+                return explodeApiProductSubscription(subscriptionModel, targetApiIds);
             }
 
-            // Regular API subscription - return as single-item list
-            return List.of(toSubscription(subscriptionModel));
+            Subscription subscription = toSubscription(subscriptionModel);
+            return targetApiIds == null || targetApiIds.contains(subscription.getApi()) ? List.of(subscription) : List.of();
         } catch (Exception e) {
             log.warn("Unable to map subscription from model [{}].", subscriptionModel.getId(), e);
             return List.of(); // Return empty list on error
         }
     }
 
-    private List<Subscription> explodeApiProductSubscription(io.gravitee.repository.management.model.Subscription subscriptionModel) {
+    private List<Subscription> explodeApiProductSubscription(
+        io.gravitee.repository.management.model.Subscription subscriptionModel,
+        Set<String> targetApiIds
+    ) {
         String productId = subscriptionModel.getReferenceId();
         if (productId == null) {
             log.warn("API Product subscription [{}] has null referenceId, skipping", subscriptionModel.getId());
@@ -84,9 +99,9 @@ public class SubscriptionMapper {
             return List.of();
         }
 
-        // Create one subscription per API in product
-        return apiIds
-            .stream()
+        // Iterate over the (usually much smaller) current synchronization batch when provided.
+        var apiIdsToMap = targetApiIds == null ? apiIds.stream() : targetApiIds.stream().filter(apiIds::contains);
+        return apiIdsToMap
             .map(apiId -> {
                 Subscription sub = toSubscription(subscriptionModel);
                 sub.setApi(apiId); // Override with individual API

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/AbstractDistributedSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/AbstractDistributedSynchronizer.java
@@ -68,7 +68,9 @@ public abstract class AbstractDistributedSynchronizer<T extends Deployable, Y ex
                     .runOn(Schedulers.from(syncDeployerExecutor))
                     .flatMap(deployable -> {
                         if (deployable.syncAction() == SyncAction.DEPLOY) {
-                            return deploy(deployer, deployable).onErrorResumeNext(throwable -> resumeOnError(initialSync, throwable));
+                            return deployAndAfter(deployer, deployable, initialSync).onErrorResumeNext(throwable ->
+                                resumeOnError(initialSync, throwable)
+                            );
                         } else if (deployable.syncAction() == SyncAction.UNDEPLOY) {
                             return undeploy(deployer, deployable).onErrorResumeNext(throwable -> resumeOnError(initialSync, throwable));
                         } else {
@@ -105,8 +107,13 @@ public abstract class AbstractDistributedSynchronizer<T extends Deployable, Y ex
 
     protected abstract Y createDeployer();
 
-    private Flowable<T> deploy(final Y apiDeployer, final T deployable) {
-        return apiDeployer.deploy(deployable).andThen(apiDeployer.doAfterDeployment(deployable)).andThen(Flowable.just(deployable));
+    /** Allows a synchronizer to specialize deployment behavior for an initial sync. */
+    protected Completable deploy(final Y deployer, final T deployable, final boolean initialSync) {
+        return deployer.deploy(deployable);
+    }
+
+    private Flowable<T> deployAndAfter(final Y deployer, final T deployable, final boolean initialSync) {
+        return deploy(deployer, deployable, initialSync).andThen(deployer.doAfterDeployment(deployable)).andThen(Flowable.just(deployable));
     }
 
     private Flowable<T> undeploy(final Y apiDeployer, final T deployable) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizer.java
@@ -24,6 +24,7 @@ import io.gravitee.gateway.services.sync.process.distributed.synchronizer.Abstra
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.apiproduct.ApiProductReactorDeployable;
 import io.gravitee.repository.distributedsync.model.DistributedEvent;
 import io.gravitee.repository.distributedsync.model.DistributedEventType;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import java.util.concurrent.ThreadPoolExecutor;
 import lombok.CustomLog;
@@ -59,6 +60,15 @@ public class DistributedApiProductSynchronizer extends AbstractDistributedSynchr
     @Override
     protected ApiProductDeployer createDeployer() {
         return deployerFactory.createApiProductDeployer();
+    }
+
+    @Override
+    protected Completable deploy(
+        final ApiProductDeployer deployer,
+        final ApiProductReactorDeployable deployable,
+        final boolean initialSync
+    ) {
+        return deployer.deploy(deployable, !initialSync);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -80,8 +81,7 @@ public class SubscriptionAppender {
             .stream()
             .collect(Collectors.toMap(ApiReactorDeployable::apiId, d -> d));
 
-        List<String> apiPlans = collectApiPlans(deployableByApi);
-        List<String> allPlans = new ArrayList<>(apiPlans);
+        Set<String> allPlans = new HashSet<>(collectApiPlans(deployableByApi));
 
         deployableByApi.forEach((apiId, deployable) -> {
             Set<String> envs = environments != null && !environments.isEmpty()
@@ -97,14 +97,19 @@ public class SubscriptionAppender {
         });
 
         if (!allPlans.isEmpty()) {
-            Map<String, List<Subscription>> subscriptionsByApi = loadSubscriptions(initialSync, allPlans, environments);
+            Map<String, List<Subscription>> subscriptionsByApi = loadSubscriptions(
+                initialSync,
+                allPlans,
+                environments,
+                deployableByApi.keySet()
+            );
             subscriptionsByApi.forEach((api, subscriptions) -> {
                 ApiReactorDeployable deployable = deployableByApi.get(api);
                 if (deployable == null) {
                     log.warn(
-                        "Cannot find api {} for subscriptions [{}]",
-                        api,
-                        subscriptions.stream().map(Subscription::getId).collect(Collectors.joining(","))
+                        "Ignoring {} subscriptions for API [{}] not present in the current synchronization batch",
+                        subscriptions.size(),
+                        api
                     );
                 } else {
                     deployable.subscriptions(subscriptions);
@@ -128,8 +133,9 @@ public class SubscriptionAppender {
 
     protected Map<String, List<Subscription>> loadSubscriptions(
         final boolean initialSync,
-        final List<String> plans,
-        final Set<String> environments
+        final Collection<String> plans,
+        final Set<String> environments,
+        final Set<String> targetApiIds
     ) {
         SubscriptionCriteria.SubscriptionCriteriaBuilder criteriaBuilder = SubscriptionCriteria.builder()
             .plans(plans)
@@ -160,7 +166,7 @@ public class SubscriptionAppender {
                 }
                 for (io.gravitee.repository.management.model.Subscription record : page) {
                     subscriptionMapper
-                        .to(record)
+                        .to(record, targetApiIds)
                         .forEach(converted -> {
                             converted.setForceDispatch(true);
                             grouped.computeIfAbsent(converted.getApi(), k -> new ArrayList<>()).add(converted);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizer.java
@@ -70,6 +70,7 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
 
     @Override
     public Completable synchronize(final Long from, final Long to, final Set<String> environments) {
+        boolean initialSync = from == null || from == -1;
         AtomicLong launchTime = new AtomicLong();
 
         return eventsFetcher
@@ -78,11 +79,11 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
                 to,
                 Event.EventProperties.API_PRODUCT_ID,
                 environments,
-                from == -1 ? INIT_EVENT_TYPES : INCREMENTAL_EVENT_TYPES
+                initialSync ? INIT_EVENT_TYPES : INCREMENTAL_EVENT_TYPES
             )
             .subscribeOn(Schedulers.from(syncFetcherExecutor))
             .rebatchRequests(syncFetcherExecutor.getMaximumPoolSize())
-            .compose(this::processEvents)
+            .compose(events -> processEvents(events, initialSync))
             .count()
             .doOnSubscribe(disposable -> launchTime.set(Instant.now().toEpochMilli()))
             .doOnSuccess(count -> {
@@ -91,7 +92,7 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
                     count,
                     (System.currentTimeMillis() - launchTime.get())
                 );
-                if (from == -1) {
+                if (initialSync) {
                     log.info(logMsg);
                 } else {
                     log.debug(logMsg);
@@ -105,7 +106,7 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
         return Order.API_PRODUCT.index();
     }
 
-    private Flowable<ApiProductReactorDeployable> processEvents(final Flowable<List<Event>> eventsFlowable) {
+    private Flowable<ApiProductReactorDeployable> processEvents(final Flowable<List<Event>> eventsFlowable, final boolean initialSync) {
         return eventsFlowable
             // fetch per page
             .flatMap(events ->
@@ -131,7 +132,7 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
                     .runOn(Schedulers.from(syncDeployerExecutor))
                     .flatMap(deployable -> {
                         if (deployable.syncAction() == SyncAction.DEPLOY) {
-                            return deployApiProduct(apiProductDeployer, deployable);
+                            return deployApiProduct(apiProductDeployer, deployable, initialSync);
                         } else if (deployable.syncAction() == SyncAction.UNDEPLOY) {
                             return undeployApiProduct(apiProductDeployer, deployable);
                         } else {
@@ -166,10 +167,11 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
 
     private Flowable<ApiProductReactorDeployable> deployApiProduct(
         ApiProductDeployer apiProductDeployer,
-        final ApiProductReactorDeployable deployable
+        final ApiProductReactorDeployable deployable,
+        final boolean initialSync
     ) {
         return apiProductDeployer
-            .deploy(deployable)
+            .deploy(deployable, !initialSync)
             .andThen(apiProductDeployer.doAfterDeployment(deployable))
             .andThen(Flowable.just(deployable))
             .onErrorResumeNext(throwable -> {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -124,6 +125,27 @@ class ApiProductDeployerTest {
 
             cut.deploy(deployable).test().assertComplete();
             verify(apiProductManager).register(eq(reactableApiProduct), any(Completable.class));
+        }
+
+        @Test
+        void should_skip_subscription_refresh_when_requested() {
+            ReactableApiProduct reactableApiProduct = ReactableApiProduct.builder()
+                .id("api-product-initial")
+                .name("Initial Product")
+                .apiIds(Set.of("api-1"))
+                .environmentId("env-id")
+                .build();
+            ApiProductReactorDeployable deployable = ApiProductReactorDeployable.builder()
+                .syncAction(SyncAction.DEPLOY)
+                .apiProductId("api-product-initial")
+                .reactableApiProduct(reactableApiProduct)
+                .subscribablePlans(Set.of("plan-1"))
+                .build();
+
+            cut.deploy(deployable, false).test().assertComplete();
+
+            verify(planService).register(deployable);
+            verify(subscriptionRefresher, never()).refresh(anySet(), anySet());
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizerTest.java
@@ -77,7 +77,7 @@ class DistributedApiProductSynchronizerTest {
         );
         when(eventsFetcher.bulkItems()).thenReturn(1);
         lenient().when(deployerFactory.createApiProductDeployer()).thenReturn(apiProductDeployer);
-        lenient().when(apiProductDeployer.deploy(any())).thenReturn(Completable.complete());
+        lenient().when(apiProductDeployer.deploy(any(), anyBoolean())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.doAfterDeployment(any())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.undeploy(any())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.doAfterUndeployment(any())).thenReturn(Completable.complete());
@@ -146,7 +146,26 @@ class DistributedApiProductSynchronizerTest {
             when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.just(distributedEvent));
             cut.synchronize(-1L, Instant.now().toEpochMilli()).test().await().assertComplete();
 
-            verify(apiProductDeployer).deploy(any());
+            verify(apiProductDeployer).deploy(any(), eq(false));
+            verify(apiProductDeployer).doAfterDeployment(any());
+        }
+
+        @Test
+        void should_refresh_subscriptions_when_fetching_incremental_deploy_event() throws InterruptedException, JsonProcessingException {
+            DistributedEvent distributedEvent = DistributedEvent.builder()
+                .id("product-id")
+                .payload(objectMapper.writeValueAsString(reactableApiProduct))
+                .type(DistributedEventType.API_PRODUCT)
+                .syncAction(DistributedSyncAction.DEPLOY)
+                .updatedAt(new Date())
+                .build();
+            long from = Instant.now().minusSeconds(1).toEpochMilli();
+
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.just(distributedEvent));
+
+            cut.synchronize(from, Instant.now().toEpochMilli()).test().await().assertComplete();
+
+            verify(apiProductDeployer).deploy(any(), eq(true));
             verify(apiProductDeployer).doAfterDeployment(any());
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
@@ -202,6 +202,27 @@ class SubscriptionMapperTest {
     }
 
     @Test
+    void should_explode_api_product_subscription_only_for_target_apis() {
+        subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
+        subscription.setReferenceId("product-1");
+        subscription.setApi(null);
+        subscription.setEnvironmentId("env-1");
+        ApiProductRegistry registry = mock(ApiProductRegistry.class);
+        ReactableApiProduct product = ReactableApiProduct.builder().id("product-1").apiIds(Set.of("api1", "api2", "api3")).build();
+        when(registry.get("product-1", "env-1")).thenReturn(product);
+        cut = new SubscriptionMapper(objectMapper, registry);
+
+        List<io.gravitee.gateway.api.service.Subscription> mapped = cut.to(subscription, Set.of("api2", "api-outside-product"));
+
+        assertThat(mapped)
+            .singleElement()
+            .satisfies(mappedSubscription -> {
+                assertThat(mappedSubscription.getApi()).isEqualTo("api2");
+                assertThat(mappedSubscription.getApiProductId()).isEqualTo("product-1");
+            });
+    }
+
+    @Test
     void should_return_empty_list_when_api_product_subscription_has_null_reference_id() {
         subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
         subscription.setReferenceId(null);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
@@ -28,17 +28,17 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMapper;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.SubscriptionCursor;
+import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -168,46 +168,45 @@ class SubscriptionAppenderTest {
     }
 
     @Test
-    void should_ignore_and_log_subscriptions_with_missing_deployable() throws TechnicalException {
+    void should_expand_api_product_subscription_only_for_apis_in_current_batch() throws TechnicalException {
         configureMemoryAppender();
         ApiReactorDeployable apiReactorDeployable1 = ApiReactorDeployable.builder()
             .apiId("api1")
             .reactableApi(mock(ReactableApi.class))
-            .subscribablePlans(new HashSet<>(Set.of("plan1")))
-            .apiKeyPlans(new HashSet<>(Set.of("plan1")))
+            .subscribablePlans(new HashSet<>(Set.of("product-plan")))
+            .apiKeyPlans(new HashSet<>(Set.of("product-plan")))
             .build();
-        io.gravitee.repository.management.model.Subscription subscription1 = new io.gravitee.repository.management.model.Subscription();
-        subscription1.setId("sub1");
-        subscription1.setApi("api1");
-        io.gravitee.repository.management.model.Subscription subscription2 = new io.gravitee.repository.management.model.Subscription();
-        subscription2.setId("sub2");
-        subscription2.setApi("api3");
-        io.gravitee.repository.management.model.Subscription subscription3 = new io.gravitee.repository.management.model.Subscription();
-        subscription3.setId("sub3");
-        subscription3.setApi("api3");
-        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(
-            List.of(subscription1, subscription2, subscription3)
-        );
-        when(
-            subscriptionRepository.searchAfter(any(), any(), argThat(cur -> cur != null && "sub3".equals(cur.id())), eq(BULK_ITEMS))
-        ).thenReturn(List.of());
         ApiReactorDeployable apiReactorDeployable2 = ApiReactorDeployable.builder()
             .apiId("api2")
             .reactableApi(mock(ReactableApi.class))
             .subscribablePlans(new HashSet<>(Set.of("nosubscriptionplan")))
             .apiKeyPlans(new HashSet<>(Set.of("nosubscriptionplan")))
             .build();
-        List<ApiReactorDeployable> deployables = cut.appends(true, List.of(apiReactorDeployable1, apiReactorDeployable2), Set.of("env"));
-        assertThat(deployables).hasSize(2);
-        assertThat(deployables.get(0).subscriptions()).hasSize(1);
-        assertThat(deployables.get(1).subscriptions()).isEmpty();
 
-        Assertions.assertThat(memoryAppender.getLoggedEvents()).hasSize(1);
-        SoftAssertions.assertSoftly(soft -> {
-            var event = memoryAppender.getLoggedEvents().get(0);
-            soft.assertThat(event.getMessage()).contains("Cannot find api {} for subscriptions [{}]");
-            soft.assertThat(event.getArgumentArray()).contains("api3", "sub2,sub3");
-        });
+        ReactableApiProduct product = ReactableApiProduct.builder().id("product-1").apiIds(Set.of("api1", "api3")).build();
+        when(apiProductRegistry.get("product-1", "env")).thenReturn(product);
+
+        io.gravitee.repository.management.model.Subscription productSubscription =
+            new io.gravitee.repository.management.model.Subscription();
+        productSubscription.setId("sub1");
+        productSubscription.setPlan("product-plan");
+        productSubscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
+        productSubscription.setReferenceId("product-1");
+        productSubscription.setEnvironmentId("env");
+        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(List.of(productSubscription));
+
+        List<ApiReactorDeployable> deployables = cut.appends(true, List.of(apiReactorDeployable1, apiReactorDeployable2), Set.of("env"));
+
+        assertThat(deployables).hasSize(2);
+        assertThat(deployables.get(0).subscriptions())
+            .singleElement()
+            .satisfies(subscription -> {
+                assertThat(subscription.getId()).isEqualTo("sub1");
+                assertThat(subscription.getApi()).isEqualTo("api1");
+                assertThat(subscription.getApiProductId()).isEqualTo("product-1");
+            });
+        assertThat(deployables.get(1).subscriptions()).isEmpty();
+        assertThat(memoryAppender.getLoggedEvents()).isEmpty();
     }
 
     private void configureMemoryAppender() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizerTest.java
@@ -20,6 +20,7 @@ import static io.gravitee.repository.management.model.EventType.DEPLOY_API_PRODU
 import static io.gravitee.repository.management.model.EventType.UNDEPLOY_API_PRODUCT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
@@ -93,7 +94,7 @@ class ApiProductSynchronizerTest {
         );
         lenient().when(latestEventFetcher.bulkItems()).thenReturn(1);
         lenient().when(deployerFactory.createApiProductDeployer()).thenReturn(apiProductDeployer);
-        lenient().when(apiProductDeployer.deploy(any())).thenReturn(Completable.complete());
+        lenient().when(apiProductDeployer.deploy(any(), anyBoolean())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.undeploy(any())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.doAfterDeployment(any())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.doAfterUndeployment(any())).thenReturn(Completable.complete());
@@ -172,7 +173,7 @@ class ApiProductSynchronizerTest {
             when(latestEventFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(event)));
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
-            verify(apiProductDeployer).deploy(any());
+            verify(apiProductDeployer).deploy(any(), eq(false));
             verify(apiProductDeployer).doAfterDeployment(any());
         }
 
@@ -188,7 +189,7 @@ class ApiProductSynchronizerTest {
             );
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
-            verify(apiProductDeployer, times(3)).deploy(any());
+            verify(apiProductDeployer, times(3)).deploy(any(), eq(false));
             verify(apiProductDeployer, times(3)).doAfterDeployment(any());
         }
 
@@ -198,13 +199,25 @@ class ApiProductSynchronizerTest {
             Event event2 = createDeployEvent("api-product-fail", "Fail Product");
 
             when(latestEventFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(event1, event2)));
-            when(apiProductDeployer.deploy(any()))
+            when(apiProductDeployer.deploy(any(), eq(false)))
                 .thenReturn(Completable.complete())
                 .thenReturn(Completable.error(new RuntimeException("Deploy failed")));
 
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
-            verify(apiProductDeployer, times(2)).deploy(any());
+            verify(apiProductDeployer, times(2)).deploy(any(), eq(false));
+        }
+
+        @Test
+        void should_refresh_subscriptions_when_processing_incremental_deploy_event() throws InterruptedException, JsonProcessingException {
+            Event event = createDeployEvent("api-product-incremental", "Incremental Product");
+            long from = Instant.now().minusSeconds(1).toEpochMilli();
+
+            when(latestEventFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(event)));
+
+            cut.synchronize(from, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
+
+            verify(apiProductDeployer).deploy(any(), eq(true));
         }
 
         private Event createDeployEvent(String apiProductId, String name) throws JsonProcessingException {
@@ -326,7 +339,7 @@ class ApiProductSynchronizerTest {
             );
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
-            verify(apiProductDeployer).deploy(any());
+            verify(apiProductDeployer).deploy(any(), eq(false));
             verify(apiProductDeployer).doAfterDeployment(any());
             verify(apiProductDeployer).undeploy(any());
             verify(apiProductDeployer).doAfterUndeployment(any());
@@ -356,7 +369,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.subscribablePlans()).containsExactly("plan-published");
@@ -376,7 +389,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.subscribablePlans()).containsExactly("plan-deprecated");
@@ -396,7 +409,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.subscribablePlans()).isEmpty();
@@ -418,7 +431,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             // CLOSED plan is excluded by the mapper — only PUBLISHED and DEPRECATED reach the gateway
@@ -456,7 +469,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.subscribablePlans()).isEmpty();
@@ -494,7 +507,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.reactableApiProduct().getTags()).containsExactlyInAnyOrder("internal", "partner");


### PR DESCRIPTION
## Summary

This PR optimizes gateway cold start when API Products contain many APIs and subscriptions.

API Product subscriptions are now expanded only for APIs in the current synchronization batch. The initial API Product synchronization also avoids refreshing all subscriptions because they are loaded immediately afterwards during API synchronization.

The fix supports both repository and distributed synchronization.

## Root cause

An API Product subscription applies to every API contained in the product. For large products, this creates a significant Cartesian expansion.

In the affected environment:

- 36,487 logical API Product subscriptions
- 218 API Products
- approximately 5.5 million required runtime subscription entries
- individual products containing up to 792 APIs

During cold start, the gateway previously:

1. Expanded and registered the complete `subscription × API` result during API Product synchronization.
2. Loaded the same subscriptions again during API synchronization.
3. For every API batch, expanded subscriptions to every API in the product.
4. Discarded entries belonging to APIs outside the current batch.
5. Generated warnings containing thousands of subscription IDs for those discarded entries.

This caused excessive temporary allocations, GC pressure, bridge queries, duplicate registration and very large log messages.

## Changes

- Add batch-scoped API Product subscription mapping.
- Expand subscriptions only for APIs present in the current synchronization batch.
- Filter regular API subscriptions to the current batch before allocation.
- Deduplicate plan IDs used in subscription repository queries.
- Replace the warning containing every subscription ID with a bounded count-only warning.
- Skip the full API Product subscription refresh during initial synchronization.
- Keep API Product subscription refresh enabled for incremental updates.
- Apply the same initial-sync behavior to distributed synchronization.
- Preserve distributed subscription and API key events emitted during API synchronization.

## Compatibility

Regular API subscriptions retain their existing 1:1 behavior.

Initial synchronization still loads only active, non-expired subscriptions and API keys using paginated repository queries.

Incremental API Product updates continue to refresh subscriptions and API keys as before.

The final runtime subscription cardinality is unchanged: every valid API Product subscription is still registered for every applicable API. This change removes duplicate and out-of-batch processing rather than changing authorization semantics.

No configuration or database migration is required.

## Expected impact

- Avoid materializing the complete API Product subscription expansion twice.
- Eliminate expansion to APIs outside the current synchronization batch.
- Significantly reduce peak heap usage and temporary allocations.
- Reduce GC and bridge load during gateway startup.
- Eliminate multi-megabyte subscription warning messages.
- Allow gateways with large API Products to complete cold start within a substantially shorter time.

## Testing

The following scenarios are covered:

- API Product subscriptions are expanded only to APIs in the current batch.
- Regular API subscriptions are still attached to the correct API.
- Initial API Product synchronization skips the redundant refresh.
- Incremental API Product synchronization still performs the refresh.
- Repository and distributed synchronization use the correct behavior.
- API Product API keys and subscriptions remain available through distributed events.

Full `gravitee-apim-gateway-services-sync` test suite:

- 675 tests
- 0 failures
- 0 errors

## Remaining limitation

The gateway still needs to retain the required runtime entries. In the affected environment this is approximately 5.5 million entries.

A longer-term improvement could avoid storing the complete `subscription × API` Cartesian representation in the gateway cache, but that requires a broader authorization-cache redesign.

