### PR TITLE
fix(gamma): keep the selected environment when navigating home

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/EnvironmentGuard.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/EnvironmentGuard.spec.tsx
@@ -18,7 +18,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { useEnvironmentStore } from './environment.store';
 import { EnvironmentGuard } from './EnvironmentGuard';
-import { TEST_ENVIRONMENTS } from '../../testing/factories';
+import { buildEnvironment, TEST_ENVIRONMENTS } from '../../testing/factories';
 import { resetAllStores, seedBootstrap, seedEnvironments } from '../../testing/helpers';
 import { PathnameProbe } from '../../testing/PathnameProbe';
 
@@ -58,6 +58,26 @@ describe('EnvironmentGuard', () => {
         await waitFor(() => {
             expect(useEnvironmentStore.getState().currentEnvironment?.id).toBe('env-2-id');
         });
+    });
+
+    it('should set current environment when the hrid differs from the id only by case', async () => {
+        const defaultEnv = buildEnvironment({ id: 'DEFAULT', hrids: ['default'], name: 'Default environment' });
+        useEnvironmentStore.setState({
+            organizationId: 'test-org',
+            environments: [buildEnvironment({ id: 'other-id', hrids: ['other'] }), defaultEnv],
+            currentEnvironment: null,
+            environmentId: '',
+            loading: false,
+            error: null,
+            initialized: true,
+        });
+
+        renderGuard('/environments/default/home');
+
+        await waitFor(() => {
+            expect(useEnvironmentStore.getState().currentEnvironment?.id).toBe('DEFAULT');
+        });
+        expect(lastPath).toBe('/environments/default/home');
     });
 
     it('should replace id in URL with primary hrid', async () => {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/RootRedirect.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/RootRedirect.spec.tsx
@@ -18,6 +18,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { useEnvironmentStore } from './environment.store';
 import { RootRedirect } from './RootRedirect';
+import { TEST_ENVIRONMENTS } from '../../testing/factories';
 import { resetAllStores, seedBootstrap, seedEnvironments } from '../../testing/helpers';
 import { PathnameProbe } from '../../testing/PathnameProbe';
 
@@ -46,6 +47,26 @@ describe('RootRedirect', () => {
             expect(lastPath).toBe('/environments/env-1/home');
         });
         expect(await screen.findByTestId('landed')).toBeTruthy();
+    });
+
+    it('should redirect / to the home of the environment the user is working in', async () => {
+        seedEnvironments();
+        const second = TEST_ENVIRONMENTS[1]!;
+        useEnvironmentStore.setState({ currentEnvironment: second, environmentId: second.id });
+
+        render(
+            <MemoryRouter initialEntries={['/']}>
+                <PathnameProbe onPath={p => (lastPath = p)} />
+                <Routes>
+                    <Route path="/" element={<RootRedirect />} />
+                    <Route path="/environments/:envHrid/home" element={<div data-testid="landed">ok</div>} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => {
+            expect(lastPath).toBe('/environments/env-2/home');
+        });
     });
 
     it('should show error when store has an error and no environments', () => {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/RootRedirect.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/RootRedirect.tsx
@@ -19,11 +19,14 @@ import { useEnvironmentStore } from './environment.store';
 import { getPrimaryHrid } from './environment.utils';
 
 /**
- * Sends users to the first environment "home" when the URL has no environment segment
- * (e.g. legacy `/` or unknown paths under the protected area).
+ * Sends users to the "home" of the environment they are currently working in when the URL has no
+ * environment segment (e.g. clicking the logo, legacy `/`, or unknown paths under the protected area),
+ * so that navigating home does not silently switch them to another environment.
+ * Falls back to the first environment when none has been selected yet.
  */
 export function RootRedirect() {
     const environments = useEnvironmentStore(s => s.environments);
+    const currentEnvironment = useEnvironmentStore(s => s.currentEnvironment);
     const loading = useEnvironmentStore(s => s.loading);
     const error = useEnvironmentStore(s => s.error);
 
@@ -44,6 +47,6 @@ export function RootRedirect() {
         );
     }
 
-    const hrid = getPrimaryHrid(environments[0]!);
+    const hrid = getPrimaryHrid(currentEnvironment ?? environments[0]!);
     return <Navigate to={`/environments/${hrid}/home`} replace />;
 }

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.utils.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.utils.spec.ts
@@ -48,5 +48,10 @@ describe('environment.utils', () => {
             const env = buildEnvironment({ id: 'abc', hrids: ['x'] });
             expect(shouldRewriteIdToHrid(env, 'x')).toBe(false);
         });
+
+        it('should be false when the primary hrid differs from the id only by case', () => {
+            const env = buildEnvironment({ id: 'DEFAULT', hrids: ['default'] });
+            expect(shouldRewriteIdToHrid(env, 'default')).toBe(false);
+        });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.utils.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.utils.ts
@@ -47,8 +47,13 @@ export function resolveEnvironmentFromSegment(environments: readonly Environment
 /**
  * True when the segment in the URL is the environment's technical id (not a primary hrid), and the env has hrids
  * to canonicalize to.
+ *
+ * A segment that already is the primary hrid never needs rewriting, even when it also matches the technical id
+ * (e.g. the default environment, whose id `DEFAULT` and hrid `default` differ only in case). Rewriting those would
+ * redirect to the very same URL and stop the guard before it syncs the current environment.
  */
 export function shouldRewriteIdToHrid(environment: Environment, segment: string): boolean {
     if (!segment || !environment.hrids?.length) return false;
+    if (getPrimaryHrid(environment).toLowerCase() === segment.toLowerCase()) return false;
     return environment.id.toLowerCase() === segment.toLowerCase();
 }


### PR DESCRIPTION
**Jira:** [FOUND-200](https://gravitee.atlassian.net/browse/FOUND-200)

## Problem

Clicking the Gravitee logo silently switched the user to a different environment, with no warning — so they could act on the wrong one.

## Cause

Two defects, both needed for the bug to disappear.

**1. `RootRedirect` ignored the current environment.** The logo navigates to `/` (`ShellLayout.tsx`), and `RootRedirect` always picked the first environment:

```tsx
const hrid = getPrimaryHrid(environments[0]!);
```

**2. `EnvironmentGuard` never synced `currentEnvironment` for the default environment.** `shouldRewriteIdToHrid` compared the URL segment only against the technical id, so an environment whose primary hrid differs from its id by case — `DEFAULT` vs `default` — was always treated as needing canonicalization. The guard redirected to the identical URL and returned early, never reaching `setCurrentEnvironment`, leaving the store pinned to `environments[0]`.

Fixing only (1) leaves the bug intact wherever (2) applies, since the redirect reads the very field (2) fails to update.

Not a design-system issue: `AppSidebar` exposes `onLogoClick` as a callback, so the routing decision is ours.

## Fix

```tsx
// RootRedirect.tsx
const hrid = getPrimaryHrid(currentEnvironment ?? environments[0]!);
```

```ts
// environment.utils.ts — a segment that already is the primary hrid is canonical
if (getPrimaryHrid(environment).toLowerCase() === segment.toLowerCase()) return false;
```

The `environments[0]` fallback keeps cold-load behaviour unchanged, since `initialize` seeds `currentEnvironment` with the first environment anyway.

## Tests

Three regression tests, each verified to fail without the corresponding fix: redirect honours `currentEnvironment`; `shouldRewriteIdToHrid` returns false for a case-only difference; the guard syncs the store for a `DEFAULT`-shaped environment.

`nx test gamma-console` 147/147; tsc, eslint, prettier clean.

Also verified manually against a local 4.12.13 stack with two environments: from a non-first environment, clicking the logo now stays put.

## Note

Separate, unreported defect in `gravitee-apim-console-webui` — `app-routing.module.ts` redirects root to a hardcoded `default`, discarding the selected environment the same way. Left out to keep this surgical; needs its own ticket.


[FOUND-200]: https://gravitee.atlassian.net/browse/FOUND-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ