### PR TITLE
refactor(gateway): cache API Product subscriptions under their scope instead of exploding them

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/subscription/SubscriptionScope.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/subscription/SubscriptionScope.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.core.subscription;
+
+import io.gravitee.gateway.api.service.Subscription;
+
+/**
+ * The entity a subscription is attached to.
+ *
+ * <p>A regular subscription belongs to an API; an API Product subscription belongs to the product,
+ * not to any single member API. Runtime caches index a subscription — and its API keys — under that
+ * scope, so a product subscription has exactly one entry however many APIs the product exposes.
+ * Lookups arrive with an API and resolve the products it belongs to.</p>
+ */
+public final class SubscriptionScope {
+
+    private SubscriptionScope() {}
+
+    public static String of(final Subscription subscription) {
+        return subscription.getApiProductId() != null ? subscription.getApiProductId() : subscription.getApi();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
@@ -55,6 +55,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.CustomLog;
 import org.slf4j.MDC;
 
@@ -73,7 +74,15 @@ public class ApiManagerImpl implements ApiManager {
     private final GatewayConfiguration gatewayConfiguration;
     private final LicenseManager licenseManager;
     private final Map<String, ReactableApi<?>> apis = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, Lock> apiLocks = new ConcurrentHashMap<>();
+    /**
+     * Fixed set of locks, one API mapped onto one stripe by hash. A map keyed by API id would grow
+     * with every API ever seen — nothing can safely evict an entry, since removing a lock another
+     * thread is about to acquire hands the two of them different locks for the same API. Striping
+     * bounds the memory instead: two APIs may share a stripe and serialize needlessly, which costs
+     * nothing outside deployment.
+     */
+    private static final int API_LOCK_STRIPES = 64;
+    private final Lock[] apiLocks = Stream.generate(ReentrantLock::new).limit(API_LOCK_STRIPES).toArray(Lock[]::new);
     private final Map<Class<? extends ReactableApi<?>>, ? extends Deployer<?>> deployers;
     private final ApiProductRegistry apiProductRegistry;
 
@@ -464,7 +473,7 @@ public class ApiManagerImpl implements ApiManager {
     }
 
     private <T> T withPerApiLock(String apiId, Callable<T> action) {
-        Lock lock = apiLocks.computeIfAbsent(apiId, k -> new ReentrantLock());
+        Lock lock = apiLocks[Math.floorMod(Objects.hashCode(apiId), API_LOCK_STRIPES)];
         lock.lock();
         try {
             return action.call();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/ApiProductRegistry.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/ApiProductRegistry.java
@@ -19,6 +19,7 @@ import io.gravitee.definition.model.v4.plan.AbstractPlan;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Arpit Mishra (arpit.mishra at graviteesource.com)
@@ -65,6 +66,20 @@ public interface ApiProductRegistry {
      * @return List of entries pairing API Product ID with plan definition
      */
     List<ApiProductPlanEntry> getApiProductPlanEntriesForApi(String apiId, String environmentId);
+
+    /**
+     * Returns the IDs of the API Products this API belongs to, across environments.
+     *
+     * <p>An API Product subscription is cached once, under the product it was taken on, instead of
+     * once per member API. Request-path lookups arrive with an API and no environment, so they use
+     * this index to know which product scopes may also hold a subscription for that API. The index
+     * is bounded by (APIs x products) — a few thousand entries — and honours the same sharding
+     * filter as the plan index, so a gateway never resolves a product it does not serve.</p>
+     *
+     * @param apiId the API ID
+     * @return the product IDs containing this API, empty if none
+     */
+    Set<String> getApiProductIdsForApi(String apiId);
 
     /**
      * Entry pairing an API Product ID with one of its plans.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImpl.java
@@ -26,8 +26,10 @@ import io.gravitee.gateway.handlers.api.sharding.ApiProductShardingFilter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -46,6 +48,12 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
     protected final Map<ApiProductRegistryKey, ReactableApiProduct> registry = new ConcurrentHashMap<>();
 
     private volatile Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> planEntriesByApi = Map.of();
+
+    /**
+     * Product IDs by API, across environments: request-path subscription lookups arrive with an API
+     * and no environment. API IDs are globally unique, so dropping the environment loses nothing.
+     */
+    private volatile Map<String, Set<String>> productIdsByApi = Map.of();
 
     private final ReadWriteLock indexLock = new ReentrantReadWriteLock();
     private final GatewayConfiguration gatewayConfiguration;
@@ -93,7 +101,7 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
         registry.clear();
         indexLock.writeLock().lock();
         try {
-            planEntriesByApi = Map.of();
+            publishIndex(Map.of());
         } finally {
             indexLock.writeLock().unlock();
         }
@@ -108,6 +116,31 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
         return entries != null ? List.copyOf(entries) : List.of();
     }
 
+    @Override
+    public Set<String> getApiProductIdsForApi(String apiId) {
+        if (apiId == null) {
+            return Set.of();
+        }
+        return productIdsByApi.getOrDefault(apiId, Set.of());
+    }
+
+    /**
+     * Publishes both views of the index together. The product-ids view is derived from the plan
+     * view rather than maintained in parallel, so the two can never disagree: an API appears here
+     * only if its product exposes at least one plan this gateway serves — which is exactly when a
+     * product subscription can be resolved for it.
+     */
+    private void publishIndex(Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> entriesByApi) {
+        Map<String, Set<String>> productIds = new HashMap<>();
+        entriesByApi.forEach((key, entries) ->
+            entries.forEach(entry -> productIds.computeIfAbsent(key.apiId(), api -> new HashSet<>()).add(entry.apiProductId()))
+        );
+        productIds.replaceAll((api, ids) -> Set.copyOf(ids));
+
+        planEntriesByApi = entriesByApi;
+        productIdsByApi = Map.copyOf(productIds);
+    }
+
     private void updateIndexForProduct(ReactableApiProduct previous, ReactableApiProduct current) {
         indexLock.writeLock().lock();
         try {
@@ -116,7 +149,7 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
                 removeProductFromMutableIndex(mutable, previous);
             }
             addProductToMutableIndex(mutable, current);
-            planEntriesByApi = Map.copyOf(mutable);
+            publishIndex(Map.copyOf(mutable));
         } finally {
             indexLock.writeLock().unlock();
         }
@@ -128,7 +161,7 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
         try {
             Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> mutable = new HashMap<>(planEntriesByApi);
             removeProductFromMutableIndex(mutable, product);
-            planEntriesByApi = Map.copyOf(mutable);
+            publishIndex(Map.copyOf(mutable));
         } finally {
             indexLock.writeLock().unlock();
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImpl.java
@@ -26,8 +26,10 @@ import io.gravitee.gateway.handlers.api.sharding.ApiProductShardingFilter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -45,7 +47,21 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
     @VisibleForTesting
     protected final Map<ApiProductRegistryKey, ReactableApiProduct> registry = new ConcurrentHashMap<>();
 
+    /**
+     * Both index views are published as deeply immutable maps and never mutated afterwards, so a
+     * reader either sees the previous version or the next one, never a half-updated one. That is
+     * what makes the plain {@code volatile} enough here: it carries the reference across threads,
+     * and immutability carries the contents.
+     */
+    @SuppressWarnings("java:S3077")
     private volatile Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> planEntriesByApi = Map.of();
+
+    /**
+     * Product IDs by API, across environments: request-path subscription lookups arrive with an API
+     * and no environment. API IDs are globally unique, so dropping the environment loses nothing.
+     */
+    @SuppressWarnings("java:S3077")
+    private volatile Map<String, Set<String>> productIdsByApi = Map.of();
 
     private final ReadWriteLock indexLock = new ReentrantReadWriteLock();
     private final GatewayConfiguration gatewayConfiguration;
@@ -93,7 +109,7 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
         registry.clear();
         indexLock.writeLock().lock();
         try {
-            planEntriesByApi = Map.of();
+            publishIndex(Map.of());
         } finally {
             indexLock.writeLock().unlock();
         }
@@ -104,19 +120,64 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
         if (apiId == null || environmentId == null) {
             return List.of();
         }
+        // Returned as is: published entries are immutable, so there is nothing to defend against
+        // and nothing to copy on a path walked once per security chain construction.
         List<ApiProductPlanEntry> entries = planEntriesByApi.get(new ApiEnvironmentKey(environmentId, apiId));
-        return entries != null ? List.copyOf(entries) : List.of();
+        return entries != null ? entries : List.of();
+    }
+
+    @Override
+    public Set<String> getApiProductIdsForApi(String apiId) {
+        if (apiId == null) {
+            return Set.of();
+        }
+        return productIdsByApi.getOrDefault(apiId, Set.of());
+    }
+
+    /**
+     * Publishes both views of the index together. The product-ids view is derived from the plan
+     * view rather than maintained in parallel, so the two can never disagree: an API appears here
+     * only if its product exposes at least one plan this gateway serves — which is exactly when a
+     * product subscription can be resolved for it.
+     */
+    private void publishIndex(Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> entriesByApi) {
+        Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> frozenEntries = new HashMap<>();
+        Map<String, Set<String>> productIds = new HashMap<>();
+        entriesByApi.forEach((key, entries) -> {
+            frozenEntries.put(key, List.copyOf(entries));
+            entries.forEach(entry -> {
+                Set<String> ids = productIds.computeIfAbsent(key.apiId(), api -> new HashSet<>());
+                ids.add(entry.apiProductId());
+            });
+        });
+        productIds.replaceAll((api, ids) -> Set.copyOf(ids));
+
+        planEntriesByApi = Map.copyOf(frozenEntries);
+        productIdsByApi = Map.copyOf(productIds);
+    }
+
+    /**
+     * Working copy of the plan index, with its lists copied too.
+     *
+     * <p>A shallow {@code new HashMap<>(planEntriesByApi)} would share its lists with the published
+     * index, and the rebuild below adds to and removes from them — mutating, in place, the very
+     * lists that in-flight requests are reading.</p>
+     */
+    private Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> mutableCopyOfIndex() {
+        Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> mutable = new HashMap<>();
+        planEntriesByApi.forEach((key, entries) -> mutable.put(key, new ArrayList<>(entries)));
+        return mutable;
     }
 
     private void updateIndexForProduct(ReactableApiProduct previous, ReactableApiProduct current) {
         indexLock.writeLock().lock();
         try {
-            Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> mutable = new HashMap<>(planEntriesByApi);
+            Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> mutable = mutableCopyOfIndex();
             if (previous != null) {
                 removeProductFromMutableIndex(mutable, previous);
             }
             addProductToMutableIndex(mutable, current);
-            planEntriesByApi = Map.copyOf(mutable);
+            publishIndex(mutable);
         } finally {
             indexLock.writeLock().unlock();
         }
@@ -126,9 +187,9 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
     private void removeIndexForProduct(ReactableApiProduct product) {
         indexLock.writeLock().lock();
         try {
-            Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> mutable = new HashMap<>(planEntriesByApi);
+            Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> mutable = mutableCopyOfIndex();
             removeProductFromMutableIndex(mutable, product);
-            planEntriesByApi = Map.copyOf(mutable);
+            publishIndex(mutable);
         } finally {
             indexLock.writeLock().unlock();
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheService.java
@@ -17,41 +17,71 @@ package io.gravitee.gateway.handlers.api.services;
 
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
 import org.springframework.util.DigestUtils;
 
+/**
+ * Runtime cache of active API keys.
+ *
+ * <p>An API key is cached once, under the scope of the subscription it belongs to — the API for a
+ * regular subscription, the API Product for an API Product subscription. Lookups arrive with an API
+ * and probe that API's own scope first, then the products the API belongs to, mirroring
+ * {@link SubscriptionCacheService}. The scope is carried by {@code ApiKey.api}, which the sync
+ * mapper fills from the subscription.</p>
+ */
 @CustomLog
+@RequiredArgsConstructor
 public class ApiKeyCacheService implements ApiKeyService {
 
+    private final ApiProductRegistry apiProductRegistry;
+
     // ConcurrentMap on purpose (not plain Map): register()/unregister() rely on thread-safe
-    // compute()/computeIfPresent() for the per-API index. Unlike SubscriptionCacheService, the
+    // compute()/computeIfPresent() for the per-scope index. Unlike SubscriptionCacheService, the
     // lambdas here are idempotent, so any honest ConcurrentMap implementation is acceptable.
     private final ConcurrentMap<CacheKey, ApiKey> cacheApiKeys = new ConcurrentHashMap<>();
     private final ConcurrentMap<CacheKey, ApiKey> cacheMd5ApiKeys = new ConcurrentHashMap<>();
-    // Holds api-key values only (the API id is already the map key); unregisterByApiId()
+    // Holds api-key values only (the scope id is already the map key); unregisterByApiId()
     // re-derives the cache keys from them.
-    private final ConcurrentMap<String, Set<String>> cacheApiKeysByApi = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Set<String>> cacheApiKeysByScope = new ConcurrentHashMap<>();
 
     /**
      * Cache key referencing the api-key's own field strings instead of a formatted composite
      * String: no String.format and no byte[] allocation on the request hot path
      * ({@link #getByApiAndKey(String, String)} runs for every API-key authenticated request).
+     *
+     * @param scope the API id, or the API Product id for an API Product subscription's key
      */
-    record CacheKey(String api, String key) {}
+    record CacheKey(String scope, String key) {}
+
+    /**
+     * The entity this key is cached under: the API for a regular subscription's key, the API
+     * Product for an API Product subscription's key.
+     *
+     * <p>{@link ApiKey} lives in the external {@code gravitee-gateway-api} artifact and has no
+     * scope field of its own, so the value rides on {@code api} — {@code ApiKeyMapper} writes
+     * {@code SubscriptionScope.of(subscription)} there. Reading it through this method rather than
+     * calling {@code getApi()} inline keeps that indirection visible at every use site instead of
+     * only in the class javadoc.</p>
+     */
+    private static String scopeOf(final ApiKey apiKey) {
+        return apiKey.getApi();
+    }
 
     @Override
     public void register(final ApiKey apiKey) {
         if (apiKey.isActive()) {
             CacheKey cacheKey = buildCacheKey(apiKey);
             log.debug(
-                "Load active api-key [id: {}] [api: {}] [plan: {}] [app: {}]",
+                "Load active api-key [id: {}] [scope: {}] [plan: {}] [app: {}]",
                 apiKey.getId(),
-                apiKey.getApi(),
+                scopeOf(apiKey),
                 apiKey.getPlan(),
                 apiKey.getApplication()
             );
@@ -66,7 +96,7 @@ public class ApiKeyCacheService implements ApiKeyService {
             cacheMd5ApiKeys.put(buildMd5CacheKey(apiKey), apiKey);
             // compute() so concurrent register/unregister calls for the same API (sync appenders
             // run in parallel) cannot lose updates or mutate a plain HashSet across threads.
-            cacheApiKeysByApi.compute(apiKey.getApi(), (api, keysByApi) -> {
+            cacheApiKeysByScope.compute(scopeOf(apiKey), (scope, keysByApi) -> {
                 Set<String> keys = keysByApi != null ? keysByApi : ConcurrentHashMap.newKeySet();
                 keys.add(apiKey.getKey());
                 return keys;
@@ -80,15 +110,15 @@ public class ApiKeyCacheService implements ApiKeyService {
     public void unregister(final ApiKey apiKey) {
         CacheKey cacheKey = buildCacheKey(apiKey);
         log.debug(
-            "Unload inactive api-key [id: {}] [api: {}] [plan: {}] [app: {}]",
+            "Unload inactive api-key [id: {}] [scope: {}] [plan: {}] [app: {}]",
             apiKey.getId(),
-            apiKey.getApi(),
+            scopeOf(apiKey),
             apiKey.getPlan(),
             apiKey.getApplication()
         );
         if (cacheApiKeys.remove(cacheKey) != null) {
             cacheMd5ApiKeys.remove(buildMd5CacheKey(apiKey));
-            cacheApiKeysByApi.computeIfPresent(apiKey.getApi(), (api, keysByApi) -> {
+            cacheApiKeysByScope.computeIfPresent(scopeOf(apiKey), (scope, keysByApi) -> {
                 keysByApi.remove(apiKey.getKey());
                 return keysByApi.isEmpty() ? null : keysByApi;
             });
@@ -98,16 +128,32 @@ public class ApiKeyCacheService implements ApiKeyService {
     @Override
     public void unregisterByApiId(final String apiId) {
         log.debug("Unload all api-key by api [api_id: {}]", apiId);
-        Set<String> keysByApi = cacheApiKeysByApi.remove(apiId);
+        unregisterByScopeId(apiId);
+    }
+
+    /**
+     * Unregisters every API key of the given API Product.
+     *
+     * <p>Undeploying one member API must not drop the keys of a product subscription — the other
+     * member APIs still serve them — so {@link #unregisterByApiId(String)} no longer reaches them.
+     * This is the matching entry point, driven by the API Product undeployment.</p>
+     */
+    public void unregisterByApiProductId(final String apiProductId) {
+        log.debug("Unload all api-key by api product [api_product_id: {}]", apiProductId);
+        unregisterByScopeId(apiProductId);
+    }
+
+    private void unregisterByScopeId(final String scopeId) {
+        Set<String> keysByApi = cacheApiKeysByScope.remove(scopeId);
         if (keysByApi != null) {
             keysByApi.forEach(key -> {
-                ApiKey evictedApiKey = cacheApiKeys.remove(buildCacheKey(apiId, key));
+                ApiKey evictedApiKey = cacheApiKeys.remove(buildCacheKey(scopeId, key));
                 if (evictedApiKey != null) {
                     cacheMd5ApiKeys.remove(buildMd5CacheKey(evictedApiKey));
                     log.debug(
-                        "Unload inactive api-key [id: {}] [api: {}] [plan: {}] [app: {}]",
+                        "Unload inactive api-key [id: {}] [scope: {}] [plan: {}] [app: {}]",
                         evictedApiKey.getId(),
-                        evictedApiKey.getApi(),
+                        scopeOf(evictedApiKey),
                         evictedApiKey.getPlan(),
                         evictedApiKey.getApplication()
                     );
@@ -118,23 +164,41 @@ public class ApiKeyCacheService implements ApiKeyService {
 
     @Override
     public Optional<ApiKey> getByApiAndKey(String api, String key) {
-        return Optional.ofNullable(cacheApiKeys.get(buildCacheKey(api, key)));
+        return lookup(cacheApiKeys, api, key);
     }
 
     @Override
     public Optional<ApiKey> getByApiAndMd5Key(String api, String md5ApiKey) {
-        return Optional.ofNullable(cacheMd5ApiKeys.get(buildCacheKey(api, md5ApiKey)));
+        return lookup(cacheMd5ApiKeys, api, md5ApiKey);
+    }
+
+    /**
+     * Probes the API's own scope, then the products the API belongs to. Most APIs belong to no
+     * product, in which case the loop does not run and this costs one map lookup as before.
+     */
+    private Optional<ApiKey> lookup(final ConcurrentMap<CacheKey, ApiKey> cache, final String api, final String key) {
+        ApiKey direct = cache.get(buildCacheKey(api, key));
+        if (direct != null) {
+            return Optional.of(direct);
+        }
+        for (String productId : apiProductRegistry.getApiProductIdsForApi(api)) {
+            ApiKey fromProduct = cache.get(buildCacheKey(productId, key));
+            if (fromProduct != null) {
+                return Optional.of(fromProduct);
+            }
+        }
+        return Optional.empty();
     }
 
     CacheKey buildCacheKey(ApiKey apiKey) {
-        return buildCacheKey(apiKey.getApi(), apiKey.getKey());
+        return buildCacheKey(scopeOf(apiKey), apiKey.getKey());
     }
 
-    CacheKey buildCacheKey(String api, String key) {
-        return new CacheKey(api, key);
+    CacheKey buildCacheKey(String scope, String key) {
+        return new CacheKey(scope, key);
     }
 
     CacheKey buildMd5CacheKey(ApiKey apiKey) {
-        return buildCacheKey(apiKey.getApi(), DigestUtils.md5DigestAsHex(apiKey.getKey().getBytes(StandardCharsets.UTF_8)));
+        return buildCacheKey(scopeOf(apiKey), DigestUtils.md5DigestAsHex(apiKey.getKey().getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheService.java
@@ -17,32 +17,48 @@ package io.gravitee.gateway.handlers.api.services;
 
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
 import org.springframework.util.DigestUtils;
 
+/**
+ * Runtime cache of active API keys.
+ *
+ * <p>An API key is cached once, under the scope of the subscription it belongs to — the API for a
+ * regular subscription, the API Product for an API Product subscription. Lookups arrive with an API
+ * and probe that API's own scope first, then the products the API belongs to, mirroring
+ * {@link SubscriptionCacheService}. The scope is carried by {@code ApiKey.api}, which the sync
+ * mapper fills from the subscription.</p>
+ */
 @CustomLog
+@RequiredArgsConstructor
 public class ApiKeyCacheService implements ApiKeyService {
 
+    private final ApiProductRegistry apiProductRegistry;
+
     // ConcurrentMap on purpose (not plain Map): register()/unregister() rely on thread-safe
-    // compute()/computeIfPresent() for the per-API index. Unlike SubscriptionCacheService, the
+    // compute()/computeIfPresent() for the per-scope index. Unlike SubscriptionCacheService, the
     // lambdas here are idempotent, so any honest ConcurrentMap implementation is acceptable.
     private final ConcurrentMap<CacheKey, ApiKey> cacheApiKeys = new ConcurrentHashMap<>();
     private final ConcurrentMap<CacheKey, ApiKey> cacheMd5ApiKeys = new ConcurrentHashMap<>();
-    // Holds api-key values only (the API id is already the map key); unregisterByApiId()
+    // Holds api-key values only (the scope id is already the map key); unregisterByApiId()
     // re-derives the cache keys from them.
-    private final ConcurrentMap<String, Set<String>> cacheApiKeysByApi = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Set<String>> cacheApiKeysByScope = new ConcurrentHashMap<>();
 
     /**
      * Cache key referencing the api-key's own field strings instead of a formatted composite
      * String: no String.format and no byte[] allocation on the request hot path
      * ({@link #getByApiAndKey(String, String)} runs for every API-key authenticated request).
+     *
+     * @param scope the API id, or the API Product id for an API Product subscription's key
      */
-    record CacheKey(String api, String key) {}
+    record CacheKey(String scope, String key) {}
 
     @Override
     public void register(final ApiKey apiKey) {
@@ -66,7 +82,7 @@ public class ApiKeyCacheService implements ApiKeyService {
             cacheMd5ApiKeys.put(buildMd5CacheKey(apiKey), apiKey);
             // compute() so concurrent register/unregister calls for the same API (sync appenders
             // run in parallel) cannot lose updates or mutate a plain HashSet across threads.
-            cacheApiKeysByApi.compute(apiKey.getApi(), (api, keysByApi) -> {
+            cacheApiKeysByScope.compute(apiKey.getApi(), (scope, keysByApi) -> {
                 Set<String> keys = keysByApi != null ? keysByApi : ConcurrentHashMap.newKeySet();
                 keys.add(apiKey.getKey());
                 return keys;
@@ -88,7 +104,7 @@ public class ApiKeyCacheService implements ApiKeyService {
         );
         if (cacheApiKeys.remove(cacheKey) != null) {
             cacheMd5ApiKeys.remove(buildMd5CacheKey(apiKey));
-            cacheApiKeysByApi.computeIfPresent(apiKey.getApi(), (api, keysByApi) -> {
+            cacheApiKeysByScope.computeIfPresent(apiKey.getApi(), (scope, keysByApi) -> {
                 keysByApi.remove(apiKey.getKey());
                 return keysByApi.isEmpty() ? null : keysByApi;
             });
@@ -98,10 +114,26 @@ public class ApiKeyCacheService implements ApiKeyService {
     @Override
     public void unregisterByApiId(final String apiId) {
         log.debug("Unload all api-key by api [api_id: {}]", apiId);
-        Set<String> keysByApi = cacheApiKeysByApi.remove(apiId);
+        unregisterByScopeId(apiId);
+    }
+
+    /**
+     * Unregisters every API key of the given API Product.
+     *
+     * <p>Undeploying one member API must not drop the keys of a product subscription — the other
+     * member APIs still serve them — so {@link #unregisterByApiId(String)} no longer reaches them.
+     * This is the matching entry point, driven by the API Product undeployment.</p>
+     */
+    public void unregisterByApiProductId(final String apiProductId) {
+        log.debug("Unload all api-key by api product [api_product_id: {}]", apiProductId);
+        unregisterByScopeId(apiProductId);
+    }
+
+    private void unregisterByScopeId(final String scopeId) {
+        Set<String> keysByApi = cacheApiKeysByScope.remove(scopeId);
         if (keysByApi != null) {
             keysByApi.forEach(key -> {
-                ApiKey evictedApiKey = cacheApiKeys.remove(buildCacheKey(apiId, key));
+                ApiKey evictedApiKey = cacheApiKeys.remove(buildCacheKey(scopeId, key));
                 if (evictedApiKey != null) {
                     cacheMd5ApiKeys.remove(buildMd5CacheKey(evictedApiKey));
                     log.debug(
@@ -118,20 +150,38 @@ public class ApiKeyCacheService implements ApiKeyService {
 
     @Override
     public Optional<ApiKey> getByApiAndKey(String api, String key) {
-        return Optional.ofNullable(cacheApiKeys.get(buildCacheKey(api, key)));
+        return lookup(cacheApiKeys, api, key);
     }
 
     @Override
     public Optional<ApiKey> getByApiAndMd5Key(String api, String md5ApiKey) {
-        return Optional.ofNullable(cacheMd5ApiKeys.get(buildCacheKey(api, md5ApiKey)));
+        return lookup(cacheMd5ApiKeys, api, md5ApiKey);
+    }
+
+    /**
+     * Probes the API's own scope, then the products the API belongs to. Most APIs belong to no
+     * product, in which case the loop does not run and this costs one map lookup as before.
+     */
+    private Optional<ApiKey> lookup(final ConcurrentMap<CacheKey, ApiKey> cache, final String api, final String key) {
+        ApiKey direct = cache.get(buildCacheKey(api, key));
+        if (direct != null) {
+            return Optional.of(direct);
+        }
+        for (String productId : apiProductRegistry.getApiProductIdsForApi(api)) {
+            ApiKey fromProduct = cache.get(buildCacheKey(productId, key));
+            if (fromProduct != null) {
+                return Optional.of(fromProduct);
+            }
+        }
+        return Optional.empty();
     }
 
     CacheKey buildCacheKey(ApiKey apiKey) {
         return buildCacheKey(apiKey.getApi(), apiKey.getKey());
     }
 
-    CacheKey buildCacheKey(String api, String key) {
-        return new CacheKey(api, key);
+    CacheKey buildCacheKey(String scope, String key) {
+        return new CacheKey(scope, key);
     }
 
     CacheKey buildMd5CacheKey(ApiKey apiKey) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -20,14 +20,16 @@ import static io.gravitee.repository.management.model.Subscription.Status.ACCEPT
 import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.core.subscription.SubscriptionScope;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.security.core.SubscriptionTrustStoreLoaderManager;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,6 +46,26 @@ import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 
+/**
+ * Runtime cache of active subscriptions.
+ *
+ * <h2>Scope</h2>
+ *
+ * A subscription is cached once, under the entity it was taken on — its <em>scope</em>: the API for
+ * a regular subscription, the API Product for an API Product subscription. It is never duplicated
+ * per member API.
+ *
+ * <p>The {@link SubscriptionService} contract is API-scoped, so lookups arrive with an API and this
+ * class resolves the scopes to probe: the API itself, then the products that API belongs to
+ * ({@link ApiProductRegistry#getApiProductIdsForApi(String)}). That reverse index is bounded by
+ * (APIs x products) — a few thousand entries — where caching one subscription per member API grows
+ * with (subscriptions x member APIs) and reaches millions of entries on large products.</p>
+ *
+ * <p>The request path already knows about products: {@code HttpSecurityChain} builds a product
+ * plan's security plan from the same registry. Flattening product subscriptions onto member APIs
+ * therefore bought nothing at read time; it only existed to fit index keys designed before API
+ * Products existed.</p>
+ */
 @CustomLog
 @RequiredArgsConstructor
 public class SubscriptionCacheService implements SubscriptionService {
@@ -51,29 +73,32 @@ public class SubscriptionCacheService implements SubscriptionService {
     private final ApiKeyService apiKeyService;
     private final SubscriptionTrustStoreLoaderManager subscriptionTrustStoreLoaderManager;
     private final ApiManager apiManager;
+    private final ApiProductRegistry apiProductRegistry;
 
-    // Caches only contains active subscriptions.
+    // Caches only contain active subscriptions.
     // Must stay backed by ConcurrentHashMap: the compute() lambdas below have side effects and
     // rely on CHM running the remapping function at most once, under the bin lock. The
     // ConcurrentMap contract alone allows implementations that retry the lambda (e.g.
     // ConcurrentSkipListMap), which would double those side effects under contention.
-    private final ConcurrentMap<IdentityKey, Subscription> cacheByApiClientId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<IdentityKey, Subscription> cacheByClientId = new ConcurrentHashMap<>();
     private final ConcurrentMap<IdentityKey, Subscription> cacheByClientCertificate = new ConcurrentHashMap<>();
-    // Single by-id index, including exploded API-Product subscriptions. Values are immutable sets
-    // (almost always a singleton), replaced atomically via compute(): keeps the per-entry footprint
-    // minimal at multi-million-subscription scale and lets readers use them without defensive copies.
-    private final ConcurrentMap<String, Set<Subscription>> cacheBySubscriptionIdAll = new ConcurrentHashMap<>();
-    // Holds subscription ids only, for per-API eviction. Identity keys are not tracked here:
-    // unregisterByApiId() re-derives them from the cached subscriptions, which keeps this index
-    // at one entry per subscription instead of three (id + 2 identity keys) at multi-million scale.
-    private final ConcurrentMap<String, Set<String>> cacheKeysByApiId = new ConcurrentHashMap<>();
+    // One entry per subscription: the by-id index is the single point where a registration is
+    // published, so every other index is maintained under its bin lock and cannot drift from it.
+    private final ConcurrentMap<String, Subscription> cacheById = new ConcurrentHashMap<>();
+    // Subscription ids by scope, for bulk eviction when an API or an API Product is undeployed.
+    // Identity keys are not tracked here: they are re-derived from the cached subscriptions.
+    private final ConcurrentMap<String, Set<String>> cacheIdsByScope = new ConcurrentHashMap<>();
 
     /**
      * Identity-cache key referencing the subscription's own field strings instead of a formatted
-     * composite String: no per-key byte[] allocation (hundreds of MB at multi-million-subscription
-     * scale) and no String.format on the request hot path. A null plan is the plan-less variant.
+     * composite String: no per-key byte[] allocation and no String.format on the request hot path.
+     * A null plan is the plan-less variant.
      */
-    private record IdentityKey(String api, String plan, String clientIdentity) {}
+    private record IdentityKey(String scope, String plan, String clientIdentity) {}
+
+    private static String scopeOf(final Subscription subscription) {
+        return SubscriptionScope.of(subscription);
+    }
 
     @Override
     public Optional<Subscription> getByApiAndSecurityToken(String api, SecurityToken securityToken, String plan) {
@@ -85,34 +110,49 @@ public class SubscriptionCacheService implements SubscriptionService {
                 .getByApiAndMd5Key(api, securityToken.getTokenValue())
                 .flatMap(apiKey -> getByApiAndId(api, apiKey.getSubscription()));
             case CLIENT_ID -> getByApiAndClientIdAndPlan(api, securityToken.getTokenValue(), plan);
-            case CERTIFICATE -> subscriptionTrustStoreLoaderManager.getByCertificate(api, plan, securityToken.getTokenValue());
+            case CERTIFICATE -> getByApiAndCertificate(api, plan, securityToken.getTokenValue());
             default -> Optional.empty();
         };
     }
 
     @Override
     public Optional<Subscription> getByApiAndClientIdAndPlan(String api, String clientId, String plan) {
-        return Optional.ofNullable(cacheByApiClientId.get(cacheKey(api, plan, clientId)));
+        Subscription direct = cacheByClientId.get(cacheKey(api, plan, clientId));
+        if (direct != null) {
+            return Optional.of(direct);
+        }
+        // Miss on the API's own scope: the subscription may have been taken on a product this API
+        // belongs to. Most APIs belong to no product, in which case this loop does not run.
+        for (String productId : apiProductRegistry.getApiProductIdsForApi(api)) {
+            Subscription fromProduct = cacheByClientId.get(cacheKey(productId, plan, clientId));
+            if (fromProduct != null) {
+                return Optional.of(fromProduct);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Subscription> getByApiAndCertificate(String api, String plan, String certificateFingerprint) {
+        Optional<Subscription> direct = subscriptionTrustStoreLoaderManager.getByCertificate(api, plan, certificateFingerprint);
+        if (direct.isPresent()) {
+            return direct;
+        }
+        for (String productId : apiProductRegistry.getApiProductIdsForApi(api)) {
+            Optional<Subscription> fromProduct = subscriptionTrustStoreLoaderManager.getByCertificate(
+                productId,
+                plan,
+                certificateFingerprint
+            );
+            if (fromProduct.isPresent()) {
+                return fromProduct;
+            }
+        }
+        return Optional.empty();
     }
 
     @Override
     public Optional<Subscription> getById(String subscriptionId) {
-        // For exploded API-Product subscriptions this returns an arbitrary leg, which matches the
-        // historical behavior of the dedicated by-id map (last-registered/rehydrated leg).
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        if (subscriptions == null || subscriptions.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(subscriptions.iterator().next());
-    }
-
-    /**
-     * Returns all subscriptions for the given ID (multiple for exploded API Product subscriptions).
-     * The returned collection is immutable.
-     */
-    public Collection<Subscription> getAllById(String subscriptionId) {
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        return subscriptions != null ? subscriptions : Collections.emptySet();
+        return Optional.ofNullable(cacheById.get(subscriptionId));
     }
 
     @Override
@@ -121,262 +161,193 @@ public class SubscriptionCacheService implements SubscriptionService {
         // take all fields (including "updatedAt" in metadata) into account
         if (ACCEPTED.name().equals(subscription.getStatus())) {
             if (subscription.getClientCertificate() != null) {
-                log.debug("Registering subscription [{}] for API [{}] by client certificate", subscription.getId(), subscription.getApi());
+                log.debug(
+                    "Registering subscription [{}] for scope [{}] by client certificate",
+                    subscription.getId(),
+                    scopeOf(subscription)
+                );
                 registerFromClientCertificate(subscription);
             } else if (subscription.getClientId() != null) {
                 log.debug(
-                    "Registering subscription [{}] for API [{}] by clientId [{}]",
+                    "Registering subscription [{}] for scope [{}] by clientId [{}]",
                     subscription.getId(),
-                    subscription.getApi(),
+                    scopeOf(subscription),
                     subscription.getClientId()
                 );
-                registerFromClientId(subscription);
+                publish(subscription, cacheByClientId);
             } else {
-                log.debug("Registering subscription [{}] for API [{}] by ID", subscription.getId(), subscription.getApi());
-                registerFromId(subscription);
+                log.debug("Registering subscription [{}] for scope [{}] by ID", subscription.getId(), scopeOf(subscription));
+                publish(subscription, null);
             }
         } else {
             log.debug(
-                "Unregistering subscription [{}] for API [{}] with status [{}]",
+                "Unregistering subscription [{}] for scope [{}] with status [{}]",
                 subscription.getId(),
-                subscription.getApi(),
+                scopeOf(subscription),
                 subscription.getStatus()
             );
             unregister(subscription);
         }
     }
 
+    private void registerFromClientCertificate(final Subscription subscription) {
+        // Ensure trust store is updated before cache to maintain certificate validation consistency.
+        // The trust store is the one place that still needs the member APIs: a certificate has to be
+        // trusted on the listeners of every API the product exposes.
+        subscriptionTrustStoreLoaderManager.registerSubscription(subscription, extractScopeServerIds(subscription));
+        publish(subscription, cacheByClientCertificate);
+    }
+
+    /**
+     * Publishes a registration and reconciles every index under the by-id bin lock.
+     *
+     * <p>Because a subscription now has exactly one cache entry, replacing it is a plain swap: the
+     * previous entry's identity keys are evicted when they differ from the ones just written, which
+     * covers a changed clientId or plan (subscription transfer), a credential-type switch, and a
+     * scope change. The old per-member-API bookkeeping — find the sibling leg for this API, keep the
+     * others — is gone with the legs it existed for.</p>
+     *
+     * @param identityCache the identity index this credential type belongs to, null when the
+     *                      subscription carries no credential and is only reachable by id
+     */
+    private void publish(final Subscription subscription, final ConcurrentMap<IdentityKey, Subscription> identityCache) {
+        cacheById.compute(subscription.getId(), (id, previous) -> {
+            if (identityCache != null) {
+                identityCache.put(identityCacheKey(subscription), subscription);
+                // Index the subscription without plan id to allow search without plan criteria.
+                identityCache.put(identityCacheKeyWithoutPlan(subscription), subscription);
+            }
+            updateCacheIdsByScope(scopeOf(subscription), id);
+
+            if (previous != null) {
+                evictStaleIdentityKeys(previous, subscription);
+                if (!Objects.equals(scopeOf(previous), scopeOf(subscription))) {
+                    evictIdFromScope(scopeOf(previous), id);
+                }
+            }
+            return subscription;
+        });
+    }
+
+    /**
+     * Evicts the identity keys of the replaced subscription that the new one does not overwrite.
+     * A key identical to one just written is left alone — removing it would undo the registration.
+     */
+    private void evictStaleIdentityKeys(final Subscription previous, final Subscription current) {
+        if (previous.getClientId() != null) {
+            removeIfStale(cacheByClientId, previous, current);
+        }
+        if (previous.getClientCertificate() != null) {
+            if (current.getClientCertificate() == null) {
+                // Credential-type switch: registerSubscription() was not called for the new state,
+                // so the trust store still holds the replaced certificate.
+                subscriptionTrustStoreLoaderManager.unregisterSubscription(previous);
+            }
+            removeIfStale(cacheByClientCertificate, previous, current);
+        }
+    }
+
+    private void removeIfStale(
+        final ConcurrentMap<IdentityKey, Subscription> cache,
+        final Subscription previous,
+        final Subscription current
+    ) {
+        boolean sameCredentialType =
+            (previous.getClientId() != null) == (current.getClientId() != null) &&
+            (previous.getClientCertificate() != null) == (current.getClientCertificate() != null);
+
+        IdentityKey previousKey = identityCacheKey(previous);
+        IdentityKey previousKeyWithoutPlan = identityCacheKeyWithoutPlan(previous);
+        if (!sameCredentialType || !previousKey.equals(identityCacheKey(current))) {
+            cache.remove(previousKey);
+        }
+        if (!sameCredentialType || !previousKeyWithoutPlan.equals(identityCacheKeyWithoutPlan(current))) {
+            cache.remove(previousKeyWithoutPlan);
+        }
+    }
+
     @Override
     public void unregister(final Subscription candidate) {
-        // Use compute() so that the isEmpty-check-then-remove is atomic with respect to
-        // concurrent register() calls on the same subscription ID. Without this, a register()
-        // interleaved between isEmpty()=true and remove() would add a new entry to the set
-        // and then have that set orphaned by the remove().
-        cacheBySubscriptionIdAll.compute(candidate.getId(), (id, allSubscriptions) -> {
-            if (allSubscriptions == null) return null;
-
-            var toEvict = allSubscriptions
-                .stream()
-                .filter(s -> Objects.equals(candidate.getApi(), s.getApi()))
-                .toList();
-
-            if (toEvict.isEmpty()) {
-                return allSubscriptions;
-            }
-
-            toEvict.forEach(existing -> {
-                unregisterFromClientId(existing);
-                unregisterFromClientCertificate(existing);
-            });
-
-            evictKeyForApi(candidate.getApi(), candidate.getId());
-            // Handle the case where the candidate carries a different clientId/cert than
-            // what was cached (e.g. a status-change event arriving after a credential update).
-            if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientId(), candidate.getClientId()))) {
-                unregisterFromClientId(candidate);
-            }
-            if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientCertificate(), candidate.getClientCertificate()))) {
-                unregisterFromClientCertificate(candidate);
-            }
-
-            // Singleton fast path: toEvict is non-empty, so the only element is being evicted
-            if (allSubscriptions.size() == 1) {
+        // compute() so the check-then-remove is atomic with respect to a concurrent register() on
+        // the same subscription id.
+        cacheById.compute(candidate.getId(), (id, cached) -> {
+            if (cached == null) {
                 return null;
             }
-
-            Set<Subscription> remaining = allSubscriptions
-                .stream()
-                .filter(s -> !Objects.equals(candidate.getApi(), s.getApi()))
-                .collect(Collectors.toUnmodifiableSet());
-            return remaining.isEmpty() ? null : remaining;
+            evictEverywhere(cached);
+            // The candidate may carry different credentials than what was cached (e.g. a status
+            // change arriving after a credential update): evict those keys too.
+            if (
+                !Objects.equals(cached.getClientId(), candidate.getClientId()) ||
+                !Objects.equals(cached.getClientCertificate(), candidate.getClientCertificate())
+            ) {
+                evictEverywhere(candidate);
+            }
+            evictIdFromScope(scopeOf(cached), id);
+            return null;
         });
     }
 
     @Override
     public void unregisterByApiId(final String apiId) {
         log.debug("Unregistering all subscriptions for API [{}]", apiId);
-        // Remove the whole entry first so no cacheKeysByApiId lock is held while updating the
-        // other caches (unregister() acquires the same locks in the opposite order).
-        Set<String> subscriptionsByApi = cacheKeysByApiId.remove(apiId);
-        if (subscriptionsByApi == null) {
-            return;
-        }
-        // Legs are only collected under the cacheBySubscriptionIdAll bin lock; the identity-map
-        // and trust-store eviction (which re-derives keys, hashing the client certificate)
-        // happens after each compute returns — those structures are not guarded by this lock.
-        List<Subscription> evictedLegs = new ArrayList<>();
-        subscriptionsByApi.forEach(subscriptionId ->
-            cacheBySubscriptionIdAll.computeIfPresent(subscriptionId, (id, all) -> {
-                // Singleton fast path: most entries hold exactly one leg
-                if (all.size() == 1) {
-                    Subscription single = all.iterator().next();
-                    if (Objects.equals(apiId, single.getApi())) {
-                        evictedLegs.add(single);
-                        return null;
-                    }
-                    return all;
-                }
-                Set<Subscription> remaining = new HashSet<>();
-                for (Subscription subscription : all) {
-                    if (Objects.equals(apiId, subscription.getApi())) {
-                        evictedLegs.add(subscription);
-                    } else {
-                        remaining.add(subscription);
-                    }
-                }
-                return remaining.isEmpty() ? null : Set.copyOf(remaining);
-            })
-        );
-        // Same per-leg eviction as unregister(): identity maps and certificate trust store
-        evictedLegs.forEach(leg -> {
-            unregisterFromClientId(leg);
-            unregisterFromClientCertificate(leg);
-        });
-    }
-
-    private void registerFromId(final Subscription subscription) {
-        Subscription cached = cachedSameApiLeg(subscription);
-        updateSubscriptionIdById(subscription);
-        updateCacheKeyByApiId(subscription.getApi(), subscription.getId());
-        // The new registration carries no credentials: any identity keys derived from the
-        // replaced leg's clientId/certificate are stale and would otherwise never be evicted.
-        if (cached != null) {
-            unregisterFromClientId(cached);
-            unregisterFromClientCertificate(cached);
-        }
+        unregisterByScopeId(apiId);
     }
 
     /**
-     * Returns the cached leg of the same subscription for the same API, or null. Exploded
-     * API-Product subscriptions may carry sibling legs for other APIs, which must not be
-     * evicted when one API's leg is replaced.
+     * Unregisters every subscription taken on the given API Product.
+     *
+     * <p>Undeploying a single member API must not drop a product subscription — the product's other
+     * APIs still serve it — so {@link #unregisterByApiId(String)} no longer reaches it. This is the
+     * matching entry point, driven by the API Product undeployment.</p>
      */
-    private Subscription cachedSameApiLeg(final Subscription subscription) {
-        Set<Subscription> existingLegs = cacheBySubscriptionIdAll.get(subscription.getId());
-        if (existingLegs != null) {
-            for (Subscription existing : existingLegs) {
-                if (Objects.equals(subscription.getApi(), existing.getApi())) {
-                    return existing;
+    public void unregisterByApiProductId(final String apiProductId) {
+        log.debug("Unregistering all subscriptions for API Product [{}]", apiProductId);
+        unregisterByScopeId(apiProductId);
+    }
+
+    private void unregisterByScopeId(final String scopeId) {
+        Set<String> subscriptionIds = cacheIdsByScope.remove(scopeId);
+        if (subscriptionIds == null) {
+            return;
+        }
+        subscriptionIds.forEach(subscriptionId ->
+            cacheById.computeIfPresent(subscriptionId, (id, cached) -> {
+                if (!Objects.equals(scopeId, scopeOf(cached))) {
+                    // Re-registered under another scope in the meantime: leave it alone.
+                    return cached;
                 }
-            }
-        }
-        return null;
+                evictEverywhere(cached);
+                return null;
+            })
+        );
     }
 
-    private void registerFromClientCertificate(final Subscription subscription) {
-        final Set<String> servers = extractApiServersId(subscription);
-
-        // Ensure trust store is updated before cache to maintain certificate validation consistency
-        subscriptionTrustStoreLoaderManager.registerSubscription(subscription, servers);
-
-        // keep the old same-API leg before the cache is updated
-        Subscription cached = cachedSameApiLeg(subscription);
-
-        // Update cache
-        updateSubscriptionIdById(subscription);
-        updateIdentityCache(subscription, cacheByClientCertificate);
-
-        // Evict if cert bundle, clientId or plan changed (e.g. subscription transfer): the keys
-        // derived from the old leg differ from the ones just registered
-        if (
-            cached != null &&
-            (!Objects.equals(subscription.getClientCertificate(), cached.getClientCertificate()) ||
-                !Objects.equals(subscription.getClientId(), cached.getClientId()) ||
-                !Objects.equals(subscription.getPlan(), cached.getPlan()))
-        ) {
-            cacheByClientCertificate.remove(identityCacheKey(cached));
-            cacheByClientCertificate.remove(identityCacheKeyWithoutPlan(cached));
-        }
-        // Credential-type switch: if the old leg was clientId-registered, its entries live in
-        // the clientId map, which this certificate registration never overwrites.
-        if (cached != null) {
-            unregisterFromClientId(cached);
-        }
-    }
-
-    private void registerFromClientId(final Subscription subscription) {
-        // Snapshot old entries before registering (cached sets are immutable)
-        Set<Subscription> cachedAll = cacheBySubscriptionIdAll.get(subscription.getId());
-        Set<Subscription> oldEntries = cachedAll != null ? cachedAll : Set.of();
-
-        updateSubscriptionIdById(subscription);
-
-        // Register new subscription first
-        updateIdentityCache(subscription, cacheByApiClientId);
-
-        // Then clean up old entries if clientId or plan changed (e.g. subscription transfer)
-        // Only compare entries for the same API — exploded subscriptions span multiple APIs
-        for (Subscription old : oldEntries) {
-            if (!Objects.equals(old.getApi(), subscription.getApi())) {
-                continue;
-            }
-            if (
-                (old.getClientId() != null && !old.getClientId().equals(subscription.getClientId())) ||
-                (old.getPlan() != null && !old.getPlan().equals(subscription.getPlan()))
-            ) {
-                unregisterFromClientId(old);
-            }
-            // Credential-type switch: if the old leg was certificate-registered, its entries
-            // live in the certificate map and trust store, never overwritten by this
-            // clientId registration.
-            unregisterFromClientCertificate(old);
-        }
-    }
-
-    private void updateIdentityCache(Subscription subscription, ConcurrentMap<IdentityKey, Subscription> cache) {
-        updateCacheKeyByApiId(subscription.getApi(), subscription.getId());
-        cache.put(identityCacheKey(subscription), subscription);
-        // Index the subscription without plan id to allow search without plan criteria.
-        cache.put(identityCacheKeyWithoutPlan(subscription), subscription);
-    }
-
-    private void updateCacheKeyByApiId(final String apiId, final String subscriptionId) {
-        // compute() so concurrent register/unregister calls for the same API (sync appenders run
-        // in parallel) cannot lose updates or mutate a plain HashSet across threads.
-        cacheKeysByApiId.compute(apiId, (id, subscriptionsByApi) -> {
-            Set<String> keys = subscriptionsByApi != null ? subscriptionsByApi : ConcurrentHashMap.newKeySet();
-            keys.add(subscriptionId);
-            return keys;
-        });
-    }
-
-    private void updateSubscriptionIdById(Subscription subscription) {
-        cacheBySubscriptionIdAll.compute(subscription.getId(), (id, existing) -> {
-            if (existing == null || existing.isEmpty()) {
-                return Set.of(subscription);
-            }
-            // Singleton fast path: replacing the same api/environment leg needs no temporary set
-            if (existing.size() == 1) {
-                Subscription single = existing.iterator().next();
-                if (
-                    Objects.equals(single.getApi(), subscription.getApi()) &&
-                    Objects.equals(single.getEnvironmentId(), subscription.getEnvironmentId())
-                ) {
-                    return Set.of(subscription);
-                }
-            }
-            Set<Subscription> updated = new HashSet<>(existing);
-            updated.removeIf(
-                s ->
-                    Objects.equals(s.getApi(), subscription.getApi()) &&
-                    Objects.equals(s.getEnvironmentId(), subscription.getEnvironmentId())
-            );
-            updated.add(subscription);
-            return updated.size() == 1 ? Set.of(subscription) : Set.copyOf(updated);
-        });
-    }
-
-    private void unregisterFromClientId(final Subscription subscription) {
+    private void evictEverywhere(final Subscription subscription) {
         if (subscription.getClientId() != null) {
-            evictIdentityCache(subscription, cacheByApiClientId);
+            evictIdentityCache(subscription, cacheByClientId);
         }
-    }
-
-    private void unregisterFromClientCertificate(final Subscription subscription) {
         if (subscription.getClientCertificate() != null) {
             subscriptionTrustStoreLoaderManager.unregisterSubscription(subscription);
             evictIdentityCache(subscription, cacheByClientCertificate);
         }
+    }
+
+    private void updateCacheIdsByScope(final String scopeId, final String subscriptionId) {
+        // compute() so concurrent register/unregister calls for the same scope (sync appenders run
+        // in parallel) cannot lose updates or mutate a plain HashSet across threads.
+        cacheIdsByScope.compute(scopeId, (id, subscriptionIds) -> {
+            Set<String> ids = subscriptionIds != null ? subscriptionIds : ConcurrentHashMap.newKeySet();
+            ids.add(subscriptionId);
+            return ids;
+        });
+    }
+
+    private void evictIdFromScope(final String scopeId, final String subscriptionId) {
+        cacheIdsByScope.computeIfPresent(scopeId, (id, subscriptionIds) -> {
+            subscriptionIds.remove(subscriptionId);
+            return subscriptionIds.isEmpty() ? null : subscriptionIds;
+        });
     }
 
     private void evictIdentityCache(Subscription subscription, ConcurrentMap<IdentityKey, Subscription> cache) {
@@ -384,66 +355,52 @@ public class SubscriptionCacheService implements SubscriptionService {
         cache.remove(identityCacheKeyWithoutPlan(subscription));
     }
 
-    private void evictKeyForApi(final String apiId, final String subscriptionId) {
-        cacheKeysByApiId.computeIfPresent(apiId, (id, keysByApi) -> {
-            keysByApi.remove(subscriptionId);
-            return keysByApi.isEmpty() ? null : keysByApi;
-        });
-    }
-
     // visible for testing
     Optional<Subscription> getByClientCertificate(final Subscription subscription) {
         if (subscription.getPlan() != null) {
             return Optional.ofNullable(cacheByClientCertificate.get(identityCacheKey(subscription)));
-        } else {
-            return Optional.ofNullable(cacheByClientCertificate.get(identityCacheKeyWithoutPlan(subscription)));
         }
+        return Optional.ofNullable(cacheByClientCertificate.get(identityCacheKeyWithoutPlan(subscription)));
     }
 
     // Visible for testing
     Optional<Subscription> getByApiAndClientId(String api, String clientId) {
-        return Optional.ofNullable(cacheByApiClientId.get(cacheKey(api, clientId)));
+        return getByApiAndClientIdAndPlan(api, clientId, null);
     }
 
     // Visible for testing
-    Set<String> getByApiId(String apiId) {
-        return cacheKeysByApiId.getOrDefault(apiId, Collections.emptySet());
+    Set<String> getByScopeId(String scopeId) {
+        return cacheIdsByScope.getOrDefault(scopeId, Collections.emptySet());
     }
 
     private Optional<Subscription> getByApiAndId(String api, String subscriptionId) {
-        Set<Subscription> subscriptions = cacheBySubscriptionIdAll.get(subscriptionId);
-        if (subscriptions == null || subscriptions.isEmpty()) {
-            // Fallback to old cache for backward compatibility
-            return getById(subscriptionId);
+        Subscription subscription = cacheById.get(subscriptionId);
+        if (subscription == null) {
+            return Optional.empty();
         }
-        // Plain loop: this runs on the request hot path for every API-key call and the set is
-        // almost always a singleton, so avoid allocating a Stream pipeline per request.
-        for (Subscription subscription : subscriptions) {
-            if (Objects.equals(api, subscription.getApi())) {
-                return Optional.of(subscription);
-            }
-        }
-        return Optional.empty();
+        return servesApi(subscription, api) ? Optional.of(subscription) : Optional.empty();
+    }
+
+    /** Whether the subscription is reachable through the given API — directly, or via its product. */
+    private boolean servesApi(final Subscription subscription, final String api) {
+        String scope = scopeOf(subscription);
+        return Objects.equals(scope, api) || apiProductRegistry.getApiProductIdsForApi(api).contains(scope);
     }
 
     private IdentityKey identityCacheKey(Subscription subscription) {
         if (subscription.getClientId() != null) {
-            Objects.requireNonNull(subscription.getClientId(), "Client ID must not be null");
-            return cacheKey(subscription.getApi(), subscription.getPlan(), subscription.getClientId());
-        } else {
-            Objects.requireNonNull(subscription.getClientCertificate(), "Client certificate must not be null");
-            return cacheKey(subscription.getApi(), subscription.getPlan(), sha256(subscription.getClientCertificate()));
+            return cacheKey(scopeOf(subscription), subscription.getPlan(), subscription.getClientId());
         }
+        Objects.requireNonNull(subscription.getClientCertificate(), "Client certificate must not be null");
+        return cacheKey(scopeOf(subscription), subscription.getPlan(), sha256(subscription.getClientCertificate()));
     }
 
     private IdentityKey identityCacheKeyWithoutPlan(Subscription subscription) {
         if (subscription.getClientId() != null) {
-            Objects.requireNonNull(subscription.getClientId(), "Client ID must not be null");
-            return cacheKey(subscription.getApi(), subscription.getClientId());
-        } else {
-            Objects.requireNonNull(subscription.getClientCertificate(), "Client certificate must not be null");
-            return cacheKey(subscription.getApi(), sha256(subscription.getClientCertificate()));
+            return cacheKey(scopeOf(subscription), null, subscription.getClientId());
         }
+        Objects.requireNonNull(subscription.getClientCertificate(), "Client certificate must not be null");
+        return cacheKey(scopeOf(subscription), null, sha256(subscription.getClientCertificate()));
     }
 
     @SneakyThrows
@@ -453,28 +410,40 @@ public class SubscriptionCacheService implements SubscriptionService {
         return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
     }
 
-    private IdentityKey cacheKey(String api, String plan, String clientIdentity) {
-        Objects.requireNonNull(plan, "Plan must not be null");
-        return new IdentityKey(api, plan, clientIdentity);
+    private IdentityKey cacheKey(String scope, String plan, String clientIdentity) {
+        return new IdentityKey(scope, plan, clientIdentity);
     }
 
-    private IdentityKey cacheKey(String api, String clientIdentity) {
-        return new IdentityKey(api, null, clientIdentity);
+    /**
+     * Server ids the subscription's certificate must be trusted on.
+     *
+     * <p>A product subscription spans every member API, and TLS trust is held by the listeners, so
+     * this is the one place a product still fans out over its APIs. The fan-out is bounded by the
+     * product size, not by the number of subscriptions.</p>
+     */
+    private Set<String> extractScopeServerIds(Subscription subscription) {
+        if (subscription.getApiProductId() == null) {
+            return serversOf(subscription.getApi());
+        }
+        ReactableApiProduct product = apiProductRegistry.get(subscription.getApiProductId(), subscription.getEnvironmentId());
+        if (product == null || product.getApiIds() == null) {
+            return Set.of();
+        }
+        Set<String> servers = new HashSet<>();
+        product.getApiIds().forEach(apiId -> servers.addAll(serversOf(apiId)));
+        return servers;
     }
 
-    private Set<String> extractApiServersId(Subscription subscription) {
-        final ReactableApi<?> reactableApi = apiManager.get(subscription.getApi());
-        final Set<String> servers;
+    private Set<String> serversOf(String apiId) {
+        final ReactableApi<?> reactableApi = apiManager.get(apiId);
         if (reactableApi instanceof Api api) {
-            servers = api
+            return api
                 .getDefinition()
                 .getListeners()
                 .stream()
                 .flatMap(l -> l.getServers() != null ? l.getServers().stream() : Stream.empty())
                 .collect(Collectors.toSet());
-        } else {
-            servers = Set.of();
         }
-        return servers;
+        return Set.of();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/sharding/ApiProductShardingFilter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/sharding/ApiProductShardingFilter.java
@@ -19,10 +19,25 @@ import io.gravitee.gateway.env.GatewayConfiguration;
 import java.util.Set;
 
 /**
- * Sharding tag matching for API Products and API Product plans (aligned with API sharding in gateway).
+ * Sharding tag matching for API Products and their plans.
  *
- * <p>Follows the same rules as APIs: tagless gateways retrieve everything; tagged gateways
- * only retrieve entities whose tags match.
+ * <p>A product follows the same rule as an API: a tagless gateway takes everything, a tagged
+ * gateway takes only what carries one of its tags — including refusing an untagged product, just as
+ * {@code ApiManagerImpl} refuses an untagged API.</p>
+ *
+ * <p><strong>A product plan does not.</strong> An untagged plan is accepted outright, where an
+ * untagged API plan goes through the ordinary rule and can make a tagged gateway skip its API. The
+ * two are pinned down by tests on both sides:</p>
+ * <ul>
+ *   <li>API: {@code ApiManagerImplTest.should_not_deploy_api_if_plan_has_non_matching_tag}</li>
+ *   <li>API Product: {@code ApiProductV4ShardingIntegrationTest.should_serve_an_untagged_plan_of_a_matching_product}</li>
+ * </ul>
+ *
+ * <p>The short-circuit below is deliberate — it was written, not inherited — but its rationale was
+ * never recorded. The defensible reading is that a product plan already sits behind its product's
+ * tags, so filtering the same perimeter twice buys nothing. Whether that should be aligned with API
+ * plans is an open product question; this note exists so that whoever picks up a bug about a
+ * product plan appearing on a gateway that should not serve it lands here directly.</p>
  */
 public final class ApiProductShardingFilter {
 
@@ -33,6 +48,7 @@ public final class ApiProductShardingFilter {
     }
 
     public static boolean matchesPlanTags(GatewayConfiguration gatewayConfiguration, Set<String> planTags) {
+        // Diverges from API plans on purpose — see the class javadoc before changing this.
         if (planTags == null || planTags.isEmpty()) {
             return true;
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -228,8 +228,8 @@ public class ApiHandlerConfiguration {
     }
 
     @Bean
-    public ApiKeyCacheService apiKeyService() {
-        return new ApiKeyCacheService();
+    public ApiKeyCacheService apiKeyService(ApiProductRegistry apiProductRegistry) {
+        return new ApiKeyCacheService(apiProductRegistry);
     }
 
     @Bean
@@ -241,9 +241,10 @@ public class ApiHandlerConfiguration {
     public SubscriptionCacheService subscriptionService(
         ApiKeyCacheService apiKeyService,
         SubscriptionTrustStoreLoaderManager subscriptionTrustStoreLoaderManager,
-        ApiManager apiManager
+        ApiManager apiManager,
+        ApiProductRegistry apiProductRegistry
     ) {
-        return new SubscriptionCacheService(apiKeyService, subscriptionTrustStoreLoaderManager, apiManager);
+        return new SubscriptionCacheService(apiKeyService, subscriptionTrustStoreLoaderManager, apiManager, apiProductRegistry);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImplTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.handlers.api.registry.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 
@@ -29,6 +30,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -203,6 +207,85 @@ class ApiProductRegistryImplTest {
             registry.clear();
 
             assertThat(registry.getAll()).isEmpty();
+        }
+    }
+
+    @Nested
+    class GetApiProductIdsForApiTest {
+
+        @Test
+        void should_return_empty_when_api_id_null_or_unknown() {
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(product);
+
+            assertThat(registry.getApiProductIdsForApi(null)).isEmpty();
+            assertThat(registry.getApiProductIdsForApi("unknown-api")).isEmpty();
+        }
+
+        @Test
+        void should_return_every_product_containing_the_api_across_environments() {
+            ReactableApiProduct first = createApiProduct("product-1", "env-1");
+            first.setApiIds(Set.of("api-1", "api-2"));
+            first.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            ReactableApiProduct second = createApiProduct("product-2", "env-2");
+            second.setApiIds(Set.of("api-1"));
+            second.setPlans(List.of(createPlan("plan-2", PlanStatus.DEPRECATED)));
+            registry.register(first);
+            registry.register(second);
+
+            // Request-path lookups have no environment: an API ID is globally unique, so both
+            // products are legitimate scopes to probe for a subscription on api-1.
+            assertThat(registry.getApiProductIdsForApi("api-1")).containsExactlyInAnyOrder("product-1", "product-2");
+            assertThat(registry.getApiProductIdsForApi("api-2")).containsExactly("product-1");
+        }
+
+        @Test
+        void should_not_return_a_product_without_any_servable_plan() {
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setApiIds(Set.of("api-1"));
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.CLOSED)));
+            registry.register(product);
+
+            // No servable plan means no subscription can resolve through this product.
+            assertThat(registry.getApiProductIdsForApi("api-1")).isEmpty();
+        }
+
+        @Test
+        void should_drop_the_api_when_the_product_is_removed() {
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setApiIds(Set.of("api-1"));
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(product);
+            assertThat(registry.getApiProductIdsForApi("api-1")).containsExactly("product-1");
+
+            registry.remove("product-1", "env-1");
+
+            assertThat(registry.getApiProductIdsForApi("api-1")).isEmpty();
+        }
+
+        @Test
+        void should_drop_the_api_when_it_leaves_the_product() {
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setApiIds(Set.of("api-1", "api-2"));
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(product);
+
+            ReactableApiProduct updated = createApiProduct("product-1", "env-1");
+            updated.setApiIds(Set.of("api-1"));
+            updated.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(updated);
+
+            assertThat(registry.getApiProductIdsForApi("api-1")).containsExactly("product-1");
+            assertThat(registry.getApiProductIdsForApi("api-2")).isEmpty();
+        }
+
+        private Plan createPlan(String id, PlanStatus status) {
+            Plan plan = new Plan();
+            plan.setId(id);
+            plan.setName("Plan " + id);
+            plan.setStatus(status);
+            return plan;
         }
     }
 
@@ -445,6 +528,84 @@ class ApiProductRegistryImplTest {
 
     @Nested
     class ConcurrencyTest {
+
+        @Test
+        void should_keep_published_plan_entries_readable_while_products_are_registered() throws Exception {
+            // Readers walk the published lists while the index is rebuilt. If a rebuild mutated the
+            // lists it had published — instead of replacing them — readers would blow up with a
+            // ConcurrentModificationException or observe a half-updated list.
+            ReactableApiProduct initial = createApiProduct("product-0", "env-1");
+            initial.setApiIds(Set.of("api-1"));
+            initial.setPlans(List.of(createPlan("plan-0", PlanStatus.PUBLISHED)));
+            registry.register(initial);
+
+            // A wide product — the longer the published list, the longer a reader spends walking it
+            // while the writer rebuilds, which is the window this guards.
+            ReactableApiProduct wide = createApiProduct("product-wide", "env-1");
+            wide.setApiIds(Set.of("api-1"));
+            wide.setPlans(
+                IntStream.range(0, 200)
+                    .mapToObj(i -> createPlan("wide-plan-" + i, PlanStatus.PUBLISHED))
+                    .toList()
+            );
+            registry.register(wide);
+
+            AtomicReference<Throwable> readerFailure = new AtomicReference<>();
+            AtomicBoolean writingDone = new AtomicBoolean(false);
+            int readerCount = 4;
+            List<Thread> readers = IntStream.range(0, readerCount)
+                .mapToObj(r ->
+                    new Thread(() -> {
+                        try {
+                            while (!writingDone.get()) {
+                                for (ApiProductRegistry.ApiProductPlanEntry entry : registry.getApiProductPlanEntriesForApi(
+                                    "api-1",
+                                    "env-1"
+                                )) {
+                                    assertThat(entry.apiProductId()).isNotNull();
+                                }
+                                assertThat(registry.getApiProductIdsForApi("api-1")).isNotNull();
+                            }
+                        } catch (Throwable t) {
+                            readerFailure.compareAndSet(null, t);
+                        }
+                    })
+                )
+                .toList();
+
+            Thread writer = new Thread(() -> {
+                for (int i = 1; i <= 2_000; i++) {
+                    ReactableApiProduct product = createApiProduct("product-" + i, "env-1");
+                    product.setApiIds(Set.of("api-1"));
+                    product.setPlans(List.of(createPlan("plan-" + i, PlanStatus.PUBLISHED)));
+                    registry.register(product);
+                    registry.remove("product-" + i, "env-1");
+                }
+                writingDone.set(true);
+            });
+
+            readers.forEach(Thread::start);
+            writer.start();
+            writer.join(30_000);
+            for (Thread reader : readers) {
+                reader.join(30_000);
+            }
+
+            assertThat(readerFailure.get()).isNull();
+        }
+
+        @Test
+        void should_publish_immutable_plan_entries() {
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setApiIds(Set.of("api-1"));
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(product);
+
+            List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-1", "env-1");
+
+            assertThat(entries).hasSize(1);
+            assertThatThrownBy(entries::clear).isInstanceOf(UnsupportedOperationException.class);
+        }
 
         @Test
         void should_handle_concurrent_registrations() throws InterruptedException {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImplTest.java
@@ -207,6 +207,85 @@ class ApiProductRegistryImplTest {
     }
 
     @Nested
+    class GetApiProductIdsForApiTest {
+
+        @Test
+        void should_return_empty_when_api_id_null_or_unknown() {
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(product);
+
+            assertThat(registry.getApiProductIdsForApi(null)).isEmpty();
+            assertThat(registry.getApiProductIdsForApi("unknown-api")).isEmpty();
+        }
+
+        @Test
+        void should_return_every_product_containing_the_api_across_environments() {
+            ReactableApiProduct first = createApiProduct("product-1", "env-1");
+            first.setApiIds(Set.of("api-1", "api-2"));
+            first.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            ReactableApiProduct second = createApiProduct("product-2", "env-2");
+            second.setApiIds(Set.of("api-1"));
+            second.setPlans(List.of(createPlan("plan-2", PlanStatus.DEPRECATED)));
+            registry.register(first);
+            registry.register(second);
+
+            // Request-path lookups have no environment: an API ID is globally unique, so both
+            // products are legitimate scopes to probe for a subscription on api-1.
+            assertThat(registry.getApiProductIdsForApi("api-1")).containsExactlyInAnyOrder("product-1", "product-2");
+            assertThat(registry.getApiProductIdsForApi("api-2")).containsExactly("product-1");
+        }
+
+        @Test
+        void should_not_return_a_product_without_any_servable_plan() {
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setApiIds(Set.of("api-1"));
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.CLOSED)));
+            registry.register(product);
+
+            // No servable plan means no subscription can resolve through this product.
+            assertThat(registry.getApiProductIdsForApi("api-1")).isEmpty();
+        }
+
+        @Test
+        void should_drop_the_api_when_the_product_is_removed() {
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setApiIds(Set.of("api-1"));
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(product);
+            assertThat(registry.getApiProductIdsForApi("api-1")).containsExactly("product-1");
+
+            registry.remove("product-1", "env-1");
+
+            assertThat(registry.getApiProductIdsForApi("api-1")).isEmpty();
+        }
+
+        @Test
+        void should_drop_the_api_when_it_leaves_the_product() {
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setApiIds(Set.of("api-1", "api-2"));
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(product);
+
+            ReactableApiProduct updated = createApiProduct("product-1", "env-1");
+            updated.setApiIds(Set.of("api-1"));
+            updated.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(updated);
+
+            assertThat(registry.getApiProductIdsForApi("api-1")).containsExactly("product-1");
+            assertThat(registry.getApiProductIdsForApi("api-2")).isEmpty();
+        }
+
+        private Plan createPlan(String id, PlanStatus status) {
+            Plan plan = new Plan();
+            plan.setId(id);
+            plan.setName("Plan " + id);
+            plan.setStatus(status);
+            return plan;
+        }
+    }
+
+    @Nested
     class GetProductPlanEntriesForApiTest {
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/ApiKeyCacheServiceTest.java
@@ -16,8 +16,11 @@
 package io.gravitee.gateway.handlers.api.services;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -39,17 +42,22 @@ import org.springframework.util.DigestUtils;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class ApiKeyCacheServiceTest {
 
+    private static final String PRODUCT_ID = "my-api-product";
+    private static final String MEMBER_API_ID = "my-member-api";
+
     private ApiKeyCacheService apiKeyService;
+    private ApiProductRegistry apiProductRegistry;
     private Map<ApiKeyCacheService.CacheKey, ApiKey> cacheApiKeys;
     private Map<ApiKeyCacheService.CacheKey, ApiKey> cacheMd5ApiKeys;
-    private Map<String, Set<String>> cacheApiKeysByApi;
+    private Map<String, Set<String>> cacheApiKeysByScope;
 
     @BeforeEach
     public void beforeEach() throws Exception {
-        apiKeyService = new ApiKeyCacheService();
+        apiProductRegistry = mock(ApiProductRegistry.class);
+        apiKeyService = new ApiKeyCacheService(apiProductRegistry);
         cacheApiKeys = (Map<ApiKeyCacheService.CacheKey, ApiKey>) ReflectionTestUtils.getField(apiKeyService, "cacheApiKeys");
         cacheMd5ApiKeys = (Map<ApiKeyCacheService.CacheKey, ApiKey>) ReflectionTestUtils.getField(apiKeyService, "cacheMd5ApiKeys");
-        cacheApiKeysByApi = (Map<String, Set<String>>) ReflectionTestUtils.getField(apiKeyService, "cacheApiKeysByApi");
+        cacheApiKeysByScope = (Map<String, Set<String>>) ReflectionTestUtils.getField(apiKeyService, "cacheApiKeysByScope");
     }
 
     @Nested
@@ -71,7 +79,7 @@ public class ApiKeyCacheServiceTest {
             assertThat(md5Actual).isNotNull();
             assertThat(md5Actual).isEqualTo(apiKey);
 
-            Set<String> actuals = cacheApiKeysByApi.get("my-api");
+            Set<String> actuals = cacheApiKeysByScope.get("my-api");
             assertThat(actuals.contains("my-key")).isTrue();
         }
 
@@ -87,7 +95,7 @@ public class ApiKeyCacheServiceTest {
             var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
             assertThat(cacheMd5ApiKeys.get(md5CacheKey)).isNull();
 
-            assertThat(cacheApiKeysByApi.get("my-api")).isNull();
+            assertThat(cacheApiKeysByScope.get("my-api")).isNull();
         }
     }
 
@@ -110,7 +118,7 @@ public class ApiKeyCacheServiceTest {
             var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
             assertThat(cacheMd5ApiKeys.get(md5CacheKey)).isNull();
 
-            assertThat(cacheApiKeysByApi.get("my-api")).isNull();
+            assertThat(cacheApiKeysByScope.get("my-api")).isNull();
         }
 
         @Test
@@ -129,7 +137,7 @@ public class ApiKeyCacheServiceTest {
             var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
             assertThat(cacheMd5ApiKeys.get(md5CacheKey)).isNull();
 
-            assertThat(cacheApiKeysByApi.get("my-api")).isNull();
+            assertThat(cacheApiKeysByScope.get("my-api")).isNull();
         }
 
         @Test
@@ -144,7 +152,7 @@ public class ApiKeyCacheServiceTest {
             var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey);
             assertThat(cacheMd5ApiKeys.get(md5CacheKey)).isNull();
 
-            assertThat(cacheApiKeysByApi.get("my-api")).isNull();
+            assertThat(cacheApiKeysByScope.get("my-api")).isNull();
         }
 
         @Test
@@ -162,7 +170,7 @@ public class ApiKeyCacheServiceTest {
             var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKey1);
             assertThat(cacheMd5ApiKeys.get(md5CacheKey)).isNull();
 
-            Set<String> apiKeysByApi = cacheApiKeysByApi.get("my-api");
+            Set<String> apiKeysByApi = cacheApiKeysByScope.get("my-api");
             assertThat(apiKeysByApi).isNotNull();
             assertThat(apiKeysByApi.size()).isEqualTo(4);
         }
@@ -173,7 +181,7 @@ public class ApiKeyCacheServiceTest {
                 ApiKey apiKey = buildApiKey("my-api", "my-key-" + i, true);
                 apiKeyService.register(apiKey);
             }
-            Set<String> apiKeysByApi = cacheApiKeysByApi.get("my-api");
+            Set<String> apiKeysByApi = cacheApiKeysByScope.get("my-api");
             assertThat(apiKeysByApi.size()).isEqualTo(5);
 
             apiKeyService.unregisterByApiId("my-api");
@@ -187,7 +195,7 @@ public class ApiKeyCacheServiceTest {
                 var md5CacheKey = apiKeyService.buildMd5CacheKey(apiKeyToUnregister);
                 assertThat(cacheMd5ApiKeys.get(md5CacheKey)).isNull();
             }
-            assertThat(cacheApiKeysByApi.get("my-api")).isNull();
+            assertThat(cacheApiKeysByScope.get("my-api")).isNull();
         }
     }
 
@@ -210,7 +218,7 @@ public class ApiKeyCacheServiceTest {
             assertThat(md5Actual).isNotNull();
             assertThat(md5Actual).isEqualTo(apiKey);
 
-            Set<String> actuals = cacheApiKeysByApi.get("my-api");
+            Set<String> actuals = cacheApiKeysByScope.get("my-api");
             assertThat(actuals.contains("my-key")).isTrue();
 
             Optional<ApiKey> keyFoundOpt = apiKeyService.getByApiAndKey("my-api", "my-key");
@@ -228,7 +236,7 @@ public class ApiKeyCacheServiceTest {
         void should_not_get_apiKey_when_not_registered() {
             assertThat(cacheApiKeys.size()).isEqualTo(0);
             assertThat(cacheMd5ApiKeys.size()).isEqualTo(0);
-            assertThat(cacheApiKeysByApi.size()).isEqualTo(0);
+            assertThat(cacheApiKeysByScope.size()).isEqualTo(0);
 
             Optional<ApiKey> keyFoundOpt = apiKeyService.getByApiAndKey("my-api", "my-key");
             assertThat(keyFoundOpt).isEmpty();
@@ -245,7 +253,7 @@ public class ApiKeyCacheServiceTest {
         void should_unregister_every_api_key_registered_concurrently_for_the_same_api() throws Exception {
             // Sync appenders register api keys of the same API from several threads
             // (services.sync.appender.parallelism). Every cache key must survive the concurrent
-            // maintenance of cacheApiKeysByApi so unregisterByApiId() can evict them all.
+            // maintenance of cacheApiKeysByScope so unregisterByApiId() can evict them all.
             int writerCount = 8;
             int keysPerWriter = 200;
             CyclicBarrier barrier = new CyclicBarrier(writerCount);
@@ -272,7 +280,56 @@ public class ApiKeyCacheServiceTest {
 
             assertThat(cacheApiKeys.isEmpty()).isTrue();
             assertThat(cacheMd5ApiKeys.isEmpty()).isTrue();
-            assertThat(cacheApiKeysByApi.isEmpty()).isTrue();
+            assertThat(cacheApiKeysByScope.isEmpty()).isTrue();
+        }
+    }
+
+    @Nested
+    class ApiProductScopeTest {
+
+        @Test
+        void should_reach_product_api_key_from_a_member_api() {
+            when(apiProductRegistry.getApiProductIdsForApi(MEMBER_API_ID)).thenReturn(Set.of(PRODUCT_ID));
+            // The sync mapper scopes an API Product subscription's key to the product
+            ApiKey apiKey = buildApiKey(PRODUCT_ID, "my-key", true);
+            apiKeyService.register(apiKey);
+
+            assertThat(apiKeyService.getByApiAndKey(MEMBER_API_ID, "my-key")).contains(apiKey);
+            assertThat(apiKeyService.getByApiAndMd5Key(MEMBER_API_ID, DigestUtils.md5DigestAsHex("my-key".getBytes()))).contains(apiKey);
+            // Cached once, under the product
+            assertThat(cacheApiKeysByScope.get(PRODUCT_ID)).isEqualTo(Set.of("my-key"));
+            assertThat(cacheApiKeysByScope.get(MEMBER_API_ID)).isNull();
+        }
+
+        @Test
+        void should_not_reach_product_api_key_from_an_api_outside_the_product() {
+            apiKeyService.register(buildApiKey(PRODUCT_ID, "my-key", true));
+
+            assertThat(apiKeyService.getByApiAndKey("api-outside", "my-key")).isEmpty();
+        }
+
+        @Test
+        void should_keep_product_api_key_when_a_member_api_is_undeployed() {
+            when(apiProductRegistry.getApiProductIdsForApi(MEMBER_API_ID)).thenReturn(Set.of(PRODUCT_ID));
+            ApiKey apiKey = buildApiKey(PRODUCT_ID, "my-key", true);
+            apiKeyService.register(apiKey);
+
+            apiKeyService.unregisterByApiId(MEMBER_API_ID);
+
+            assertThat(apiKeyService.getByApiAndKey(MEMBER_API_ID, "my-key")).contains(apiKey);
+        }
+
+        @Test
+        void should_evict_product_api_keys_when_the_product_is_undeployed() {
+            when(apiProductRegistry.getApiProductIdsForApi(MEMBER_API_ID)).thenReturn(Set.of(PRODUCT_ID));
+            apiKeyService.register(buildApiKey(PRODUCT_ID, "my-key", true));
+
+            apiKeyService.unregisterByApiProductId(PRODUCT_ID);
+
+            assertThat(apiKeyService.getByApiAndKey(MEMBER_API_ID, "my-key")).isEmpty();
+            assertThat(cacheApiKeys.isEmpty()).isTrue();
+            assertThat(cacheMd5ApiKeys.isEmpty()).isTrue();
+            assertThat(cacheApiKeysByScope.isEmpty()).isTrue();
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.handlers.api.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,7 +25,9 @@ import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
 import io.gravitee.gateway.reactor.ReactableApi;
@@ -61,6 +64,7 @@ class SubscriptionCacheServiceTest {
     private static final String SUB_ID_2 = "my-test-subscription-id-2";
     private static final String CLIENT_ID = "my-test-client-id";
     private static final String CLIENT_CERTIFICATE = "my-test-client-certificate";
+    private static final String PRODUCT_ID = "my-test-api-product-id";
 
     @Mock
     private ApiKeyService apiKeyService;
@@ -71,11 +75,25 @@ class SubscriptionCacheServiceTest {
     @Mock
     private ApiManager apiManager;
 
+    @Mock
+    private ApiProductRegistry apiProductRegistry;
+
     private SubscriptionCacheService subscriptionService;
 
     @BeforeEach
     void setup() {
-        subscriptionService = new SubscriptionCacheService(apiKeyService, subscriptionTrustStoreLoaderManager, apiManager);
+        subscriptionService = new SubscriptionCacheService(
+            apiKeyService,
+            subscriptionTrustStoreLoaderManager,
+            apiManager,
+            apiProductRegistry
+        );
+    }
+
+    /** Makes API_ID and API_ID_2 members of PRODUCT_ID, as the registry would after a deployment. */
+    private void givenProductWithMemberApis() {
+        lenient().when(apiProductRegistry.getApiProductIdsForApi(API_ID)).thenReturn(Set.of(PRODUCT_ID));
+        lenient().when(apiProductRegistry.getApiProductIdsForApi(API_ID_2)).thenReturn(Set.of(PRODUCT_ID));
     }
 
     @Nested
@@ -96,7 +114,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getByClientCertificate(lookupWithoutPlan)).isPresent().get().isEqualTo(subscription);
 
             // By api
-            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
+            assertThat(subscriptionService.getByScopeId(API_ID)).containsExactly(SUB_ID);
 
             ArgumentCaptor<Set<String>> serversListCaptor = ArgumentCaptor.forClass(Set.class);
             verify(subscriptionTrustStoreLoaderManager).registerSubscription(eq(subscription), serversListCaptor.capture());
@@ -123,7 +141,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getByClientCertificate(lookupWithoutPlan)).isPresent().get().isEqualTo(subscription);
 
             // By api
-            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
+            assertThat(subscriptionService.getByScopeId(API_ID)).containsExactly(SUB_ID);
 
             ArgumentCaptor<Set<String>> serversListCaptor = ArgumentCaptor.forClass(Set.class);
             verify(subscriptionTrustStoreLoaderManager).registerSubscription(eq(subscription), serversListCaptor.capture());
@@ -155,7 +173,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getByClientCertificate(lookupWithoutPlan)).isPresent().get().isEqualTo(subscriptionUpdated);
 
             // By api
-            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
+            assertThat(subscriptionService.getByScopeId(API_ID)).containsExactly(SUB_ID);
         }
 
         @Test
@@ -175,7 +193,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isPresent().get().isEqualTo(subscription);
 
             // By api
-            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
+            assertThat(subscriptionService.getByScopeId(API_ID)).containsExactly(SUB_ID);
         }
 
         @Test
@@ -275,7 +293,7 @@ class SubscriptionCacheServiceTest {
                 .isEqualTo(subscriptionUpdated);
 
             // By api
-            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
+            assertThat(subscriptionService.getByScopeId(API_ID)).containsExactly(SUB_ID);
         }
 
         @Test
@@ -285,7 +303,7 @@ class SubscriptionCacheServiceTest {
 
             assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(subscription);
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID)).containsExactly(SUB_ID);
+            assertThat(subscriptionService.getByScopeId(API_ID)).containsExactly(SUB_ID);
         }
 
         @Test
@@ -370,9 +388,8 @@ class SubscriptionCacheServiceTest {
         @Test
         void should_replace_stale_metadata_when_api_key_subscription_is_re_registered_with_updated_metadata() {
             // Simulates incremental gateway sync after a PUT /subscriptions/{id} that only changes metadata.
-            // Before the fix, cacheBySubscriptionIdAll accumulated both old and new entries (because
-            // Subscription.equals() is deep and includes metadata), causing getByApiAndId / getByApiAndSecurityToken
-            // to non-deterministically return the stale subscription.
+            // The by-id index holds exactly one entry per subscription, so the re-registration replaces
+            // the previous one instead of accumulating next to it.
             Subscription initial = buildAcceptedSubscription(SUB_ID, API_ID);
             initial.setMetadata(Map.of("key", "foo"));
             initial.setEnvironmentId("env-1");
@@ -390,9 +407,6 @@ class SubscriptionCacheServiceTest {
                 .extracting(s -> s.getMetadata().get("key"))
                 .isEqualTo("bar");
 
-            // getAllById must contain exactly one entry (no stale accumulation)
-            assertThat(subscriptionService.getAllById(SUB_ID)).hasSize(1);
-
             // API key lookup path (getByApiAndId) must also return the fresh metadata
             ApiKey apiKey = new ApiKey();
             apiKey.setSubscription(SUB_ID);
@@ -406,32 +420,6 @@ class SubscriptionCacheServiceTest {
         }
 
         @Test
-        void should_not_evict_subscription_from_another_environment_with_same_id_and_api() {
-            // Guards against CRD subscriptions where operators control the ID and could (by misconfiguration)
-            // use the same id across environments on the same gateway instance.
-            Subscription envA = buildAcceptedSubscription(SUB_ID, API_ID);
-            envA.setMetadata(Map.of("key", "env-a-value"));
-            envA.setEnvironmentId("env-a");
-            subscriptionService.register(envA);
-
-            Subscription envB = buildAcceptedSubscription(SUB_ID, API_ID);
-            envB.setMetadata(Map.of("key", "env-b-value"));
-            envB.setEnvironmentId("env-b");
-            subscriptionService.register(envB);
-
-            // Both legs must coexist since they belong to different environments
-            assertThat(subscriptionService.getAllById(SUB_ID)).hasSize(2);
-
-            // Updating env-a metadata must not evict env-b's entry
-            Subscription envAUpdated = buildAcceptedSubscription(SUB_ID, API_ID);
-            envAUpdated.setMetadata(Map.of("key", "env-a-updated"));
-            envAUpdated.setEnvironmentId("env-a");
-            subscriptionService.register(envAUpdated);
-
-            assertThat(subscriptionService.getAllById(SUB_ID)).hasSize(2);
-        }
-
-        @Test
         void should_not_register_subscription_when_subscription_is_not_accepted() {
             Subscription subscription = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscription.setStatus(io.gravitee.repository.management.model.Subscription.Status.CLOSED.name());
@@ -441,7 +429,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
             assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID)).isEmpty();
         }
     }
 
@@ -461,7 +449,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getByClientCertificate(subscription)).isEmpty();
             Subscription lookupWithoutPlan = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, null);
             assertThat(subscriptionService.getByClientCertificate(lookupWithoutPlan)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID)).isEmpty();
         }
 
         @Test
@@ -476,7 +464,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
             assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID)).isEmpty();
         }
 
         @Test
@@ -487,7 +475,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
             assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID)).isEmpty();
         }
 
         @Test
@@ -500,7 +488,7 @@ class SubscriptionCacheServiceTest {
 
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
             assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID)).isEmpty();
         }
 
         @Test
@@ -512,19 +500,19 @@ class SubscriptionCacheServiceTest {
 
             assertThat(subscriptionService.getById(SUB_ID)).isPresent();
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isPresent().get().isEqualTo(subApi1);
-            assertThat(subscriptionService.getByApiId(API_ID)).isNotEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID)).isNotEmpty();
 
             subscriptionService.unregisterByApiId(API_ID);
 
             // API_ID subscriptions are gone
             assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID)).isEmpty();
 
             // API_ID_2 subscriptions are intact
             assertThat(subscriptionService.getById(SUB_ID_2)).isPresent().get().isEqualTo(subApi2);
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).isPresent().get().isEqualTo(subApi2);
-            assertThat(subscriptionService.getByApiId(API_ID_2)).isNotEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID_2)).isNotEmpty();
         }
 
         @Test
@@ -536,53 +524,19 @@ class SubscriptionCacheServiceTest {
 
             assertThat(subscriptionService.getById(SUB_ID)).isPresent();
             assertThat(subscriptionService.getByClientCertificate(subApi1)).isPresent().get().isEqualTo(subApi1);
-            assertThat(subscriptionService.getByApiId(API_ID)).isNotEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID)).isNotEmpty();
 
             subscriptionService.unregisterByApiId(API_ID);
 
             // API_ID subscriptions are gone
             assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
             assertThat(subscriptionService.getByClientCertificate(subApi1)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID)).isEmpty();
 
             // API_ID_2 subscriptions are intact
             assertThat(subscriptionService.getById(SUB_ID_2)).isPresent().get().isEqualTo(subApi2);
             assertThat(subscriptionService.getByClientCertificate(subApi2)).isPresent().get().isEqualTo(subApi2);
-            assertThat(subscriptionService.getByApiId(API_ID_2)).isNotEmpty();
-        }
-
-        @Test
-        void should_unregister_all_exploded_subscriptions_sharing_same_subscription_id() {
-            // Same subscription ID and plan (the API Product plan) exploded across two APIs
-            Subscription subApi1 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
-            Subscription subApi2 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID_2, CLIENT_ID, PLAN_ID);
-            subscriptionService.register(subApi1);
-            subscriptionService.register(subApi2);
-
-            subscriptionService.unregister(subApi1);
-            subscriptionService.unregister(subApi2);
-
-            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).isEmpty();
-            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
-            assertThat(subscriptionService.getAllById(SUB_ID)).isEmpty();
-        }
-
-        @Test
-        void should_unregister_all_exploded_subscriptions_regardless_of_unregister_order() {
-            // Unregistering in the opposite order must produce the same result
-            Subscription subApi1 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
-            Subscription subApi2 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID_2, CLIENT_ID, PLAN_ID);
-            subscriptionService.register(subApi1);
-            subscriptionService.register(subApi2);
-
-            subscriptionService.unregister(subApi2);
-            subscriptionService.unregister(subApi1);
-
-            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).isEmpty();
-            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
-            assertThat(subscriptionService.getAllById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID_2)).isNotEmpty();
         }
 
         @Test
@@ -597,7 +551,7 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
             assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID)).isEmpty();
         }
 
         @Test
@@ -610,55 +564,11 @@ class SubscriptionCacheServiceTest {
             Subscription staleCandidate = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, "clientId-old", PLAN_ID);
             subscriptionService.unregister(staleCandidate);
 
-            // The API leg is removed
+            // The subscription is removed
             assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
-            assertThat(subscriptionService.getAllById(SUB_ID)).isEmpty();
             // Both the current and the stale client-id keys are gone
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, "clientId-current", PLAN_ID)).isEmpty();
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, "clientId-old", PLAN_ID)).isEmpty();
-        }
-
-        @Test
-        void should_keep_sibling_subscription_accessible_after_one_leg_unregistered() {
-            // Same subscription ID exploded across two APIs (API Product scenario)
-            Subscription subApi1 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
-            Subscription subApi2 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID_2, CLIENT_ID, PLAN_ID);
-            subscriptionService.register(subApi1);
-            subscriptionService.register(subApi2);
-
-            // Unregister only the first leg (subApi2 is the last-registered and sits in cacheBySubscriptionId)
-            subscriptionService.unregister(subApi1);
-
-            // API_ID leg is gone
-            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
-
-            // API_ID_2 leg is still alive — getById must agree with getAllById
-            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).isPresent().contains(subApi2);
-            assertThat(subscriptionService.getAllById(SUB_ID)).containsExactly(subApi2);
-            assertThat(subscriptionService.getById(SUB_ID)).isPresent();
-        }
-
-        @Test
-        void should_keep_getById_consistent_when_last_registered_leg_is_unregistered_first() {
-            // Same subscription ID exploded across two APIs (API Product scenario).
-            // subApi2 is registered last, so it wins the cacheBySubscriptionId single slot.
-            Subscription subApi1 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
-            Subscription subApi2 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID_2, CLIENT_ID, PLAN_ID);
-            subscriptionService.register(subApi1);
-            subscriptionService.register(subApi2);
-
-            // Unregister the leg that currently occupies cacheBySubscriptionId
-            subscriptionService.unregister(subApi2);
-
-            // API_ID_2 leg is gone
-            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID_2)).isEmpty();
-
-            // API_ID leg is still alive — getById must agree with getAllById
-            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isPresent().contains(subApi1);
-            assertThat(subscriptionService.getAllById(SUB_ID)).containsExactly(subApi1);
-            assertThat(subscriptionService.getById(SUB_ID)).isPresent();
         }
     }
 
@@ -753,9 +663,9 @@ class SubscriptionCacheServiceTest {
         }
 
         @Test
-        void should_get_all_exploded_subscriptions_by_id() {
+        void should_not_get_subscription_of_another_api_with_the_same_client_id() {
             Subscription subApi1 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
-            Subscription subApi2 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID_2, CLIENT_ID, PLAN_ID_2);
+            Subscription subApi2 = buildAcceptedSubscriptionWithClientId(SUB_ID_2, API_ID_2, CLIENT_ID, PLAN_ID_2);
             subscriptionService.register(subApi1);
             subscriptionService.register(subApi2);
 
@@ -767,35 +677,131 @@ class SubscriptionCacheServiceTest {
             );
             assertThat(subscriptionService.getByApiAndSecurityToken(API_ID_2, SecurityToken.forClientId("unknown"), PLAN_ID_2)).isEmpty();
         }
+    }
+
+    @Nested
+    class ApiProductScopeTest {
 
         @Test
-        void should_get_one_leg_by_id_for_exploded_subscription() {
-            Subscription subApi1 = buildAcceptedSubscription(SUB_ID, API_ID);
-            Subscription subApi2 = buildAcceptedSubscription(SUB_ID, API_ID_2);
-            subscriptionService.register(subApi1);
-            subscriptionService.register(subApi2);
+        void should_cache_product_subscription_once_and_reach_it_from_every_member_api() {
+            givenProductWithMemberApis();
+            Subscription subscription = buildAcceptedProductSubscriptionWithClientId(SUB_ID, PRODUCT_ID, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(subscription);
 
-            assertThat(subscriptionService.getById(SUB_ID)).get().isIn(subApi1, subApi2);
+            // A single entry, indexed under the product
+            assertThat(subscriptionService.getByScopeId(PRODUCT_ID)).containsExactly(SUB_ID);
+            assertThat(subscriptionService.getByScopeId(API_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID_2)).isEmpty();
+
+            // Reachable from every member API, with and without the plan
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).contains(subscription);
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).contains(subscription);
+            assertThat(subscriptionService.getByApiAndClientId(API_ID_2, CLIENT_ID)).contains(subscription);
         }
 
         @Test
-        void should_get_exploded_subscription_by_api_key_for_each_api_leg() {
-            Subscription subApi1 = buildAcceptedSubscription(SUB_ID, API_ID);
-            Subscription subApi2 = buildAcceptedSubscription(SUB_ID, API_ID_2);
-            subscriptionService.register(subApi1);
-            subscriptionService.register(subApi2);
+        void should_not_reach_product_subscription_from_an_api_outside_the_product() {
+            givenProductWithMemberApis();
+            subscriptionService.register(buildAcceptedProductSubscriptionWithClientId(SUB_ID, PRODUCT_ID, CLIENT_ID, PLAN_ID));
+
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan("api-outside", CLIENT_ID, PLAN_ID)).isEmpty();
+        }
+
+        @Test
+        void should_resolve_product_subscription_by_api_key_from_a_member_api() {
+            givenProductWithMemberApis();
+            Subscription subscription = buildAcceptedProductSubscriptionWithClientId(SUB_ID, PRODUCT_ID, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(subscription);
 
             ApiKey apiKey = new ApiKey();
             apiKey.setSubscription(SUB_ID);
-            when(apiKeyService.getByApiAndKey(API_ID, "apiKeyValue")).thenReturn(Optional.of(apiKey));
             when(apiKeyService.getByApiAndKey(API_ID_2, "apiKeyValue")).thenReturn(Optional.of(apiKey));
 
-            assertThat(subscriptionService.getByApiAndSecurityToken(API_ID, SecurityToken.forApiKey("apiKeyValue"), PLAN_ID)).contains(
-                subApi1
-            );
             assertThat(subscriptionService.getByApiAndSecurityToken(API_ID_2, SecurityToken.forApiKey("apiKeyValue"), PLAN_ID)).contains(
-                subApi2
+                subscription
             );
+        }
+
+        @Test
+        void should_resolve_product_subscription_by_certificate_from_a_member_api() {
+            givenProductWithMemberApis();
+            Subscription subscription = buildAcceptedProductSubscriptionWithClientCertificate(
+                SUB_ID,
+                PRODUCT_ID,
+                CLIENT_CERTIFICATE,
+                PLAN_ID
+            );
+            when(subscriptionTrustStoreLoaderManager.getByCertificate(API_ID, PLAN_ID, CLIENT_CERTIFICATE)).thenReturn(Optional.empty());
+            when(subscriptionTrustStoreLoaderManager.getByCertificate(PRODUCT_ID, PLAN_ID, CLIENT_CERTIFICATE)).thenReturn(
+                Optional.of(subscription)
+            );
+
+            assertThat(
+                subscriptionService.getByApiAndSecurityToken(API_ID, SecurityToken.forClientCertificate(CLIENT_CERTIFICATE), PLAN_ID)
+            ).contains(subscription);
+        }
+
+        @Test
+        void should_trust_product_certificate_on_the_servers_of_every_member_api() {
+            ReactableApiProduct product = new ReactableApiProduct();
+            product.setId(PRODUCT_ID);
+            product.setApiIds(Set.of(API_ID, API_ID_2));
+            when(apiProductRegistry.get(PRODUCT_ID, "env-1")).thenReturn(product);
+            when(apiManager.get(API_ID)).thenReturn((ReactableApi) apiWithServers("server1"));
+            when(apiManager.get(API_ID_2)).thenReturn((ReactableApi) apiWithServers("server2"));
+
+            Subscription subscription = buildAcceptedProductSubscriptionWithClientCertificate(
+                SUB_ID,
+                PRODUCT_ID,
+                CLIENT_CERTIFICATE,
+                PLAN_ID
+            );
+            subscription.setEnvironmentId("env-1");
+            subscriptionService.register(subscription);
+
+            ArgumentCaptor<Set<String>> servers = ArgumentCaptor.forClass(Set.class);
+            verify(subscriptionTrustStoreLoaderManager).registerSubscription(eq(subscription), servers.capture());
+            assertThat(servers.getValue()).containsExactlyInAnyOrder("server1", "server2");
+        }
+
+        @Test
+        void should_keep_product_subscription_when_a_member_api_is_undeployed() {
+            givenProductWithMemberApis();
+            Subscription subscription = buildAcceptedProductSubscriptionWithClientId(SUB_ID, PRODUCT_ID, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(subscription);
+
+            subscriptionService.unregisterByApiId(API_ID);
+
+            // The product's other APIs still serve it
+            assertThat(subscriptionService.getById(SUB_ID)).contains(subscription);
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).contains(subscription);
+        }
+
+        @Test
+        void should_evict_product_subscription_when_the_product_is_undeployed() {
+            givenProductWithMemberApis();
+            Subscription subscription = buildAcceptedProductSubscriptionWithClientId(SUB_ID, PRODUCT_ID, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(subscription);
+
+            subscriptionService.unregisterByApiProductId(PRODUCT_ID);
+
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(PRODUCT_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).isEmpty();
+        }
+
+        @Test
+        void should_move_subscription_between_scopes_when_it_is_re_registered_on_another_scope() {
+            givenProductWithMemberApis();
+            subscriptionService.register(buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID));
+
+            Subscription onProduct = buildAcceptedProductSubscriptionWithClientId(SUB_ID, PRODUCT_ID, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(onProduct);
+
+            assertThat(subscriptionService.getByScopeId(API_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(PRODUCT_ID)).containsExactly(SUB_ID);
+            assertThat(subscriptionService.getById(SUB_ID)).contains(onProduct);
         }
     }
 
@@ -819,7 +825,7 @@ class SubscriptionCacheServiceTest {
 
             subscriptionService.unregisterByApiId(API_ID);
             assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
-            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID)).isEmpty();
         }
 
         @Test
@@ -1009,8 +1015,34 @@ class SubscriptionCacheServiceTest {
                     assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, "client-" + suffix, PLAN_ID)).isEmpty();
                 }
             }
-            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+            assertThat(subscriptionService.getByScopeId(API_ID)).isEmpty();
         }
+    }
+
+    private static Api apiWithServers(String... servers) {
+        Api api = new Api(new io.gravitee.definition.model.v4.Api());
+        HttpListener listener = new HttpListener();
+        listener.setServers(List.of(servers));
+        api.getDefinition().setListeners(List.of(listener));
+        return api;
+    }
+
+    /** An API Product subscription carries no API of its own: the product is its scope. */
+    private Subscription buildAcceptedProductSubscriptionWithClientId(String id, String productId, String clientId, String plan) {
+        Subscription subscription = buildAcceptedSubscriptionWithClientId(id, null, clientId, plan);
+        subscription.setApiProductId(productId);
+        return subscription;
+    }
+
+    private Subscription buildAcceptedProductSubscriptionWithClientCertificate(
+        String id,
+        String productId,
+        String clientCertificate,
+        String plan
+    ) {
+        Subscription subscription = buildAcceptedSubscriptionWithClientCertificate(id, null, clientCertificate, plan);
+        subscription.setApiProductId(productId);
+        return subscription;
     }
 
     private Subscription buildAcceptedSubscription(String id, String apiId) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManager.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.security.core;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.core.subscription.SubscriptionScope;
 import io.gravitee.gateway.security.core.exception.MalformedCertificateException;
 import io.gravitee.node.api.certificate.KeyStoreEvent;
 import io.gravitee.node.api.server.ServerManager;
@@ -162,15 +163,20 @@ public class SubscriptionTrustStoreLoaderManager {
         subscriptions.remove(new CacheKey(subscriptionCertificate));
     }
 
-    record CacheKey(String api, String plan, String fingerPrint) {
+    /**
+     * @param scope the entity the subscription was taken on: the API for a regular subscription,
+     *              the API Product for an API Product subscription. Callers look up by API and fall
+     *              back to the products that API belongs to.
+     */
+    record CacheKey(String scope, String plan, String fingerPrint) {
         public CacheKey {
-            Objects.requireNonNull(api, "API must not be null");
+            Objects.requireNonNull(scope, "Subscription scope must not be null");
             Objects.requireNonNull(fingerPrint, "Certificate fingerprint must not be null");
         }
 
         public CacheKey(SubscriptionCertificate subscriptionCertificate) {
             this(
-                subscriptionCertificate.subscription().getApi(),
+                SubscriptionScope.of(subscriptionCertificate.subscription()),
                 subscriptionCertificate.subscription().getPlan(),
                 subscriptionCertificate.fingerprint()
             );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
@@ -220,10 +220,9 @@ public class SyncConfiguration {
     public SubscriptionAppender subscriptionAppender(
         SubscriptionRepository subscriptionRepository,
         SubscriptionMapper subscriptionMapper,
-        ApiProductRegistry apiProductRegistry,
         @Value("${services.sync.subscription.bulk_items:" + DEFAULT_SUBSCRIPTION_BULK_ITEMS + "}") int bulkItems
     ) {
-        return new SubscriptionAppender(subscriptionRepository, subscriptionMapper, apiProductRegistry, bulkItems);
+        return new SubscriptionAppender(subscriptionRepository, subscriptionMapper, bulkItems);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployer.java
@@ -23,7 +23,6 @@ import io.gravitee.gateway.services.sync.process.repository.service.PlanService;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.apiproduct.ApiProductReactorDeployable;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -46,29 +45,13 @@ public class ApiProductDeployer implements Deployer<ApiProductReactorDeployable>
         String apiProductId = deployable.apiProductId();
 
         log.debug("Deploying API Product [{}]", apiProductId);
-        // Capture old product before register() replaces it (needed to compute removed APIs on update)
-        ReactableApiProduct oldProduct = apiProductManager.get(apiProductId);
         Set<String> newApiIds = reactableApiProduct.getApiIds() != null ? reactableApiProduct.getApiIds() : Set.of();
 
-        Completable doBeforeEmit = Completable.complete();
-        if (oldProduct != null && oldProduct.getApiIds() != null && !oldProduct.getApiIds().isEmpty()) {
-            Set<String> removedApiIds = oldProduct
-                .getApiIds()
-                .stream()
-                .filter(id -> !newApiIds.contains(id))
-                .collect(Collectors.toSet());
-            if (!removedApiIds.isEmpty()) {
-                doBeforeEmit = doBeforeEmit.andThen(
-                    subscriptionRefresher.unregisterRemovedApis(
-                        removedApiIds,
-                        deployable.subscribablePlans(),
-                        Set.of(reactableApiProduct.getEnvironmentId())
-                    )
-                );
-            }
-        }
-        doBeforeEmit = doBeforeEmit.andThen(Completable.fromRunnable(() -> registerApiProductPlans(deployable)));
-        if (newApiIds != null && !newApiIds.isEmpty()) {
+        // Removing an API from the product needs no subscription eviction: a product subscription is
+        // cached under the product, and the registry stops resolving the removed API to it, so the
+        // API can no longer reach it. Only the product's own undeployment evicts.
+        Completable doBeforeEmit = Completable.fromRunnable(() -> registerApiProductPlans(deployable));
+        if (!newApiIds.isEmpty()) {
             doBeforeEmit = doBeforeEmit.andThen(
                 subscriptionRefresher.refresh(deployable.subscribablePlans(), Set.of(reactableApiProduct.getEnvironmentId()))
             );
@@ -115,16 +98,9 @@ public class ApiProductDeployer implements Deployer<ApiProductReactorDeployable>
             try {
                 log.debug("Undeploying API Product [{}]", apiProductId);
 
-                // Capture product and plans BEFORE unregister removes them (needed for subscription/API key cleanup)
-                ReactableApiProduct currentProduct = apiProductManager.get(apiProductId);
-                Set<String> subscribablePlans = planService.getSubscribablePlansForApiProduct(apiProductId);
-
-                // Unregister subscriptions and API keys for all APIs in the product (must run before manager unregister)
-                if (currentProduct != null && currentProduct.getApiIds() != null && !currentProduct.getApiIds().isEmpty()) {
-                    subscriptionRefresher
-                        .unregisterRemovedApis(currentProduct.getApiIds(), subscribablePlans, Set.of(currentProduct.getEnvironmentId()))
-                        .blockingAwait();
-                }
+                // Subscriptions and API keys are cached under the product: one bulk eviction, no
+                // repository round-trip and no fan-out over the member APIs.
+                subscriptionRefresher.unregisterByApiProduct(apiProductId).blockingAwait();
 
                 apiProductManager.unregister(apiProductId);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
@@ -21,9 +21,9 @@ import static io.gravitee.repository.management.model.Subscription.Status.PAUSED
 import static io.gravitee.repository.management.model.Subscription.Status.PENDING;
 
 import io.gravitee.gateway.api.service.ApiKey;
-import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.Subscription;
-import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.handlers.api.services.ApiKeyCacheService;
+import io.gravitee.gateway.handlers.api.services.SubscriptionCacheService;
 import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMapper;
 import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.mapper.ApiKeyMapper;
@@ -33,17 +33,29 @@ import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
-import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.CustomLog;
 
+/**
+ * Owns the runtime state of API Product subscriptions: the product deployment loads them, the
+ * product undeployment evicts them.
+ *
+ * <p>A product subscription is not attached to any member API, so the API synchronizer no longer
+ * sees it — {@code SubscriptionAppender} only collects the APIs' own plans. This class is the single
+ * writer for that state, which removes the double registration a member API's deployment used to
+ * cause.</p>
+ */
 @CustomLog
 public class ApiProductSubscriptionRefresher {
 
@@ -53,8 +65,8 @@ public class ApiProductSubscriptionRefresher {
     private final ApiKeyRepository apiKeyRepository;
     private final SubscriptionMapper subscriptionMapper;
     private final ApiKeyMapper apiKeyMapper;
-    private final SubscriptionService subscriptionService;
-    private final ApiKeyService apiKeyService;
+    private final SubscriptionCacheService subscriptionService;
+    private final ApiKeyCacheService apiKeyService;
     private final int bulkItems;
     private final int subscriptionsChunkSize;
 
@@ -63,8 +75,8 @@ public class ApiProductSubscriptionRefresher {
         ApiKeyRepository apiKeyRepository,
         SubscriptionMapper subscriptionMapper,
         ApiKeyMapper apiKeyMapper,
-        SubscriptionService subscriptionService,
-        ApiKeyService apiKeyService,
+        SubscriptionCacheService subscriptionService,
+        ApiKeyCacheService apiKeyService,
         int bulkItems,
         int subscriptionsChunkSize
     ) {
@@ -85,9 +97,10 @@ public class ApiProductSubscriptionRefresher {
     }
 
     /**
-     * Refreshes subscriptions for the given API Product plans.
-     * Loads all subscriptions for the plans, explodes them to all APIs via SubscriptionMapper,
-     * and deploys them using the subscription and API key deployers.
+     * Refreshes the runtime state of the subscriptions taken on the given API Product plans.
+     *
+     * <p>Subscriptions are walked page by page and registered along with their API keys, so a
+     * product with hundreds of thousands of subscriptions never has to be held in memory at once.</p>
      *
      * @param subscribablePlans the plan IDs to refresh subscriptions for
      * @param environments the environments to filter by
@@ -101,32 +114,16 @@ public class ApiProductSubscriptionRefresher {
 
         return Completable.fromRunnable(() -> {
             try {
-                // Load subscriptions for the product plans
-                List<Subscription> subscriptions = loadSubscriptions(subscribablePlans, environments);
-                log.debug("Loaded {} subscriptions for API Product plans", subscriptions.size());
-
-                // Deploy subscriptions
-                subscriptions.forEach(subscription -> {
-                    try {
-                        subscriptionService.register(subscription);
-                        log.debug("Deployed subscription [{}] for api [{}]", subscription.getId(), subscription.getApi());
-                    } catch (Exception e) {
-                        log.warn("Failed to deploy subscription [{}]", subscription.getId(), e);
-                    }
+                forEachSubscriptionPage(subscribablePlans, environments, page -> {
+                    page.forEach(subscription ->
+                        quietly(() -> subscriptionService.register(subscription), subscription.getId(), "subscription")
+                    );
+                    loadApiKeys(page, environments).forEach(apiKey ->
+                        quietly(() -> apiKeyService.register(apiKey), apiKey.getId(), "API key")
+                    );
                 });
-
-                // Load and deploy API keys
-                List<ApiKey> apiKeys = loadApiKeys(subscriptions, environments);
-                log.debug("Loaded {} API keys for subscriptions", apiKeys.size());
-
-                apiKeys.forEach(apiKey -> {
-                    try {
-                        apiKeyService.register(apiKey);
-                        log.debug("Deployed API key [{}] for api [{}]", apiKey.getId(), apiKey.getApi());
-                    } catch (Exception e) {
-                        log.warn("Failed to deploy API key [{}]", apiKey.getId(), e);
-                    }
-                });
+            } catch (SyncException ex) {
+                throw ex;
             } catch (Exception ex) {
                 throw new SyncException("Error occurred when refreshing subscriptions for API Product", ex);
             }
@@ -134,78 +131,79 @@ public class ApiProductSubscriptionRefresher {
     }
 
     /**
-     * Unregisters subscriptions and API keys for APIs that were removed from the API Product.
+     * Evicts every subscription and API key taken on the given API Product.
      *
-     * @param removedApiIds APIs that were removed from the product
-     * @param subscribablePlans the product's plan IDs
-     * @param environments the environments to filter by
+     * <p>Both caches index a product subscription under the product itself, so this is a single
+     * bulk eviction — no fan-out over the member APIs, and undeploying one member API never drops a
+     * subscription the product's other APIs still serve.</p>
+     *
+     * @param apiProductId the API Product being undeployed
      */
-    public Completable unregisterRemovedApis(
-        final Set<String> removedApiIds,
-        final Set<String> subscribablePlans,
-        final Set<String> environments
-    ) {
-        if (removedApiIds == null || removedApiIds.isEmpty() || subscribablePlans == null || subscribablePlans.isEmpty()) {
+    public Completable unregisterByApiProduct(final String apiProductId) {
+        if (apiProductId == null) {
             return Completable.complete();
         }
-
         return Completable.fromRunnable(() -> {
-            try {
-                var repoSubs = loadSubscriptionModels(subscribablePlans, environments);
-                var subsToUnregister = repoSubs
-                    .stream()
-                    .filter(s -> s.getReferenceType() == SubscriptionReferenceType.API_PRODUCT)
-                    .flatMap(s -> removedApiIds.stream().map(id -> subscriptionMapper.toSubscriptionForApi(s, id)))
-                    .toList();
-
-                subsToUnregister.forEach(sub ->
-                    unregisterQuietly(() -> subscriptionService.unregister(sub), sub.getId(), "subscription", sub.getApi())
-                );
-                loadApiKeys(subsToUnregister, environments)
-                    .stream()
-                    .filter(k -> removedApiIds.contains(k.getApi()))
-                    .forEach(k -> unregisterQuietly(() -> apiKeyService.unregister(k), k.getId(), "API key", k.getApi()));
-            } catch (Exception ex) {
-                throw new SyncException("Error occurred when unregistering subscriptions for removed APIs from API Product", ex);
-            }
+            subscriptionService.unregisterByApiProductId(apiProductId);
+            apiKeyService.unregisterByApiProductId(apiProductId);
+            log.debug("Unregistered subscriptions and API keys of API Product [{}]", apiProductId);
         });
     }
 
-    private void unregisterQuietly(Runnable action, String itemId, String type, String apiId) {
+    private void quietly(final Runnable action, final String itemId, final String type) {
         try {
             action.run();
-            log.debug("Unregistered {} [{}] for removed api [{}]", type, itemId, apiId);
         } catch (Exception e) {
-            log.warn("Failed to unregister {} for api [{}]", type, apiId, e);
+            log.warn("Failed to deploy {} [{}]", type, itemId, e);
         }
     }
 
-    private List<io.gravitee.repository.management.model.Subscription> loadSubscriptionModels(
+    /**
+     * Walks the subscriptions of the given plans, one repository page at a time.
+     *
+     * <p>Warmup pages by (plan, id): the sort field "plan" pairs with the byPlanAndId cursor so the
+     * repository's order and keyset seek agree — same contract as {@code SubscriptionAppender}.</p>
+     */
+    private void forEachSubscriptionPage(
         final Set<String> plans,
-        final Set<String> environments
+        final Set<String> environments,
+        final Consumer<List<Subscription>> pageConsumer
     ) {
-        SubscriptionCriteria.SubscriptionCriteriaBuilder criteriaBuilder = SubscriptionCriteria.builder()
-            .plans(plans)
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder()
+            .plans(List.copyOf(plans))
             .environments(environments)
-            .statuses(INCREMENTAL_STATUS);
+            .statuses(INCREMENTAL_STATUS)
+            .build();
+        var sortable = new SortableBuilder().field("plan").order(Order.ASC).build();
 
+        SubscriptionCursor cursor = null;
         try {
-            return subscriptionRepository.search(
-                criteriaBuilder.build(),
-                new SortableBuilder().field("updatedAt").order(Order.ASC).build()
-            );
+            while (true) {
+                List<io.gravitee.repository.management.model.Subscription> page = subscriptionRepository.searchAfter(
+                    criteria,
+                    sortable,
+                    cursor,
+                    bulkItems
+                );
+                if (page == null || page.isEmpty()) {
+                    return;
+                }
+                List<Subscription> converted = page
+                    .stream()
+                    .flatMap(record -> subscriptionMapper.to(record).stream())
+                    .peek(subscription -> subscription.setForceDispatch(true))
+                    .toList();
+                pageConsumer.accept(converted);
+                if (page.size() < bulkItems) {
+                    return;
+                }
+                cursor = SubscriptionCursor.byPlanAndId(page.getLast().getPlan(), page.getLast().getId());
+            }
+        } catch (SyncException ex) {
+            throw ex;
         } catch (Exception ex) {
             throw new SyncException("Error occurred when retrieving subscriptions for API Product", ex);
         }
-    }
-
-    private List<Subscription> loadSubscriptions(final Set<String> plans, final Set<String> environments) {
-        List<io.gravitee.repository.management.model.Subscription> repoSubscriptions = loadSubscriptionModels(plans, environments);
-        return repoSubscriptions
-            .stream()
-            .flatMap(subscription -> subscriptionMapper.to(subscription).stream())
-            .peek(subscriptionConverted -> subscriptionConverted.setForceDispatch(true))
-            .toList();
     }
 
     private List<ApiKey> loadApiKeys(final List<Subscription> subscriptions, final Set<String> environments) {
@@ -213,10 +211,10 @@ public class ApiProductSubscriptionRefresher {
             return List.of();
         }
 
-        Map<String, List<Subscription>> subscriptionsByIdMulti = subscriptions.stream().collect(Collectors.groupingBy(Subscription::getId));
+        Map<String, List<Subscription>> subscriptionsById = subscriptions.stream().collect(Collectors.groupingBy(Subscription::getId));
         // Sort for deterministic chunk boundaries — same rationale as ApiKeyAppender.
-        List<String> subscriptionIds = new ArrayList<>(subscriptionsByIdMulti.keySet());
-        subscriptionIds.sort(java.util.Comparator.naturalOrder());
+        List<String> subscriptionIds = new ArrayList<>(subscriptionsById.keySet());
+        subscriptionIds.sort(Comparator.naturalOrder());
 
         var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
         List<ApiKey> result = new ArrayList<>();
@@ -255,9 +253,9 @@ public class ApiProductSubscriptionRefresher {
                             .getSubscriptions()
                             .stream()
                             .flatMap(subscriptionId -> {
-                                List<Subscription> subsForId = subscriptionsByIdMulti.get(subscriptionId);
+                                List<Subscription> subsForId = subscriptionsById.get(subscriptionId);
                                 if (subsForId == null || subsForId.isEmpty()) {
-                                    return java.util.stream.Stream.empty();
+                                    return Stream.<ApiKey>empty();
                                 }
                                 return subsForId.stream().map(subscription -> apiKeyMapper.to(record, subscription));
                             })

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/SubscriptionDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/SubscriptionDeployer.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.command.SubscriptionFailureCommand;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.core.subscription.SubscriptionScope;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
 import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatcher;
 import io.gravitee.gateway.services.sync.process.common.model.SubscriptionDeployable;
@@ -70,7 +71,9 @@ public class SubscriptionDeployer implements Deployer<SubscriptionDeployable> {
                     .forEach(subscription -> {
                         try {
                             if (Subscription.Type.PUSH == subscription.getType()) {
-                                dispatchableSubscription.compute(subscription.getApi(), (apiId, subscriptions) -> {
+                                // Keyed by scope, not by API: a product subscription carries no API
+                                // of its own, and doAfterDeployment drains the same key.
+                                dispatchableSubscription.compute(SubscriptionScope.of(subscription), (scope, subscriptions) -> {
                                     if (subscriptions == null) {
                                         subscriptions = new ArrayList<>();
                                     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -48,7 +48,7 @@ public class SubscriptionMapper {
     public List<Subscription> to(io.gravitee.repository.management.model.Subscription subscriptionModel) {
         try {
             if (subscriptionModel.getReferenceType() == SubscriptionReferenceType.API_PRODUCT) {
-                return explodeApiProductSubscription(subscriptionModel);
+                return toApiProductSubscription(subscriptionModel);
             }
 
             // Regular API subscription - return as single-item list
@@ -59,7 +59,15 @@ public class SubscriptionMapper {
         }
     }
 
-    private List<Subscription> explodeApiProductSubscription(io.gravitee.repository.management.model.Subscription subscriptionModel) {
+    /**
+     * Maps an API Product subscription to a single runtime subscription, scoped to the product.
+     *
+     * <p>It used to be duplicated once per member API, which made the cache grow with
+     * (subscriptions x member APIs). The runtime now caches it under its product and resolves
+     * API to product at lookup time, so one repository record yields exactly one runtime
+     * subscription — whatever the size of the product.</p>
+     */
+    private List<Subscription> toApiProductSubscription(io.gravitee.repository.management.model.Subscription subscriptionModel) {
         String productId = subscriptionModel.getReferenceId();
         if (productId == null) {
             log.warn("API Product subscription [{}] has null referenceId, skipping", subscriptionModel.getId());
@@ -84,17 +92,11 @@ public class SubscriptionMapper {
             return List.of();
         }
 
-        // Create one subscription per API in product
-        return apiIds
-            .stream()
-            .map(apiId -> {
-                Subscription sub = toSubscription(subscriptionModel);
-                sub.setApi(apiId); // Override with individual API
-                sub.setApiProductId(productId);
-
-                return sub;
-            })
-            .toList();
+        Subscription subscription = toSubscription(subscriptionModel);
+        // No single member API owns this subscription: the product is its scope.
+        subscription.setApi(null);
+        subscription.setApiProductId(intern(productId));
+        return List.of(subscription);
     }
 
     private Subscription toSubscription(io.gravitee.repository.management.model.Subscription subscriptionModel) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -138,19 +138,6 @@ public class SubscriptionMapper {
         return subscription;
     }
 
-    /**
-     * Creates a Subscription for a specific API from a repository model.
-     * Used when unregistering product subscriptions for APIs removed from the product.
-     */
-    public Subscription toSubscriptionForApi(io.gravitee.repository.management.model.Subscription subscriptionModel, String apiId) {
-        Subscription sub = toSubscription(subscriptionModel);
-        sub.setApi(apiId);
-        if (subscriptionModel.getReferenceId() != null) {
-            sub.setApiProductId(subscriptionModel.getReferenceId());
-        }
-        return sub;
-    }
-
     /** Never intern id/clientId/clientCertificate: unique per subscription, they would only pollute the pool. */
     private static String intern(String value) {
         return value == null ? null : STRING_INTERNER.intern(value);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LatestEventFetcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LatestEventFetcher.java
@@ -106,26 +106,47 @@ public class LatestEventFetcher {
         return builder.build();
     }
 
-    public List<Event> fetchLatestForApiIds(Set<String> apiIds, Set<String> environments, Set<EventType> eventTypes) {
+    /**
+     * Latest events of the given APIs, one page at a time.
+     *
+     * <p>Paginated like {@link #fetchLatest}: an event payload carries a whole API definition, so
+     * loading them all at once would hold every member API of a product in memory for the duration
+     * of the resync. A repository failure ends the stream after a warning rather than failing the
+     * caller, so one unreadable page cannot abort a resync.</p>
+     */
+    public Flowable<List<Event>> fetchLatestForApiIds(Set<String> apiIds, Set<String> environments, Set<EventType> eventTypes) {
         if (apiIds == null || apiIds.isEmpty()) {
-            return List.of();
+            return Flowable.empty();
         }
-        try {
-            List<Event> events = eventLatestRepository.search(
-                EventCriteria.builder()
-                    .types(eventTypes)
-                    .environments(environments)
-                    .property(Event.EventProperties.API_ID.getValue(), apiIds)
+        return Flowable.<List<Event>, EventPageable>generate(
+            () ->
+                EventPageable.builder()
+                    .index(0)
+                    .size(bulkItems)
+                    .criteria(
+                        EventCriteria.builder()
+                            .types(eventTypes)
+                            .environments(environments)
+                            .property(Event.EventProperties.API_ID.getValue(), apiIds)
+                            .build()
+                    )
                     .build(),
-                Event.EventProperties.API_ID,
-                null,
-                null
-            );
-            return events != null ? events : List.of();
-        } catch (Exception e) {
-            log.warn("Failed to batch-fetch latest events for {} API(s): {}", apiIds.size(), e.getMessage());
-            return List.of();
-        }
+            (page, emitter) -> {
+                try {
+                    List<Event> events = eventLatestRepository.search(page.criteria, Event.EventProperties.API_ID, page.index, page.size);
+                    if (events != null && !events.isEmpty()) {
+                        emitter.onNext(events);
+                        page.index++;
+                    }
+                    if (events == null || events.size() < page.size) {
+                        emitter.onComplete();
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to batch-fetch latest events for {} API(s): {}", apiIds.size(), e.getMessage());
+                    emitter.onComplete();
+                }
+            }
+        );
     }
 
     @Builder

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiKeyMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiKeyMapper.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.services.sync.process.repository.mapper;
 
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.core.subscription.SubscriptionScope;
 import java.util.Optional;
 import lombok.CustomLog;
 
@@ -33,7 +34,9 @@ public class ApiKeyMapper {
             .paused(apiKeyModel.isPaused());
         if (subscription != null) {
             apiKeyBuilder
-                .api(subscription.getApi())
+                // The key is cached under the subscription's scope: the product for a product
+                // subscription, so one entry instead of one per member API.
+                .api(SubscriptionScope.of(subscription))
                 .plan(subscription.getPlan())
                 .subscription(subscription.getId())
                 .active(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/service/PlanService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/service/PlanService.java
@@ -58,17 +58,6 @@ public class PlanService {
         }
     }
 
-    /**
-     * Returns subscribable plan IDs for the given API Product (before unregister)
-     */
-    public Set<String> getSubscribablePlansForApiProduct(final String apiProductId) {
-        if (apiProductId == null) {
-            return Set.of();
-        }
-        Set<String> plans = plansPerApiProduct.get(apiProductId);
-        return plans != null ? Set.copyOf(plans) : Set.of();
-    }
-
     public boolean isDeployed(final String apiId, final String planId) {
         return isDeployed(apiId, planId, Plan.PlanReferenceType.API);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
@@ -23,6 +23,7 @@ import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
+import io.gravitee.gateway.handlers.api.services.ApiKeyCacheService;
 import io.gravitee.gateway.handlers.api.services.SubscriptionCacheService;
 import io.gravitee.gateway.services.sync.process.common.deployer.ApiProductSubscriptionRefresher;
 import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
@@ -505,8 +506,8 @@ public class RepositorySyncConfiguration {
         ApiKeyRepository apiKeyRepository,
         SubscriptionMapper subscriptionMapper,
         ApiKeyMapper apiKeyMapper,
-        SubscriptionService subscriptionService,
-        ApiKeyService apiKeyService,
+        SubscriptionCacheService subscriptionService,
+        ApiKeyCacheService apiKeyService,
         @Value(
             "${services.sync.apikey.bulk_items:" + io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_APIKEY_BULK_ITEMS + "}"
         ) int bulkItems,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
@@ -248,9 +248,10 @@ public class RepositorySyncConfiguration {
         @Lazy ApiSynchronizer apiSynchronizer,
         ApiManager apiManager,
         @Qualifier("syncDeployerExecutor") ThreadPoolExecutor syncDeployerExecutor,
-        EventManager eventManager
+        EventManager eventManager,
+        @Lazy DefaultSyncManager syncManager
     ) {
-        return new RepositoryApiMemberResyncTrigger(apiSynchronizer, apiManager, syncDeployerExecutor, eventManager);
+        return new RepositoryApiMemberResyncTrigger(apiSynchronizer, apiManager, syncDeployerExecutor, eventManager, syncManager::syncDone);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizer.java
@@ -106,13 +106,10 @@ public class ApiSynchronizer extends AbstractApiSynchronizer implements Reposito
         if (apiIds == null || apiIds.isEmpty()) {
             return Completable.complete();
         }
-        List<Event> events = eventsFetcher.fetchLatestForApiIds(apiIds, environments, MEMBER_API_RESYNC_EVENT_TYPES);
-        if (events.isEmpty()) {
-            log.debug("No API events found to resync member APIs {}", apiIds);
-            return Completable.complete();
-        }
-        log.debug("Resyncing {} member API(s) after API Product change", events.size());
-        return processEvents(false, Flowable.fromIterable(events).buffer(bulkEvents()), environments)
+        log.debug("Resyncing {} member API(s) after API Product change", apiIds.size());
+        // The fetcher already emits pages of bulkEvents(), so events are deployed as they arrive
+        // instead of being materialized as a whole.
+        return processEvents(false, eventsFetcher.fetchLatestForApiIds(apiIds, environments, MEMBER_API_RESYNC_EVENT_TYPES), environments)
             .ignoreElements()
             .subscribeOn(Schedulers.from(syncFetcherExecutor));
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTrigger.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTrigger.java
@@ -21,7 +21,7 @@ import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
-import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.observers.DisposableCompletableObserver;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -86,8 +86,7 @@ public class RepositoryApiMemberResyncTrigger {
             log.debug("Initial synchronization still running — skipping resync of {} member API(s)", apiIds.size());
             return;
         }
-        final Disposable[] holder = new Disposable[1];
-        holder[0] = Completable.defer(() -> {
+        Completable pipeline = Completable.defer(() -> {
             log.debug("Scheduling resync of {} member API(s) in environment [{}]", apiIds.size(), environmentId);
             return apiSynchronizer
                 .resyncMemberApis(apiIds, Set.of(environmentId))
@@ -97,26 +96,33 @@ public class RepositoryApiMemberResyncTrigger {
                         apiManager.reEvaluateAfterProductChange(productId, apiIds);
                     })
                 );
-        })
-            .subscribeOn(Schedulers.from(syncDeployerExecutor))
-            .doFinally(() -> {
-                Disposable disposable = holder[0];
-                if (disposable != null) {
-                    disposables.remove(disposable);
-                }
-            })
-            .subscribe(
-                () -> log.debug("Member API resync + re-evaluation completed for product [{}] in env [{}]", productId, environmentId),
-                error ->
-                    log.error(
-                        "Member API resync pipeline failed for product [{}] in env [{}]: {}",
-                        productId,
-                        environmentId,
-                        error.getMessage(),
-                        error
-                    )
-            );
-        disposables.add(holder[0]);
+        }).subscribeOn(Schedulers.from(syncDeployerExecutor));
+
+        // The observer knows its own identity from the start, so it can take itself out of the
+        // composite whatever the order of events. Capturing the Disposable returned by subscribe()
+        // could not: a pipeline finishing first would find nothing to remove, and the entry added
+        // afterwards would stay forever.
+        DisposableCompletableObserver observer = new DisposableCompletableObserver() {
+            @Override
+            public void onComplete() {
+                log.debug("Member API resync + re-evaluation completed for product [{}] in env [{}]", productId, environmentId);
+                disposables.delete(this);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                log.error(
+                    "Member API resync pipeline failed for product [{}] in env [{}]: {}",
+                    productId,
+                    environmentId,
+                    error.getMessage(),
+                    error
+                );
+                disposables.delete(this);
+            }
+        };
+        disposables.add(observer);
+        pipeline.subscribe(observer);
     }
 
     public void dispose() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTrigger.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTrigger.java
@@ -25,6 +25,7 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.BooleanSupplier;
 import lombok.CustomLog;
 
 /**
@@ -37,6 +38,9 @@ import lombok.CustomLog;
  * This ordering guarantees that a newly-eligible API is deployed <em>before</em>
  * an ineligible one is undeployed, eliminating the brief unavailability window
  * that would occur if undeploy were handled independently.
+ *
+ * <p>Only runs once the initial synchronization is over: before that, the API synchronizer
+ * deploys every member API on its own.</p>
  */
 @CustomLog
 public class RepositoryApiMemberResyncTrigger {
@@ -44,17 +48,20 @@ public class RepositoryApiMemberResyncTrigger {
     private final ApiSynchronizer apiSynchronizer;
     private final ApiManager apiManager;
     private final ThreadPoolExecutor syncDeployerExecutor;
+    private final BooleanSupplier initialSyncDone;
     private final CompositeDisposable disposables = new CompositeDisposable();
 
     public RepositoryApiMemberResyncTrigger(
         ApiSynchronizer apiSynchronizer,
         ApiManager apiManager,
         ThreadPoolExecutor syncDeployerExecutor,
-        EventManager eventManager
+        EventManager eventManager,
+        BooleanSupplier initialSyncDone
     ) {
         this.apiSynchronizer = apiSynchronizer;
         this.apiManager = apiManager;
         this.syncDeployerExecutor = syncDeployerExecutor;
+        this.initialSyncDone = initialSyncDone;
 
         eventManager.subscribeForEvents(
             event -> {
@@ -69,6 +76,14 @@ public class RepositoryApiMemberResyncTrigger {
 
     private void handleProductChange(String productId, String environmentId, Set<String> apiIds) {
         if (environmentId == null || apiIds == null || apiIds.isEmpty()) {
+            return;
+        }
+        // API Products are synchronized before APIs (Order.API_PRODUCT < Order.API), so during the
+        // initial synchronization every member API is about to be deployed by the API synchronizer
+        // anyway. Resyncing here would reload and redeploy all of them for nothing — and hold their
+        // events in memory while doing so, on the very path where the node is heaviest.
+        if (!initialSyncDone.getAsBoolean()) {
+            log.debug("Initial synchronization still running — skipping resync of {} member API(s)", apiIds.size());
             return;
         }
         final Disposable[] holder = new Disposable[1];

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
@@ -19,10 +19,8 @@ import static io.gravitee.repository.management.model.Subscription.Status.ACCEPT
 import static io.gravitee.repository.management.model.Subscription.Status.CLOSED;
 import static io.gravitee.repository.management.model.Subscription.Status.PAUSED;
 import static io.gravitee.repository.management.model.Subscription.Status.PENDING;
-import static java.util.stream.Collectors.groupingBy;
 
 import io.gravitee.gateway.api.service.Subscription;
-import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMapper;
 import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
@@ -36,7 +34,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
@@ -48,26 +45,24 @@ public class SubscriptionAppender {
     private static final List<String> INCREMENTAL_STATUS = List.of(ACCEPTED.name(), CLOSED.name(), PAUSED.name(), PENDING.name());
     private final SubscriptionRepository subscriptionRepository;
     private final SubscriptionMapper subscriptionMapper;
-    private final ApiProductRegistry apiProductRegistry;
     private final int bulkItems;
 
-    public SubscriptionAppender(
-        SubscriptionRepository subscriptionRepository,
-        SubscriptionMapper subscriptionMapper,
-        ApiProductRegistry apiProductRegistry,
-        int bulkItems
-    ) {
+    public SubscriptionAppender(SubscriptionRepository subscriptionRepository, SubscriptionMapper subscriptionMapper, int bulkItems) {
         if (bulkItems <= 0) {
             throw new IllegalArgumentException("bulkItems must be > 0 (got " + bulkItems + ")");
         }
         this.subscriptionRepository = subscriptionRepository;
         this.subscriptionMapper = subscriptionMapper;
-        this.apiProductRegistry = apiProductRegistry;
         this.bulkItems = bulkItems;
     }
 
     /**
-     * Fetching subscriptions for given deployables
+     * Fetching subscriptions for given deployables.
+     *
+     * <p>Only the APIs' own plans are considered. An API Product subscription is not attached to any
+     * member API — it is owned by the product, deployed and evicted by {@code ApiProductDeployer}
+     * through {@code ApiProductSubscriptionRefresher}.</p>
+     *
      * @param deployables the deployables to update
      * @return the deployables updated with subscriptions
      */
@@ -80,21 +75,7 @@ public class SubscriptionAppender {
             .stream()
             .collect(Collectors.toMap(ApiReactorDeployable::apiId, d -> d));
 
-        List<String> apiPlans = collectApiPlans(deployableByApi);
-        List<String> allPlans = new ArrayList<>(apiPlans);
-
-        deployableByApi.forEach((apiId, deployable) -> {
-            Set<String> envs = environments != null && !environments.isEmpty()
-                ? environments
-                : Optional.ofNullable(deployable.reactableApi())
-                    .map(a -> a.getEnvironmentId())
-                    .map(Set::of)
-                    .orElse(Set.of());
-            Set<String> apiProductPlans = collectApiProductPlans(apiId, envs);
-            deployable.subscribablePlans().addAll(apiProductPlans);
-            deployable.apiKeyPlans().addAll(apiProductPlans);
-            allPlans.addAll(apiProductPlans);
-        });
+        List<String> allPlans = collectApiPlans(deployableByApi);
 
         if (!allPlans.isEmpty()) {
             Map<String, List<Subscription>> subscriptionsByApi = loadSubscriptions(initialSync, allPlans, environments);
@@ -116,14 +97,6 @@ public class SubscriptionAppender {
 
     private List<String> collectApiPlans(Map<String, ApiReactorDeployable> deployableByApi) {
         return deployableByApi.values().stream().map(ApiReactorDeployable::subscribablePlans).flatMap(Collection::stream).toList();
-    }
-
-    private Set<String> collectApiProductPlans(String apiId, Set<String> envs) {
-        return envs
-            .stream()
-            .flatMap(envId -> apiProductRegistry.getApiProductPlanEntriesForApi(apiId, envId).stream())
-            .map(e -> e.plan().getId())
-            .collect(Collectors.toSet());
     }
 
     protected Map<String, List<Subscription>> loadSubscriptions(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apikey/ApiKeySynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apikey/ApiKeySynchronizer.java
@@ -63,7 +63,7 @@ public class ApiKeySynchronizer implements RepositorySynchronizer {
                         .flatMapIterable(s -> s)
                         .flatMap(apiKey ->
                             Flowable.fromIterable(apiKey.getSubscriptions())
-                                .flatMapIterable(subscriptionId -> subscriptionService.getAllById(subscriptionId))
+                                .mapOptional(subscriptionService::getById)
                                 .map(subscription -> apiKeyMapper.to(apiKey, java.util.Optional.of(subscription)))
                         )
                         .map(apiKey ->

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/subscription/SingleSubscriptionDeployable.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/subscription/SingleSubscriptionDeployable.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.services.sync.process.repository.synchronizer.subscription;
 
 import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.core.subscription.SubscriptionScope;
 import io.gravitee.gateway.services.sync.process.common.model.SubscriptionDeployable;
 import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
 import java.util.List;
@@ -49,8 +50,12 @@ public class SingleSubscriptionDeployable implements SubscriptionDeployable {
         return subscription.getId();
     }
 
+    /**
+     * The entity the subscription is attached to: its API, or its API Product when it was taken on
+     * a product — a product subscription carries no API of its own.
+     */
     public String apiId() {
-        return subscription.getApi();
+        return SubscriptionScope.of(subscription);
     }
 
     public Set<String> plans() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductDeployerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -73,7 +74,7 @@ class ApiProductDeployerTest {
             .when(distributedSyncService.distributeIfNeeded(any(ApiProductReactorDeployable.class)))
             .thenReturn(Completable.complete());
         lenient().when(subscriptionRefresher.refresh(anySet(), anySet())).thenReturn(Completable.complete());
-        lenient().when(subscriptionRefresher.unregisterRemovedApis(anySet(), anySet(), anySet())).thenReturn(Completable.complete());
+        lenient().when(subscriptionRefresher.unregisterByApiProduct(any())).thenReturn(Completable.complete());
         lenient()
             .when(apiProductManager.register(any(ReactableApiProduct.class), any(Completable.class)))
             .thenAnswer(invocation -> invocation.getArgument(1));
@@ -149,13 +150,9 @@ class ApiProductDeployerTest {
         }
 
         @Test
-        void should_unregister_removed_apis_when_deploying_product_update() {
-            ReactableApiProduct oldProduct = ReactableApiProduct.builder()
-                .id("api-product-123")
-                .apiIds(Set.of("api-1", "api-2"))
-                .environmentId("env-1")
-                .build();
-
+        void should_only_refresh_subscriptions_when_deploying_a_product_update() {
+            // A member API removed from the product needs no eviction: the subscription stays cached
+            // under the product and the registry simply stops resolving that API to it.
             ReactableApiProduct newProduct = ReactableApiProduct.builder()
                 .id("api-product-123")
                 .name("Updated Product")
@@ -172,15 +169,14 @@ class ApiProductDeployerTest {
                 .subscribablePlans(Set.of("plan-1"))
                 .build();
 
-            when(apiProductManager.get("api-product-123")).thenReturn(oldProduct);
             when(apiProductManager.register(any(ReactableApiProduct.class), any(Completable.class))).thenAnswer(invocation ->
                 invocation.getArgument(1)
             );
 
             cut.deploy(deployable).test().assertComplete();
 
-            verify(subscriptionRefresher).unregisterRemovedApis(eq(Set.of("api-2")), eq(Set.of("plan-1")), eq(Set.of("env-1")));
             verify(subscriptionRefresher).refresh(eq(Set.of("plan-1")), eq(Set.of("env-1")));
+            verify(subscriptionRefresher, never()).unregisterByApiProduct(any());
         }
     }
 
@@ -214,15 +210,6 @@ class ApiProductDeployerTest {
 
         @Test
         void should_unregister_subscriptions_and_api_keys_when_undeploying_deployed_product() {
-            ReactableApiProduct deployedProduct = ReactableApiProduct.builder()
-                .id("api-product-123")
-                .apiIds(Set.of("api-1", "api-2"))
-                .environmentId("env-1")
-                .build();
-
-            when(apiProductManager.get("api-product-123")).thenReturn(deployedProduct);
-            when(planService.getSubscribablePlansForApiProduct("api-product-123")).thenReturn(Set.of("plan-1"));
-
             ApiProductReactorDeployable deployable = ApiProductReactorDeployable.builder()
                 .syncAction(SyncAction.UNDEPLOY)
                 .apiProductId("api-product-123")
@@ -230,7 +217,7 @@ class ApiProductDeployerTest {
 
             cut.undeploy(deployable).test().assertComplete();
 
-            verify(subscriptionRefresher).unregisterRemovedApis(eq(Set.of("api-1", "api-2")), eq(Set.of("plan-1")), eq(Set.of("env-1")));
+            verify(subscriptionRefresher).unregisterByApiProduct("api-product-123");
             verify(apiProductManager).unregister("api-product-123");
             verify(planService).unregister(deployable);
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
@@ -24,9 +24,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.api.service.ApiKey;
-import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.Subscription;
-import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.handlers.api.services.ApiKeyCacheService;
+import io.gravitee.gateway.handlers.api.services.SubscriptionCacheService;
 import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMapper;
 import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.mapper.ApiKeyMapper;
@@ -59,6 +59,7 @@ class ApiProductSubscriptionRefresherTest {
     private static final String SUB_1 = "sub-1";
     private static final String API_1 = "api-1";
     private static final String KEY_ID = "key-id";
+    private static final String PRODUCT_1 = "product-1";
 
     @Mock
     private SubscriptionRepository subscriptionRepository;
@@ -73,10 +74,10 @@ class ApiProductSubscriptionRefresherTest {
     private ApiKeyMapper apiKeyMapper;
 
     @Mock
-    private SubscriptionService subscriptionService;
+    private SubscriptionCacheService subscriptionService;
 
     @Mock
-    private ApiKeyService apiKeyService;
+    private ApiKeyCacheService apiKeyService;
 
     private ApiProductSubscriptionRefresher cut;
 
@@ -104,14 +105,14 @@ class ApiProductSubscriptionRefresherTest {
         void returns_complete_when_plans_null_or_empty() throws TechnicalException {
             cut.refresh(null, Set.of(ENV_1)).test().assertComplete();
             cut.refresh(Set.of(), Set.of(ENV_1)).test().assertComplete();
-            verify(subscriptionRepository, never()).search(any(), any());
+            verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), any(int.class));
         }
 
         @Test
         void loads_and_deploys_subscriptions() throws TechnicalException {
             var repoSub = productSubscription(SUB_1, PLAN_1, ENV_1);
             var gatewaySub = Subscription.builder().id(SUB_1).api(API_1).plan(PLAN_1).build();
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoSub));
             when(subscriptionMapper.to(repoSub)).thenReturn(List.of(gatewaySub));
 
             cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
@@ -125,7 +126,7 @@ class ApiProductSubscriptionRefresherTest {
             var gatewaySub = Subscription.builder().id(SUB_1).api(API_1).plan(PLAN_1).build();
             var repoKey = productApiKey(KEY_ID, ENV_1, SUB_1);
             var gatewayKey = ApiKey.builder().id(KEY_ID).api(API_1).subscription(SUB_1).build();
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoSub));
             when(subscriptionMapper.to(repoSub)).thenReturn(List.of(gatewaySub));
             when(apiKeyRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoKey));
             when(apiKeyMapper.to(repoKey, gatewaySub)).thenReturn(gatewayKey);
@@ -138,11 +139,11 @@ class ApiProductSubscriptionRefresherTest {
 
         @Test
         void does_not_call_api_key_repository_when_no_subscriptions() throws TechnicalException {
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of());
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of());
 
             cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
 
-            verify(subscriptionRepository).search(any(), any());
+            verify(subscriptionRepository).searchAfter(any(), any(), any(), eq(BULK_ITEMS));
             verify(apiKeyRepository, never()).searchAfter(any(), any(), any(), any(int.class));
         }
 
@@ -165,7 +166,7 @@ class ApiProductSubscriptionRefresherTest {
             var repoSubs = IntStream.range(0, 5)
                 .mapToObj(i -> productSubscription("sub" + i, PLAN_1, ENV_1))
                 .toList();
-            when(subscriptionRepository.search(any(), any())).thenReturn(repoSubs);
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(repoSubs);
             var gatewaySubs = IntStream.range(0, 5)
                 .mapToObj(i -> Subscription.builder().id("sub" + i).api(API_1).plan(PLAN_1).build())
                 .toList();
@@ -209,56 +210,45 @@ class ApiProductSubscriptionRefresherTest {
 
         @Test
         void throws_when_repository_fails() throws TechnicalException {
-            when(subscriptionRepository.search(any(), any())).thenThrow(new TechnicalException("DB error"));
+            when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenThrow(new TechnicalException("DB error"));
 
             var thrown = catchThrowable(() -> cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).blockingAwait());
 
             assertThat(thrown)
                 .isInstanceOf(SyncException.class)
-                .hasMessageContaining("Error occurred when refreshing subscriptions for API Product");
-            assertThat(thrown.getCause().getCause()).isInstanceOf(TechnicalException.class);
+                .hasMessageContaining("Error occurred when retrieving subscriptions for API Product");
+            assertThat(thrown.getCause()).isInstanceOf(TechnicalException.class);
         }
     }
 
     @Nested
-    class UnregisterRemovedApisTest {
+    class UnregisterByApiProductTest {
 
         @Test
-        void returns_complete_when_removedApiIds_null_or_empty() throws TechnicalException {
-            cut.unregisterRemovedApis(null, Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
-            cut.unregisterRemovedApis(Set.of(), Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
-            verify(subscriptionRepository, never()).search(any(), any());
+        void returns_complete_when_api_product_id_is_null() throws TechnicalException {
+            cut.unregisterByApiProduct(null).test().assertComplete();
+
+            verify(subscriptionService, never()).unregisterByApiProductId(any());
+            verify(apiKeyService, never()).unregisterByApiProductId(any());
+            verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), any(int.class));
         }
 
         @Test
-        void returns_complete_when_plans_empty() throws TechnicalException {
-            cut.unregisterRemovedApis(Set.of("api-removed"), Set.of(), Set.of(ENV_1)).test().assertComplete();
-            verify(subscriptionRepository, never()).search(any(), any());
-        }
+        void evicts_subscriptions_and_api_keys_of_the_product_without_hitting_the_repository() throws TechnicalException {
+            cut.unregisterByApiProduct(PRODUCT_1).test().assertComplete();
 
-        @Test
-        void unregisters_subscriptions_and_api_keys_for_removed_apis() throws TechnicalException {
-            var repoSub = productSubscription(SUB_1, PLAN_1, ENV_1);
-            var subForRemoved = Subscription.builder().id(SUB_1).api("api-removed").plan(PLAN_1).build();
-            var repoKey = productApiKey(KEY_ID, ENV_1, SUB_1);
-            var gatewayKey = ApiKey.builder().id(KEY_ID).api("api-removed").subscription(SUB_1).build();
-
-            when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
-            when(subscriptionMapper.toSubscriptionForApi(repoSub, "api-removed")).thenReturn(subForRemoved);
-            when(apiKeyRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoKey));
-            when(apiKeyMapper.to(repoKey, subForRemoved)).thenReturn(gatewayKey);
-
-            cut.unregisterRemovedApis(Set.of("api-removed"), Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
-
-            verify(subscriptionService).unregister(subForRemoved);
-            verify(apiKeyService).unregister(gatewayKey);
+            verify(subscriptionService).unregisterByApiProductId(PRODUCT_1);
+            verify(apiKeyService).unregisterByApiProductId(PRODUCT_1);
+            // Both caches index product subscriptions by product: no lookup needed to find them back
+            verify(subscriptionRepository, never()).searchAfter(any(), any(), any(), any(int.class));
+            verify(apiKeyRepository, never()).searchAfter(any(), any(), any(), any(int.class));
         }
     }
 
     private static io.gravitee.repository.management.model.Subscription productSubscription(String id, String plan, String env) {
         var s = new io.gravitee.repository.management.model.Subscription();
         s.setId(id);
-        s.setReferenceId("product-1");
+        s.setReferenceId(PRODUCT_1);
         s.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
         s.setPlan(plan);
         s.setStatus(io.gravitee.repository.management.model.Subscription.Status.ACCEPTED);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LatestEventFetcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LatestEventFetcherTest.java
@@ -167,26 +167,46 @@ class LatestEventFetcherTest {
     }
 
     @Test
-    void should_return_empty_list_when_fetching_events_for_empty_api_ids() {
-        Assertions.assertThat(cut.fetchLatestForApiIds(Set.of(), Set.of("env"), Set.of(EventType.PUBLISH_API))).isEmpty();
-        Assertions.assertThat(cut.fetchLatestForApiIds(null, Set.of("env"), Set.of(EventType.PUBLISH_API))).isEmpty();
+    void should_emit_nothing_when_fetching_events_for_empty_api_ids() {
+        cut.fetchLatestForApiIds(Set.of(), Set.of("env"), Set.of(EventType.PUBLISH_API)).test().assertComplete().assertNoValues();
+        cut.fetchLatestForApiIds(null, Set.of("env"), Set.of(EventType.PUBLISH_API)).test().assertComplete().assertNoValues();
         verifyNoInteractions(eventLatestRepository);
     }
 
     @Test
     void should_fetch_latest_events_for_specific_api_ids() {
+        LatestEventFetcher fetcher = new LatestEventFetcher(eventLatestRepository, 2);
         Event event = new Event();
-        when(eventLatestRepository.search(any(), eq(Event.EventProperties.API_ID), isNull(), isNull())).thenReturn(List.of(event));
+        when(eventLatestRepository.search(any(), eq(Event.EventProperties.API_ID), eq(0L), eq(2L))).thenReturn(List.of(event));
 
-        Assertions.assertThat(
-            cut.fetchLatestForApiIds(Set.of("api-1", "api-2"), Set.of("env"), Set.of(EventType.START_API))
-        ).containsExactly(event);
+        fetcher
+            .fetchLatestForApiIds(Set.of("api-1", "api-2"), Set.of("env"), Set.of(EventType.START_API))
+            .test()
+            .assertComplete()
+            .assertValue(List.of(event));
     }
 
     @Test
-    void should_return_empty_list_when_repository_search_fails_for_api_ids() {
+    void should_page_through_events_for_specific_api_ids() {
+        // A full page means there may be more: the fetcher must ask for the next one instead of
+        // loading every member API's event in one unpaginated search.
+        LatestEventFetcher fetcher = new LatestEventFetcher(eventLatestRepository, 2);
+        List<Event> fullPage = List.of(new Event(), new Event());
+        List<Event> lastPage = List.of(new Event());
+        when(eventLatestRepository.search(any(), eq(Event.EventProperties.API_ID), eq(0L), eq(2L))).thenReturn(fullPage);
+        when(eventLatestRepository.search(any(), eq(Event.EventProperties.API_ID), eq(1L), eq(2L))).thenReturn(lastPage);
+
+        fetcher
+            .fetchLatestForApiIds(Set.of("api-1"), Set.of("env"), Set.of(EventType.PUBLISH_API))
+            .test()
+            .assertComplete()
+            .assertValues(fullPage, lastPage);
+    }
+
+    @Test
+    void should_end_the_stream_when_repository_search_fails_for_api_ids() {
         when(eventLatestRepository.search(any(), any(), any(), any())).thenThrow(new RuntimeException("db down"));
 
-        Assertions.assertThat(cut.fetchLatestForApiIds(Set.of("api-1"), Set.of("env"), Set.of(EventType.PUBLISH_API))).isEmpty();
+        cut.fetchLatestForApiIds(Set.of("api-1"), Set.of("env"), Set.of(EventType.PUBLISH_API)).test().assertComplete().assertNoValues();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
@@ -184,7 +184,9 @@ class SubscriptionMapperTest {
     }
 
     @Test
-    void should_explode_api_product_subscription_into_one_per_api() {
+    void should_map_api_product_subscription_to_a_single_product_scoped_subscription() {
+        // Whatever the size of the product, one repository record yields one runtime subscription:
+        // the runtime caches it under the product and resolves API to product at lookup time.
         subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT);
         subscription.setReferenceId("product-1");
         subscription.setApi(null);
@@ -196,9 +198,10 @@ class SubscriptionMapperTest {
 
         List<io.gravitee.gateway.api.service.Subscription> mapped = cut.to(subscription);
 
-        assertThat(mapped).hasSize(2);
-        assertThat(mapped).extracting(io.gravitee.gateway.api.service.Subscription::getApi).containsExactlyInAnyOrder("api1", "api2");
-        assertThat(mapped).allMatch(s -> "id".equals(s.getId()) && "product-1".equals(s.getApiProductId()));
+        assertThat(mapped).hasSize(1);
+        assertThat(mapped.getFirst().getApi()).isNull();
+        assertThat(mapped.getFirst().getApiProductId()).isEqualTo("product-1");
+        assertThat(mapped.getFirst().getId()).isEqualTo("id");
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
@@ -485,7 +485,7 @@ class ApiSynchronizerTest {
 
         @Test
         void should_not_deploy_when_no_repository_events_found_for_member_apis() throws InterruptedException {
-            when(eventsFetcher.fetchLatestForApiIds(eq(Set.of("api-1")), eq(Set.of("env")), any())).thenReturn(List.of());
+            when(eventsFetcher.fetchLatestForApiIds(eq(Set.of("api-1")), eq(Set.of("env")), any())).thenReturn(Flowable.empty());
 
             cut.resyncMemberApis(Set.of("api-1"), Set.of("env")).test().await().assertComplete();
 
@@ -500,7 +500,7 @@ class ApiSynchronizerTest {
             event.setPayload(objectMapper.writeValueAsString(repoApi));
             event.setType(PUBLISH_API);
 
-            when(eventsFetcher.fetchLatestForApiIds(eq(Set.of("api")), eq(Set.of("env")), any())).thenReturn(List.of(event));
+            when(eventsFetcher.fetchLatestForApiIds(eq(Set.of("api")), eq(Set.of("env")), any())).thenReturn(Flowable.just(List.of(event)));
             when(apiManager.requiredActionFor(argThat(argument -> argument.getId().equals("api")))).thenReturn(ActionOnApi.DEPLOY);
 
             cut.resyncMemberApis(Set.of("api"), Set.of("env")).test().await().assertComplete();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
@@ -136,7 +136,6 @@ class ApiSynchronizerTest {
                     objectMapper,
                     org.mockito.Mockito.mock(io.gravitee.gateway.handlers.api.registry.ApiProductRegistry.class)
                 ),
-                org.mockito.Mockito.mock(io.gravitee.gateway.handlers.api.registry.ApiProductRegistry.class),
                 100
             ),
             new ApiKeyAppender(apiKeyRepository, new ApiKeyMapper(), 100, 900),

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTriggerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTriggerTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,12 +68,13 @@ class RepositoryApiMemberResyncTriggerTest {
     private ArgumentCaptor<EventListener<ApiProductEventType, ApiProductChangedEvent>> listenerCaptor;
 
     private ThreadPoolExecutor syncDeployerExecutor;
+    private final AtomicBoolean initialSyncDone = new AtomicBoolean(true);
     private RepositoryApiMemberResyncTrigger cut;
 
     @BeforeEach
     void setUp() {
         syncDeployerExecutor = new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
-        cut = new RepositoryApiMemberResyncTrigger(apiSynchronizer, apiManager, syncDeployerExecutor, eventManager);
+        cut = new RepositoryApiMemberResyncTrigger(apiSynchronizer, apiManager, syncDeployerExecutor, eventManager, initialSyncDone::get);
         verify(eventManager).subscribeForEvents(listenerCaptor.capture(), eq(ApiProductEventType.DEPLOY), eq(ApiProductEventType.UPDATE));
     }
 
@@ -135,6 +137,20 @@ class RepositoryApiMemberResyncTriggerTest {
             .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-1"))));
 
         awaitPipelineCompletion();
+        verify(apiManager, never()).reEvaluateAfterProductChange(any(), any());
+    }
+
+    @Test
+    void should_not_resync_while_the_initial_synchronization_is_running() {
+        // API Products are synchronized before APIs, so the API synchronizer is about to deploy
+        // every member API on its own: resyncing here would reload and redeploy them for nothing.
+        initialSyncDone.set(false);
+
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.DEPLOY, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-1"))));
+
+        verify(apiSynchronizer, never()).resyncMemberApis(any(), any());
         verify(apiManager, never()).reEvaluateAfterProductChange(any(), any());
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
@@ -72,9 +72,8 @@ class SubscriptionAppenderTest {
 
     @BeforeEach
     public void beforeEach() {
-        when(apiProductRegistry.getApiProductPlanEntriesForApi(any(), any())).thenReturn(List.of());
         SubscriptionMapper subscriptionMapper = new SubscriptionMapper(objectMapper, apiProductRegistry);
-        cut = new SubscriptionAppender(subscriptionRepository, subscriptionMapper, apiProductRegistry, BULK_ITEMS);
+        cut = new SubscriptionAppender(subscriptionRepository, subscriptionMapper, BULK_ITEMS);
         memoryAppender.reset();
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apikey/ApiKeySynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apikey/ApiKeySynchronizerTest.java
@@ -128,7 +128,7 @@ class ApiKeySynchronizerTest {
             subscription.setApi("api");
             subscription.setPlan("plan");
             subscription.setStatus(io.gravitee.repository.management.model.Subscription.Status.ACCEPTED.name());
-            when(subscriptionService.getAllById("subscription")).thenReturn(List.of(subscription));
+            when(subscriptionService.getById("subscription")).thenReturn(java.util.Optional.of(subscription));
 
             when(apiKeyFetcher.fetchLatest(any(), any(), any())).thenReturn(Flowable.just(List.of(apiKey)));
             cut.synchronize(Instant.now().toEpochMilli(), Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
@@ -149,7 +149,7 @@ class ApiKeySynchronizerTest {
             subscription.setApi("api");
             subscription.setPlan("plan");
             subscription.setStatus(io.gravitee.repository.management.model.Subscription.Status.CLOSED.name());
-            when(subscriptionService.getAllById("subscription")).thenReturn(List.of(subscription));
+            when(subscriptionService.getById("subscription")).thenReturn(java.util.Optional.of(subscription));
 
             when(apiKeyFetcher.fetchLatest(any(), any(), any())).thenReturn(Flowable.just(List.of(apiKey)));
             cut.synchronize(Instant.now().toEpochMilli(), Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4RealCacheIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4RealCacheIntegrationTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_APIKEY_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import io.gravitee.gateway.handlers.api.manager.ApiManager;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.gateway.handlers.api.services.ApiKeyCacheService;
+import io.gravitee.gateway.handlers.api.services.SubscriptionCacheService;
+import io.gravitee.gateway.security.core.SubscriptionTrustStoreLoaderManager;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Scenarios running against the real subscription and api-key caches, so the assertions come from
+ * the gateway's own resolution rather than from a stub. {@link ApiProductV4IntegrationTest} drives
+ * its outcomes with {@code when(...)}, which cannot show that a product subscription registered
+ * once is reachable from every member API.
+ *
+ * <p>Kept in its own file rather than as another nested class: the SDK starts one gateway per
+ * annotated class, and these scenarios need their own.</p>
+ *
+ * <p>Covers the acceptance criteria of APIM-12491 — a product subscription governs access to every
+ * member API, and APIs outside a product are untouched.</p>
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DeployApi({ "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" })
+class ApiProductV4RealCacheIntegrationTest extends ApiProductV4IntegrationTest.TestPreparer {
+
+    private static final String ENV_ID = "DEFAULT";
+    private static final String API_1_ID = "my-api-v4-1";
+    private static final String API_2_ID = "my-api-v4-2";
+    private static final String API_3_ID = "my-api-v4-3";
+    private static final String API_1_PATH = "/test-1";
+    private static final String API_2_PATH = "/test-2";
+    private static final String API_3_PATH = "/test-3";
+
+    private static final String REAL_PRODUCT_ID = "real-cache-product";
+    private static final String REAL_PLAN_ID = "real-cache-product-plan";
+    private static final String REAL_KEY = "real-cache-key";
+    private static final String REAL_SUBSCRIPTION_ID = "real-cache-subscription";
+
+    @BeforeEach
+    void useRealCaches() {
+        useRealSubscriptionCaches();
+    }
+
+    /**
+     * One subscription, taken on the product, reachable from every member API — and from none
+     * of the APIs outside it.
+     */
+    @Test
+    void should_resolve_one_product_subscription_from_every_member_api(HttpClient client) {
+        deployProductWithApiKeyPlan(Set.of(API_1_ID, API_2_ID));
+        registerProductSubscriptionAndKey();
+
+        assertStatus(client, API_1_PATH, REAL_KEY, 200);
+        assertStatus(client, API_2_PATH, REAL_KEY, 200);
+        // API 3 is deployed but not part of the product
+        assertStatus(client, API_3_PATH, REAL_KEY, 401);
+    }
+
+    /** Detaching an API stops resolution for it while the others keep working. */
+    @Test
+    void should_stop_resolving_for_an_api_detached_from_the_product(HttpClient client) {
+        deployProductWithApiKeyPlan(Set.of(API_1_ID, API_2_ID));
+        registerProductSubscriptionAndKey();
+        assertStatus(client, API_1_PATH, REAL_KEY, 200);
+
+        redeployProductWithApiKeyPlan(Set.of(API_2_ID));
+
+        assertStatus(client, API_1_PATH, REAL_KEY, 401);
+        assertStatus(client, API_2_PATH, REAL_KEY, 200);
+    }
+
+    /** Attaching an API makes the existing subscription resolve for it, with no new key. */
+    @Test
+    void should_start_resolving_for_an_api_attached_to_the_product(HttpClient client) {
+        deployProductWithApiKeyPlan(Set.of(API_1_ID));
+        registerProductSubscriptionAndKey();
+        assertStatus(client, API_2_PATH, REAL_KEY, 401);
+
+        redeployProductWithApiKeyPlan(Set.of(API_1_ID, API_2_ID));
+
+        assertStatus(client, API_1_PATH, REAL_KEY, 200);
+        assertStatus(client, API_2_PATH, REAL_KEY, 200);
+    }
+
+    /** Undeploying the product evicts the subscription for all of its APIs at once. */
+    @Test
+    void should_stop_resolving_everywhere_once_the_product_is_undeployed(HttpClient client) {
+        deployProductWithApiKeyPlan(Set.of(API_1_ID, API_2_ID));
+        registerProductSubscriptionAndKey();
+        assertStatus(client, API_1_PATH, REAL_KEY, 200);
+
+        undeployApiProduct(REAL_PRODUCT_ID);
+
+        assertStatus(client, API_1_PATH, REAL_KEY, 401);
+        assertStatus(client, API_2_PATH, REAL_KEY, 401);
+    }
+
+    /**
+     * APIM-12491: an API outside any product keeps behaving exactly as before — its own plan
+     * still governs access, and a product key grants nothing on it.
+     */
+    @Test
+    void should_leave_an_api_outside_any_product_untouched(HttpClient client) {
+        deployProductWithApiKeyPlan(Set.of(API_1_ID));
+        registerProductSubscriptionAndKey();
+
+        // API 3 has its own api-key plan; the product key must not open it
+        assertStatus(client, API_3_PATH, REAL_KEY, 401);
+
+        registerApiSubscriptionAndKey(API_3_ID, "own-key", "own-subscription");
+        assertStatus(client, API_3_PATH, "own-key", 200);
+    }
+
+    /**
+     * Routes the subscription and api-key beans to real caches for this test.
+     *
+     * <p>The SDK exposes both as bare Mockito mocks: every lookup answers empty and every
+     * registration is swallowed, so a test can only assert what it stubbed itself. That is enough to
+     * drive a scenario, but it cannot show that a subscription registered on one side is reachable
+     * from the request path — which is the whole point of API Product scoping, a product
+     * subscription being stored under its product and resolved through the registry.</p>
+     *
+     * <p>Wired with {@code doAnswer}, never {@code when(...)}: on a partial mock the latter invokes
+     * the delegate while stubbing, with the nulls that argument matchers produce.</p>
+     *
+     * <p>Kept here rather than in the SDK: one test needs it, and AbstractGatewayTest is public API
+     * for every plugin that writes integration tests.</p>
+     */
+    private void useRealSubscriptionCaches() {
+        final ApiProductRegistry apiProductRegistry = getBean(ApiProductRegistry.class);
+        final ApiKeyService apiKeyBean = getBean(ApiKeyService.class);
+        final SubscriptionService subscriptionBean = getBean(SubscriptionService.class);
+
+        final ApiKeyCacheService realApiKeys = new ApiKeyCacheService(apiProductRegistry);
+        doAnswer(inv -> realApiKeys.getByApiAndKey(inv.getArgument(0), inv.getArgument(1)))
+            .when(apiKeyBean)
+            .getByApiAndKey(any(), any());
+        doAnswer(inv -> realApiKeys.getByApiAndMd5Key(inv.getArgument(0), inv.getArgument(1)))
+            .when(apiKeyBean)
+            .getByApiAndMd5Key(any(), any());
+        doAnswer(inv -> {
+            realApiKeys.register(inv.getArgument(0));
+            return null;
+        })
+            .when(apiKeyBean)
+            .register(any());
+        doAnswer(inv -> {
+            realApiKeys.unregister(inv.getArgument(0));
+            return null;
+        })
+            .when(apiKeyBean)
+            .unregister(any());
+
+        // Built on the api-key bean, not on realApiKeys, so the api-key path still goes through
+        // whatever the test has stubbed on it.
+        final SubscriptionCacheService realSubscriptions = new SubscriptionCacheService(
+            apiKeyBean,
+            getBean(SubscriptionTrustStoreLoaderManager.class),
+            getBean(ApiManager.class),
+            apiProductRegistry
+        );
+        doAnswer(inv -> realSubscriptions.getByApiAndSecurityToken(inv.getArgument(0), inv.getArgument(1), inv.getArgument(2)))
+            .when(subscriptionBean)
+            .getByApiAndSecurityToken(any(), any(), any());
+        doAnswer(inv -> realSubscriptions.getByApiAndClientIdAndPlan(inv.getArgument(0), inv.getArgument(1), inv.getArgument(2)))
+            .when(subscriptionBean)
+            .getByApiAndClientIdAndPlan(any(), any(), any());
+        doAnswer(inv -> realSubscriptions.getById(inv.getArgument(0)))
+            .when(subscriptionBean)
+            .getById(any());
+        doAnswer(inv -> {
+            realSubscriptions.register(inv.getArgument(0));
+            return null;
+        })
+            .when(subscriptionBean)
+            .register(any());
+        doAnswer(inv -> {
+            realSubscriptions.unregister(inv.getArgument(0));
+            return null;
+        })
+            .when(subscriptionBean)
+            .unregister(any());
+    }
+
+    private void deployProductWithApiKeyPlan(Set<String> apiIds) {
+        // The plan must be on the product before it is deployed: deployment is what emits the
+        // event that rebuilds each member API's security chain. Adding plans afterwards writes
+        // straight to the registry and notifies nobody.
+        ReactableApiProduct p = product(REAL_PRODUCT_ID, apiIds);
+        p.setPlans(List.of(productPlan(REAL_PLAN_ID, "api-key", PlanStatus.PUBLISHED)));
+        deployApiProduct(p);
+    }
+
+    private void redeployProductWithApiKeyPlan(Set<String> apiIds) {
+        ReactableApiProduct p = product(REAL_PRODUCT_ID, apiIds);
+        p.setPlans(List.of(productPlan(REAL_PLAN_ID, "api-key", PlanStatus.PUBLISHED)));
+        redeployApiProduct(p);
+    }
+
+    /** Registers the subscription on the product itself — the scope this PR introduces. */
+    private void registerProductSubscriptionAndKey() {
+        Subscription subscription = new Subscription();
+        subscription.setId(REAL_SUBSCRIPTION_ID);
+        subscription.setApi(null);
+        subscription.setApiProductId(REAL_PRODUCT_ID);
+        subscription.setPlan(REAL_PLAN_ID);
+        subscription.setApplication("application-id");
+        subscription.setStatus("ACCEPTED");
+        subscription.setEnvironmentId(ENV_ID);
+        getBean(SubscriptionService.class).register(subscription);
+
+        ApiKey apiKey = new ApiKey();
+        apiKey.setId("key-" + REAL_KEY);
+        apiKey.setApi(REAL_PRODUCT_ID);
+        apiKey.setKey(REAL_KEY);
+        apiKey.setPlan(REAL_PLAN_ID);
+        apiKey.setSubscription(REAL_SUBSCRIPTION_ID);
+        apiKey.setApplication("application-id");
+        apiKey.setActive(true);
+        getBean(ApiKeyService.class).register(apiKey);
+    }
+
+    private void registerApiSubscriptionAndKey(String apiId, String key, String subscriptionId) {
+        Subscription subscription = new Subscription();
+        subscription.setId(subscriptionId);
+        subscription.setApi(apiId);
+        subscription.setPlan(PLAN_APIKEY_ID);
+        subscription.setApplication("application-id");
+        subscription.setStatus("ACCEPTED");
+        subscription.setEnvironmentId(ENV_ID);
+        getBean(SubscriptionService.class).register(subscription);
+
+        ApiKey apiKey = new ApiKey();
+        apiKey.setId("key-" + key);
+        apiKey.setApi(apiId);
+        apiKey.setKey(key);
+        apiKey.setPlan(PLAN_APIKEY_ID);
+        apiKey.setSubscription(subscriptionId);
+        apiKey.setApplication("application-id");
+        apiKey.setActive(true);
+        getBean(ApiKeyService.class).register(apiKey);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4RealCacheIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4RealCacheIntegrationTest.java
@@ -146,6 +146,52 @@ class ApiProductV4RealCacheIntegrationTest extends ApiProductV4IntegrationTest.T
     }
 
     /**
+     * APIM-12491, priority rules. The member APIs carry an api-key plan of their own on top of the
+     * product's, so both coexist on API 1. A product key opens it, and so does a key of its own
+     * plan — the product plan takes precedence in the chain without shutting the API plan down.
+     */
+    @Test
+    void should_serve_both_a_product_key_and_an_api_own_key_on_the_same_api(HttpClient client) {
+        deployProductWithApiKeyPlan(Set.of(API_1_ID));
+        registerProductSubscriptionAndKey();
+        registerApiSubscriptionAndKey(API_1_ID, "api-own-key", "api-own-subscription");
+
+        assertStatus(client, API_1_PATH, REAL_KEY, 200);
+        assertStatus(client, API_1_PATH, "api-own-key", 200);
+    }
+
+    /**
+     * APIM-12491, fallback. With no product subscription for that key, the API-level plan still
+     * governs access exactly as it did before the API joined a product.
+     */
+    @Test
+    void should_fall_back_to_the_api_own_plan_when_no_product_subscription_matches(HttpClient client) {
+        deployProductWithApiKeyPlan(Set.of(API_1_ID));
+        registerApiSubscriptionAndKey(API_1_ID, "api-own-key", "api-own-subscription");
+
+        // Nothing was registered on the product scope
+        assertStatus(client, API_1_PATH, REAL_KEY, 401);
+        assertStatus(client, API_1_PATH, "api-own-key", 200);
+    }
+
+    /**
+     * Detaching the API from the product must not disturb its own plan: the product key stops
+     * working, the API's own key keeps working.
+     */
+    @Test
+    void should_keep_the_api_own_plan_working_after_it_leaves_the_product(HttpClient client) {
+        deployProductWithApiKeyPlan(Set.of(API_1_ID, API_2_ID));
+        registerProductSubscriptionAndKey();
+        registerApiSubscriptionAndKey(API_1_ID, "api-own-key", "api-own-subscription");
+        assertStatus(client, API_1_PATH, REAL_KEY, 200);
+
+        redeployProductWithApiKeyPlan(Set.of(API_2_ID));
+
+        assertStatus(client, API_1_PATH, REAL_KEY, 401);
+        assertStatus(client, API_1_PATH, "api-own-key", 200);
+    }
+
+    /**
      * Routes the subscription and api-key beans to real caches for this test.
      *
      * <p>The SDK exposes both as bare Mockito mocks: every lookup answers empty and every

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4ShardingIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4ShardingIntegrationTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * How API Product sharding tags decide what a gateway serves.
+ *
+ * <p>The gateway here runs with the {@code internal} tag. Products and product plans carry their
+ * own tags, and the registry indexes a product plan for an API only when both match — which is what
+ * makes a product subscription resolvable through that API.</p>
+ *
+ * <p>Asserted on the registry rather than through HTTP calls: what sharding decides is whether an
+ * API resolves to a product at all, and the registry is where that decision is made and observable.
+ * A request-level assertion would only show a 401 without telling which of the many reasons caused
+ * it.</p>
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DeployApi({ "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json" })
+class ApiProductV4ShardingIntegrationTest extends ApiProductV4IntegrationTest.TestPreparer {
+
+    private static final String SHARDING_TAGS_PROPERTY = "tags";
+    private static final String GATEWAY_TAG = "internal";
+    private static final String OTHER_TAG = "external";
+    private static final String ENV_ID = "DEFAULT";
+    private static final String API_1_ID = "my-api-v4-1";
+    private static final String PRODUCT_ID = "sharding-product";
+    private static final String PLAN_ID = "sharding-product-plan";
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder builder) {
+        builder.setSystemProperty(SHARDING_TAGS_PROPERTY, GATEWAY_TAG);
+    }
+
+    /**
+     * The SDK writes gateway configuration through {@link System#setProperty} and never clears it,
+     * so a sharding tag set here would otherwise outlive this class and make every later test run
+     * on a tagged gateway — where untagged APIs are not deployed at all, and calls answer 404.
+     */
+    @AfterAll
+    static void clearShardingTags() {
+        System.clearProperty(SHARDING_TAGS_PROPERTY);
+    }
+
+    @Test
+    void should_serve_a_product_whose_tags_match_the_gateway() {
+        deployProduct(Set.of(GATEWAY_TAG), null);
+
+        assertThat(registry().getApiProductIdsForApi(API_1_ID)).containsExactly(PRODUCT_ID);
+        assertThat(registry().getApiProductPlanEntriesForApi(API_1_ID, ENV_ID)).hasSize(1);
+    }
+
+    @Test
+    void should_ignore_a_product_whose_tags_do_not_match_the_gateway() {
+        deployProduct(Set.of(OTHER_TAG), null);
+
+        assertThat(registry().getApiProductIdsForApi(API_1_ID)).isEmpty();
+        assertThat(registry().getApiProductPlanEntriesForApi(API_1_ID, ENV_ID)).isEmpty();
+    }
+
+    /**
+     * Products and plans do not treat the absence of tags alike, and the difference is deliberate:
+     * {@code ApiProductShardingFilter} short-circuits an untagged plan to accepted, while an
+     * untagged product goes through the ordinary sharding rule — a tagged gateway serves only what
+     * carries its tags, exactly as it does for APIs. An untagged product is therefore invisible
+     * here, and would be served by an untagged gateway.
+     */
+    @Test
+    void should_ignore_an_untagged_product_on_a_tagged_gateway() {
+        deployProduct(null, null);
+
+        assertThat(registry().getApiProductIdsForApi(API_1_ID)).isEmpty();
+    }
+
+    /**
+     * The counterpart: an untagged plan rides on its product's tags.
+     *
+     * <p>This is where API Products part company with APIs. An untagged <em>API</em> plan goes
+     * through the ordinary rule and can make a tagged gateway skip its API entirely — see
+     * {@code ApiManagerImplTest.should_not_deploy_api_if_plan_has_non_matching_tag}. An untagged
+     * <em>product</em> plan is accepted outright. The reasoning behind that short-circuit is
+     * recorded on {@code ApiProductShardingFilter}; this test pins the behaviour down either way.</p>
+     */
+    @Test
+    void should_serve_an_untagged_plan_of_a_matching_product() {
+        deployProduct(Set.of(GATEWAY_TAG), null);
+
+        assertThat(registry().getApiProductPlanEntriesForApi(API_1_ID, ENV_ID)).hasSize(1);
+    }
+
+    /**
+     * A plan carries its own tags on top of the product's. A plan the gateway does not serve leaves
+     * the API with nothing to subscribe through, so the product stops resolving for it entirely.
+     */
+    @Test
+    void should_ignore_a_plan_whose_tags_do_not_match_the_gateway() {
+        deployProduct(Set.of(GATEWAY_TAG), Set.of(OTHER_TAG));
+
+        assertThat(registry().getApiProductPlanEntriesForApi(API_1_ID, ENV_ID)).isEmpty();
+        assertThat(registry().getApiProductIdsForApi(API_1_ID)).isEmpty();
+    }
+
+    @Test
+    void should_serve_a_plan_whose_tags_match_the_gateway() {
+        deployProduct(Set.of(GATEWAY_TAG), Set.of(GATEWAY_TAG));
+
+        assertThat(registry().getApiProductPlanEntriesForApi(API_1_ID, ENV_ID)).hasSize(1);
+        assertThat(registry().getApiProductIdsForApi(API_1_ID)).containsExactly(PRODUCT_ID);
+    }
+
+    /**
+     * The API's own tags play no part here: membership of a served product is what exposes it,
+     * whatever the API itself is tagged with. Worth pinning down, since this is the eligibility
+     * question left open on the PR.
+     */
+    @Test
+    void should_not_let_the_api_own_tags_decide_product_resolution() {
+        deployProduct(Set.of(GATEWAY_TAG), Set.of(GATEWAY_TAG));
+
+        // The deployed APIs carry no tag of their own, yet resolve to the product
+        assertThat(registry().getApiProductIdsForApi(API_1_ID)).containsExactly(PRODUCT_ID);
+    }
+
+    @Test
+    void should_stop_serving_a_product_retagged_away_from_the_gateway() {
+        deployProduct(Set.of(GATEWAY_TAG), null);
+        assertThat(registry().getApiProductIdsForApi(API_1_ID)).containsExactly(PRODUCT_ID);
+
+        redeployProduct(Set.of(OTHER_TAG), null);
+
+        assertThat(registry().getApiProductIdsForApi(API_1_ID)).isEmpty();
+    }
+
+    private ApiProductRegistry registry() {
+        return getBean(ApiProductRegistry.class);
+    }
+
+    private void deployProduct(Set<String> productTags, Set<String> planTags) {
+        deployApiProduct(buildProduct(productTags, planTags));
+    }
+
+    private void redeployProduct(Set<String> productTags, Set<String> planTags) {
+        redeployApiProduct(buildProduct(productTags, planTags));
+    }
+
+    private ReactableApiProduct buildProduct(Set<String> productTags, Set<String> planTags) {
+        Plan plan = Plan.builder()
+            .id(PLAN_ID)
+            .name("ShardingPlan")
+            .security(PlanSecurity.builder().type("api-key").build())
+            .status(PlanStatus.PUBLISHED)
+            .mode(PlanMode.STANDARD)
+            .tags(planTags)
+            .build();
+
+        return ReactableApiProduct.builder()
+            .id(PRODUCT_ID)
+            .name("Sharding product")
+            .version("1.0.0")
+            .apiIds(Set.of(API_1_ID))
+            .environmentId(ENV_ID)
+            .tags(productTags)
+            .plans(List.of(plan))
+            .build();
+    }
+}


### PR DESCRIPTION
## Issue

No Jira ticket for this one — it started from the production incident behind #19000
and stayed on that thread. The behaviour it touches is specified by
[APIM-12491](https://gravitee.atlassian.net/browse/APIM-12491), whose acceptance criteria
the added tests now cover.

## Description

An API Product subscription was exploded into one runtime subscription per member
API, so the gateway caches grew with (subscriptions × member APIs). On the affected
installation, 36,487 logical subscriptions became roughly 5.5M runtime entries and
the gateway ran out of memory at startup.

This changes what a cache entry represents. A subscription is now stored once, under
the entity it was taken on — its *scope*: the API for a regular subscription, the API
Product for a product one. The `SubscriptionService` contract stays API-scoped, so
lookups still arrive with an API and this resolves the products that API belongs to,
through a reverse index bounded by (APIs × products) — a few thousand entries.

Flattening never bought anything at read time: the request path already knew about
products, since `HttpSecurityChain` builds a product plan's security plan from that
same registry. The expansion only existed to fit index keys designed before API
Products.

Removing it moves ownership as a consequence. The API synchronizer no longer sees
product subscriptions at all — `SubscriptionAppender` collects only each API's own
plans — and `ApiProductDeployer` becomes their single writer: a paginated refresh on
deploy, a bulk eviction by scope on undeploy. That removes the cold-start double
registration by construction, with no `initialSync` flag. Dropping an API from a
product needs no eviction either: the subscription stays cached under the product and
the registry simply stops resolving that API to it.

Four commits fix defects found while working in this area, each independent of the
scope change:

- the member API resync ran during the initial synchronization, where it is pure
  duplication (API Products are synchronized before APIs), and loaded every member
  API's event through an unpaginated search;
- `apiLocks` grew by one `ReentrantLock` per API ever seen, never cleaned up;
- the resync trigger could leave a terminated disposable in its composite forever;
- the product plan index was rebuilt from a **shallow** copy, so adding or removing a
  product mutated, in place, the lists that in-flight requests were walking to build
  their security chain. This is what SonarCloud's `java:S3077` was pointing at. The
  rebuild now works on its own copy and publishes frozen lists.

## Additional context

**Test coverage was the weak point, and it has changed.** The SDK exposes
`SubscriptionService` and `ApiKeyService` as Mockito mocks, so no integration test ever
exercised the real caches: helpers like `denyKeyForApi` stub them, and a scenario
asserting a 401 after detaching an API from a product was really asserting that a mock
told to return empty causes a 401. Three commits address this:

- `ApiProductV4RealCacheIntegrationTest` routes both beans to real cache instances and
  asserts what the gateway itself resolves — one subscription taken on the product is
  reachable from every member API and from none outside it, detaching stops resolution
  for that API alone, reattaching restores it with no new key, undeploying the product
  evicts everywhere at once;
- the same class covers a product plan and an API plan coexisting on one API, and the
  fallback to the API's own plan when nothing matches on the product scope;
- `ApiProductV4ShardingIntegrationTest` covers sharding tags, which had no integration
  coverage at all.

The delegation is wired with `doAnswer`, never `when(...)`: on a partial mock the latter
invokes the delegate while stubbing, with the nulls argument matchers produce — which is
what made a first attempt at flipping the SDK default fail 236 tests. It is private to the
test rather than added to `AbstractGatewayTest`, so **the SDK is untouched** and nothing
changes for the other 80 integration tests or for plugin repositories.

**An asymmetry surfaced while writing the sharding tests**, and is recorded rather than
changed. A product follows the same rule as an API: a tagged gateway refuses it when
untagged. A product *plan* does not — an untagged one is accepted outright, where an
untagged API plan goes through the ordinary rule and can make the gateway skip its API.
The class javadoc of `ApiProductShardingFilter` now states both rules and names the test
pinning each side, so a bug report about a product plan appearing on the wrong gateway
lands there directly. Behaviour is unchanged; whether to align it is a product question.

**Behaviour change.** Two subscriptions sharing an id and an API across environments no
longer coexist — last write wins. Lookups never carried an environment, so the extra legs
were never observable; `getById` already returned an arbitrary one.

**One acceptance criterion remains untested.** APIM-12491 states that API-level plan
checks are skipped when a product subscription matches. That is not observable from a
status code — the chain stopping at the product plan and the API plan answering both
yield a 200 — and proving it means observing the retained plan, which the SDK does not
expose. The ordering itself is covered where it is decided, in `HttpSecurityChain`'s
construction.

**Still open, deliberately out of scope.** `8cee817b82` also widened deployment
eligibility: an API whose tags do not match the gateway becomes eligible as soon as it
belongs to a served product. That is a product decision and is untouched here, but it is
the most likely explanation for the live-set size seen on the affected node, and it
deserves its own discussion. `should_not_let_the_api_own_tags_decide_product_resolution`
now pins the current behaviour down either way.

**Review order.** The commits are meant to be read in sequence and each one builds and
passes on its own. `SubscriptionScope` first (a shared helper, no caller), then the cache
change — necessarily atomic, since the mapper cannot stop exploding before the caches know
how to index by scope — then the ownership move, then the fixes, then the tests.

**Validation.** 2,118 unit tests across `gateway-core`, `gateway-security-core`,
`gateway-handlers-api` and `gateway-services-sync`, and the full integration suite at
1,325 tests — up from 1,309 before this branch, with no regression. Prettier applied.


[APIM-12491]: https://gravitee.atlassian.net/browse/APIM-12491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ