### PR TITLE
feat(gamma-platform): delete user and toggle service account

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserProfileCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserProfileCard.tsx
@@ -37,6 +37,7 @@ import {
 
 interface UserProfileCardProps {
     readonly user: OrganizationUser;
+    readonly headerActions?: ReactNode;
 }
 
 function ProfileMetaColumn({ label, icon, children }: Readonly<{ label: string; icon?: ReactNode; children: ReactNode }>) {
@@ -51,7 +52,7 @@ function ProfileMetaColumn({ label, icon, children }: Readonly<{ label: string; 
     );
 }
 
-export function UserProfileCard({ user }: UserProfileCardProps) {
+export function UserProfileCard({ user, headerActions }: UserProfileCardProps) {
     const displayName = formatUserDisplayName(user);
     const organizationRoles = getOrganizationRoles(user.roles);
     const organizationRoleLabels = formatRoleNames(organizationRoles);
@@ -61,25 +62,28 @@ export function UserProfileCard({ user }: UserProfileCardProps) {
     return (
         <Card>
             <CardContent className="space-y-6 pt-6">
-                <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
-                    <UserAvatar name={displayName} size="lg" />
-                    <div className="min-w-0 flex-1 space-y-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                            <h1 className="text-2xl font-semibold tracking-tight">{displayName}</h1>
-                            <Badge variant={detailStatusBadgeVariant(user.status)}>{formatUserStatus(user.status)}</Badge>
-                            {user.isServiceAccount ? (
-                                <Badge variant="outline" className="text-xs uppercase">
-                                    Service account
-                                </Badge>
-                            ) : null}
-                            {user.primary_owner ? (
-                                <Badge variant="outline" className="text-xs uppercase">
-                                    Owner
-                                </Badge>
-                            ) : null}
+                <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex min-w-0 flex-1 flex-col gap-5 sm:flex-row sm:items-start">
+                        <UserAvatar name={displayName} size="lg" />
+                        <div className="min-w-0 flex-1 space-y-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                                <h1 className="text-2xl font-semibold tracking-tight">{displayName}</h1>
+                                <Badge variant={detailStatusBadgeVariant(user.status)}>{formatUserStatus(user.status)}</Badge>
+                                {user.isServiceAccount ? (
+                                    <Badge variant="outline" className="text-xs uppercase">
+                                        Service account
+                                    </Badge>
+                                ) : null}
+                                {user.primary_owner ? (
+                                    <Badge variant="outline" className="text-xs uppercase">
+                                        Primary Owner
+                                    </Badge>
+                                ) : null}
+                            </div>
+                            {user.email ? <p className="text-sm text-muted-foreground">{user.email}</p> : null}
                         </div>
-                        {user.email ? <p className="text-sm text-muted-foreground">{user.email}</p> : null}
                     </div>
+                    {headerActions ? <div className="flex shrink-0 flex-wrap gap-2">{headerActions}</div> : null}
                 </div>
 
                 <div className="grid gap-6 border-t pt-6 sm:grid-cols-2 lg:grid-cols-4">

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UsersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UsersTable.tsx
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Badge, Button, DataTable, DataTableEmptyState, DateCell, Input } from '@gravitee/graphene-core';
-import { SearchIcon } from '@gravitee/graphene-core/icons';
+import { Badge, Button, DataTable, DataTableEmptyState, DateCell, Input, type DataTableProps } from '@gravitee/graphene-core';
+import { SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
 import { useId, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -23,10 +23,16 @@ import { NON_SORTABLE_COLUMN } from '../../applications/utils/dataTableHeaders';
 import type { ColCell } from '../../applications/utils/dataTableTypes';
 import type { OrganizationUser } from '../types/user';
 import { USER_LIST_PAGE_SIZE_OPTIONS } from '../utils/paginationConstants';
-import { formatRoleSummary, formatSourceLabel, formatUserStatus, statusBadgeVariant } from '../utils/userDisplay';
+import {
+    canDeleteOrganizationUser,
+    formatSourceLabel,
+    formatUserStatus,
+    isOrganizationServiceAccount,
+    statusBadgeVariant,
+} from '../utils/userDisplay';
 
-function buildColumns() {
-    return [
+function buildColumns(canDelete: boolean, onDeleteUser?: (user: OrganizationUser) => void): DataTableProps<OrganizationUser>['columns'] {
+    const columns: DataTableProps<OrganizationUser>['columns'] = [
         {
             id: 'user',
             accessorFn: (user: OrganizationUser) => user.displayName ?? user.email ?? user.id,
@@ -49,7 +55,12 @@ function buildColumns() {
                                 </Button>
                                 {user.primary_owner ? (
                                     <Badge variant="outline" className="text-xs uppercase">
-                                        Owner
+                                        Primary Owner
+                                    </Badge>
+                                ) : null}
+                                {isOrganizationServiceAccount(user) ? (
+                                    <Badge variant="outline" className="text-xs uppercase">
+                                        Service account
                                     </Badge>
                                 ) : null}
                                 {(user.number_of_active_tokens ?? 0) > 0 ? (
@@ -85,15 +96,6 @@ function buildColumns() {
             ),
         },
         {
-            id: 'roles',
-            accessorFn: (user: OrganizationUser) => formatRoleSummary(user.roles),
-            header: 'Roles',
-            ...NON_SORTABLE_COLUMN,
-            cell: ({ row }: ColCell<OrganizationUser>) => (
-                <span className="text-sm text-muted-foreground">{formatRoleSummary(row.original.roles)}</span>
-            ),
-        },
-        {
             id: 'lastActivity',
             accessorFn: (user: OrganizationUser) => user.lastConnectionAt ?? 0,
             header: 'Last Login',
@@ -107,6 +109,38 @@ function buildColumns() {
             },
         },
     ];
+
+    if (canDelete && onDeleteUser) {
+        columns.push({
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            size: 56,
+            enableSorting: false,
+            cell: ({ row }: ColCell<OrganizationUser>) => {
+                const user = row.original;
+                if (!canDeleteOrganizationUser(user)) {
+                    return <div className="flex justify-end" />;
+                }
+                const displayName = user.displayName ?? user.email ?? user.id;
+                return (
+                    <div className="flex justify-end">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="size-8 text-muted-foreground hover:text-destructive"
+                            aria-label={`Delete user ${displayName}`}
+                            onClick={() => onDeleteUser(user)}
+                        >
+                            <Trash2Icon className="size-4" aria-hidden />
+                        </Button>
+                    </div>
+                );
+            },
+        });
+    }
+
+    return columns;
 }
 
 interface UsersTableProps {
@@ -121,6 +155,8 @@ interface UsersTableProps {
     readonly onPageChange: (page: number) => void;
     readonly onPageSizeChange: (size: number) => void;
     readonly onAddUser?: () => void;
+    readonly canDelete?: boolean;
+    readonly onDeleteUser?: (user: OrganizationUser) => void;
 }
 
 export function UsersTable({
@@ -135,9 +171,11 @@ export function UsersTable({
     onPageChange,
     onPageSizeChange,
     onAddUser,
+    canDelete = false,
+    onDeleteUser,
 }: UsersTableProps) {
     const searchInputId = useId();
-    const columns = useMemo(() => buildColumns(), []);
+    const columns = useMemo(() => buildColumns(canDelete, onDeleteUser), [canDelete, onDeleteUser]);
 
     if (isFirstUse) {
         return (

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useUserMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useUserMutations.ts
@@ -20,9 +20,11 @@ import { resolveOrganizationId } from '../../../shared/api/apimClient';
 import {
     addUserToGroup,
     createOrganizationUser,
+    deleteOrganizationUser,
     processUserRegistration,
     removeUserFromGroup,
     updateOrganizationUserRoles,
+    updateOrganizationUserServiceAccount,
     updateUserGroupMembership,
 } from '../services/organizationUsers';
 import type { AddUserGroupMembershipPayload, NewPreRegisterUserPayload, UpdateUserRolesPayload } from '../types/user';
@@ -46,11 +48,33 @@ export function useCreateOrganizationUser() {
     });
 }
 
+export function useDeleteOrganizationUser() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (userId: string) => deleteOrganizationUser(userId),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: organizationUserKeys.all });
+        },
+    });
+}
+
 export function useProcessUserRegistration(userId: string | undefined) {
     const queryClient = useQueryClient();
 
     return useMutation({
         mutationFn: (accepted: boolean) => processUserRegistration(userId!, accepted),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: organizationUserKeys.all });
+        },
+    });
+}
+
+export function useUpdateOrganizationUserServiceAccount(userId: string | undefined) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (serviceAccount: boolean) => updateOrganizationUserServiceAccount(userId!, serviceAccount),
         onSuccess: () => {
             void queryClient.invalidateQueries({ queryKey: organizationUserKeys.all });
         },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.spec.ts
@@ -16,6 +16,7 @@
 import {
     addUserToGroup,
     createOrganizationUser,
+    deleteOrganizationUser,
     getOrganizationUser,
     getOrganizationUserApiProducts,
     getOrganizationUserApis,
@@ -31,6 +32,7 @@ import {
     processUserRegistration,
     removeUserFromGroup,
     updateOrganizationUserRoles,
+    updateOrganizationUserServiceAccount,
     updateUserGroupMembership,
 } from './organizationUsers';
 import {
@@ -270,6 +272,27 @@ describe('organizationUsers service', () => {
         expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users/user-1/_process', {
             method: 'POST',
             body: JSON.stringify(true),
+        });
+    });
+
+    it('updates organization user service account status', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue(undefined);
+
+        await updateOrganizationUserServiceAccount('user-1', true);
+
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users/user-1/serviceAccount', {
+            method: 'PATCH',
+            body: JSON.stringify({ serviceAccount: true }),
+        });
+    });
+
+    it('deletes an organization user', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue(undefined);
+
+        await deleteOrganizationUser('user-1');
+
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users/user-1', {
+            method: 'DELETE',
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.ts
@@ -204,6 +204,19 @@ export async function processUserRegistration(userId: string, accepted: boolean)
     });
 }
 
+export async function updateOrganizationUserServiceAccount(userId: string, serviceAccount: boolean): Promise<void> {
+    await apimFetchJsonOrg<void>(`/users/${encodeURIComponent(userId)}/serviceAccount`, {
+        method: 'PATCH',
+        body: JSON.stringify({ serviceAccount }),
+    });
+}
+
+export async function deleteOrganizationUser(userId: string): Promise<void> {
+    await apimFetchJsonOrg<void>(`/users/${encodeURIComponent(userId)}`, {
+        method: 'DELETE',
+    });
+}
+
 export async function listOrganizationRoles(): Promise<OrganizationRole[]> {
     return apimFetchJsonOrg<OrganizationRole[]>('/configuration/rolescopes/ORGANIZATION/roles');
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {
+    canConvertToServiceAccount,
     formatCustomFieldValue,
     formatUserDisplayName,
     formatUserTimestamp,
@@ -57,5 +58,13 @@ describe('userDetailDisplay utilities', () => {
     it('formats timestamps for profile metadata', () => {
         expect(formatUserTimestamp(undefined)).toBe('Never');
         expect(formatUserTimestamp(Date.parse('2025-07-10'))).toMatch(/Jul 10, 2025|10 Jul 2025/);
+    });
+
+    it('allows service account conversion only for gravitee users without a password flag', () => {
+        expect(canConvertToServiceAccount({ isServiceAccount: undefined, hasPassword: false, source: 'gravitee' })).toBe(true);
+        expect(canConvertToServiceAccount({ isServiceAccount: false, hasPassword: false, source: 'gravitee' })).toBe(false);
+        expect(canConvertToServiceAccount({ isServiceAccount: undefined, hasPassword: true, source: 'gravitee' })).toBe(false);
+        expect(canConvertToServiceAccount({ isServiceAccount: undefined, hasPassword: false, source: 'ldap' })).toBe(false);
+        expect(canConvertToServiceAccount({ isServiceAccount: true, hasPassword: false, source: 'gravitee' })).toBe(false);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.ts
@@ -76,3 +76,7 @@ export function formatCustomFieldValue(value: unknown): string {
     }
     return JSON.stringify(value);
 }
+
+export function canConvertToServiceAccount(user: Pick<OrganizationUser, 'isServiceAccount' | 'hasPassword' | 'source'>): boolean {
+    return user.isServiceAccount === null && user.hasPassword !== true && user.source === 'gravitee';
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.spec.ts
@@ -17,7 +17,10 @@ import {
     formatSourceLabel,
     formatTruncatedRoleSummary,
     formatUserStatus,
+    canDeleteOrganizationUser,
     isDuplicateUserError,
+    isOrganizationServiceAccount,
+    isStillPrimaryOwnerError,
     isValidEmail,
     sanitizeTextInput,
     statusBadgeVariant,
@@ -71,5 +74,22 @@ describe('userDisplay utilities', () => {
         expect(isDuplicateUserError('A user [jane@company.com] already exists for organization DEFAULT.')).toBe(true);
         expect(isDuplicateUserError('A dictionary with name [Airport IATA Codes] already exists in this environment.')).toBe(false);
         expect(isDuplicateUserError('Member already exists')).toBe(false);
+    });
+
+    it('identifies organization service accounts from the API flag', () => {
+        expect(isOrganizationServiceAccount({ isServiceAccount: true })).toBe(true);
+        expect(isOrganizationServiceAccount({ isServiceAccount: false })).toBe(false);
+        expect(isOrganizationServiceAccount({})).toBe(false);
+    });
+
+    it('allows deleting only non-primary-owner users that are not already archived', () => {
+        expect(canDeleteOrganizationUser({ primary_owner: false, status: 'ACTIVE' })).toBe(true);
+        expect(canDeleteOrganizationUser({ primary_owner: true, status: 'ACTIVE' })).toBe(false);
+        expect(canDeleteOrganizationUser({ primary_owner: false, status: 'ARCHIVED' })).toBe(false);
+    });
+
+    it('detects primary-owner delete API errors', () => {
+        expect(isStillPrimaryOwnerError("The user is still primary owner of '2' APIs and '1' Applications.")).toBe(true);
+        expect(isStillPrimaryOwnerError('Failed to delete user.')).toBe(false);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { OrganizationUser } from '../types/user';
+
 /** Strips HTML tags from user-provided name fields before submit. */
 export function sanitizeTextInput(value: string): string {
     return value.replace(/<[^>]*>/g, '').trim();
@@ -133,4 +135,17 @@ export function detailStatusBadgeVariant(status: string | undefined): StatusBadg
 export function isDuplicateUserError(message: string): boolean {
     const lower = message.toLowerCase();
     return lower.includes('user cannot be created') || lower.includes('already exists for organization');
+}
+
+export function isOrganizationServiceAccount(user: Pick<{ isServiceAccount?: boolean }, 'isServiceAccount'>): boolean {
+    return user.isServiceAccount === true;
+}
+
+export function canDeleteOrganizationUser(user: Pick<OrganizationUser, 'primary_owner' | 'status'>): boolean {
+    return !user.primary_owner && user.status?.toUpperCase() !== 'ARCHIVED';
+}
+
+export function isStillPrimaryOwnerError(message: string): boolean {
+    const lower = message.toLowerCase();
+    return lower.includes('still primary owner') || lower.includes('user.notdeletable') || lower.includes('group.notdeletable');
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.spec.tsx
@@ -27,7 +27,11 @@ import {
     useOrganizationRoleCatalog,
     useOrganizationUser,
 } from '../features/users/hooks/useOrganizationUser';
-import { useProcessUserRegistration, useUpdateOrganizationUserRoles } from '../features/users/hooks/useUserMutations';
+import {
+    useProcessUserRegistration,
+    useUpdateOrganizationUserRoles,
+    useUpdateOrganizationUserServiceAccount,
+} from '../features/users/hooks/useUserMutations';
 import type { OrganizationUser } from '../features/users/types/user';
 import {
     ORGANIZATION_USER_CREATE_PERMISSION,
@@ -77,6 +81,7 @@ jest.mock('../features/users/components/UserGroupMembershipsCard', () => ({
 jest.mock('../features/users/hooks/useUserMutations', () => ({
     useProcessUserRegistration: jest.fn(),
     useUpdateOrganizationUserRoles: jest.fn(),
+    useUpdateOrganizationUserServiceAccount: jest.fn(),
 }));
 
 const mockUseHasPermission = jest.mocked(useHasPermission);
@@ -85,6 +90,7 @@ const mockUseOrganizationEnvironments = jest.mocked(useOrganizationEnvironments)
 const mockUseOrganizationRoleCatalog = jest.mocked(useOrganizationRoleCatalog);
 const mockUseEnvironmentRoleCatalog = jest.mocked(useEnvironmentRoleCatalog);
 const mockUseProcessUserRegistration = jest.mocked(useProcessUserRegistration);
+const mockUseUpdateOrganizationUserServiceAccount = jest.mocked(useUpdateOrganizationUserServiceAccount);
 const mockUseUpdateOrganizationUserRoles = jest.mocked(useUpdateOrganizationUserRoles);
 
 async function commitOrganizationRoleChange(user: ReturnType<typeof userEvent.setup>, roleLabel: string) {
@@ -186,6 +192,10 @@ describe('UserDetailPage', () => {
             mutate: jest.fn(),
             isPending: false,
         } as unknown as ReturnType<typeof useProcessUserRegistration>);
+        mockUseUpdateOrganizationUserServiceAccount.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as unknown as ReturnType<typeof useUpdateOrganizationUserServiceAccount>);
         mockUseUpdateOrganizationUserRoles.mockReturnValue({
             mutate: jest.fn(),
             isPending: false,
@@ -455,6 +465,104 @@ describe('UserDetailPage', () => {
 
         await screen.findByRole('heading', { name: 'Anna Schmidt' });
         expect(screen.queryByText('Registration Pending')).toBeNull();
+    });
+
+    it('shows convert to service account for eligible gravitee users when update permission is granted', async () => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUser.mockReturnValue({
+            data: {
+                ...DETAIL_USER,
+                status: 'ACTIVE',
+                source: 'gravitee',
+                isServiceAccount: undefined,
+                hasPassword: false,
+            },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+
+        renderUserDetailPage();
+
+        expect(await screen.findByRole('button', { name: 'Convert to service account' })).toBeTruthy();
+    });
+
+    it('hides convert to service account when the user already has a password flag', async () => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUser.mockReturnValue({
+            data: {
+                ...DETAIL_USER,
+                status: 'ACTIVE',
+                source: 'gravitee',
+                isServiceAccount: undefined,
+                hasPassword: true,
+            },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+
+        renderUserDetailPage();
+
+        await screen.findByRole('heading', { name: 'Anna Schmidt' });
+        expect(screen.queryByRole('button', { name: 'Convert to service account' })).toBeNull();
+    });
+
+    it('opens a confirmation dialog and submits service account conversion after confirm', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn();
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUser.mockReturnValue({
+            data: {
+                ...DETAIL_USER,
+                status: 'ACTIVE',
+                source: 'gravitee',
+                isServiceAccount: undefined,
+                hasPassword: false,
+            },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+        mockUseUpdateOrganizationUserServiceAccount.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useUpdateOrganizationUserServiceAccount>);
+
+        renderUserDetailPage();
+
+        await user.click(await screen.findByRole('button', { name: 'Convert to service account' }));
+        const dialog = await screen.findByRole('dialog');
+        expect(dialog.textContent).toMatch(/convert Anna Schmidt to a service account/i);
+        expect(dialog.textContent).toMatch(/cannot be undone/i);
+
+        await user.click(within(dialog).getByRole('button', { name: 'Convert' }));
+        expect(mutate).toHaveBeenCalledWith(true, expect.any(Object));
+    });
+
+    it('shows a success toast after service account conversion', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn((_serviceAccount: boolean, options?: { onSuccess?: () => void }) => options?.onSuccess?.());
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUser.mockReturnValue({
+            data: {
+                ...DETAIL_USER,
+                status: 'ACTIVE',
+                source: 'gravitee',
+                isServiceAccount: undefined,
+                hasPassword: false,
+            },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+        mockUseUpdateOrganizationUserServiceAccount.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useUpdateOrganizationUserServiceAccount>);
+
+        renderUserDetailPage();
+
+        await user.click(await screen.findByRole('button', { name: 'Convert to service account' }));
+        await user.click(within(await screen.findByRole('dialog')).getByRole('button', { name: 'Convert' }));
+
+        await waitFor(() => expect(notify.success).toHaveBeenCalledWith('User "Anna Schmidt" has been converted to a service account'));
     });
 
     it('shows a not-found message when the user fails to load', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.tsx
@@ -30,8 +30,12 @@ import {
     useOrganizationRoleCatalog,
     useOrganizationUser,
 } from '../features/users/hooks/useOrganizationUser';
-import { useProcessUserRegistration, useUpdateOrganizationUserRoles } from '../features/users/hooks/useUserMutations';
-import { formatUserDisplayName, roleLabelsForIds } from '../features/users/utils/userDetailDisplay';
+import {
+    useProcessUserRegistration,
+    useUpdateOrganizationUserRoles,
+    useUpdateOrganizationUserServiceAccount,
+} from '../features/users/hooks/useUserMutations';
+import { canConvertToServiceAccount, formatUserDisplayName, roleLabelsForIds } from '../features/users/utils/userDetailDisplay';
 import {
     ORGANIZATION_USER_CREATE_PERMISSION,
     ORGANIZATION_USER_DELETE_PERMISSION,
@@ -49,12 +53,14 @@ export function UserDetailPage() {
     const canCreate = useHasPermission({ anyOf: [ORGANIZATION_USER_CREATE_PERMISSION] });
     const canDelete = useHasPermission({ anyOf: [ORGANIZATION_USER_DELETE_PERMISSION] });
     const [registrationConfirm, setRegistrationConfirm] = useState<RegistrationConfirmAction | null>(null);
+    const [convertToServiceAccountConfirmOpen, setConvertToServiceAccountConfirmOpen] = useState(false);
 
     const { data: user, isLoading: userLoading, isError: userError } = useOrganizationUser(userId);
     const { data: environments = [], isLoading: environmentsLoading } = useOrganizationEnvironments();
     const { data: organizationRoles = [], isLoading: organizationRolesLoading } = useOrganizationRoleCatalog();
     const { data: environmentRoles = [], isLoading: environmentRolesLoading } = useEnvironmentRoleCatalog();
     const processRegistration = useProcessUserRegistration(userId);
+    const convertToServiceAccount = useUpdateOrganizationUserServiceAccount(userId);
     const updateUserRoles = useUpdateOrganizationUserRoles(userId);
 
     const isActiveUser = user?.status?.toUpperCase() === 'ACTIVE';
@@ -83,6 +89,19 @@ export function UserDetailPage() {
     function handleRegistrationConfirm() {
         if (!registrationConfirm) return;
         handleProcessRegistration(registrationConfirm === 'accept');
+    }
+
+    function handleConvertToServiceAccountConfirm() {
+        convertToServiceAccount.mutate(true, {
+            onSuccess: () => {
+                setConvertToServiceAccountConfirmOpen(false);
+                const displayName = user ? formatUserDisplayName(user) : 'User';
+                notify.success(`User "${displayName}" has been converted to a service account`);
+            },
+            onError: error => {
+                notify.error(error, 'Failed to convert user to a service account.');
+            },
+        });
     }
 
     function handleOrganizationRolesChange(roleIds: string[]) {
@@ -150,6 +169,7 @@ export function UserDetailPage() {
     }
 
     const showRegistrationBanner = canUpdate && user.status?.toUpperCase() === 'PENDING';
+    const showConvertToServiceAccount = canUpdate && canConvertToServiceAccount(user);
     const userDisplayName = formatUserDisplayName(user);
 
     return (
@@ -161,7 +181,23 @@ export function UserDetailPage() {
                 </Link>
             </Button>
 
-            <UserProfileCard user={user} />
+            <UserProfileCard
+                user={user}
+                headerActions={
+                    showConvertToServiceAccount ? (
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            aria-label="Convert to service account"
+                            disabled={convertToServiceAccount.isPending}
+                            onClick={() => setConvertToServiceAccountConfirmOpen(true)}
+                        >
+                            Convert to service account
+                        </Button>
+                    ) : undefined
+                }
+            />
 
             {showRegistrationBanner ? (
                 <UserRegistrationPendingBanner
@@ -186,6 +222,24 @@ export function UserDetailPage() {
                     destructive={registrationConfirm === 'reject'}
                     isPending={processRegistration.isPending}
                     onConfirm={handleRegistrationConfirm}
+                />
+            ) : null}
+
+            {convertToServiceAccountConfirmOpen ? (
+                <ConfirmDialog
+                    open
+                    onOpenChange={open => !open && !convertToServiceAccount.isPending && setConvertToServiceAccountConfirmOpen(false)}
+                    title="Convert to service account"
+                    description={
+                        <>
+                            Are you sure you want to convert <strong>{userDisplayName}</strong> to a service account? This action cannot be
+                            undone.
+                        </>
+                    }
+                    confirmLabel="Convert"
+                    pendingLabel="Converting…"
+                    isPending={convertToServiceAccount.isPending}
+                    onConfirm={handleConvertToServiceAccountConfirm}
                 />
             ) : null}
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UsersPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UsersPage.spec.tsx
@@ -17,11 +17,12 @@ import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { buttonHarness, inputHarness, renderWithGraphene } from '@gravitee/graphene-core/testing';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 
 import { UsersPage } from './UsersPage';
 import { useOrganizationUsers } from '../features/users/hooks/useOrganizationUsers';
-import { useCreateOrganizationUser } from '../features/users/hooks/useUserMutations';
+import { useCreateOrganizationUser, useDeleteOrganizationUser } from '../features/users/hooks/useUserMutations';
 import type { OrganizationUser } from '../features/users/types/user';
 import { notify } from '../shared/notify';
 
@@ -36,6 +37,7 @@ jest.mock('../features/users/hooks/useOrganizationUsers', () => ({
 
 jest.mock('../features/users/hooks/useUserMutations', () => ({
     useCreateOrganizationUser: jest.fn(),
+    useDeleteOrganizationUser: jest.fn(),
 }));
 
 jest.mock('../shared/notify', () => ({
@@ -45,6 +47,7 @@ jest.mock('../shared/notify', () => ({
 const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseOrganizationUsers = jest.mocked(useOrganizationUsers);
 const mockUseCreateOrganizationUser = jest.mocked(useCreateOrganizationUser);
+const mockUseDeleteOrganizationUser = jest.mocked(useDeleteOrganizationUser);
 
 const SAMPLE_USERS: OrganizationUser[] = [
     {
@@ -67,6 +70,17 @@ const SAMPLE_USERS: OrganizationUser[] = [
         roles: [{ name: 'Admin', scope: 'ORGANIZATION' }],
         primary_owner: true,
         number_of_active_tokens: 1,
+    },
+    {
+        id: 'user-3',
+        displayName: 'Automation Bot',
+        email: 'bot@company.com',
+        status: 'ACTIVE',
+        source: 'gravitee',
+        isServiceAccount: true,
+        roles: [{ name: 'User', scope: 'ORGANIZATION' }],
+        primary_owner: false,
+        number_of_active_tokens: 0,
     },
 ];
 
@@ -108,7 +122,7 @@ describe('UsersPage', () => {
         mockUseOrganizationUsers.mockReturnValue({
             data: {
                 data: SAMPLE_USERS,
-                page: { current: 1, size: 10, per_page: 10, total_pages: 1, total_elements: 2 },
+                page: { current: 1, size: 10, per_page: 10, total_pages: 1, total_elements: 3 },
             },
             isLoading: false,
             isError: false,
@@ -117,20 +131,23 @@ describe('UsersPage', () => {
             mutate: jest.fn(),
             isPending: false,
         } as unknown as ReturnType<typeof useCreateOrganizationUser>);
+        mockUseDeleteOrganizationUser.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as unknown as ReturnType<typeof useDeleteOrganizationUser>);
     });
 
     afterEach(() => {
         jest.clearAllMocks();
     });
 
-    it('renders users from the API with source and role columns', async () => {
+    it('renders users from the API with source column', async () => {
         mockUseHasPermission.mockReturnValue(false);
         renderUsersPage();
 
         expect(await screen.findByRole('link', { name: 'Jane Doe' })).toBeTruthy();
         expect(screen.getByText('john@company.com')).toBeTruthy();
-        expect(screen.getByText('Gravitee')).toBeTruthy();
-        expect(screen.getByText('Admin')).toBeTruthy();
+        expect(screen.getAllByText('Gravitee').length).toBeGreaterThanOrEqual(1);
     });
 
     it('links each user name to the user detail page', async () => {
@@ -140,6 +157,21 @@ describe('UsersPage', () => {
         const janeLink = await screen.findByRole('link', { name: 'Jane Doe' });
         expect(janeLink.getAttribute('href')).toBe('/user-1');
         expect(screen.getByRole('link', { name: 'John Doe' }).getAttribute('href')).toBe('/user-2');
+    });
+
+    it('shows pending registration status in the users list', async () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderUsersPage();
+
+        expect(await screen.findByText('Pending')).toBeTruthy();
+        expect(screen.getAllByText('Active').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('shows a service account badge in the users list', async () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderUsersPage();
+
+        expect(await screen.findByText('Service account')).toBeTruthy();
     });
 
     it('hides Add User when the user lacks create permission', async () => {
@@ -194,6 +226,33 @@ describe('UsersPage', () => {
             service: false,
         });
         expect(notify.success).toHaveBeenCalledWith('New user successfully registered!');
+    });
+
+    it('shows delete actions for deletable users when delete permission is granted', async () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }) => anyOf?.includes('organization-user-d') ?? false);
+        renderUsersPage();
+
+        expect(await screen.findByRole('button', { name: 'Delete user Jane Doe' })).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Delete user John Doe' })).toBeNull();
+    });
+
+    it('opens a confirmation dialog and deletes a user after confirm', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn((_userId: string, options?: { onSuccess?: () => void }) => options?.onSuccess?.());
+        mockUseHasPermission.mockImplementation(({ anyOf }) => anyOf?.includes('organization-user-d') ?? false);
+        mockUseDeleteOrganizationUser.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useDeleteOrganizationUser>);
+
+        renderUsersPage();
+
+        await user.click(await screen.findByRole('button', { name: 'Delete user Jane Doe' }));
+        expect(await screen.findByRole('dialog')).toBeTruthy();
+        await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+        await waitFor(() => expect(mutate).toHaveBeenCalledWith('user-1', expect.any(Object)));
+        expect(notify.success).toHaveBeenCalledWith('User Jane Doe is being deleted!');
     });
 
     it('shows a load error message when the users query fails', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UsersPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UsersPage.tsx
@@ -21,15 +21,18 @@ import { useEffect, useState } from 'react';
 import { AddUserSheet } from '../features/users/components/AddUserSheet';
 import { UsersTable } from '../features/users/components/UsersTable';
 import { useOrganizationUsers } from '../features/users/hooks/useOrganizationUsers';
-import { useCreateOrganizationUser } from '../features/users/hooks/useUserMutations';
-import type { NewPreRegisterUserPayload } from '../features/users/types/user';
+import { useCreateOrganizationUser, useDeleteOrganizationUser } from '../features/users/hooks/useUserMutations';
+import type { NewPreRegisterUserPayload, OrganizationUser } from '../features/users/types/user';
 import { DEFAULT_USER_LIST_PAGE_SIZE, USER_SEARCH_DEBOUNCE_MS } from '../features/users/utils/paginationConstants';
-import { isDuplicateUserError } from '../features/users/utils/userDisplay';
-import { ORGANIZATION_USER_CREATE_PERMISSION } from '../features/users/utils/userPermissions';
+import { formatUserDisplayName } from '../features/users/utils/userDetailDisplay';
+import { isDuplicateUserError, isStillPrimaryOwnerError } from '../features/users/utils/userDisplay';
+import { ORGANIZATION_USER_CREATE_PERMISSION, ORGANIZATION_USER_DELETE_PERMISSION } from '../features/users/utils/userPermissions';
+import { ConfirmDialog } from '../shared/components/ConfirmDialog';
 import { notify } from '../shared/notify';
 
 export function UsersPage() {
     const canCreate = useHasPermission({ anyOf: [ORGANIZATION_USER_CREATE_PERMISSION] });
+    const canDelete = useHasPermission({ anyOf: [ORGANIZATION_USER_DELETE_PERMISSION] });
 
     const [search, setSearch] = useState('');
     const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -37,8 +40,10 @@ export function UsersPage() {
     const [pageSize, setPageSize] = useState(DEFAULT_USER_LIST_PAGE_SIZE);
     const [sheetOpen, setSheetOpen] = useState(false);
     const [submitEmailError, setSubmitEmailError] = useState<string | null>(null);
+    const [userToDelete, setUserToDelete] = useState<OrganizationUser | null>(null);
 
     const createMutation = useCreateOrganizationUser();
+    const deleteMutation = useDeleteOrganizationUser();
 
     useEffect(() => {
         const timer = setTimeout(() => setDebouncedSearch(search), USER_SEARCH_DEBOUNCE_MS);
@@ -92,6 +97,25 @@ export function UsersPage() {
         });
     }
 
+    function handleDeleteConfirm() {
+        if (!userToDelete) return;
+        const displayName = formatUserDisplayName(userToDelete);
+        deleteMutation.mutate(userToDelete.id, {
+            onSuccess: () => {
+                setUserToDelete(null);
+                notify.success(`User ${displayName} is being deleted!`);
+            },
+            onError: error => {
+                const message = error instanceof Error ? error.message : '';
+                if (isStillPrimaryOwnerError(message)) {
+                    notify.error(error, message);
+                    return;
+                }
+                notify.error(error, 'Failed to delete user.');
+            },
+        });
+    }
+
     if (isError) {
         return (
             <div className="flex items-center justify-center p-8">
@@ -108,7 +132,7 @@ export function UsersPage() {
                     <p className="text-sm text-muted-foreground">Manage users and service accounts across your organization.</p>
                 </div>
                 {canCreate && !isFirstUse ? (
-                    <Button className="shrink-0" size="sm" onClick={openCreateSheet}>
+                    <Button size="sm" className="shrink-0" onClick={openCreateSheet}>
                         <PlusIcon className="size-4" aria-hidden />
                         Add User
                     </Button>
@@ -127,7 +151,27 @@ export function UsersPage() {
                 onPageChange={setPage}
                 onPageSizeChange={setPageSize}
                 onAddUser={canCreate ? openCreateSheet : undefined}
+                canDelete={canDelete}
+                onDeleteUser={user => setUserToDelete(user)}
             />
+
+            {userToDelete ? (
+                <ConfirmDialog
+                    open
+                    onOpenChange={open => !open && !deleteMutation.isPending && setUserToDelete(null)}
+                    title="Delete a user"
+                    description={
+                        <>
+                            Are you sure you want to delete the user <strong>{formatUserDisplayName(userToDelete)}</strong>?
+                        </>
+                    }
+                    confirmLabel="Delete"
+                    pendingLabel="Deleting…"
+                    destructive
+                    isPending={deleteMutation.isPending}
+                    onConfirm={handleDeleteConfirm}
+                />
+            ) : null}
 
             <AddUserSheet
                 open={sheetOpen}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-89
https://gravitee.atlassian.net/browse/FOUND-90

## Description

Extend Gamma platform **Organization Users** to match classic console behavior and add missing user-management actions.
### Users list
- Fix **Primary Owner** badge label (was incorrectly shown as “Owner”)
- Show **Service account** badge for service accounts
- Remove **Roles** column (list API does not return roles; classic has no roles column)
- Add **Delete user** action with confirmation dialog, permission gating, and primary-owner/archived guards
- Improve status display (e.g. Pending registration)

### User detail
- Add **Convert to service account** action for eligible Gravitee users (`isServiceAccount == null`, no password, source `gravitee`), with confirmation dialog
- Support header actions on `UserProfileCard`


https://github.com/user-attachments/assets/d3c4c92c-6d13-4f1e-9510-4bb57a36ba05
