### PR TITLE
fix(gateway): stop duplicating and over-expanding API Product subscriptions

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployer.java
@@ -68,11 +68,12 @@ public class ApiProductDeployer implements Deployer<ApiProductReactorDeployable>
             }
         }
         doBeforeEmit = doBeforeEmit.andThen(Completable.fromRunnable(() -> registerApiProductPlans(deployable)));
-        if (newApiIds != null && !newApiIds.isEmpty()) {
-            doBeforeEmit = doBeforeEmit.andThen(
-                subscriptionRefresher.refresh(deployable.subscribablePlans(), Set.of(reactableApiProduct.getEnvironmentId()))
-            );
-        }
+
+        // Subscriptions are deliberately NOT registered here. SubscriptionAppender already registers
+        // them for every member API: at initial sync because the API synchronizer runs right after
+        // this one, and on a runtime product change because RepositoryApiMemberResyncTrigger re-runs
+        // the API pipeline for the member APIs. Doing it here as well loaded and expanded the whole
+        // product subscription set a second time, serially, per product.
 
         return apiProductManager
             .register(reactableApiProduct, doBeforeEmit)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -46,9 +46,21 @@ public class SubscriptionMapper {
     private final ApiProductRegistry apiProductRegistry;
 
     public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel) {
+        return to(subscriptionModel, null);
+    }
+
+    /**
+     * Maps a repository subscription, expanding API Product subscriptions across the product's APIs.
+     *
+     * @param apiScope when non-null, an API Product subscription is only expanded for the APIs it
+     *                 contains. Callers that process APIs in batches pass the current batch so the
+     *                 expansion does not materialise subscriptions they are about to discard.
+     *                 {@code null} expands across every API of the product.
+     */
+    public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel, Set<String> apiScope) {
         try {
             if (subscriptionModel.getReferenceType() == SubscriptionReferenceType.API_PRODUCT) {
-                return explodeApiProductSubscription(subscriptionModel);
+                return explodeApiProductSubscription(subscriptionModel, apiScope);
             }
 
             // Regular API subscription - return as single-item list
@@ -59,7 +71,10 @@ public class SubscriptionMapper {
         }
     }
 
-    private List<Subscription> explodeApiProductSubscription(io.gravitee.repository.management.model.Subscription subscriptionModel) {
+    private List<Subscription> explodeApiProductSubscription(
+        io.gravitee.repository.management.model.Subscription subscriptionModel,
+        Set<String> apiScope
+    ) {
         String productId = subscriptionModel.getReferenceId();
         if (productId == null) {
             log.warn("API Product subscription [{}] has null referenceId, skipping", subscriptionModel.getId());
@@ -84,9 +99,10 @@ public class SubscriptionMapper {
             return List.of();
         }
 
-        // Create one subscription per API in product
+        // Create one subscription per API in product, skipping APIs the caller is not handling now
         return apiIds
             .stream()
+            .filter(apiId -> apiScope == null || apiScope.contains(apiId))
             .map(apiId -> {
                 Subscription sub = toSubscription(subscriptionModel);
                 sub.setApi(apiId); // Override with individual API

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
@@ -44,6 +44,13 @@ import lombok.CustomLog;
 @CustomLog
 public class SubscriptionAppender {
 
+    /**
+     * Cap on the subscription ids listed in the "cannot find api" warning. The full list is
+     * unbounded — one such line has been observed at 64 KB — and it is built as a log argument, so
+     * the cost is paid whatever the configured log level.
+     */
+    private static final int WARN_SAMPLE_SIZE = 5;
+
     private static final List<String> INITIAL_STATUS = List.of(ACCEPTED.name());
     private static final List<String> INCREMENTAL_STATUS = List.of(ACCEPTED.name(), CLOSED.name(), PAUSED.name(), PENDING.name());
     private final SubscriptionRepository subscriptionRepository;
@@ -97,14 +104,20 @@ public class SubscriptionAppender {
         });
 
         if (!allPlans.isEmpty()) {
-            Map<String, List<Subscription>> subscriptionsByApi = loadSubscriptions(initialSync, allPlans, environments);
+            Map<String, List<Subscription>> subscriptionsByApi = loadSubscriptions(
+                initialSync,
+                allPlans,
+                environments,
+                deployableByApi.keySet()
+            );
             subscriptionsByApi.forEach((api, subscriptions) -> {
                 ApiReactorDeployable deployable = deployableByApi.get(api);
                 if (deployable == null) {
                     log.warn(
-                        "Cannot find api {} for subscriptions [{}]",
+                        "Cannot find api {} for {} subscription(s), sample: [{}]",
                         api,
-                        subscriptions.stream().map(Subscription::getId).collect(Collectors.joining(","))
+                        subscriptions.size(),
+                        subscriptions.stream().limit(WARN_SAMPLE_SIZE).map(Subscription::getId).collect(Collectors.joining(","))
                     );
                 } else {
                     deployable.subscriptions(subscriptions);
@@ -129,7 +142,8 @@ public class SubscriptionAppender {
     protected Map<String, List<Subscription>> loadSubscriptions(
         final boolean initialSync,
         final List<String> plans,
-        final Set<String> environments
+        final Set<String> environments,
+        final Set<String> apiScope
     ) {
         SubscriptionCriteria.SubscriptionCriteriaBuilder criteriaBuilder = SubscriptionCriteria.builder()
             .plans(plans)
@@ -160,7 +174,7 @@ public class SubscriptionAppender {
                 }
                 for (io.gravitee.repository.management.model.Subscription record : page) {
                     subscriptionMapper
-                        .to(record)
+                        .to(record, apiScope)
                         .forEach(converted -> {
                             converted.setForceDispatch(true);
                             grouped.computeIfAbsent(converted.getApi(), k -> new ArrayList<>()).add(converted);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -180,7 +181,35 @@ class ApiProductDeployerTest {
             cut.deploy(deployable).test().assertComplete();
 
             verify(subscriptionRefresher).unregisterRemovedApis(eq(Set.of("api-2")), eq(Set.of("plan-1")), eq(Set.of("env-1")));
-            verify(subscriptionRefresher).refresh(eq(Set.of("plan-1")), eq(Set.of("env-1")));
+        }
+
+        @Test
+        void should_not_register_subscriptions_on_deploy_since_the_api_sync_path_already_registers_them() {
+            ReactableApiProduct product = ReactableApiProduct.builder()
+                .id("api-product-123")
+                .name("Product")
+                .version("1.0")
+                .apiIds(Set.of("api-1", "api-2"))
+                .environmentId("env-1")
+                .build();
+
+            ApiProductReactorDeployable deployable = ApiProductReactorDeployable.builder()
+                .syncAction(SyncAction.DEPLOY)
+                .apiProductId("api-product-123")
+                .reactableApiProduct(product)
+                .subscribablePlans(Set.of("plan-1"))
+                .build();
+
+            when(apiProductManager.register(any(ReactableApiProduct.class), any(Completable.class))).thenAnswer(invocation ->
+                invocation.getArgument(1)
+            );
+
+            cut.deploy(deployable).test().assertComplete();
+
+            // Registering here duplicates what SubscriptionAppender does for every member API, both at
+            // initial sync (order API_PRODUCT runs before order API) and on a runtime product change
+            // (RepositoryApiMemberResyncTrigger re-runs the API pipeline for the member APIs).
+            verify(subscriptionRefresher, never()).refresh(any(), any());
         }
     }
 
@@ -411,7 +440,7 @@ class ApiProductDeployerTest {
     class DeployCallbackBehaviorTest {
 
         @Test
-        void should_invoke_registerApiProductPlans_and_subscriptionRefresher_when_callback_runs() {
+        void should_invoke_registerApiProductPlans_when_callback_runs() {
             when(apiProductManager.register(any(ReactableApiProduct.class), any(Completable.class))).thenAnswer(invocation ->
                 invocation.getArgument(1)
             );
@@ -435,7 +464,6 @@ class ApiProductDeployerTest {
             cut.deploy(deployable).test().assertComplete();
 
             verify(planService).register(deployable);
-            verify(subscriptionRefresher).refresh(Set.of("plan-1"), Set.of("env-id"));
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
@@ -205,9 +205,90 @@ class SubscriptionAppenderTest {
         Assertions.assertThat(memoryAppender.getLoggedEvents()).hasSize(1);
         SoftAssertions.assertSoftly(soft -> {
             var event = memoryAppender.getLoggedEvents().get(0);
-            soft.assertThat(event.getMessage()).contains("Cannot find api {} for subscriptions [{}]");
-            soft.assertThat(event.getArgumentArray()).contains("api3", "sub2,sub3");
+            soft.assertThat(event.getMessage()).contains("Cannot find api {} for {} subscription(s), sample: [{}]");
+            soft.assertThat(event.getArgumentArray()).contains("api3", 2, "sub2,sub3");
         });
+    }
+
+    @Test
+    void should_bound_the_warning_to_a_count_and_a_capped_sample() throws TechnicalException {
+        configureMemoryAppender();
+
+        List<io.gravitee.repository.management.model.Subscription> orphans = new java.util.ArrayList<>();
+        for (int i = 1; i <= 7; i++) {
+            io.gravitee.repository.management.model.Subscription sub = new io.gravitee.repository.management.model.Subscription();
+            sub.setId("orphan" + i);
+            sub.setPlan("plan1");
+            sub.setApi("apiNotInBatch");
+            orphans.add(sub);
+        }
+        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(orphans);
+        when(subscriptionRepository.searchAfter(any(), any(), org.mockito.ArgumentMatchers.notNull(), eq(BULK_ITEMS))).thenReturn(
+            List.of()
+        );
+
+        ApiReactorDeployable deployable = ApiReactorDeployable.builder()
+            .apiId("api1")
+            .reactableApi(mock(ReactableApi.class))
+            .subscribablePlans(new HashSet<>(Set.of("plan1")))
+            .apiKeyPlans(new HashSet<>(Set.of("plan1")))
+            .build();
+
+        cut.appends(true, List.of(deployable), Set.of("env"));
+
+        Assertions.assertThat(memoryAppender.getLoggedEvents()).hasSize(1);
+        var event = memoryAppender.getLoggedEvents().get(0);
+        String rendered = event.getFormattedMessage();
+        SoftAssertions.assertSoftly(soft -> {
+            // the count is reported in full...
+            soft.assertThat(rendered).contains("7");
+            // ...but the ID list is capped, so one warning can never grow with the subscription count
+            soft.assertThat(rendered).doesNotContain("orphan6");
+            soft.assertThat(rendered).doesNotContain("orphan7");
+        });
+    }
+
+    @Test
+    void should_not_expand_api_product_subscriptions_to_apis_outside_the_current_batch() throws TechnicalException {
+        configureMemoryAppender();
+
+        // Product "prod1" spans api1 (in this batch) and api2 (in some other batch of the same sync).
+        io.gravitee.gateway.handlers.api.ReactableApiProduct product = io.gravitee.gateway.handlers.api.ReactableApiProduct.builder()
+            .id("prod1")
+            .environmentId("env")
+            .apiIds(Set.of("api1", "api2"))
+            .build();
+        when(apiProductRegistry.get("prod1", "env")).thenReturn(product);
+        when(apiProductRegistry.getApiProductPlanEntriesForApi("api1", "env")).thenReturn(
+            List.of(
+                new io.gravitee.gateway.handlers.api.registry.ApiProductRegistry.ApiProductPlanEntry(
+                    "prod1",
+                    io.gravitee.definition.model.v4.plan.Plan.builder().id("pplan").build()
+                )
+            )
+        );
+
+        io.gravitee.repository.management.model.Subscription productSub = new io.gravitee.repository.management.model.Subscription();
+        productSub.setId("psub1");
+        productSub.setPlan("pplan");
+        productSub.setReferenceType(io.gravitee.repository.management.model.SubscriptionReferenceType.API_PRODUCT);
+        productSub.setReferenceId("prod1");
+        productSub.setEnvironmentId("env");
+        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(List.of(productSub));
+
+        ApiReactorDeployable onlyApi1 = ApiReactorDeployable.builder()
+            .apiId("api1")
+            .reactableApi(mock(ReactableApi.class))
+            .subscribablePlans(new HashSet<>())
+            .apiKeyPlans(new HashSet<>())
+            .build();
+
+        List<ApiReactorDeployable> deployables = cut.appends(true, List.of(onlyApi1), Set.of("env"));
+
+        // api1 still gets its product subscription...
+        assertThat(deployables.get(0).subscriptions()).hasSize(1);
+        // ...and api2 is never materialised, so nothing is discarded and nothing is logged.
+        Assertions.assertThat(memoryAppender.getLoggedEvents()).isEmpty();
     }
 
     private void configureMemoryAppender() {


### PR DESCRIPTION
> **Overlaps #18993 and #18994**, which were opened independently against `4.12.x` for the same
> incident within minutes of this work. See *Relationship to the other two PRs* at the bottom — this
> PR is the narrowest of the three and should probably be closed in favour of #18993 unless the
> warning treatment here is preferred.

## Problem

An API Product subscription is materialised once per member API. On a deployment where products span
several hundred APIs, gateway initial sync never finishes: the `sync-process` probe stays not-ready,
the pod is killed, and the whole sync restarts against the management API.

Three paths in the sync pipeline each expand the same product subscription set.

### 1. `ApiProductDeployer` registered the whole product subscription set per product

`deploy()` called `ApiProductSubscriptionRefresher.refresh()` for every product, which loads the
product's subscriptions and registers a leg for each member API. The API Product synchronizer
(`Order.API_PRODUCT` = 11) runs immediately before the API synchronizer (`Order.API` = 12), and the
list is walked with `concatMapCompletable`, so this ran strictly serially — one product at a time.

Measured on the reported deployment: **296 products in 280,795 ms, single-threaded on
`gio.sync-deployer-0`.**

### 2. `SubscriptionAppender` expanded across the whole product, then discarded most of it

`SubscriptionAppender` processes APIs in batches of `services.sync.bulk_items` (default 100), but
`SubscriptionMapper` exploded a product subscription across the product's *entire* API list. Legs for
APIs outside the current batch were allocated, grouped into a map, and dropped.

Because a product's APIs are spread across the event stream rather than grouped, nearly every batch
touches a large product.

### 3. Every discarded leg was logged with the full subscription id list

The warning joined all discarded subscription ids into one line:

```java
log.warn("Cannot find api {} for subscriptions [{}]", api,
         subscriptions.stream().map(Subscription::getId).collect(Collectors.joining(",")));
```

The joined string is built as a *method argument*, so it is allocated before the level check — the
allocation happens at any configured log level.

Measured across two log captures from the incident:

| | capture 1 | capture 2 |
|---|---|---|
| warning lines | 1,080 of 1,151 total lines | 205 |
| bytes per line | 64,839 (exactly, every line) | 49,835 avg |
| total | 66.8 MB in 6.06 s | 9.7 MB in 85 ms (~114 MB/s) |
| distinct APIs | 775 | — |

GC in the same window reported `Minor Collection (Allocation Rate)`.

## Changes

| File | Change |
|---|---|
| `SubscriptionMapper` | New overload `to(model, Set<String> apiScope)`. The scope is applied to the product's api ids **before** mapping, so out-of-scope legs are never allocated. `null` keeps the existing expand-everything behaviour. |
| `SubscriptionAppender` | Passes `deployableByApi.keySet()` — the batch it is actually handling — as the scope. |
| `SubscriptionAppender` | The warning now reports a count plus a sample capped at 5 ids, instead of joining every id. |
| `ApiProductDeployer` | Drops the deploy-time subscription registration. |

The unscoped `to(model)` overload is deliberately retained: `SubscriptionSynchronizer` (order 13) and
`LocalApiSynchronizer` handle single subscription events that must still reach every API of the
product.

### Why dropping the deploy-time registration is safe

`SubscriptionAppender` already registers a leg for every member API:

- **at initial sync**, because the API synchronizer runs immediately after the API Product
  synchronizer, over the same event set;
- **on a runtime product change**, because `ApiProductManagerImpl` emits a `DEPLOY` event that
  `RepositoryApiMemberResyncTrigger` consumes and re-runs the API pipeline for the member APIs.

`unregisterRemovedApis` is untouched — removing an API from a product still evicts its legs.

## Testing

`gravitee-apim-gateway-services-sync`: **681 tests, 0 failures, 0 errors**, run on the `4.12.x` base.

New tests:

- `should_not_expand_api_product_subscriptions_to_apis_outside_the_current_batch`
- `should_bound_the_warning_to_a_count_and_a_capped_sample` — 7 orphaned subscriptions, asserts the
  count is reported and that ids 6 and 7 do not appear
- `should_not_register_subscriptions_on_deploy_since_the_api_sync_path_already_registers_them`

## Not measured

There is **no before/after startup timing** and no reproduction at the 296-product / 775-API scale.
The tests prove the mechanism changed. They do not prove the pod starts. Whichever of these three
PRs is taken forward should be validated against a realistic product set before it is relied on.

## Relationship to the other two PRs

Three of us converged on the same batch-scoping fix independently.

| | #18993 | #18994 | this |
|---|---|---|---|
| Batch-scope the product explosion | yes (`Predicate<String>`) | yes (`Set<String>`) | yes (`Set<String>`) |
| Skip the deploy-time refresh | no — paginates it instead | yes, initial sync only | yes, entirely |
| Bound the warning | leaves it | count only | count + 5-id sample |
| Distributed sync path | — | yes | no |
| Paginate the refresher, `ACCEPTED` only | yes | — | no |
| `SyncConfiguration` pools stuck single-threaded | yes | — | no |
| `SubscriptionCacheService` leg index O(P)→O(1) | yes | — | no |

**#18993 covers strictly more than this PR.** It carries two findings absent here that look like they
matter more than the expansion itself: the sync executors never grew past one thread because
`corePoolSize` was 1 behind an unbounded queue, and registering a product leg was O(P), making a
warmup O(P²).

**#18994 covers the same ground as this PR** plus the distributed-sync path, which this PR does not
touch — that path was set aside here after distributed sync was confirmed disabled on the affected
deployment, but it is needed for a general fix.

Two differences here are worth keeping whichever PR wins:

- **The warning keeps a bounded sample rather than dropping the ids entirely.** A count alone tells
  you the batch skipped something; five ids let you go look at one. The whole-list join is what has
  to go, not the ids.
- **`ApiProductDeployer` drops the deploy-time registration outright** rather than gating it on
  initial sync. If the incremental path genuinely still needs it, the gated form in #18994 is the
  safer call and this is wrong — worth settling explicitly rather than by whichever merges first.
