### PR TITLE
fix(gateway): optimize API Product subscription synchronization

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheService.java
@@ -28,6 +28,9 @@ import org.springframework.util.DigestUtils;
 @CustomLog
 public class ApiKeyCacheService implements ApiKeyService {
 
+    private static final int MD5_CACHE_STRIPES = 16;
+    private static final int MAX_MD5_VALUES_PER_STRIPE = 8_192;
+
     // ConcurrentMap on purpose (not plain Map): register()/unregister() rely on thread-safe
     // compute()/computeIfPresent() for the per-API index. Unlike SubscriptionCacheService, the
     // lambdas here are idempotent, so any honest ConcurrentMap implementation is acceptable.
@@ -36,6 +39,15 @@ public class ApiKeyCacheService implements ApiKeyService {
     // Holds api-key values only (the API id is already the map key); unregisterByApiId()
     // re-derives the cache keys from them.
     private final ConcurrentMap<String, Set<String>> cacheApiKeysByApi = new ConcurrentHashMap<>();
+
+    // API Product expansion registers the same raw key once per member API. Cache the digest by
+    // raw key so millions of runtime legs do not repeat the byte[] allocation and MD5 operation.
+    // Stripes keep lookups concurrent; each stripe is independently bounded to avoid retaining
+    // every historical key on gateways with millions of unrelated direct subscriptions.
+    @SuppressWarnings("unchecked")
+    private final ConcurrentMap<String, String>[] md5ByRawKey = java.util.stream.IntStream.range(0, MD5_CACHE_STRIPES)
+        .mapToObj(ignored -> new ConcurrentHashMap<String, String>())
+        .toArray(ConcurrentMap[]::new);
 
     /**
      * Cache key referencing the api-key's own field strings instead of a formatted composite
@@ -135,6 +147,25 @@ public class ApiKeyCacheService implements ApiKeyService {
     }
 
     CacheKey buildMd5CacheKey(ApiKey apiKey) {
-        return buildCacheKey(apiKey.getApi(), DigestUtils.md5DigestAsHex(apiKey.getKey().getBytes(StandardCharsets.UTF_8)));
+        return buildCacheKey(apiKey.getApi(), md5(apiKey.getKey()));
+    }
+
+    private String md5(String rawKey) {
+        ConcurrentMap<String, String> stripe = md5ByRawKey[spread(rawKey.hashCode()) & (MD5_CACHE_STRIPES - 1)];
+        String cached = stripe.get(rawKey);
+        if (cached != null) {
+            return cached;
+        }
+
+        // Approximate bounding is sufficient: a concurrent overshoot is small, and clearing one
+        // stripe only causes later cache misses; it cannot affect authentication correctness.
+        if (stripe.size() >= MAX_MD5_VALUES_PER_STRIPE) {
+            stripe.clear();
+        }
+        return stripe.computeIfAbsent(rawKey, key -> DigestUtils.md5DigestAsHex(key.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static int spread(int hash) {
+        return hash ^ (hash >>> 16);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -39,6 +38,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +47,11 @@ import lombok.SneakyThrows;
 @CustomLog
 @RequiredArgsConstructor
 public class SubscriptionCacheService implements SubscriptionService {
+
+    private static final int SUBSCRIPTION_LOCK_STRIPES = 1024;
+    private static final Object[] SUBSCRIPTION_LOCKS = IntStream.range(0, SUBSCRIPTION_LOCK_STRIPES)
+        .mapToObj(ignored -> new Object())
+        .toArray();
 
     private final ApiKeyService apiKeyService;
     private final SubscriptionTrustStoreLoaderManager subscriptionTrustStoreLoaderManager;
@@ -59,10 +64,11 @@ public class SubscriptionCacheService implements SubscriptionService {
     // ConcurrentSkipListMap), which would double those side effects under contention.
     private final ConcurrentMap<IdentityKey, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
     private final ConcurrentMap<IdentityKey, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
-    // Single by-id index, including exploded API-Product subscriptions. Values are immutable sets
-    // (almost always a singleton), replaced atomically via compute(): keeps the per-entry footprint
-    // minimal at multi-million-subscription scale and lets readers use them without defensive copies.
-    private final ConcurrentMap<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
+    // Single by-id index, including exploded API-Product subscriptions. Plain API subscriptions
+    // keep a compact singleton value. Only an id with several API/environment legs is promoted to
+    // a ConcurrentHashMap, making API-Product registration O(1) without allocating one map per
+    // regular subscription at multi-million-subscription scale.
+    private final ConcurrentMap<String, SubscriptionLegs> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
     // Holds subscription ids only, for per-API eviction. Identity keys are not tracked here:
     // unregisterByApiId() re-derives them from the cached subscriptions, which keeps this index
     // at one entry per subscription instead of three (id + 2 identity keys) at multi-million scale.
@@ -74,6 +80,38 @@ public class SubscriptionCacheService implements SubscriptionService {
      * scale) and no String.format on the request hot path. A null plan is the plan-less variant.
      */
     private record IdentityKey(String api, String plan, String clientIdentity) {}
+
+    private record LegKey(String api, String environmentId) {}
+
+    private sealed interface SubscriptionLegs permits SingleSubscriptionLeg, MultipleSubscriptionLegs {
+        Collection<Subscription> values();
+    }
+
+    private record SingleSubscriptionLeg(Subscription subscription) implements SubscriptionLegs {
+        @Override
+        public Collection<Subscription> values() {
+            return List.of(subscription);
+        }
+    }
+
+    private static final class MultipleSubscriptionLegs implements SubscriptionLegs {
+
+        private final ConcurrentMap<LegKey, Subscription> subscriptions = new ConcurrentHashMap<>();
+
+        private MultipleSubscriptionLegs(Subscription first, Subscription second) {
+            subscriptions.put(legKey(first), first);
+            subscriptions.put(legKey(second), second);
+        }
+
+        @Override
+        public Collection<Subscription> values() {
+            return subscriptions.values();
+        }
+    }
+
+    private static LegKey legKey(Subscription subscription) {
+        return new LegKey(subscription.getApi(), subscription.getEnvironmentId());
+    }
 
     @Override
     public Optional<Subscription> getByApiAndSecurityToken(String api, SecurityToken securityToken, String plan) {
@@ -99,11 +137,11 @@ public class SubscriptionCacheService implements SubscriptionService {
     public Optional<Subscription> getById(String subscriptionId) {
         // For exploded API-Product subscriptions this returns an arbitrary leg, which matches the
         // historical behavior of the dedicated by-id map (last-registered/rehydrated leg).
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        if (subscriptions == null || subscriptions.isEmpty()) {
+        SubscriptionLegs subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
+        if (subscriptions == null) {
             return Optional.empty();
         }
-        return Optional.of(subscriptions.iterator().next());
+        return subscriptions.values().stream().findFirst();
     }
 
     /**
@@ -111,43 +149,61 @@ public class SubscriptionCacheService implements SubscriptionService {
      * The returned collection is immutable.
      */
     public Collection<Subscription> getAllById(String subscriptionId) {
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        return subscriptions != null ? subscriptions : Collections.emptySet();
+        SubscriptionLegs subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
+        if (subscriptions == null) {
+            return Collections.emptySet();
+        }
+        if (subscriptions instanceof SingleSubscriptionLeg single) {
+            return single.values();
+        }
+        return List.copyOf(subscriptions.values());
     }
 
     @Override
     public void register(final Subscription subscription) {
-        // only once per synchronization window
-        // take all fields (including "updatedAt" in metadata) into account
-        if (ACCEPTED.name().equals(subscription.getStatus())) {
-            if (subscription.getClientCertificate() != null) {
-                log.debug("Registering subscription [{}] for API [{}] by client certificate", subscription.getId(), subscription.getApi());
-                registerFromClientCertificate(subscription);
-            } else if (subscription.getClientId() != null) {
+        synchronized (subscriptionLock(subscription.getId())) {
+            // only once per synchronization window
+            // take all fields (including "updatedAt" in metadata) into account
+            if (ACCEPTED.name().equals(subscription.getStatus())) {
+                if (subscription.getClientCertificate() != null) {
+                    log.debug(
+                        "Registering subscription [{}] for API [{}] by client certificate",
+                        subscription.getId(),
+                        subscription.getApi()
+                    );
+                    registerFromClientCertificate(subscription);
+                } else if (subscription.getClientId() != null) {
+                    log.debug(
+                        "Registering subscription [{}] for API [{}] by clientId [{}]",
+                        subscription.getId(),
+                        subscription.getApi(),
+                        subscription.getClientId()
+                    );
+                    registerFromClientId(subscription);
+                } else {
+                    log.debug("Registering subscription [{}] for API [{}] by ID", subscription.getId(), subscription.getApi());
+                    registerFromId(subscription);
+                }
+            } else {
                 log.debug(
-                    "Registering subscription [{}] for API [{}] by clientId [{}]",
+                    "Unregistering subscription [{}] for API [{}] with status [{}]",
                     subscription.getId(),
                     subscription.getApi(),
-                    subscription.getClientId()
+                    subscription.getStatus()
                 );
-                registerFromClientId(subscription);
-            } else {
-                log.debug("Registering subscription [{}] for API [{}] by ID", subscription.getId(), subscription.getApi());
-                registerFromId(subscription);
+                unregisterInternal(subscription);
             }
-        } else {
-            log.debug(
-                "Unregistering subscription [{}] for API [{}] with status [{}]",
-                subscription.getId(),
-                subscription.getApi(),
-                subscription.getStatus()
-            );
-            unregister(subscription);
         }
     }
 
     @Override
     public void unregister(final Subscription candidate) {
+        synchronized (subscriptionLock(candidate.getId())) {
+            unregisterInternal(candidate);
+        }
+    }
+
+    private void unregisterInternal(final Subscription candidate) {
         // Use compute() so that the isEmpty-check-then-remove is atomic with respect to
         // concurrent register() calls on the same subscription ID. Without this, a register()
         // interleaved between isEmpty()=true and remove() would add a new entry to the set
@@ -156,6 +212,7 @@ public class SubscriptionCacheService implements SubscriptionService {
             if (allSubscriptions == null) return null;
 
             var toEvict = allSubscriptions
+                .values()
                 .stream()
                 .filter(s -> Objects.equals(candidate.getApi(), s.getApi()))
                 .toList();
@@ -179,58 +236,40 @@ public class SubscriptionCacheService implements SubscriptionService {
                 unregisterFromClientCertificate(candidate);
             }
 
-            // Singleton fast path: toEvict is non-empty, so the only element is being evicted
-            if (allSubscriptions.size() == 1) {
-                return null;
-            }
-
-            Set<Subscription> remaining = allSubscriptions
-                .stream()
-                .filter(s -> !Objects.equals(candidate.getApi(), s.getApi()))
-                .collect(Collectors.toUnmodifiableSet());
-            return remaining.isEmpty() ? null : remaining;
+            return removeApiLegs(allSubscriptions, candidate.getApi());
         });
     }
 
     @Override
     public void unregisterByApiId(final String apiId) {
         log.debug("Unregistering all subscriptions for API [{}]", apiId);
-        // Remove the whole entry first so no cacheKeysByApiId lock is held while updating the
-        // other caches (unregister() acquires the same locks in the opposite order).
-        Set<String> subscriptionsByApi = cacheKeysByApiId.remove(apiId);
+        Set<String> subscriptionsByApi = cacheKeysByApiId.get(apiId);
         if (subscriptionsByApi == null) {
             return;
         }
-        // Legs are only collected under the cacheBySubscriptionIdAll bin lock; the identity-map
-        // and trust-store eviction (which re-derives keys, hashing the client certificate)
-        // happens after each compute returns — those structures are not guarded by this lock.
-        List<Subscription> evictedLegs = new ArrayList<>();
-        subscriptionsByApi.forEach(subscriptionId ->
-            cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, all) -> {
-                // Singleton fast path: most entries hold exactly one leg
-                if (all.size() == 1) {
-                    Subscription single = all.iterator().next();
-                    if (Objects.equals(apiId, single.getApi())) {
-                        evictedLegs.add(single);
-                        return null;
-                    }
-                    return all;
-                }
-                Set<Subscription> remaining = new HashSet<>();
-                for (Subscription subscription : all) {
-                    if (Objects.equals(apiId, subscription.getApi())) {
-                        evictedLegs.add(subscription);
-                    } else {
-                        remaining.add(subscription);
-                    }
-                }
-                return remaining.isEmpty() ? null : Set.copyOf(remaining);
-            })
-        );
-        // Same per-leg eviction as unregister(): identity maps and certificate trust store
-        evictedLegs.forEach(leg -> {
-            unregisterFromClientId(leg);
-            unregisterFromClientCertificate(leg);
+        // Snapshot the ids, but leave the live API index in place. Each evicted leg removes its
+        // own index entry atomically below. Removing the whole bucket first would race with a new
+        // registration: it could create a replacement bucket before its by-id leg was evicted,
+        // leaving a stale API index entry behind.
+        List.copyOf(subscriptionsByApi).forEach(subscriptionId -> {
+            synchronized (subscriptionLock(subscriptionId)) {
+                List<Subscription> evictedLegs = new ArrayList<>();
+                cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, all) -> {
+                    all
+                        .values()
+                        .stream()
+                        .filter(subscription -> Objects.equals(apiId, subscription.getApi()))
+                        .forEach(evictedLegs::add);
+                    return removeApiLegs(all, apiId);
+                });
+                // Keep secondary indexes consistent with the by-id index before allowing another
+                // registration for the same subscription id.
+                evictedLegs.forEach(leg -> {
+                    unregisterFromClientId(leg);
+                    unregisterFromClientCertificate(leg);
+                    evictKeyForApi(leg.getApi(), leg.getId());
+                });
+            }
         });
     }
 
@@ -252,12 +291,22 @@ public class SubscriptionCacheService implements SubscriptionService {
      * evicted when one API's leg is replaced.
      */
     private Subscription cachedSameApiLeg(final Subscription subscription) {
-        Set<Subscription> existingLegs = cacheBySubscriptionIdAll.get(subscription.getId());
-        if (existingLegs != null) {
-            for (Subscription existing : existingLegs) {
-                if (Objects.equals(subscription.getApi(), existing.getApi())) {
-                    return existing;
-                }
+        SubscriptionLegs existingLegs = cacheBySubscriptionIdAll.get(subscription.getId());
+        if (existingLegs == null) {
+            return null;
+        }
+        if (existingLegs instanceof SingleSubscriptionLeg single) {
+            return Objects.equals(subscription.getApi(), single.subscription().getApi()) ? single.subscription() : null;
+        }
+
+        MultipleSubscriptionLegs multiple = (MultipleSubscriptionLegs) existingLegs;
+        Subscription exact = multiple.subscriptions.get(legKey(subscription));
+        if (exact != null) {
+            return exact;
+        }
+        for (Subscription existing : multiple.values()) {
+            if (Objects.equals(subscription.getApi(), existing.getApi())) {
+                return existing;
             }
         }
         return null;
@@ -295,31 +344,27 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private void registerFromClientId(final Subscription subscription) {
-        // Snapshot old entries before registering (cached sets are immutable)
-        Set<Subscription> cachedAll = cacheBySubscriptionIdAll.get(subscription.getId());
-        Set<Subscription> oldEntries = cachedAll != null ? cachedAll : Set.of();
+        // Only the same-API leg can be replaced. Looking it up directly keeps registration O(1)
+        // for API-Product subscriptions instead of snapshotting every sibling leg.
+        Subscription cached = cachedSameApiLeg(subscription);
 
         updateSubscriptionIdById(subscription);
 
         // Register new subscription first
         updateIdentityCache(subscription, cacheByApiClientId);
 
-        // Then clean up old entries if clientId or plan changed (e.g. subscription transfer)
-        // Only compare entries for the same API — exploded subscriptions span multiple APIs
-        for (Subscription old : oldEntries) {
-            if (!Objects.equals(old.getApi(), subscription.getApi())) {
-                continue;
-            }
+        // Then clean up the old leg if clientId or plan changed (e.g. subscription transfer)
+        if (cached != null) {
             if (
-                (old.getClientId() != null && !old.getClientId().equals(subscription.getClientId())) ||
-                (old.getPlan() != null && !old.getPlan().equals(subscription.getPlan()))
+                (cached.getClientId() != null && !cached.getClientId().equals(subscription.getClientId())) ||
+                (cached.getPlan() != null && !cached.getPlan().equals(subscription.getPlan()))
             ) {
-                unregisterFromClientId(old);
+                unregisterFromClientId(cached);
             }
             // Credential-type switch: if the old leg was certificate-registered, its entries
             // live in the certificate map and trust store, never overwritten by this
             // clientId registration.
-            unregisterFromClientCertificate(old);
+            unregisterFromClientCertificate(cached);
         }
     }
 
@@ -342,28 +387,41 @@ public class SubscriptionCacheService implements SubscriptionService {
 
     private void updateSubscriptionIdById(Subscription subscription) {
         cacheBySubscriptionIdAll.compute(subscription.getId(), (id, existing) -> {
-            if (existing == null || existing.isEmpty()) {
-                return Set.of(subscription);
+            if (existing == null) {
+                return new SingleSubscriptionLeg(subscription);
             }
-            // Singleton fast path: replacing the same api/environment leg needs no temporary set
-            if (existing.size() == 1) {
-                Subscription single = existing.iterator().next();
-                if (
-                    Objects.equals(single.getApi(), subscription.getApi()) &&
-                    Objects.equals(single.getEnvironmentId(), subscription.getEnvironmentId())
-                ) {
-                    return Set.of(subscription);
+            if (existing instanceof SingleSubscriptionLeg single) {
+                if (legKey(single.subscription()).equals(legKey(subscription))) {
+                    return new SingleSubscriptionLeg(subscription);
                 }
+                return new MultipleSubscriptionLegs(single.subscription(), subscription);
             }
-            Set<Subscription> updated = new HashSet<>(existing);
-            updated.removeIf(
-                s ->
-                    Objects.equals(s.getApi(), subscription.getApi()) &&
-                    Objects.equals(s.getEnvironmentId(), subscription.getEnvironmentId())
-            );
-            updated.add(subscription);
-            return updated.size() == 1 ? Set.of(subscription) : Set.copyOf(updated);
+            MultipleSubscriptionLegs multiple = (MultipleSubscriptionLegs) existing;
+            multiple.subscriptions.put(legKey(subscription), subscription);
+            return multiple;
         });
+    }
+
+    private static SubscriptionLegs removeApiLegs(SubscriptionLegs existing, String apiId) {
+        if (existing instanceof SingleSubscriptionLeg single) {
+            return Objects.equals(apiId, single.subscription().getApi()) ? null : single;
+        }
+
+        MultipleSubscriptionLegs multiple = (MultipleSubscriptionLegs) existing;
+        multiple.subscriptions.entrySet().removeIf(entry -> Objects.equals(apiId, entry.getKey().api()));
+        if (multiple.subscriptions.isEmpty()) {
+            return null;
+        }
+        if (multiple.subscriptions.size() == 1) {
+            return new SingleSubscriptionLeg(multiple.subscriptions.values().iterator().next());
+        }
+        return multiple;
+    }
+
+    private static Object subscriptionLock(String subscriptionId) {
+        int hash = subscriptionId.hashCode();
+        hash ^= hash >>> 16;
+        return SUBSCRIPTION_LOCKS[hash & (SUBSCRIPTION_LOCK_STRIPES - 1)];
     }
 
     private void unregisterFromClientId(final Subscription subscription) {
@@ -411,14 +469,14 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private Optional<Subscription> getByApiAndId(String api, String subscriptionId) {
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        if (subscriptions == null || subscriptions.isEmpty()) {
+        SubscriptionLegs subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
+        if (subscriptions == null) {
             // Fallback to old cache for backward compatibility
             return getById(subscriptionId);
         }
-        // Plain loop: this runs on the request hot path for every API-key call and the set is
+        // Plain loop: this runs on the request hot path for every API-key call and the index is
         // almost always a singleton, so avoid allocating a Stream pipeline per request.
-        for (Subscription subscription : subscriptions) {
+        for (Subscription subscription : subscriptions.values()) {
             if (Objects.equals(api, subscription.getApi())) {
                 return Optional.of(subscription);
             }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -57,11 +57,10 @@ public class SubscriptionCacheService implements SubscriptionService {
     private final SubscriptionTrustStoreLoaderManager subscriptionTrustStoreLoaderManager;
     private final ApiManager apiManager;
 
-    // Caches only contains active subscriptions.
-    // Must stay backed by ConcurrentHashMap: the compute() lambdas below have side effects and
-    // rely on CHM running the remapping function at most once, under the bin lock. The
-    // ConcurrentMap contract alone allows implementations that retry the lambda (e.g.
-    // ConcurrentSkipListMap), which would double those side effects under contention.
+    // Caches only contain active subscriptions. Mutations for one subscription id are serialized
+    // by subscriptionLock(id). The maps remain concurrent because request-path readers and updates
+    // for different subscription ids still run concurrently; compute() also publishes each by-id
+    // representation change atomically to those lock-free readers.
     private final ConcurrentMap<IdentityKey, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
     private final ConcurrentMap<IdentityKey, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
     // Single by-id index, including exploded API-Product subscriptions. Plain API subscriptions
@@ -141,12 +140,14 @@ public class SubscriptionCacheService implements SubscriptionService {
         if (subscriptions == null) {
             return Optional.empty();
         }
-        return subscriptions.values().stream().findFirst();
+        var iterator = subscriptions.values().iterator();
+        return iterator.hasNext() ? Optional.of(iterator.next()) : Optional.empty();
     }
 
     /**
      * Returns all subscriptions for the given ID (multiple for exploded API Product subscriptions).
-     * The returned collection is immutable.
+     * The returned collection cannot be modified through this handle. Multi-leg subscriptions
+     * expose a weakly-consistent concurrent view so callers can iterate without an O(P) snapshot.
      */
     public Collection<Subscription> getAllById(String subscriptionId) {
         SubscriptionLegs subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
@@ -156,7 +157,7 @@ public class SubscriptionCacheService implements SubscriptionService {
         if (subscriptions instanceof SingleSubscriptionLeg single) {
             return single.values();
         }
-        return List.copyOf(subscriptions.values());
+        return Collections.unmodifiableCollection(subscriptions.values());
     }
 
     @Override
@@ -204,10 +205,8 @@ public class SubscriptionCacheService implements SubscriptionService {
     }
 
     private void unregisterInternal(final Subscription candidate) {
-        // Use compute() so that the isEmpty-check-then-remove is atomic with respect to
-        // concurrent register() calls on the same subscription ID. Without this, a register()
-        // interleaved between isEmpty()=true and remove() would add a new entry to the set
-        // and then have that set orphaned by the remove().
+        // The caller holds subscriptionLock(id), which serializes mutations for this subscription.
+        // compute() atomically publishes the resulting representation to lock-free readers.
         cacheBySubscriptionIdAll.compute(candidate.getId(), (id, allSubscriptions) -> {
             if (allSubscriptions == null) return null;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -197,6 +197,38 @@ public class SubscriptionCacheService implements SubscriptionService {
         }
     }
 
+    /**
+     * Registers a subscription while hydrating an empty cache during gateway cold start.
+     *
+     * <p>The regular registration path must look for and clean up a previous leg because it is
+     * also used by incremental updates. For a new API Product leg that lookup scans sibling APIs
+     * when there is no exact match. Repeating it for every API turns a product subscription into
+     * O(number of APIs squared) work. Initial repository sync contains unique, active legs and
+     * starts from an empty cache, so it can publish them directly through the concurrent indexes.
+     * Certificate subscriptions keep per-subscription serialization for trust-store ordering but
+     * still skip the incremental replacement lookup.</p>
+     */
+    public void registerInitial(final Subscription subscription) {
+        if (!ACCEPTED.name().equals(subscription.getStatus())) {
+            register(subscription);
+            return;
+        }
+
+        if (subscription.getClientCertificate() != null) {
+            synchronized (subscriptionLock(subscription.getId())) {
+                subscriptionTrustStoreLoaderManager.registerSubscription(subscription, extractApiServersId(subscription));
+                updateSubscriptionIdById(subscription);
+                updateIdentityCache(subscription, cacheByClientCertificate);
+            }
+        } else if (subscription.getClientId() != null) {
+            updateSubscriptionIdById(subscription);
+            updateIdentityCache(subscription, cacheByApiClientId);
+        } else {
+            updateSubscriptionIdById(subscription);
+            updateCacheKeyByApiId(subscription.getApi(), subscription.getId());
+        }
+    }
+
     @Override
     public void unregister(final Subscription candidate) {
         synchronized (subscriptionLock(candidate.getId())) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheServiceTest.java
@@ -76,6 +76,17 @@ public class ApiKeyCacheServiceTest {
         }
 
         @Test
+        void should_reuse_md5_value_when_product_key_is_registered_for_several_apis() {
+            ApiKey first = buildApiKey("api-1", new String("shared-key"), true);
+            ApiKey second = buildApiKey("api-2", new String("shared-key"), true);
+
+            apiKeyService.register(first);
+            apiKeyService.register(second);
+
+            assertThat(apiKeyService.buildMd5CacheKey(first).key()).isSameAs(apiKeyService.buildMd5CacheKey(second).key());
+        }
+
+        @Test
         void should_not_register_apiKey_when_apiKey_is_inactive() {
             ApiKey apiKey = buildApiKey("my-api", "my-key", false);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.handlers.api.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -1010,6 +1012,79 @@ class SubscriptionCacheServiceTest {
                 }
             }
             assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+        }
+
+        @Test
+        void should_keep_every_leg_of_one_subscription_registered_concurrently() throws Exception {
+            int writerCount = 8;
+            int legsPerWriter = 100;
+            CyclicBarrier barrier = new CyclicBarrier(writerCount);
+            List<Future<?>> futures = new ArrayList<>();
+
+            try (ExecutorService writers = Executors.newFixedThreadPool(writerCount)) {
+                for (int writer = 0; writer < writerCount; writer++) {
+                    int writerId = writer;
+                    futures.add(
+                        writers.submit(() -> {
+                            barrier.await();
+                            for (int leg = 0; leg < legsPerWriter; leg++) {
+                                String apiId = "api-" + writerId + "-" + leg;
+                                subscriptionService.register(buildAcceptedSubscriptionWithClientId(SUB_ID, apiId, CLIENT_ID, PLAN_ID));
+                            }
+                            return null;
+                        })
+                    );
+                }
+                for (Future<?> future : futures) {
+                    future.get(10, TimeUnit.SECONDS);
+                }
+            }
+
+            assertThat(subscriptionService.getAllById(SUB_ID))
+                .hasSize(writerCount * legsPerWriter)
+                .extracting(Subscription::getApi)
+                .doesNotHaveDuplicates();
+        }
+
+        @Test
+        void should_not_remove_a_new_registration_while_an_old_leg_is_being_unregistered() throws Exception {
+            Subscription old = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, "old-certificate", PLAN_ID);
+            Subscription replacement = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, "new-certificate", PLAN_ID);
+            subscriptionService.register(old);
+
+            CountDownLatch unregisterStarted = new CountDownLatch(1);
+            CountDownLatch allowUnregisterToFinish = new CountDownLatch(1);
+            CountDownLatch registerStarted = new CountDownLatch(1);
+            AtomicBoolean registerFinished = new AtomicBoolean(false);
+            doAnswer(invocation -> {
+                unregisterStarted.countDown();
+                assertThat(allowUnregisterToFinish.await(5, TimeUnit.SECONDS)).isTrue();
+                return null;
+            })
+                .when(subscriptionTrustStoreLoaderManager)
+                .unregisterSubscription(old);
+
+            try (ExecutorService workers = Executors.newFixedThreadPool(2)) {
+                Future<?> unregister = workers.submit(() -> subscriptionService.unregister(old));
+                assertThat(unregisterStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+                Future<?> register = workers.submit(() -> {
+                    registerStarted.countDown();
+                    subscriptionService.register(replacement);
+                    registerFinished.set(true);
+                });
+                assertThat(registerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+                assertThat(registerFinished).isFalse();
+
+                allowUnregisterToFinish.countDown();
+                unregister.get(5, TimeUnit.SECONDS);
+                register.get(5, TimeUnit.SECONDS);
+            }
+
+            assertThat(subscriptionService.getById(SUB_ID)).contains(replacement);
+            assertThat(subscriptionService.getByClientCertificate(old)).isEmpty();
+            assertThat(subscriptionService.getByClientCertificate(replacement)).contains(replacement);
+            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -1047,7 +1047,7 @@ class SubscriptionCacheServiceTest {
         }
 
         @Test
-        void should_not_remove_a_new_registration_while_an_old_leg_is_being_unregistered() throws Exception {
+        void should_serialize_registration_with_unregister_by_api_id() throws Exception {
             Subscription old = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, "old-certificate", PLAN_ID);
             Subscription replacement = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, "new-certificate", PLAN_ID);
             subscriptionService.register(old);
@@ -1055,7 +1055,6 @@ class SubscriptionCacheServiceTest {
             CountDownLatch unregisterStarted = new CountDownLatch(1);
             CountDownLatch allowUnregisterToFinish = new CountDownLatch(1);
             CountDownLatch registerStarted = new CountDownLatch(1);
-            AtomicBoolean registerFinished = new AtomicBoolean(false);
             doAnswer(invocation -> {
                 unregisterStarted.countDown();
                 assertThat(allowUnregisterToFinish.await(5, TimeUnit.SECONDS)).isTrue();
@@ -1065,26 +1064,46 @@ class SubscriptionCacheServiceTest {
                 .unregisterSubscription(old);
 
             try (ExecutorService workers = Executors.newFixedThreadPool(2)) {
-                Future<?> unregister = workers.submit(() -> subscriptionService.unregister(old));
+                Future<?> unregister = workers.submit(() -> subscriptionService.unregisterByApiId(API_ID));
                 assertThat(unregisterStarted.await(5, TimeUnit.SECONDS)).isTrue();
 
-                Future<?> register = workers.submit(() -> {
+                Thread register = new Thread(() -> {
                     registerStarted.countDown();
                     subscriptionService.register(replacement);
-                    registerFinished.set(true);
                 });
+                register.start();
                 assertThat(registerStarted.await(5, TimeUnit.SECONDS)).isTrue();
-                assertThat(registerFinished).isFalse();
-
-                allowUnregisterToFinish.countDown();
+                try {
+                    // A platform thread attempting to enter the held subscription monitor reaches
+                    // BLOCKED. This proves it actually contended instead of merely not being scheduled.
+                    assertThat(awaitThreadState(register, Thread.State.BLOCKED, 5, TimeUnit.SECONDS)).isTrue();
+                } finally {
+                    allowUnregisterToFinish.countDown();
+                }
                 unregister.get(5, TimeUnit.SECONDS);
-                register.get(5, TimeUnit.SECONDS);
+                register.join(TimeUnit.SECONDS.toMillis(5));
+                assertThat(register.isAlive()).isFalse();
             }
 
             assertThat(subscriptionService.getById(SUB_ID)).contains(replacement);
             assertThat(subscriptionService.getByClientCertificate(old)).isEmpty();
             assertThat(subscriptionService.getByClientCertificate(replacement)).contains(replacement);
             assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
+        }
+
+        private boolean awaitThreadState(Thread thread, Thread.State expected, long timeout, TimeUnit unit) throws InterruptedException {
+            long deadline = System.nanoTime() + unit.toNanos(timeout);
+            while (System.nanoTime() < deadline) {
+                Thread.State state = thread.getState();
+                if (state == expected) {
+                    return true;
+                }
+                if (state == Thread.State.TERMINATED) {
+                    return false;
+                }
+                Thread.sleep(1);
+            }
+            return thread.getState() == expected;
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -106,6 +106,18 @@ class SubscriptionCacheServiceTest {
         }
 
         @Test
+        void should_register_initial_subscription_with_client_certificate() {
+            Subscription subscription = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, PLAN_ID);
+
+            subscriptionService.registerInitial(subscription);
+
+            assertThat(subscriptionService.getById(SUB_ID)).contains(subscription);
+            assertThat(subscriptionService.getByClientCertificate(subscription)).contains(subscription);
+            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
+            verify(subscriptionTrustStoreLoaderManager).registerSubscription(subscription, Set.of());
+        }
+
+        @Test
         void should_register_subscription_with_client_certificate_for_api_servers() {
             final Api api = new Api(new io.gravitee.definition.model.v4.Api());
             final HttpListener httpListener = new HttpListener();
@@ -1030,6 +1042,40 @@ class SubscriptionCacheServiceTest {
                             for (int leg = 0; leg < legsPerWriter; leg++) {
                                 String apiId = "api-" + writerId + "-" + leg;
                                 subscriptionService.register(buildAcceptedSubscriptionWithClientId(SUB_ID, apiId, CLIENT_ID, PLAN_ID));
+                            }
+                            return null;
+                        })
+                    );
+                }
+                for (Future<?> future : futures) {
+                    future.get(10, TimeUnit.SECONDS);
+                }
+            }
+
+            assertThat(subscriptionService.getAllById(SUB_ID))
+                .hasSize(writerCount * legsPerWriter)
+                .extracting(Subscription::getApi)
+                .doesNotHaveDuplicates();
+        }
+
+        @Test
+        void should_keep_every_leg_when_initial_registration_runs_concurrently() throws Exception {
+            int writerCount = 8;
+            int legsPerWriter = 100;
+            CyclicBarrier barrier = new CyclicBarrier(writerCount);
+            List<Future<?>> futures = new ArrayList<>();
+
+            try (ExecutorService writers = Executors.newFixedThreadPool(writerCount)) {
+                for (int writer = 0; writer < writerCount; writer++) {
+                    int writerId = writer;
+                    futures.add(
+                        writers.submit(() -> {
+                            barrier.await();
+                            for (int leg = 0; leg < legsPerWriter; leg++) {
+                                String apiId = "initial-api-" + writerId + "-" + leg;
+                                subscriptionService.registerInitial(
+                                    buildAcceptedSubscriptionWithClientId(SUB_ID, apiId, CLIENT_ID, PLAN_ID)
+                                );
                             }
                             return null;
                         })

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployer.java
@@ -42,6 +42,16 @@ public class ApiProductDeployer implements Deployer<ApiProductReactorDeployable>
 
     @Override
     public Completable deploy(ApiProductReactorDeployable deployable) {
+        return deploy(deployable, true);
+    }
+
+    /**
+     * Deploys an API Product and optionally refreshes its subscriptions. During an initial sync,
+     * subscriptions are appended while APIs are deployed immediately after API Products, so doing
+     * the refresh here would build and register the complete product-subscription Cartesian product
+     * twice.
+     */
+    public Completable deploy(ApiProductReactorDeployable deployable, boolean refreshSubscriptions) {
         ReactableApiProduct reactableApiProduct = deployable.reactableApiProduct();
         String apiProductId = deployable.apiProductId();
 
@@ -68,7 +78,7 @@ public class ApiProductDeployer implements Deployer<ApiProductReactorDeployable>
             }
         }
         doBeforeEmit = doBeforeEmit.andThen(Completable.fromRunnable(() -> registerApiProductPlans(deployable)));
-        if (newApiIds != null && !newApiIds.isEmpty()) {
+        if (refreshSubscriptions && !newApiIds.isEmpty()) {
             doBeforeEmit = doBeforeEmit.andThen(
                 subscriptionRefresher.refresh(deployable.subscribablePlans(), Set.of(reactableApiProduct.getEnvironmentId()))
             );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
@@ -50,7 +50,6 @@ import lombok.CustomLog;
 public class ApiProductSubscriptionRefresher {
 
     private static final List<String> INCREMENTAL_STATUS = List.of(ACCEPTED.name(), CLOSED.name(), PAUSED.name(), PENDING.name());
-    private static final List<String> DEPLOY_STATUS = List.of(ACCEPTED.name());
 
     private final SubscriptionRepository subscriptionRepository;
     private final ApiKeyRepository apiKeyRepository;
@@ -105,7 +104,9 @@ public class ApiProductSubscriptionRefresher {
         return Completable.fromRunnable(() -> {
             try {
                 long[] deployed = { 0, 0 };
-                forEachSubscriptionPage(subscribablePlans, environments, DEPLOY_STATUS, repoSubscriptions -> {
+                // Keep non-active statuses in the incremental reconciliation: register() evicts
+                // their potentially stale cache legs when a previous status event was missed.
+                forEachSubscriptionPage(subscribablePlans, environments, INCREMENTAL_STATUS, repoSubscriptions -> {
                     List<Subscription> subscriptions = mapSubscriptions(repoSubscriptions);
                     subscriptions.forEach(subscription -> {
                         try {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
@@ -33,6 +33,7 @@ import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.reactivex.rxjava3.core.Completable;
@@ -41,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 
@@ -48,6 +50,7 @@ import lombok.CustomLog;
 public class ApiProductSubscriptionRefresher {
 
     private static final List<String> INCREMENTAL_STATUS = List.of(ACCEPTED.name(), CLOSED.name(), PAUSED.name(), PENDING.name());
+    private static final List<String> DEPLOY_STATUS = List.of(ACCEPTED.name());
 
     private final SubscriptionRepository subscriptionRepository;
     private final ApiKeyRepository apiKeyRepository;
@@ -86,8 +89,8 @@ public class ApiProductSubscriptionRefresher {
 
     /**
      * Refreshes subscriptions for the given API Product plans.
-     * Loads all subscriptions for the plans, explodes them to all APIs via SubscriptionMapper,
-     * and deploys them using the subscription and API key deployers.
+     * Pages subscriptions for the plans, explodes and deploys one page at a time via
+     * SubscriptionMapper, and releases the page before loading the next one.
      *
      * @param subscribablePlans the plan IDs to refresh subscriptions for
      * @param environments the environments to filter by
@@ -101,32 +104,30 @@ public class ApiProductSubscriptionRefresher {
 
         return Completable.fromRunnable(() -> {
             try {
-                // Load subscriptions for the product plans
-                List<Subscription> subscriptions = loadSubscriptions(subscribablePlans, environments);
-                log.debug("Loaded {} subscriptions for API Product plans", subscriptions.size());
+                long[] deployed = { 0, 0 };
+                forEachSubscriptionPage(subscribablePlans, environments, DEPLOY_STATUS, repoSubscriptions -> {
+                    List<Subscription> subscriptions = mapSubscriptions(repoSubscriptions);
+                    subscriptions.forEach(subscription -> {
+                        try {
+                            subscriptionService.register(subscription);
+                            deployed[0]++;
+                            log.debug("Deployed subscription [{}] for api [{}]", subscription.getId(), subscription.getApi());
+                        } catch (Exception e) {
+                            log.warn("Failed to deploy subscription [{}]", subscription.getId(), e);
+                        }
+                    });
 
-                // Deploy subscriptions
-                subscriptions.forEach(subscription -> {
-                    try {
-                        subscriptionService.register(subscription);
-                        log.debug("Deployed subscription [{}] for api [{}]", subscription.getId(), subscription.getApi());
-                    } catch (Exception e) {
-                        log.warn("Failed to deploy subscription [{}]", subscription.getId(), e);
-                    }
+                    loadApiKeys(subscriptions, environments).forEach(apiKey -> {
+                        try {
+                            apiKeyService.register(apiKey);
+                            deployed[1]++;
+                            log.debug("Deployed API key [{}] for api [{}]", apiKey.getId(), apiKey.getApi());
+                        } catch (Exception e) {
+                            log.warn("Failed to deploy API key [{}]", apiKey.getId(), e);
+                        }
+                    });
                 });
-
-                // Load and deploy API keys
-                List<ApiKey> apiKeys = loadApiKeys(subscriptions, environments);
-                log.debug("Loaded {} API keys for subscriptions", apiKeys.size());
-
-                apiKeys.forEach(apiKey -> {
-                    try {
-                        apiKeyService.register(apiKey);
-                        log.debug("Deployed API key [{}] for api [{}]", apiKey.getId(), apiKey.getApi());
-                    } catch (Exception e) {
-                        log.warn("Failed to deploy API key [{}]", apiKey.getId(), e);
-                    }
-                });
+                log.debug("Deployed {} subscriptions and {} API keys for API Product plans", deployed[0], deployed[1]);
             } catch (Exception ex) {
                 throw new SyncException("Error occurred when refreshing subscriptions for API Product", ex);
             }
@@ -151,20 +152,21 @@ public class ApiProductSubscriptionRefresher {
 
         return Completable.fromRunnable(() -> {
             try {
-                var repoSubs = loadSubscriptionModels(subscribablePlans, environments);
-                var subsToUnregister = repoSubs
-                    .stream()
-                    .filter(s -> s.getReferenceType() == SubscriptionReferenceType.API_PRODUCT)
-                    .flatMap(s -> removedApiIds.stream().map(id -> subscriptionMapper.toSubscriptionForApi(s, id)))
-                    .toList();
+                forEachSubscriptionPage(subscribablePlans, environments, INCREMENTAL_STATUS, repoSubscriptions -> {
+                    var subsToUnregister = repoSubscriptions
+                        .stream()
+                        .filter(s -> s.getReferenceType() == SubscriptionReferenceType.API_PRODUCT)
+                        .flatMap(s -> removedApiIds.stream().map(id -> subscriptionMapper.toSubscriptionForApi(s, id)))
+                        .toList();
 
-                subsToUnregister.forEach(sub ->
-                    unregisterQuietly(() -> subscriptionService.unregister(sub), sub.getId(), "subscription", sub.getApi())
-                );
-                loadApiKeys(subsToUnregister, environments)
-                    .stream()
-                    .filter(k -> removedApiIds.contains(k.getApi()))
-                    .forEach(k -> unregisterQuietly(() -> apiKeyService.unregister(k), k.getId(), "API key", k.getApi()));
+                    subsToUnregister.forEach(sub ->
+                        unregisterQuietly(() -> subscriptionService.unregister(sub), sub.getId(), "subscription", sub.getApi())
+                    );
+                    loadApiKeys(subsToUnregister, environments)
+                        .stream()
+                        .filter(k -> removedApiIds.contains(k.getApi()))
+                        .forEach(k -> unregisterQuietly(() -> apiKeyService.unregister(k), k.getId(), "API key", k.getApi()));
+                });
             } catch (Exception ex) {
                 throw new SyncException("Error occurred when unregistering subscriptions for removed APIs from API Product", ex);
             }
@@ -180,27 +182,37 @@ public class ApiProductSubscriptionRefresher {
         }
     }
 
-    private List<io.gravitee.repository.management.model.Subscription> loadSubscriptionModels(
+    private void forEachSubscriptionPage(
         final Set<String> plans,
-        final Set<String> environments
+        final Set<String> environments,
+        final List<String> statuses,
+        final Consumer<List<io.gravitee.repository.management.model.Subscription>> pageConsumer
     ) {
-        SubscriptionCriteria.SubscriptionCriteriaBuilder criteriaBuilder = SubscriptionCriteria.builder()
-            .plans(plans)
-            .environments(environments)
-            .statuses(INCREMENTAL_STATUS);
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder().plans(plans).environments(environments).statuses(statuses).build();
+        var sortable = new SortableBuilder().field("plan").order(Order.ASC).build();
+        SubscriptionCursor cursor = null;
 
-        try {
-            return subscriptionRepository.search(
-                criteriaBuilder.build(),
-                new SortableBuilder().field("updatedAt").order(Order.ASC).build()
-            );
-        } catch (Exception ex) {
-            throw new SyncException("Error occurred when retrieving subscriptions for API Product", ex);
+        while (true) {
+            final List<io.gravitee.repository.management.model.Subscription> page;
+            try {
+                page = subscriptionRepository.searchAfter(criteria, sortable, cursor, bulkItems);
+            } catch (Exception ex) {
+                throw new SyncException("Error occurred when retrieving subscriptions for API Product", ex);
+            }
+            if (page == null || page.isEmpty()) {
+                return;
+            }
+
+            pageConsumer.accept(page);
+            if (page.size() < bulkItems) {
+                return;
+            }
+            var last = page.getLast();
+            cursor = SubscriptionCursor.byPlanAndId(last.getPlan(), last.getId());
         }
     }
 
-    private List<Subscription> loadSubscriptions(final Set<String> plans, final Set<String> environments) {
-        List<io.gravitee.repository.management.model.Subscription> repoSubscriptions = loadSubscriptionModels(plans, environments);
+    private List<Subscription> mapSubscriptions(final List<io.gravitee.repository.management.model.Subscription> repoSubscriptions) {
         return repoSubscriptions
             .stream()
             .flatMap(subscription -> subscriptionMapper.to(subscription).stream())

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/SubscriptionDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/SubscriptionDeployer.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.command.SubscriptionFailureCommand;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.handlers.api.services.SubscriptionCacheService;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
 import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatcher;
 import io.gravitee.gateway.services.sync.process.common.model.SubscriptionDeployable;
@@ -78,7 +79,11 @@ public class SubscriptionDeployer implements Deployer<SubscriptionDeployable> {
                                     return subscriptions;
                                 });
                             }
-                            subscriptionService.register(subscription);
+                            if (deployable.initialSync() && subscriptionService instanceof SubscriptionCacheService cacheService) {
+                                cacheService.registerInitial(subscription);
+                            } else {
+                                subscriptionService.register(subscription);
+                            }
                             log.debug("Subscription [{}] deployed for api [{}] ", subscription.getId(), subscription.getApi());
                         } catch (Exception e) {
                             log.warn("An error occurred when trying to deploy subscription [{}].", subscription.getId(), e);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -46,20 +46,35 @@ public class SubscriptionMapper {
     private final ApiProductRegistry apiProductRegistry;
 
     public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel) {
+        return to(subscriptionModel, null);
+    }
+
+    /**
+     * Maps a repository subscription only for the requested APIs. This prevents an API Product
+     * subscription from being expanded to every API in the product when an API synchronizer is
+     * currently processing only a small batch of those APIs.
+     *
+     * @param subscriptionModel the repository subscription
+     * @param targetApiIds APIs to map, or {@code null} to map every API
+     */
+    public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel, Set<String> targetApiIds) {
         try {
             if (subscriptionModel.getReferenceType() == SubscriptionReferenceType.API_PRODUCT) {
-                return explodeApiProductSubscription(subscriptionModel);
+                return explodeApiProductSubscription(subscriptionModel, targetApiIds);
             }
 
-            // Regular API subscription - return as single-item list
-            return List.of(toSubscription(subscriptionModel));
+            Subscription subscription = toSubscription(subscriptionModel);
+            return targetApiIds == null || targetApiIds.contains(subscription.getApi()) ? List.of(subscription) : List.of();
         } catch (Exception e) {
             log.warn("Unable to map subscription from model [{}].", subscriptionModel.getId(), e);
             return List.of(); // Return empty list on error
         }
     }
 
-    private List<Subscription> explodeApiProductSubscription(io.gravitee.repository.management.model.Subscription subscriptionModel) {
+    private List<Subscription> explodeApiProductSubscription(
+        io.gravitee.repository.management.model.Subscription subscriptionModel,
+        Set<String> targetApiIds
+    ) {
         String productId = subscriptionModel.getReferenceId();
         if (productId == null) {
             log.warn("API Product subscription [{}] has null referenceId, skipping", subscriptionModel.getId());
@@ -84,9 +99,9 @@ public class SubscriptionMapper {
             return List.of();
         }
 
-        // Create one subscription per API in product
-        return apiIds
-            .stream()
+        // Iterate over the (usually much smaller) current synchronization batch when provided.
+        var apiIdsToMap = targetApiIds == null ? apiIds.stream() : targetApiIds.stream().filter(apiIds::contains);
+        return apiIdsToMap
             .map(apiId -> {
                 Subscription sub = toSubscription(subscriptionModel);
                 sub.setApi(apiId); // Override with individual API

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -99,17 +99,41 @@ public class SubscriptionMapper {
             return List.of();
         }
 
+        // Map the repository record once. API Product subscriptions can fan out to hundreds of
+        // APIs, and parsing the configuration/copying metadata for every leg made this work
+        // proportional to the full Cartesian expansion instead of the repository record count.
+        Subscription template = toSubscription(subscriptionModel);
+
         // Iterate over the (usually much smaller) current synchronization batch when provided.
         var apiIdsToMap = targetApiIds == null ? apiIds.stream() : targetApiIds.stream().filter(apiIds::contains);
-        return apiIdsToMap
-            .map(apiId -> {
-                Subscription sub = toSubscription(subscriptionModel);
-                sub.setApi(apiId); // Override with individual API
-                sub.setApiProductId(productId);
+        return apiIdsToMap.map(apiId -> copyForApi(template, apiId, productId)).toList();
+    }
 
-                return sub;
-            })
-            .toList();
+    /**
+     * Creates the small mutable shell required by the runtime cache while sharing the immutable
+     * values of one logical API Product subscription. Runtime consumers only read configuration,
+     * metadata and dates; incremental updates replace the complete cached leg rather than mutate
+     * those values in place.
+     */
+    private Subscription copyForApi(Subscription template, String apiId, String productId) {
+        Subscription subscription = new Subscription();
+        subscription.setApi(intern(apiId));
+        subscription.setApplication(template.getApplication());
+        subscription.setApplicationName(template.getApplicationName());
+        subscription.setClientId(template.getClientId());
+        subscription.setClientCertificate(template.getClientCertificate());
+        subscription.setStartingAt(template.getStartingAt());
+        subscription.setEndingAt(template.getEndingAt());
+        subscription.setId(template.getId());
+        subscription.setPlan(template.getPlan());
+        subscription.setStatus(template.getStatus());
+        subscription.setConsumerStatus(template.getConsumerStatus());
+        subscription.setType(template.getType());
+        subscription.setConfiguration(template.getConfiguration());
+        subscription.setMetadata(template.getMetadata());
+        subscription.setEnvironmentId(template.getEnvironmentId());
+        subscription.setApiProductId(intern(productId));
+        return subscription;
     }
 
     private Subscription toSubscription(io.gravitee.repository.management.model.Subscription subscriptionModel) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/model/SubscriptionDeployable.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/model/SubscriptionDeployable.java
@@ -29,4 +29,12 @@ public interface SubscriptionDeployable extends ApiDeployable {
     SubscriptionDeployable subscriptions(final List<Subscription> subscriptions);
 
     Set<String> subscribablePlans();
+
+    /**
+     * Initial repository hydration starts with an empty cache and contains only active records.
+     * Implementations can use this signal to skip incremental replacement bookkeeping.
+     */
+    default boolean initialSync() {
+        return false;
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/AbstractDistributedSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/AbstractDistributedSynchronizer.java
@@ -68,7 +68,9 @@ public abstract class AbstractDistributedSynchronizer<T extends Deployable, Y ex
                     .runOn(Schedulers.from(syncDeployerExecutor))
                     .flatMap(deployable -> {
                         if (deployable.syncAction() == SyncAction.DEPLOY) {
-                            return deploy(deployer, deployable).onErrorResumeNext(throwable -> resumeOnError(initialSync, throwable));
+                            return deployAndAfter(deployer, deployable, initialSync).onErrorResumeNext(throwable ->
+                                resumeOnError(initialSync, throwable)
+                            );
                         } else if (deployable.syncAction() == SyncAction.UNDEPLOY) {
                             return undeploy(deployer, deployable).onErrorResumeNext(throwable -> resumeOnError(initialSync, throwable));
                         } else {
@@ -105,8 +107,13 @@ public abstract class AbstractDistributedSynchronizer<T extends Deployable, Y ex
 
     protected abstract Y createDeployer();
 
-    private Flowable<T> deploy(final Y apiDeployer, final T deployable) {
-        return apiDeployer.deploy(deployable).andThen(apiDeployer.doAfterDeployment(deployable)).andThen(Flowable.just(deployable));
+    /** Allows a synchronizer to specialize deployment behavior for an initial sync. */
+    protected Completable deploy(final Y deployer, final T deployable, final boolean initialSync) {
+        return deployer.deploy(deployable);
+    }
+
+    private Flowable<T> deployAndAfter(final Y deployer, final T deployable, final boolean initialSync) {
+        return deploy(deployer, deployable, initialSync).andThen(deployer.doAfterDeployment(deployable)).andThen(Flowable.just(deployable));
     }
 
     private Flowable<T> undeploy(final Y apiDeployer, final T deployable) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizer.java
@@ -24,6 +24,7 @@ import io.gravitee.gateway.services.sync.process.distributed.synchronizer.Abstra
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.apiproduct.ApiProductReactorDeployable;
 import io.gravitee.repository.distributedsync.model.DistributedEvent;
 import io.gravitee.repository.distributedsync.model.DistributedEventType;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import java.util.concurrent.ThreadPoolExecutor;
 import lombok.CustomLog;
@@ -59,6 +60,15 @@ public class DistributedApiProductSynchronizer extends AbstractDistributedSynchr
     @Override
     protected ApiProductDeployer createDeployer() {
         return deployerFactory.createApiProductDeployer();
+    }
+
+    @Override
+    protected Completable deploy(
+        final ApiProductDeployer deployer,
+        final ApiProductReactorDeployable deployable,
+        final boolean initialSync
+    ) {
+        return deployer.deploy(deployable, !initialSync);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/AbstractApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/AbstractApiSynchronizer.java
@@ -116,6 +116,7 @@ public abstract class AbstractApiSynchronizer {
                             ApiReactorDeployable.builder()
                                 .apiId(reactableApi.getId())
                                 .syncAction(SyncAction.DEPLOY)
+                                .initialSync(initialSync)
                                 .reactableApi(reactableApi)
                                 .build()
                         )

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiReactorDeployable.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiReactorDeployable.java
@@ -50,6 +50,8 @@ public class ApiReactorDeployable implements ApiKeyDeployable, SubscriptionDeplo
 
     private SyncAction syncAction;
 
+    private boolean initialSync;
+
     @Builder.Default
     private List<Subscription> subscriptions = List.of();
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -80,8 +81,7 @@ public class SubscriptionAppender {
             .stream()
             .collect(Collectors.toMap(ApiReactorDeployable::apiId, d -> d));
 
-        List<String> apiPlans = collectApiPlans(deployableByApi);
-        List<String> allPlans = new ArrayList<>(apiPlans);
+        Set<String> allPlans = new HashSet<>(collectApiPlans(deployableByApi));
 
         deployableByApi.forEach((apiId, deployable) -> {
             Set<String> envs = environments != null && !environments.isEmpty()
@@ -97,14 +97,19 @@ public class SubscriptionAppender {
         });
 
         if (!allPlans.isEmpty()) {
-            Map<String, List<Subscription>> subscriptionsByApi = loadSubscriptions(initialSync, allPlans, environments);
+            Map<String, List<Subscription>> subscriptionsByApi = loadSubscriptions(
+                initialSync,
+                allPlans,
+                environments,
+                deployableByApi.keySet()
+            );
             subscriptionsByApi.forEach((api, subscriptions) -> {
                 ApiReactorDeployable deployable = deployableByApi.get(api);
                 if (deployable == null) {
                     log.warn(
-                        "Cannot find api {} for subscriptions [{}]",
-                        api,
-                        subscriptions.stream().map(Subscription::getId).collect(Collectors.joining(","))
+                        "Ignoring {} subscriptions for API [{}] not present in the current synchronization batch",
+                        subscriptions.size(),
+                        api
                     );
                 } else {
                     deployable.subscriptions(subscriptions);
@@ -128,8 +133,9 @@ public class SubscriptionAppender {
 
     protected Map<String, List<Subscription>> loadSubscriptions(
         final boolean initialSync,
-        final List<String> plans,
-        final Set<String> environments
+        final Collection<String> plans,
+        final Set<String> environments,
+        final Set<String> targetApiIds
     ) {
         SubscriptionCriteria.SubscriptionCriteriaBuilder criteriaBuilder = SubscriptionCriteria.builder()
             .plans(plans)
@@ -160,7 +166,7 @@ public class SubscriptionAppender {
                 }
                 for (io.gravitee.repository.management.model.Subscription record : page) {
                     subscriptionMapper
-                        .to(record)
+                        .to(record, targetApiIds)
                         .forEach(converted -> {
                             converted.setForceDispatch(true);
                             grouped.computeIfAbsent(converted.getApi(), k -> new ArrayList<>()).add(converted);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizer.java
@@ -70,6 +70,7 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
 
     @Override
     public Completable synchronize(final Long from, final Long to, final Set<String> environments) {
+        boolean initialSync = from == null || from == -1;
         AtomicLong launchTime = new AtomicLong();
 
         return eventsFetcher
@@ -78,11 +79,11 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
                 to,
                 Event.EventProperties.API_PRODUCT_ID,
                 environments,
-                from == -1 ? INIT_EVENT_TYPES : INCREMENTAL_EVENT_TYPES
+                initialSync ? INIT_EVENT_TYPES : INCREMENTAL_EVENT_TYPES
             )
             .subscribeOn(Schedulers.from(syncFetcherExecutor))
             .rebatchRequests(syncFetcherExecutor.getMaximumPoolSize())
-            .compose(this::processEvents)
+            .compose(events -> processEvents(events, initialSync))
             .count()
             .doOnSubscribe(disposable -> launchTime.set(Instant.now().toEpochMilli()))
             .doOnSuccess(count -> {
@@ -91,7 +92,7 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
                     count,
                     (System.currentTimeMillis() - launchTime.get())
                 );
-                if (from == -1) {
+                if (initialSync) {
                     log.info(logMsg);
                 } else {
                     log.debug(logMsg);
@@ -105,7 +106,7 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
         return Order.API_PRODUCT.index();
     }
 
-    private Flowable<ApiProductReactorDeployable> processEvents(final Flowable<List<Event>> eventsFlowable) {
+    private Flowable<ApiProductReactorDeployable> processEvents(final Flowable<List<Event>> eventsFlowable, final boolean initialSync) {
         return eventsFlowable
             // fetch per page
             .flatMap(events ->
@@ -131,7 +132,7 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
                     .runOn(Schedulers.from(syncDeployerExecutor))
                     .flatMap(deployable -> {
                         if (deployable.syncAction() == SyncAction.DEPLOY) {
-                            return deployApiProduct(apiProductDeployer, deployable);
+                            return deployApiProduct(apiProductDeployer, deployable, initialSync);
                         } else if (deployable.syncAction() == SyncAction.UNDEPLOY) {
                             return undeployApiProduct(apiProductDeployer, deployable);
                         } else {
@@ -166,10 +167,11 @@ public class ApiProductSynchronizer implements RepositorySynchronizer {
 
     private Flowable<ApiProductReactorDeployable> deployApiProduct(
         ApiProductDeployer apiProductDeployer,
-        final ApiProductReactorDeployable deployable
+        final ApiProductReactorDeployable deployable,
+        final boolean initialSync
     ) {
         return apiProductDeployer
-            .deploy(deployable)
+            .deploy(deployable, !initialSync)
             .andThen(apiProductDeployer.doAfterDeployment(deployable))
             .andThen(Flowable.just(deployable))
             .onErrorResumeNext(throwable -> {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -124,6 +125,27 @@ class ApiProductDeployerTest {
 
             cut.deploy(deployable).test().assertComplete();
             verify(apiProductManager).register(eq(reactableApiProduct), any(Completable.class));
+        }
+
+        @Test
+        void should_skip_subscription_refresh_when_requested() {
+            ReactableApiProduct reactableApiProduct = ReactableApiProduct.builder()
+                .id("api-product-initial")
+                .name("Initial Product")
+                .apiIds(Set.of("api-1"))
+                .environmentId("env-id")
+                .build();
+            ApiProductReactorDeployable deployable = ApiProductReactorDeployable.builder()
+                .syncAction(SyncAction.DEPLOY)
+                .apiProductId("api-product-initial")
+                .reactableApiProduct(reactableApiProduct)
+                .subscribablePlans(Set.of("plan-1"))
+                .build();
+
+            cut.deploy(deployable, false).test().assertComplete();
+
+            verify(planService).register(deployable);
+            verify(subscriptionRefresher, never()).refresh(anySet(), anySet());
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
@@ -35,6 +35,7 @@ import io.gravitee.gateway.services.sync.process.repository.mapper.ApiKeyMapper;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
+import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import java.util.List;
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -108,6 +110,17 @@ class ApiProductSubscriptionRefresherTest {
             cut.refresh(null, Set.of(ENV_1)).test().assertComplete();
             cut.refresh(Set.of(), Set.of(ENV_1)).test().assertComplete();
             verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), anyInt());
+        }
+
+        @Test
+        void reconciles_all_incremental_subscription_statuses() throws TechnicalException {
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of());
+
+            cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
+
+            var criteriaCaptor = ArgumentCaptor.forClass(SubscriptionCriteria.class);
+            verify(subscriptionRepository).searchAfter(criteriaCaptor.capture(), any(), any(), eq(BULK_ITEMS));
+            assertThat(criteriaCaptor.getValue().getStatuses()).containsExactlyInAnyOrder("ACCEPTED", "CLOSED", "PAUSED", "PENDING");
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
@@ -18,7 +18,9 @@ package io.gravitee.gateway.services.sync.process.common.deployer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,6 +35,7 @@ import io.gravitee.gateway.services.sync.process.repository.mapper.ApiKeyMapper;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import java.util.List;
 import java.util.Set;
@@ -104,14 +107,14 @@ class ApiProductSubscriptionRefresherTest {
         void returns_complete_when_plans_null_or_empty() throws TechnicalException {
             cut.refresh(null, Set.of(ENV_1)).test().assertComplete();
             cut.refresh(Set.of(), Set.of(ENV_1)).test().assertComplete();
-            verify(subscriptionRepository, never()).search(any(), any());
+            verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), anyInt());
         }
 
         @Test
         void loads_and_deploys_subscriptions() throws TechnicalException {
             var repoSub = productSubscription(SUB_1, PLAN_1, ENV_1);
             var gatewaySub = Subscription.builder().id(SUB_1).api(API_1).plan(PLAN_1).build();
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoSub));
             when(subscriptionMapper.to(repoSub)).thenReturn(List.of(gatewaySub));
 
             cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
@@ -125,7 +128,7 @@ class ApiProductSubscriptionRefresherTest {
             var gatewaySub = Subscription.builder().id(SUB_1).api(API_1).plan(PLAN_1).build();
             var repoKey = productApiKey(KEY_ID, ENV_1, SUB_1);
             var gatewayKey = ApiKey.builder().id(KEY_ID).api(API_1).subscription(SUB_1).build();
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoSub));
             when(subscriptionMapper.to(repoSub)).thenReturn(List.of(gatewaySub));
             when(apiKeyRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoKey));
             when(apiKeyMapper.to(repoKey, gatewaySub)).thenReturn(gatewayKey);
@@ -138,11 +141,11 @@ class ApiProductSubscriptionRefresherTest {
 
         @Test
         void does_not_call_api_key_repository_when_no_subscriptions() throws TechnicalException {
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of());
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of());
 
             cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
 
-            verify(subscriptionRepository).search(any(), any());
+            verify(subscriptionRepository).searchAfter(any(), any(), any(), eq(BULK_ITEMS));
             verify(apiKeyRepository, never()).searchAfter(any(), any(), any(), any(int.class));
         }
 
@@ -165,7 +168,7 @@ class ApiProductSubscriptionRefresherTest {
             var repoSubs = IntStream.range(0, 5)
                 .mapToObj(i -> productSubscription("sub" + i, PLAN_1, ENV_1))
                 .toList();
-            when(subscriptionRepository.search(any(), any())).thenReturn(repoSubs);
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(repoSubs);
             var gatewaySubs = IntStream.range(0, 5)
                 .mapToObj(i -> Subscription.builder().id("sub" + i).api(API_1).plan(PLAN_1).build())
                 .toList();
@@ -209,7 +212,7 @@ class ApiProductSubscriptionRefresherTest {
 
         @Test
         void throws_when_repository_fails() throws TechnicalException {
-            when(subscriptionRepository.search(any(), any())).thenThrow(new TechnicalException("DB error"));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenThrow(new TechnicalException("DB error"));
 
             var thrown = catchThrowable(() -> cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).blockingAwait());
 
@@ -217,6 +220,84 @@ class ApiProductSubscriptionRefresherTest {
                 .isInstanceOf(SyncException.class)
                 .hasMessageContaining("Error occurred when refreshing subscriptions for API Product");
             assertThat(thrown.getCause().getCause()).isInstanceOf(TechnicalException.class);
+        }
+
+        @Test
+        void deploys_each_subscription_page_before_loading_the_next_one() throws TechnicalException {
+            var localCut = new ApiProductSubscriptionRefresher(
+                subscriptionRepository,
+                apiKeyRepository,
+                subscriptionMapper,
+                apiKeyMapper,
+                subscriptionService,
+                apiKeyService,
+                2,
+                CHUNK_SIZE
+            );
+            var repoSub1 = productSubscription("sub-1", PLAN_1, ENV_1);
+            var repoSub2 = productSubscription("sub-2", PLAN_1, ENV_1);
+            var repoSub3 = productSubscription("sub-3", PLAN_1, ENV_1);
+            var gatewaySub1 = Subscription.builder().id("sub-1").api(API_1).plan(PLAN_1).build();
+            var gatewaySub2 = Subscription.builder().id("sub-2").api(API_1).plan(PLAN_1).build();
+            var gatewaySub3 = Subscription.builder().id("sub-3").api(API_1).plan(PLAN_1).build();
+
+            when(subscriptionRepository.searchAfter(any(), any(), eq(null), eq(2))).thenReturn(List.of(repoSub1, repoSub2));
+            when(subscriptionRepository.searchAfter(any(), any(), any(SubscriptionCursor.class), eq(2))).thenReturn(List.of(repoSub3));
+            when(subscriptionMapper.to(repoSub1)).thenReturn(List.of(gatewaySub1));
+            when(subscriptionMapper.to(repoSub2)).thenReturn(List.of(gatewaySub2));
+            when(subscriptionMapper.to(repoSub3)).thenReturn(List.of(gatewaySub3));
+
+            localCut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
+
+            var ordered = inOrder(subscriptionRepository, subscriptionService);
+            ordered.verify(subscriptionRepository).searchAfter(any(), any(), eq(null), eq(2));
+            ordered.verify(subscriptionService).register(gatewaySub1);
+            ordered.verify(subscriptionService).register(gatewaySub2);
+            ordered.verify(subscriptionRepository).searchAfter(any(), any(), any(SubscriptionCursor.class), eq(2));
+            ordered.verify(subscriptionService).register(gatewaySub3);
+        }
+
+        @Test
+        void maps_a_federated_api_key_for_subscriptions_from_different_pages() throws TechnicalException {
+            var localCut = new ApiProductSubscriptionRefresher(
+                subscriptionRepository,
+                apiKeyRepository,
+                subscriptionMapper,
+                apiKeyMapper,
+                subscriptionService,
+                apiKeyService,
+                1,
+                CHUNK_SIZE
+            );
+            var repoSub1 = productSubscription("sub-1", PLAN_1, ENV_1);
+            var repoSub2 = productSubscription("sub-2", PLAN_1, ENV_1);
+            var gatewaySub1 = Subscription.builder().id("sub-1").api(API_1).plan(PLAN_1).build();
+            var gatewaySub2 = Subscription.builder().id("sub-2").api(API_1).plan(PLAN_1).build();
+            var federated = productApiKey("federated", ENV_1, "sub-1");
+            federated.setSubscriptions(List.of("sub-1", "sub-2"));
+            var gatewayKey1 = ApiKey.builder().id("key-sub-1").api(API_1).subscription("sub-1").build();
+            var gatewayKey2 = ApiKey.builder().id("key-sub-2").api(API_1).subscription("sub-2").build();
+
+            when(subscriptionRepository.searchAfter(any(), any(), eq(null), eq(1))).thenReturn(List.of(repoSub1));
+            when(subscriptionRepository.searchAfter(any(), any(), any(SubscriptionCursor.class), eq(1))).thenReturn(
+                List.of(repoSub2),
+                List.of()
+            );
+            when(subscriptionMapper.to(repoSub1)).thenReturn(List.of(gatewaySub1));
+            when(subscriptionMapper.to(repoSub2)).thenReturn(List.of(gatewaySub2));
+            when(apiKeyRepository.searchAfter(any(), any(), any(), eq(1))).thenReturn(
+                List.of(federated),
+                List.of(),
+                List.of(federated),
+                List.of()
+            );
+            when(apiKeyMapper.to(federated, gatewaySub1)).thenReturn(gatewayKey1);
+            when(apiKeyMapper.to(federated, gatewaySub2)).thenReturn(gatewayKey2);
+
+            localCut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
+
+            verify(apiKeyService).register(gatewayKey1);
+            verify(apiKeyService).register(gatewayKey2);
         }
     }
 
@@ -227,13 +308,13 @@ class ApiProductSubscriptionRefresherTest {
         void returns_complete_when_removedApiIds_null_or_empty() throws TechnicalException {
             cut.unregisterRemovedApis(null, Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
             cut.unregisterRemovedApis(Set.of(), Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
-            verify(subscriptionRepository, never()).search(any(), any());
+            verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), anyInt());
         }
 
         @Test
         void returns_complete_when_plans_empty() throws TechnicalException {
             cut.unregisterRemovedApis(Set.of("api-removed"), Set.of(), Set.of(ENV_1)).test().assertComplete();
-            verify(subscriptionRepository, never()).search(any(), any());
+            verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), anyInt());
         }
 
         @Test
@@ -243,7 +324,7 @@ class ApiProductSubscriptionRefresherTest {
             var repoKey = productApiKey(KEY_ID, ENV_1, SUB_1);
             var gatewayKey = ApiKey.builder().id(KEY_ID).api("api-removed").subscription(SUB_1).build();
 
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoSub));
             when(subscriptionMapper.toSubscriptionForApi(repoSub, "api-removed")).thenReturn(subForRemoved);
             when(apiKeyRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoKey));
             when(apiKeyMapper.to(repoKey, subForRemoved)).thenReturn(gatewayKey);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/SubscriptionDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/SubscriptionDeployerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.handlers.api.services.SubscriptionCacheService;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
 import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatcher;
@@ -110,6 +111,32 @@ class SubscriptionDeployerTest {
             verify(subscriptionService).register(subscription1);
             verify(subscriptionService, never()).register(subscription2);
             verifyNoMoreInteractions(subscriptionService);
+        }
+
+        @Test
+        void should_use_fast_registration_when_hydrating_the_initial_cache() {
+            SubscriptionCacheService cacheService = mock(SubscriptionCacheService.class);
+            SubscriptionDeployer initialSyncDeployer = new SubscriptionDeployer(
+                cacheService,
+                subscriptionDispatcher,
+                commandRepository,
+                node,
+                new ObjectMapper(),
+                new NoopDistributedSyncService()
+            );
+            Subscription subscription = Subscription.builder().plan("plan").id("subscription").build();
+            ApiReactorDeployable deployable = ApiReactorDeployable.builder()
+                .apiId("apiId")
+                .initialSync(true)
+                .reactableApi(mock(ReactableApi.class))
+                .subscribablePlans(Set.of("plan"))
+                .subscriptions(List.of(subscription))
+                .build();
+
+            initialSyncDeployer.deploy(deployable).test().assertComplete();
+
+            verify(cacheService).registerInitial(subscription);
+            verify(cacheService, never()).register(subscription);
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/synchronizer/apiproduct/DistributedApiProductSynchronizerTest.java
@@ -77,7 +77,7 @@ class DistributedApiProductSynchronizerTest {
         );
         when(eventsFetcher.bulkItems()).thenReturn(1);
         lenient().when(deployerFactory.createApiProductDeployer()).thenReturn(apiProductDeployer);
-        lenient().when(apiProductDeployer.deploy(any())).thenReturn(Completable.complete());
+        lenient().when(apiProductDeployer.deploy(any(), anyBoolean())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.doAfterDeployment(any())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.undeploy(any())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.doAfterUndeployment(any())).thenReturn(Completable.complete());
@@ -146,7 +146,26 @@ class DistributedApiProductSynchronizerTest {
             when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.just(distributedEvent));
             cut.synchronize(-1L, Instant.now().toEpochMilli()).test().await().assertComplete();
 
-            verify(apiProductDeployer).deploy(any());
+            verify(apiProductDeployer).deploy(any(), eq(false));
+            verify(apiProductDeployer).doAfterDeployment(any());
+        }
+
+        @Test
+        void should_refresh_subscriptions_when_fetching_incremental_deploy_event() throws InterruptedException, JsonProcessingException {
+            DistributedEvent distributedEvent = DistributedEvent.builder()
+                .id("product-id")
+                .payload(objectMapper.writeValueAsString(reactableApiProduct))
+                .type(DistributedEventType.API_PRODUCT)
+                .syncAction(DistributedSyncAction.DEPLOY)
+                .updatedAt(new Date())
+                .build();
+            long from = Instant.now().minusSeconds(1).toEpochMilli();
+
+            when(eventsFetcher.fetchLatest(any(), any(), any(), any())).thenReturn(Flowable.just(distributedEvent));
+
+            cut.synchronize(from, Instant.now().toEpochMilli()).test().await().assertComplete();
+
+            verify(apiProductDeployer).deploy(any(), eq(true));
             verify(apiProductDeployer).doAfterDeployment(any());
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
@@ -202,6 +202,27 @@ class SubscriptionMapperTest {
     }
 
     @Test
+    void should_explode_api_product_subscription_only_for_target_apis() {
+        subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
+        subscription.setReferenceId("product-1");
+        subscription.setApi(null);
+        subscription.setEnvironmentId("env-1");
+        ApiProductRegistry registry = mock(ApiProductRegistry.class);
+        ReactableApiProduct product = ReactableApiProduct.builder().id("product-1").apiIds(Set.of("api1", "api2", "api3")).build();
+        when(registry.get("product-1", "env-1")).thenReturn(product);
+        cut = new SubscriptionMapper(objectMapper, registry);
+
+        List<io.gravitee.gateway.api.service.Subscription> mapped = cut.to(subscription, Set.of("api2", "api-outside-product"));
+
+        assertThat(mapped)
+            .singleElement()
+            .satisfies(mappedSubscription -> {
+                assertThat(mappedSubscription.getApi()).isEqualTo("api2");
+                assertThat(mappedSubscription.getApiProductId()).isEqualTo("product-1");
+            });
+    }
+
+    @Test
     void should_return_empty_list_when_api_product_subscription_has_null_reference_id() {
         subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
         subscription.setReferenceId(null);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
@@ -199,6 +199,9 @@ class SubscriptionMapperTest {
         assertThat(mapped).hasSize(2);
         assertThat(mapped).extracting(io.gravitee.gateway.api.service.Subscription::getApi).containsExactlyInAnyOrder("api1", "api2");
         assertThat(mapped).allMatch(s -> "id".equals(s.getId()) && "product-1".equals(s.getApiProductId()));
+        assertThat(mapped.get(0)).isNotSameAs(mapped.get(1));
+        assertThat(mapped.get(0).getConfiguration()).isSameAs(mapped.get(1).getConfiguration());
+        assertThat(mapped.get(0).getMetadata()).isSameAs(mapped.get(1).getMetadata());
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
@@ -28,17 +28,17 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMapper;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.SubscriptionCursor;
+import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -168,46 +168,45 @@ class SubscriptionAppenderTest {
     }
 
     @Test
-    void should_ignore_and_log_subscriptions_with_missing_deployable() throws TechnicalException {
+    void should_expand_api_product_subscription_only_for_apis_in_current_batch() throws TechnicalException {
         configureMemoryAppender();
         ApiReactorDeployable apiReactorDeployable1 = ApiReactorDeployable.builder()
             .apiId("api1")
             .reactableApi(mock(ReactableApi.class))
-            .subscribablePlans(new HashSet<>(Set.of("plan1")))
-            .apiKeyPlans(new HashSet<>(Set.of("plan1")))
+            .subscribablePlans(new HashSet<>(Set.of("product-plan")))
+            .apiKeyPlans(new HashSet<>(Set.of("product-plan")))
             .build();
-        io.gravitee.repository.management.model.Subscription subscription1 = new io.gravitee.repository.management.model.Subscription();
-        subscription1.setId("sub1");
-        subscription1.setApi("api1");
-        io.gravitee.repository.management.model.Subscription subscription2 = new io.gravitee.repository.management.model.Subscription();
-        subscription2.setId("sub2");
-        subscription2.setApi("api3");
-        io.gravitee.repository.management.model.Subscription subscription3 = new io.gravitee.repository.management.model.Subscription();
-        subscription3.setId("sub3");
-        subscription3.setApi("api3");
-        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(
-            List.of(subscription1, subscription2, subscription3)
-        );
-        when(
-            subscriptionRepository.searchAfter(any(), any(), argThat(cur -> cur != null && "sub3".equals(cur.id())), eq(BULK_ITEMS))
-        ).thenReturn(List.of());
         ApiReactorDeployable apiReactorDeployable2 = ApiReactorDeployable.builder()
             .apiId("api2")
             .reactableApi(mock(ReactableApi.class))
             .subscribablePlans(new HashSet<>(Set.of("nosubscriptionplan")))
             .apiKeyPlans(new HashSet<>(Set.of("nosubscriptionplan")))
             .build();
-        List<ApiReactorDeployable> deployables = cut.appends(true, List.of(apiReactorDeployable1, apiReactorDeployable2), Set.of("env"));
-        assertThat(deployables).hasSize(2);
-        assertThat(deployables.get(0).subscriptions()).hasSize(1);
-        assertThat(deployables.get(1).subscriptions()).isEmpty();
 
-        Assertions.assertThat(memoryAppender.getLoggedEvents()).hasSize(1);
-        SoftAssertions.assertSoftly(soft -> {
-            var event = memoryAppender.getLoggedEvents().get(0);
-            soft.assertThat(event.getMessage()).contains("Cannot find api {} for subscriptions [{}]");
-            soft.assertThat(event.getArgumentArray()).contains("api3", "sub2,sub3");
-        });
+        ReactableApiProduct product = ReactableApiProduct.builder().id("product-1").apiIds(Set.of("api1", "api3")).build();
+        when(apiProductRegistry.get("product-1", "env")).thenReturn(product);
+
+        io.gravitee.repository.management.model.Subscription productSubscription =
+            new io.gravitee.repository.management.model.Subscription();
+        productSubscription.setId("sub1");
+        productSubscription.setPlan("product-plan");
+        productSubscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
+        productSubscription.setReferenceId("product-1");
+        productSubscription.setEnvironmentId("env");
+        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(List.of(productSubscription));
+
+        List<ApiReactorDeployable> deployables = cut.appends(true, List.of(apiReactorDeployable1, apiReactorDeployable2), Set.of("env"));
+
+        assertThat(deployables).hasSize(2);
+        assertThat(deployables.get(0).subscriptions())
+            .singleElement()
+            .satisfies(subscription -> {
+                assertThat(subscription.getId()).isEqualTo("sub1");
+                assertThat(subscription.getApi()).isEqualTo("api1");
+                assertThat(subscription.getApiProductId()).isEqualTo("product-1");
+            });
+        assertThat(deployables.get(1).subscriptions()).isEmpty();
+        assertThat(memoryAppender.getLoggedEvents()).isEmpty();
     }
 
     private void configureMemoryAppender() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizerTest.java
@@ -20,6 +20,7 @@ import static io.gravitee.repository.management.model.EventType.DEPLOY_API_PRODU
 import static io.gravitee.repository.management.model.EventType.UNDEPLOY_API_PRODUCT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
@@ -93,7 +94,7 @@ class ApiProductSynchronizerTest {
         );
         lenient().when(latestEventFetcher.bulkItems()).thenReturn(1);
         lenient().when(deployerFactory.createApiProductDeployer()).thenReturn(apiProductDeployer);
-        lenient().when(apiProductDeployer.deploy(any())).thenReturn(Completable.complete());
+        lenient().when(apiProductDeployer.deploy(any(), anyBoolean())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.undeploy(any())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.doAfterDeployment(any())).thenReturn(Completable.complete());
         lenient().when(apiProductDeployer.doAfterUndeployment(any())).thenReturn(Completable.complete());
@@ -172,7 +173,7 @@ class ApiProductSynchronizerTest {
             when(latestEventFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(event)));
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
-            verify(apiProductDeployer).deploy(any());
+            verify(apiProductDeployer).deploy(any(), eq(false));
             verify(apiProductDeployer).doAfterDeployment(any());
         }
 
@@ -188,7 +189,7 @@ class ApiProductSynchronizerTest {
             );
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
-            verify(apiProductDeployer, times(3)).deploy(any());
+            verify(apiProductDeployer, times(3)).deploy(any(), eq(false));
             verify(apiProductDeployer, times(3)).doAfterDeployment(any());
         }
 
@@ -198,13 +199,25 @@ class ApiProductSynchronizerTest {
             Event event2 = createDeployEvent("api-product-fail", "Fail Product");
 
             when(latestEventFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(event1, event2)));
-            when(apiProductDeployer.deploy(any()))
+            when(apiProductDeployer.deploy(any(), eq(false)))
                 .thenReturn(Completable.complete())
                 .thenReturn(Completable.error(new RuntimeException("Deploy failed")));
 
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
-            verify(apiProductDeployer, times(2)).deploy(any());
+            verify(apiProductDeployer, times(2)).deploy(any(), eq(false));
+        }
+
+        @Test
+        void should_refresh_subscriptions_when_processing_incremental_deploy_event() throws InterruptedException, JsonProcessingException {
+            Event event = createDeployEvent("api-product-incremental", "Incremental Product");
+            long from = Instant.now().minusSeconds(1).toEpochMilli();
+
+            when(latestEventFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(event)));
+
+            cut.synchronize(from, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
+
+            verify(apiProductDeployer).deploy(any(), eq(true));
         }
 
         private Event createDeployEvent(String apiProductId, String name) throws JsonProcessingException {
@@ -326,7 +339,7 @@ class ApiProductSynchronizerTest {
             );
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
-            verify(apiProductDeployer).deploy(any());
+            verify(apiProductDeployer).deploy(any(), eq(false));
             verify(apiProductDeployer).doAfterDeployment(any());
             verify(apiProductDeployer).undeploy(any());
             verify(apiProductDeployer).doAfterUndeployment(any());
@@ -356,7 +369,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.subscribablePlans()).containsExactly("plan-published");
@@ -376,7 +389,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.subscribablePlans()).containsExactly("plan-deprecated");
@@ -396,7 +409,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.subscribablePlans()).isEmpty();
@@ -418,7 +431,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             // CLOSED plan is excluded by the mapper — only PUBLISHED and DEPRECATED reach the gateway
@@ -456,7 +469,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.subscribablePlans()).isEmpty();
@@ -494,7 +507,7 @@ class ApiProductSynchronizerTest {
             cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
 
             ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
-            verify(apiProductDeployer).deploy(captor.capture());
+            verify(apiProductDeployer).deploy(captor.capture(), eq(false));
 
             ApiProductReactorDeployable deployable = captor.getValue();
             assertThat(deployable.reactableApiProduct().getTags()).containsExactlyInAnyOrder("internal", "partner");


### PR DESCRIPTION
## Description

This PR combines and extends the approaches proposed in #18993 and #18994 to address gateway startup failures caused by large API Product subscription expansions.

A logical API Product subscription is expanded into one runtime subscription per member API. In the affected environment, 36,487 database subscriptions expand into approximately 5.5 million gateway entries.

## Root cause

The gateway was doing unnecessary work and allocating excessive amounts of memory during synchronization:

- API Product subscriptions could be processed twice during initial synchronization.
- Subscriptions were expanded for APIs outside the current deployment batch.
- Adding every expanded leg copied an increasingly large immutable set, resulting in O(P²) work for a product containing P APIs.
- The API Product refresher materialized all subscriptions and their expanded runtime entries before registration.
- Some warning messages included very large collections of subscription IDs.
- Concurrent registration and eviction could leave the subscription cache indexes inconsistent.

## Changes

### Initial synchronization

- Skip API Product subscription refresh during initial synchronization.
- Let the API subscription synchronizer populate the cache once.
- Apply this behavior to both repository and distributed synchronization.

### Expansion scope

- Expand API Product subscriptions only for APIs present in the current deployment batch.
- Deduplicate product plans before loading their subscriptions.
- Replace large subscription-ID warning payloads with a count and bounded sample.

### Subscription cache

- Introduce a hybrid cache representation:
  - regular 1:1 subscriptions remain compact singleton entries;
  - entries are promoted to a concurrent leg map only when a subscription targets multiple API/environment pairs.
- Make registration of expanded legs O(1), avoiding repeated immutable-set copies.
- Serialize mutations per subscription ID using striped locks.
- Keep the by-ID, identity, certificate, trust-store and per-API indexes consistent during registration and eviction.
- Fix the `unregisterByApiId` race without removing an entire live API index bucket before individual entries are evicted.

### Incremental API Product refresh

- Fetch subscriptions using keyset pagination.
- Process each page independently:
  1. fetch repository subscriptions;
  2. expand the current page;
  3. register subscriptions and API keys;
  4. release the page before fetching the next one.
- Fetch only `ACCEPTED` subscriptions on the deployment path.
- Continue fetching all relevant statuses on the eviction path so subscriptions that left `ACCEPTED` can still be removed.
- Preserve correct federated API-key mapping when referenced subscriptions span multiple pages.

## Expected impact

- API Product subscriptions are no longer processed twice during cold start.
- Cache insertion changes from O(P²) copying to approximately O(P).
- Peak refresher memory is bounded by one subscription page and its runtime expansion instead of the entire product.
- Regular subscriptions do not pay the memory cost of a per-subscription concurrent map.
- Repository bridge response sizes are bounded by `services.sync.bulk_items`.
- Both standard and distributed synchronization follow the same initial-sync behavior.
- No global executor or synchronization parallelism change is introduced.

This does not remove the underlying subscription × API runtime expansion, but it substantially reduces duplicate work, temporary allocations, bridge payload size and cache insertion overhead.

## Validation

Executed on JDK 21:

- `SubscriptionCacheServiceTest`
- `ApiProductSubscriptionRefresherTest`
- `SubscriptionAppenderTest`
- repository and distributed `SubscriptionMapperTest`
- `ApiProductDeployerTest`
- `ApiProductSynchronizerTest`
- `DistributedApiProductSynchronizerTest`

Result: 123 tests, 0 failures, 0 errors.

Additional validation:

- Prettier formatting applied.
- `git diff --check` passes.
- Added concurrent cache registration and eviction coverage.
- Added explicit page-by-page processing coverage.
- Added coverage for federated API keys spanning subscription pages.