### PR TITLE
feat(gamma-platform): generate personal token

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/GenerateUserTokenDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/GenerateUserTokenDialog.spec.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { buttonHarness, inputHarness, renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { GenerateUserTokenDialog } from './GenerateUserTokenDialog';
+import { notify } from '../../../shared/notify';
+import { useCreateOrganizationUserToken } from '../hooks/useUserMutations';
+
+jest.mock('../utils/userTokenDisplay', () => ({
+    ...jest.requireActual('../utils/userTokenDisplay'),
+    buildTokenUsageExample: jest
+        .fn()
+        .mockResolvedValue(
+            'curl -H "Authorization: Bearer generated-token" "http://localhost:8083/management/organizations/DEFAULT/environments/DEFAULT"',
+        ),
+}));
+
+jest.mock('../hooks/useUserMutations', () => ({
+    useCreateOrganizationUserToken: jest.fn(),
+}));
+
+jest.mock('../../../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    };
+});
+
+const mockUseCreateOrganizationUserToken = jest.mocked(useCreateOrganizationUserToken);
+
+function renderDialog(overrides: Partial<Parameters<typeof GenerateUserTokenDialog>[0]> = {}) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return renderWithGraphene(
+        <QueryClientProvider client={queryClient}>
+            <GenerateUserTokenDialog open userId="user-1" environmentId="DEFAULT" onOpenChange={jest.fn()} {...overrides} />
+        </QueryClientProvider>,
+    );
+}
+
+describe('GenerateUserTokenDialog', () => {
+    beforeEach(() => {
+        mockUseCreateOrganizationUserToken.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as unknown as ReturnType<typeof useCreateOrganizationUserToken>);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('submits a token name and shows the generated token with usage example', async () => {
+        const mutate = jest.fn((_payload, options?: { onSuccess?: (token: unknown) => void }) =>
+            options?.onSuccess?.({
+                id: 'token-1',
+                name: 'CI token',
+                token: 'generated-token',
+                created_at: Date.now(),
+            }),
+        );
+        mockUseCreateOrganizationUserToken.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useCreateOrganizationUserToken>);
+
+        renderDialog();
+
+        await inputHarness({ name: /name/i }).type('CI token');
+        await buttonHarness({ name: 'Generate' }).click();
+
+        await waitFor(() => expect(mutate).toHaveBeenCalledWith({ name: 'CI token' }, expect.any(Object)));
+        expect(await screen.findByText('generated-token')).toBeTruthy();
+        expect(await screen.findByText(/curl -H "Authorization: Bearer generated-token"/)).toBeTruthy();
+        expect(notify.success).toHaveBeenCalledWith('Token successfully created!');
+    });
+
+    it('keeps generate disabled until the name is valid', async () => {
+        renderDialog();
+
+        const generateButton = () => screen.getByRole('button', { name: 'Generate' }) as HTMLButtonElement;
+        expect(generateButton().disabled).toBe(true);
+
+        await inputHarness({ name: /name/i }).type('a');
+        expect(generateButton().disabled).toBe(true);
+
+        await inputHarness({ name: /name/i }).type('b');
+        expect(generateButton().disabled).toBe(false);
+    });
+
+    it('shows duplicate token errors inline instead of a toast', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn((_payload, options?: { onError?: (error: Error) => void }) =>
+            options?.onError?.(new Error('A token with the name [CI token] already exists.')),
+        );
+        mockUseCreateOrganizationUserToken.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useCreateOrganizationUserToken>);
+
+        renderDialog();
+
+        await inputHarness({ name: /name/i }).type('CI token');
+        await user.click(screen.getByRole('button', { name: 'Generate' }));
+
+        expect(await screen.findByText('A token with the name [CI token] already exists.')).toBeTruthy();
+        expect(notify.error).not.toHaveBeenCalled();
+    });
+
+    it('shows the copy warning only once in the success state', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn((_payload, options?: { onSuccess?: (token: unknown) => void }) =>
+            options?.onSuccess?.({
+                id: 'token-1',
+                name: 'CI token',
+                token: 'generated-token',
+                created_at: Date.now(),
+            }),
+        );
+        mockUseCreateOrganizationUserToken.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useCreateOrganizationUserToken>);
+
+        renderDialog();
+
+        await inputHarness({ name: /name/i }).type('CI token');
+        await user.click(screen.getByRole('button', { name: 'Generate' }));
+
+        await screen.findByText('generated-token');
+        expect(screen.getAllByText(/Make sure to copy your new personal access token now/i)).toHaveLength(1);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/GenerateUserTokenDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/GenerateUserTokenDialog.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+} from '@gravitee/graphene-core';
+import { CopyIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useId, useMemo, useState } from 'react';
+
+import { copyTextToClipboardWithNotifyHandler } from '../../../shared/copyToClipboard';
+import { notify } from '../../../shared/notify';
+import { useCreateOrganizationUserToken } from '../hooks/useUserMutations';
+import type { OrganizationUserToken } from '../types/user';
+import { buildTokenUsageExample, isDuplicateTokenError, TOKEN_NAME_MAX_LENGTH, validateTokenName } from '../utils/userTokenDisplay';
+
+interface GenerateUserTokenDialogProps {
+    readonly open: boolean;
+    readonly userId: string;
+    readonly environmentId: string;
+    readonly onOpenChange: (open: boolean) => void;
+}
+
+function TokenCopyField({ label, value }: Readonly<{ label: string; value: string }>) {
+    return (
+        <div className="min-w-0 space-y-2">
+            <p className="text-sm font-medium text-foreground">{label}</p>
+            <div className="flex min-w-0 items-start gap-2 rounded-md border bg-muted/40 p-3">
+                <code className="min-w-0 flex-1 break-all [overflow-wrap:anywhere] font-mono text-sm text-foreground">{value}</code>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8 shrink-0"
+                    aria-label={`Copy ${label.toLowerCase()}`}
+                    onClick={() => copyTextToClipboardWithNotifyHandler(value, 'Copied to clipboard')}
+                >
+                    <CopyIcon className="size-4" aria-hidden />
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+export function GenerateUserTokenDialog({ open, userId, environmentId, onOpenChange }: GenerateUserTokenDialogProps) {
+    const nameInputId = useId();
+    const [name, setName] = useState('');
+    const [nameError, setNameError] = useState<string | null>(null);
+    const [generatedToken, setGeneratedToken] = useState<OrganizationUserToken | null>(null);
+    const [usageExample, setUsageExample] = useState('');
+    const createToken = useCreateOrganizationUserToken(userId);
+
+    useEffect(() => {
+        if (!open) {
+            setName('');
+            setNameError(null);
+            setGeneratedToken(null);
+            setUsageExample('');
+        }
+    }, [open]);
+
+    useEffect(() => {
+        if (!generatedToken?.token) {
+            setUsageExample('');
+            return;
+        }
+        let cancelled = false;
+        void buildTokenUsageExample(generatedToken.token, environmentId).then(example => {
+            if (!cancelled) {
+                setUsageExample(example);
+            }
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [environmentId, generatedToken]);
+
+    const trimmedName = name.trim();
+    const nameLengthHint = `${trimmedName.length}/${TOKEN_NAME_MAX_LENGTH}`;
+    const canGenerate = useMemo(() => validateTokenName(name) === null, [name]);
+
+    function handleOpenChange(nextOpen: boolean) {
+        if (!nextOpen && createToken.isPending) {
+            return;
+        }
+        onOpenChange(nextOpen);
+    }
+
+    function handleGenerate() {
+        const validationError = validateTokenName(name);
+        if (validationError) {
+            setNameError(validationError);
+            return;
+        }
+
+        setNameError(null);
+        createToken.mutate(
+            { name: trimmedName },
+            {
+                onSuccess: token => {
+                    notify.success('Token successfully created!');
+                    setGeneratedToken(token);
+                },
+                onError: error => {
+                    const message = error instanceof Error ? error.message : '';
+                    if (isDuplicateTokenError(message)) {
+                        setNameError(message);
+                        return;
+                    }
+                    notify.error(error, 'Failed to generate token.');
+                },
+            },
+        );
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent className="w-full max-w-xl overflow-hidden" showCloseButton={false}>
+                <DialogHeader>
+                    <DialogTitle>Generate a token</DialogTitle>
+                    {!generatedToken ? <DialogDescription>What&apos;s this token for?</DialogDescription> : null}
+                </DialogHeader>
+
+                {!generatedToken ? (
+                    <div className="space-y-2 py-2">
+                        <Label htmlFor={nameInputId}>Name *</Label>
+                        <Input
+                            id={nameInputId}
+                            value={name}
+                            maxLength={TOKEN_NAME_MAX_LENGTH}
+                            autoComplete="off"
+                            aria-invalid={Boolean(nameError)}
+                            aria-describedby={nameError ? `${nameInputId}-error` : `${nameInputId}-hint`}
+                            onChange={event => {
+                                setName(event.target.value);
+                                if (nameError) {
+                                    setNameError(null);
+                                }
+                            }}
+                        />
+                        <div className="flex items-start justify-between gap-3 text-xs text-muted-foreground">
+                            <span id={`${nameInputId}-hint`}>What&apos;s this token for?</span>
+                            <span>{nameLengthHint}</span>
+                        </div>
+                        {nameError ? (
+                            <p id={`${nameInputId}-error`} className="text-sm text-destructive">
+                                {nameError}
+                            </p>
+                        ) : null}
+                    </div>
+                ) : (
+                    <div className="min-w-0 space-y-4 py-2">
+                        <Alert>
+                            <AlertDescription>
+                                Make sure to copy your new personal access token now. You won&apos;t be able to see it again.
+                            </AlertDescription>
+                        </Alert>
+                        {generatedToken.token ? <TokenCopyField label="Token" value={generatedToken.token} /> : null}
+                        {usageExample ? <TokenCopyField label="Usage" value={usageExample} /> : null}
+                    </div>
+                )}
+
+                <DialogFooter className="sm:justify-end">
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline" disabled={createToken.isPending}>
+                            {generatedToken ? 'Close' : 'Cancel'}
+                        </Button>
+                    </DialogClose>
+                    {!generatedToken ? (
+                        <Button type="button" disabled={!canGenerate || createToken.isPending} onClick={handleGenerate}>
+                            {createToken.isPending ? 'Generating…' : 'Generate'}
+                        </Button>
+                    ) : null}
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserPersonalAccessTokensCard.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserPersonalAccessTokensCard.spec.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { UserPersonalAccessTokensCard } from './UserPersonalAccessTokensCard';
+import { notify } from '../../../shared/notify';
+import { useOrganizationUserTokens } from '../hooks/useOrganizationUser';
+import { useCreateOrganizationUserToken, useRevokeOrganizationUserToken } from '../hooks/useUserMutations';
+
+jest.mock('../hooks/useOrganizationUser', () => ({
+    useOrganizationUserTokens: jest.fn(),
+}));
+
+jest.mock('../hooks/useUserMutations', () => ({
+    useCreateOrganizationUserToken: jest.fn(),
+    useRevokeOrganizationUserToken: jest.fn(),
+}));
+
+jest.mock('../../../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    };
+});
+
+const mockUseOrganizationUserTokens = jest.mocked(useOrganizationUserTokens);
+const mockUseCreateOrganizationUserToken = jest.mocked(useCreateOrganizationUserToken);
+const mockUseRevokeOrganizationUserToken = jest.mocked(useRevokeOrganizationUserToken);
+
+function renderCard(overrides: Partial<Parameters<typeof UserPersonalAccessTokensCard>[0]> = {}) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return renderWithGraphene(
+        <QueryClientProvider client={queryClient}>
+            <UserPersonalAccessTokensCard userId="user-1" environmentId="DEFAULT" canGenerate canRevoke {...overrides} />
+        </QueryClientProvider>,
+    );
+}
+
+describe('UserPersonalAccessTokensCard', () => {
+    beforeEach(() => {
+        mockUseOrganizationUserTokens.mockReturnValue({
+            data: [],
+            isLoading: false,
+        } as ReturnType<typeof useOrganizationUserTokens>);
+        mockUseCreateOrganizationUserToken.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as unknown as ReturnType<typeof useCreateOrganizationUserToken>);
+        mockUseRevokeOrganizationUserToken.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as unknown as ReturnType<typeof useRevokeOrganizationUserToken>);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('shows the empty state CTA without a header button when no tokens exist', async () => {
+        const user = userEvent.setup();
+        renderCard();
+
+        expect(await screen.findByText('No personal access tokens')).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Generate Token' })).toBeTruthy();
+        expect(screen.queryAllByRole('button', { name: 'Generate Token' })).toHaveLength(1);
+
+        await user.click(screen.getByRole('button', { name: 'Generate Token' }));
+        expect(await screen.findByRole('dialog')).toBeTruthy();
+        expect(screen.getByRole('dialog').textContent).toMatch(/Generate a token/i);
+    });
+
+    it('shows the header generate button and table when tokens exist', async () => {
+        mockUseOrganizationUserTokens.mockReturnValue({
+            data: [{ id: 'token-1', name: 'My token', created_at: 1630373735403, last_use_at: 1631017105654 }],
+            isLoading: false,
+        } as ReturnType<typeof useOrganizationUserTokens>);
+
+        renderCard();
+
+        expect(await screen.findByText('My token')).toBeTruthy();
+        expect(screen.getByText('1 active token')).toBeTruthy();
+        expect(screen.getAllByRole('button', { name: 'Generate Token' })).toHaveLength(1);
+        expect(screen.getByRole('button', { name: 'Revoke token My token' })).toBeTruthy();
+    });
+
+    it('hides generate and revoke actions without the corresponding permissions', async () => {
+        mockUseOrganizationUserTokens.mockReturnValue({
+            data: [{ id: 'token-1', name: 'My token', created_at: 1630373735403 }],
+            isLoading: false,
+        } as ReturnType<typeof useOrganizationUserTokens>);
+
+        renderCard({ canGenerate: false, canRevoke: false });
+
+        expect(await screen.findByText('My token')).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Generate Token' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Revoke token My token' })).toBeNull();
+    });
+
+    it('revokes a token after confirmation', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn((_tokenId: string, options?: { onSuccess?: () => void }) => options?.onSuccess?.());
+        mockUseOrganizationUserTokens.mockReturnValue({
+            data: [{ id: 'token-1', name: 'My token', created_at: 1630373735403 }],
+            isLoading: false,
+        } as ReturnType<typeof useOrganizationUserTokens>);
+        mockUseRevokeOrganizationUserToken.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useRevokeOrganizationUserToken>);
+
+        renderCard({ canGenerate: false, canRevoke: true });
+
+        await user.click(await screen.findByRole('button', { name: 'Revoke token My token' }));
+        const dialog = await screen.findByRole('dialog');
+        expect(dialog.textContent).toMatch(/revoke the token/i);
+        expect(dialog.textContent).toMatch(/My token/);
+
+        await user.click(within(dialog).getByRole('button', { name: 'Revoke' }));
+
+        await waitFor(() => expect(mutate).toHaveBeenCalledWith('token-1', expect.any(Object)));
+        expect(notify.success).toHaveBeenCalledWith('Token successfully deleted!');
+    });
+
+    it('shows a loading skeleton while tokens are loading', () => {
+        mockUseOrganizationUserTokens.mockReturnValue({
+            data: undefined,
+            isLoading: true,
+        } as ReturnType<typeof useOrganizationUserTokens>);
+
+        const { container } = renderCard();
+
+        expect(container.querySelector('.animate-pulse')).toBeTruthy();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserPersonalAccessTokensCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserPersonalAccessTokensCard.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    DataTable,
+    DateCell,
+    Empty,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+    Skeleton,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { KeyIcon, PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useMemo, useState } from 'react';
+
+import { GenerateUserTokenDialog } from './GenerateUserTokenDialog';
+import { ConfirmDialog } from '../../../shared/components/ConfirmDialog';
+import { notify } from '../../../shared/notify';
+import type { ColCell } from '../../applications/utils/dataTableTypes';
+import { useOrganizationUserTokens } from '../hooks/useOrganizationUser';
+import { useRevokeOrganizationUserToken } from '../hooks/useUserMutations';
+import type { OrganizationUserToken } from '../types/user';
+import { formatTokenTimestamp } from '../utils/userTokenDisplay';
+
+interface UserPersonalAccessTokensCardProps {
+    readonly userId: string;
+    readonly environmentId: string;
+    readonly canGenerate: boolean;
+    readonly canRevoke: boolean;
+}
+
+function buildColumns(
+    canRevoke: boolean,
+    onRevokeToken?: (token: OrganizationUserToken) => void,
+): DataTableProps<OrganizationUserToken>['columns'] {
+    const columns: DataTableProps<OrganizationUserToken>['columns'] = [
+        {
+            id: 'name',
+            accessorFn: (token: OrganizationUserToken) => token.name,
+            header: 'Name',
+            enableSorting: false,
+            cell: ({ row }: ColCell<OrganizationUserToken>) => <span className="font-medium text-foreground">{row.original.name}</span>,
+        },
+        {
+            id: 'createdAt',
+            accessorFn: (token: OrganizationUserToken) => token.created_at ?? 0,
+            header: 'Created at',
+            enableSorting: false,
+            cell: ({ row }: ColCell<OrganizationUserToken>) => {
+                const createdAt = row.original.created_at;
+                return createdAt ? <DateCell value={new Date(createdAt)} /> : <span className="text-muted-foreground">—</span>;
+            },
+        },
+        {
+            id: 'lastUseAt',
+            accessorFn: (token: OrganizationUserToken) => token.last_use_at ?? 0,
+            header: 'Last use',
+            enableSorting: false,
+            cell: ({ row }: ColCell<OrganizationUserToken>) => (
+                <span className="text-sm text-muted-foreground">{formatTokenTimestamp(row.original.last_use_at)}</span>
+            ),
+        },
+    ];
+
+    if (canRevoke && onRevokeToken) {
+        columns.push({
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            size: 56,
+            enableSorting: false,
+            cell: ({ row }: ColCell<OrganizationUserToken>) => (
+                <div className="flex justify-end">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-8 text-muted-foreground hover:text-destructive"
+                        aria-label={`Revoke token ${row.original.name}`}
+                        onClick={() => onRevokeToken(row.original)}
+                    >
+                        <Trash2Icon className="size-4" aria-hidden />
+                    </Button>
+                </div>
+            ),
+        });
+    }
+
+    return columns;
+}
+
+export function UserPersonalAccessTokensCard({ userId, environmentId, canGenerate, canRevoke }: UserPersonalAccessTokensCardProps) {
+    const { data: tokens = [], isLoading } = useOrganizationUserTokens(userId);
+    const revokeToken = useRevokeOrganizationUserToken(userId);
+    const [generateOpen, setGenerateOpen] = useState(false);
+    const [tokenToRevoke, setTokenToRevoke] = useState<OrganizationUserToken | null>(null);
+
+    const columns = useMemo(() => buildColumns(canRevoke, token => setTokenToRevoke(token)), [canRevoke]);
+    const activeTokenCount = tokens.length;
+    const subtitle = activeTokenCount === 0 ? 'No active tokens' : `${activeTokenCount} active token${activeTokenCount === 1 ? '' : 's'}`;
+
+    function handleRevokeConfirm() {
+        if (!tokenToRevoke) {
+            return;
+        }
+        revokeToken.mutate(tokenToRevoke.id, {
+            onSuccess: () => {
+                setTokenToRevoke(null);
+                notify.success('Token successfully deleted!');
+            },
+            onError: error => {
+                notify.error(error, 'Failed to revoke token.');
+            },
+        });
+    }
+
+    return (
+        <>
+            <Card>
+                <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0 pb-3">
+                    <div className="space-y-1">
+                        <CardTitle className="text-base">Personal Access Tokens</CardTitle>
+                        <CardDescription>{subtitle}</CardDescription>
+                    </div>
+                    {canGenerate && tokens.length > 0 ? (
+                        <Button type="button" size="sm" variant="outline" onClick={() => setGenerateOpen(true)}>
+                            <PlusIcon className="size-4" aria-hidden />
+                            Generate Token
+                        </Button>
+                    ) : null}
+                </CardHeader>
+                <CardContent>
+                    {isLoading ? (
+                        <Skeleton className="h-32 w-full rounded-lg" />
+                    ) : tokens.length === 0 ? (
+                        <Empty className="border border-dashed rounded-lg py-10">
+                            <EmptyHeader>
+                                <EmptyMedia variant="icon">
+                                    <KeyIcon className="size-5" aria-hidden />
+                                </EmptyMedia>
+                                <EmptyTitle>No personal access tokens</EmptyTitle>
+                                <EmptyDescription>Generate one for API or CI/CD access.</EmptyDescription>
+                            </EmptyHeader>
+                            {canGenerate ? (
+                                <Button type="button" size="sm" onClick={() => setGenerateOpen(true)}>
+                                    <PlusIcon className="size-4" aria-hidden />
+                                    Generate Token
+                                </Button>
+                            ) : null}
+                        </Empty>
+                    ) : (
+                        <DataTable columns={columns} data={tokens} />
+                    )}
+                </CardContent>
+            </Card>
+
+            {canGenerate ? (
+                <GenerateUserTokenDialog open={generateOpen} userId={userId} environmentId={environmentId} onOpenChange={setGenerateOpen} />
+            ) : null}
+
+            {tokenToRevoke ? (
+                <ConfirmDialog
+                    open
+                    destructive
+                    title="Revoke a token"
+                    description={
+                        <>
+                            Are you sure you want to revoke the token <strong>{tokenToRevoke.name}</strong>?
+                        </>
+                    }
+                    confirmLabel="Revoke"
+                    pendingLabel="Revoking…"
+                    isPending={revokeToken.isPending}
+                    onOpenChange={open => !open && !revokeToken.isPending && setTokenToRevoke(null)}
+                    onConfirm={handleRevokeConfirm}
+                />
+            ) : null}
+        </>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useOrganizationUser.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useOrganizationUser.ts
@@ -26,6 +26,7 @@ import {
     listGroupMembershipRoleCatalog,
     listOrganizationEnvironments,
     listOrganizationRoles,
+    listOrganizationUserTokens,
 } from '../services/organizationUsers';
 import type { GroupMembershipRoleCatalogScope } from '../types/user';
 import { organizationUserKeys } from '../utils/queryKeys';
@@ -116,5 +117,13 @@ export function useEnvironmentRoleCatalog() {
     return useQuery({
         queryKey: organizationUserKeys.environmentRoles(),
         queryFn: listEnvironmentRoles,
+    });
+}
+
+export function useOrganizationUserTokens(userId: string | undefined) {
+    return useQuery({
+        queryKey: organizationUserKeys.tokens(userId ?? ''),
+        queryFn: () => listOrganizationUserTokens(userId!),
+        enabled: Boolean(userId),
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useUserMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useUserMutations.ts
@@ -20,14 +20,21 @@ import { resolveOrganizationId } from '../../../shared/api/apimClient';
 import {
     addUserToGroup,
     createOrganizationUser,
+    createOrganizationUserToken,
     deleteOrganizationUser,
     processUserRegistration,
     removeUserFromGroup,
+    revokeOrganizationUserToken,
     updateOrganizationUserRoles,
     updateOrganizationUserServiceAccount,
     updateUserGroupMembership,
 } from '../services/organizationUsers';
-import type { AddUserGroupMembershipPayload, NewPreRegisterUserPayload, UpdateUserRolesPayload } from '../types/user';
+import type {
+    AddUserGroupMembershipPayload,
+    NewOrganizationUserTokenPayload,
+    NewPreRegisterUserPayload,
+    UpdateUserRolesPayload,
+} from '../types/user';
 import { organizationUserKeys } from '../utils/queryKeys';
 
 function invalidateOrganizationUserGroupMembershipQueries(queryClient: QueryClient, userId: string, environmentId: string): void {
@@ -77,6 +84,41 @@ export function useUpdateOrganizationUserServiceAccount(userId: string | undefin
         mutationFn: (serviceAccount: boolean) => updateOrganizationUserServiceAccount(userId!, serviceAccount),
         onSuccess: () => {
             void queryClient.invalidateQueries({ queryKey: organizationUserKeys.all });
+        },
+    });
+}
+
+function invalidateOrganizationUserListQueries(queryClient: QueryClient): void {
+    void queryClient.invalidateQueries({
+        predicate: query =>
+            Array.isArray(query.queryKey) && query.queryKey[0] === organizationUserKeys.all[0] && query.queryKey[1] === 'list',
+    });
+}
+
+export function useCreateOrganizationUserToken(userId: string | undefined) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (payload: NewOrganizationUserTokenPayload) => createOrganizationUserToken(userId!, payload),
+        onSuccess: () => {
+            if (userId) {
+                void queryClient.invalidateQueries({ queryKey: organizationUserKeys.tokens(userId) });
+                invalidateOrganizationUserListQueries(queryClient);
+            }
+        },
+    });
+}
+
+export function useRevokeOrganizationUserToken(userId: string | undefined) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (tokenId: string) => revokeOrganizationUserToken(userId!, tokenId),
+        onSuccess: () => {
+            if (userId) {
+                void queryClient.invalidateQueries({ queryKey: organizationUserKeys.tokens(userId) });
+                invalidateOrganizationUserListQueries(queryClient);
+            }
         },
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.spec.ts
@@ -16,6 +16,7 @@
 import {
     addUserToGroup,
     createOrganizationUser,
+    createOrganizationUserToken,
     deleteOrganizationUser,
     getOrganizationUser,
     getOrganizationUserApiProducts,
@@ -29,7 +30,9 @@ import {
     listOrganizationEnvironments,
     listOrganizationRoles,
     listOrganizationUsers,
+    listOrganizationUserTokens,
     processUserRegistration,
+    revokeOrganizationUserToken,
     removeUserFromGroup,
     updateOrganizationUserRoles,
     updateOrganizationUserServiceAccount,
@@ -292,6 +295,30 @@ describe('organizationUsers service', () => {
         await deleteOrganizationUser('user-1');
 
         expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users/user-1', {
+            method: 'DELETE',
+        });
+    });
+
+    it('loads, creates, and revokes organization user tokens', async () => {
+        mockApimFetchJsonOrg.mockResolvedValueOnce([{ id: 'token-1', name: 'My token', created_at: 1 }]);
+        await expect(listOrganizationUserTokens('user-1')).resolves.toEqual([{ id: 'token-1', name: 'My token', created_at: 1 }]);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users/user-1/tokens');
+
+        mockApimFetchJsonOrg.mockResolvedValueOnce({ id: 'token-2', name: 'CI token', token: 'secret', created_at: 2 });
+        await expect(createOrganizationUserToken('user-1', { name: 'CI token' })).resolves.toEqual({
+            id: 'token-2',
+            name: 'CI token',
+            token: 'secret',
+            created_at: 2,
+        });
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users/user-1/tokens', {
+            method: 'POST',
+            body: JSON.stringify({ name: 'CI token' }),
+        });
+
+        mockApimFetchJsonOrg.mockResolvedValueOnce(undefined);
+        await revokeOrganizationUserToken('user-1', 'token-1');
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users/user-1/tokens/token-1', {
             method: 'DELETE',
         });
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.ts
@@ -20,11 +20,13 @@ import type {
     GroupMemberRolePayload,
     GroupMembershipRoleCatalogScope,
     IdentityProviderListItem,
+    NewOrganizationUserTokenPayload,
     NewPreRegisterUserPayload,
     OrganizationEnvironment,
     OrganizationRole,
     OrganizationUser,
     OrganizationUserListResponse,
+    OrganizationUserToken,
     UpdateUserRolesPayload,
     UserGroupsListResponse,
     UserInheritedApi,
@@ -213,6 +215,26 @@ export async function updateOrganizationUserServiceAccount(userId: string, servi
 
 export async function deleteOrganizationUser(userId: string): Promise<void> {
     await apimFetchJsonOrg<void>(`/users/${encodeURIComponent(userId)}`, {
+        method: 'DELETE',
+    });
+}
+
+export async function listOrganizationUserTokens(userId: string): Promise<OrganizationUserToken[]> {
+    return apimFetchJsonOrg<OrganizationUserToken[]>(`/users/${encodeURIComponent(userId)}/tokens`);
+}
+
+export async function createOrganizationUserToken(
+    userId: string,
+    payload: NewOrganizationUserTokenPayload,
+): Promise<OrganizationUserToken> {
+    return apimFetchJsonOrg<OrganizationUserToken>(`/users/${encodeURIComponent(userId)}/tokens`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+    });
+}
+
+export async function revokeOrganizationUserToken(userId: string, tokenId: string): Promise<void> {
+    await apimFetchJsonOrg<void>(`/users/${encodeURIComponent(userId)}/tokens/${encodeURIComponent(tokenId)}`, {
         method: 'DELETE',
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/types/user.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/types/user.ts
@@ -175,3 +175,16 @@ export interface IdentityProviderListItem {
 export type UserType = 'EXTERNAL_USER' | 'SERVICE_ACCOUNT';
 
 export const GRAVITEE_IDP: IdentityProviderListItem = { id: 'gravitee', name: 'Gravitee' };
+
+export interface OrganizationUserToken {
+    id: string;
+    name: string;
+    token?: string;
+    created_at: number;
+    expires_at?: number;
+    last_use_at?: number;
+}
+
+export interface NewOrganizationUserTokenPayload {
+    name: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/queryKeys.ts
@@ -27,4 +27,5 @@ export const organizationUserKeys = {
     environments: () => [...organizationUserKeys.all, 'environments'] as const,
     organizationRoles: () => [...organizationUserKeys.all, 'organization-roles'] as const,
     environmentRoles: () => [...organizationUserKeys.all, 'environment-roles'] as const,
+    tokens: (userId: string) => [...organizationUserKeys.all, 'tokens', userId] as const,
 };

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.ts
@@ -78,5 +78,7 @@ export function formatCustomFieldValue(value: unknown): string {
 }
 
 export function canConvertToServiceAccount(user: Pick<OrganizationUser, 'isServiceAccount' | 'hasPassword' | 'source'>): boolean {
-    return user.isServiceAccount === null && user.hasPassword !== true && user.source === 'gravitee';
+    return (
+        (user.isServiceAccount === null || user.isServiceAccount === undefined) && user.hasPassword !== true && user.source === 'gravitee'
+    );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userTokenDisplay.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userTokenDisplay.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { buildTokenUsageExample, formatTokenTimestamp, isDuplicateTokenError, validateTokenName } from './userTokenDisplay';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    loadApimBootstrap: jest.fn().mockResolvedValue({
+        managementBaseURL: 'http://localhost:8083/management',
+        organizationId: 'DEFAULT',
+    }),
+}));
+
+describe('userTokenDisplay utilities', () => {
+    it('validates token names like classic console', () => {
+        expect(validateTokenName('')).toBe('Name is required.');
+        expect(validateTokenName('a')).toBe('Name has to be at least 2 characters long.');
+        expect(validateTokenName('ab')).toBeNull();
+        expect(validateTokenName('a'.repeat(64))).toBeNull();
+        expect(validateTokenName('a'.repeat(65))).toBe('Name has to be at most 64 characters long.');
+    });
+
+    it('detects duplicate token API errors', () => {
+        expect(isDuplicateTokenError('A token with the name [External] already exists.')).toBe(true);
+        expect(isDuplicateTokenError('Failed to generate token.')).toBe(false);
+    });
+
+    it('builds a curl usage example for the selected environment', async () => {
+        await expect(buildTokenUsageExample('token-value', 'DEFAULT')).resolves.toBe(
+            'curl -H "Authorization: Bearer token-value" "http://localhost:8083/management/organizations/DEFAULT/environments/DEFAULT"',
+        );
+    });
+
+    it('formats token timestamps for table display', () => {
+        expect(formatTokenTimestamp(undefined)).toBe('never');
+        expect(formatTokenTimestamp(Date.parse('2021-08-31T01:35:35.403Z'))).toMatch(/Aug 31, 2021|31 Aug 2021/);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userTokenDisplay.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userTokenDisplay.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { loadApimBootstrap } from '../../../shared/api/apimClient';
+
+export const TOKEN_NAME_MAX_LENGTH = 64;
+export const TOKEN_NAME_MIN_LENGTH = 2;
+
+export function validateTokenName(name: string): string | null {
+    const trimmed = name.trim();
+    if (!trimmed) {
+        return 'Name is required.';
+    }
+    if (trimmed.length < TOKEN_NAME_MIN_LENGTH) {
+        return `Name has to be at least ${TOKEN_NAME_MIN_LENGTH} characters long.`;
+    }
+    if (trimmed.length > TOKEN_NAME_MAX_LENGTH) {
+        return `Name has to be at most ${TOKEN_NAME_MAX_LENGTH} characters long.`;
+    }
+    return null;
+}
+
+export function isDuplicateTokenError(message: string): boolean {
+    const lower = message.toLowerCase();
+    return lower.includes('token.alreadyexists') || lower.includes('a token with the name');
+}
+
+export function formatTokenTimestamp(timestamp: number | undefined): string {
+    if (!timestamp) {
+        return 'never';
+    }
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'medium' }).format(new Date(timestamp));
+}
+
+export async function buildTokenUsageExample(token: string, environmentId: string): Promise<string> {
+    const { managementBaseURL, organizationId } = await loadApimBootstrap();
+    const environmentUrl = `${managementBaseURL}/organizations/${organizationId}/environments/${environmentId}`;
+    return `curl -H "Authorization: Bearer ${token}" "${environmentUrl}"`;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.spec.tsx
@@ -42,6 +42,7 @@ import { notify } from '../shared/notify';
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasPermission: jest.fn(),
+    useEnvironment: jest.fn().mockReturnValue({ id: 'DEFAULT' }),
 }));
 
 jest.mock('../shared/notify', () => ({
@@ -76,6 +77,12 @@ const mockUserGroupMembershipsCard = jest.fn(
 
 jest.mock('../features/users/components/UserGroupMembershipsCard', () => ({
     UserGroupMembershipsCard: (props: Parameters<typeof mockUserGroupMembershipsCard>[0]) => mockUserGroupMembershipsCard(props),
+}));
+
+jest.mock('../features/users/components/UserPersonalAccessTokensCard', () => ({
+    UserPersonalAccessTokensCard: ({ canGenerate, canRevoke }: { canGenerate: boolean; canRevoke: boolean }) => (
+        <div data-testid="personal-access-tokens" data-can-generate={String(canGenerate)} data-can-revoke={String(canRevoke)} />
+    ),
 }));
 
 jest.mock('../features/users/hooks/useUserMutations', () => ({
@@ -563,6 +570,25 @@ describe('UserDetailPage', () => {
         await user.click(within(await screen.findByRole('dialog')).getByRole('button', { name: 'Convert' }));
 
         await waitFor(() => expect(notify.success).toHaveBeenCalledWith('User "Anna Schmidt" has been converted to a service account'));
+    });
+
+    it('passes token permissions separately for generate and revoke actions', async () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: readonly string[] }) => {
+            if (anyOf.includes(ORGANIZATION_USER_UPDATE_PERMISSION)) {
+                return true;
+            }
+            if (anyOf.includes(ORGANIZATION_USER_DELETE_PERMISSION)) {
+                return false;
+            }
+            return false;
+        });
+
+        renderUserDetailPage();
+
+        await screen.findByRole('heading', { name: 'Anna Schmidt' });
+        const tokensCard = screen.getByTestId('personal-access-tokens');
+        expect(tokensCard.getAttribute('data-can-generate')).toBe('true');
+        expect(tokensCard.getAttribute('data-can-revoke')).toBe('false');
     });
 
     it('shows a not-found message when the user fails to load', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { Button, Skeleton } from '@gravitee/graphene-core';
 import { ArrowLeftIcon } from '@gravitee/graphene-core/icons';
 import { useState } from 'react';
@@ -22,6 +22,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { UserEnvironmentRolesCard } from '../features/users/components/UserEnvironmentRolesCard';
 import { UserGroupMembershipsCard } from '../features/users/components/UserGroupMembershipsCard';
 import { UserOrganizationRolesCard } from '../features/users/components/UserOrganizationRolesCard';
+import { UserPersonalAccessTokensCard } from '../features/users/components/UserPersonalAccessTokensCard';
 import { UserProfileCard } from '../features/users/components/UserProfileCard';
 import { UserRegistrationPendingBanner } from '../features/users/components/UserRegistrationPendingBanner';
 import {
@@ -62,6 +63,7 @@ export function UserDetailPage() {
     const processRegistration = useProcessUserRegistration(userId);
     const convertToServiceAccount = useUpdateOrganizationUserServiceAccount(userId);
     const updateUserRoles = useUpdateOrganizationUserRoles(userId);
+    const shellEnvironment = useEnvironment();
 
     const isActiveUser = user?.status?.toUpperCase() === 'ACTIVE';
     const rolesEditable = canUpdate && isActiveUser;
@@ -171,6 +173,7 @@ export function UserDetailPage() {
     const showRegistrationBanner = canUpdate && user.status?.toUpperCase() === 'PENDING';
     const showConvertToServiceAccount = canUpdate && canConvertToServiceAccount(user);
     const userDisplayName = formatUserDisplayName(user);
+    const tokenEnvironmentId = shellEnvironment?.id ?? environments[0]?.id ?? 'DEFAULT';
 
     return (
         <div className="space-y-6">
@@ -270,6 +273,13 @@ export function UserDetailPage() {
                 rolesEditable={rolesEditable}
                 canAddToGroup={canAddToGroup}
                 canRemoveFromGroup={canRemoveFromGroup}
+            />
+
+            <UserPersonalAccessTokensCard
+                userId={user.id}
+                environmentId={tokenEnvironmentId}
+                canGenerate={canUpdate}
+                canRevoke={canDelete}
             />
         </div>
     );


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-201

## Description

Adds personal access token management to the Gamma platform user detail page, achieving parity with the classic console tokens section.
- **List tokens** on user detail with Name, Created at, and Last use columns
- **Generate token** via a two-step dialog (name → one-time token + curl usage example with copy)
- **Revoke token** with confirmation dialog
- **Permission gating** aligned with classic: `organization-user-u` for generate, `organization-user-d` for revoke
- **Empty state** follows Graphene first-use pattern (single CTA in empty state; header button appears once tokens exist)

https://github.com/user-attachments/assets/5a8f51aa-769e-492c-9ae4-34b33236a368

