### PR TITLE
perf(gateway): make API Product cold start scale with product size

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -59,10 +59,13 @@ public class SubscriptionCacheService implements SubscriptionService {
     // ConcurrentSkipListMap), which would double those side effects under contention.
     private final ConcurrentMap<IdentityKey, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
     private final ConcurrentMap<IdentityKey, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
-    // Single by-id index, including exploded API-Product subscriptions. Values are immutable sets
-    // (almost always a singleton), replaced atomically via compute(): keeps the per-entry footprint
-    // minimal at multi-million-subscription scale and lets readers use them without defensive copies.
-    private final ConcurrentMap<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
+    // Single by-id index, including exploded API-Product subscriptions. Each entry maps a leg's
+    // identity (api, environmentId) to its subscription, so registering one leg is an O(1) put.
+    // The previous immutable-set representation had to copy the whole set per registration, which
+    // made warming up an API Product quadratic in its API count: a product spanning P APIs cost
+    // ~P² element copies per subscription, which dominates cold start once P reaches the hundreds.
+    // Inner maps are ConcurrentHashMap so the outer compute() lambdas stay side-effect-safe.
+    private final ConcurrentMap<String, ConcurrentMap<LegKey, Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
     // Holds subscription ids only, for per-API eviction. Identity keys are not tracked here:
     // unregisterByApiId() re-derives them from the cached subscriptions, which keeps this index
     // at one entry per subscription instead of three (id + 2 identity keys) at multi-million scale.
@@ -74,6 +77,16 @@ public class SubscriptionCacheService implements SubscriptionService {
      * scale) and no String.format on the request hot path. A null plan is the plan-less variant.
      */
     private record IdentityKey(String api, String plan, String clientIdentity) {}
+
+    /**
+     * Identity of a single leg of a subscription. A plain API subscription has exactly one leg; an
+     * exploded API-Product subscription has one per API in the product.
+     */
+    private record LegKey(String api, String environmentId) {}
+
+    private static LegKey legKey(Subscription subscription) {
+        return new LegKey(subscription.getApi(), subscription.getEnvironmentId());
+    }
 
     @Override
     public Optional<Subscription> getByApiAndSecurityToken(String api, SecurityToken securityToken, String plan) {
@@ -99,20 +112,23 @@ public class SubscriptionCacheService implements SubscriptionService {
     public Optional<Subscription> getById(String subscriptionId) {
         // For exploded API-Product subscriptions this returns an arbitrary leg, which matches the
         // historical behavior of the dedicated by-id map (last-registered/rehydrated leg).
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        if (subscriptions == null || subscriptions.isEmpty()) {
+        ConcurrentMap<LegKey, Subscription> legs = cacheBySubscriptionIdAll.get(subscriptionId);
+        if (legs == null) {
             return Optional.empty();
         }
-        return Optional.of(subscriptions.iterator().next());
+        // hasNext() rather than isEmpty()-then-next(): a concurrent unregister may drain the map
+        // between the two calls.
+        Iterator<Subscription> iterator = legs.values().iterator();
+        return iterator.hasNext() ? Optional.of(iterator.next()) : Optional.empty();
     }
 
     /**
      * Returns all subscriptions for the given ID (multiple for exploded API Product subscriptions).
-     * The returned collection is immutable.
+     * The returned collection is an unmodifiable, weakly-consistent view of the cached legs.
      */
     public Collection<Subscription> getAllById(String subscriptionId) {
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        return subscriptions != null ? subscriptions : Collections.emptySet();
+        ConcurrentMap<LegKey, Subscription> legs = cacheBySubscriptionIdAll.get(subscriptionId);
+        return legs != null ? Collections.unmodifiableCollection(legs.values()) : Collections.emptySet();
     }
 
     @Override
@@ -148,48 +164,46 @@ public class SubscriptionCacheService implements SubscriptionService {
 
     @Override
     public void unregister(final Subscription candidate) {
-        // Use compute() so that the isEmpty-check-then-remove is atomic with respect to
-        // concurrent register() calls on the same subscription ID. Without this, a register()
-        // interleaved between isEmpty()=true and remove() would add a new entry to the set
-        // and then have that set orphaned by the remove().
-        cacheBySubscriptionIdAll.compute(candidate.getId(), (id, allSubscriptions) -> {
-            if (allSubscriptions == null) return null;
-
-            var toEvict = allSubscriptions
-                .stream()
-                .filter(s -> Objects.equals(candidate.getApi(), s.getApi()))
-                .toList();
-
-            if (toEvict.isEmpty()) {
-                return allSubscriptions;
-            }
-
-            toEvict.forEach(existing -> {
-                unregisterFromClientId(existing);
-                unregisterFromClientCertificate(existing);
-            });
-
-            evictKeyForApi(candidate.getApi(), candidate.getId());
-            // Handle the case where the candidate carries a different clientId/cert than
-            // what was cached (e.g. a status-change event arriving after a credential update).
-            if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientId(), candidate.getClientId()))) {
-                unregisterFromClientId(candidate);
-            }
-            if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientCertificate(), candidate.getClientCertificate()))) {
-                unregisterFromClientCertificate(candidate);
-            }
-
-            // Singleton fast path: toEvict is non-empty, so the only element is being evicted
-            if (allSubscriptions.size() == 1) {
-                return null;
-            }
-
-            Set<Subscription> remaining = allSubscriptions
-                .stream()
-                .filter(s -> !Objects.equals(candidate.getApi(), s.getApi()))
-                .collect(Collectors.toUnmodifiableSet());
-            return remaining.isEmpty() ? null : remaining;
+        // Use compute() so that the drain-then-remove is atomic with respect to concurrent
+        // register() calls on the same subscription ID. Without this, a register() interleaved
+        // between the emptiness check and the removal would add a leg and then have the whole
+        // entry orphaned by the removal.
+        // Legs are only collected under the bin lock; the identity-map and trust-store eviction
+        // (which hashes the client certificate) runs after compute returns, matching
+        // unregisterByApiId() and keeping the lock hold short.
+        List<Subscription> toEvict = new ArrayList<>();
+        cacheBySubscriptionIdAll.compute(candidate.getId(), (id, legs) -> {
+            if (legs == null) return null;
+            legs
+                .entrySet()
+                .removeIf(entry -> {
+                    if (Objects.equals(candidate.getApi(), entry.getKey().api())) {
+                        toEvict.add(entry.getValue());
+                        return true;
+                    }
+                    return false;
+                });
+            return legs.isEmpty() ? null : legs;
         });
+
+        if (toEvict.isEmpty()) {
+            return;
+        }
+
+        toEvict.forEach(existing -> {
+            unregisterFromClientId(existing);
+            unregisterFromClientCertificate(existing);
+        });
+
+        evictKeyForApi(candidate.getApi(), candidate.getId());
+        // Handle the case where the candidate carries a different clientId/cert than
+        // what was cached (e.g. a status-change event arriving after a credential update).
+        if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientId(), candidate.getClientId()))) {
+            unregisterFromClientId(candidate);
+        }
+        if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientCertificate(), candidate.getClientCertificate()))) {
+            unregisterFromClientCertificate(candidate);
+        }
     }
 
     @Override
@@ -206,25 +220,17 @@ public class SubscriptionCacheService implements SubscriptionService {
         // happens after each compute returns — those structures are not guarded by this lock.
         List<Subscription> evictedLegs = new ArrayList<>();
         subscriptionsByApi.forEach(subscriptionId ->
-            cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, all) -> {
-                // Singleton fast path: most entries hold exactly one leg
-                if (all.size() == 1) {
-                    Subscription single = all.iterator().next();
-                    if (Objects.equals(apiId, single.getApi())) {
-                        evictedLegs.add(single);
-                        return null;
-                    }
-                    return all;
-                }
-                Set<Subscription> remaining = new HashSet<>();
-                for (Subscription subscription : all) {
-                    if (Objects.equals(apiId, subscription.getApi())) {
-                        evictedLegs.add(subscription);
-                    } else {
-                        remaining.add(subscription);
-                    }
-                }
-                return remaining.isEmpty() ? null : Set.copyOf(remaining);
+            cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, legs) -> {
+                legs
+                    .entrySet()
+                    .removeIf(entry -> {
+                        if (Objects.equals(apiId, entry.getKey().api())) {
+                            evictedLegs.add(entry.getValue());
+                            return true;
+                        }
+                        return false;
+                    });
+                return legs.isEmpty() ? null : legs;
             })
         );
         // Same per-leg eviction as unregister(): identity maps and certificate trust store
@@ -252,12 +258,19 @@ public class SubscriptionCacheService implements SubscriptionService {
      * evicted when one API's leg is replaced.
      */
     private Subscription cachedSameApiLeg(final Subscription subscription) {
-        Set<Subscription> existingLegs = cacheBySubscriptionIdAll.get(subscription.getId());
-        if (existingLegs != null) {
-            for (Subscription existing : existingLegs) {
-                if (Objects.equals(subscription.getApi(), existing.getApi())) {
-                    return existing;
-                }
+        ConcurrentMap<LegKey, Subscription> legs = cacheBySubscriptionIdAll.get(subscription.getId());
+        if (legs == null) {
+            return null;
+        }
+        Subscription exact = legs.get(legKey(subscription));
+        if (exact != null) {
+            return exact;
+        }
+        // Fall back to an api-only match so a leg cached under a different environmentId (e.g.
+        // registered before the field was populated) is still found and evicted.
+        for (Subscription existing : legs.values()) {
+            if (Objects.equals(subscription.getApi(), existing.getApi())) {
+                return existing;
             }
         }
         return null;
@@ -295,31 +308,28 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private void registerFromClientId(final Subscription subscription) {
-        // Snapshot old entries before registering (cached sets are immutable)
-        Set<Subscription> cachedAll = cacheBySubscriptionIdAll.get(subscription.getId());
-        Set<Subscription> oldEntries = cachedAll != null ? cachedAll : Set.of();
+        // Only the same-API leg is ever acted on below, so look it up directly instead of
+        // snapshotting every leg: copying the full set here would have kept registration linear in
+        // the product's API count, i.e. quadratic over a full warmup.
+        Subscription cached = cachedSameApiLeg(subscription);
 
         updateSubscriptionIdById(subscription);
 
         // Register new subscription first
         updateIdentityCache(subscription, cacheByApiClientId);
 
-        // Then clean up old entries if clientId or plan changed (e.g. subscription transfer)
-        // Only compare entries for the same API — exploded subscriptions span multiple APIs
-        for (Subscription old : oldEntries) {
-            if (!Objects.equals(old.getApi(), subscription.getApi())) {
-                continue;
-            }
+        // Then clean up the old leg if clientId or plan changed (e.g. subscription transfer)
+        if (cached != null) {
             if (
-                (old.getClientId() != null && !old.getClientId().equals(subscription.getClientId())) ||
-                (old.getPlan() != null && !old.getPlan().equals(subscription.getPlan()))
+                (cached.getClientId() != null && !cached.getClientId().equals(subscription.getClientId())) ||
+                (cached.getPlan() != null && !cached.getPlan().equals(subscription.getPlan()))
             ) {
-                unregisterFromClientId(old);
+                unregisterFromClientId(cached);
             }
             // Credential-type switch: if the old leg was certificate-registered, its entries
             // live in the certificate map and trust store, never overwritten by this
             // clientId registration.
-            unregisterFromClientCertificate(old);
+            unregisterFromClientCertificate(cached);
         }
     }
 
@@ -341,28 +351,16 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private void updateSubscriptionIdById(Subscription subscription) {
-        cacheBySubscriptionIdAll.compute(subscription.getId(), (id, existing) -> {
-            if (existing == null || existing.isEmpty()) {
-                return Set.of(subscription);
-            }
-            // Singleton fast path: replacing the same api/environment leg needs no temporary set
-            if (existing.size() == 1) {
-                Subscription single = existing.iterator().next();
-                if (
-                    Objects.equals(single.getApi(), subscription.getApi()) &&
-                    Objects.equals(single.getEnvironmentId(), subscription.getEnvironmentId())
-                ) {
-                    return Set.of(subscription);
-                }
-            }
-            Set<Subscription> updated = new HashSet<>(existing);
-            updated.removeIf(
-                s ->
-                    Objects.equals(s.getApi(), subscription.getApi()) &&
-                    Objects.equals(s.getEnvironmentId(), subscription.getEnvironmentId())
-            );
-            updated.add(subscription);
-            return updated.size() == 1 ? Set.of(subscription) : Set.copyOf(updated);
+        // O(1) regardless of how many legs the subscription already has: the leg key is the
+        // (api, environmentId) pair the previous implementation matched on, so putting under that
+        // key replaces the same leg it used to filter out — without copying the set.
+        // compute() rather than computeIfAbsent()+put(): it keeps the inner-map creation and the
+        // put atomic against a concurrent unregister() removing the outer entry in between, which
+        // would otherwise orphan the leg we just registered.
+        cacheBySubscriptionIdAll.compute(subscription.getId(), (id, legs) -> {
+            ConcurrentMap<LegKey, Subscription> target = legs != null ? legs : new ConcurrentHashMap<>();
+            target.put(legKey(subscription), subscription);
+            return target;
         });
     }
 
@@ -411,14 +409,14 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private Optional<Subscription> getByApiAndId(String api, String subscriptionId) {
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        if (subscriptions == null || subscriptions.isEmpty()) {
+        ConcurrentMap<LegKey, Subscription> legs = cacheBySubscriptionIdAll.get(subscriptionId);
+        if (legs == null || legs.isEmpty()) {
             // Fallback to old cache for backward compatibility
             return getById(subscriptionId);
         }
-        // Plain loop: this runs on the request hot path for every API-key call and the set is
+        // Plain loop: this runs on the request hot path for every API-key call and the map is
         // almost always a singleton, so avoid allocating a Stream pipeline per request.
-        for (Subscription subscription : subscriptions) {
+        for (Subscription subscription : legs.values()) {
             if (Objects.equals(api, subscription.getApi())) {
                 return Optional.of(subscription);
             }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
@@ -112,8 +112,12 @@ public class SyncConfiguration {
     @Bean("syncFetcherExecutor")
     public ThreadPoolExecutor syncFetcherExecutor(@Value("${services.sync.fetcher:-1}") int syncFetcher) {
         int poolSize = syncFetcher != -1 ? syncFetcher : POOL_SIZE;
+        // Core size must equal the max size: ThreadPoolExecutor only grows past the core size when the
+        // queue rejects an offer, and the unbounded LinkedBlockingQueue below never does. With a core of
+        // 1 the pool stayed single-threaded forever, so services.sync.fetcher and the parallel() rails in
+        // AbstractApiSynchronizer had no effect. allowCoreThreadTimeOut keeps idle nodes cheap.
         final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
-            1,
+            poolSize,
             poolSize,
             15L,
             TimeUnit.SECONDS,
@@ -130,8 +134,11 @@ public class SyncConfiguration {
     @Bean("syncDeployerExecutor")
     public ThreadPoolExecutor syncDeployerExecutor(@Value("${services.sync.deployer:-1}") int syncDeployer) {
         int poolSize = syncDeployer != -1 ? syncDeployer : POOL_SIZE;
+        // See syncFetcherExecutor: core size must equal max size for the pool to ever grow past one
+        // thread. This is what makes the .parallel(getMaximumPoolSize()) fan-out in
+        // AbstractApiSynchronizer actually deploy APIs concurrently instead of serialising them.
         final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
-            1,
+            poolSize,
             poolSize,
             15L,
             TimeUnit.SECONDS,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployer.java
@@ -42,6 +42,22 @@ public class ApiProductDeployer implements Deployer<ApiProductReactorDeployable>
 
     @Override
     public Completable deploy(ApiProductReactorDeployable deployable) {
+        return deploy(deployable, true);
+    }
+
+    /**
+     * Deploys an API Product, optionally refreshing its subscriptions.
+     * <p>
+     * An initial sync should pass {@code false}. The API synchronizer runs immediately after the API
+     * Product synchronizer over the same event set, and its {@link
+     * io.gravitee.gateway.services.sync.process.repository.synchronizer.api.SubscriptionAppender}
+     * registers a leg for every member API anyway — so refreshing here builds and registers the
+     * whole product-subscription expansion a second time, serially, once per product.
+     * <p>
+     * Incremental deployments still refresh: a product whose API list or plans changed has no API
+     * event to piggyback on.
+     */
+    public Completable deploy(ApiProductReactorDeployable deployable, boolean refreshSubscriptions) {
         ReactableApiProduct reactableApiProduct = deployable.reactableApiProduct();
         String apiProductId = deployable.apiProductId();
 
@@ -68,7 +84,7 @@ public class ApiProductDeployer implements Deployer<ApiProductReactorDeployable>
             }
         }
         doBeforeEmit = doBeforeEmit.andThen(Completable.fromRunnable(() -> registerApiProductPlans(deployable)));
-        if (newApiIds != null && !newApiIds.isEmpty()) {
+        if (refreshSubscriptions && !newApiIds.isEmpty()) {
             doBeforeEmit = doBeforeEmit.andThen(
                 subscriptionRefresher.refresh(deployable.subscribablePlans(), Set.of(reactableApiProduct.getEnvironmentId()))
             );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
@@ -33,6 +33,7 @@ import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.reactivex.rxjava3.core.Completable;
@@ -48,6 +49,11 @@ import lombok.CustomLog;
 public class ApiProductSubscriptionRefresher {
 
     private static final List<String> INCREMENTAL_STATUS = List.of(ACCEPTED.name(), CLOSED.name(), PAUSED.name(), PENDING.name());
+    // The deploy path only ever registers ACCEPTED subscriptions (SubscriptionCacheService.register
+    // unregisters anything else), so pulling the other three statuses just to discard them scales
+    // the fetch with the deployment's whole subscription history. Eviction paths still need
+    // INCREMENTAL_STATUS: they must see a subscription that has left ACCEPTED.
+    private static final List<String> DEPLOY_STATUS = List.of(ACCEPTED.name());
 
     private final SubscriptionRepository subscriptionRepository;
     private final ApiKeyRepository apiKeyRepository;
@@ -151,7 +157,9 @@ public class ApiProductSubscriptionRefresher {
 
         return Completable.fromRunnable(() -> {
             try {
-                var repoSubs = loadSubscriptionModels(subscribablePlans, environments);
+                // Eviction path: keeps INCREMENTAL_STATUS so legs of subscriptions that have since
+                // left ACCEPTED are still unregistered for the removed APIs.
+                var repoSubs = loadSubscriptionModels(subscribablePlans, environments, INCREMENTAL_STATUS);
                 var subsToUnregister = repoSubs
                     .stream()
                     .filter(s -> s.getReferenceType() == SubscriptionReferenceType.API_PRODUCT)
@@ -182,25 +190,45 @@ public class ApiProductSubscriptionRefresher {
 
     private List<io.gravitee.repository.management.model.Subscription> loadSubscriptionModels(
         final Set<String> plans,
-        final Set<String> environments
+        final Set<String> environments,
+        final List<String> statuses
     ) {
-        SubscriptionCriteria.SubscriptionCriteriaBuilder criteriaBuilder = SubscriptionCriteria.builder()
-            .plans(plans)
-            .environments(environments)
-            .statuses(INCREMENTAL_STATUS);
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder().plans(plans).environments(environments).statuses(statuses).build();
+        // Keyset pagination, matching SubscriptionAppender and SubscriptionFetcher. The previous
+        // unpaginated search() returned every matching row in one response, which over the HTTP
+        // repository bridge is serialised into a single body on the mAPI event loop.
+        var sortable = new SortableBuilder().field("plan").order(Order.ASC).build();
 
+        List<io.gravitee.repository.management.model.Subscription> all = new ArrayList<>();
+        SubscriptionCursor cursor = null;
         try {
-            return subscriptionRepository.search(
-                criteriaBuilder.build(),
-                new SortableBuilder().field("updatedAt").order(Order.ASC).build()
-            );
+            while (true) {
+                List<io.gravitee.repository.management.model.Subscription> page = subscriptionRepository.searchAfter(
+                    criteria,
+                    sortable,
+                    cursor,
+                    bulkItems
+                );
+                if (page == null || page.isEmpty()) {
+                    return all;
+                }
+                all.addAll(page);
+                if (page.size() < bulkItems) {
+                    return all;
+                }
+                cursor = SubscriptionCursor.byPlanAndId(page.getLast().getPlan(), page.getLast().getId());
+            }
         } catch (Exception ex) {
             throw new SyncException("Error occurred when retrieving subscriptions for API Product", ex);
         }
     }
 
     private List<Subscription> loadSubscriptions(final Set<String> plans, final Set<String> environments) {
-        List<io.gravitee.repository.management.model.Subscription> repoSubscriptions = loadSubscriptionModels(plans, environments);
+        List<io.gravitee.repository.management.model.Subscription> repoSubscriptions = loadSubscriptionModels(
+            plans,
+            environments,
+            DEPLOY_STATUS
+        );
         return repoSubscriptions
             .stream()
             .flatMap(subscription -> subscriptionMapper.to(subscription).stream())

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Predicate;
+import java.util.stream.Stream;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -47,26 +47,27 @@ public class SubscriptionMapper {
     private final ApiProductRegistry apiProductRegistry;
 
     public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel) {
-        return to(subscriptionModel, apiId -> true);
+        return to(subscriptionModel, null);
     }
 
     /**
-     * Maps a subscription model, restricting an API-Product explosion to the APIs passing
-     * {@code apiFilter}.
+     * Maps a subscription model, restricting an API-Product explosion to {@code retainedApis}.
      * <p>
      * Callers that deploy a bounded set of APIs — the sync appenders, which work one batch at a
      * time — should pass that set. A product subscription otherwise materialises one leg per API in
      * the entire product and the caller throws away every leg outside its batch: for a product
      * spanning P APIs synced in batches of B, that allocated P/B times more objects than it kept.
      * <p>
-     * The filter deliberately does not apply to plain API subscriptions. Those carry exactly one
-     * leg, and an api outside the caller's batch means the subscription's api disagrees with the
+     * The restriction deliberately does not apply to plain API subscriptions. Those carry exactly
+     * one leg, and an api outside the caller's batch means the subscription's api disagrees with the
      * API owning its plan — a data inconsistency the caller should surface, not silently drop.
+     *
+     * @param retainedApis APIs to expand for, or {@code null} to expand across the whole product.
      */
-    public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel, Predicate<String> apiFilter) {
+    public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel, Set<String> retainedApis) {
         try {
             if (subscriptionModel.getReferenceType() == SubscriptionReferenceType.API_PRODUCT) {
-                return explodeApiProductSubscription(subscriptionModel, apiFilter);
+                return explodeApiProductSubscription(subscriptionModel, retainedApis);
             }
 
             // Regular API subscription - return as single-item list
@@ -79,7 +80,7 @@ public class SubscriptionMapper {
 
     private List<Subscription> explodeApiProductSubscription(
         io.gravitee.repository.management.model.Subscription subscriptionModel,
-        Predicate<String> apiFilter
+        Set<String> retainedApis
     ) {
         String productId = subscriptionModel.getReferenceId();
         if (productId == null) {
@@ -105,11 +106,16 @@ public class SubscriptionMapper {
             return List.of();
         }
 
-        // Create one subscription per API in product, skipping APIs the caller has no use for
-        // (filter applied before mapping so discarded legs are never allocated)
-        return apiIds
-            .stream()
-            .filter(apiFilter)
+        // Create one subscription per API in product, skipping APIs the caller has no use for.
+        // The restriction is applied before mapping, so discarded legs are never allocated, and it
+        // walks the smaller of the two sets: a batch of B APIs against a product of P costs
+        // min(B, P) lookups rather than always P.
+        Stream<String> expandedApis = retainedApis == null
+            ? apiIds.stream()
+            : (retainedApis.size() < apiIds.size()
+                    ? retainedApis.stream().filter(apiIds::contains)
+                    : apiIds.stream().filter(retainedApis::contains));
+        return expandedApis
             .map(apiId -> {
                 Subscription sub = toSubscription(subscriptionModel);
                 sub.setApi(apiId); // Override with individual API

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -46,9 +47,26 @@ public class SubscriptionMapper {
     private final ApiProductRegistry apiProductRegistry;
 
     public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel) {
+        return to(subscriptionModel, apiId -> true);
+    }
+
+    /**
+     * Maps a subscription model, restricting an API-Product explosion to the APIs passing
+     * {@code apiFilter}.
+     * <p>
+     * Callers that deploy a bounded set of APIs — the sync appenders, which work one batch at a
+     * time — should pass that set. A product subscription otherwise materialises one leg per API in
+     * the entire product and the caller throws away every leg outside its batch: for a product
+     * spanning P APIs synced in batches of B, that allocated P/B times more objects than it kept.
+     * <p>
+     * The filter deliberately does not apply to plain API subscriptions. Those carry exactly one
+     * leg, and an api outside the caller's batch means the subscription's api disagrees with the
+     * API owning its plan — a data inconsistency the caller should surface, not silently drop.
+     */
+    public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel, Predicate<String> apiFilter) {
         try {
             if (subscriptionModel.getReferenceType() == SubscriptionReferenceType.API_PRODUCT) {
-                return explodeApiProductSubscription(subscriptionModel);
+                return explodeApiProductSubscription(subscriptionModel, apiFilter);
             }
 
             // Regular API subscription - return as single-item list
@@ -59,7 +77,10 @@ public class SubscriptionMapper {
         }
     }
 
-    private List<Subscription> explodeApiProductSubscription(io.gravitee.repository.management.model.Subscription subscriptionModel) {
+    private List<Subscription> explodeApiProductSubscription(
+        io.gravitee.repository.management.model.Subscription subscriptionModel,
+        Predicate<String> apiFilter
+    ) {
         String productId = subscriptionModel.getReferenceId();
         if (productId == null) {
             log.warn("API Product subscription [{}] has null referenceId, skipping", subscriptionModel.getId());
@@ -84,9 +105,11 @@ public class SubscriptionMapper {
             return List.of();
         }
 
-        // Create one subscription per API in product
+        // Create one subscription per API in product, skipping APIs the caller has no use for
+        // (filter applied before mapping so discarded legs are never allocated)
         return apiIds
             .stream()
+            .filter(apiFilter)
             .map(apiId -> {
                 Subscription sub = toSubscription(subscriptionModel);
                 sub.setApi(apiId); // Override with individual API

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/AbstractDistributedSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/AbstractDistributedSynchronizer.java
@@ -68,7 +68,9 @@ public abstract class AbstractDistributedSynchronizer<T extends Deployable, Y ex
                     .runOn(Schedulers.from(syncDeployerExecutor))
                     .flatMap(deployable -> {
                         if (deployable.syncAction() == SyncAction.DEPLOY) {
-                            return deploy(deployer, deployable).onErrorResumeNext(throwable -> resumeOnError(initialSync, throwable));
+                            return deployAndAfter(deployer, deployable, initialSync).onErrorResumeNext(throwable ->
+                                resumeOnError(initialSync, throwable)
+                            );
                         } else if (deployable.syncAction() == SyncAction.UNDEPLOY) {
                             return undeploy(deployer, deployable).onErrorResumeNext(throwable -> resumeOnError(initialSync, throwable));
                         } else {
@@ -105,8 +107,13 @@ public abstract class AbstractDistributedSynchronizer<T extends Deployable, Y ex
 
     protected abstract Y createDeployer();
 
-    private Flowable<T> deploy(final Y apiDeployer, final T deployable) {
-        return apiDeployer.deploy(deployable).andThen(apiDeployer.doAfterDeployment(deployable)).andThen(Flowable.just(deployable));
+    /** Allows a synchronizer to specialize deployment behavior for an initial sync. */
+    protected Completable deploy(final Y deployer, final T deployable, final boolean initialSync) {
+        return deployer.deploy(deployable);
+    }
+
+    private Flowable<T> deployAndAfter(final Y deployer, final T deployable, final boolean initialSync) {
+        return deploy(deployer, deployable, initialSync).andThen(deployer.doAfterDeployment(deployable)).andThen(Flowable.just(deployable));
     }
 
     private Flowable<T> undeploy(final Y apiDeployer, final T deployable) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizer.java
@@ -24,6 +24,7 @@ import io.gravitee.gateway.services.sync.process.distributed.synchronizer.Abstra
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.apiproduct.ApiProductReactorDeployable;
 import io.gravitee.repository.distributedsync.model.DistributedEvent;
 import io.gravitee.repository.distributedsync.model.DistributedEventType;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import java.util.concurrent.ThreadPoolExecutor;
 import lombok.CustomLog;
@@ -59,6 +60,15 @@ public class DistributedApiProductSynchronizer extends AbstractDistributedSynchr
     @Override
     protected ApiProductDeployer createDeployer() {
         return deployerFactory.createApiProductDeployer();
+    }
+
+    @Override
+    protected Completable deploy(
+        final ApiProductDeployer deployer,
+        final ApiProductReactorDeployable deployable,
+        final boolean initialSync
+    ) {
+        return deployer.deploy(deployable, !initialSync);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
@@ -34,11 +34,11 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 
@@ -47,6 +47,8 @@ public class SubscriptionAppender {
 
     private static final List<String> INITIAL_STATUS = List.of(ACCEPTED.name());
     private static final List<String> INCREMENTAL_STATUS = List.of(ACCEPTED.name(), CLOSED.name(), PAUSED.name(), PENDING.name());
+    /** Enough ids to go look one up, few enough that a broken dataset cannot flood the log. */
+    private static final int WARN_SAMPLE_SIZE = 5;
     private final SubscriptionRepository subscriptionRepository;
     private final SubscriptionMapper subscriptionMapper;
     private final ApiProductRegistry apiProductRegistry;
@@ -81,8 +83,9 @@ public class SubscriptionAppender {
             .stream()
             .collect(Collectors.toMap(ApiReactorDeployable::apiId, d -> d));
 
-        List<String> apiPlans = collectApiPlans(deployableByApi);
-        List<String> allPlans = new ArrayList<>(apiPlans);
+        // A Set, not a List: the same product plan is collected once per member API in the batch, and
+        // every duplicate widened the repository's plan criteria for no extra rows.
+        Set<String> allPlans = new HashSet<>(collectApiPlans(deployableByApi));
 
         deployableByApi.forEach((apiId, deployable) -> {
             Set<String> envs = environments != null && !environments.isEmpty()
@@ -115,10 +118,14 @@ public class SubscriptionAppender {
             subscriptionsByApi.forEach((api, subscriptions) -> {
                 ApiReactorDeployable deployable = deployableByApi.get(api);
                 if (deployable == null) {
+                    // A count and a capped sample, never the whole id list. Joining every id
+                    // produced single log lines of 64 KB, built as a method argument — so allocated
+                    // before the level check, at any configured level.
                     log.warn(
-                        "Cannot find api {} for subscriptions [{}]",
+                        "Cannot find api {} for {} subscription(s), sample: [{}]",
                         api,
-                        subscriptions.stream().map(Subscription::getId).collect(Collectors.joining(","))
+                        subscriptions.size(),
+                        subscriptions.stream().limit(WARN_SAMPLE_SIZE).map(Subscription::getId).collect(Collectors.joining(","))
                     );
                 } else {
                     deployable.subscriptions(subscriptions);
@@ -142,7 +149,7 @@ public class SubscriptionAppender {
 
     protected Map<String, List<Subscription>> loadSubscriptions(
         final boolean initialSync,
-        final List<String> plans,
+        final Collection<String> plans,
         final Set<String> environments
     ) {
         return loadSubscriptions(initialSync, plans, environments, null);
@@ -153,11 +160,10 @@ public class SubscriptionAppender {
      */
     protected Map<String, List<Subscription>> loadSubscriptions(
         final boolean initialSync,
-        final List<String> plans,
+        final Collection<String> plans,
         final Set<String> environments,
         final Set<String> retainedApis
     ) {
-        final Predicate<String> apiFilter = retainedApis == null ? apiId -> true : retainedApis::contains;
         SubscriptionCriteria.SubscriptionCriteriaBuilder criteriaBuilder = SubscriptionCriteria.builder()
             .plans(plans)
             .environments(environments);
@@ -187,7 +193,7 @@ public class SubscriptionAppender {
                 }
                 for (io.gravitee.repository.management.model.Subscription record : page) {
                     subscriptionMapper
-                        .to(record, apiFilter)
+                        .to(record, retainedApis)
                         .forEach(converted -> {
                             converted.setForceDispatch(true);
                             grouped.computeIfAbsent(converted.getApi(), k -> new ArrayList<>()).add(converted);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 
@@ -97,7 +98,20 @@ public class SubscriptionAppender {
         });
 
         if (!allPlans.isEmpty()) {
-            Map<String, List<Subscription>> subscriptionsByApi = loadSubscriptions(initialSync, allPlans, environments);
+            // Restrict the API-Product explosion to this batch's APIs. Product subscriptions were
+            // otherwise exploded across every API in the product and each leg outside the batch
+            // discarded here — for a product spanning P APIs synced in batches of B, that allocated
+            // P/B times more legs than it kept, and logged the full subscription id list per
+            // discarded API.
+            // Plain API subscriptions are still mapped unfiltered, so the warning below keeps
+            // reporting the case it was written for: a subscription whose api disagrees with the
+            // API owning its plan.
+            Map<String, List<Subscription>> subscriptionsByApi = loadSubscriptions(
+                initialSync,
+                allPlans,
+                environments,
+                deployableByApi.keySet()
+            );
             subscriptionsByApi.forEach((api, subscriptions) -> {
                 ApiReactorDeployable deployable = deployableByApi.get(api);
                 if (deployable == null) {
@@ -131,6 +145,19 @@ public class SubscriptionAppender {
         final List<String> plans,
         final Set<String> environments
     ) {
+        return loadSubscriptions(initialSync, plans, environments, null);
+    }
+
+    /**
+     * @param retainedApis APIs whose legs should be materialised, or {@code null} to keep every leg.
+     */
+    protected Map<String, List<Subscription>> loadSubscriptions(
+        final boolean initialSync,
+        final List<String> plans,
+        final Set<String> environments,
+        final Set<String> retainedApis
+    ) {
+        final Predicate<String> apiFilter = retainedApis == null ? apiId -> true : retainedApis::contains;
         SubscriptionCriteria.SubscriptionCriteriaBuilder criteriaBuilder = SubscriptionCriteria.builder()
             .plans(plans)
             .environments(environments);
@@ -160,7 +187,7 @@ public class SubscriptionAppender {
                 }
                 for (io.gravitee.repository.management.model.Subscription record : page) {
                     subscriptionMapper
-                        .to(record)
+                        .to(record, apiFilter)
                         .forEach(converted -> {
                             converted.setForceDispatch(true);
                             grouped.computeIfAbsent(converted.getApi(), k -> new ArrayList<>()).add(converted);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizer.java
@@ -70,6 +70,7 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
 
     @Override
     public Completable synchronize(final Long from, final Long to, final Set<String> environments) {
+        boolean initialSync = from == null || from == -1;
         AtomicLong launchTime = new AtomicLong();
 
         return eventsFetcher
@@ -78,11 +79,11 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
                 to,
                 Event.EventProperties.API_PRODUCT_ID,
                 environments,
-                from == -1 ? INIT_EVENT_TYPES : INCREMENTAL_EVENT_TYPES
+                initialSync ? INIT_EVENT_TYPES : INCREMENTAL_EVENT_TYPES
             )
             .subscribeOn(Schedulers.from(syncFetcherExecutor))
             .rebatchRequests(syncFetcherExecutor.getMaximumPoolSize())
-            .compose(this::processEvents)
+            .compose(events -> processEvents(events, initialSync))
             .count()
             .doOnSubscribe(disposable -> launchTime.set(Instant.now().toEpochMilli()))
             .doOnSuccess(count -> {
@@ -91,7 +92,7 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
                     count,
                     (System.currentTimeMillis() - launchTime.get())
                 );
-                if (from == -1) {
+                if (initialSync) {
                     log.info(logMsg);
                 } else {
                     log.debug(logMsg);
@@ -105,7 +106,7 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
         return Order.API_PRODUCT.index();
     }
 
-    private Flowable<ApiProductReactorDeployable> processEvents(final Flowable<List<Event>> eventsFlowable) {
+    private Flowable<ApiProductReactorDeployable> processEvents(final Flowable<List<Event>> eventsFlowable, final boolean initialSync) {
         return eventsFlowable
             // fetch per page
             .flatMap(events ->
@@ -131,7 +132,7 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
                     .runOn(Schedulers.from(syncDeployerExecutor))
                     .flatMap(deployable -> {
                         if (deployable.syncAction() == SyncAction.DEPLOY) {
-                            return deployApiProduct(apiProductDeployer, deployable);
+                            return deployApiProduct(apiProductDeployer, deployable, initialSync);
                         } else if (deployable.syncAction() == SyncAction.UNDEPLOY) {
                             return undeployApiProduct(apiProductDeployer, deployable);
                         } else {
@@ -166,10 +167,11 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
 
     private Flowable<ApiProductReactorDeployable> deployApiProduct(
         ApiProductDeployer apiProductDeployer,
-        final ApiProductReactorDeployable deployable
+        final ApiProductReactorDeployable deployable,
+        final boolean initialSync
     ) {
         return apiProductDeployer
-            .deploy(deployable)
+            .deploy(deployable, !initialSync)
             .andThen(apiProductDeployer.doAfterDeployment(deployable))
             .andThen(Flowable.just(deployable))
             .onErrorResumeNext(throwable -> {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/SyncConfigurationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/SyncConfigurationTest.java
@@ -21,11 +21,19 @@ import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatch
 import io.gravitee.gateway.services.sync.process.deployer.NoOpSubscriptionDispatcher;
 import io.gravitee.gateway.services.sync.process.repository.service.PlanService;
 import io.reactivex.rxjava3.core.Completable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
 /**
@@ -52,6 +60,45 @@ class SyncConfigurationTest {
     @Test
     void should_provide_plan_service() {
         Assertions.assertThat(cut.planService()).isInstanceOf(PlanService.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("syncExecutors")
+    void should_run_tasks_concurrently_on_a_sync_executor(String name, Function<Integer, ThreadPoolExecutor> factory)
+        throws InterruptedException {
+        final int poolSize = 3;
+        final ThreadPoolExecutor executor = factory.apply(poolSize);
+        try {
+            // Behavioural, not structural: each task blocks until every other task has started, so the
+            // latch can only reach zero if the pool really runs them in parallel. A pool that stays
+            // single-threaded — as both did while corePoolSize was 1 behind an unbounded queue, which
+            // never rejects and so never triggers growth — deadlocks here and the await times out.
+            final CountDownLatch started = new CountDownLatch(poolSize);
+            for (int i = 0; i < poolSize; i++) {
+                executor.execute(() -> {
+                    started.countDown();
+                    try {
+                        started.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+            }
+
+            Assertions.assertThat(started.await(5, TimeUnit.SECONDS)).as("%s ran %d tasks concurrently", name, poolSize).isTrue();
+            // Idle threads must still expire, so an idle gateway does not hold the extra threads.
+            Assertions.assertThat(executor.allowsCoreThreadTimeOut()).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static Stream<Arguments> syncExecutors() {
+        final SyncConfiguration configuration = new SyncConfiguration();
+        return Stream.of(
+            Arguments.of("syncFetcherExecutor", (Function<Integer, ThreadPoolExecutor>) configuration::syncFetcherExecutor),
+            Arguments.of("syncDeployerExecutor", (Function<Integer, ThreadPoolExecutor>) configuration::syncDeployerExecutor)
+        );
     }
 
     private static class DummySubscriptionDispatcher implements SubscriptionDispatcher {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
@@ -204,6 +204,40 @@ class ApiProductDeployerTest {
             verify(subscriptionRefresher).unregisterRemovedApis(eq(Set.of("api-2")), eq(Set.of("plan-1")), eq(Set.of("env-1")));
             verify(subscriptionRefresher).refresh(eq(Set.of("plan-1")), eq(Set.of("env-1")));
         }
+
+        @Test
+        void should_unregister_removed_apis_even_when_subscription_refresh_is_skipped() {
+            ReactableApiProduct oldProduct = ReactableApiProduct.builder()
+                .id("api-product-123")
+                .apiIds(Set.of("api-1", "api-2"))
+                .environmentId("env-1")
+                .build();
+
+            ReactableApiProduct newProduct = ReactableApiProduct.builder()
+                .id("api-product-123")
+                .name("Updated Product")
+                .version("1.0")
+                .apiIds(Set.of("api-1"))
+                .environmentId("env-1")
+                .deployedAt(new Date())
+                .build();
+
+            ApiProductReactorDeployable deployable = ApiProductReactorDeployable.builder()
+                .syncAction(SyncAction.DEPLOY)
+                .apiProductId("api-product-123")
+                .reactableApiProduct(newProduct)
+                .subscribablePlans(Set.of("plan-1"))
+                .build();
+
+            when(apiProductManager.get("api-product-123")).thenReturn(oldProduct);
+
+            cut.deploy(deployable, false).test().assertComplete();
+
+            // Eviction of removed APIs is not gated by the refresh flag: legs of an API that left
+            // the product must go even during an initial sync, where only the refresh is redundant.
+            verify(subscriptionRefresher).unregisterRemovedApis(eq(Set.of("api-2")), eq(Set.of("plan-1")), eq(Set.of("env-1")));
+            verify(subscriptionRefresher, never()).refresh(anySet(), anySet());
+        }
     }
 
     @Nested

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -124,6 +125,27 @@ class ApiProductDeployerTest {
 
             cut.deploy(deployable).test().assertComplete();
             verify(apiProductManager).register(eq(reactableApiProduct), any(Completable.class));
+        }
+
+        @Test
+        void should_skip_subscription_refresh_when_requested() {
+            ReactableApiProduct reactableApiProduct = ReactableApiProduct.builder()
+                .id("api-product-initial")
+                .name("Initial Product")
+                .apiIds(Set.of("api-1"))
+                .environmentId("env-id")
+                .build();
+            ApiProductReactorDeployable deployable = ApiProductReactorDeployable.builder()
+                .syncAction(SyncAction.DEPLOY)
+                .apiProductId("api-product-initial")
+                .reactableApiProduct(reactableApiProduct)
+                .subscribablePlans(Set.of("plan-1"))
+                .build();
+
+            cut.deploy(deployable, false).test().assertComplete();
+
+            verify(planService).register(deployable);
+            verify(subscriptionRefresher, never()).refresh(anySet(), anySet());
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.sync.process.common.deployer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -104,14 +105,14 @@ class ApiProductSubscriptionRefresherTest {
         void returns_complete_when_plans_null_or_empty() throws TechnicalException {
             cut.refresh(null, Set.of(ENV_1)).test().assertComplete();
             cut.refresh(Set.of(), Set.of(ENV_1)).test().assertComplete();
-            verify(subscriptionRepository, never()).search(any(), any());
+            verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), anyInt());
         }
 
         @Test
         void loads_and_deploys_subscriptions() throws TechnicalException {
             var repoSub = productSubscription(SUB_1, PLAN_1, ENV_1);
             var gatewaySub = Subscription.builder().id(SUB_1).api(API_1).plan(PLAN_1).build();
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoSub));
             when(subscriptionMapper.to(repoSub)).thenReturn(List.of(gatewaySub));
 
             cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
@@ -125,7 +126,7 @@ class ApiProductSubscriptionRefresherTest {
             var gatewaySub = Subscription.builder().id(SUB_1).api(API_1).plan(PLAN_1).build();
             var repoKey = productApiKey(KEY_ID, ENV_1, SUB_1);
             var gatewayKey = ApiKey.builder().id(KEY_ID).api(API_1).subscription(SUB_1).build();
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoSub));
             when(subscriptionMapper.to(repoSub)).thenReturn(List.of(gatewaySub));
             when(apiKeyRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoKey));
             when(apiKeyMapper.to(repoKey, gatewaySub)).thenReturn(gatewayKey);
@@ -138,11 +139,11 @@ class ApiProductSubscriptionRefresherTest {
 
         @Test
         void does_not_call_api_key_repository_when_no_subscriptions() throws TechnicalException {
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of());
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of());
 
             cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
 
-            verify(subscriptionRepository).search(any(), any());
+            verify(subscriptionRepository).searchAfter(any(), any(), any(), eq(BULK_ITEMS));
             verify(apiKeyRepository, never()).searchAfter(any(), any(), any(), any(int.class));
         }
 
@@ -165,7 +166,7 @@ class ApiProductSubscriptionRefresherTest {
             var repoSubs = IntStream.range(0, 5)
                 .mapToObj(i -> productSubscription("sub" + i, PLAN_1, ENV_1))
                 .toList();
-            when(subscriptionRepository.search(any(), any())).thenReturn(repoSubs);
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(repoSubs);
             var gatewaySubs = IntStream.range(0, 5)
                 .mapToObj(i -> Subscription.builder().id("sub" + i).api(API_1).plan(PLAN_1).build())
                 .toList();
@@ -209,7 +210,7 @@ class ApiProductSubscriptionRefresherTest {
 
         @Test
         void throws_when_repository_fails() throws TechnicalException {
-            when(subscriptionRepository.search(any(), any())).thenThrow(new TechnicalException("DB error"));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenThrow(new TechnicalException("DB error"));
 
             var thrown = catchThrowable(() -> cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).blockingAwait());
 
@@ -227,13 +228,13 @@ class ApiProductSubscriptionRefresherTest {
         void returns_complete_when_removedApiIds_null_or_empty() throws TechnicalException {
             cut.unregisterRemovedApis(null, Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
             cut.unregisterRemovedApis(Set.of(), Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
-            verify(subscriptionRepository, never()).search(any(), any());
+            verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), anyInt());
         }
 
         @Test
         void returns_complete_when_plans_empty() throws TechnicalException {
             cut.unregisterRemovedApis(Set.of("api-removed"), Set.of(), Set.of(ENV_1)).test().assertComplete();
-            verify(subscriptionRepository, never()).search(any(), any());
+            verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), anyInt());
         }
 
         @Test
@@ -243,7 +244,7 @@ class ApiProductSubscriptionRefresherTest {
             var repoKey = productApiKey(KEY_ID, ENV_1, SUB_1);
             var gatewayKey = ApiKey.builder().id(KEY_ID).api("api-removed").subscription(SUB_1).build();
 
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoSub));
             when(subscriptionMapper.toSubscriptionForApi(repoSub, "api-removed")).thenReturn(subForRemoved);
             when(apiKeyRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoKey));
             when(apiKeyMapper.to(repoKey, subForRemoved)).thenReturn(gatewayKey);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizerTest.java
@@ -77,7 +77,7 @@ class DistributedApiProductSynchronizerTest {
         );
         when(eventsFetcher.bulkItems()).thenReturn(1);
         lenient().when(deployerFactory.createApiProductDeployer()).thenReturn(apiProductDeployer);
-        lenient().when(apiProductDeployer.deploy(any())).thenReturn(Completable.complete());
+        lenient().when(apiProductDeployer.deploy(any(), anyBoolean())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.doAfterDeployment(any())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.undeploy(any())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.doAfterUndeployment(any())).thenReturn(Completable.complete());
@@ -146,7 +146,26 @@ class DistributedApiProductSynchronizerTest {
             when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.just(distributedEvent));
             cut.synchronize(-1L, Instant.now().toEpochMilli()).test().await().assertComplete();
 
-            verify(apiProductDeployer).deploy(any());
+            verify(apiProductDeployer).deploy(any(), eq(false));
+            verify(apiProductDeployer).doAfterDeployment(any());
+        }
+
+        @Test
+        void should_refresh_subscriptions_when_fetching_incremental_deploy_event() throws InterruptedException, JsonProcessingException {
+            DistributedEvent distributedEvent = DistributedEvent.builder()
+                .id("product-id")
+                .payload(objectMapper.writeValueAsString(reactableApiProduct))
+                .type(DistributedEventType.API_PRODUCT)
+                .syncAction(DistributedSyncAction.DEPLOY)
+                .updatedAt(new Date())
+                .build();
+            long from = Instant.now().minusSeconds(1).toEpochMilli();
+
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.just(distributedEvent));
+
+            cut.synchronize(from, Instant.now().toEpochMilli()).test().await().assertComplete();
+
+            verify(apiProductDeployer).deploy(any(), eq(true));
             verify(apiProductDeployer).doAfterDeployment(any());
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
@@ -202,6 +202,27 @@ class SubscriptionMapperTest {
     }
 
     @Test
+    void should_explode_api_product_subscription_only_for_target_apis() {
+        subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
+        subscription.setReferenceId("product-1");
+        subscription.setApi(null);
+        subscription.setEnvironmentId("env-1");
+        ApiProductRegistry registry = mock(ApiProductRegistry.class);
+        ReactableApiProduct product = ReactableApiProduct.builder().id("product-1").apiIds(Set.of("api1", "api2", "api3")).build();
+        when(registry.get("product-1", "env-1")).thenReturn(product);
+        cut = new SubscriptionMapper(objectMapper, registry);
+
+        List<io.gravitee.gateway.api.service.Subscription> mapped = cut.to(subscription, Set.of("api2", "api-outside-product"));
+
+        assertThat(mapped)
+            .singleElement()
+            .satisfies(mappedSubscription -> {
+                assertThat(mappedSubscription.getApi()).isEqualTo("api2");
+                assertThat(mappedSubscription.getApiProductId()).isEqualTo("product-1");
+            });
+    }
+
+    @Test
     void should_return_empty_list_when_api_product_subscription_has_null_reference_id() {
         subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
         subscription.setReferenceId(null);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
@@ -223,6 +223,29 @@ class SubscriptionMapperTest {
     }
 
     @Test
+    void should_restrict_explosion_to_target_apis_when_product_is_smaller_than_target_set() {
+        subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
+        subscription.setReferenceId("product-1");
+        subscription.setApi(null);
+        subscription.setEnvironmentId("env-1");
+        ApiProductRegistry registry = mock(ApiProductRegistry.class);
+        // Two product APIs against five target APIs: the explosion walks the product's api list
+        // (the smaller set) and must still intersect it with the targets, not keep it whole.
+        ReactableApiProduct product = ReactableApiProduct.builder().id("product-1").apiIds(Set.of("api1", "api-not-deployed")).build();
+        when(registry.get("product-1", "env-1")).thenReturn(product);
+        cut = new SubscriptionMapper(objectMapper, registry);
+
+        List<io.gravitee.gateway.api.service.Subscription> mapped = cut.to(subscription, Set.of("api1", "api2", "api3", "api4", "api5"));
+
+        assertThat(mapped)
+            .singleElement()
+            .satisfies(mappedSubscription -> {
+                assertThat(mappedSubscription.getApi()).isEqualTo("api1");
+                assertThat(mappedSubscription.getApiProductId()).isEqualTo("product-1");
+            });
+    }
+
+    @Test
     void should_return_empty_list_when_api_product_subscription_has_null_reference_id() {
         subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
         subscription.setReferenceId(null);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
@@ -241,8 +241,11 @@ class SubscriptionAppenderTest {
         SoftAssertions.assertSoftly(soft -> {
             // The count is reported in full...
             soft.assertThat(rendered).contains("7 subscription(s)");
-            // ...but the id list stops at the cap, so a broken dataset cannot produce a 64 KB line.
+            // ...but the id list stops exactly at the cap: the last id inside it is present, the
+            // first one past it is not — so a broken dataset cannot produce a 64 KB line, and a
+            // silently shrunken cap cannot pass either.
             soft.assertThat(rendered).contains("orphan1");
+            soft.assertThat(rendered).contains("orphan5");
             soft.assertThat(rendered).doesNotContain("orphan6");
             soft.assertThat(rendered).doesNotContain("orphan7");
         });

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
@@ -210,6 +210,40 @@ class SubscriptionAppenderTest {
         });
     }
 
+    @Test
+    void should_only_materialise_api_product_legs_for_apis_in_the_current_batch() throws TechnicalException {
+        configureMemoryAppender();
+        // A product spanning three APIs, but only one of them is in this deployment batch.
+        io.gravitee.gateway.handlers.api.ReactableApiProduct product = mock(io.gravitee.gateway.handlers.api.ReactableApiProduct.class);
+        when(product.getApiIds()).thenReturn(Set.of("api1", "api2", "api3"));
+        when(apiProductRegistry.get("product1", "env")).thenReturn(product);
+
+        io.gravitee.repository.management.model.Subscription productSub = new io.gravitee.repository.management.model.Subscription();
+        productSub.setId("sub1");
+        productSub.setPlan("plan1");
+        productSub.setEnvironmentId("env");
+        productSub.setReferenceType(io.gravitee.repository.management.model.SubscriptionReferenceType.API_PRODUCT);
+        productSub.setReferenceId("product1");
+        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(List.of(productSub));
+
+        ApiReactorDeployable deployable = ApiReactorDeployable.builder()
+            .apiId("api1")
+            .reactableApi(mock(ReactableApi.class))
+            .subscribablePlans(new HashSet<>(Set.of("plan1")))
+            .apiKeyPlans(new HashSet<>(Set.of("plan1")))
+            .build();
+
+        List<ApiReactorDeployable> deployables = cut.appends(true, List.of(deployable), Set.of("env"));
+
+        // Only the in-batch leg is built: api2 and api3 legs are never allocated...
+        assertThat(deployables).hasSize(1);
+        assertThat(deployables.get(0).subscriptions()).hasSize(1);
+        assertThat(deployables.get(0).subscriptions().get(0).getApi()).isEqualTo("api1");
+        assertThat(deployables.get(0).subscriptions().get(0).getApiProductId()).isEqualTo("product1");
+        // ...so no warning is emitted for them either.
+        Assertions.assertThat(memoryAppender.getLoggedEvents()).isEmpty();
+    }
+
     private void configureMemoryAppender() {
         Logger logger = (Logger) LoggerFactory.getLogger(SubscriptionAppender.class);
         memoryAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
@@ -205,8 +205,46 @@ class SubscriptionAppenderTest {
         Assertions.assertThat(memoryAppender.getLoggedEvents()).hasSize(1);
         SoftAssertions.assertSoftly(soft -> {
             var event = memoryAppender.getLoggedEvents().get(0);
-            soft.assertThat(event.getMessage()).contains("Cannot find api {} for subscriptions [{}]");
-            soft.assertThat(event.getArgumentArray()).contains("api3", "sub2,sub3");
+            soft.assertThat(event.getMessage()).contains("Cannot find api {} for {} subscription(s), sample: [{}]");
+            soft.assertThat(event.getArgumentArray()).contains("api3", 2, "sub2,sub3");
+        });
+    }
+
+    @Test
+    void should_bound_the_warning_to_a_count_and_a_capped_sample() throws TechnicalException {
+        configureMemoryAppender();
+        ApiReactorDeployable deployable = ApiReactorDeployable.builder()
+            .apiId("api1")
+            .reactableApi(mock(ReactableApi.class))
+            .subscribablePlans(new HashSet<>(Set.of("plan1")))
+            .apiKeyPlans(new HashSet<>(Set.of("plan1")))
+            .build();
+
+        // Seven orphans against a sample cap of five.
+        List<io.gravitee.repository.management.model.Subscription> orphans = new ArrayList<>();
+        for (int i = 1; i <= 7; i++) {
+            io.gravitee.repository.management.model.Subscription orphan = new io.gravitee.repository.management.model.Subscription();
+            orphan.setId("orphan" + i);
+            orphan.setApi("missing-api");
+            orphans.add(orphan);
+        }
+        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(orphans);
+        when(
+            subscriptionRepository.searchAfter(any(), any(), argThat(cur -> cur != null && "orphan7".equals(cur.id())), eq(BULK_ITEMS))
+        ).thenReturn(List.of());
+
+        cut.appends(true, List.of(deployable), Set.of("env"));
+
+        Assertions.assertThat(memoryAppender.getLoggedEvents()).hasSize(1);
+        var event = memoryAppender.getLoggedEvents().get(0);
+        String rendered = event.getFormattedMessage();
+        SoftAssertions.assertSoftly(soft -> {
+            // The count is reported in full...
+            soft.assertThat(rendered).contains("7 subscription(s)");
+            // ...but the id list stops at the cap, so a broken dataset cannot produce a 64 KB line.
+            soft.assertThat(rendered).contains("orphan1");
+            soft.assertThat(rendered).doesNotContain("orphan6");
+            soft.assertThat(rendered).doesNotContain("orphan7");
         });
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizerTest.java
@@ -20,6 +20,7 @@ import static io.gravitee.repository.management.model.EventType.DEPLOY_API_PRODU
 import static io.gravitee.repository.management.model.EventType.UNDEPLOY_API_PRODUCT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
@@ -93,7 +94,7 @@ class ApiProductSynchronizerTest {
         );
         lenient().when(latestEventFetcher.bulkItems()).thenReturn(1);
         lenient().when(deployerFactory.createApiProductDeployer()).thenReturn(apiProductDeployer);
-        lenient().when(apiProductDeployer.deploy(any())).thenReturn(Completable.complete());
+        lenient().when(apiProductDeployer.deploy(any(), anyBoolean())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.undeploy(any())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.doAfterDeployment(any())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.doAfterUndeployment(any())).thenReturn(Completable.complete());
@@ -172,7 +173,7 @@ class ApiProductSynchronizerTest {
             when(latestEventFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(event)));
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
-            verify(apiProductDeployer).deploy(any());
+            verify(apiProductDeployer).deploy(any(), eq(false));
             verify(apiProductDeployer).doAfterDeployment(any());
         }
 
@@ -188,7 +189,7 @@ class ApiProductSynchronizerTest {
             );
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
-            verify(apiProductDeployer, times(3)).deploy(any());
+            verify(apiProductDeployer, times(3)).deploy(any(), eq(false));
             verify(apiProductDeployer, times(3)).doAfterDeployment(any());
         }
 
@@ -198,13 +199,25 @@ class ApiProductSynchronizerTest {
             Event event2 = createDeployEvent("api-product-fail", "Fail Product");
 
             when(latestEventFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(event1, event2)));
-            when(apiProductDeployer.deploy(any()))
+            when(apiProductDeployer.deploy(any(), eq(false)))
                 .thenReturn(Completable.complete())
                 .thenReturn(Completable.error(new RuntimeException("Deploy failed")));
 
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
-            verify(apiProductDeployer, times(2)).deploy(any());
+            verify(apiProductDeployer, times(2)).deploy(any(), eq(false));
+        }
+
+        @Test
+        void should_refresh_subscriptions_when_processing_incremental_deploy_event() throws InterruptedException, JsonProcessingException {
+            Event event = createDeployEvent("api-product-incremental", "Incremental Product");
+            long from = Instant.now().minusSeconds(1).toEpochMilli();
+
+            when(latestEventFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(event)));
+
+            cut.synchronize(from, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
+
+            verify(apiProductDeployer).deploy(any(), eq(true));
         }
 
         private Event createDeployEvent(String apiProductId, String name) throws JsonProcessingException {
@@ -326,7 +339,7 @@ class ApiProductSynchronizerTest {
             );
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
-            verify(apiProductDeployer).deploy(any());
+            verify(apiProductDeployer).deploy(any(), eq(false));
             verify(apiProductDeployer).doAfterDeployment(any());
             verify(apiProductDeployer).undeploy(any());
             verify(apiProductDeployer).doAfterUndeployment(any());
@@ -356,7 +369,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.subscribablePlans()).containsExactly("plan-published");
@@ -376,7 +389,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.subscribablePlans()).containsExactly("plan-deprecated");
@@ -396,7 +409,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.subscribablePlans()).isEmpty();
@@ -418,7 +431,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             // CLOSED plan is excluded by the mapper — only PUBLISHED and DEPRECATED reach the gateway
@@ -456,7 +469,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.subscribablePlans()).isEmpty();
@@ -494,7 +507,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.reactableApiProduct().getTags()).containsExactlyInAnyOrder("internal", "partner");


### PR DESCRIPTION
Supersedes #18993, #18994 and #18995 — three PRs opened independently against `4.12.x` within
minutes of each other for the same incident. This is the union of all three, plus tests for the two
changes that had none. If it is taken, the other three should be closed.

Credit is preserved: the first four commits are @wbabyte's, unmodified. @gutek9's distributed-sync
work and plan deduplication are carried in the final commit.

## Problem

An API Product subscription is materialised once per member API. On a deployment where products span
several hundred APIs, gateway initial sync never finishes: the `sync-process` probe stays not-ready,
the pod is killed, and the whole sync restarts against the management API.

Notation: **P** = APIs in a product, **S** = its ACCEPTED subscriptions, **B** = `services.sync.bulk_items`.

Six defects compose to produce this.

| # | Defect | Found in |
|---|---|---|
| 1 | Sync executors were permanently single-threaded | #18993 |
| 2 | Registering one subscription leg was O(P), making a product warmup O(P²) | #18993 |
| 3 | Product subscriptions were exploded across all P APIs, then discarded | all three |
| 4 | The refresher issued an unpaginated query including CLOSED | #18993 |
| 5 | The deploy path re-registered the whole expansion, serially, per product | #18994, #18995 |
| 6 | Every discarded leg was logged with the full subscription id list | #18994, #18995 |

### 1. Sync executors were permanently single-threaded

Both pools were built as `new ThreadPoolExecutor(1, poolSize, …, new LinkedBlockingQueue<>(), …)`.
`ThreadPoolExecutor` only creates a thread beyond `corePoolSize` when the queue *rejects* an offer,
and an unbounded `LinkedBlockingQueue` never rejects. The pools ran with exactly one thread
regardless of `poolSize`, so `services.sync.fetcher` / `services.sync.deployer` had no effect and the
`.parallel(getMaximumPoolSize())` fan-out in `AbstractApiSynchronizer` created N rails that all
funnelled through one thread.

This is now covered by a behavioural test — three tasks that each block until all three have
started. It deadlocks and times out on a single-threaded pool; both parameterised cases were
confirmed failing against the exact pre-fix configuration.

### 2. Registering a leg was O(P)

Legs were held in an immutable `Set<Subscription>`, copied on every registration. The singleton fast
path never applies to an exploded product subscription, whose set grows to P legs — so registering a
product's legs cost ~P² element copies per subscription. The index is now
`ConcurrentMap<String, ConcurrentMap<LegKey, Subscription>>` keyed on `(api, environmentId)`, the
exact pair the old code filtered on, making registration an O(1) put.

### 3–6

Product explosion is now restricted to the API set the caller is deploying, applied *before* mapping
so out-of-batch legs are never allocated; the deploy-time refresh is skipped during initial sync
(the API synchronizer runs immediately after over the same event set and registers the legs anyway);
the refresher paginates by `(plan, id)` keyset and requests `ACCEPTED` only on the deploy path; and
the orphan warning reports a count with a sample capped at five ids.

## Where this differs from the three source PRs

Every difference below is a deliberate choice between two source PRs that disagreed, or an addition.

**Explosion restriction walks the smaller set.** #18993 filtered the product's api list (P lookups);
#18994 filtered the batch (B lookups). Taken: whichever is smaller, so a batch of 100 against a
product of 792 costs 100.

**Plain API subscriptions are not filtered.** #18994 filtered them too, which silently drops a
subscription whose api disagrees with the API owning its plan. #18993 deliberately left them
unfiltered so the orphan warning still reports that inconsistency. Taken: #18993's choice, and the
test for it is kept rather than replaced.

**The deploy-time refresh is gated, not removed.** #18995 removed it outright, arguing the API sync
path covers both initial sync and runtime product changes. That is the riskier reading — an
incremental product change has no API event to piggyback on. Taken: #18994's gating, which costs
nothing at cold start and cannot regress the incremental path.

**The warning keeps a bounded sample.** #18994 made it count-only; #18993 left it alone. Taken:
count plus five ids. A count tells you the batch skipped something; ids let you go look at one. The
whole-list join is what had to go, not the ids.

**Two new tests** for changes that shipped without any: the executor concurrency test above, and a
capped-sample test asserting the count is reported in full while ids past the cap are absent.

## Testing

| Module | Tests | Result |
|---|---|---|
| `gravitee-apim-gateway-services-sync` | 688 | 0 failures, 0 errors |
| `gravitee-apim-gateway-handlers-api` | 982 | 0 failures, 0 errors |

`SubscriptionCacheServiceTest` (46 tests, including concurrent-update and multi-leg eviction cases)
passes unmodified against the rewritten leg index — that is the main evidence the O(1) rewrite in
commit 2 preserves behaviour.

**Every behavioural change was mutation-checked** — the fix reverted, the test confirmed failing,
the fix restored:

| Mutation | Failed |
|---|---|
| Pool config restored to `(1, poolSize)` | `should_run_tasks_concurrently_on_a_sync_executor` ×2, timing out at 5 s |
| Explosion restriction disabled | `should_explode_api_product_subscription_only_for_target_apis`, `should_only_materialise_api_product_legs_for_apis_in_the_current_batch` |
| `refreshSubscriptions` gate removed | `should_skip_subscription_refresh_when_requested` |
| Sample cap removed | `should_bound_the_warning_to_a_count_and_a_capped_sample` |
| Sample cap shrunk from 5 to 4 | `should_bound_the_warning_to_a_count_and_a_capped_sample`, on the boundary id |
| Small-product explosion arm filter swapped to `apiIds` | `should_restrict_explosion_to_target_apis_when_product_is_smaller_than_target_set` |
| Removed-api eviction folded under the refresh gate | `should_unregister_removed_apis_even_when_subscription_refresh_is_skipped` |

The last three rows come from a review pass on this PR, which closed three coverage gaps: the
sample cap is now pinned exactly (not just "bounded"), the explosion arm that walks a product
smaller than the batch is exercised, and removed-api eviction is pinned as independent of the
`refreshSubscriptions` flag — a future edit folding it under the gate fails the suite.

## Not measured

There is **no before/after startup timing** and no reproduction at the 296-product / 775-API scale.
The tests prove each mechanism changed and that each test can fail. They do not prove the pod starts.
This should be validated against a realistic product set before it is relied on for the incident.

## Risk

The executor change is the one to watch: it converts API deployment from serial to concurrent across
the whole sync pipeline. That is the fan-out the code was already written for — `.parallel()` rails
that were silently collapsing onto one thread — but any latent ordering assumption in a deployer
would surface here rather than in the pieces above.

