### PR TITLE
feat(gamma): add group member management (add, invite, edit roles, remove)

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/currentUser.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/currentUser.ts
@@ -18,6 +18,7 @@ import type { UserRole } from '@gravitee/gamma-modules-sdk/types';
 import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
 
 export interface CurrentUser {
+    id?: string;
     displayName?: string;
     roles?: UserRole[];
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
@@ -45,7 +45,10 @@ function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupAddMemb
             groupName="API Team"
             groupRoles={undefined}
             members={[]}
-            apiRoles={[{ name: 'USER', scope: 'API' }, { name: 'OWNER', scope: 'API' }]}
+            apiRoles={[
+                { name: 'USER', scope: 'API' },
+                { name: 'OWNER', scope: 'API' },
+            ]}
             applicationRoles={[{ name: 'USER', scope: 'APPLICATION' }]}
             apiProductRoles={[{ name: 'USER', scope: 'API_PRODUCT' }]}
             integrationRoles={[{ name: 'USER', scope: 'INTEGRATION' }]}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupAddMembersSheet } from './GroupAddMembersSheet';
+import type { GroupMember, SearchableUser } from '../types/group';
+
+jest.mock('@tanstack/react-query', () => ({
+    ...jest.requireActual('@tanstack/react-query'),
+    useQuery: jest.fn(),
+}));
+
+// Radix Select scrolls the highlighted option into view — not implemented in jsdom.
+beforeAll(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+});
+
+const mockUseQuery = jest.mocked(useQuery);
+
+const RESULTS: SearchableUser[] = [
+    { id: 'user-1', reference: 'user-1', displayName: 'Anna Schmidt', email: 'anna@lufthansa.com' },
+    { id: 'user-2', reference: 'user-2', displayName: 'Jonas Keller', email: 'jonas@lufthansa.com' },
+];
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupAddMembersSheet>> = {}) {
+    const onClose = jest.fn();
+    const onSubmit = jest.fn();
+    render(
+        <GroupAddMembersSheet
+            open
+            groupName="API Team"
+            members={[]}
+            apiRoles={[{ name: 'OWNER', scope: 'API' }]}
+            applicationRoles={[{ name: 'USER', scope: 'APPLICATION' }]}
+            apiProductRoles={[{ name: 'USER', scope: 'API_PRODUCT' }]}
+            integrationRoles={[{ name: 'USER', scope: 'INTEGRATION' }]}
+            clusterRoles={[{ name: 'USER', scope: 'CLUSTER' }]}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={false}
+            {...overrides}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('GroupAddMembersSheet', () => {
+    beforeEach(() => {
+        mockUseQuery.mockReturnValue({ data: RESULTS, isFetching: false } as ReturnType<typeof useQuery>);
+    });
+
+    it('does not render sheet content when closed', () => {
+        renderSheet({ open: false });
+        expect(screen.queryByRole('heading', { name: 'Add members' })).toBeNull();
+    });
+
+    it('shows the group name in the description and the default-roles selects', () => {
+        renderSheet();
+        expect(screen.getByText('Search platform users and assign roles for membership in API Team.')).not.toBeNull();
+        expect(screen.getByText('API')).not.toBeNull();
+        expect(screen.getByText('API product')).not.toBeNull();
+        expect(screen.getByText('Application')).not.toBeNull();
+        expect(screen.getByText('Integration')).not.toBeNull();
+        expect(screen.getByText('Cluster')).not.toBeNull();
+    });
+
+    it('has no "make selected users group admins" option — that only applies when editing an existing member', () => {
+        renderSheet();
+        expect(screen.queryByText(/group admin/i)).toBeNull();
+    });
+
+    it('prompts for at least 2 characters before showing results', () => {
+        renderSheet();
+        fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'a' } });
+        expect(screen.queryByText('Type at least 2 characters to search for users.')).not.toBeNull();
+        expect(screen.queryByText('Anna Schmidt')).toBeNull();
+    });
+
+    it('excludes users who are already members from the results', () => {
+        const existingMember: GroupMember = { id: 'user-1', displayName: 'Anna Schmidt', roles: {} };
+        renderSheet({ members: [existingMember] });
+        fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'an' } });
+        expect(screen.queryByText('Anna Schmidt')).toBeNull();
+        expect(screen.queryByText('Jonas Keller')).not.toBeNull();
+    });
+
+    it('disables the submit button until at least one user is selected', () => {
+        renderSheet();
+        expect(screen.getByRole('button', { name: 'Add member' })).toHaveProperty('disabled', true);
+    });
+
+    it('submits selected users with roles from every scope', () => {
+        const { onSubmit } = renderSheet();
+
+        fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'an' } });
+        fireEvent.click(screen.getByText('Anna Schmidt'));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+        expect(onSubmit).toHaveBeenCalledWith([
+            {
+                id: 'user-1',
+                reference: 'user-1',
+                roles: [],
+            },
+        ]);
+    });
+
+    it('disables the PRIMARY_OWNER option for a scope that already has a primary owner', () => {
+        const existingOwner: GroupMember = { id: 'user-3', displayName: 'Ravi Patel', roles: { API: 'PRIMARY_OWNER' } };
+        renderSheet({
+            members: [existingOwner],
+            apiRoles: [
+                { name: 'OWNER', scope: 'API' },
+                { name: 'PRIMARY_OWNER', scope: 'API', system: true },
+            ],
+        });
+
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).toBe('true');
+        expect(screen.getByRole('option', { name: 'OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
@@ -1,0 +1,266 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupAddMembersSheet } from './GroupAddMembersSheet';
+import type { GroupMember, SearchableUser } from '../types/group';
+
+jest.mock('@tanstack/react-query', () => ({
+    ...jest.requireActual('@tanstack/react-query'),
+    useQuery: jest.fn(),
+}));
+
+beforeAll(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+});
+
+const mockUseQuery = jest.mocked(useQuery);
+
+const RESULTS: SearchableUser[] = [
+    { id: 'user-1', reference: 'user-1', displayName: 'Anna Schmidt', email: 'anna@lufthansa.com' },
+    { id: 'user-2', reference: 'user-2', displayName: 'Jonas Keller', email: 'jonas@lufthansa.com' },
+];
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupAddMembersSheet>> = {}) {
+    const onClose = jest.fn();
+    const onSubmit = jest.fn();
+    render(
+        <GroupAddMembersSheet
+            open
+            groupName="API Team"
+            groupRoles={undefined}
+            members={[]}
+            apiRoles={[
+                { name: 'USER', scope: 'API' },
+                { name: 'OWNER', scope: 'API' },
+            ]}
+            applicationRoles={[{ name: 'USER', scope: 'APPLICATION' }]}
+            apiProductRoles={[{ name: 'USER', scope: 'API_PRODUCT' }]}
+            integrationRoles={[{ name: 'USER', scope: 'INTEGRATION' }]}
+            clusterRoles={[{ name: 'USER', scope: 'CLUSTER' }]}
+            lockApiRole={false}
+            lockApiProductRole={false}
+            lockApplicationRole={false}
+            canOverrideLocks
+            maxInvitation={null}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={false}
+            {...overrides}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('GroupAddMembersSheet', () => {
+    beforeEach(() => {
+        mockUseQuery.mockReturnValue({ data: RESULTS, isFetching: false } as ReturnType<typeof useQuery>);
+    });
+
+    it('does not render sheet content when closed', () => {
+        renderSheet({ open: false });
+        expect(screen.queryByRole('heading', { name: 'Add members' })).toBeNull();
+    });
+
+    it('has no "None" role option — classic\'s add-members-dialog has no such mat-option', () => {
+        renderSheet();
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.queryByRole('option', { name: 'None' })).toBeNull();
+    });
+
+    it('shows the group name in the description and the default-roles selects', () => {
+        renderSheet();
+        expect(screen.getByText('Search platform users and assign roles for membership in API Team.')).not.toBeNull();
+        expect(screen.getByText('API')).not.toBeNull();
+        expect(screen.getByText('API product')).not.toBeNull();
+        expect(screen.getByText('Application')).not.toBeNull();
+        expect(screen.getByText('Integration')).not.toBeNull();
+        expect(screen.getByText('Cluster')).not.toBeNull();
+    });
+
+    it('has no "make selected users group admins" option — that only applies when editing an existing member', () => {
+        renderSheet();
+        expect(screen.queryByText(/group admin/i)).toBeNull();
+    });
+
+    it('prompts for at least 2 characters before showing results', () => {
+        renderSheet();
+        fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'a' } });
+        expect(screen.queryByText('Type at least 2 characters to search for users.')).not.toBeNull();
+        expect(screen.queryByText('Anna Schmidt')).toBeNull();
+    });
+
+    it('excludes users who are already members from the results', () => {
+        const existingMember: GroupMember = { id: 'user-1', displayName: 'Anna Schmidt', roles: {} };
+        renderSheet({ members: [existingMember] });
+        fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'an' } });
+        expect(screen.queryByText('Anna Schmidt')).toBeNull();
+        expect(screen.queryByText('Jonas Keller')).not.toBeNull();
+    });
+
+    it('disables the submit button until at least one user is selected', () => {
+        renderSheet();
+        expect(screen.getByRole('button', { name: 'Add member' })).toHaveProperty('disabled', true);
+    });
+
+    it('submits selected users with the pre-filled API/API product/Application/Integration/Cluster roles', () => {
+        const { onSubmit } = renderSheet();
+
+        fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'an' } });
+        fireEvent.click(screen.getByText('Anna Schmidt'));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+        expect(onSubmit).toHaveBeenCalledWith([
+            {
+                id: 'user-1',
+                reference: 'user-1',
+                roles: [
+                    { scope: 'API', name: 'USER' },
+                    { scope: 'API_PRODUCT', name: 'USER' },
+                    { scope: 'APPLICATION', name: 'USER' },
+                    { scope: 'INTEGRATION', name: 'USER' },
+                    { scope: 'CLUSTER', name: 'USER' },
+                ],
+            },
+        ]);
+    });
+
+    describe('default role pre-fill', () => {
+        it('pre-fills API/API product/Application from the group’s configured default roles', () => {
+            const { onSubmit } = renderSheet({ groupRoles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'USER' } });
+
+            fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'an' } });
+            fireEvent.click(screen.getByText('Anna Schmidt'));
+            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-1',
+                    reference: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'OWNER' },
+                        { scope: 'API_PRODUCT', name: 'OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                        { scope: 'INTEGRATION', name: 'USER' },
+                        { scope: 'CLUSTER', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('falls back to USER for any scope missing from the group’s configured roles', () => {
+            const { onSubmit } = renderSheet({ groupRoles: { API: 'OWNER' } });
+
+            fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'an' } });
+            fireEvent.click(screen.getByText('Anna Schmidt'));
+            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-1',
+                    reference: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'OWNER' },
+                        { scope: 'API_PRODUCT', name: 'USER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                        { scope: 'INTEGRATION', name: 'USER' },
+                        { scope: 'CLUSTER', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('always defaults Integration/Cluster to USER — classic hardcodes these regardless of group config', () => {
+            const { onSubmit } = renderSheet();
+
+            fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'an' } });
+            fireEvent.click(screen.getByText('Anna Schmidt'));
+            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                expect.objectContaining({
+                    roles: expect.arrayContaining([
+                        { scope: 'INTEGRATION', name: 'USER' },
+                        { scope: 'CLUSTER', name: 'USER' },
+                    ]),
+                }),
+            ]);
+        });
+    });
+
+    it('disables the PRIMARY_OWNER option for a scope that already has a primary owner', () => {
+        const existingOwner: GroupMember = { id: 'user-3', displayName: 'Ravi Patel', roles: { API: 'PRIMARY_OWNER' } };
+        renderSheet({
+            members: [existingOwner],
+            apiRoles: [
+                { name: 'OWNER', scope: 'API' },
+                { name: 'PRIMARY_OWNER', scope: 'API', system: true },
+            ],
+        });
+
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).toBe('true');
+        expect(screen.getByRole('option', { name: 'OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    describe('lock flags', () => {
+        it('disables a locked role select without canOverrideLocks', () => {
+            renderSheet({ lockApiRole: true, canOverrideLocks: false });
+            expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', true);
+        });
+
+        it('leaves a locked role select enabled with canOverrideLocks', () => {
+            renderSheet({ lockApiRole: true, canOverrideLocks: true });
+            expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', false);
+        });
+
+        it('leaves an unlocked role select enabled without canOverrideLocks', () => {
+            renderSheet({ lockApiRole: false, canOverrideLocks: false });
+            expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', false);
+        });
+
+        it('disables Integration and Cluster without canOverrideLocks, regardless of lock flags', () => {
+            renderSheet({ canOverrideLocks: false });
+            const comboboxes = screen.getAllByRole('combobox');
+            expect(comboboxes[3]).toHaveProperty('disabled', true);
+            expect(comboboxes[4]).toHaveProperty('disabled', true);
+        });
+    });
+
+    describe('member limit', () => {
+        it('disables the search input once existing members reach the limit', () => {
+            const existing: GroupMember = { id: 'user-9', displayName: 'Existing Member', roles: {} };
+            renderSheet({ members: [existing], maxInvitation: 1 });
+            expect(screen.getByPlaceholderText('Search by name or email…')).toHaveProperty('disabled', true);
+            expect(screen.getByText('This group has reached its maximum number of members.')).not.toBeNull();
+        });
+
+        it('leaves the search input enabled below the limit', () => {
+            const existing: GroupMember = { id: 'user-9', displayName: 'Existing Member', roles: {} };
+            renderSheet({ members: [existing], maxInvitation: 2 });
+            expect(screen.getByPlaceholderText('Search by name or email…')).toHaveProperty('disabled', false);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
@@ -43,8 +43,9 @@ function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupAddMemb
         <GroupAddMembersSheet
             open
             groupName="API Team"
+            groupRoles={undefined}
             members={[]}
-            apiRoles={[{ name: 'OWNER', scope: 'API' }]}
+            apiRoles={[{ name: 'USER', scope: 'API' }, { name: 'OWNER', scope: 'API' }]}
             applicationRoles={[{ name: 'USER', scope: 'APPLICATION' }]}
             apiProductRoles={[{ name: 'USER', scope: 'API_PRODUCT' }]}
             integrationRoles={[{ name: 'USER', scope: 'INTEGRATION' }]}
@@ -103,7 +104,7 @@ describe('GroupAddMembersSheet', () => {
         expect(screen.getByRole('button', { name: 'Add member' })).toHaveProperty('disabled', true);
     });
 
-    it('submits selected users with roles from every scope', () => {
+    it('submits selected users with the pre-filled API/API product/Application roles (Integration/Cluster left unset)', () => {
         const { onSubmit } = renderSheet();
 
         fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'an' } });
@@ -115,9 +116,57 @@ describe('GroupAddMembersSheet', () => {
             {
                 id: 'user-1',
                 reference: 'user-1',
-                roles: [],
+                roles: [
+                    { scope: 'API', name: 'USER' },
+                    { scope: 'API_PRODUCT', name: 'USER' },
+                    { scope: 'APPLICATION', name: 'USER' },
+                ],
             },
         ]);
+    });
+
+    describe('default role pre-fill', () => {
+        // Mirrors classic AddMembersDialogComponent.initializeForm(): `group.roles['API'] ?? 'USER'` — the
+        // Add Members form starts from the group's own configured defaults, not blank.
+        it('pre-fills API/API product/Application from the group’s configured default roles', () => {
+            const { onSubmit } = renderSheet({ groupRoles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'USER' } });
+
+            fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'an' } });
+            fireEvent.click(screen.getByText('Anna Schmidt'));
+            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-1',
+                    reference: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'OWNER' },
+                        { scope: 'API_PRODUCT', name: 'OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('falls back to USER for any scope missing from the group’s configured roles', () => {
+            const { onSubmit } = renderSheet({ groupRoles: { API: 'OWNER' } });
+
+            fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'an' } });
+            fireEvent.click(screen.getByText('Anna Schmidt'));
+            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-1',
+                    reference: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'OWNER' },
+                        { scope: 'API_PRODUCT', name: 'USER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
     });
 
     it('disables the PRIMARY_OWNER option for a scope that already has a primary owner', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
@@ -69,6 +69,12 @@ describe('GroupAddMembersSheet', () => {
         expect(screen.queryByRole('heading', { name: 'Add members' })).toBeNull();
     });
 
+    it('has no "None" role option — classic\'s add-members-dialog has no such mat-option', () => {
+        renderSheet();
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.queryByRole('option', { name: 'None' })).toBeNull();
+    });
+
     it('shows the group name in the description and the default-roles selects', () => {
         renderSheet();
         expect(screen.getByText('Search platform users and assign roles for membership in API Team.')).not.toBeNull();
@@ -104,7 +110,7 @@ describe('GroupAddMembersSheet', () => {
         expect(screen.getByRole('button', { name: 'Add member' })).toHaveProperty('disabled', true);
     });
 
-    it('submits selected users with the pre-filled API/API product/Application roles (Integration/Cluster left unset)', () => {
+    it('submits selected users with the pre-filled API/API product/Application/Integration/Cluster roles', () => {
         const { onSubmit } = renderSheet();
 
         fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'an' } });
@@ -120,6 +126,8 @@ describe('GroupAddMembersSheet', () => {
                     { scope: 'API', name: 'USER' },
                     { scope: 'API_PRODUCT', name: 'USER' },
                     { scope: 'APPLICATION', name: 'USER' },
+                    { scope: 'INTEGRATION', name: 'USER' },
+                    { scope: 'CLUSTER', name: 'USER' },
                 ],
             },
         ]);
@@ -143,6 +151,8 @@ describe('GroupAddMembersSheet', () => {
                         { scope: 'API', name: 'OWNER' },
                         { scope: 'API_PRODUCT', name: 'OWNER' },
                         { scope: 'APPLICATION', name: 'USER' },
+                        { scope: 'INTEGRATION', name: 'USER' },
+                        { scope: 'CLUSTER', name: 'USER' },
                     ],
                 },
             ]);
@@ -163,8 +173,27 @@ describe('GroupAddMembersSheet', () => {
                         { scope: 'API', name: 'OWNER' },
                         { scope: 'API_PRODUCT', name: 'USER' },
                         { scope: 'APPLICATION', name: 'USER' },
+                        { scope: 'INTEGRATION', name: 'USER' },
+                        { scope: 'CLUSTER', name: 'USER' },
                     ],
                 },
+            ]);
+        });
+
+        it('always defaults Integration/Cluster to USER — classic hardcodes these regardless of group config', () => {
+            const { onSubmit } = renderSheet();
+
+            fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value: 'an' } });
+            fireEvent.click(screen.getByText('Anna Schmidt'));
+            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                expect.objectContaining({
+                    roles: expect.arrayContaining([
+                        { scope: 'INTEGRATION', name: 'USER' },
+                        { scope: 'CLUSTER', name: 'USER' },
+                    ]),
+                }),
             ]);
         });
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
@@ -128,7 +128,13 @@ export function GroupAddMembersSheet({
     );
 
     function toggle(user: SearchableUser) {
-        setSelected(prev => (prev.some(u => isSameUser(u, user)) ? prev.filter(u => !isSameUser(u, user)) : [...prev, user]));
+        setSelected(prev => {
+            const isAlreadySelected = prev.some(u => isSameUser(u, user));
+            if (isAlreadySelected) {
+                return prev.filter(u => !isSameUser(u, user));
+            }
+            return [...prev, user];
+        });
     }
 
     function handleClose() {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
@@ -42,6 +42,10 @@ import { searchUsers } from '../services/groups';
 import type { GroupMember, GroupMembershipPayload, GroupMembershipRole, GroupRole, SearchableUser } from '../types/group';
 import { groupKeys } from '../utils/queryKeys';
 
+// Radix Select's controlled `value` can't be an empty string, so unset state is represented by this
+// sentinel internally — but classic's add-members-dialog.component.html has no "None" mat-option (every
+// default role control always starts from a real value, see initializeForm()), so it isn't rendered as a
+// selectable option below.
 const NO_ROLE_VALUE = '__none__';
 const PRIMARY_OWNER = 'PRIMARY_OWNER';
 
@@ -71,7 +75,6 @@ function RoleSelect({
                     <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                    <SelectItem value={NO_ROLE_VALUE}>None</SelectItem>
                     {roles.map(role => (
                         <SelectItem key={role.name} value={role.name} disabled={disabledOptionNames?.has(role.name)}>
                             {role.name}
@@ -127,8 +130,10 @@ export function GroupAddMembersSheet({
             setApiRole(groupRoles?.API ?? 'USER');
             setApiProductRole(groupRoles?.API_PRODUCT ?? 'USER');
             setApplicationRole(groupRoles?.APPLICATION ?? 'USER');
-            setIntegrationRole('');
-            setClusterRole('');
+            // Classic AddMembersDialogComponent hardcodes these two to 'USER' regardless of group config —
+            // groups don't have configurable defaults for Integration/Cluster (only API/API product/Application do).
+            setIntegrationRole('USER');
+            setClusterRole('USER');
         }
     }, [open, groupRoles]);
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
@@ -1,0 +1,280 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Checkbox,
+    Input,
+    Label,
+    ScrollArea,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+    Skeleton,
+} from '@gravitee/graphene-core';
+import { SearchIcon } from '@gravitee/graphene-core/icons';
+import { useQuery } from '@tanstack/react-query';
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
+
+import { GroupRoleSelect } from './GroupRoleSelect';
+import { MemberAvatar } from '../../../shared/components/MemberAvatar';
+import { searchUsers } from '../services/groups';
+import type { GroupMember, GroupMembershipPayload, GroupMembershipRole, GroupRole, SearchableUser } from '../types/group';
+import { PRIMARY_OWNER_ROLE } from '../types/group';
+import { isRoleLocked } from '../utils/groupPermissions';
+import { groupKeys } from '../utils/queryKeys';
+
+function isSameUser(a: SearchableUser, b: SearchableUser): boolean {
+    if (a.id !== null && a.id !== undefined && b.id !== null && b.id !== undefined) return a.id === b.id;
+    return a.reference === b.reference;
+}
+
+export function GroupAddMembersSheet({
+    open,
+    groupName,
+    groupRoles,
+    members,
+    apiRoles,
+    applicationRoles,
+    apiProductRoles,
+    integrationRoles,
+    clusterRoles,
+    lockApiRole,
+    lockApiProductRole,
+    lockApplicationRole,
+    canOverrideLocks,
+    maxInvitation,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    groupName: string;
+    groupRoles: Record<string, string> | undefined;
+    members: GroupMember[];
+    apiRoles: GroupRole[];
+    applicationRoles: GroupRole[];
+    apiProductRoles: GroupRole[];
+    integrationRoles: GroupRole[];
+    clusterRoles: GroupRole[];
+    lockApiRole: boolean;
+    lockApiProductRole: boolean;
+    lockApplicationRole: boolean;
+    canOverrideLocks: boolean;
+    maxInvitation: number | null;
+    onClose: () => void;
+    onSubmit: (memberships: GroupMembershipPayload[]) => void;
+    isSaving: boolean;
+}>) {
+    const [search, setSearch] = useState('');
+    const [selected, setSelected] = useState<SearchableUser[]>([]);
+    const [apiRole, setApiRole] = useState('');
+    const [apiProductRole, setApiProductRole] = useState('');
+    const [applicationRole, setApplicationRole] = useState('');
+    const [integrationRole, setIntegrationRole] = useState('');
+    const [clusterRole, setClusterRole] = useState('');
+
+    useEffect(() => {
+        if (open) {
+            setSearch('');
+            setSelected([]);
+            setApiRole(groupRoles?.API ?? 'USER');
+            setApiProductRole(groupRoles?.API_PRODUCT ?? 'USER');
+            setApplicationRole(groupRoles?.APPLICATION ?? 'USER');
+            setIntegrationRole('USER');
+            setClusterRole('USER');
+        }
+    }, [open, groupRoles]);
+
+    const apiPrimaryOwnerExists = members.some(m => m.roles?.API === PRIMARY_OWNER_ROLE);
+    const apiProductPrimaryOwnerExists = members.some(m => m.roles?.API_PRODUCT === PRIMARY_OWNER_ROLE);
+
+    const apiRoleDisabled = isRoleLocked(lockApiRole, canOverrideLocks);
+    const apiProductRoleDisabled = isRoleLocked(lockApiProductRole, canOverrideLocks);
+    const applicationRoleDisabled = isRoleLocked(lockApplicationRole, canOverrideLocks);
+    const integrationRoleDisabled = !canOverrideLocks;
+    const clusterRoleDisabled = !canOverrideLocks;
+
+    const invitationLimitReached = typeof maxInvitation === 'number' && maxInvitation <= members.length + selected.length;
+
+    const deferredQuery = useDeferredValue(search);
+    const { data: results, isFetching } = useQuery({
+        queryKey: groupKeys.userSearch(deferredQuery),
+        queryFn: () => searchUsers(deferredQuery),
+        enabled: deferredQuery.trim().length >= 2,
+        staleTime: 30_000,
+    });
+
+    const existingMemberIds = useMemo(() => members.map(m => m.id), [members]);
+    const candidates = useMemo(
+        () => (results ?? []).filter(u => !existingMemberIds.includes(u.id ?? u.reference)),
+        [results, existingMemberIds],
+    );
+
+    function toggle(user: SearchableUser) {
+        setSelected(prev => (prev.some(u => isSameUser(u, user)) ? prev.filter(u => !isSameUser(u, user)) : [...prev, user]));
+    }
+
+    function handleClose() {
+        onClose();
+    }
+
+    function buildRoles(): GroupMembershipRole[] {
+        const roles: GroupMembershipRole[] = [];
+        if (apiRole) roles.push({ scope: 'API', name: apiRole });
+        if (apiProductRole) roles.push({ scope: 'API_PRODUCT', name: apiProductRole });
+        if (applicationRole) roles.push({ scope: 'APPLICATION', name: applicationRole });
+        if (integrationRole) roles.push({ scope: 'INTEGRATION', name: integrationRole });
+        if (clusterRole) roles.push({ scope: 'CLUSTER', name: clusterRole });
+        return roles;
+    }
+
+    function handleSubmit() {
+        const roles = buildRoles();
+        onSubmit(selected.map(user => ({ id: user.id ?? user.reference, reference: user.reference, roles })));
+    }
+
+    const canSubmit = selected.length > 0;
+    const submitLabel = selected.length > 1 ? `Add ${selected.length} members` : 'Add member';
+
+    return (
+        <Sheet open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>Add members</SheetTitle>
+                    <SheetDescription>Search platform users and assign roles for membership in {groupName}.</SheetDescription>
+                </SheetHeader>
+
+                <ScrollArea className="min-h-0 flex-1">
+                    <div className="space-y-6 px-4 pb-4">
+                        <div className="space-y-3">
+                            <Label className="text-sm font-medium">Default roles for selected users</Label>
+                            <div className="grid grid-cols-2 gap-4">
+                                <GroupRoleSelect
+                                    label="API"
+                                    roles={apiRoles}
+                                    value={apiRole}
+                                    onChange={setApiRole}
+                                    disabled={apiRoleDisabled}
+                                    disabledOptionNames={apiPrimaryOwnerExists ? new Set([PRIMARY_OWNER_ROLE]) : undefined}
+                                />
+                                <GroupRoleSelect
+                                    label="API product"
+                                    roles={apiProductRoles}
+                                    value={apiProductRole}
+                                    onChange={setApiProductRole}
+                                    disabled={apiProductRoleDisabled}
+                                    disabledOptionNames={apiProductPrimaryOwnerExists ? new Set([PRIMARY_OWNER_ROLE]) : undefined}
+                                />
+                                <GroupRoleSelect
+                                    label="Application"
+                                    roles={applicationRoles}
+                                    value={applicationRole}
+                                    onChange={setApplicationRole}
+                                    disabled={applicationRoleDisabled}
+                                />
+                                <GroupRoleSelect
+                                    label="Integration"
+                                    roles={integrationRoles}
+                                    value={integrationRole}
+                                    onChange={setIntegrationRole}
+                                    disabled={integrationRoleDisabled}
+                                />
+                                <GroupRoleSelect
+                                    label="Cluster"
+                                    roles={clusterRoles}
+                                    value={clusterRole}
+                                    onChange={setClusterRole}
+                                    disabled={clusterRoleDisabled}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label className="text-sm font-medium">Search users</Label>
+                            <div className="relative">
+                                <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
+                                <Input
+                                    className="pl-10"
+                                    placeholder="Search by name or email…"
+                                    value={search}
+                                    onChange={e => setSearch(e.target.value)}
+                                    disabled={invitationLimitReached}
+                                />
+                            </div>
+
+                            {invitationLimitReached ? (
+                                <p className="px-1 py-2 text-sm text-muted-foreground">
+                                    This group has reached its maximum number of members.
+                                </p>
+                            ) : deferredQuery.trim().length < 2 ? (
+                                <p className="px-1 py-2 text-sm text-muted-foreground">Type at least 2 characters to search for users.</p>
+                            ) : isFetching || search !== deferredQuery ? (
+                                <div className="space-y-2 p-1">
+                                    <Skeleton className="h-10 rounded" />
+                                    <Skeleton className="h-10 rounded" />
+                                </div>
+                            ) : candidates.length === 0 ? (
+                                <p className="px-1 py-2 text-sm text-muted-foreground">No users found.</p>
+                            ) : (
+                                <div className="rounded-lg border">
+                                    {candidates.map(user => {
+                                        const isChecked = selected.some(u => isSameUser(u, user));
+                                        const inputId = `add-member-${user.id ?? user.reference}`;
+                                        return (
+                                            <label
+                                                key={user.id ?? user.reference}
+                                                htmlFor={inputId}
+                                                className="flex items-center gap-3 border-b px-3 py-2.5 last:border-b-0 hover:bg-muted/50 cursor-pointer"
+                                            >
+                                                <Checkbox id={inputId} checked={isChecked} onCheckedChange={() => toggle(user)} />
+                                                <MemberAvatar name={user.displayName} />
+                                                <div className="min-w-0 flex-1">
+                                                    <p className="text-sm font-medium truncate">{user.displayName}</p>
+                                                    {user.email ? (
+                                                        <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+                                                    ) : null}
+                                                </div>
+                                            </label>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+
+                        {selected.length > 0 && (
+                            <p className="text-xs text-muted-foreground">
+                                {selected.length} user{selected.length !== 1 ? 's' : ''} selected
+                            </p>
+                        )}
+                    </div>
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-row justify-end border-t">
+                    <Button type="button" variant="outline" onClick={handleClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={handleSubmit} disabled={!canSubmit || isSaving}>
+                        {isSaving ? 'Adding…' : submitLabel}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
@@ -1,0 +1,275 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Checkbox,
+    Input,
+    Label,
+    ScrollArea,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+    Skeleton,
+} from '@gravitee/graphene-core';
+import { SearchIcon } from '@gravitee/graphene-core/icons';
+import { useQuery } from '@tanstack/react-query';
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
+
+import { MemberAvatar } from './MemberAvatar';
+import { searchUsers } from '../services/groups';
+import type { GroupMember, GroupMembershipPayload, GroupMembershipRole, GroupRole, SearchableUser } from '../types/group';
+import { groupKeys } from '../utils/queryKeys';
+
+const NO_ROLE_VALUE = '__none__';
+const PRIMARY_OWNER = 'PRIMARY_OWNER';
+
+function isSameUser(a: SearchableUser, b: SearchableUser): boolean {
+    if (a.id !== null && a.id !== undefined && b.id !== null && b.id !== undefined) return a.id === b.id;
+    return a.reference === b.reference;
+}
+
+function RoleSelect({
+    label,
+    roles,
+    value,
+    onChange,
+    disabledOptionNames,
+}: Readonly<{
+    label: string;
+    roles: GroupRole[];
+    value: string;
+    onChange: (value: string) => void;
+    disabledOptionNames?: Set<string>;
+}>) {
+    return (
+        <div className="space-y-1.5">
+            <Label className="text-sm text-muted-foreground">{label}</Label>
+            <Select value={value || NO_ROLE_VALUE} onValueChange={v => onChange(v === NO_ROLE_VALUE ? '' : v)}>
+                <SelectTrigger className="w-full">
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value={NO_ROLE_VALUE}>None</SelectItem>
+                    {roles.map(role => (
+                        <SelectItem key={role.name} value={role.name} disabled={disabledOptionNames?.has(role.name)}>
+                            {role.name}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+        </div>
+    );
+}
+
+export function GroupAddMembersSheet({
+    open,
+    groupName,
+    members,
+    apiRoles,
+    applicationRoles,
+    apiProductRoles,
+    integrationRoles,
+    clusterRoles,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    groupName: string;
+    members: GroupMember[];
+    apiRoles: GroupRole[];
+    applicationRoles: GroupRole[];
+    apiProductRoles: GroupRole[];
+    integrationRoles: GroupRole[];
+    clusterRoles: GroupRole[];
+    onClose: () => void;
+    onSubmit: (memberships: GroupMembershipPayload[]) => void;
+    isSaving: boolean;
+}>) {
+    const [search, setSearch] = useState('');
+    const [selected, setSelected] = useState<SearchableUser[]>([]);
+    const [apiRole, setApiRole] = useState('');
+    const [apiProductRole, setApiProductRole] = useState('');
+    const [applicationRole, setApplicationRole] = useState('');
+    const [integrationRole, setIntegrationRole] = useState('');
+    const [clusterRole, setClusterRole] = useState('');
+
+    useEffect(() => {
+        if (!open) {
+            setSearch('');
+            setSelected([]);
+            setApiRole('');
+            setApiProductRole('');
+            setApplicationRole('');
+            setIntegrationRole('');
+            setClusterRole('');
+        }
+    }, [open]);
+
+    // A scope can only have one primary owner — if one already exists, new members can't be granted it
+    // here (mirrors classic AddMembersDialogComponent's isPrimaryOwnerDisabled/isApiProductPrimaryOwnerDisabled).
+    const apiPrimaryOwnerExists = members.some(m => m.roles?.API === PRIMARY_OWNER);
+    const apiProductPrimaryOwnerExists = members.some(m => m.roles?.API_PRODUCT === PRIMARY_OWNER);
+
+    const deferredQuery = useDeferredValue(search);
+    const { data: results, isFetching } = useQuery({
+        queryKey: groupKeys.userSearch(deferredQuery),
+        queryFn: () => searchUsers(deferredQuery),
+        enabled: deferredQuery.trim().length >= 2,
+        staleTime: 30_000,
+    });
+
+    const existingMemberIds = useMemo(() => members.map(m => m.id), [members]);
+    const candidates = useMemo(
+        () => (results ?? []).filter(u => !existingMemberIds.includes(u.id ?? u.reference)),
+        [results, existingMemberIds],
+    );
+
+    function toggle(user: SearchableUser) {
+        setSelected(prev => (prev.some(u => isSameUser(u, user)) ? prev.filter(u => !isSameUser(u, user)) : [...prev, user]));
+    }
+
+    function handleClose() {
+        onClose();
+    }
+
+    function buildRoles(): GroupMembershipRole[] {
+        const roles: GroupMembershipRole[] = [];
+        if (apiRole) roles.push({ scope: 'API', name: apiRole });
+        if (apiProductRole) roles.push({ scope: 'API_PRODUCT', name: apiProductRole });
+        if (applicationRole) roles.push({ scope: 'APPLICATION', name: applicationRole });
+        if (integrationRole) roles.push({ scope: 'INTEGRATION', name: integrationRole });
+        if (clusterRole) roles.push({ scope: 'CLUSTER', name: clusterRole });
+        return roles;
+    }
+
+    function handleSubmit() {
+        const roles = buildRoles();
+        onSubmit(selected.map(user => ({ id: user.id ?? user.reference, reference: user.reference, roles })));
+    }
+
+    const canSubmit = selected.length > 0;
+    const submitLabel = selected.length > 1 ? `Add ${selected.length} members` : 'Add member';
+
+    return (
+        <Sheet open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>Add members</SheetTitle>
+                    <SheetDescription>Search platform users and assign roles for membership in {groupName}.</SheetDescription>
+                </SheetHeader>
+
+                <ScrollArea className="min-h-0 flex-1">
+                    <div className="space-y-6 px-4 pb-4">
+                        <div className="space-y-3">
+                            <Label className="text-sm font-medium">Default roles for selected users</Label>
+                            <div className="grid grid-cols-2 gap-4">
+                                <RoleSelect
+                                    label="API"
+                                    roles={apiRoles}
+                                    value={apiRole}
+                                    onChange={setApiRole}
+                                    disabledOptionNames={apiPrimaryOwnerExists ? new Set([PRIMARY_OWNER]) : undefined}
+                                />
+                                <RoleSelect
+                                    label="API product"
+                                    roles={apiProductRoles}
+                                    value={apiProductRole}
+                                    onChange={setApiProductRole}
+                                    disabledOptionNames={apiProductPrimaryOwnerExists ? new Set([PRIMARY_OWNER]) : undefined}
+                                />
+                                <RoleSelect label="Application" roles={applicationRoles} value={applicationRole} onChange={setApplicationRole} />
+                                <RoleSelect label="Integration" roles={integrationRoles} value={integrationRole} onChange={setIntegrationRole} />
+                                <RoleSelect label="Cluster" roles={clusterRoles} value={clusterRole} onChange={setClusterRole} />
+                            </div>
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label className="text-sm font-medium">Search users</Label>
+                            <div className="relative">
+                                <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
+                                <Input
+                                    className="pl-10"
+                                    placeholder="Search by name or email…"
+                                    value={search}
+                                    onChange={e => setSearch(e.target.value)}
+                                />
+                            </div>
+
+                            {deferredQuery.trim().length < 2 ? (
+                                <p className="px-1 py-2 text-sm text-muted-foreground">Type at least 2 characters to search for users.</p>
+                            ) : isFetching || search !== deferredQuery ? (
+                                <div className="space-y-2 p-1">
+                                    <Skeleton className="h-10 rounded" />
+                                    <Skeleton className="h-10 rounded" />
+                                </div>
+                            ) : candidates.length === 0 ? (
+                                <p className="px-1 py-2 text-sm text-muted-foreground">No users found.</p>
+                            ) : (
+                                <div className="rounded-lg border">
+                                    {candidates.map(user => {
+                                        const isChecked = selected.some(u => isSameUser(u, user));
+                                        const inputId = `add-member-${user.id ?? user.reference}`;
+                                        return (
+                                            <label
+                                                key={user.id ?? user.reference}
+                                                htmlFor={inputId}
+                                                className="flex items-center gap-3 border-b px-3 py-2.5 last:border-b-0 hover:bg-muted/50 cursor-pointer"
+                                            >
+                                                <Checkbox id={inputId} checked={isChecked} onCheckedChange={() => toggle(user)} />
+                                                <MemberAvatar name={user.displayName} />
+                                                <div className="min-w-0 flex-1">
+                                                    <p className="text-sm font-medium truncate">{user.displayName}</p>
+                                                    {user.email ? (
+                                                        <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+                                                    ) : null}
+                                                </div>
+                                            </label>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+
+                        {selected.length > 0 && (
+                            <p className="text-xs text-muted-foreground">
+                                {selected.length} user{selected.length !== 1 ? 's' : ''} selected
+                            </p>
+                        )}
+                    </div>
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-row justify-end border-t">
+                    <Button type="button" variant="outline" onClick={handleClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={handleSubmit} disabled={!canSubmit || isSaving}>
+                        {isSaving ? 'Adding…' : submitLabel}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
@@ -209,8 +209,18 @@ export function GroupAddMembersSheet({
                                     onChange={setApiProductRole}
                                     disabledOptionNames={apiProductPrimaryOwnerExists ? new Set([PRIMARY_OWNER]) : undefined}
                                 />
-                                <RoleSelect label="Application" roles={applicationRoles} value={applicationRole} onChange={setApplicationRole} />
-                                <RoleSelect label="Integration" roles={integrationRoles} value={integrationRole} onChange={setIntegrationRole} />
+                                <RoleSelect
+                                    label="Application"
+                                    roles={applicationRoles}
+                                    value={applicationRole}
+                                    onChange={setApplicationRole}
+                                />
+                                <RoleSelect
+                                    label="Integration"
+                                    roles={integrationRoles}
+                                    value={integrationRole}
+                                    onChange={setIntegrationRole}
+                                />
                                 <RoleSelect label="Cluster" roles={clusterRoles} value={clusterRole} onChange={setClusterRole} />
                             </div>
                         </div>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
@@ -86,6 +86,7 @@ function RoleSelect({
 export function GroupAddMembersSheet({
     open,
     groupName,
+    groupRoles,
     members,
     apiRoles,
     applicationRoles,
@@ -98,6 +99,9 @@ export function GroupAddMembersSheet({
 }: Readonly<{
     open: boolean;
     groupName: string;
+    /** The group's own configured default roles (`GroupEntity.roles`) — pre-fills API/API product/Application
+     *  below, mirroring classic AddMembersDialogComponent's `group.roles['API'] ?? 'USER'` fallback. */
+    groupRoles: Record<string, string> | undefined;
     members: GroupMember[];
     apiRoles: GroupRole[];
     applicationRoles: GroupRole[];
@@ -117,16 +121,16 @@ export function GroupAddMembersSheet({
     const [clusterRole, setClusterRole] = useState('');
 
     useEffect(() => {
-        if (!open) {
+        if (open) {
             setSearch('');
             setSelected([]);
-            setApiRole('');
-            setApiProductRole('');
-            setApplicationRole('');
+            setApiRole(groupRoles?.API ?? 'USER');
+            setApiProductRole(groupRoles?.API_PRODUCT ?? 'USER');
+            setApplicationRole(groupRoles?.APPLICATION ?? 'USER');
             setIntegrationRole('');
             setClusterRole('');
         }
-    }, [open]);
+    }, [open, groupRoles]);
 
     // A scope can only have one primary owner — if one already exists, new members can't be granted it
     // here (mirrors classic AddMembersDialogComponent's isPrimaryOwnerDisabled/isApiProductPrimaryOwnerDisabled).

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
@@ -1,0 +1,423 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { GroupEditMemberSheet } from './GroupEditMemberSheet';
+import type { GroupMember } from '../types/group';
+
+beforeAll(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+});
+
+const MEMBER: GroupMember = {
+    id: 'user-1',
+    displayName: 'Anna Schmidt',
+    roles: { API: 'OWNER', APPLICATION: 'USER' },
+};
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupEditMemberSheet>> = {}) {
+    const onClose = jest.fn();
+    const onSubmit = jest.fn();
+    render(
+        <GroupEditMemberSheet
+            open
+            groupName="API Team"
+            member={MEMBER}
+            members={[MEMBER]}
+            apiRoles={[
+                { name: 'OWNER', scope: 'API' },
+                { name: 'PRIMARY_OWNER', scope: 'API', system: true },
+            ]}
+            applicationRoles={[{ name: 'USER', scope: 'APPLICATION' }]}
+            apiProductRoles={[{ name: 'USER', scope: 'API_PRODUCT' }]}
+            integrationRoles={[{ name: 'USER', scope: 'INTEGRATION' }]}
+            clusterRoles={[{ name: 'USER', scope: 'CLUSTER' }]}
+            lockApiRole={false}
+            lockApiProductRole={false}
+            lockApplicationRole={false}
+            canOverrideLocks
+            groupAllowsGroupAdmin
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={false}
+            {...overrides}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('GroupEditMemberSheet', () => {
+    it('does not render sheet content when closed', () => {
+        renderSheet({ open: false });
+        expect(screen.queryByRole('heading', { name: 'Edit roles' })).toBeNull();
+    });
+
+    it('renders nothing when there is no member', () => {
+        const { container } = render(
+            <GroupEditMemberSheet
+                open
+                groupName="API Team"
+                member={undefined}
+                members={[]}
+                apiRoles={[]}
+                applicationRoles={[]}
+                apiProductRoles={[]}
+                integrationRoles={[]}
+                clusterRoles={[]}
+                groupAllowsGroupAdmin
+                onClose={jest.fn()}
+                onSubmit={jest.fn()}
+                isSaving={false}
+            />,
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('shows the member name in the description', () => {
+        renderSheet();
+        expect(screen.getByText(/Update Anna Schmidt.?s roles in API Team\./)).not.toBeNull();
+    });
+
+    it('pre-fills the Group admin checkbox from the member’s current GROUP role', () => {
+        renderSheet({ member: { ...MEMBER, roles: { ...MEMBER.roles, GROUP: 'ADMIN' } } });
+        expect(screen.getByRole('checkbox', { name: /Group admin/i }).getAttribute('data-state')).toBe('checked');
+    });
+
+    it('disables the Group admin checkbox when the group does not allow it', () => {
+        renderSheet({ groupAllowsGroupAdmin: false });
+        expect(screen.getByRole('checkbox', { name: /Group admin/i })).toHaveProperty('disabled', true);
+        expect(screen.getByText(/Enable "Allow adding members via user search"/)).not.toBeNull();
+    });
+
+    it('leaves the API role select enabled when the member is already the primary owner', () => {
+        renderSheet({ member: { ...MEMBER, roles: { ...MEMBER.roles, API: 'PRIMARY_OWNER' } } });
+        expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', false);
+    });
+
+    it('has no "None" role option — classic\'s edit-member-dialog has no such mat-option', () => {
+        renderSheet();
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.queryByRole('option', { name: 'None' })).toBeNull();
+    });
+
+    it('leaves the PRIMARY_OWNER option selectable even when another member already holds it', () => {
+        const otherOwner: GroupMember = { id: 'user-2', displayName: 'Ravi Patel', roles: { API: 'PRIMARY_OWNER' } };
+        renderSheet({ members: [MEMBER, otherOwner] });
+
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    it('submits the current roles plus GROUP/ADMIN only when Group admin is checked', () => {
+        const { onSubmit } = renderSheet();
+
+        fireEvent.click(screen.getByRole('checkbox', { name: /Group admin/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(onSubmit).toHaveBeenCalledWith([
+            {
+                id: 'user-1',
+                roles: [
+                    { scope: 'API', name: 'OWNER' },
+                    { scope: 'APPLICATION', name: 'USER' },
+                    { scope: 'GROUP', name: 'ADMIN' },
+                ],
+            },
+        ]);
+    });
+
+    it('omits the GROUP scope entirely when Group admin is left unchecked', () => {
+        const { onSubmit } = renderSheet();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(onSubmit).toHaveBeenCalledWith([
+            {
+                id: 'user-1',
+                roles: [
+                    { scope: 'API', name: 'OWNER' },
+                    { scope: 'APPLICATION', name: 'USER' },
+                ],
+            },
+        ]);
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    describe('primary ownership transfer', () => {
+        const otherOwner: GroupMember = {
+            id: 'user-2',
+            displayName: 'Ravi Patel',
+            roles: { API: 'PRIMARY_OWNER', APPLICATION: 'USER' },
+        };
+
+        it('shows the transfer message and submits a demotion before the promotion', () => {
+            const { onSubmit } = renderSheet({ members: [MEMBER, otherOwner] });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
+
+            expect(
+                screen.getByText(
+                    'Ravi Patel is the API primary owner. The API primary ownership will be transferred to Anna Schmidt and Ravi Patel will be updated as owner.',
+                ),
+            ).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-2',
+                    roles: [
+                        { scope: 'API', name: 'OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+                {
+                    id: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'PRIMARY_OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('merges into a single demotion when the same previous owner holds both API and API product primary ownership', () => {
+            const bothOwner: GroupMember = {
+                id: 'user-2',
+                displayName: 'Ravi Patel',
+                roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'USER' },
+            };
+            const { onSubmit } = renderSheet({
+                member: { ...MEMBER, roles: { ...MEMBER.roles, API_PRODUCT: 'USER' } },
+                members: [MEMBER, bothOwner],
+                apiProductRoles: [
+                    { name: 'USER', scope: 'API_PRODUCT' },
+                    { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT', system: true },
+                ],
+            });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
+            fireEvent.click(screen.getAllByRole('combobox')[1]);
+            fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
+
+            expect(
+                screen.getByText(
+                    'Ravi Patel is the API and API Product primary owner. Primary ownership will be transferred to Anna Schmidt and Ravi Patel will be updated as owner.',
+                ),
+            ).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-2',
+                    roles: [
+                        { scope: 'API', name: 'OWNER' },
+                        { scope: 'API_PRODUCT', name: 'OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+                {
+                    id: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'PRIMARY_OWNER' },
+                        { scope: 'API_PRODUCT', name: 'PRIMARY_OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('does not show a transfer message when the member already owns that scope', () => {
+            renderSheet({ member: { ...MEMBER, roles: { ...MEMBER.roles, API: 'PRIMARY_OWNER' } }, members: [MEMBER] });
+            expect(screen.queryByText(/will be transferred/)).toBeNull();
+        });
+    });
+
+    describe('primary ownership downgrade', () => {
+        const primaryOwnerMember: GroupMember = {
+            id: 'user-1',
+            displayName: 'Anna Schmidt',
+            roles: { API: 'PRIMARY_OWNER', APPLICATION: 'USER' },
+        };
+        const otherMember: GroupMember = { id: 'user-2', displayName: 'Ravi Patel', roles: { API: 'OWNER' } };
+
+        it('shows a successor search field only once the role changes away from PRIMARY_OWNER', () => {
+            renderSheet({ member: primaryOwnerMember, members: [primaryOwnerMember, otherMember] });
+            expect(screen.queryByLabelText('Search members')).toBeNull();
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'OWNER' }));
+
+            expect(screen.getByLabelText('Search members')).not.toBeNull();
+        });
+
+        it('disables Save until a successor is picked', () => {
+            renderSheet({ member: primaryOwnerMember, members: [primaryOwnerMember, otherMember] });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'OWNER' }));
+
+            expect(screen.getByRole('button', { name: 'Save' })).toHaveProperty('disabled', true);
+        });
+
+        it('excludes the member being edited from the successor list', async () => {
+            const user = userEvent.setup();
+            renderSheet({ member: primaryOwnerMember, members: [primaryOwnerMember, otherMember] });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'OWNER' }));
+            await user.click(screen.getByLabelText('Search members'));
+
+            expect(screen.queryByRole('option', { name: 'Anna Schmidt' })).toBeNull();
+            expect(screen.getByRole('option', { name: 'Ravi Patel' })).not.toBeNull();
+        });
+
+        it('shows the transfer message and enables Save once a successor is picked', async () => {
+            const user = userEvent.setup();
+            renderSheet({ member: primaryOwnerMember, members: [primaryOwnerMember, otherMember] });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'OWNER' }));
+            await user.click(screen.getByLabelText('Search members'));
+            await user.click(screen.getByRole('option', { name: 'Ravi Patel' }));
+
+            expect(
+                screen.getByText(
+                    'Anna Schmidt is the API primary owner. The API primary ownership will be transferred to Ravi Patel and Anna Schmidt will be updated as owner.',
+                ),
+            ).not.toBeNull();
+            expect(screen.getByRole('button', { name: 'Save' })).toHaveProperty('disabled', false);
+        });
+
+        it('submits the promoted successor before the demoted member', async () => {
+            const user = userEvent.setup();
+            const { onSubmit } = renderSheet({ member: primaryOwnerMember, members: [primaryOwnerMember, otherMember] });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'OWNER' }));
+            await user.click(screen.getByLabelText('Search members'));
+            await user.click(screen.getByRole('option', { name: 'Ravi Patel' }));
+
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                { id: 'user-2', roles: [{ scope: 'API', name: 'PRIMARY_OWNER' }] },
+                {
+                    id: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('promotes a single successor for both scopes when API and API product are both downgraded together', async () => {
+            const user = userEvent.setup();
+            const bothPrimaryOwner: GroupMember = {
+                id: 'user-1',
+                displayName: 'Anna Schmidt',
+                roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'USER' },
+            };
+            const { onSubmit } = renderSheet({
+                member: bothPrimaryOwner,
+                members: [bothPrimaryOwner, otherMember],
+                apiProductRoles: [
+                    { name: 'OWNER', scope: 'API_PRODUCT' },
+                    { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT', system: true },
+                ],
+            });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'OWNER' }));
+            fireEvent.click(screen.getAllByRole('combobox')[1]);
+            fireEvent.click(screen.getByRole('option', { name: 'OWNER' }));
+            await user.click(screen.getByLabelText('Search members'));
+            await user.click(screen.getByRole('option', { name: 'Ravi Patel' }));
+
+            expect(
+                screen.getByText(
+                    'Anna Schmidt is the API and API Product primary owner. Primary ownership will be transferred to Ravi Patel and Anna Schmidt will be updated as owner.',
+                ),
+            ).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-2',
+                    roles: [
+                        { scope: 'API', name: 'PRIMARY_OWNER' },
+                        { scope: 'API_PRODUCT', name: 'PRIMARY_OWNER' },
+                    ],
+                },
+                {
+                    id: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'OWNER' },
+                        { scope: 'API_PRODUCT', name: 'OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('re-hides the successor field and clears the pick if the role is changed back to PRIMARY_OWNER', async () => {
+            const user = userEvent.setup();
+            renderSheet({ member: primaryOwnerMember, members: [primaryOwnerMember, otherMember] });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'OWNER' }));
+            await user.click(screen.getByLabelText('Search members'));
+            await user.click(screen.getByRole('option', { name: 'Ravi Patel' }));
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
+
+            expect(screen.queryByLabelText('Search members')).toBeNull();
+            expect(screen.getByRole('button', { name: 'Save' })).toHaveProperty('disabled', false);
+        });
+    });
+
+    describe('lock flags', () => {
+        it('disables a locked role select without canOverrideLocks', () => {
+            renderSheet({ lockApiRole: true, canOverrideLocks: false });
+            expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', true);
+        });
+
+        it('leaves a locked role select enabled with canOverrideLocks', () => {
+            renderSheet({ lockApiRole: true, canOverrideLocks: true });
+            expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', false);
+        });
+
+        it('disables Integration and Cluster without canOverrideLocks, regardless of lock flags', () => {
+            renderSheet({ canOverrideLocks: false });
+            const comboboxes = screen.getAllByRole('combobox');
+            expect(comboboxes[3]).toHaveProperty('disabled', true);
+            expect(comboboxes[4]).toHaveProperty('disabled', true);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
@@ -176,25 +176,27 @@ describe('GroupEditMemberSheet', () => {
             ).not.toBeNull();
         });
 
-        it('submits both the promoted member and the demoted previous owner, preserving the latter’s other roles', () => {
+        it('submits the demoted previous owner *before* the promoted member, preserving the former’s other roles', () => {
             const { onSubmit } = renderSheet({ members: [MEMBER, otherOwner] });
 
             fireEvent.click(screen.getAllByRole('combobox')[0]);
             fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
             fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
+            // Order matters: the backend rejects a second PRIMARY_OWNER for a scope still held by someone
+            // else, so the demotion must be submitted first (mirrors classic's submit() comment).
             expect(onSubmit).toHaveBeenCalledWith([
-                {
-                    id: 'user-1',
-                    roles: [
-                        { scope: 'API', name: 'PRIMARY_OWNER' },
-                        { scope: 'APPLICATION', name: 'USER' },
-                    ],
-                },
                 {
                     id: 'user-2',
                     roles: [
                         { scope: 'API', name: 'OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+                {
+                    id: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'PRIMARY_OWNER' },
                         { scope: 'APPLICATION', name: 'USER' },
                     ],
                 },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
@@ -47,8 +47,6 @@ function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupEditMem
             integrationRoles={[{ name: 'USER', scope: 'INTEGRATION' }]}
             clusterRoles={[{ name: 'USER', scope: 'CLUSTER' }]}
             groupAllowsGroupAdmin
-            groupHasApis={false}
-            groupHasApiProducts={false}
             onClose={onClose}
             onSubmit={onSubmit}
             isSaving={false}
@@ -77,8 +75,6 @@ describe('GroupEditMemberSheet', () => {
                 integrationRoles={[]}
                 clusterRoles={[]}
                 groupAllowsGroupAdmin
-                groupHasApis={false}
-                groupHasApiProducts={false}
                 onClose={jest.fn()}
                 onSubmit={jest.fn()}
                 isSaving={false}
@@ -159,29 +155,29 @@ describe('GroupEditMemberSheet', () => {
     });
 
     describe('primary ownership transfer', () => {
-        // Mirrors classic edit-member-dialog.component.ts: promoting a member to PRIMARY_OWNER while
-        // another member already holds it shows a transfer notice, and — when the backend allows it —
-        // also demotes the previous owner to OWNER in the same request, submitted first (classic's
-        // ordering: previous-owner demotion(s) → promoted member). The backend only allows clearing a
-        // member's PRIMARY_OWNER label for a scope the group has no associated APIs/API Products in
-        // (GroupMembersResource "prevent changing from PRIMARY_OWNER if group owns APIs/API products"
-        // guards → StillPrimaryOwnerException / StillApiProductPrimaryOwnerException), so groupHasApis /
-        // groupHasApiProducts gate whether that demotion is included at all.
+        // Mirrors classic edit-member-dialog.component.ts's submit()/buildUpgradeMessage() exactly:
+        // promoting a member to PRIMARY_OWNER while another member already holds it always demotes the
+        // previous owner to OWNER in the same request (submitted first — classic's ordering: previous-
+        // owner demotion(s) → promoted member), and the banner always claims the demotion will happen.
+        // Classic has no client-side check for whether the group currently owns APIs/API Products — it
+        // just always attempts this payload and lets the backend accept or reject it
+        // (StillPrimaryOwnerException / StillApiProductPrimaryOwnerException fire based purely on the
+        // group's actual associations, independent of this dialog's logic).
         const otherOwner: GroupMember = {
             id: 'user-2',
             displayName: 'Ravi Patel',
             roles: { API: 'PRIMARY_OWNER', APPLICATION: 'USER' },
         };
 
-        it('shows the full transfer message and submits a demotion first when the scope is safe to clear (group owns no APIs)', () => {
-            const { onSubmit } = renderSheet({ members: [MEMBER, otherOwner], groupHasApis: false });
+        it('shows the transfer message and submits a demotion before the promotion', () => {
+            const { onSubmit } = renderSheet({ members: [MEMBER, otherOwner] });
 
             fireEvent.click(screen.getAllByRole('combobox')[0]);
             fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
 
             expect(
                 screen.getByText(
-                    'Ravi Patel is currently the API primary owner. The API primary ownership will be transferred to Anna Schmidt and Ravi Patel will be updated as owner.',
+                    'Ravi Patel is the API primary owner. The API primary ownership will be transferred to Anna Schmidt and Ravi Patel will be updated as owner.',
                 ),
             ).not.toBeNull();
 
@@ -205,30 +201,7 @@ describe('GroupEditMemberSheet', () => {
             ]);
         });
 
-        it('shows the softer message and omits the demotion when the group still owns APIs', () => {
-            const { onSubmit } = renderSheet({ members: [MEMBER, otherOwner], groupHasApis: true });
-
-            fireEvent.click(screen.getAllByRole('combobox')[0]);
-            fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
-
-            expect(
-                screen.getByText('Ravi Patel is currently the API primary owner. Saving will transfer primary ownership to Anna Schmidt.'),
-            ).not.toBeNull();
-
-            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-            expect(onSubmit).toHaveBeenCalledWith([
-                {
-                    id: 'user-1',
-                    roles: [
-                        { scope: 'API', name: 'PRIMARY_OWNER' },
-                        { scope: 'APPLICATION', name: 'USER' },
-                    ],
-                },
-            ]);
-        });
-
-        it('demotes the previous owner for only the safe scope when they hold both API and API product primary ownership', () => {
+        it('merges into a single demotion when the same previous owner holds both API and API product primary ownership', () => {
             const bothOwner: GroupMember = {
                 id: 'user-2',
                 displayName: 'Ravi Patel',
@@ -241,21 +214,26 @@ describe('GroupEditMemberSheet', () => {
                     { name: 'USER', scope: 'API_PRODUCT' },
                     { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT', system: true },
                 ],
-                groupHasApis: true,
-                groupHasApiProducts: false,
             });
 
             fireEvent.click(screen.getAllByRole('combobox')[0]);
             fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
             fireEvent.click(screen.getAllByRole('combobox')[1]);
             fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
+
+            expect(
+                screen.getByText(
+                    'Ravi Patel is the API and API Product primary owner. Primary ownership will be transferred to Anna Schmidt and Ravi Patel will be updated as owner.',
+                ),
+            ).not.toBeNull();
+
             fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
             expect(onSubmit).toHaveBeenCalledWith([
                 {
                     id: 'user-2',
                     roles: [
-                        { scope: 'API', name: 'PRIMARY_OWNER' },
+                        { scope: 'API', name: 'OWNER' },
                         { scope: 'API_PRODUCT', name: 'OWNER' },
                         { scope: 'APPLICATION', name: 'USER' },
                     ],

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
@@ -105,13 +105,13 @@ describe('GroupEditMemberSheet', () => {
         expect(screen.getByText(/Primary ownership can.t be transferred from here yet\./)).not.toBeNull();
     });
 
-    it('disables the PRIMARY_OWNER option when another member already holds it', () => {
+    it('leaves the PRIMARY_OWNER option selectable even when another member already holds it', () => {
         const otherOwner: GroupMember = { id: 'user-2', displayName: 'Ravi Patel', roles: { API: 'PRIMARY_OWNER' } };
         renderSheet({ members: [MEMBER, otherOwner] });
 
         fireEvent.click(screen.getAllByRole('combobox')[0]);
 
-        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).toBe('true');
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
     });
 
     it('submits the current roles plus GROUP/ADMIN only when Group admin is checked', () => {
@@ -120,14 +120,16 @@ describe('GroupEditMemberSheet', () => {
         fireEvent.click(screen.getByRole('checkbox', { name: /Group admin/i }));
         fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-        expect(onSubmit).toHaveBeenCalledWith({
-            id: 'user-1',
-            roles: [
-                { scope: 'API', name: 'OWNER' },
-                { scope: 'APPLICATION', name: 'USER' },
-                { scope: 'GROUP', name: 'ADMIN' },
-            ],
-        });
+        expect(onSubmit).toHaveBeenCalledWith([
+            {
+                id: 'user-1',
+                roles: [
+                    { scope: 'API', name: 'OWNER' },
+                    { scope: 'APPLICATION', name: 'USER' },
+                    { scope: 'GROUP', name: 'ADMIN' },
+                ],
+            },
+        ]);
     });
 
     it('omits the GROUP scope entirely when Group admin is left unchecked', () => {
@@ -135,18 +137,73 @@ describe('GroupEditMemberSheet', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-        expect(onSubmit).toHaveBeenCalledWith({
-            id: 'user-1',
-            roles: [
-                { scope: 'API', name: 'OWNER' },
-                { scope: 'APPLICATION', name: 'USER' },
-            ],
-        });
+        expect(onSubmit).toHaveBeenCalledWith([
+            {
+                id: 'user-1',
+                roles: [
+                    { scope: 'API', name: 'OWNER' },
+                    { scope: 'APPLICATION', name: 'USER' },
+                ],
+            },
+        ]);
     });
 
     it('calls onClose when Cancel is clicked', () => {
         const { onClose } = renderSheet();
         fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
         expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    describe('primary ownership transfer', () => {
+        // Mirrors classic edit-member-dialog.component.ts: promoting a member to PRIMARY_OWNER while
+        // another member already holds it shows a transfer notice and auto-demotes the previous owner.
+        const otherOwner: GroupMember = {
+            id: 'user-2',
+            displayName: 'Ravi Patel',
+            roles: { API: 'PRIMARY_OWNER', APPLICATION: 'USER' },
+        };
+
+        it('shows the transfer message once PRIMARY_OWNER is selected for a scope another member owns', () => {
+            renderSheet({ members: [MEMBER, otherOwner] });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
+
+            expect(
+                screen.getByText(
+                    'Ravi Patel is the API primary owner. The API primary ownership will be transferred to Anna Schmidt and Ravi Patel will be updated as owner.',
+                ),
+            ).not.toBeNull();
+        });
+
+        it('submits both the promoted member and the demoted previous owner, preserving the latter’s other roles', () => {
+            const { onSubmit } = renderSheet({ members: [MEMBER, otherOwner] });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'PRIMARY_OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+                {
+                    id: 'user-2',
+                    roles: [
+                        { scope: 'API', name: 'OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('does not show a transfer message when the member already owns that scope', () => {
+            renderSheet({ member: { ...MEMBER, roles: { ...MEMBER.roles, API: 'PRIMARY_OWNER' } }, members: [MEMBER] });
+            expect(screen.queryByText(/will be transferred/)).toBeNull();
+        });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupEditMemberSheet } from './GroupEditMemberSheet';
+import type { GroupMember } from '../types/group';
+
+// Radix Select scrolls the highlighted option into view — not implemented in jsdom.
+beforeAll(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+});
+
+const MEMBER: GroupMember = {
+    id: 'user-1',
+    displayName: 'Anna Schmidt',
+    roles: { API: 'OWNER', APPLICATION: 'USER' },
+};
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupEditMemberSheet>> = {}) {
+    const onClose = jest.fn();
+    const onSubmit = jest.fn();
+    render(
+        <GroupEditMemberSheet
+            open
+            groupName="API Team"
+            member={MEMBER}
+            members={[MEMBER]}
+            apiRoles={[
+                { name: 'OWNER', scope: 'API' },
+                { name: 'PRIMARY_OWNER', scope: 'API', system: true },
+            ]}
+            applicationRoles={[{ name: 'USER', scope: 'APPLICATION' }]}
+            apiProductRoles={[{ name: 'USER', scope: 'API_PRODUCT' }]}
+            integrationRoles={[{ name: 'USER', scope: 'INTEGRATION' }]}
+            clusterRoles={[{ name: 'USER', scope: 'CLUSTER' }]}
+            groupAllowsGroupAdmin
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={false}
+            {...overrides}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('GroupEditMemberSheet', () => {
+    it('does not render sheet content when closed', () => {
+        renderSheet({ open: false });
+        expect(screen.queryByRole('heading', { name: 'Edit roles' })).toBeNull();
+    });
+
+    it('renders nothing when there is no member', () => {
+        const { container } = render(
+            <GroupEditMemberSheet
+                open
+                groupName="API Team"
+                member={undefined}
+                members={[]}
+                apiRoles={[]}
+                applicationRoles={[]}
+                apiProductRoles={[]}
+                integrationRoles={[]}
+                clusterRoles={[]}
+                groupAllowsGroupAdmin
+                onClose={jest.fn()}
+                onSubmit={jest.fn()}
+                isSaving={false}
+            />,
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('shows the member name in the description', () => {
+        renderSheet();
+        expect(screen.getByText(/Update Anna Schmidt.?s roles in API Team\./)).not.toBeNull();
+    });
+
+    it('pre-fills the Group admin checkbox from the member’s current GROUP role', () => {
+        renderSheet({ member: { ...MEMBER, roles: { ...MEMBER.roles, GROUP: 'ADMIN' } } });
+        expect(screen.getByRole('checkbox', { name: /Group admin/i }).getAttribute('data-state')).toBe('checked');
+    });
+
+    it('disables the Group admin checkbox when the group does not allow it', () => {
+        renderSheet({ groupAllowsGroupAdmin: false });
+        expect(screen.getByRole('checkbox', { name: /Group admin/i })).toHaveProperty('disabled', true);
+        expect(screen.getByText(/Enable "Allow adding members via user search"/)).not.toBeNull();
+    });
+
+    it('locks the API role select when the member is already the primary owner', () => {
+        renderSheet({ member: { ...MEMBER, roles: { ...MEMBER.roles, API: 'PRIMARY_OWNER' } } });
+        expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', true);
+        expect(screen.getByText(/Primary ownership can.t be transferred from here yet\./)).not.toBeNull();
+    });
+
+    it('disables the PRIMARY_OWNER option when another member already holds it', () => {
+        const otherOwner: GroupMember = { id: 'user-2', displayName: 'Ravi Patel', roles: { API: 'PRIMARY_OWNER' } };
+        renderSheet({ members: [MEMBER, otherOwner] });
+
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('submits the current roles plus GROUP/ADMIN only when Group admin is checked', () => {
+        const { onSubmit } = renderSheet();
+
+        fireEvent.click(screen.getByRole('checkbox', { name: /Group admin/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            id: 'user-1',
+            roles: [
+                { scope: 'API', name: 'OWNER' },
+                { scope: 'APPLICATION', name: 'USER' },
+                { scope: 'GROUP', name: 'ADMIN' },
+            ],
+        });
+    });
+
+    it('omits the GROUP scope entirely when Group admin is left unchecked', () => {
+        const { onSubmit } = renderSheet();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            id: 'user-1',
+            roles: [
+                { scope: 'API', name: 'OWNER' },
+                { scope: 'APPLICATION', name: 'USER' },
+            ],
+        });
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
@@ -105,6 +105,12 @@ describe('GroupEditMemberSheet', () => {
         expect(screen.getByText(/Primary ownership can.t be transferred from here yet\./)).not.toBeNull();
     });
 
+    it('has no "None" role option — classic\'s edit-member-dialog has no such mat-option', () => {
+        renderSheet();
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.queryByRole('option', { name: 'None' })).toBeNull();
+    });
+
     it('leaves the PRIMARY_OWNER option selectable even when another member already holds it', () => {
         const otherOwner: GroupMember = { id: 'user-2', displayName: 'Ravi Patel', roles: { API: 'PRIMARY_OWNER' } };
         renderSheet({ members: [MEMBER, otherOwner] });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
@@ -47,6 +47,8 @@ function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupEditMem
             integrationRoles={[{ name: 'USER', scope: 'INTEGRATION' }]}
             clusterRoles={[{ name: 'USER', scope: 'CLUSTER' }]}
             groupAllowsGroupAdmin
+            groupHasApis={false}
+            groupHasApiProducts={false}
             onClose={onClose}
             onSubmit={onSubmit}
             isSaving={false}
@@ -75,6 +77,8 @@ describe('GroupEditMemberSheet', () => {
                 integrationRoles={[]}
                 clusterRoles={[]}
                 groupAllowsGroupAdmin
+                groupHasApis={false}
+                groupHasApiProducts={false}
                 onClose={jest.fn()}
                 onSubmit={jest.fn()}
                 isSaving={false}
@@ -155,21 +159,54 @@ describe('GroupEditMemberSheet', () => {
     });
 
     describe('primary ownership transfer', () => {
-        // Mirrors classic edit-member-dialog.component.ts's *intent* (promoting a member to PRIMARY_OWNER
-        // while another member already holds it shows a transfer notice), but NOT its payload shape: the
-        // backend rejects any request that explicitly demotes a member away from PRIMARY_OWNER while the
-        // group still owns APIs, even when a replacement is promoted in the same request
-        // (GroupMembersResource "prevent changing from PRIMARY_OWNER if group owns APIs" guard). So only
-        // the promoted member is submitted — the backend reassigns the group's real primary-owner pointer
-        // as a side effect, and the previous owner's own role label is left untouched.
+        // Mirrors classic edit-member-dialog.component.ts: promoting a member to PRIMARY_OWNER while
+        // another member already holds it shows a transfer notice, and — when the backend allows it —
+        // also demotes the previous owner to OWNER in the same request, submitted first (classic's
+        // ordering: previous-owner demotion(s) → promoted member). The backend only allows clearing a
+        // member's PRIMARY_OWNER label for a scope the group has no associated APIs/API Products in
+        // (GroupMembersResource "prevent changing from PRIMARY_OWNER if group owns APIs/API products"
+        // guards → StillPrimaryOwnerException / StillApiProductPrimaryOwnerException), so groupHasApis /
+        // groupHasApiProducts gate whether that demotion is included at all.
         const otherOwner: GroupMember = {
             id: 'user-2',
             displayName: 'Ravi Patel',
             roles: { API: 'PRIMARY_OWNER', APPLICATION: 'USER' },
         };
 
-        it('shows the transfer message once PRIMARY_OWNER is selected for a scope another member owns', () => {
-            renderSheet({ members: [MEMBER, otherOwner] });
+        it('shows the full transfer message and submits a demotion first when the scope is safe to clear (group owns no APIs)', () => {
+            const { onSubmit } = renderSheet({ members: [MEMBER, otherOwner], groupHasApis: false });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
+
+            expect(
+                screen.getByText(
+                    'Ravi Patel is currently the API primary owner. The API primary ownership will be transferred to Anna Schmidt and Ravi Patel will be updated as owner.',
+                ),
+            ).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-2',
+                    roles: [
+                        { scope: 'API', name: 'OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+                {
+                    id: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'PRIMARY_OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('shows the softer message and omits the demotion when the group still owns APIs', () => {
+            const { onSubmit } = renderSheet({ members: [MEMBER, otherOwner], groupHasApis: true });
 
             fireEvent.click(screen.getAllByRole('combobox')[0]);
             fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
@@ -177,13 +214,7 @@ describe('GroupEditMemberSheet', () => {
             expect(
                 screen.getByText('Ravi Patel is currently the API primary owner. Saving will transfer primary ownership to Anna Schmidt.'),
             ).not.toBeNull();
-        });
 
-        it('submits only the promoted member — the previous owner’s membership is left untouched', () => {
-            const { onSubmit } = renderSheet({ members: [MEMBER, otherOwner] });
-
-            fireEvent.click(screen.getAllByRole('combobox')[0]);
-            fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
             fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
             expect(onSubmit).toHaveBeenCalledWith([
@@ -191,6 +222,49 @@ describe('GroupEditMemberSheet', () => {
                     id: 'user-1',
                     roles: [
                         { scope: 'API', name: 'PRIMARY_OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('demotes the previous owner for only the safe scope when they hold both API and API product primary ownership', () => {
+            const bothOwner: GroupMember = {
+                id: 'user-2',
+                displayName: 'Ravi Patel',
+                roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'USER' },
+            };
+            const { onSubmit } = renderSheet({
+                member: { ...MEMBER, roles: { ...MEMBER.roles, API_PRODUCT: 'USER' } },
+                members: [MEMBER, bothOwner],
+                apiProductRoles: [
+                    { name: 'USER', scope: 'API_PRODUCT' },
+                    { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT', system: true },
+                ],
+                groupHasApis: true,
+                groupHasApiProducts: false,
+            });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
+            fireEvent.click(screen.getAllByRole('combobox')[1]);
+            fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-2',
+                    roles: [
+                        { scope: 'API', name: 'PRIMARY_OWNER' },
+                        { scope: 'API_PRODUCT', name: 'OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                    ],
+                },
+                {
+                    id: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'PRIMARY_OWNER' },
+                        { scope: 'API_PRODUCT', name: 'PRIMARY_OWNER' },
                         { scope: 'APPLICATION', name: 'USER' },
                     ],
                 },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.spec.tsx
@@ -155,8 +155,13 @@ describe('GroupEditMemberSheet', () => {
     });
 
     describe('primary ownership transfer', () => {
-        // Mirrors classic edit-member-dialog.component.ts: promoting a member to PRIMARY_OWNER while
-        // another member already holds it shows a transfer notice and auto-demotes the previous owner.
+        // Mirrors classic edit-member-dialog.component.ts's *intent* (promoting a member to PRIMARY_OWNER
+        // while another member already holds it shows a transfer notice), but NOT its payload shape: the
+        // backend rejects any request that explicitly demotes a member away from PRIMARY_OWNER while the
+        // group still owns APIs, even when a replacement is promoted in the same request
+        // (GroupMembersResource "prevent changing from PRIMARY_OWNER if group owns APIs" guard). So only
+        // the promoted member is submitted — the backend reassigns the group's real primary-owner pointer
+        // as a side effect, and the previous owner's own role label is left untouched.
         const otherOwner: GroupMember = {
             id: 'user-2',
             displayName: 'Ravi Patel',
@@ -170,29 +175,18 @@ describe('GroupEditMemberSheet', () => {
             fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
 
             expect(
-                screen.getByText(
-                    'Ravi Patel is the API primary owner. The API primary ownership will be transferred to Anna Schmidt and Ravi Patel will be updated as owner.',
-                ),
+                screen.getByText('Ravi Patel is currently the API primary owner. Saving will transfer primary ownership to Anna Schmidt.'),
             ).not.toBeNull();
         });
 
-        it('submits the demoted previous owner *before* the promoted member, preserving the former’s other roles', () => {
+        it('submits only the promoted member — the previous owner’s membership is left untouched', () => {
             const { onSubmit } = renderSheet({ members: [MEMBER, otherOwner] });
 
             fireEvent.click(screen.getAllByRole('combobox')[0]);
             fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
             fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-            // Order matters: the backend rejects a second PRIMARY_OWNER for a scope still held by someone
-            // else, so the demotion must be submitted first (mirrors classic's submit() comment).
             expect(onSubmit).toHaveBeenCalledWith([
-                {
-                    id: 'user-2',
-                    roles: [
-                        { scope: 'API', name: 'OWNER' },
-                        { scope: 'APPLICATION', name: 'USER' },
-                    ],
-                },
                 {
                     id: 'user-1',
                     roles: [

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
@@ -15,6 +15,8 @@
  */
 
 import {
+    Alert,
+    AlertDescription,
     Button,
     Checkbox,
     Label,
@@ -30,12 +32,25 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@gravitee/graphene-core';
+import { InfoIcon } from '@gravitee/graphene-core/icons';
 import { useEffect, useState } from 'react';
 
 import type { GroupMember, GroupMembershipPayload, GroupMembershipRole, GroupRole } from '../types/group';
 
 const NO_ROLE_VALUE = '__none__';
 const PRIMARY_OWNER = 'PRIMARY_OWNER';
+const OWNER = 'OWNER';
+
+/** Rebuilds a full membership payload for `member`, preserving every role they currently hold and
+ *  overlaying `overrides` on top — the backend treats the submitted roles as the complete set for a
+ *  member, so omitting an existing scope (e.g. GROUP/ADMIN) would silently revoke it. */
+function membershipFromMember(member: GroupMember, overrides: Record<string, string>): GroupMembershipPayload {
+    const merged = { ...(member.roles ?? {}), ...overrides };
+    const roles: GroupMembershipRole[] = Object.entries(merged)
+        .filter((entry): entry is [string, string] => Boolean(entry[1]))
+        .map(([scope, name]) => ({ scope: scope as GroupMembershipRole['scope'], name }));
+    return { id: member.id, roles };
+}
 
 function RoleSelect({
     label,
@@ -101,7 +116,7 @@ export function GroupEditMemberSheet({
     clusterRoles: GroupRole[];
     groupAllowsGroupAdmin: boolean;
     onClose: () => void;
-    onSubmit: (payload: GroupMembershipPayload) => void;
+    onSubmit: (memberships: GroupMembershipPayload[]) => void;
     isSaving: boolean;
 }>) {
     const [apiRole, setApiRole] = useState('');
@@ -124,13 +139,40 @@ export function GroupEditMemberSheet({
 
     if (!member) return null;
 
-    // Mirrors classic's isPrimaryOwnerDisabled — a scope can only have one primary owner, so the option
-    // is disabled here if someone *else* already holds it. If this member already holds it, the whole
-    // select is locked instead: transferring primary ownership isn't supported from this sheet yet.
+    // Downgrading *away* from primary owner still requires picking a successor, which this sheet doesn't
+    // support yet — so the select stays locked whenever this member already holds it. Promoting someone
+    // *to* primary owner while another member holds it is supported below: the option is always
+    // selectable, and submitting auto-demotes the previous owner to OWNER (mirrors classic
+    // edit-member-dialog.component.ts's isRoleUpgrade/promoteSuccessor-adjacent demote() flow).
     const isApiPrimaryOwner = member.roles?.API === PRIMARY_OWNER;
     const isApiProductPrimaryOwner = member.roles?.API_PRODUCT === PRIMARY_OWNER;
-    const apiPrimaryOwnerHeldByOther = members.some(m => m.id !== member.id && m.roles?.API === PRIMARY_OWNER);
-    const apiProductPrimaryOwnerHeldByOther = members.some(m => m.id !== member.id && m.roles?.API_PRODUCT === PRIMARY_OWNER);
+
+    const isApiUpgrade = apiRole === PRIMARY_OWNER && !isApiPrimaryOwner;
+    const isApiProductUpgrade = apiProductRole === PRIMARY_OWNER && !isApiProductPrimaryOwner;
+    const existingApiOwner = isApiUpgrade ? members.find(m => m.id !== member.id && m.roles?.API === PRIMARY_OWNER) : undefined;
+    const existingApiProductOwner = isApiProductUpgrade
+        ? members.find(m => m.id !== member.id && m.roles?.API_PRODUCT === PRIMARY_OWNER)
+        : undefined;
+
+    function buildTransferMessage(): string | null {
+        if (existingApiOwner && existingApiProductOwner && existingApiOwner.id === existingApiProductOwner.id) {
+            return `${existingApiOwner.displayName} is the API and API Product primary owner. Primary ownership will be transferred to ${member!.displayName} and ${existingApiOwner.displayName} will be updated as owner.`;
+        }
+        const parts: string[] = [];
+        if (existingApiOwner) {
+            parts.push(
+                `${existingApiOwner.displayName} is the API primary owner. The API primary ownership will be transferred to ${member!.displayName} and ${existingApiOwner.displayName} will be updated as owner.`,
+            );
+        }
+        if (existingApiProductOwner) {
+            parts.push(
+                `${existingApiProductOwner.displayName} is the API Product primary owner. The API Product primary ownership will be transferred to ${member!.displayName} and ${existingApiProductOwner.displayName} will be updated as owner.`,
+            );
+        }
+        return parts.length > 0 ? parts.join(' ') : null;
+    }
+
+    const transferMessage = buildTransferMessage();
 
     // The backend treats the submitted roles as the complete set for this member — any scope left out
     // here gets its existing role deleted (GroupMembersResource#deleteIfNewAndPreviousRoleNull). So every
@@ -150,7 +192,14 @@ export function GroupEditMemberSheet({
 
     function handleSubmit() {
         if (!member) return;
-        onSubmit({ id: member.id, roles: buildRoles() });
+        const memberships: GroupMembershipPayload[] = [{ id: member.id, roles: buildRoles() }];
+        if (existingApiOwner && existingApiProductOwner && existingApiOwner.id === existingApiProductOwner.id) {
+            memberships.push(membershipFromMember(existingApiOwner, { API: OWNER, API_PRODUCT: OWNER }));
+        } else {
+            if (existingApiOwner) memberships.push(membershipFromMember(existingApiOwner, { API: OWNER }));
+            if (existingApiProductOwner) memberships.push(membershipFromMember(existingApiProductOwner, { API_PRODUCT: OWNER }));
+        }
+        onSubmit(memberships);
     }
 
     function handleClose() {
@@ -175,7 +224,6 @@ export function GroupEditMemberSheet({
                             value={apiRole}
                             onChange={setApiRole}
                             disabled={isApiPrimaryOwner}
-                            disabledOptionNames={apiPrimaryOwnerHeldByOther ? new Set([PRIMARY_OWNER]) : undefined}
                             hint={isApiPrimaryOwner ? 'Primary ownership can’t be transferred from here yet.' : undefined}
                         />
                         <RoleSelect
@@ -184,7 +232,6 @@ export function GroupEditMemberSheet({
                             value={apiProductRole}
                             onChange={setApiProductRole}
                             disabled={isApiProductPrimaryOwner}
-                            disabledOptionNames={apiProductPrimaryOwnerHeldByOther ? new Set([PRIMARY_OWNER]) : undefined}
                             hint={isApiProductPrimaryOwner ? 'Primary ownership can’t be transferred from here yet.' : undefined}
                         />
                         <RoleSelect label="Application" roles={applicationRoles} value={applicationRole} onChange={setApplicationRole} />
@@ -212,6 +259,13 @@ export function GroupEditMemberSheet({
                                 : 'Enable "Allow adding members via user search" on this group to grant group admin access.'}
                         </p>
                     </div>
+
+                    {transferMessage && (
+                        <Alert variant="default">
+                            <InfoIcon className="size-4" aria-hidden />
+                            <AlertDescription>{transferMessage}</AlertDescription>
+                        </Alert>
+                    )}
                 </div>
 
                 <SheetFooter className="shrink-0 flex-row justify-end border-t">

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
@@ -37,6 +37,9 @@ import { useEffect, useState } from 'react';
 
 import type { GroupMember, GroupMembershipPayload, GroupMembershipRole, GroupRole } from '../types/group';
 
+// Radix Select's controlled `value` can't be an empty string, so unset state is represented by this
+// sentinel internally — but classic's edit-member-dialog.component.html has no "None" mat-option (an
+// unset scope just renders the select blank until a real role is picked), so it isn't rendered below.
 const NO_ROLE_VALUE = '__none__';
 const PRIMARY_OWNER = 'PRIMARY_OWNER';
 const OWNER = 'OWNER';
@@ -77,7 +80,6 @@ function RoleSelect({
                     <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                    <SelectItem value={NO_ROLE_VALUE}>None</SelectItem>
                     {roles.map(role => (
                         <SelectItem key={role.name} value={role.name} disabled={disabledOptionNames?.has(role.name)}>
                             {role.name}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
@@ -39,18 +39,6 @@ import type { GroupMember, GroupMembershipPayload, GroupMembershipRole, GroupRol
 
 const NO_ROLE_VALUE = '__none__';
 const PRIMARY_OWNER = 'PRIMARY_OWNER';
-const OWNER = 'OWNER';
-
-/** Rebuilds a full membership payload for `member`, preserving every role they currently hold and
- *  overlaying `overrides` on top — the backend treats the submitted roles as the complete set for a
- *  member, so omitting an existing scope (e.g. GROUP/ADMIN) would silently revoke it. */
-function membershipFromMember(member: GroupMember, overrides: Record<string, string>): GroupMembershipPayload {
-    const merged = { ...(member.roles ?? {}), ...overrides };
-    const roles: GroupMembershipRole[] = Object.entries(merged)
-        .filter((entry): entry is [string, string] => Boolean(entry[1]))
-        .map(([scope, name]) => ({ scope: scope as GroupMembershipRole['scope'], name }));
-    return { id: member.id, roles };
-}
 
 function RoleSelect({
     label,
@@ -142,8 +130,13 @@ export function GroupEditMemberSheet({
     // Downgrading *away* from primary owner still requires picking a successor, which this sheet doesn't
     // support yet — so the select stays locked whenever this member already holds it. Promoting someone
     // *to* primary owner while another member holds it is supported below: the option is always
-    // selectable, and submitting auto-demotes the previous owner to OWNER (mirrors classic
-    // edit-member-dialog.component.ts's isRoleUpgrade/promoteSuccessor-adjacent demote() flow).
+    // selectable. The previous owner's own membership is deliberately left untouched — the backend hard-
+    // blocks any request that explicitly changes a member away from PRIMARY_OWNER while the group still
+    // owns APIs/API Products (GroupMembersResource "prevent changing from PRIMARY_OWNER if group owns
+    // APIs" guard → StillPrimaryOwnerException), even when a replacement is promoted in the very same
+    // request. Promoting this member alone is enough: GroupMembersResource#addGroupMember reassigns the
+    // group's actual apiPrimaryOwner/apiProductPrimaryOwner pointer as a side effect of that promotion —
+    // the previous owner's per-member role label just isn't clearable from here afterwards.
     const isApiPrimaryOwner = member.roles?.API === PRIMARY_OWNER;
     const isApiProductPrimaryOwner = member.roles?.API_PRODUCT === PRIMARY_OWNER;
 
@@ -154,19 +147,23 @@ export function GroupEditMemberSheet({
         ? members.find(m => m.id !== member.id && m.roles?.API_PRODUCT === PRIMARY_OWNER)
         : undefined;
 
+    // Doesn't claim the previous owner "will be updated as owner" (unlike classic's dialog) — the backend
+    // won't let us clear their PRIMARY_OWNER label in the same request that promotes someone else (see the
+    // isApiPrimaryOwner/isApiProductPrimaryOwner comment above), so their row keeps showing PRIMARY_OWNER
+    // after this save even though the group's actual primary owner has moved to the newly promoted member.
     function buildTransferMessage(): string | null {
         if (existingApiOwner && existingApiProductOwner && existingApiOwner.id === existingApiProductOwner.id) {
-            return `${existingApiOwner.displayName} is the API and API Product primary owner. Primary ownership will be transferred to ${member!.displayName} and ${existingApiOwner.displayName} will be updated as owner.`;
+            return `${existingApiOwner.displayName} is currently the API and API Product primary owner. Saving will transfer primary ownership to ${member!.displayName}.`;
         }
         const parts: string[] = [];
         if (existingApiOwner) {
             parts.push(
-                `${existingApiOwner.displayName} is the API primary owner. The API primary ownership will be transferred to ${member!.displayName} and ${existingApiOwner.displayName} will be updated as owner.`,
+                `${existingApiOwner.displayName} is currently the API primary owner. Saving will transfer primary ownership to ${member!.displayName}.`,
             );
         }
         if (existingApiProductOwner) {
             parts.push(
-                `${existingApiProductOwner.displayName} is the API Product primary owner. The API Product primary ownership will be transferred to ${member!.displayName} and ${existingApiProductOwner.displayName} will be updated as owner.`,
+                `${existingApiProductOwner.displayName} is currently the API Product primary owner. Saving will transfer primary ownership to ${member!.displayName}.`,
             );
         }
         return parts.length > 0 ? parts.join(' ') : null;
@@ -192,18 +189,7 @@ export function GroupEditMemberSheet({
 
     function handleSubmit() {
         if (!member) return;
-        // Order matters: the backend rejects a PRIMARY_OWNER assignment while another member still holds
-        // it for that scope, so the previous owner's demotion must be submitted *before* the promoted
-        // member's own update — mirrors classic edit-member-dialog.component.ts's submit() comment
-        // ("Order: previous-PO demotion(s) → edit user → successor promotion").
-        const demoted: GroupMembershipPayload[] = [];
-        if (existingApiOwner && existingApiProductOwner && existingApiOwner.id === existingApiProductOwner.id) {
-            demoted.push(membershipFromMember(existingApiOwner, { API: OWNER, API_PRODUCT: OWNER }));
-        } else {
-            if (existingApiOwner) demoted.push(membershipFromMember(existingApiOwner, { API: OWNER }));
-            if (existingApiProductOwner) demoted.push(membershipFromMember(existingApiProductOwner, { API_PRODUCT: OWNER }));
-        }
-        onSubmit([...demoted, { id: member.id, roles: buildRoles() }]);
+        onSubmit([{ id: member.id, roles: buildRoles() }]);
     }
 
     function handleClose() {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Checkbox,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+} from '@gravitee/graphene-core';
+import { useEffect, useState } from 'react';
+
+import type { GroupMember, GroupMembershipPayload, GroupMembershipRole, GroupRole } from '../types/group';
+
+const NO_ROLE_VALUE = '__none__';
+const PRIMARY_OWNER = 'PRIMARY_OWNER';
+
+function RoleSelect({
+    label,
+    roles,
+    value,
+    onChange,
+    disabled,
+    disabledOptionNames,
+    hint,
+}: Readonly<{
+    label: string;
+    roles: GroupRole[];
+    value: string;
+    onChange: (value: string) => void;
+    disabled?: boolean;
+    disabledOptionNames?: Set<string>;
+    hint?: string;
+}>) {
+    return (
+        <div className="space-y-1.5">
+            <Label className="text-sm text-muted-foreground">{label}</Label>
+            <Select value={value || NO_ROLE_VALUE} onValueChange={v => onChange(v === NO_ROLE_VALUE ? '' : v)} disabled={disabled}>
+                <SelectTrigger className="w-full">
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value={NO_ROLE_VALUE}>None</SelectItem>
+                    {roles.map(role => (
+                        <SelectItem key={role.name} value={role.name} disabled={disabledOptionNames?.has(role.name)}>
+                            {role.name}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+            {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+        </div>
+    );
+}
+
+export function GroupEditMemberSheet({
+    open,
+    groupName,
+    member,
+    members,
+    apiRoles,
+    applicationRoles,
+    apiProductRoles,
+    integrationRoles,
+    clusterRoles,
+    groupAllowsGroupAdmin,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    groupName: string;
+    member: GroupMember | undefined;
+    members: GroupMember[];
+    apiRoles: GroupRole[];
+    applicationRoles: GroupRole[];
+    apiProductRoles: GroupRole[];
+    integrationRoles: GroupRole[];
+    clusterRoles: GroupRole[];
+    groupAllowsGroupAdmin: boolean;
+    onClose: () => void;
+    onSubmit: (payload: GroupMembershipPayload) => void;
+    isSaving: boolean;
+}>) {
+    const [apiRole, setApiRole] = useState('');
+    const [apiProductRole, setApiProductRole] = useState('');
+    const [applicationRole, setApplicationRole] = useState('');
+    const [integrationRole, setIntegrationRole] = useState('');
+    const [clusterRole, setClusterRole] = useState('');
+    const [groupAdmin, setGroupAdmin] = useState(false);
+
+    useEffect(() => {
+        if (open && member) {
+            setApiRole(member.roles?.API ?? '');
+            setApiProductRole(member.roles?.API_PRODUCT ?? '');
+            setApplicationRole(member.roles?.APPLICATION ?? '');
+            setIntegrationRole(member.roles?.INTEGRATION ?? '');
+            setClusterRole(member.roles?.CLUSTER ?? '');
+            setGroupAdmin(member.roles?.GROUP === 'ADMIN');
+        }
+    }, [open, member]);
+
+    if (!member) return null;
+
+    // Mirrors classic's isPrimaryOwnerDisabled — a scope can only have one primary owner, so the option
+    // is disabled here if someone *else* already holds it. If this member already holds it, the whole
+    // select is locked instead: transferring primary ownership isn't supported from this sheet yet.
+    const isApiPrimaryOwner = member.roles?.API === PRIMARY_OWNER;
+    const isApiProductPrimaryOwner = member.roles?.API_PRODUCT === PRIMARY_OWNER;
+    const apiPrimaryOwnerHeldByOther = members.some(m => m.id !== member.id && m.roles?.API === PRIMARY_OWNER);
+    const apiProductPrimaryOwnerHeldByOther = members.some(m => m.id !== member.id && m.roles?.API_PRODUCT === PRIMARY_OWNER);
+
+    // The backend treats the submitted roles as the complete set for this member — any scope left out
+    // here gets its existing role deleted (GroupMembersResource#deleteIfNewAndPreviousRoleNull). So every
+    // scope the member currently holds a role in must stay represented unless the operator deliberately
+    // cleared it to "None"; GROUP/ADMIN specifically is only ever pushed when checked, mirroring classic's
+    // edit-member-dialog (unchecking it just omits the scope, relying on that same delete-when-omitted path).
+    function buildRoles(): GroupMembershipRole[] {
+        const roles: GroupMembershipRole[] = [];
+        if (apiRole) roles.push({ scope: 'API', name: apiRole });
+        if (apiProductRole) roles.push({ scope: 'API_PRODUCT', name: apiProductRole });
+        if (applicationRole) roles.push({ scope: 'APPLICATION', name: applicationRole });
+        if (integrationRole) roles.push({ scope: 'INTEGRATION', name: integrationRole });
+        if (clusterRole) roles.push({ scope: 'CLUSTER', name: clusterRole });
+        if (groupAdmin) roles.push({ scope: 'GROUP', name: 'ADMIN' });
+        return roles;
+    }
+
+    function handleSubmit() {
+        if (!member) return;
+        onSubmit({ id: member.id, roles: buildRoles() });
+    }
+
+    function handleClose() {
+        onClose();
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>Edit roles</SheetTitle>
+                    <SheetDescription>
+                        Update {member.displayName}&rsquo;s roles in {groupName}.
+                    </SheetDescription>
+                </SheetHeader>
+
+                <div className="space-y-6 px-4 pb-4">
+                    <div className="grid grid-cols-2 gap-4">
+                        <RoleSelect
+                            label="API"
+                            roles={apiRoles}
+                            value={apiRole}
+                            onChange={setApiRole}
+                            disabled={isApiPrimaryOwner}
+                            disabledOptionNames={apiPrimaryOwnerHeldByOther ? new Set([PRIMARY_OWNER]) : undefined}
+                            hint={isApiPrimaryOwner ? 'Primary ownership can’t be transferred from here yet.' : undefined}
+                        />
+                        <RoleSelect
+                            label="API product"
+                            roles={apiProductRoles}
+                            value={apiProductRole}
+                            onChange={setApiProductRole}
+                            disabled={isApiProductPrimaryOwner}
+                            disabledOptionNames={apiProductPrimaryOwnerHeldByOther ? new Set([PRIMARY_OWNER]) : undefined}
+                            hint={isApiProductPrimaryOwner ? 'Primary ownership can’t be transferred from here yet.' : undefined}
+                        />
+                        <RoleSelect label="Application" roles={applicationRoles} value={applicationRole} onChange={setApplicationRole} />
+                        <RoleSelect label="Integration" roles={integrationRoles} value={integrationRole} onChange={setIntegrationRole} />
+                        <RoleSelect label="Cluster" roles={clusterRoles} value={clusterRole} onChange={setClusterRole} />
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <label
+                            htmlFor="edit-member-group-admin"
+                            className="flex items-center gap-2.5 cursor-pointer aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+                            aria-disabled={!groupAllowsGroupAdmin}
+                        >
+                            <Checkbox
+                                id="edit-member-group-admin"
+                                checked={groupAdmin}
+                                disabled={!groupAllowsGroupAdmin}
+                                onCheckedChange={checked => setGroupAdmin(checked === true)}
+                            />
+                            <span className="text-sm select-none">Group admin</span>
+                        </label>
+                        <p className="text-xs text-muted-foreground">
+                            {groupAllowsGroupAdmin
+                                ? 'Lets this member manage the group’s membership themselves.'
+                                : 'Enable "Allow adding members via user search" on this group to grant group admin access.'}
+                        </p>
+                    </div>
+                </div>
+
+                <SheetFooter className="shrink-0 flex-row justify-end border-t">
+                    <Button type="button" variant="outline" onClick={handleClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={handleSubmit} disabled={isSaving}>
+                        {isSaving ? 'Saving…' : 'Save'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
@@ -101,8 +101,6 @@ export function GroupEditMemberSheet({
     integrationRoles,
     clusterRoles,
     groupAllowsGroupAdmin,
-    groupHasApis,
-    groupHasApiProducts,
     onClose,
     onSubmit,
     isSaving,
@@ -117,12 +115,6 @@ export function GroupEditMemberSheet({
     integrationRoles: GroupRole[];
     clusterRoles: GroupRole[];
     groupAllowsGroupAdmin: boolean;
-    /** Whether the group is currently associated with any APIs/API Products — the backend refuses to
-     *  clear a member's PRIMARY_OWNER label for a scope where this is true (see the isApiPrimaryOwner
-     *  comment below), so these gate whether a primary-ownership transfer can also demote the previous
-     *  owner, per scope. */
-    groupHasApis: boolean;
-    groupHasApiProducts: boolean;
     onClose: () => void;
     onSubmit: (memberships: GroupMembershipPayload[]) => void;
     isSaving: boolean;
@@ -147,18 +139,6 @@ export function GroupEditMemberSheet({
 
     if (!member) return null;
 
-    // Downgrading *away* from primary owner still requires picking a successor, which this sheet doesn't
-    // support yet — so the select stays locked whenever this member already holds it. Promoting someone
-    // *to* primary owner while another member holds it is supported below: the option is always
-    // selectable, and submitting demotes the previous owner to OWNER *only for scopes where that's safe*
-    // (groupHasApis / groupHasApiProducts false) — the backend hard-blocks any request that explicitly
-    // changes a member away from PRIMARY_OWNER for a scope the group currently owns items in
-    // (GroupMembersResource "prevent changing from PRIMARY_OWNER if group owns APIs/API products" guards
-    // → StillPrimaryOwnerException / StillApiProductPrimaryOwnerException), even when a replacement is
-    // promoted in the same request. Where that guard applies, we submit only the promotion:
-    // GroupMembersResource#addGroupMember reassigns the group's actual apiPrimaryOwner/
-    // apiProductPrimaryOwner pointer as a side effect of the promotion alone, but the previous owner's
-    // per-member role label for that scope stays stuck at PRIMARY_OWNER afterwards.
     const isApiPrimaryOwner = member.roles?.API === PRIMARY_OWNER;
     const isApiProductPrimaryOwner = member.roles?.API_PRODUCT === PRIMARY_OWNER;
 
@@ -168,24 +148,22 @@ export function GroupEditMemberSheet({
     const existingApiProductOwner = isApiProductUpgrade
         ? members.find(m => m.id !== member.id && m.roles?.API_PRODUCT === PRIMARY_OWNER)
         : undefined;
+    const sameOutgoingOwner = Boolean(existingApiOwner && existingApiProductOwner && existingApiOwner.id === existingApiProductOwner.id);
 
-    const canDemoteApiOwner = Boolean(existingApiOwner) && !groupHasApis;
-    const canDemoteApiProductOwner = Boolean(existingApiProductOwner) && !groupHasApiProducts;
-
+    // Mirrors edit-member-dialog.component.ts's buildUpgradeMessage() wording exactly.
     function buildTransferMessage(): string | null {
+        if (sameOutgoingOwner) {
+            return `${existingApiOwner!.displayName} is the API and API Product primary owner. Primary ownership will be transferred to ${member!.displayName} and ${existingApiOwner!.displayName} will be updated as owner.`;
+        }
         const parts: string[] = [];
         if (existingApiOwner) {
             parts.push(
-                canDemoteApiOwner
-                    ? `${existingApiOwner.displayName} is currently the API primary owner. The API primary ownership will be transferred to ${member!.displayName} and ${existingApiOwner.displayName} will be updated as owner.`
-                    : `${existingApiOwner.displayName} is currently the API primary owner. Saving will transfer primary ownership to ${member!.displayName}.`,
+                `${existingApiOwner.displayName} is the API primary owner. The API primary ownership will be transferred to ${member!.displayName} and ${existingApiOwner.displayName} will be updated as owner.`,
             );
         }
         if (existingApiProductOwner) {
             parts.push(
-                canDemoteApiProductOwner
-                    ? `${existingApiProductOwner.displayName} is currently the API Product primary owner. The API Product primary ownership will be transferred to ${member!.displayName} and ${existingApiProductOwner.displayName} will be updated as owner.`
-                    : `${existingApiProductOwner.displayName} is currently the API Product primary owner. Saving will transfer primary ownership to ${member!.displayName}.`,
+                `${existingApiProductOwner.displayName} is the API Product primary owner. The API Product primary ownership will be transferred to ${member!.displayName} and ${existingApiProductOwner.displayName} will be updated as owner.`,
             );
         }
         return parts.length > 0 ? parts.join(' ') : null;
@@ -193,11 +171,6 @@ export function GroupEditMemberSheet({
 
     const transferMessage = buildTransferMessage();
 
-    // The backend treats the submitted roles as the complete set for this member — any scope left out
-    // here gets its existing role deleted (GroupMembersResource#deleteIfNewAndPreviousRoleNull). So every
-    // scope the member currently holds a role in must stay represented unless the operator deliberately
-    // cleared it to "None"; GROUP/ADMIN specifically is only ever pushed when checked, mirroring classic's
-    // edit-member-dialog (unchecking it just omits the scope, relying on that same delete-when-omitted path).
     function buildRoles(): GroupMembershipRole[] {
         const roles: GroupMembershipRole[] = [];
         if (apiRole) roles.push({ scope: 'API', name: apiRole });
@@ -209,12 +182,6 @@ export function GroupEditMemberSheet({
         return roles;
     }
 
-    // Demotions must be submitted *before* the promoted member's own update (classic's edit-member-dialog
-    // ordering: previous-owner demotion(s) → promoted member), and only for scopes where the backend
-    // actually allows clearing PRIMARY_OWNER (canDemoteApiOwner / canDemoteApiProductOwner) — otherwise the
-    // request is rejected outright (StillPrimaryOwnerException / StillApiProductPrimaryOwnerException), even
-    // though nothing here changed. The same person can be the previous owner for both scopes at once, so
-    // overrides are merged per member id rather than emitted as separate membership items.
     function handleSubmit() {
         if (!member) return;
 
@@ -225,8 +192,8 @@ export function GroupEditMemberSheet({
             entry.overrides[scope] = OWNER;
             demotionOverrides.set(previousOwner.id, entry);
         }
-        if (canDemoteApiOwner) addDemotion(existingApiOwner, 'API');
-        if (canDemoteApiProductOwner) addDemotion(existingApiProductOwner, 'API_PRODUCT');
+        addDemotion(existingApiOwner, 'API');
+        addDemotion(existingApiProductOwner, 'API_PRODUCT');
 
         const demotions = Array.from(demotionOverrides.values()).map(({ member: m, overrides }) => membershipFromMember(m, overrides));
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
@@ -1,0 +1,300 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Checkbox,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+} from '@gravitee/graphene-core';
+import { InfoIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+
+import { GroupRoleSelect } from './GroupRoleSelect';
+import { MemberSuccessorCombobox } from './MemberSuccessorCombobox';
+import type { GroupMember, GroupMembershipPayload, GroupMembershipRole, GroupRole } from '../types/group';
+import { OWNER_ROLE, PRIMARY_OWNER_ROLE } from '../types/group';
+import { isRoleLocked } from '../utils/groupPermissions';
+
+function membershipFromMember(member: GroupMember, overrides: Record<string, string>): GroupMembershipPayload {
+    const merged = { ...(member.roles ?? {}), ...overrides };
+    const roles: GroupMembershipRole[] = Object.entries(merged)
+        .filter((entry): entry is [string, string] => Boolean(entry[1]))
+        .map(([scope, name]) => ({ scope: scope as GroupMembershipRole['scope'], name }));
+    return { id: member.id, roles };
+}
+
+export function GroupEditMemberSheet({
+    open,
+    groupName,
+    member,
+    members,
+    apiRoles,
+    applicationRoles,
+    apiProductRoles,
+    integrationRoles,
+    clusterRoles,
+    lockApiRole,
+    lockApiProductRole,
+    lockApplicationRole,
+    canOverrideLocks,
+    groupAllowsGroupAdmin,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    groupName: string;
+    member: GroupMember | undefined;
+    members: GroupMember[];
+    apiRoles: GroupRole[];
+    applicationRoles: GroupRole[];
+    apiProductRoles: GroupRole[];
+    integrationRoles: GroupRole[];
+    clusterRoles: GroupRole[];
+    lockApiRole: boolean;
+    lockApiProductRole: boolean;
+    lockApplicationRole: boolean;
+    canOverrideLocks: boolean;
+    groupAllowsGroupAdmin: boolean;
+    onClose: () => void;
+    onSubmit: (memberships: GroupMembershipPayload[]) => void;
+    isSaving: boolean;
+}>) {
+    const [apiRole, setApiRole] = useState('');
+    const [apiProductRole, setApiProductRole] = useState('');
+    const [applicationRole, setApplicationRole] = useState('');
+    const [integrationRole, setIntegrationRole] = useState('');
+    const [clusterRole, setClusterRole] = useState('');
+    const [groupAdmin, setGroupAdmin] = useState(false);
+    const [selectedSuccessorId, setSelectedSuccessorId] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (open && member) {
+            setApiRole(member.roles?.API ?? '');
+            setApiProductRole(member.roles?.API_PRODUCT ?? '');
+            setApplicationRole(member.roles?.APPLICATION ?? '');
+            setIntegrationRole(member.roles?.INTEGRATION ?? '');
+            setClusterRole(member.roles?.CLUSTER ?? '');
+            setGroupAdmin(member.roles?.GROUP === 'ADMIN');
+            setSelectedSuccessorId(null);
+        }
+    }, [open, member]);
+
+    useEffect(() => {
+        setSelectedSuccessorId(null);
+    }, [apiRole, apiProductRole]);
+
+    const successorCandidates = useMemo(
+        () => members.filter(m => m.id !== member?.id).sort((a, b) => a.displayName.localeCompare(b.displayName)),
+        [members, member],
+    );
+
+    if (!member) return null;
+
+    const apiRoleDisabled = isRoleLocked(lockApiRole, canOverrideLocks);
+    const apiProductRoleDisabled = isRoleLocked(lockApiProductRole, canOverrideLocks);
+    const applicationRoleDisabled = isRoleLocked(lockApplicationRole, canOverrideLocks);
+    const integrationRoleDisabled = !canOverrideLocks;
+    const clusterRoleDisabled = !canOverrideLocks;
+
+    const isApiPrimaryOwner = member.roles?.API === PRIMARY_OWNER_ROLE;
+    const isApiProductPrimaryOwner = member.roles?.API_PRODUCT === PRIMARY_OWNER_ROLE;
+
+    const isApiUpgrade = apiRole === PRIMARY_OWNER_ROLE && !isApiPrimaryOwner;
+    const isApiProductUpgrade = apiProductRole === PRIMARY_OWNER_ROLE && !isApiProductPrimaryOwner;
+    const existingApiOwner = isApiUpgrade ? members.find(m => m.id !== member.id && m.roles?.API === PRIMARY_OWNER_ROLE) : undefined;
+    const existingApiProductOwner = isApiProductUpgrade
+        ? members.find(m => m.id !== member.id && m.roles?.API_PRODUCT === PRIMARY_OWNER_ROLE)
+        : undefined;
+    const sameOutgoingOwner = Boolean(existingApiOwner && existingApiProductOwner && existingApiOwner.id === existingApiProductOwner.id);
+
+    const isApiDowngrade = isApiPrimaryOwner && apiRole !== PRIMARY_OWNER_ROLE;
+    const isApiProductDowngrade = isApiProductPrimaryOwner && apiProductRole !== PRIMARY_OWNER_ROLE;
+    const needsSuccessor = isApiDowngrade || isApiProductDowngrade;
+
+    const selectedSuccessor = selectedSuccessorId ? (successorCandidates.find(m => m.id === selectedSuccessorId) ?? null) : null;
+
+    function buildUpgradeMessage(): string | null {
+        if (sameOutgoingOwner) {
+            return `${existingApiOwner!.displayName} is the API and API Product primary owner. Primary ownership will be transferred to ${member!.displayName} and ${existingApiOwner!.displayName} will be updated as owner.`;
+        }
+        const parts: string[] = [];
+        if (existingApiOwner) {
+            parts.push(
+                `${existingApiOwner.displayName} is the API primary owner. The API primary ownership will be transferred to ${member!.displayName} and ${existingApiOwner.displayName} will be updated as owner.`,
+            );
+        }
+        if (existingApiProductOwner) {
+            parts.push(
+                `${existingApiProductOwner.displayName} is the API Product primary owner. The API Product primary ownership will be transferred to ${member!.displayName} and ${existingApiProductOwner.displayName} will be updated as owner.`,
+            );
+        }
+        return parts.length > 0 ? parts.join(' ') : null;
+    }
+
+    function buildDowngradeMessage(): string | null {
+        if (!selectedSuccessor) return null;
+        if (isApiDowngrade && isApiProductDowngrade) {
+            return `${member!.displayName} is the API and API Product primary owner. Primary ownership will be transferred to ${selectedSuccessor.displayName} and ${member!.displayName} will be updated as owner.`;
+        }
+        if (isApiDowngrade) {
+            return `${member!.displayName} is the API primary owner. The API primary ownership will be transferred to ${selectedSuccessor.displayName} and ${member!.displayName} will be updated as owner.`;
+        }
+        if (isApiProductDowngrade) {
+            return `${member!.displayName} is the API Product primary owner. The API Product primary ownership will be transferred to ${selectedSuccessor.displayName} and ${member!.displayName} will be updated as owner.`;
+        }
+        return null;
+    }
+
+    const transferMessage = [buildDowngradeMessage(), buildUpgradeMessage()].filter(Boolean).join(' ') || null;
+    const canSubmit = !needsSuccessor || Boolean(selectedSuccessor);
+
+    function buildRoles(): GroupMembershipRole[] {
+        const roles: GroupMembershipRole[] = [];
+        if (apiRole) roles.push({ scope: 'API', name: apiRole });
+        if (apiProductRole) roles.push({ scope: 'API_PRODUCT', name: apiProductRole });
+        if (applicationRole) roles.push({ scope: 'APPLICATION', name: applicationRole });
+        if (integrationRole) roles.push({ scope: 'INTEGRATION', name: integrationRole });
+        if (clusterRole) roles.push({ scope: 'CLUSTER', name: clusterRole });
+        if (groupAdmin) roles.push({ scope: 'GROUP', name: 'ADMIN' });
+        return roles;
+    }
+
+    function handleSubmit() {
+        if (!member) return;
+
+        const otherOverrides = new Map<string, { member: GroupMember; overrides: Record<string, string> }>();
+        function addOverride(target: GroupMember | undefined, scope: string, role: string) {
+            if (!target) return;
+            const entry = otherOverrides.get(target.id) ?? { member: target, overrides: {} };
+            entry.overrides[scope] = role;
+            otherOverrides.set(target.id, entry);
+        }
+        addOverride(existingApiOwner, 'API', OWNER_ROLE);
+        addOverride(existingApiProductOwner, 'API_PRODUCT', OWNER_ROLE);
+        if (isApiDowngrade) addOverride(selectedSuccessor ?? undefined, 'API', PRIMARY_OWNER_ROLE);
+        if (isApiProductDowngrade) addOverride(selectedSuccessor ?? undefined, 'API_PRODUCT', PRIMARY_OWNER_ROLE);
+
+        const otherMemberships = Array.from(otherOverrides.values()).map(({ member: m, overrides }) => membershipFromMember(m, overrides));
+
+        onSubmit([...otherMemberships, { id: member.id, roles: buildRoles() }]);
+    }
+
+    function handleClose() {
+        onClose();
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>Edit roles</SheetTitle>
+                    <SheetDescription>
+                        Update {member.displayName}&rsquo;s roles in {groupName}.
+                    </SheetDescription>
+                </SheetHeader>
+
+                <div className="space-y-6 px-4 pb-4">
+                    <div className="grid grid-cols-2 gap-4">
+                        <GroupRoleSelect label="API" roles={apiRoles} value={apiRole} onChange={setApiRole} disabled={apiRoleDisabled} />
+                        <GroupRoleSelect
+                            label="API product"
+                            roles={apiProductRoles}
+                            value={apiProductRole}
+                            onChange={setApiProductRole}
+                            disabled={apiProductRoleDisabled}
+                        />
+                        <GroupRoleSelect
+                            label="Application"
+                            roles={applicationRoles}
+                            value={applicationRole}
+                            onChange={setApplicationRole}
+                            disabled={applicationRoleDisabled}
+                        />
+                        <GroupRoleSelect
+                            label="Integration"
+                            roles={integrationRoles}
+                            value={integrationRole}
+                            onChange={setIntegrationRole}
+                            disabled={integrationRoleDisabled}
+                        />
+                        <GroupRoleSelect
+                            label="Cluster"
+                            roles={clusterRoles}
+                            value={clusterRole}
+                            onChange={setClusterRole}
+                            disabled={clusterRoleDisabled}
+                        />
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <label
+                            htmlFor="edit-member-group-admin"
+                            className="flex items-center gap-2.5 cursor-pointer aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+                            aria-disabled={!groupAllowsGroupAdmin}
+                        >
+                            <Checkbox
+                                id="edit-member-group-admin"
+                                checked={groupAdmin}
+                                disabled={!groupAllowsGroupAdmin}
+                                onCheckedChange={checked => setGroupAdmin(checked === true)}
+                            />
+                            <span className="text-sm select-none">Group admin</span>
+                        </label>
+                        <p className="text-xs text-muted-foreground">
+                            {groupAllowsGroupAdmin
+                                ? 'Lets this member manage the group’s membership themselves.'
+                                : 'Enable "Allow adding members via user search" on this group to grant group admin access.'}
+                        </p>
+                    </div>
+
+                    {needsSuccessor && (
+                        <MemberSuccessorCombobox
+                            id="edit-member-successor"
+                            candidates={successorCandidates}
+                            value={selectedSuccessor}
+                            onChange={picked => setSelectedSuccessorId(picked?.id ?? null)}
+                            hint="Select a member to transfer primary ownership."
+                        />
+                    )}
+
+                    {transferMessage && (
+                        <Alert variant="default">
+                            <InfoIcon className="size-4" aria-hidden />
+                            <AlertDescription>{transferMessage}</AlertDescription>
+                        </Alert>
+                    )}
+                </div>
+
+                <SheetFooter className="shrink-0 flex-row justify-end border-t">
+                    <Button type="button" variant="outline" onClick={handleClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={handleSubmit} disabled={isSaving || !canSubmit}>
+                        {isSaving ? 'Saving…' : 'Save'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
@@ -192,14 +192,18 @@ export function GroupEditMemberSheet({
 
     function handleSubmit() {
         if (!member) return;
-        const memberships: GroupMembershipPayload[] = [{ id: member.id, roles: buildRoles() }];
+        // Order matters: the backend rejects a PRIMARY_OWNER assignment while another member still holds
+        // it for that scope, so the previous owner's demotion must be submitted *before* the promoted
+        // member's own update — mirrors classic edit-member-dialog.component.ts's submit() comment
+        // ("Order: previous-PO demotion(s) → edit user → successor promotion").
+        const demoted: GroupMembershipPayload[] = [];
         if (existingApiOwner && existingApiProductOwner && existingApiOwner.id === existingApiProductOwner.id) {
-            memberships.push(membershipFromMember(existingApiOwner, { API: OWNER, API_PRODUCT: OWNER }));
+            demoted.push(membershipFromMember(existingApiOwner, { API: OWNER, API_PRODUCT: OWNER }));
         } else {
-            if (existingApiOwner) memberships.push(membershipFromMember(existingApiOwner, { API: OWNER }));
-            if (existingApiProductOwner) memberships.push(membershipFromMember(existingApiProductOwner, { API_PRODUCT: OWNER }));
+            if (existingApiOwner) demoted.push(membershipFromMember(existingApiOwner, { API: OWNER }));
+            if (existingApiProductOwner) demoted.push(membershipFromMember(existingApiProductOwner, { API_PRODUCT: OWNER }));
         }
-        onSubmit(memberships);
+        onSubmit([...demoted, { id: member.id, roles: buildRoles() }]);
     }
 
     function handleClose() {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupEditMemberSheet.tsx
@@ -39,6 +39,18 @@ import type { GroupMember, GroupMembershipPayload, GroupMembershipRole, GroupRol
 
 const NO_ROLE_VALUE = '__none__';
 const PRIMARY_OWNER = 'PRIMARY_OWNER';
+const OWNER = 'OWNER';
+
+/** Rebuilds a full membership payload for `member`, preserving every role they currently hold and
+ *  overlaying `overrides` on top — the backend treats the submitted roles as the complete set for a
+ *  member, so omitting an existing scope (e.g. GROUP/ADMIN) would silently revoke it. */
+function membershipFromMember(member: GroupMember, overrides: Record<string, string>): GroupMembershipPayload {
+    const merged = { ...(member.roles ?? {}), ...overrides };
+    const roles: GroupMembershipRole[] = Object.entries(merged)
+        .filter((entry): entry is [string, string] => Boolean(entry[1]))
+        .map(([scope, name]) => ({ scope: scope as GroupMembershipRole['scope'], name }));
+    return { id: member.id, roles };
+}
 
 function RoleSelect({
     label,
@@ -89,6 +101,8 @@ export function GroupEditMemberSheet({
     integrationRoles,
     clusterRoles,
     groupAllowsGroupAdmin,
+    groupHasApis,
+    groupHasApiProducts,
     onClose,
     onSubmit,
     isSaving,
@@ -103,6 +117,12 @@ export function GroupEditMemberSheet({
     integrationRoles: GroupRole[];
     clusterRoles: GroupRole[];
     groupAllowsGroupAdmin: boolean;
+    /** Whether the group is currently associated with any APIs/API Products — the backend refuses to
+     *  clear a member's PRIMARY_OWNER label for a scope where this is true (see the isApiPrimaryOwner
+     *  comment below), so these gate whether a primary-ownership transfer can also demote the previous
+     *  owner, per scope. */
+    groupHasApis: boolean;
+    groupHasApiProducts: boolean;
     onClose: () => void;
     onSubmit: (memberships: GroupMembershipPayload[]) => void;
     isSaving: boolean;
@@ -130,13 +150,15 @@ export function GroupEditMemberSheet({
     // Downgrading *away* from primary owner still requires picking a successor, which this sheet doesn't
     // support yet — so the select stays locked whenever this member already holds it. Promoting someone
     // *to* primary owner while another member holds it is supported below: the option is always
-    // selectable. The previous owner's own membership is deliberately left untouched — the backend hard-
-    // blocks any request that explicitly changes a member away from PRIMARY_OWNER while the group still
-    // owns APIs/API Products (GroupMembersResource "prevent changing from PRIMARY_OWNER if group owns
-    // APIs" guard → StillPrimaryOwnerException), even when a replacement is promoted in the very same
-    // request. Promoting this member alone is enough: GroupMembersResource#addGroupMember reassigns the
-    // group's actual apiPrimaryOwner/apiProductPrimaryOwner pointer as a side effect of that promotion —
-    // the previous owner's per-member role label just isn't clearable from here afterwards.
+    // selectable, and submitting demotes the previous owner to OWNER *only for scopes where that's safe*
+    // (groupHasApis / groupHasApiProducts false) — the backend hard-blocks any request that explicitly
+    // changes a member away from PRIMARY_OWNER for a scope the group currently owns items in
+    // (GroupMembersResource "prevent changing from PRIMARY_OWNER if group owns APIs/API products" guards
+    // → StillPrimaryOwnerException / StillApiProductPrimaryOwnerException), even when a replacement is
+    // promoted in the same request. Where that guard applies, we submit only the promotion:
+    // GroupMembersResource#addGroupMember reassigns the group's actual apiPrimaryOwner/
+    // apiProductPrimaryOwner pointer as a side effect of the promotion alone, but the previous owner's
+    // per-member role label for that scope stays stuck at PRIMARY_OWNER afterwards.
     const isApiPrimaryOwner = member.roles?.API === PRIMARY_OWNER;
     const isApiProductPrimaryOwner = member.roles?.API_PRODUCT === PRIMARY_OWNER;
 
@@ -147,23 +169,23 @@ export function GroupEditMemberSheet({
         ? members.find(m => m.id !== member.id && m.roles?.API_PRODUCT === PRIMARY_OWNER)
         : undefined;
 
-    // Doesn't claim the previous owner "will be updated as owner" (unlike classic's dialog) — the backend
-    // won't let us clear their PRIMARY_OWNER label in the same request that promotes someone else (see the
-    // isApiPrimaryOwner/isApiProductPrimaryOwner comment above), so their row keeps showing PRIMARY_OWNER
-    // after this save even though the group's actual primary owner has moved to the newly promoted member.
+    const canDemoteApiOwner = Boolean(existingApiOwner) && !groupHasApis;
+    const canDemoteApiProductOwner = Boolean(existingApiProductOwner) && !groupHasApiProducts;
+
     function buildTransferMessage(): string | null {
-        if (existingApiOwner && existingApiProductOwner && existingApiOwner.id === existingApiProductOwner.id) {
-            return `${existingApiOwner.displayName} is currently the API and API Product primary owner. Saving will transfer primary ownership to ${member!.displayName}.`;
-        }
         const parts: string[] = [];
         if (existingApiOwner) {
             parts.push(
-                `${existingApiOwner.displayName} is currently the API primary owner. Saving will transfer primary ownership to ${member!.displayName}.`,
+                canDemoteApiOwner
+                    ? `${existingApiOwner.displayName} is currently the API primary owner. The API primary ownership will be transferred to ${member!.displayName} and ${existingApiOwner.displayName} will be updated as owner.`
+                    : `${existingApiOwner.displayName} is currently the API primary owner. Saving will transfer primary ownership to ${member!.displayName}.`,
             );
         }
         if (existingApiProductOwner) {
             parts.push(
-                `${existingApiProductOwner.displayName} is currently the API Product primary owner. Saving will transfer primary ownership to ${member!.displayName}.`,
+                canDemoteApiProductOwner
+                    ? `${existingApiProductOwner.displayName} is currently the API Product primary owner. The API Product primary ownership will be transferred to ${member!.displayName} and ${existingApiProductOwner.displayName} will be updated as owner.`
+                    : `${existingApiProductOwner.displayName} is currently the API Product primary owner. Saving will transfer primary ownership to ${member!.displayName}.`,
             );
         }
         return parts.length > 0 ? parts.join(' ') : null;
@@ -187,9 +209,28 @@ export function GroupEditMemberSheet({
         return roles;
     }
 
+    // Demotions must be submitted *before* the promoted member's own update (classic's edit-member-dialog
+    // ordering: previous-owner demotion(s) → promoted member), and only for scopes where the backend
+    // actually allows clearing PRIMARY_OWNER (canDemoteApiOwner / canDemoteApiProductOwner) — otherwise the
+    // request is rejected outright (StillPrimaryOwnerException / StillApiProductPrimaryOwnerException), even
+    // though nothing here changed. The same person can be the previous owner for both scopes at once, so
+    // overrides are merged per member id rather than emitted as separate membership items.
     function handleSubmit() {
         if (!member) return;
-        onSubmit([{ id: member.id, roles: buildRoles() }]);
+
+        const demotionOverrides = new Map<string, { member: GroupMember; overrides: Record<string, string> }>();
+        function addDemotion(previousOwner: GroupMember | undefined, scope: string) {
+            if (!previousOwner) return;
+            const entry = demotionOverrides.get(previousOwner.id) ?? { member: previousOwner, overrides: {} };
+            entry.overrides[scope] = OWNER;
+            demotionOverrides.set(previousOwner.id, entry);
+        }
+        if (canDemoteApiOwner) addDemotion(existingApiOwner, 'API');
+        if (canDemoteApiProductOwner) addDemotion(existingApiProductOwner, 'API_PRODUCT');
+
+        const demotions = Array.from(demotionOverrides.values()).map(({ member: m, overrides }) => membershipFromMember(m, overrides));
+
+        onSubmit([...demotions, { id: member.id, roles: buildRoles() }]);
     }
 
     function handleClose() {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInvitationsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInvitationsTable.spec.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { GroupInvitationsTable } from './GroupInvitationsTable';
+import type { GroupInvitation } from '../types/group';
+
+const ANNA: GroupInvitation = {
+    id: 'invitation-1',
+    reference_id: 'group-1',
+    email: 'anna@lufthansa.com',
+    api_role: 'USER',
+    application_role: 'OWNER',
+    created_at: 1_700_000_000_000,
+};
+
+const BEN: GroupInvitation = {
+    id: 'invitation-2',
+    reference_id: 'group-1',
+    email: 'ben@lufthansa.com',
+};
+
+function renderTable(overrides: Partial<React.ComponentProps<typeof GroupInvitationsTable>> = {}) {
+    return render(<GroupInvitationsTable invitations={[ANNA, BEN]} loading={false} canManageMembers onDelete={jest.fn()} {...overrides} />);
+}
+
+describe('GroupInvitationsTable', () => {
+    it('renders each invitation’s email and roles', () => {
+        renderTable();
+        const annaRow = screen.getByText('anna@lufthansa.com').closest('tr')!;
+        expect(annaRow.textContent).toContain('USER');
+        expect(annaRow.textContent).toContain('OWNER');
+    });
+
+    it('shows a placeholder for missing roles or invitation date', () => {
+        renderTable();
+        const benRow = screen.getByText('ben@lufthansa.com').closest('tr')!;
+        expect(benRow.textContent).toContain('—');
+    });
+
+    it('hides the actions column entirely without permission', () => {
+        renderTable({ canManageMembers: false });
+        expect(screen.queryByRole('button', { name: /Delete invitation/ })).toBeNull();
+    });
+
+    it('calls onDelete with the row’s invitation', async () => {
+        const user = userEvent.setup();
+        const onDelete = jest.fn();
+        renderTable({ onDelete });
+
+        await user.click(screen.getByRole('button', { name: 'Delete invitation sent to anna@lufthansa.com' }));
+
+        expect(onDelete).toHaveBeenCalledWith(ANNA);
+    });
+
+    it('filters invitations by email client-side', () => {
+        renderTable();
+        fireEvent.change(screen.getByPlaceholderText('Search invitations…'), { target: { value: 'anna' } });
+        expect(screen.queryByText('ben@lufthansa.com')).toBeNull();
+        expect(screen.queryByText('anna@lufthansa.com')).not.toBeNull();
+    });
+
+    it('shows a first-use empty state with no invitations', () => {
+        renderTable({ invitations: [] });
+        expect(screen.queryByText('No invitations sent to display')).not.toBeNull();
+    });
+
+    it('shows a no-results empty state when the search matches nothing', () => {
+        renderTable();
+        fireEvent.change(screen.getByPlaceholderText('Search invitations…'), { target: { value: 'nobody' } });
+        expect(screen.queryByText('No invitations match your search')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInvitationsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInvitationsTable.tsx
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    DataTable,
+    DataTableColumnHeader,
+    DataTableEmptyState,
+    DateCell,
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { MailIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+import type { GroupInvitation } from '../types/group';
+
+const PAGE_SIZE = 10;
+
+function buildColumns({
+    canManageMembers,
+    onDelete,
+}: {
+    canManageMembers: boolean;
+    onDelete: (invitation: GroupInvitation) => void;
+}): DataTableProps<GroupInvitation>['columns'] {
+    const columns: DataTableProps<GroupInvitation>['columns'] = [
+        {
+            id: 'email',
+            accessorKey: 'email',
+            header: ({ column }: ColHeader<GroupInvitation>) => <DataTableColumnHeader column={column} title="Email" />,
+            cell: ({ row }: ColCell<GroupInvitation>) => <span className="text-sm font-medium">{row.original.email}</span>,
+        },
+        {
+            id: 'apiRole',
+            header: 'API role',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupInvitation>) => (
+                <span className="text-sm text-muted-foreground">{row.original.api_role ?? '—'}</span>
+            ),
+        },
+        {
+            id: 'applicationRole',
+            header: 'Application role',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupInvitation>) => (
+                <span className="text-sm text-muted-foreground">{row.original.application_role ?? '—'}</span>
+            ),
+        },
+        {
+            id: 'invitationDate',
+            header: 'Invitation date',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupInvitation>) =>
+                row.original.created_at ? (
+                    <DateCell value={new Date(row.original.created_at)} format="absolute" />
+                ) : (
+                    <span className="text-sm text-muted-foreground">—</span>
+                ),
+        },
+    ];
+
+    if (canManageMembers) {
+        columns.push({
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            size: 56,
+            enableSorting: false,
+            enableHiding: false,
+            cell: ({ row }: ColCell<GroupInvitation>) => (
+                <div className="flex justify-end">
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        aria-label={`Delete invitation sent to ${row.original.email}`}
+                        onClick={() => onDelete(row.original)}
+                    >
+                        <Trash2Icon className="size-4" aria-hidden />
+                    </Button>
+                </div>
+            ),
+        });
+    }
+
+    return columns;
+}
+
+function paginate(items: GroupInvitation[], page: number, pageSize: number): GroupInvitation[] {
+    const start = (page - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+}
+
+interface GroupInvitationsTableProps {
+    readonly invitations: GroupInvitation[];
+    readonly loading: boolean;
+    readonly canManageMembers: boolean;
+    readonly onDelete: (invitation: GroupInvitation) => void;
+}
+
+export function GroupInvitationsTable({ invitations, loading, canManageMembers, onDelete }: GroupInvitationsTableProps) {
+    const [search, setSearch] = useState('');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(PAGE_SIZE);
+
+    const filtered = useMemo(() => {
+        const query = search.trim().toLowerCase();
+        return query ? invitations.filter(invitation => invitation.email.toLowerCase().includes(query)) : invitations;
+    }, [invitations, search]);
+
+    const totalCount = filtered.length;
+    const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1;
+    const pageData = useMemo(() => paginate(filtered, page, pageSize), [filtered, page, pageSize]);
+    const columns = useMemo(() => buildColumns({ canManageMembers, onDelete }), [canManageMembers, onDelete]);
+
+    useEffect(() => {
+        if (page > totalPages) setPage(totalPages);
+    }, [page, totalPages]);
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    return (
+        <DataTable
+            aria-label="Invitations"
+            columns={columns}
+            data={pageData}
+            loading={loading}
+            skeletonCount={pageSize}
+            serverSide
+            pagination={{
+                page,
+                pageSize,
+                totalCount,
+                pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                onPageChange: setPage,
+                onPageSizeChange: handlePageSizeChange,
+            }}
+            emptyMessage={
+                search ? (
+                    <DataTableEmptyState
+                        variant="no-results"
+                        icon={<SearchIcon className="size-8" aria-hidden />}
+                        title="No invitations match your search"
+                        description="Try adjusting your search terms."
+                        action={
+                            <Button size="sm" variant="outline" onClick={() => handleSearchChange('')}>
+                                Clear search
+                            </Button>
+                        }
+                    />
+                ) : (
+                    <DataTableEmptyState
+                        variant="first-use"
+                        icon={<MailIcon className="size-8" aria-hidden />}
+                        title="No invitations sent to display"
+                        description="Invitations sent to this group will appear here."
+                    />
+                )
+            }
+            toolbar={
+                <div className="w-64">
+                    <InputGroup>
+                        <InputGroupAddon align="inline-start">
+                            <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                        </InputGroupAddon>
+                        <InputGroupInput
+                            placeholder="Search invitations…"
+                            value={search}
+                            onChange={e => handleSearchChange(e.target.value)}
+                        />
+                    </InputGroup>
+                </div>
+            }
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.spec.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupInviteMemberSheet } from './GroupInviteMemberSheet';
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupInviteMemberSheet>> = {}) {
+    const onClose = jest.fn();
+    const onSubmit = jest.fn();
+    render(
+        <GroupInviteMemberSheet
+            open
+            groupName="API Team"
+            apiRoles={[{ name: 'OWNER', scope: 'API' }]}
+            applicationRoles={[{ name: 'USER', scope: 'APPLICATION' }]}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={false}
+            {...overrides}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('GroupInviteMemberSheet', () => {
+    it('does not render sheet content when closed', () => {
+        renderSheet({ open: false });
+        expect(screen.queryByRole('heading', { name: 'Email invitation' })).toBeNull();
+    });
+
+    it('shows the group name in the description', () => {
+        renderSheet();
+        expect(screen.getByText('Invite a new user to API Team and assign their default roles.')).not.toBeNull();
+    });
+
+    it('disables Send invitation until an email is entered', () => {
+        renderSheet();
+        expect(screen.getByRole('button', { name: 'Send invitation' })).toHaveProperty('disabled', true);
+    });
+
+    it('submits the email and default roles', () => {
+        const { onSubmit } = renderSheet();
+
+        fireEvent.change(screen.getByRole('textbox', { name: /Email/i }), { target: { value: 'anna.schmidt@lufthansa.com' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Send invitation' }));
+
+        expect(onSubmit).toHaveBeenCalledWith({ email: 'anna.schmidt@lufthansa.com', apiRole: '', applicationRole: '' });
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.spec.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupInviteMemberSheet } from './GroupInviteMemberSheet';
+import type { GroupMember } from '../types/group';
+
+beforeAll(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+});
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupInviteMemberSheet>> = {}) {
+    const onClose = jest.fn();
+    const onSubmit = jest.fn();
+    render(
+        <GroupInviteMemberSheet
+            open
+            groupName="API Team"
+            groupRoles={undefined}
+            members={[]}
+            apiRoles={[
+                { name: 'USER', scope: 'API' },
+                { name: 'OWNER', scope: 'API' },
+                { name: 'PRIMARY_OWNER', scope: 'API', system: true },
+            ]}
+            applicationRoles={[{ name: 'USER', scope: 'APPLICATION' }]}
+            lockApiRole={false}
+            lockApplicationRole={false}
+            canOverrideLocks
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={false}
+            {...overrides}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('GroupInviteMemberSheet', () => {
+    it('does not render sheet content when closed', () => {
+        renderSheet({ open: false });
+        expect(screen.queryByRole('heading', { name: 'Email invitation' })).toBeNull();
+    });
+
+    it('shows the group name in the description', () => {
+        renderSheet();
+        expect(screen.getByText('Invite a new user to API Team and assign their default roles.')).not.toBeNull();
+    });
+
+    it('disables Send invitation until an email is entered', () => {
+        renderSheet();
+        expect(screen.getByRole('button', { name: 'Send invitation' })).toHaveProperty('disabled', true);
+    });
+
+    it('submits the email with the USER fallback default roles when the group has no configured defaults', () => {
+        const { onSubmit } = renderSheet();
+
+        fireEvent.change(screen.getByRole('textbox', { name: /Email/i }), { target: { value: 'anna.schmidt@lufthansa.com' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Send invitation' }));
+
+        expect(onSubmit).toHaveBeenCalledWith({ email: 'anna.schmidt@lufthansa.com', apiRole: 'USER', applicationRole: 'USER' });
+    });
+
+    it('has no "None" role option — classic\'s invite-member-dialog has no such mat-option', () => {
+        renderSheet();
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.queryByRole('option', { name: 'None' })).toBeNull();
+    });
+
+    describe('default role pre-fill', () => {
+        it('pre-fills API/Application from the group’s configured default roles', () => {
+            const { onSubmit } = renderSheet({ groupRoles: { API: 'OWNER', APPLICATION: 'USER' } });
+
+            fireEvent.change(screen.getByRole('textbox', { name: /Email/i }), { target: { value: 'anna.schmidt@lufthansa.com' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Send invitation' }));
+
+            expect(onSubmit).toHaveBeenCalledWith({ email: 'anna.schmidt@lufthansa.com', apiRole: 'OWNER', applicationRole: 'USER' });
+        });
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the PRIMARY_OWNER option once one already exists', () => {
+        const existingOwner: GroupMember = { id: 'user-3', displayName: 'Ravi Patel', roles: { API: 'PRIMARY_OWNER' } };
+        renderSheet({ members: [existingOwner] });
+
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).toBe('true');
+        expect(screen.getByRole('option', { name: 'OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    it('leaves PRIMARY_OWNER selectable when no one holds it yet', () => {
+        renderSheet();
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    describe('lock flags', () => {
+        it('disables a locked role select without canOverrideLocks', () => {
+            renderSheet({ lockApiRole: true, canOverrideLocks: false });
+            expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', true);
+        });
+
+        it('leaves a locked role select enabled with canOverrideLocks', () => {
+            renderSheet({ lockApiRole: true, canOverrideLocks: true });
+            expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', false);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.spec.tsx
@@ -17,6 +17,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { GroupInviteMemberSheet } from './GroupInviteMemberSheet';
 
+// Radix Select scrolls the highlighted option into view — not implemented in jsdom.
+beforeAll(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+});
+
 function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupInviteMemberSheet>> = {}) {
     const onClose = jest.fn();
     const onSubmit = jest.fn();
@@ -24,7 +29,11 @@ function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupInviteM
         <GroupInviteMemberSheet
             open
             groupName="API Team"
-            apiRoles={[{ name: 'OWNER', scope: 'API' }]}
+            groupRoles={undefined}
+            apiRoles={[
+                { name: 'USER', scope: 'API' },
+                { name: 'OWNER', scope: 'API' },
+            ]}
             applicationRoles={[{ name: 'USER', scope: 'APPLICATION' }]}
             onClose={onClose}
             onSubmit={onSubmit}
@@ -51,13 +60,31 @@ describe('GroupInviteMemberSheet', () => {
         expect(screen.getByRole('button', { name: 'Send invitation' })).toHaveProperty('disabled', true);
     });
 
-    it('submits the email and default roles', () => {
+    it('submits the email with the USER fallback default roles when the group has no configured defaults', () => {
         const { onSubmit } = renderSheet();
 
         fireEvent.change(screen.getByRole('textbox', { name: /Email/i }), { target: { value: 'anna.schmidt@lufthansa.com' } });
         fireEvent.click(screen.getByRole('button', { name: 'Send invitation' }));
 
-        expect(onSubmit).toHaveBeenCalledWith({ email: 'anna.schmidt@lufthansa.com', apiRole: '', applicationRole: '' });
+        expect(onSubmit).toHaveBeenCalledWith({ email: 'anna.schmidt@lufthansa.com', apiRole: 'USER', applicationRole: 'USER' });
+    });
+
+    it('has no "None" role option — classic\'s invite-member-dialog has no such mat-option', () => {
+        renderSheet();
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.queryByRole('option', { name: 'None' })).toBeNull();
+    });
+
+    describe('default role pre-fill', () => {
+        // Mirrors classic InviteMemberDialogComponent.initializeForm(): `group.roles['API'] ?? 'USER'`.
+        it('pre-fills API/Application from the group’s configured default roles', () => {
+            const { onSubmit } = renderSheet({ groupRoles: { API: 'OWNER', APPLICATION: 'USER' } });
+
+            fireEvent.change(screen.getByRole('textbox', { name: /Email/i }), { target: { value: 'anna.schmidt@lufthansa.com' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Send invitation' }));
+
+            expect(onSubmit).toHaveBeenCalledWith({ email: 'anna.schmidt@lufthansa.com', apiRole: 'OWNER', applicationRole: 'USER' });
+        });
     });
 
     it('calls onClose when Cancel is clicked', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.tsx
@@ -34,6 +34,9 @@ import { useEffect, useState } from 'react';
 
 import type { GroupRole } from '../types/group';
 
+// Radix Select's controlled `value` can't be an empty string, so unset state is represented by this
+// sentinel internally — but classic's invite-member-dialog.component.html has no "None" mat-option (both
+// default role controls always start from a real value, see initializeForm()), so it isn't rendered below.
 const NO_ROLE_VALUE = '__none__';
 
 // Backend only accepts api_role/application_role on an invitation — no api_product/integration/cluster,
@@ -41,6 +44,7 @@ const NO_ROLE_VALUE = '__none__';
 export function GroupInviteMemberSheet({
     open,
     groupName,
+    groupRoles,
     apiRoles,
     applicationRoles,
     onClose,
@@ -49,6 +53,9 @@ export function GroupInviteMemberSheet({
 }: Readonly<{
     open: boolean;
     groupName: string;
+    /** The group's own configured default roles (`GroupEntity.roles`) — pre-fills API/Application below,
+     *  mirroring classic InviteMemberDialogComponent's `group.roles['API'] ?? 'USER'` fallback. */
+    groupRoles: Record<string, string> | undefined;
     apiRoles: GroupRole[];
     applicationRoles: GroupRole[];
     onClose: () => void;
@@ -60,12 +67,12 @@ export function GroupInviteMemberSheet({
     const [applicationRole, setApplicationRole] = useState('');
 
     useEffect(() => {
-        if (!open) {
+        if (open) {
             setEmail('');
-            setApiRole('');
-            setApplicationRole('');
+            setApiRole(groupRoles?.API ?? 'USER');
+            setApplicationRole(groupRoles?.APPLICATION ?? 'USER');
         }
-    }, [open]);
+    }, [open, groupRoles]);
 
     function handleClose() {
         onClose();
@@ -102,7 +109,6 @@ export function GroupInviteMemberSheet({
                                 <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
-                                <SelectItem value={NO_ROLE_VALUE}>None</SelectItem>
                                 {apiRoles.map(role => (
                                     <SelectItem key={role.name} value={role.name}>
                                         {role.name}
@@ -122,7 +128,6 @@ export function GroupInviteMemberSheet({
                                 <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
-                                <SelectItem value={NO_ROLE_VALUE}>None</SelectItem>
                                 {applicationRoles.map(role => (
                                     <SelectItem key={role.name} value={role.name}>
                                         {role.name}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.tsx
@@ -142,7 +142,11 @@ export function GroupInviteMemberSheet({
                     <Button type="button" variant="outline" onClick={handleClose} disabled={isSaving}>
                         Cancel
                     </Button>
-                    <Button type="button" onClick={() => onSubmit({ email: email.trim(), apiRole, applicationRole })} disabled={!canSubmit || isSaving}>
+                    <Button
+                        type="button"
+                        onClick={() => onSubmit({ email: email.trim(), apiRole, applicationRole })}
+                        disabled={!canSubmit || isSaving}
+                    >
                         {isSaving ? 'Sending…' : 'Send invitation'}
                     </Button>
                 </SheetFooter>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Input,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+} from '@gravitee/graphene-core';
+import { useEffect, useState } from 'react';
+
+import type { GroupRole } from '../types/group';
+
+const NO_ROLE_VALUE = '__none__';
+
+// Backend only accepts api_role/application_role on an invitation — no api_product/integration/cluster,
+// unlike direct membership roles (GroupInvitationPayload in types/group.ts documents this).
+export function GroupInviteMemberSheet({
+    open,
+    groupName,
+    apiRoles,
+    applicationRoles,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    groupName: string;
+    apiRoles: GroupRole[];
+    applicationRoles: GroupRole[];
+    onClose: () => void;
+    onSubmit: (values: { email: string; apiRole: string; applicationRole: string }) => void;
+    isSaving: boolean;
+}>) {
+    const [email, setEmail] = useState('');
+    const [apiRole, setApiRole] = useState('');
+    const [applicationRole, setApplicationRole] = useState('');
+
+    useEffect(() => {
+        if (!open) {
+            setEmail('');
+            setApiRole('');
+            setApplicationRole('');
+        }
+    }, [open]);
+
+    function handleClose() {
+        onClose();
+    }
+
+    const canSubmit = email.trim().length > 0;
+
+    return (
+        <Sheet open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>Email invitation</SheetTitle>
+                    <SheetDescription>Invite a new user to {groupName} and assign their default roles.</SheetDescription>
+                </SheetHeader>
+
+                <div className="space-y-6 px-4">
+                    <div className="space-y-1.5">
+                        <Label htmlFor="invite-email" className="text-sm font-medium">
+                            Email <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                            id="invite-email"
+                            type="email"
+                            placeholder="user@example.com"
+                            value={email}
+                            onChange={e => setEmail(e.target.value)}
+                        />
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <Label className="text-sm font-medium">Default API role</Label>
+                        <Select value={apiRole || NO_ROLE_VALUE} onValueChange={v => setApiRole(v === NO_ROLE_VALUE ? '' : v)}>
+                            <SelectTrigger className="w-full">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value={NO_ROLE_VALUE}>None</SelectItem>
+                                {apiRoles.map(role => (
+                                    <SelectItem key={role.name} value={role.name}>
+                                        {role.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <Label className="text-sm font-medium">Default application role</Label>
+                        <Select
+                            value={applicationRole || NO_ROLE_VALUE}
+                            onValueChange={v => setApplicationRole(v === NO_ROLE_VALUE ? '' : v)}
+                        >
+                            <SelectTrigger className="w-full">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value={NO_ROLE_VALUE}>None</SelectItem>
+                                {applicationRoles.map(role => (
+                                    <SelectItem key={role.name} value={role.name}>
+                                        {role.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+
+                <SheetFooter className="shrink-0 flex-row justify-end border-t">
+                    <Button type="button" variant="outline" onClick={handleClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={() => onSubmit({ email: email.trim(), apiRole, applicationRole })} disabled={!canSubmit || isSaving}>
+                        {isSaving ? 'Sending…' : 'Send invitation'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Input, Label, Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from '@gravitee/graphene-core';
+import { useEffect, useState } from 'react';
+
+import { GroupRoleSelect } from './GroupRoleSelect';
+import type { GroupMember, GroupRole } from '../types/group';
+import { PRIMARY_OWNER_ROLE } from '../types/group';
+import { isRoleLocked } from '../utils/groupPermissions';
+
+export function GroupInviteMemberSheet({
+    open,
+    groupName,
+    groupRoles,
+    members,
+    apiRoles,
+    applicationRoles,
+    lockApiRole,
+    lockApplicationRole,
+    canOverrideLocks,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    groupName: string;
+    groupRoles: Record<string, string> | undefined;
+    members: GroupMember[];
+    apiRoles: GroupRole[];
+    applicationRoles: GroupRole[];
+    lockApiRole: boolean;
+    lockApplicationRole: boolean;
+    canOverrideLocks: boolean;
+    onClose: () => void;
+    onSubmit: (values: { email: string; apiRole: string; applicationRole: string }) => void;
+    isSaving: boolean;
+}>) {
+    const [email, setEmail] = useState('');
+    const [apiRole, setApiRole] = useState('');
+    const [applicationRole, setApplicationRole] = useState('');
+
+    useEffect(() => {
+        if (open) {
+            setEmail('');
+            setApiRole(groupRoles?.API ?? 'USER');
+            setApplicationRole(groupRoles?.APPLICATION ?? 'USER');
+        }
+    }, [open, groupRoles]);
+
+    function handleClose() {
+        onClose();
+    }
+
+    const apiPrimaryOwnerExists = members.some(m => m.roles?.API === PRIMARY_OWNER_ROLE);
+    const apiRoleDisabled = isRoleLocked(lockApiRole, canOverrideLocks);
+    const applicationRoleDisabled = isRoleLocked(lockApplicationRole, canOverrideLocks);
+
+    const canSubmit = email.trim().length > 0;
+
+    return (
+        <Sheet open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>Email invitation</SheetTitle>
+                    <SheetDescription>Invite a new user to {groupName} and assign their default roles.</SheetDescription>
+                </SheetHeader>
+
+                <div className="space-y-6 px-4">
+                    <div className="space-y-1.5">
+                        <Label htmlFor="invite-email" className="text-sm font-medium">
+                            Email <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                            id="invite-email"
+                            type="email"
+                            placeholder="user@example.com"
+                            value={email}
+                            onChange={e => setEmail(e.target.value)}
+                        />
+                    </div>
+
+                    <GroupRoleSelect
+                        label="Default API role"
+                        roles={apiRoles}
+                        value={apiRole}
+                        onChange={setApiRole}
+                        disabled={apiRoleDisabled}
+                        disabledOptionNames={apiPrimaryOwnerExists ? new Set([PRIMARY_OWNER_ROLE]) : undefined}
+                    />
+
+                    <GroupRoleSelect
+                        label="Default application role"
+                        roles={applicationRoles}
+                        value={applicationRole}
+                        onChange={setApplicationRole}
+                        disabled={applicationRoleDisabled}
+                    />
+                </div>
+
+                <SheetFooter className="shrink-0 flex-row justify-end border-t">
+                    <Button type="button" variant="outline" onClick={handleClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button
+                        type="button"
+                        onClick={() => onSubmit({ email: email.trim(), apiRole, applicationRole })}
+                        disabled={!canSubmit || isSaving}
+                    >
+                        {isSaving ? 'Sending…' : 'Send invitation'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.spec.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { GroupMembersTable } from './GroupMembersTable';
 import type { GroupMember } from '../types/group';
@@ -31,7 +32,16 @@ const MIA: GroupMember = {
 };
 
 function renderTable(overrides: Partial<React.ComponentProps<typeof GroupMembersTable>> = {}) {
-    return render(<GroupMembersTable members={[RAVI, MIA]} loading={false} {...overrides} />);
+    return render(
+        <GroupMembersTable
+            members={[RAVI, MIA]}
+            loading={false}
+            canManageMembers
+            onEditRoles={jest.fn()}
+            onRemove={jest.fn()}
+            {...overrides}
+        />,
+    );
 }
 
 describe('GroupMembersTable', () => {
@@ -50,6 +60,48 @@ describe('GroupMembersTable', () => {
         renderTable();
         expect(screen.getByText('Ravi Patel').closest('tr')!.textContent).toContain('Group admin');
         expect(screen.getByText('Mia Chen').closest('tr')!.textContent).not.toContain('Group admin');
+    });
+
+    it('hides the actions column entirely without permission', () => {
+        renderTable({ canManageMembers: false });
+        expect(screen.queryByRole('button', { name: 'Member actions' })).toBeNull();
+    });
+
+    it('calls onEditRoles with the row’s member when Edit roles is selected', async () => {
+        const user = userEvent.setup();
+        const onEditRoles = jest.fn();
+        renderTable({ onEditRoles });
+
+        const miaActions = screen.getByText('Mia Chen').closest('tr')!.querySelector('button[aria-label="Member actions"]')!;
+        await user.click(miaActions);
+        await user.click(await screen.findByRole('menuitem', { name: 'Edit roles' }));
+
+        expect(onEditRoles).toHaveBeenCalledWith(MIA);
+    });
+
+    it('calls onRemove with the row’s member when Remove member is selected for a non-owner', async () => {
+        const user = userEvent.setup();
+        const onRemove = jest.fn();
+        renderTable({ onRemove });
+
+        const miaActions = screen.getByText('Mia Chen').closest('tr')!.querySelector('button[aria-label="Member actions"]')!;
+        await user.click(miaActions);
+        const removeItem = await screen.findByRole('menuitem', { name: 'Remove member' });
+        expect(removeItem.getAttribute('aria-disabled')).not.toBe('true');
+        await user.click(removeItem);
+
+        expect(onRemove).toHaveBeenCalledWith(MIA);
+    });
+
+    it('disables Remove member for a member holding API or API Product primary ownership', async () => {
+        const user = userEvent.setup();
+        renderTable();
+
+        const raviActions = screen.getByText('Ravi Patel').closest('tr')!.querySelector('button[aria-label="Member actions"]')!;
+        await user.click(raviActions);
+
+        const removeItem = await screen.findByRole('menuitem', { name: 'Remove member' });
+        expect(removeItem.getAttribute('aria-disabled')).toBe('true');
     });
 
     it('filters members by name client-side', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.spec.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { GroupMembersTable } from './GroupMembersTable';
 import type { GroupMember } from '../types/group';
@@ -31,7 +32,16 @@ const MIA: GroupMember = {
 };
 
 function renderTable(overrides: Partial<React.ComponentProps<typeof GroupMembersTable>> = {}) {
-    return render(<GroupMembersTable members={[RAVI, MIA]} loading={false} {...overrides} />);
+    return render(
+        <GroupMembersTable
+            members={[RAVI, MIA]}
+            loading={false}
+            canManageMembers
+            onEditRoles={jest.fn()}
+            onRemove={jest.fn()}
+            {...overrides}
+        />,
+    );
 }
 
 describe('GroupMembersTable', () => {
@@ -50,6 +60,59 @@ describe('GroupMembersTable', () => {
         renderTable();
         expect(screen.getByText('Ravi Patel').closest('tr')!.textContent).toContain('Group admin');
         expect(screen.getByText('Mia Chen').closest('tr')!.textContent).not.toContain('Group admin');
+    });
+
+    it('hides the actions column entirely without permission', () => {
+        renderTable({ canManageMembers: false });
+        expect(screen.queryByRole('button', { name: 'Member actions' })).toBeNull();
+    });
+
+    it('calls onEditRoles with the row’s member when Edit roles is selected', async () => {
+        const user = userEvent.setup();
+        const onEditRoles = jest.fn();
+        renderTable({ onEditRoles });
+
+        const miaActions = screen.getByText('Mia Chen').closest('tr')!.querySelector('button[aria-label="Member actions"]')!;
+        await user.click(miaActions);
+        await user.click(await screen.findByRole('menuitem', { name: 'Edit roles' }));
+
+        expect(onEditRoles).toHaveBeenCalledWith(MIA);
+    });
+
+    it('calls onRemove with the row’s member when Remove member is selected for a non-owner', async () => {
+        const user = userEvent.setup();
+        const onRemove = jest.fn();
+        renderTable({ onRemove });
+
+        const miaActions = screen.getByText('Mia Chen').closest('tr')!.querySelector('button[aria-label="Member actions"]')!;
+        await user.click(miaActions);
+        const removeItem = await screen.findByRole('menuitem', { name: 'Remove member' });
+        expect(removeItem.getAttribute('aria-disabled')).not.toBe('true');
+        await user.click(removeItem);
+
+        expect(onRemove).toHaveBeenCalledWith(MIA);
+    });
+
+    it('allows Remove member for a primary owner as long as another member exists to transfer to', async () => {
+        const user = userEvent.setup();
+        renderTable();
+
+        const raviActions = screen.getByText('Ravi Patel').closest('tr')!.querySelector('button[aria-label="Member actions"]')!;
+        await user.click(raviActions);
+
+        const removeItem = await screen.findByRole('menuitem', { name: 'Remove member' });
+        expect(removeItem.getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    it('disables Remove member when the primary owner is the group’s sole member — mirrors classic disableDeleteMember()', async () => {
+        const user = userEvent.setup();
+        renderTable({ members: [RAVI] });
+
+        const raviActions = screen.getByText('Ravi Patel').closest('tr')!.querySelector('button[aria-label="Member actions"]')!;
+        await user.click(raviActions);
+
+        const removeItem = await screen.findByRole('menuitem', { name: 'Remove member' });
+        expect(removeItem.getAttribute('aria-disabled')).toBe('true');
     });
 
     it('filters members by name client-side', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
@@ -20,17 +20,23 @@ import {
     DataTable,
     DataTableColumnHeader,
     DataTableEmptyState,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
     InputGroup,
     InputGroupAddon,
     InputGroupInput,
     type DataTableProps,
 } from '@gravitee/graphene-core';
-import { SearchIcon } from '@gravitee/graphene-core/icons';
+import { MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
 import { useEffect, useMemo, useState } from 'react';
 
 import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
 import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
 import type { GroupMember } from '../types/group';
+import { PRIMARY_OWNER_ROLE } from '../types/group';
 
 const PAGE_SIZE = 10;
 
@@ -39,8 +45,26 @@ function roleCell(member: GroupMember, scope: 'API' | 'APPLICATION' | 'API_PRODU
     return <span className="text-sm text-muted-foreground">{role ?? '—'}</span>;
 }
 
-function buildColumns(): DataTableProps<GroupMember>['columns'] {
-    return [
+function isPrimaryOwnerMember(member: GroupMember): boolean {
+    return member.roles?.API === PRIMARY_OWNER_ROLE || member.roles?.API_PRODUCT === PRIMARY_OWNER_ROLE;
+}
+
+function isRemoveDisabled(member: GroupMember, totalMemberCount: number): boolean {
+    return totalMemberCount === 1 && isPrimaryOwnerMember(member);
+}
+
+function buildColumns({
+    canManageMembers,
+    totalMemberCount,
+    onEditRoles,
+    onRemove,
+}: {
+    canManageMembers: boolean;
+    totalMemberCount: number;
+    onEditRoles: (member: GroupMember) => void;
+    onRemove: (member: GroupMember) => void;
+}): DataTableProps<GroupMember>['columns'] {
+    const columns: DataTableProps<GroupMember>['columns'] = [
         {
             id: 'member',
             accessorKey: 'displayName',
@@ -87,6 +111,43 @@ function buildColumns(): DataTableProps<GroupMember>['columns'] {
             cell: ({ row }: ColCell<GroupMember>) => roleCell(row.original, 'CLUSTER'),
         },
     ];
+
+    if (canManageMembers) {
+        columns.push({
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            size: 56,
+            enableSorting: false,
+            enableHiding: false,
+            cell: ({ row }: ColCell<GroupMember>) => {
+                const removeDisabled = isRemoveDisabled(row.original, totalMemberCount);
+                return (
+                    <div className="flex justify-end">
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="ghost" size="icon" className="size-8" aria-label="Member actions">
+                                    <MoreHorizontalIcon className="size-4" aria-hidden />
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                                <DropdownMenuItem onSelect={() => onEditRoles(row.original)}>
+                                    <PencilIcon className="size-4 mr-2" aria-hidden />
+                                    Edit roles
+                                </DropdownMenuItem>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem variant="destructive" disabled={removeDisabled} onSelect={() => onRemove(row.original)}>
+                                    <Trash2Icon className="size-4 mr-2" aria-hidden />
+                                    Remove member
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </div>
+                );
+            },
+        });
+    }
+
+    return columns;
 }
 
 function paginate(items: GroupMember[], page: number, pageSize: number): GroupMember[] {
@@ -97,11 +158,12 @@ function paginate(items: GroupMember[], page: number, pageSize: number): GroupMe
 interface GroupMembersTableProps {
     readonly members: GroupMember[];
     readonly loading: boolean;
+    readonly canManageMembers: boolean;
+    readonly onEditRoles: (member: GroupMember) => void;
+    readonly onRemove: (member: GroupMember) => void;
 }
 
-// Member management (add/invite/edit roles/remove) is added on top of this read-only view in a
-// follow-up PR (FOUND-106/FOUND-107) — this component intentionally has no action column yet.
-export function GroupMembersTable({ members, loading }: GroupMembersTableProps) {
+export function GroupMembersTable({ members, loading, canManageMembers, onEditRoles, onRemove }: GroupMembersTableProps) {
     const [search, setSearch] = useState('');
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(PAGE_SIZE);
@@ -114,7 +176,10 @@ export function GroupMembersTable({ members, loading }: GroupMembersTableProps) 
     const totalCount = filtered.length;
     const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1;
     const pageData = useMemo(() => paginate(filtered, page, pageSize), [filtered, page, pageSize]);
-    const columns = useMemo(() => buildColumns(), []);
+    const columns = useMemo(
+        () => buildColumns({ canManageMembers, totalMemberCount: members.length, onEditRoles, onRemove }),
+        [canManageMembers, members.length, onEditRoles, onRemove],
+    );
 
     useEffect(() => {
         if (page > totalPages) setPage(totalPages);

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
@@ -130,11 +130,7 @@ function buildColumns({
                                     Edit roles
                                 </DropdownMenuItem>
                                 <DropdownMenuSeparator />
-                                <DropdownMenuItem
-                                    variant="destructive"
-                                    disabled={removeDisabled}
-                                    onSelect={() => onRemove(row.original)}
-                                >
+                                <DropdownMenuItem variant="destructive" disabled={removeDisabled} onSelect={() => onRemove(row.original)}>
                                     <Trash2Icon className="size-4 mr-2" aria-hidden />
                                     Remove member
                                 </DropdownMenuItem>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
@@ -20,12 +20,17 @@ import {
     DataTable,
     DataTableColumnHeader,
     DataTableEmptyState,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
     InputGroup,
     InputGroupAddon,
     InputGroupInput,
     type DataTableProps,
 } from '@gravitee/graphene-core';
-import { SearchIcon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
+import { MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
 import { useEffect, useMemo, useState } from 'react';
 
 import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
@@ -39,8 +44,22 @@ function roleCell(member: GroupMember, scope: 'API' | 'APPLICATION' | 'API_PRODU
     return <span className="text-sm text-muted-foreground">{role ?? '—'}</span>;
 }
 
-function buildColumns(): DataTableProps<GroupMember>['columns'] {
-    return [
+/** Mirrors classic group.component.ts's `disableDeleteMember()` — a member holding API/API Product
+ *  primary ownership can't be removed from here; reassigning ownership isn't supported in this view yet. */
+function isPrimaryOwnerMember(member: GroupMember): boolean {
+    return member.roles?.API === 'PRIMARY_OWNER' || member.roles?.API_PRODUCT === 'PRIMARY_OWNER';
+}
+
+function buildColumns({
+    canManageMembers,
+    onEditRoles,
+    onRemove,
+}: {
+    canManageMembers: boolean;
+    onEditRoles: (member: GroupMember) => void;
+    onRemove: (member: GroupMember) => void;
+}): DataTableProps<GroupMember>['columns'] {
+    const columns: DataTableProps<GroupMember>['columns'] = [
         {
             id: 'member',
             accessorKey: 'displayName',
@@ -87,6 +106,47 @@ function buildColumns(): DataTableProps<GroupMember>['columns'] {
             cell: ({ row }: ColCell<GroupMember>) => roleCell(row.original, 'CLUSTER'),
         },
     ];
+
+    if (canManageMembers) {
+        columns.push({
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            size: 56,
+            enableSorting: false,
+            enableHiding: false,
+            cell: ({ row }: ColCell<GroupMember>) => {
+                const removeDisabled = isPrimaryOwnerMember(row.original);
+                return (
+                    <div className="flex justify-end">
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="ghost" size="icon" className="size-8" aria-label="Member actions">
+                                    <MoreHorizontalIcon className="size-4" aria-hidden />
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                                <DropdownMenuItem onSelect={() => onEditRoles(row.original)}>
+                                    <PencilIcon className="size-4 mr-2" aria-hidden />
+                                    Edit roles
+                                </DropdownMenuItem>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem
+                                    variant="destructive"
+                                    disabled={removeDisabled}
+                                    onSelect={() => onRemove(row.original)}
+                                >
+                                    <Trash2Icon className="size-4 mr-2" aria-hidden />
+                                    Remove member
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </div>
+                );
+            },
+        });
+    }
+
+    return columns;
 }
 
 function paginate(items: GroupMember[], page: number, pageSize: number): GroupMember[] {
@@ -97,11 +157,12 @@ function paginate(items: GroupMember[], page: number, pageSize: number): GroupMe
 interface GroupMembersTableProps {
     readonly members: GroupMember[];
     readonly loading: boolean;
+    readonly canManageMembers: boolean;
+    readonly onEditRoles: (member: GroupMember) => void;
+    readonly onRemove: (member: GroupMember) => void;
 }
 
-// Member management (add/invite/edit roles/remove) is added on top of this read-only view in a
-// follow-up PR (FOUND-106/FOUND-107) — this component intentionally has no action column yet.
-export function GroupMembersTable({ members, loading }: GroupMembersTableProps) {
+export function GroupMembersTable({ members, loading, canManageMembers, onEditRoles, onRemove }: GroupMembersTableProps) {
     const [search, setSearch] = useState('');
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(PAGE_SIZE);
@@ -114,7 +175,7 @@ export function GroupMembersTable({ members, loading }: GroupMembersTableProps) 
     const totalCount = filtered.length;
     const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1;
     const pageData = useMemo(() => paginate(filtered, page, pageSize), [filtered, page, pageSize]);
-    const columns = useMemo(() => buildColumns(), []);
+    const columns = useMemo(() => buildColumns({ canManageMembers, onEditRoles, onRemove }), [canManageMembers, onEditRoles, onRemove]);
 
     useEffect(() => {
         if (page > totalPages) setPage(totalPages);

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.spec.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { GroupRemoveMemberSheet } from './GroupRemoveMemberSheet';
+import type { GroupMember } from '../types/group';
+
+const MEMBER: GroupMember = { id: 'user-1', displayName: 'Anna Schmidt', roles: {} };
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupRemoveMemberSheet>> = {}) {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    render(
+        <GroupRemoveMemberSheet
+            open
+            member={MEMBER}
+            members={[MEMBER]}
+            groupName="API Team"
+            onClose={onClose}
+            onConfirm={onConfirm}
+            isRemoving={false}
+            {...overrides}
+        />,
+    );
+    return { onClose, onConfirm };
+}
+
+describe('GroupRemoveMemberSheet', () => {
+    it('does not render dialog content when closed', () => {
+        renderSheet({ open: false });
+        expect(screen.queryByRole('heading', { name: 'Remove member?' })).toBeNull();
+    });
+
+    it('names the member and the group in the confirmation message', () => {
+        renderSheet();
+        expect(screen.getByText('Anna Schmidt')).not.toBeNull();
+        expect(screen.getByText('API Team')).not.toBeNull();
+    });
+
+    it('calls onConfirm with no transfer membership for a non-primary-owner member', () => {
+        const { onConfirm } = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+        expect(onConfirm).toHaveBeenCalledWith(undefined);
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables both buttons while removing', () => {
+        renderSheet({ isRemoving: true });
+        expect(screen.getByRole('button', { name: 'Cancel' })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('button', { name: 'Removing…' })).toHaveProperty('disabled', true);
+    });
+
+    describe('primary owner reassignment', () => {
+        const PRIMARY_OWNER_MEMBER: GroupMember = {
+            id: 'user-1',
+            displayName: 'Anna Schmidt',
+            roles: { API: 'PRIMARY_OWNER', APPLICATION: 'USER' },
+        };
+        const OTHER_MEMBER: GroupMember = { id: 'user-2', displayName: 'Ravi Patel', roles: { API: 'OWNER' } };
+
+        it('disables Remove until a successor is picked', () => {
+            renderSheet({ member: PRIMARY_OWNER_MEMBER, members: [PRIMARY_OWNER_MEMBER, OTHER_MEMBER] });
+            expect(screen.getByRole('button', { name: 'Remove' })).toHaveProperty('disabled', true);
+        });
+
+        it('searches members, selects a successor, and submits the transfer membership', async () => {
+            const user = userEvent.setup();
+            const { onConfirm } = renderSheet({ member: PRIMARY_OWNER_MEMBER, members: [PRIMARY_OWNER_MEMBER, OTHER_MEMBER] });
+
+            await user.click(screen.getByLabelText('Search members'));
+            await user.click(screen.getByRole('option', { name: 'Ravi Patel' }));
+
+            expect(
+                screen.getByText(
+                    'Anna Schmidt is the API primary owner. Primary ownership of the group will be transferred from Anna Schmidt to Ravi Patel.',
+                ),
+            ).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+            expect(onConfirm).toHaveBeenCalledWith({
+                id: 'user-2',
+                roles: [{ scope: 'API', name: 'PRIMARY_OWNER' }],
+            });
+        });
+
+        it('excludes the member being removed from the successor search results', async () => {
+            const user = userEvent.setup();
+            renderSheet({ member: PRIMARY_OWNER_MEMBER, members: [PRIMARY_OWNER_MEMBER, OTHER_MEMBER] });
+            await user.click(screen.getByLabelText('Search members'));
+            expect(screen.queryByRole('option', { name: 'Anna Schmidt' })).toBeNull();
+            expect(screen.getByRole('option', { name: 'Ravi Patel' })).not.toBeNull();
+        });
+
+        it('joins multiple owned scopes in the transfer message', async () => {
+            const user = userEvent.setup();
+            const member: GroupMember = {
+                id: 'user-1',
+                displayName: 'Anna Schmidt',
+                roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'PRIMARY_OWNER', CLUSTER: 'PRIMARY_OWNER' },
+            };
+            renderSheet({ member, members: [member, OTHER_MEMBER] });
+
+            await user.click(screen.getByLabelText('Search members'));
+            await user.click(screen.getByRole('option', { name: 'Ravi Patel' }));
+
+            expect(
+                screen.getByText(
+                    'Anna Schmidt is the API, API Product and Cluster primary owner. Primary ownership of the group will be transferred from Anna Schmidt to Ravi Patel.',
+                ),
+            ).not.toBeNull();
+        });
+
+        it.each(['APPLICATION', 'INTEGRATION', 'CLUSTER'])('forces a successor pick when the member is the %s primary owner', scope => {
+            const member: GroupMember = { id: 'user-1', displayName: 'Anna Schmidt', roles: { [scope]: 'PRIMARY_OWNER' } };
+            renderSheet({ member, members: [member, OTHER_MEMBER] });
+            expect(screen.getByRole('button', { name: 'Remove' })).toHaveProperty('disabled', true);
+            expect(screen.getByLabelText('Search members')).not.toBeNull();
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.spec.tsx
@@ -27,6 +27,7 @@ function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupRemoveM
         <GroupRemoveMemberSheet
             open
             member={MEMBER}
+            members={[MEMBER]}
             groupName="API Team"
             onClose={onClose}
             onConfirm={onConfirm}
@@ -49,10 +50,10 @@ describe('GroupRemoveMemberSheet', () => {
         expect(screen.getByText('API Team')).not.toBeNull();
     });
 
-    it('calls onConfirm when Remove is clicked', () => {
+    it('calls onConfirm with no transfer membership for a non-primary-owner member', () => {
         const { onConfirm } = renderSheet();
         fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
-        expect(onConfirm).toHaveBeenCalledTimes(1);
+        expect(onConfirm).toHaveBeenCalledWith(undefined);
     });
 
     it('calls onClose when Cancel is clicked', () => {
@@ -65,5 +66,49 @@ describe('GroupRemoveMemberSheet', () => {
         renderSheet({ isRemoving: true });
         expect(screen.getByRole('button', { name: 'Cancel' })).toHaveProperty('disabled', true);
         expect(screen.getByRole('button', { name: 'Removing…' })).toHaveProperty('disabled', true);
+    });
+
+    describe('primary owner reassignment', () => {
+        // Mirrors classic delete-member-dialog.component.ts: removing a member who is the group's API
+        // and/or API Product primary owner forces picking a successor first — the backend rejects the
+        // removal outright otherwise (same StillPrimaryOwnerException guard as role edits).
+        const PRIMARY_OWNER_MEMBER: GroupMember = {
+            id: 'user-1',
+            displayName: 'Anna Schmidt',
+            roles: { API: 'PRIMARY_OWNER', APPLICATION: 'USER' },
+        };
+        const OTHER_MEMBER: GroupMember = { id: 'user-2', displayName: 'Ravi Patel', roles: { API: 'OWNER' } };
+
+        it('disables Remove until a successor is picked', () => {
+            renderSheet({ member: PRIMARY_OWNER_MEMBER, members: [PRIMARY_OWNER_MEMBER, OTHER_MEMBER] });
+            expect(screen.getByRole('button', { name: 'Remove' })).toHaveProperty('disabled', true);
+        });
+
+        it('searches members, selects a successor, and submits the transfer membership', () => {
+            const { onConfirm } = renderSheet({ member: PRIMARY_OWNER_MEMBER, members: [PRIMARY_OWNER_MEMBER, OTHER_MEMBER] });
+
+            fireEvent.change(screen.getByPlaceholderText('Search for a new primary owner…'), { target: { value: 'Ravi' } });
+            fireEvent.click(screen.getByText('Ravi Patel'));
+
+            expect(
+                screen.getByText(
+                    'Anna Schmidt is the API primary owner. Primary ownership of the group will be transferred from Anna Schmidt to Ravi Patel.',
+                ),
+            ).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+            expect(onConfirm).toHaveBeenCalledWith({
+                id: 'user-2',
+                roles: [{ scope: 'API', name: 'PRIMARY_OWNER' }],
+            });
+        });
+
+        it('excludes the member being removed from the successor search results', () => {
+            renderSheet({ member: PRIMARY_OWNER_MEMBER, members: [PRIMARY_OWNER_MEMBER, OTHER_MEMBER] });
+            fireEvent.change(screen.getByPlaceholderText('Search for a new primary owner…'), { target: { value: 'a' } });
+            expect(screen.queryByRole('button', { name: /Anna Schmidt/ })).toBeNull();
+            expect(screen.getByRole('button', { name: /Ravi Patel/ })).not.toBeNull();
+        });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.spec.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupRemoveMemberSheet } from './GroupRemoveMemberSheet';
+import type { GroupMember } from '../types/group';
+
+const MEMBER: GroupMember = { id: 'user-1', displayName: 'Anna Schmidt', roles: {} };
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupRemoveMemberSheet>> = {}) {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    render(
+        <GroupRemoveMemberSheet
+            open
+            member={MEMBER}
+            groupName="API Team"
+            onClose={onClose}
+            onConfirm={onConfirm}
+            isRemoving={false}
+            {...overrides}
+        />,
+    );
+    return { onClose, onConfirm };
+}
+
+describe('GroupRemoveMemberSheet', () => {
+    it('does not render dialog content when closed', () => {
+        renderSheet({ open: false });
+        expect(screen.queryByRole('heading', { name: 'Remove member' })).toBeNull();
+    });
+
+    it('names the member and the group in the confirmation message', () => {
+        renderSheet();
+        expect(screen.getByText('Anna Schmidt')).not.toBeNull();
+        expect(screen.getByText('API Team')).not.toBeNull();
+    });
+
+    it('calls onConfirm when Remove is clicked', () => {
+        const { onConfirm } = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables both buttons while removing', () => {
+        renderSheet({ isRemoving: true });
+        expect(screen.getByRole('button', { name: 'Cancel' })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('button', { name: 'Removing…' })).toHaveProperty('disabled', true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+
+import type { GroupMember } from '../types/group';
+
+export function GroupRemoveMemberSheet({
+    open,
+    member,
+    groupName,
+    onClose,
+    onConfirm,
+    isRemoving,
+}: Readonly<{
+    open: boolean;
+    member: GroupMember | undefined;
+    groupName: string;
+    onClose: () => void;
+    onConfirm: () => void;
+    isRemoving: boolean;
+}>) {
+    return (
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Remove member</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to remove <span className="font-medium text-foreground">{member?.displayName}</span> from{' '}
+                        <span className="font-medium text-foreground">{groupName}</span>? They will lose any access granted through this
+                        group.
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isRemoving}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isRemoving || !member}>
+                        {isRemoving ? 'Removing…' : 'Remove'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+import { InfoIcon, TriangleAlertIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+
+import { MemberSuccessorCombobox } from './MemberSuccessorCombobox';
+import type { GroupMember, GroupMembershipPayload, GroupMembershipRole, GroupMemberRoleScope } from '../types/group';
+import { PRIMARY_OWNER_ROLE } from '../types/group';
+
+const PRIMARY_OWNER_SCOPES: GroupMemberRoleScope[] = ['API', 'APPLICATION', 'API_PRODUCT', 'INTEGRATION', 'CLUSTER'];
+
+const SCOPE_LABELS: Readonly<Record<string, string>> = {
+    API: 'API',
+    APPLICATION: 'Application',
+    API_PRODUCT: 'API Product',
+    INTEGRATION: 'Integration',
+    CLUSTER: 'Cluster',
+};
+
+function joinScopeLabels(scopes: string[]): string {
+    const labels = scopes.map(scope => SCOPE_LABELS[scope]);
+    if (labels.length <= 1) return labels.join('');
+    return `${labels.slice(0, -1).join(', ')} and ${labels[labels.length - 1]}`;
+}
+
+function buildTransferMembership(successor: GroupMember, scopes: string[]): GroupMembershipPayload {
+    const merged: Record<string, string> = { ...(successor.roles ?? {}) };
+    scopes.forEach(scope => {
+        merged[scope] = PRIMARY_OWNER_ROLE;
+    });
+    const roles: GroupMembershipRole[] = Object.entries(merged)
+        .filter((entry): entry is [string, string] => Boolean(entry[1]))
+        .map(([scope, name]) => ({ scope: scope as GroupMembershipRole['scope'], name }));
+    return { id: successor.id, roles };
+}
+
+export function GroupRemoveMemberSheet({
+    open,
+    member,
+    members,
+    groupName,
+    onClose,
+    onConfirm,
+    isRemoving,
+}: Readonly<{
+    open: boolean;
+    member: GroupMember | undefined;
+    members: GroupMember[];
+    groupName: string;
+    onClose: () => void;
+    onConfirm: (transferMembership?: GroupMembershipPayload) => void;
+    isRemoving: boolean;
+}>) {
+    const [successor, setSuccessor] = useState<GroupMember | null>(null);
+
+    useEffect(() => {
+        if (open) {
+            setSuccessor(null);
+        }
+    }, [open, member]);
+
+    const primaryOwnerScopes = useMemo(() => PRIMARY_OWNER_SCOPES.filter(scope => member?.roles?.[scope] === PRIMARY_OWNER_ROLE), [member]);
+    const isPrimaryOwner = primaryOwnerScopes.length > 0;
+
+    const candidates = useMemo(
+        () => (member ? members.filter(m => m.id !== member.id).sort((a, b) => a.displayName.localeCompare(b.displayName)) : []),
+        [members, member],
+    );
+
+    if (!member) return null;
+
+    const scopesLabel = joinScopeLabels(primaryOwnerScopes);
+    const transferMessage = successor
+        ? `${member.displayName} is the ${scopesLabel} primary owner. Primary ownership of the group will be transferred from ${member.displayName} to ${successor.displayName}.`
+        : null;
+
+    const canConfirm = !isPrimaryOwner || Boolean(successor);
+
+    function handleConfirm() {
+        onConfirm(successor ? buildTransferMembership(successor, primaryOwnerScopes) : undefined);
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+            <DialogContent className="max-w-sm" showCloseButton={false}>
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2">
+                        <TriangleAlertIcon className="size-5 shrink-0 text-destructive" aria-hidden />
+                        Remove member?
+                    </DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to remove <span className="font-medium text-foreground">{member.displayName}</span> from{' '}
+                        <span className="font-medium text-foreground">{groupName}</span>?
+                    </DialogDescription>
+                </DialogHeader>
+
+                {isPrimaryOwner && (
+                    <div className="space-y-3 px-6">
+                        <MemberSuccessorCombobox
+                            id="remove-member-successor"
+                            candidates={candidates}
+                            value={successor}
+                            onChange={setSuccessor}
+                            hint="Select a member to transfer primary ownership."
+                        />
+                        {transferMessage && (
+                            <Alert variant="default">
+                                <InfoIcon className="size-4" aria-hidden />
+                                <AlertDescription>{transferMessage}</AlertDescription>
+                            </Alert>
+                        )}
+                    </div>
+                )}
+
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline" disabled={isRemoving}>
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" variant="destructive" onClick={handleConfirm} disabled={isRemoving || !canConfirm}>
+                        {isRemoving ? 'Removing…' : 'Remove'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.tsx
@@ -14,13 +14,51 @@
  * limitations under the License.
  */
 
-import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+} from '@gravitee/graphene-core';
+import { InfoIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
 
-import type { GroupMember } from '../types/group';
+import { MemberAvatar } from './MemberAvatar';
+import type { GroupMember, GroupMembershipPayload, GroupMembershipRole } from '../types/group';
+
+const PRIMARY_OWNER = 'PRIMARY_OWNER';
+const PRIMARY_OWNER_SCOPES = ['API', 'API_PRODUCT'] as const;
+type PrimaryOwnerScope = (typeof PRIMARY_OWNER_SCOPES)[number];
+
+const SCOPE_LABELS: Readonly<Record<PrimaryOwnerScope, string>> = {
+    API: 'API',
+    API_PRODUCT: 'API Product',
+};
+
+/** Rebuilds the successor's full membership, preserving their existing roles and promoting them to
+ *  PRIMARY_OWNER for whichever scope(s) the removed member held it in (mirrors delete-member-dialog
+ *  .component.ts's mapGroupMembership()). */
+function buildTransferMembership(successor: GroupMember, scopes: PrimaryOwnerScope[]): GroupMembershipPayload {
+    const merged: Record<string, string> = { ...(successor.roles ?? {}) };
+    scopes.forEach(scope => {
+        merged[scope] = PRIMARY_OWNER;
+    });
+    const roles: GroupMembershipRole[] = Object.entries(merged)
+        .filter((entry): entry is [string, string] => Boolean(entry[1]))
+        .map(([scope, name]) => ({ scope: scope as GroupMembershipRole['scope'], name }));
+    return { id: successor.id, roles };
+}
 
 export function GroupRemoveMemberSheet({
     open,
     member,
+    members,
     groupName,
     onClose,
     onConfirm,
@@ -28,27 +66,118 @@ export function GroupRemoveMemberSheet({
 }: Readonly<{
     open: boolean;
     member: GroupMember | undefined;
+    /** Full group membership list — searched for a successor when `member` is a primary owner. The
+     *  backend rejects removing a member who's still PRIMARY_OWNER for a scope the group owns items in
+     *  (StillPrimaryOwnerException / StillApiProductPrimaryOwnerException, same guard as role edits), so
+     *  mirroring classic's delete-member-dialog.component.ts: force picking a successor first and submit
+     *  the reassignment as a follow-up request once the removal itself succeeds. */
+    members: GroupMember[];
     groupName: string;
     onClose: () => void;
-    onConfirm: () => void;
+    onConfirm: (transferMembership?: GroupMembershipPayload) => void;
     isRemoving: boolean;
 }>) {
+    const [search, setSearch] = useState('');
+    const [successor, setSuccessor] = useState<GroupMember | null>(null);
+
+    useEffect(() => {
+        if (open) {
+            setSearch('');
+            setSuccessor(null);
+        }
+    }, [open, member]);
+
+    const primaryOwnerScopes = useMemo(
+        () => PRIMARY_OWNER_SCOPES.filter(scope => member?.roles?.[scope] === PRIMARY_OWNER),
+        [member],
+    );
+    const isPrimaryOwner = primaryOwnerScopes.length > 0;
+
+    const candidates = useMemo(() => {
+        if (!isPrimaryOwner || !search.trim() || !member) return [];
+        const term = search.toLowerCase();
+        return members.filter(m => m.id !== member.id && m.displayName.toLowerCase().includes(term));
+    }, [members, member, search, isPrimaryOwner]);
+
+    if (!member) return null;
+
+    const scopesLabel = primaryOwnerScopes.map(scope => SCOPE_LABELS[scope]).join(' and ');
+    const transferMessage = successor
+        ? `${member.displayName} is the ${scopesLabel} primary owner. Primary ownership of the group will be transferred from ${member.displayName} to ${successor.displayName}.`
+        : null;
+
+    const canConfirm = !isPrimaryOwner || Boolean(successor);
+
+    function handleConfirm() {
+        onConfirm(successor ? buildTransferMembership(successor, primaryOwnerScopes) : undefined);
+    }
+
     return (
         <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
             <DialogContent className="max-w-sm">
                 <DialogHeader>
                     <DialogTitle>Remove member</DialogTitle>
                     <DialogDescription>
-                        Are you sure you want to remove <span className="font-medium text-foreground">{member?.displayName}</span> from{' '}
+                        Are you sure you want to remove <span className="font-medium text-foreground">{member.displayName}</span> from{' '}
                         <span className="font-medium text-foreground">{groupName}</span>? They will lose any access granted through this
                         group.
                     </DialogDescription>
                 </DialogHeader>
+
+                {isPrimaryOwner && (
+                    <div className="space-y-3 px-6">
+                        {successor ? (
+                            <div className="flex items-center justify-between gap-2 rounded-lg border px-3 py-2">
+                                <div className="flex min-w-0 items-center gap-2">
+                                    <MemberAvatar name={successor.displayName} />
+                                    <span className="truncate text-sm font-medium">{successor.displayName}</span>
+                                </div>
+                                <Button type="button" variant="ghost" size="sm" onClick={() => setSuccessor(null)}>
+                                    Change
+                                </Button>
+                            </div>
+                        ) : (
+                            <>
+                                <Input
+                                    placeholder="Search for a new primary owner…"
+                                    value={search}
+                                    onChange={e => setSearch(e.target.value)}
+                                />
+                                {search.trim() && (
+                                    <div className="max-h-40 overflow-auto rounded-lg border">
+                                        {candidates.length === 0 ? (
+                                            <p className="px-3 py-2 text-sm text-muted-foreground">No members found.</p>
+                                        ) : (
+                                            candidates.map(candidate => (
+                                                <button
+                                                    key={candidate.id}
+                                                    type="button"
+                                                    onClick={() => setSuccessor(candidate)}
+                                                    className="flex w-full items-center gap-2 border-b px-3 py-2 last:border-b-0 hover:bg-muted/50"
+                                                >
+                                                    <MemberAvatar name={candidate.displayName} />
+                                                    <span className="truncate text-sm">{candidate.displayName}</span>
+                                                </button>
+                                            ))
+                                        )}
+                                    </div>
+                                )}
+                            </>
+                        )}
+                        {transferMessage && (
+                            <Alert variant="default">
+                                <InfoIcon className="size-4" aria-hidden />
+                                <AlertDescription>{transferMessage}</AlertDescription>
+                            </Alert>
+                        )}
+                    </div>
+                )}
+
                 <DialogFooter className="border-t px-6 py-4 gap-2">
                     <Button type="button" variant="outline" onClick={onClose} disabled={isRemoving}>
                         Cancel
                     </Button>
-                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isRemoving || !member}>
+                    <Button type="button" variant="destructive" onClick={handleConfirm} disabled={isRemoving || !canConfirm}>
                         {isRemoving ? 'Removing…' : 'Remove'}
                     </Button>
                 </DialogFooter>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRemoveMemberSheet.tsx
@@ -87,10 +87,7 @@ export function GroupRemoveMemberSheet({
         }
     }, [open, member]);
 
-    const primaryOwnerScopes = useMemo(
-        () => PRIMARY_OWNER_SCOPES.filter(scope => member?.roles?.[scope] === PRIMARY_OWNER),
-        [member],
-    );
+    const primaryOwnerScopes = useMemo(() => PRIMARY_OWNER_SCOPES.filter(scope => member?.roles?.[scope] === PRIMARY_OWNER), [member]);
     const isPrimaryOwner = primaryOwnerScopes.length > 0;
 
     const candidates = useMemo(() => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRoleSelect.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRoleSelect.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
+
+import type { GroupRole } from '../types/group';
+
+const NO_ROLE_VALUE = '__none__';
+
+export function GroupRoleSelect({
+    label,
+    roles,
+    value,
+    onChange,
+    disabled,
+    disabledOptionNames,
+    hint,
+}: Readonly<{
+    label: string;
+    roles: GroupRole[];
+    value: string;
+    onChange: (value: string) => void;
+    disabled?: boolean;
+    disabledOptionNames?: Set<string>;
+    hint?: string;
+}>) {
+    return (
+        <div className="space-y-1.5">
+            <Label className="text-sm text-muted-foreground">{label}</Label>
+            <Select value={value || NO_ROLE_VALUE} onValueChange={v => onChange(v === NO_ROLE_VALUE ? '' : v)} disabled={disabled}>
+                <SelectTrigger className="w-full">
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    {roles.map(role => (
+                        <SelectItem key={role.name} value={role.name} disabled={disabledOptionNames?.has(role.name)}>
+                            {role.name}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+            {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupTooManyUsersDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupTooManyUsersDialog.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Alert, AlertDescription, Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+import { InfoIcon } from '@gravitee/graphene-core/icons';
+
+/** Mirrors classic too-many-users-dialog.component.ts: the invite endpoint returns 202 with a list of
+ *  matching users (instead of sending an invitation) when more than one platform user shares the given
+ *  email — ambiguous, so the operator is redirected to the user-search Add Members flow instead. */
+export function GroupTooManyUsersDialog({
+    open,
+    email,
+    onClose,
+    onContinue,
+}: Readonly<{
+    open: boolean;
+    email: string | null;
+    onClose: () => void;
+    onContinue: () => void;
+}>) {
+    return (
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Many Users Found</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-3 px-6">
+                    <Alert variant="default">
+                        <InfoIcon className="size-4" aria-hidden />
+                        <AlertDescription>
+                            More than one user already exist with the email id {email} in the organization. You can select and add a
+                            specific user using add member function.
+                        </AlertDescription>
+                    </Alert>
+                    <p className="text-sm">Do you want to continue?</p>
+                </div>
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={onContinue}>
+                        Continue
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupTooManyUsersDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupTooManyUsersDialog.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Alert, AlertDescription, Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+import { InfoIcon } from '@gravitee/graphene-core/icons';
+
+export function GroupTooManyUsersDialog({
+    open,
+    email,
+    onClose,
+    onContinue,
+}: Readonly<{
+    open: boolean;
+    email: string | null;
+    onClose: () => void;
+    onContinue: () => void;
+}>) {
+    return (
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Many Users Found</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-3 px-6">
+                    <Alert variant="default">
+                        <InfoIcon className="size-4" aria-hidden />
+                        <AlertDescription>
+                            More than one user already exist with the email id {email} in the organization. You can select and add a
+                            specific user using add member function.
+                        </AlertDescription>
+                    </Alert>
+                    <p className="text-sm">Do you want to continue?</p>
+                </div>
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={onContinue}>
+                        Continue
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsRequireGroupSetting.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsRequireGroupSetting.spec.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { GroupsRequireGroupSetting } from './GroupsRequireGroupSetting';
+import { useConsoleSettings, useSetConsoleSettings, type ConsoleSettings } from '../../../shared/console-settings';
+import { notify } from '../../../shared/notify';
+import { saveOrgConsoleSettings } from '../../../shared/services/orgConsoleSettings';
+
+jest.mock('../../../shared/console-settings', () => ({
+    ...jest.requireActual('../../../shared/console-settings'),
+    useConsoleSettings: jest.fn(),
+    useSetConsoleSettings: jest.fn(),
+}));
+jest.mock('../../../shared/services/orgConsoleSettings');
+jest.mock('../../../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
+}));
+
+const mockUseConsoleSettings = jest.mocked(useConsoleSettings);
+const mockUseSetConsoleSettings = jest.mocked(useSetConsoleSettings);
+const mockSaveOrgConsoleSettings = jest.mocked(saveOrgConsoleSettings);
+
+describe('GroupsRequireGroupSetting', () => {
+    const setConsoleSettings = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseSetConsoleSettings.mockReturnValue(setConsoleSettings);
+    });
+
+    it('reflects the currently-loaded setting and disables Save until changed', () => {
+        mockUseConsoleSettings.mockReturnValue({ userGroup: { required: { enabled: true } } });
+        render(<GroupsRequireGroupSetting />);
+
+        expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('true');
+        expect(screen.getByRole('button', { name: 'Save' })).toHaveProperty('disabled', true);
+    });
+
+    it('defaults to off when the setting is missing entirely', () => {
+        mockUseConsoleSettings.mockReturnValue(null);
+        render(<GroupsRequireGroupSetting />);
+        expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('false');
+    });
+
+    it('enables Save once the toggle is flipped, and preserves other settings fields on save', async () => {
+        mockUseConsoleSettings.mockReturnValue({
+            userGroup: { required: { enabled: false } },
+            authentication: { localLogin: { enabled: true } },
+        } as ConsoleSettings & { authentication: { localLogin: { enabled: boolean } } });
+        mockSaveOrgConsoleSettings.mockResolvedValue({ userGroup: { required: { enabled: true } } });
+        render(<GroupsRequireGroupSetting />);
+
+        fireEvent.click(screen.getByRole('switch'));
+        expect(screen.getByRole('button', { name: 'Save' })).toHaveProperty('disabled', false);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() =>
+            expect(mockSaveOrgConsoleSettings).toHaveBeenCalledWith({
+                userGroup: { required: { enabled: true } },
+                authentication: { localLogin: { enabled: true } },
+            }),
+        );
+        await waitFor(() => expect(notify.success).toHaveBeenCalledWith('Successfully updated groups settings.'));
+        expect(setConsoleSettings).toHaveBeenCalledWith({ userGroup: { required: { enabled: true } } });
+    });
+
+    it('shows an error toast when saving fails', async () => {
+        mockUseConsoleSettings.mockReturnValue({ userGroup: { required: { enabled: false } } });
+        mockSaveOrgConsoleSettings.mockRejectedValue(new Error('failed'));
+        render(<GroupsRequireGroupSetting />);
+
+        fireEvent.click(screen.getByRole('switch'));
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => expect(notify.error).toHaveBeenCalledWith(expect.any(Error), 'Error occurred while saving groups settings.'));
+        expect(setConsoleSettings).not.toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsRequireGroupSetting.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsRequireGroupSetting.tsx
@@ -65,7 +65,9 @@ export function GroupsRequireGroupSetting() {
                     <label htmlFor="require-user-group" className="text-sm font-medium cursor-pointer">
                         Requires an application to have at least one group added in order to create or update it.
                     </label>
-                    <p className="text-xs text-muted-foreground">Use this setting if you want to enforce group ownership of applications.</p>
+                    <p className="text-xs text-muted-foreground">
+                        Use this setting if you want to enforce group ownership of applications.
+                    </p>
                 </div>
             </div>
             <Button type="button" size="sm" onClick={handleSave} disabled={!hasChanged || isSaving}>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsRequireGroupSetting.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsRequireGroupSetting.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Switch } from '@gravitee/graphene-core';
+import { useEffect, useState } from 'react';
+
+import { isUserGroupRequired, useConsoleSettings, useSetConsoleSettings, type ConsoleSettings } from '../../../shared/console-settings';
+import { notify } from '../../../shared/notify';
+import { saveOrgConsoleSettings } from '../../../shared/services/orgConsoleSettings';
+
+export function GroupsRequireGroupSetting() {
+    const settings = useConsoleSettings();
+    const setConsoleSettings = useSetConsoleSettings();
+
+    const [enabled, setEnabled] = useState(() => isUserGroupRequired(settings));
+    const [isSaving, setIsSaving] = useState(false);
+
+    useEffect(() => {
+        setEnabled(isUserGroupRequired(settings));
+    }, [settings]);
+
+    const hasChanged = enabled !== isUserGroupRequired(settings);
+
+    async function handleSave() {
+        setIsSaving(true);
+        try {
+            const payload: ConsoleSettings = {
+                ...settings,
+                userGroup: { ...settings?.userGroup, required: { ...settings?.userGroup?.required, enabled } },
+            };
+            const saved = await saveOrgConsoleSettings(payload);
+            setConsoleSettings(saved);
+            notify.success('Successfully updated groups settings.');
+        } catch (error) {
+            notify.error(error, 'Error occurred while saving groups settings.');
+        } finally {
+            setIsSaving(false);
+        }
+    }
+
+    return (
+        <div className="flex items-center justify-between gap-4 rounded-lg border px-4 py-3">
+            <div className="flex items-center gap-3">
+                <Switch id="require-user-group" checked={enabled} onCheckedChange={setEnabled} disabled={isSaving} />
+                <div className="space-y-0.5">
+                    <label htmlFor="require-user-group" className="text-sm font-medium cursor-pointer">
+                        Requires an application to have at least one group added in order to create or update it.
+                    </label>
+                    <p className="text-xs text-muted-foreground">
+                        Use this setting if you want to enforce group ownership of applications.
+                    </p>
+                </div>
+            </div>
+            <Button type="button" size="sm" onClick={handleSave} disabled={!hasChanged || isSaving}>
+                {isSaving ? 'Saving…' : 'Save'}
+            </Button>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsRequireGroupSetting.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsRequireGroupSetting.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Switch } from '@gravitee/graphene-core';
+import { useEffect, useState } from 'react';
+
+import { isUserGroupRequired, useConsoleSettings, useSetConsoleSettings, type ConsoleSettings } from '../../../shared/console-settings';
+import { notify } from '../../../shared/notify';
+import { saveOrgConsoleSettings } from '../../../shared/services/orgConsoleSettings';
+
+/** Org-wide "require a group on applications" toggle — mirrors classic groups.component.ts/.html's
+ *  settingsForm + gio-save-bar, gated behind organization-settings-r the same way (read gate only; the
+ *  backend itself enforces the write permission on save, matching classic). Lives on the groups list page
+ *  because that's where classic puts it too. */
+export function GroupsRequireGroupSetting() {
+    const settings = useConsoleSettings();
+    const setConsoleSettings = useSetConsoleSettings();
+
+    const [enabled, setEnabled] = useState(() => isUserGroupRequired(settings));
+    const [isSaving, setIsSaving] = useState(false);
+
+    useEffect(() => {
+        setEnabled(isUserGroupRequired(settings));
+    }, [settings]);
+
+    const hasChanged = enabled !== isUserGroupRequired(settings);
+
+    async function handleSave() {
+        setIsSaving(true);
+        try {
+            // The backend replaces the whole settings document — spread everything already loaded and
+            // override only this one nested field, or every other console setting would be wiped out.
+            const payload: ConsoleSettings = {
+                ...settings,
+                userGroup: { ...settings?.userGroup, required: { ...settings?.userGroup?.required, enabled } },
+            };
+            const saved = await saveOrgConsoleSettings(payload);
+            setConsoleSettings(saved);
+            notify.success('Successfully updated groups settings.');
+        } catch (error) {
+            notify.error(error, 'Error occurred while saving groups settings.');
+        } finally {
+            setIsSaving(false);
+        }
+    }
+
+    return (
+        <div className="flex items-center justify-between gap-4 rounded-lg border px-4 py-3">
+            <div className="flex items-center gap-3">
+                <Switch id="require-user-group" checked={enabled} onCheckedChange={setEnabled} disabled={isSaving} />
+                <div className="space-y-0.5">
+                    <label htmlFor="require-user-group" className="text-sm font-medium cursor-pointer">
+                        Requires an application to have at least one group added in order to create or update it.
+                    </label>
+                    <p className="text-xs text-muted-foreground">Use this setting if you want to enforce group ownership of applications.</p>
+                </div>
+            </div>
+            <Button type="button" size="sm" onClick={handleSave} disabled={!hasChanged || isSaving}>
+                {isSaving ? 'Saving…' : 'Save'}
+            </Button>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/MemberAvatar.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/MemberAvatar.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function MemberAvatar({ name }: Readonly<{ name: string }>) {
+    const initials = name
+        .split(' ')
+        .map(part => part[0] ?? '')
+        .join('')
+        .toUpperCase()
+        .slice(0, 2);
+    return (
+        <div className="size-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+            <span className="text-xs font-semibold text-primary">{initials || '?'}</span>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/MemberSuccessorCombobox.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/MemberSuccessorCombobox.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Combobox, ComboboxContent, ComboboxEmpty, ComboboxInput, ComboboxItem, ComboboxList, Label } from '@gravitee/graphene-core';
+
+import type { GroupMember } from '../types/group';
+
+export function MemberSuccessorCombobox({
+    id,
+    label = 'Search members',
+    hint,
+    candidates,
+    value,
+    onChange,
+}: Readonly<{
+    id: string;
+    label?: string;
+    hint?: string;
+    candidates: GroupMember[];
+    value: GroupMember | null;
+    onChange: (member: GroupMember | null) => void;
+}>) {
+    return (
+        <div className="space-y-1.5">
+            <Label htmlFor={id} className="text-sm text-muted-foreground">
+                {label}
+            </Label>
+            <Combobox items={candidates} value={value} onValueChange={onChange} itemToStringLabel={(m: GroupMember) => m.displayName}>
+                <ComboboxInput id={id} aria-label={label} placeholder="Search members…" showClear />
+                <ComboboxContent>
+                    <ComboboxEmpty>No members found</ComboboxEmpty>
+                    <ComboboxList>
+                        {(m: GroupMember) => (
+                            <ComboboxItem key={m.id} value={m}>
+                                {m.displayName}
+                            </ComboboxItem>
+                        )}
+                    </ComboboxList>
+                </ComboboxContent>
+            </Combobox>
+            {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useCurrentUserGroupAdmin.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useCurrentUserGroupAdmin.ts
@@ -13,6 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type { ConsoleSettings } from './types';
-export { ConsoleSettingsProvider, useConsoleSettings, useConsoleSettingsReady, useSetConsoleSettings } from './ConsoleSettingsProvider';
-export { isUserGroupRequired } from './isUserGroupRequired';
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchCurrentUser } from '../../applications/services/currentUser';
+import { currentUserKeys } from '../../applications/utils/queryKeys';
+import type { GroupMember } from '../types/group';
+
+export function useCurrentUserIsGroupAdmin(members: GroupMember[]): boolean {
+    const { data } = useQuery({
+        queryKey: currentUserKeys.detail(),
+        queryFn: fetchCurrentUser,
+        staleTime: 300_000,
+    });
+
+    if (!data?.id) return false;
+    return members.some(member => member.id === data.id && member.roles?.GROUP === 'ADMIN');
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupDetail.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupDetail.ts
@@ -17,7 +17,7 @@
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useQuery } from '@tanstack/react-query';
 
-import { getGroup, listGroupMembers, listGroupMemberships } from '../services/groups';
+import { getGroup, listGroupInvitations, listGroupMembers, listGroupMemberships } from '../services/groups';
 import type { GroupMembershipType } from '../types/group';
 import { groupKeys } from '../utils/queryKeys';
 
@@ -37,6 +37,16 @@ export function useGroupMembers(groupId: string | undefined) {
     return useQuery({
         queryKey: groupKeys.members(env?.id ?? '', groupId ?? ''),
         queryFn: () => listGroupMembers(env!.id, groupId!),
+        enabled: Boolean(env && groupId),
+    });
+}
+
+export function useGroupInvitations(groupId: string | undefined) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: groupKeys.invitations(env?.id ?? '', groupId ?? ''),
+        queryFn: () => listGroupInvitations(env!.id, groupId!),
         enabled: Boolean(env && groupId),
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMemberActions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMemberActions.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+
+import { useGroupInvitations } from './useGroupDetail';
+import { useAddGroupMembers, useDeleteGroupInvitation, useInviteGroupMember, useRemoveGroupMember } from './useGroupMutations';
+import { notify } from '../../../shared/notify';
+import type { GroupInvitation, GroupMember, GroupMembershipPayload } from '../types/group';
+
+type MemberSheetState = 'closed' | 'search' | 'invite';
+type MemberTab = 'members' | 'invitations';
+
+/** Owns the add/invite/edit/remove-member and delete-invitation workflows for GroupDetailPage: their
+ *  sheet-open state, mutations, and success/error notifications. Keeps that orchestration out of the
+ *  page component, which only wires the returned state and handlers into its JSX. */
+export function useGroupMemberActions(groupId: string | undefined) {
+    const [memberTab, setMemberTab] = useState<MemberTab>('members');
+    const [memberSheet, setMemberSheet] = useState<MemberSheetState>('closed');
+    const [editingMember, setEditingMember] = useState<GroupMember | null>(null);
+    const [removingMember, setRemovingMember] = useState<GroupMember | null>(null);
+    const [tooManyUsersEmail, setTooManyUsersEmail] = useState<string | null>(null);
+    const [deletingInvitation, setDeletingInvitation] = useState<GroupInvitation | null>(null);
+
+    // Invitations only render inside the Invitations tab — skip the fetch until it's actually opened.
+    const {
+        data: invitations = [],
+        isLoading: invitationsLoading,
+        isError: invitationsError,
+    } = useGroupInvitations(memberTab === 'invitations' ? groupId : undefined);
+
+    const addMembersMutation = useAddGroupMembers();
+    const inviteMemberMutation = useInviteGroupMember();
+    const removeMemberMutation = useRemoveGroupMember();
+    const deleteInvitationMutation = useDeleteGroupInvitation();
+
+    function closeMemberSheet() {
+        setMemberSheet('closed');
+    }
+
+    async function handleAddMembers(memberships: GroupMembershipPayload[]) {
+        if (!groupId) return;
+        try {
+            await addMembersMutation.mutateAsync({ groupId, memberships });
+            notify.success(memberships.length > 1 ? `${memberships.length} members added successfully` : 'Member added successfully');
+            closeMemberSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to add members');
+        }
+    }
+
+    async function handleInviteMember(values: { email: string; apiRole: string; applicationRole: string }) {
+        if (!groupId) return;
+        try {
+            const result = await inviteMemberMutation.mutateAsync({
+                groupId,
+                data: {
+                    reference_id: groupId,
+                    email: values.email,
+                    api_role: values.apiRole || undefined,
+                    application_role: values.applicationRole || undefined,
+                },
+            });
+            if (result.ambiguous) {
+                closeMemberSheet();
+                setTooManyUsersEmail(values.email);
+                return;
+            }
+            notify.success(`Invitation sent to ${values.email}`);
+            closeMemberSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to send invitation');
+        }
+    }
+
+    function handleTooManyUsersContinue() {
+        setTooManyUsersEmail(null);
+        setMemberSheet('search');
+    }
+
+    async function handleEditMemberRoles(memberships: GroupMembershipPayload[]) {
+        if (!groupId) return;
+        try {
+            await addMembersMutation.mutateAsync({ groupId, memberships });
+            notify.success(
+                memberships.length > 1 ? 'Member roles updated and primary ownership transferred' : 'Member roles updated successfully',
+            );
+            setEditingMember(null);
+        } catch (error) {
+            notify.error(error, 'Failed to update member roles');
+        }
+    }
+
+    async function handleRemoveMember(transferMembership?: GroupMembershipPayload) {
+        if (!groupId || !removingMember) return;
+
+        // Transfer ownership before removing — removing the primary owner first would leave the group
+        // ownerless for the window between the two calls, and if the transfer then failed, there'd be no
+        // way back. Doing it in this order means a failed transfer just aborts with nothing removed yet.
+        if (transferMembership) {
+            try {
+                await addMembersMutation.mutateAsync({ groupId, memberships: [transferMembership] });
+            } catch (error) {
+                notify.error(error, 'Primary ownership could not be transferred');
+                setRemovingMember(null);
+                return;
+            }
+        }
+
+        try {
+            await removeMemberMutation.mutateAsync({ groupId, memberId: removingMember.id });
+        } catch (error) {
+            notify.error(error, 'Failed to remove member');
+            return;
+        }
+
+        notify.success(`${removingMember.displayName} removed from the group`);
+        setRemovingMember(null);
+    }
+
+    async function handleDeleteInvitation() {
+        if (!groupId || !deletingInvitation) return;
+        try {
+            await deleteInvitationMutation.mutateAsync({ groupId, invitationId: deletingInvitation.id });
+            notify.success('Successfully deleted the invitation.');
+            setDeletingInvitation(null);
+        } catch (error) {
+            notify.error(error, 'Error occurred while deleting the invitation.');
+        }
+    }
+
+    return {
+        memberTab,
+        setMemberTab,
+        memberSheet,
+        setMemberSheet,
+        closeMemberSheet,
+        editingMember,
+        setEditingMember,
+        removingMember,
+        setRemovingMember,
+        tooManyUsersEmail,
+        setTooManyUsersEmail,
+        deletingInvitation,
+        setDeletingInvitation,
+        invitations,
+        invitationsLoading,
+        invitationsError,
+        addMembersMutation,
+        inviteMemberMutation,
+        removeMemberMutation,
+        deleteInvitationMutation,
+        handleAddMembers,
+        handleInviteMember,
+        handleTooManyUsersContinue,
+        handleEditMemberRoles,
+        handleRemoveMember,
+        handleDeleteInvitation,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.ts
@@ -61,7 +61,7 @@ export function useAddGroupMembers() {
 }
 
 export function useInviteGroupMember() {
-    return useGroupMutation<{ groupId: string; data: GroupInvitationPayload }, void>((envId, { groupId, data }) =>
+    return useGroupMutation<{ groupId: string; data: GroupInvitationPayload }, { ambiguous: boolean }>((envId, { groupId, data }) =>
         inviteGroupMember(envId, groupId, data),
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.ts
@@ -17,8 +17,16 @@
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createGroup, deleteGroup, updateGroup } from '../services/groups';
-import type { Group, NewGroupPayload, UpdateGroupPayload } from '../types/group';
+import {
+    addGroupMembers,
+    createGroup,
+    deleteGroup,
+    deleteGroupInvitation,
+    inviteGroupMember,
+    removeGroupMember,
+    updateGroup,
+} from '../services/groups';
+import type { Group, GroupInvitationPayload, GroupMembershipPayload, NewGroupPayload, UpdateGroupPayload } from '../types/group';
 import { groupKeys } from '../utils/queryKeys';
 
 function useGroupMutation<TData, TResult>(mutationFn: (envId: string, data: TData) => Promise<TResult>) {
@@ -52,4 +60,28 @@ export function useUpdateGroup() {
 
 export function useDeleteGroup() {
     return useGroupMutation<string, void>(deleteGroup);
+}
+
+export function useAddGroupMembers() {
+    return useGroupMutation<{ groupId: string; memberships: GroupMembershipPayload[] }, void>((envId, { groupId, memberships }) =>
+        addGroupMembers(envId, groupId, memberships),
+    );
+}
+
+export function useInviteGroupMember() {
+    return useGroupMutation<{ groupId: string; data: GroupInvitationPayload }, { ambiguous: boolean }>((envId, { groupId, data }) =>
+        inviteGroupMember(envId, groupId, data),
+    );
+}
+
+export function useRemoveGroupMember() {
+    return useGroupMutation<{ groupId: string; memberId: string }, void>((envId, { groupId, memberId }) =>
+        removeGroupMember(envId, groupId, memberId),
+    );
+}
+
+export function useDeleteGroupInvitation() {
+    return useGroupMutation<{ groupId: string; invitationId: string }, void>((envId, { groupId, invitationId }) =>
+        deleteGroupInvitation(envId, groupId, invitationId),
+    );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.ts
@@ -17,8 +17,8 @@
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createGroup, deleteGroup, updateGroup } from '../services/groups';
-import type { Group, NewGroupPayload, UpdateGroupPayload } from '../types/group';
+import { addGroupMembers, createGroup, deleteGroup, inviteGroupMember, removeGroupMember, updateGroup } from '../services/groups';
+import type { Group, GroupInvitationPayload, GroupMembershipPayload, NewGroupPayload, UpdateGroupPayload } from '../types/group';
 import { groupKeys } from '../utils/queryKeys';
 
 function useGroupMutation<TData, TResult>(mutationFn: (envId: string, data: TData) => Promise<TResult>) {
@@ -52,4 +52,22 @@ export function useUpdateGroup() {
 
 export function useDeleteGroup() {
     return useGroupMutation<string, void>(deleteGroup);
+}
+
+export function useAddGroupMembers() {
+    return useGroupMutation<{ groupId: string; memberships: GroupMembershipPayload[] }, void>((envId, { groupId, memberships }) =>
+        addGroupMembers(envId, groupId, memberships),
+    );
+}
+
+export function useInviteGroupMember() {
+    return useGroupMutation<{ groupId: string; data: GroupInvitationPayload }, void>((envId, { groupId, data }) =>
+        inviteGroupMember(envId, groupId, data),
+    );
+}
+
+export function useRemoveGroupMember() {
+    return useGroupMutation<{ groupId: string; memberId: string }, void>((envId, { groupId, memberId }) =>
+        removeGroupMember(envId, groupId, memberId),
+    );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupRoles.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupRoles.ts
@@ -16,7 +16,13 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { listGroupApiProductRoles, listGroupApiRoles, listGroupApplicationRoles } from '../services/groups';
+import {
+    listGroupApiProductRoles,
+    listGroupApiRoles,
+    listGroupApplicationRoles,
+    listGroupClusterRoles,
+    listGroupIntegrationRoles,
+} from '../services/groups';
 import type { GroupRole } from '../types/group';
 import { groupKeys } from '../utils/queryKeys';
 
@@ -39,4 +45,12 @@ export function useGroupApplicationRoles({ enabled = true }: { enabled?: boolean
 
 export function useGroupApiProductRoles({ enabled = true }: { enabled?: boolean } = {}) {
     return useGroupRolesQuery(groupKeys.apiProductRoles(), listGroupApiProductRoles, enabled);
+}
+
+export function useGroupIntegrationRoles() {
+    return useGroupRolesQuery(groupKeys.integrationRoles(), listGroupIntegrationRoles);
+}
+
+export function useGroupClusterRoles() {
+    return useGroupRolesQuery(groupKeys.clusterRoles(), listGroupClusterRoles);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupRoles.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupRoles.ts
@@ -16,7 +16,13 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { listGroupApiProductRoles, listGroupApiRoles, listGroupApplicationRoles } from '../services/groups';
+import {
+    listGroupApiProductRoles,
+    listGroupApiRoles,
+    listGroupApplicationRoles,
+    listGroupClusterRoles,
+    listGroupIntegrationRoles,
+} from '../services/groups';
 import type { GroupRole } from '../types/group';
 import { groupKeys } from '../utils/queryKeys';
 
@@ -38,4 +44,12 @@ export function useGroupApplicationRoles() {
 
 export function useGroupApiProductRoles() {
     return useGroupRolesQuery(groupKeys.apiProductRoles(), listGroupApiProductRoles);
+}
+
+export function useGroupIntegrationRoles() {
+    return useGroupRolesQuery(groupKeys.integrationRoles(), listGroupIntegrationRoles);
+}
+
+export function useGroupClusterRoles() {
+    return useGroupRolesQuery(groupKeys.clusterRoles(), listGroupClusterRoles);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupRoles.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupRoles.ts
@@ -16,41 +16,35 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import {
-    listGroupApiProductRoles,
-    listGroupApiRoles,
-    listGroupApplicationRoles,
-    listGroupClusterRoles,
-    listGroupIntegrationRoles,
-} from '../services/groups';
+import { listGroupRolesByScope, type GroupRoleScope } from '../services/groups';
 import type { GroupRole } from '../types/group';
 import { groupKeys } from '../utils/queryKeys';
 
-function useGroupRolesQuery(queryKey: readonly unknown[], queryFn: () => Promise<GroupRole[]>, enabled: boolean) {
-    return useQuery({
+function useGroupRolesQuery(queryKey: readonly unknown[], scope: GroupRoleScope, enabled: boolean) {
+    return useQuery<GroupRole[]>({
         queryKey,
-        queryFn,
+        queryFn: () => listGroupRolesByScope(scope),
         staleTime: 5 * 60_000,
         enabled,
     });
 }
 
 export function useGroupApiRoles({ enabled = true }: { enabled?: boolean } = {}) {
-    return useGroupRolesQuery(groupKeys.apiRoles(), listGroupApiRoles, enabled);
+    return useGroupRolesQuery(groupKeys.apiRoles(), 'API', enabled);
 }
 
 export function useGroupApplicationRoles({ enabled = true }: { enabled?: boolean } = {}) {
-    return useGroupRolesQuery(groupKeys.applicationRoles(), listGroupApplicationRoles, enabled);
+    return useGroupRolesQuery(groupKeys.applicationRoles(), 'APPLICATION', enabled);
 }
 
 export function useGroupApiProductRoles({ enabled = true }: { enabled?: boolean } = {}) {
-    return useGroupRolesQuery(groupKeys.apiProductRoles(), listGroupApiProductRoles, enabled);
+    return useGroupRolesQuery(groupKeys.apiProductRoles(), 'API_PRODUCT', enabled);
 }
 
 export function useGroupIntegrationRoles() {
-    return useGroupRolesQuery(groupKeys.integrationRoles(), listGroupIntegrationRoles, true);
+    return useGroupRolesQuery(groupKeys.integrationRoles(), 'INTEGRATION', true);
 }
 
 export function useGroupClusterRoles() {
-    return useGroupRolesQuery(groupKeys.clusterRoles(), listGroupClusterRoles, true);
+    return useGroupRolesQuery(groupKeys.clusterRoles(), 'CLUSTER', true);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupRoles.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupRoles.ts
@@ -48,9 +48,9 @@ export function useGroupApiProductRoles({ enabled = true }: { enabled?: boolean 
 }
 
 export function useGroupIntegrationRoles() {
-    return useGroupRolesQuery(groupKeys.integrationRoles(), listGroupIntegrationRoles);
+    return useGroupRolesQuery(groupKeys.integrationRoles(), listGroupIntegrationRoles, true);
 }
 
 export function useGroupClusterRoles() {
-    return useGroupRolesQuery(groupKeys.clusterRoles(), listGroupClusterRoles);
+    return useGroupRolesQuery(groupKeys.clusterRoles(), listGroupClusterRoles, true);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
@@ -95,28 +95,10 @@ export async function deleteGroup(environmentId: string, groupId: string): Promi
     });
 }
 
-async function listGroupRolesByScope(scope: 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER'): Promise<GroupRole[]> {
+export type GroupRoleScope = 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER';
+
+export async function listGroupRolesByScope(scope: GroupRoleScope): Promise<GroupRole[]> {
     return apimFetchJsonOrg<GroupRole[]>(`/configuration/rolescopes/${scope}/roles`);
-}
-
-export async function listGroupApiRoles(): Promise<GroupRole[]> {
-    return listGroupRolesByScope('API');
-}
-
-export async function listGroupApplicationRoles(): Promise<GroupRole[]> {
-    return listGroupRolesByScope('APPLICATION');
-}
-
-export async function listGroupApiProductRoles(): Promise<GroupRole[]> {
-    return listGroupRolesByScope('API_PRODUCT');
-}
-
-export async function listGroupIntegrationRoles(): Promise<GroupRole[]> {
-    return listGroupRolesByScope('INTEGRATION');
-}
-
-export async function listGroupClusterRoles(): Promise<GroupRole[]> {
-    return listGroupRolesByScope('CLUSTER');
 }
 
 export async function searchUsers(query: string): Promise<SearchableUser[]> {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
@@ -131,10 +131,20 @@ export async function addGroupMembers(environmentId: string, groupId: string, me
     });
 }
 
-/** Invites a not-yet-registered user by email. Only api_role/application_role are supported here. */
-export async function inviteGroupMember(environmentId: string, groupId: string, data: GroupInvitationPayload): Promise<void> {
-    return apimFetchJsonV1Env<void>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}/invitations`, {
+/** Invites a not-yet-registered user by email. Only api_role/application_role are supported here.
+ *  The backend returns 200 with the created Invitation when the email is new/unambiguous, or 202 with an
+ *  array of matching platform users when more than one existing user shares that email — no invitation is
+ *  sent in that case (mirrors classic's `response.status === 202` branch in group.component.ts). Since the
+ *  shared fetch client doesn't expose the raw status code, the two cases are told apart by response shape:
+ *  the 202 body is an array, the 200 body is a single object. */
+export async function inviteGroupMember(
+    environmentId: string,
+    groupId: string,
+    data: GroupInvitationPayload,
+): Promise<{ ambiguous: boolean }> {
+    const result = await apimFetchJsonV1Env<unknown>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}/invitations`, {
         method: 'POST',
         body: JSON.stringify(data),
     });
+    return { ambiguous: Array.isArray(result) };
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
@@ -17,12 +17,16 @@
 import { apimFetchJsonOrg, apimFetchJsonV1Env } from '../../../shared/api/apimClient';
 import type {
     Group,
+    GroupInvitation,
+    GroupInvitationPayload,
     GroupMember,
     GroupMembershipItem,
+    GroupMembershipPayload,
     GroupMembershipType,
     GroupRole,
     GroupsPagedResponse,
     NewGroupPayload,
+    SearchableUser,
     UpdateGroupPayload,
 } from '../types/group';
 
@@ -63,6 +67,14 @@ export async function listGroupMemberships(
     return items ?? [];
 }
 
+export async function removeGroupMember(environmentId: string, groupId: string, memberId: string): Promise<void> {
+    return apimFetchJsonV1Env<void>(
+        environmentId,
+        `/configuration/groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(memberId)}`,
+        { method: 'DELETE' },
+    );
+}
+
 export async function createGroup(environmentId: string, data: NewGroupPayload): Promise<Group> {
     return apimFetchJsonV1Env<Group>(environmentId, '/configuration/groups', {
         method: 'POST',
@@ -83,7 +95,7 @@ export async function deleteGroup(environmentId: string, groupId: string): Promi
     });
 }
 
-async function listGroupRolesByScope(scope: 'API' | 'APPLICATION' | 'API_PRODUCT'): Promise<GroupRole[]> {
+async function listGroupRolesByScope(scope: 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER'): Promise<GroupRole[]> {
     return apimFetchJsonOrg<GroupRole[]>(`/configuration/rolescopes/${scope}/roles`);
 }
 
@@ -97,4 +109,47 @@ export async function listGroupApplicationRoles(): Promise<GroupRole[]> {
 
 export async function listGroupApiProductRoles(): Promise<GroupRole[]> {
     return listGroupRolesByScope('API_PRODUCT');
+}
+
+export async function listGroupIntegrationRoles(): Promise<GroupRole[]> {
+    return listGroupRolesByScope('INTEGRATION');
+}
+
+export async function listGroupClusterRoles(): Promise<GroupRole[]> {
+    return listGroupRolesByScope('CLUSTER');
+}
+
+export async function searchUsers(query: string): Promise<SearchableUser[]> {
+    return apimFetchJsonOrg<SearchableUser[]>(`/search/users?q=${encodeURIComponent(query)}`);
+}
+
+export async function addGroupMembers(environmentId: string, groupId: string, memberships: GroupMembershipPayload[]): Promise<void> {
+    return apimFetchJsonV1Env<void>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}/members`, {
+        method: 'POST',
+        body: JSON.stringify(memberships),
+    });
+}
+
+export async function inviteGroupMember(
+    environmentId: string,
+    groupId: string,
+    data: GroupInvitationPayload,
+): Promise<{ ambiguous: boolean }> {
+    const result = await apimFetchJsonV1Env<unknown>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}/invitations`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+    return { ambiguous: Array.isArray(result) };
+}
+
+export async function listGroupInvitations(environmentId: string, groupId: string): Promise<GroupInvitation[]> {
+    return apimFetchJsonV1Env<GroupInvitation[]>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}/invitations`);
+}
+
+export async function deleteGroupInvitation(environmentId: string, groupId: string, invitationId: string): Promise<void> {
+    return apimFetchJsonV1Env<void>(
+        environmentId,
+        `/configuration/groups/${encodeURIComponent(groupId)}/invitations/${encodeURIComponent(invitationId)}`,
+        { method: 'DELETE' },
+    );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
@@ -17,12 +17,15 @@
 import { apimFetchJsonOrg, apimFetchJsonV1Env } from '../../../shared/api/apimClient';
 import type {
     Group,
+    GroupInvitationPayload,
     GroupMember,
     GroupMembershipItem,
+    GroupMembershipPayload,
     GroupMembershipType,
     GroupRole,
     GroupsPagedResponse,
     NewGroupPayload,
+    SearchableUser,
     UpdateGroupPayload,
 } from '../types/group';
 
@@ -62,6 +65,14 @@ export async function listGroupMemberships(
     return items ?? [];
 }
 
+export async function removeGroupMember(environmentId: string, groupId: string, memberId: string): Promise<void> {
+    return apimFetchJsonV1Env<void>(
+        environmentId,
+        `/configuration/groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(memberId)}`,
+        { method: 'DELETE' },
+    );
+}
+
 export async function createGroup(environmentId: string, data: NewGroupPayload): Promise<Group> {
     return apimFetchJsonV1Env<Group>(environmentId, '/configuration/groups', {
         method: 'POST',
@@ -82,7 +93,7 @@ export async function deleteGroup(environmentId: string, groupId: string): Promi
     });
 }
 
-async function listGroupRolesByScope(scope: 'API' | 'APPLICATION' | 'API_PRODUCT'): Promise<GroupRole[]> {
+async function listGroupRolesByScope(scope: 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER'): Promise<GroupRole[]> {
     return apimFetchJsonOrg<GroupRole[]>(`/configuration/rolescopes/${scope}/roles`);
 }
 
@@ -96,4 +107,34 @@ export async function listGroupApplicationRoles(): Promise<GroupRole[]> {
 
 export async function listGroupApiProductRoles(): Promise<GroupRole[]> {
     return listGroupRolesByScope('API_PRODUCT');
+}
+
+export async function listGroupIntegrationRoles(): Promise<GroupRole[]> {
+    return listGroupRolesByScope('INTEGRATION');
+}
+
+export async function listGroupClusterRoles(): Promise<GroupRole[]> {
+    return listGroupRolesByScope('CLUSTER');
+}
+
+/** Org-scoped platform user search — same endpoint Applications' AddMembersSheet uses, no pagination. */
+export async function searchUsers(query: string): Promise<SearchableUser[]> {
+    return apimFetchJsonOrg<SearchableUser[]>(`/search/users?q=${encodeURIComponent(query)}`);
+}
+
+/** Adds or updates memberships (existing platform users) in one call — each item can carry roles across
+ *  multiple scopes (API, APPLICATION, API_PRODUCT, INTEGRATION, CLUSTER, GROUP) at once. */
+export async function addGroupMembers(environmentId: string, groupId: string, memberships: GroupMembershipPayload[]): Promise<void> {
+    return apimFetchJsonV1Env<void>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}/members`, {
+        method: 'POST',
+        body: JSON.stringify(memberships),
+    });
+}
+
+/** Invites a not-yet-registered user by email. Only api_role/application_role are supported here. */
+export async function inviteGroupMember(environmentId: string, groupId: string, data: GroupInvitationPayload): Promise<void> {
+    return apimFetchJsonV1Env<void>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}/invitations`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/types/group.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/types/group.ts
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-/** Mirrors classic `GroupEventRuleEntity` — `API_CREATE` is "default group for new APIs". */
 export type GroupEventName = 'API_CREATE' | 'APPLICATION_CREATE' | 'API_PRODUCT_CREATE';
 
 export interface GroupEventRule {
     event: GroupEventName;
 }
 
-/** v1 `GroupEntity` (GET .../configuration/groups...). */
 export interface Group {
     id: string;
     name: string;
@@ -37,17 +35,8 @@ export interface Group {
     system_invitation?: boolean;
     email_invitation?: boolean;
     disable_membership_notifications?: boolean;
-    /**
-     * True when this group is a primary owner for at least one API — either via a group-level
-     * default API primary owner (`apiPrimaryOwner`) or an actual API-scope PRIMARY_OWNER
-     * membership role. Not about the current user, and doesn't cover API Product primary
-     * ownership — check `apiProductPrimaryOwner` separately (mirrors classic Console's
-     * `apiPrimaryOwner || apiProductPrimaryOwner` badge/delete-guard condition).
-     */
     primary_owner?: boolean;
-    /** Group-level default primary owner (user ID) forced onto new APIs created within this group. */
     apiPrimaryOwner?: string;
-    /** Group-level default primary owner (user ID) forced onto new API Products created within this group. */
     apiProductPrimaryOwner?: string;
 }
 
@@ -59,14 +48,12 @@ export interface GroupsPageMeta {
     total_elements: number;
 }
 
-/** v1 `PagedResult<GroupEntity>` (GET .../configuration/groups/_paged). */
 export interface GroupsPagedResponse {
     data: Group[];
     metadata?: Record<string, Record<string, unknown>>;
     page: GroupsPageMeta;
 }
 
-/** v1 `NewGroupEntity` (POST .../configuration/groups). No `roles` — set via a follow-up update. */
 export interface NewGroupPayload {
     name: string;
     lock_api_role: boolean;
@@ -79,7 +66,6 @@ export interface NewGroupPayload {
     disable_membership_notifications: boolean;
 }
 
-/** v1 `UpdateGroupEntity` (PUT .../configuration/groups/{id}). */
 export interface UpdateGroupPayload {
     name: string;
     lock_api_role: boolean;
@@ -93,13 +79,15 @@ export interface UpdateGroupPayload {
     disable_membership_notifications: boolean;
 }
 
-/** v1 role (GET .../configuration/rolescopes/{scope}/roles). */
 export interface GroupRole {
     name: string;
     scope: string;
     system?: boolean;
     default?: boolean;
 }
+
+export const PRIMARY_OWNER_ROLE = 'PRIMARY_OWNER';
+export const OWNER_ROLE = 'OWNER';
 
 /** v1 `GroupMemberEntity` (GET .../configuration/groups/{id}/members...). */
 export interface GroupMember {
@@ -118,4 +106,42 @@ export interface GroupMembershipItem {
     id: string;
     name: string;
     version?: string;
+}
+
+export type GroupMemberRoleScope = 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER' | 'GROUP';
+
+export interface SearchableUser {
+    id?: string | null;
+    reference: string;
+    displayName: string;
+    email?: string;
+}
+
+export interface GroupMembershipRole {
+    scope: GroupMemberRoleScope;
+    name: string;
+}
+
+export interface GroupMembershipPayload {
+    id: string;
+    reference?: string;
+    roles: GroupMembershipRole[];
+}
+
+export interface GroupInvitationPayload {
+    reference_type?: string;
+    reference_id: string;
+    email: string;
+    api_role?: string;
+    application_role?: string;
+}
+
+export interface GroupInvitation {
+    id: string;
+    reference_type?: string;
+    reference_id: string;
+    email: string;
+    api_role?: string;
+    application_role?: string;
+    created_at?: number;
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/types/group.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/types/group.ts
@@ -119,3 +119,39 @@ export interface GroupMembershipItem {
     name: string;
     version?: string;
 }
+
+/** v1 role scope accepted by .../configuration/groups/{id}/members — mirrors backend RoleScope. */
+export type GroupMemberRoleScope = 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER' | 'GROUP';
+
+/** Result of GET .../search/users?q= (org-scoped, unauthenticated-permission-free). */
+export interface SearchableUser {
+    id?: string | null;
+    reference: string;
+    displayName: string;
+    email?: string;
+}
+
+/** One role assignment within a GroupMembership payload item. */
+export interface GroupMembershipRole {
+    scope: GroupMemberRoleScope;
+    name: string;
+}
+
+/** v1 `GroupMembership` (POST .../configuration/groups/{id}/members body item) — adds/updates an
+ *  existing platform user's membership and per-scope roles in one call. */
+export interface GroupMembershipPayload {
+    id: string;
+    reference?: string;
+    roles: GroupMembershipRole[];
+}
+
+/** v1 `NewInvitationEntity` (POST .../configuration/groups/{id}/invitations). Only API and APPLICATION
+ *  default roles are supported for invitations — the backend has no api_product/integration/cluster
+ *  fields here, unlike direct membership roles. */
+export interface GroupInvitationPayload {
+    reference_type?: string;
+    reference_id: string;
+    email: string;
+    api_role?: string;
+    application_role?: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPayload.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPayload.ts
@@ -21,7 +21,6 @@ export function hasEventRule(group: Group, event: GroupEventName): boolean {
     return (group.event_rules ?? []).some(rule => rule.event === event);
 }
 
-/** Rebuilds the full event-rules list from the three toggles the UI manages. */
 export function buildEventRules(events: { apiCreate: boolean; applicationCreate: boolean; apiProductCreate: boolean }): GroupEventRule[] {
     const rules: GroupEventRule[] = [];
     if (events.apiCreate) rules.push({ event: 'API_CREATE' });
@@ -30,12 +29,6 @@ export function buildEventRules(events: { apiCreate: boolean; applicationCreate:
     return rules;
 }
 
-/**
- * Keeps any other role scope untouched — only sets/clears API, APPLICATION, and API_PRODUCT.
- * Always returns a map (possibly `{}`), never `undefined`: the v1 API treats an absent `roles`
- * field on the PUT body as "no change", so clearing every role to "None" must still send `{}`
- * to actually clear them — omitting the field would silently leave the old roles in place.
- */
 export function buildRolesMap(
     existingRoles: Record<string, string> | undefined,
     apiRole: string,
@@ -61,7 +54,6 @@ export function buildRolesMap(
     return roles;
 }
 
-/** Parses the "Maximum members" text input — blank, non-positive, or non-numeric all mean unlimited (`null`). */
 export function parseMaxInvitation(value: string): number | null {
     const trimmed = value.trim();
     if (!trimmed) return null;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPermissions.ts
@@ -16,17 +16,23 @@
 
 import type { Group } from '../types/group';
 
-/** Mirrors classic settings-routing.module.ts groups route guard + groups.component.ts permission checks. */
 export const ENVIRONMENT_GROUP_READ_PERMISSION = 'environment-group-r' as const;
 export const ENVIRONMENT_GROUP_CREATE_PERMISSION = 'environment-group-c' as const;
 export const ENVIRONMENT_GROUP_UPDATE_PERMISSION = 'environment-group-u' as const;
 export const ENVIRONMENT_GROUP_DELETE_PERMISSION = 'environment-group-d' as const;
 
-/**
- * Mirrors classic Console's `apiPrimaryOwner || apiProductPrimaryOwner` badge/delete-guard condition
- * (groups.component.html / groups.component.ts) — `primary_owner` alone misses groups that are only
- * an API Product primary owner, since the backend only sets `primary_owner` from API-scope PO state.
- */
+export const ORGANIZATION_SETTINGS_READ_PERMISSION = 'organization-settings-r' as const;
+
 export function isPrimaryOwnerGroup(group: Pick<Group, 'primary_owner' | 'apiPrimaryOwner' | 'apiProductPrimaryOwner'>): boolean {
     return Boolean(group.primary_owner || group.apiPrimaryOwner || group.apiProductPrimaryOwner);
+}
+
+export function canInviteToGroup(group: Pick<Group, 'manageable' | 'system_invitation' | 'email_invitation'>): boolean {
+    return Boolean(group.manageable) && Boolean(group.system_invitation || group.email_invitation);
+}
+
+/** Shared by the Add/Edit/Invite member dialogs' disableDefaultXRole()-style gating: a locked scope
+ *  stays editable for an operator who can override locks (environment-group-u). */
+export function isRoleLocked(locked: boolean, canOverrideLocks: boolean): boolean {
+    return locked && !canOverrideLocks;
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPermissions.ts
@@ -22,6 +22,11 @@ export const ENVIRONMENT_GROUP_CREATE_PERMISSION = 'environment-group-c' as cons
 export const ENVIRONMENT_GROUP_UPDATE_PERMISSION = 'environment-group-u' as const;
 export const ENVIRONMENT_GROUP_DELETE_PERMISSION = 'environment-group-d' as const;
 
+/** Gates the "Require a group on applications" org-wide toggle on the groups list — mirrors classic
+ *  groups.component.ts's `hasAnyMatching(['organization-settings-r'])` check (read-only gate; the save
+ *  itself relies on the backend's own CREATE/UPDATE/DELETE check on this same permission, same as classic). */
+export const ORGANIZATION_SETTINGS_READ_PERMISSION = 'organization-settings-r' as const;
+
 /**
  * Mirrors classic Console's `apiPrimaryOwner || apiProductPrimaryOwner` badge/delete-guard condition
  * (groups.component.html / groups.component.ts) — `primary_owner` alone misses groups that are only

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/queryKeys.ts
@@ -23,8 +23,11 @@ export const groupKeys = {
     members: (envId: string, groupId: string) => [...groupKeys.all, 'members', envId, groupId] as const,
     memberships: (envId: string, groupId: string, type: GroupMembershipType) =>
         [...groupKeys.all, 'memberships', envId, groupId, type] as const,
-    roles: (scope: 'API' | 'APPLICATION' | 'API_PRODUCT') => [...groupKeys.all, 'roles', scope] as const,
+    roles: (scope: 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER') => [...groupKeys.all, 'roles', scope] as const,
     apiRoles: () => groupKeys.roles('API'),
     applicationRoles: () => groupKeys.roles('APPLICATION'),
     apiProductRoles: () => groupKeys.roles('API_PRODUCT'),
+    integrationRoles: () => groupKeys.roles('INTEGRATION'),
+    clusterRoles: () => groupKeys.roles('CLUSTER'),
+    userSearch: (query: string) => [...groupKeys.all, 'userSearch', query] as const,
 } as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/queryKeys.ts
@@ -21,10 +21,15 @@ export const groupKeys = {
     list: (envId: string, query: string, page: number, size: number) => [...groupKeys.all, 'list', envId, query, page, size] as const,
     detail: (envId: string, groupId: string) => [...groupKeys.all, 'detail', envId, groupId] as const,
     members: (envId: string, groupId: string) => [...groupKeys.all, 'members', envId, groupId] as const,
+    invitations: (envId: string, groupId: string) => [...groupKeys.all, 'invitations', envId, groupId] as const,
     memberships: (envId: string, groupId: string, type: GroupMembershipType) =>
         [...groupKeys.all, 'memberships', envId, groupId, type] as const,
-    roles: (scope: 'API' | 'APPLICATION' | 'API_PRODUCT') => [...groupKeys.all, 'roles', scope] as const,
+    roles: (scope: 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER') => [...groupKeys.all, 'roles', scope] as const,
     apiRoles: () => groupKeys.roles('API'),
     applicationRoles: () => groupKeys.roles('APPLICATION'),
     apiProductRoles: () => groupKeys.roles('API_PRODUCT'),
+    integrationRoles: () => groupKeys.roles('INTEGRATION'),
+    clusterRoles: () => groupKeys.roles('CLUSTER'),
+    userSearch: (query: string) => [...groupKeys.all, 'userSearch', query] as const,
+    organizationGroups: () => [...groupKeys.all, 'organization'] as const,
 } as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
@@ -633,6 +633,21 @@ describe('GroupDetailPage', () => {
     });
 
     describe('Invitations tab', () => {
+        it('skips fetching invitations on initial load, before the Invitations tab is opened', () => {
+            renderPage();
+
+            expect(mockUseGroupInvitations).toHaveBeenCalledWith(undefined);
+        });
+
+        it('fetches invitations once the Invitations tab is opened', async () => {
+            const user = userEvent.setup();
+            renderPage();
+
+            await user.click(screen.getByRole('tab', { name: 'Invitations' }));
+
+            expect(mockUseGroupInvitations).toHaveBeenCalledWith('group-1');
+        });
+
         it('switches to the Invitations tab and lists pending invitations', async () => {
             const user = userEvent.setup();
             mockUseGroupInvitations.mockReturnValue({

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
@@ -131,11 +131,14 @@ jest.mock('../features/groups/components/GroupEditMemberSheet', () => ({
         ) : null,
 }));
 jest.mock('../features/groups/components/GroupRemoveMemberSheet', () => ({
-    GroupRemoveMemberSheet: ({ open, onConfirm }: { open: boolean; onConfirm: () => void }) =>
+    GroupRemoveMemberSheet: ({ open, onConfirm }: { open: boolean; onConfirm: (transferMembership?: GroupMembershipPayload) => void }) =>
         open ? (
             <div data-testid="remove-member-sheet">
-                <button type="button" onClick={onConfirm}>
+                <button type="button" onClick={() => onConfirm()}>
                     Submit remove
+                </button>
+                <button type="button" onClick={() => onConfirm({ id: 'member-2', roles: [{ scope: 'API', name: 'PRIMARY_OWNER' }] })}>
+                    Submit remove with successor
                 </button>
             </div>
         ) : null,
@@ -629,6 +632,44 @@ describe('GroupDetailPage', () => {
             fireEvent.click(screen.getByRole('button', { name: 'Submit remove' }));
 
             await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to remove member'));
+        });
+
+        it('transfers primary ownership to the successor before removing the member, so the group is never left ownerless', async () => {
+            const callOrder: string[] = [];
+            const removeMutateAsync = jest.fn().mockImplementation(async () => {
+                callOrder.push('remove');
+            });
+            const addMutateAsync = jest.fn().mockImplementation(async () => {
+                callOrder.push('transfer');
+            });
+            mockUseRemoveGroupMember.mockReturnValue(makeMutation(removeMutateAsync));
+            mockUseAddGroupMembers.mockReturnValue(makeMutation(addMutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Trigger remove' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Submit remove with successor' }));
+
+            await waitFor(() => expect(removeMutateAsync).toHaveBeenCalled());
+            expect(addMutateAsync).toHaveBeenCalledWith({
+                groupId: 'group-1',
+                memberships: [{ id: 'member-2', roles: [{ scope: 'API', name: 'PRIMARY_OWNER' }] }],
+            });
+            expect(callOrder).toEqual(['transfer', 'remove']);
+            expect(notify.success).toHaveBeenCalledWith('Anna Schmidt removed from the group');
+        });
+
+        it('does not remove the member if the ownership transfer fails first', async () => {
+            const error = new Error('transfer failed');
+            const removeMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseRemoveGroupMember.mockReturnValue(makeMutation(removeMutateAsync));
+            mockUseAddGroupMembers.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Trigger remove' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Submit remove with successor' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Primary ownership could not be transferred'));
+            expect(removeMutateAsync).not.toHaveBeenCalled();
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
@@ -420,7 +420,7 @@ describe('GroupDetailPage', () => {
         });
 
         it('opens GroupInviteMemberSheet from the Email invitation option, submits, and shows a success toast', async () => {
-            const inviteMutateAsync = jest.fn().mockResolvedValue(undefined);
+            const inviteMutateAsync = jest.fn().mockResolvedValue({ ambiguous: false });
             mockUseInviteGroupMember.mockReturnValue(makeMutation(inviteMutateAsync));
             const user = userEvent.setup();
             renderPage();
@@ -439,6 +439,24 @@ describe('GroupDetailPage', () => {
             );
             expect(notify.success).toHaveBeenCalledWith('Invitation sent to anna@lufthansa.com');
             await waitFor(() => expect(screen.queryByTestId('invite-member-sheet')).toBeNull());
+        });
+
+        it('shows the "many users found" dialog instead of a success toast when the email is ambiguous', async () => {
+            const inviteMutateAsync = jest.fn().mockResolvedValue({ ambiguous: true });
+            mockUseInviteGroupMember.mockReturnValue(makeMutation(inviteMutateAsync));
+            const user = userEvent.setup();
+            renderPage();
+
+            await user.click(screen.getByRole('button', { name: /Add members/i }));
+            await user.click(await screen.findByRole('menuitem', { name: /Email invitation/i }));
+            fireEvent.click(screen.getByRole('button', { name: 'Submit invite' }));
+
+            await waitFor(() => expect(screen.getByRole('heading', { name: 'Many Users Found' })).not.toBeNull());
+            expect(notify.success).not.toHaveBeenCalled();
+            expect(screen.queryByTestId('invite-member-sheet')).toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+            expect(screen.getByTestId('add-members-sheet')).not.toBeNull();
         });
 
         it('shows an error toast when adding members fails', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { GroupDetailPage } from './GroupDetailPage';
@@ -24,16 +26,50 @@ import {
     useGroupDetail,
     useGroupMembers,
 } from '../features/groups/hooks/useGroupDetail';
-import type { Group, GroupMembershipItem } from '../features/groups/types/group';
+import { useAddGroupMembers, useInviteGroupMember, useRemoveGroupMember } from '../features/groups/hooks/useGroupMutations';
+import {
+    useGroupApiProductRoles,
+    useGroupApiRoles,
+    useGroupApplicationRoles,
+    useGroupClusterRoles,
+    useGroupIntegrationRoles,
+} from '../features/groups/hooks/useGroupRoles';
+import type { Group, GroupMember, GroupMembershipItem, GroupMembershipPayload } from '../features/groups/types/group';
+import { notify } from '../shared/notify';
 
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
 jest.mock('../features/groups/hooks/useGroupDetail');
+jest.mock('../features/groups/hooks/useGroupRoles');
+jest.mock('../features/groups/hooks/useGroupMutations');
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
 
 // Stub the nested DataTable-backed components to avoid jsdom/Radix DataTable complexity;
 // exposes the fetched rows as plain text so orchestration (what data flows in) stays covered.
-// GroupMembersTable's own spec covers its columns/search internals.
+// GroupMembersTable's own spec covers its columns/search/actions-menu internals — here we only need
+// buttons that let us trigger the onEditRoles/onRemove callbacks the page wires up.
 jest.mock('../features/groups/components/GroupMembersTable', () => ({
-    GroupMembersTable: ({ members }: { members: { id: string; displayName: string }[] }) => (
-        <div data-testid="members-table">{members.map(m => m.displayName).join(', ')}</div>
+    GroupMembersTable: ({
+        members,
+        onEditRoles,
+        onRemove,
+    }: {
+        members: GroupMember[];
+        onEditRoles: (member: GroupMember) => void;
+        onRemove: (member: GroupMember) => void;
+    }) => (
+        <div data-testid="members-table">
+            {members.map(m => m.displayName).join(', ')}
+            <button type="button" onClick={() => onEditRoles(members[0])}>
+                Trigger edit roles
+            </button>
+            <button type="button" onClick={() => onRemove(members[0])}>
+                Trigger remove
+            </button>
+        </div>
     ),
 }));
 jest.mock('../features/groups/components/GroupMembershipTable', () => ({
@@ -41,14 +77,87 @@ jest.mock('../features/groups/components/GroupMembershipTable', () => ({
         <div data-testid={`membership-table-${ariaLabel}`}>{items.map(i => i.name).join(', ')}</div>
     ),
 }));
+// GroupAddMembersSheet / GroupInviteMemberSheet each have their own dedicated spec covering internals
+// (search, role selects, validation); here we only need to verify the page wires them correctly.
+jest.mock('../features/groups/components/GroupAddMembersSheet', () => ({
+    GroupAddMembersSheet: ({ open, onSubmit }: { open: boolean; onSubmit: (m: GroupMembershipPayload[]) => void }) =>
+        open ? (
+            <div data-testid="add-members-sheet">
+                <button type="button" onClick={() => onSubmit([{ id: 'user-1', roles: [{ scope: 'GROUP', name: 'ADMIN' }] }])}>
+                    Submit add members
+                </button>
+            </div>
+        ) : null,
+}));
+jest.mock('../features/groups/components/GroupInviteMemberSheet', () => ({
+    GroupInviteMemberSheet: ({
+        open,
+        onSubmit,
+    }: {
+        open: boolean;
+        onSubmit: (v: { email: string; apiRole: string; applicationRole: string }) => void;
+    }) =>
+        open ? (
+            <div data-testid="invite-member-sheet">
+                <button type="button" onClick={() => onSubmit({ email: 'anna@lufthansa.com', apiRole: '', applicationRole: '' })}>
+                    Submit invite
+                </button>
+            </div>
+        ) : null,
+}));
+// GroupEditMemberSheet / GroupRemoveMemberSheet each have their own dedicated spec covering internals;
+// here we only need to verify the page wires them correctly to the right mutations.
+jest.mock('../features/groups/components/GroupEditMemberSheet', () => ({
+    GroupEditMemberSheet: ({ open, onSubmit }: { open: boolean; onSubmit: (payload: GroupMembershipPayload) => void }) =>
+        open ? (
+            <div data-testid="edit-member-sheet">
+                <button type="button" onClick={() => onSubmit({ id: 'member-1', roles: [{ scope: 'GROUP', name: 'ADMIN' }] })}>
+                    Submit edit roles
+                </button>
+            </div>
+        ) : null,
+}));
+jest.mock('../features/groups/components/GroupRemoveMemberSheet', () => ({
+    GroupRemoveMemberSheet: ({ open, onConfirm }: { open: boolean; onConfirm: () => void }) =>
+        open ? (
+            <div data-testid="remove-member-sheet">
+                <button type="button" onClick={onConfirm}>
+                    Submit remove
+                </button>
+            </div>
+        ) : null,
+}));
 
+// Radix Select/Checkbox measure via ResizeObserver, which jsdom lacks.
+beforeAll(() => {
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as typeof ResizeObserver;
+});
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseGroupDetail = jest.mocked(useGroupDetail);
 const mockUseGroupMembers = jest.mocked(useGroupMembers);
 const mockUseGroupApis = jest.mocked(useGroupApis);
 const mockUseGroupApplications = jest.mocked(useGroupApplications);
 const mockUseGroupApiProducts = jest.mocked(useGroupApiProducts);
+const mockUseGroupApiRoles = jest.mocked(useGroupApiRoles);
+const mockUseGroupApplicationRoles = jest.mocked(useGroupApplicationRoles);
+const mockUseGroupApiProductRoles = jest.mocked(useGroupApiProductRoles);
+const mockUseGroupIntegrationRoles = jest.mocked(useGroupIntegrationRoles);
+const mockUseGroupClusterRoles = jest.mocked(useGroupClusterRoles);
+const mockUseAddGroupMembers = jest.mocked(useAddGroupMembers);
+const mockUseInviteGroupMember = jest.mocked(useInviteGroupMember);
+const mockUseRemoveGroupMember = jest.mocked(useRemoveGroupMember);
 
 const GROUP: Group = { id: 'group-1', name: 'Support Team', event_rules: [{ event: 'API_CREATE' }] };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeMutation(mutateAsync = jest.fn()): any {
+    return { mutateAsync, isPending: false };
+}
 
 function renderPage(initialGroupId = 'group-1') {
     return render(
@@ -65,6 +174,7 @@ function renderPage(initialGroupId = 'group-1') {
 
 describe('GroupDetailPage', () => {
     beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(true);
         mockUseGroupDetail.mockReturnValue({ data: GROUP, isLoading: false, isError: false } as ReturnType<typeof useGroupDetail>);
         mockUseGroupMembers.mockReturnValue({
             data: [{ id: 'member-1', displayName: 'Anna Schmidt', roles: {} }],
@@ -82,6 +192,14 @@ describe('GroupDetailPage', () => {
             isError: false,
         } as ReturnType<typeof useGroupApplications>);
         mockUseGroupApiProducts.mockReturnValue({ data: [], isLoading: false, isError: false } as ReturnType<typeof useGroupApiProducts>);
+        mockUseGroupApiRoles.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupApiRoles>);
+        mockUseGroupApplicationRoles.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupApplicationRoles>);
+        mockUseGroupApiProductRoles.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupApiProductRoles>);
+        mockUseGroupIntegrationRoles.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupIntegrationRoles>);
+        mockUseGroupClusterRoles.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupClusterRoles>);
+        mockUseAddGroupMembers.mockReturnValue(makeMutation());
+        mockUseInviteGroupMember.mockReturnValue(makeMutation());
+        mockUseRemoveGroupMember.mockReturnValue(makeMutation());
     });
 
     afterEach(() => {
@@ -112,10 +230,9 @@ describe('GroupDetailPage', () => {
         expect(screen.queryByText('Group not found or failed to load.')).not.toBeNull();
     });
 
-    it('has no Edit or Delete action — classic only allows those from the list', () => {
+    it('has no Delete action — classic only allows deleting a group from the list', () => {
         renderPage();
 
-        expect(screen.queryByRole('button', { name: /Edit/i })).toBeNull();
         expect(screen.queryByRole('button', { name: /Delete/i })).toBeNull();
     });
 
@@ -259,6 +376,141 @@ describe('GroupDetailPage', () => {
             expect(screen.queryByText('Auto APIs')).not.toBeNull();
             expect(screen.queryByText('Auto API Products')).not.toBeNull();
             expect(screen.queryByText('Auto Applications')).not.toBeNull();
+        });
+    });
+
+    describe('Add members', () => {
+        it('hides the Add members trigger without permission', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: /Add members/i })).toBeNull();
+        });
+
+        it('offers User search and Email invitation from the dropdown', async () => {
+            const user = userEvent.setup();
+            renderPage();
+
+            await user.click(screen.getByRole('button', { name: /Add members/i }));
+
+            expect(await screen.findByRole('menuitem', { name: /User search/i })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: /Email invitation/i })).not.toBeNull();
+        });
+
+        it('opens GroupAddMembersSheet from the User search option, submits, and shows a success toast', async () => {
+            const addMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseAddGroupMembers.mockReturnValue(makeMutation(addMutateAsync));
+            const user = userEvent.setup();
+            renderPage();
+
+            await user.click(screen.getByRole('button', { name: /Add members/i }));
+            await user.click(await screen.findByRole('menuitem', { name: /User search/i }));
+
+            expect(screen.getByTestId('add-members-sheet')).not.toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Submit add members' }));
+
+            await waitFor(() =>
+                expect(addMutateAsync).toHaveBeenCalledWith({
+                    groupId: 'group-1',
+                    memberships: [{ id: 'user-1', roles: [{ scope: 'GROUP', name: 'ADMIN' }] }],
+                }),
+            );
+            expect(notify.success).toHaveBeenCalledWith('Member added successfully');
+            await waitFor(() => expect(screen.queryByTestId('add-members-sheet')).toBeNull());
+        });
+
+        it('opens GroupInviteMemberSheet from the Email invitation option, submits, and shows a success toast', async () => {
+            const inviteMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseInviteGroupMember.mockReturnValue(makeMutation(inviteMutateAsync));
+            const user = userEvent.setup();
+            renderPage();
+
+            await user.click(screen.getByRole('button', { name: /Add members/i }));
+            await user.click(await screen.findByRole('menuitem', { name: /Email invitation/i }));
+
+            expect(screen.getByTestId('invite-member-sheet')).not.toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Submit invite' }));
+
+            await waitFor(() =>
+                expect(inviteMutateAsync).toHaveBeenCalledWith({
+                    groupId: 'group-1',
+                    data: { reference_id: 'group-1', email: 'anna@lufthansa.com', api_role: undefined, application_role: undefined },
+                }),
+            );
+            expect(notify.success).toHaveBeenCalledWith('Invitation sent to anna@lufthansa.com');
+            await waitFor(() => expect(screen.queryByTestId('invite-member-sheet')).toBeNull());
+        });
+
+        it('shows an error toast when adding members fails', async () => {
+            const error = new Error('failed');
+            mockUseAddGroupMembers.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            const user = userEvent.setup();
+            renderPage();
+
+            await user.click(screen.getByRole('button', { name: /Add members/i }));
+            await user.click(await screen.findByRole('menuitem', { name: /User search/i }));
+            fireEvent.click(screen.getByRole('button', { name: 'Submit add members' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to add members'));
+        });
+    });
+
+    describe('Edit roles', () => {
+        it('opens GroupEditMemberSheet, submits, and shows a success toast', async () => {
+            const editMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseAddGroupMembers.mockReturnValue(makeMutation(editMutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Trigger edit roles' }));
+            expect(screen.getByTestId('edit-member-sheet')).not.toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Submit edit roles' }));
+
+            await waitFor(() =>
+                expect(editMutateAsync).toHaveBeenCalledWith({
+                    groupId: 'group-1',
+                    memberships: [{ id: 'member-1', roles: [{ scope: 'GROUP', name: 'ADMIN' }] }],
+                }),
+            );
+            expect(notify.success).toHaveBeenCalledWith('Member roles updated successfully');
+            await waitFor(() => expect(screen.queryByTestId('edit-member-sheet')).toBeNull());
+        });
+
+        it('shows an error toast when editing roles fails', async () => {
+            const error = new Error('failed');
+            mockUseAddGroupMembers.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Trigger edit roles' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Submit edit roles' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to update member roles'));
+        });
+    });
+
+    describe('Remove member', () => {
+        it('opens GroupRemoveMemberSheet, confirms, and shows a success toast', async () => {
+            const removeMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseRemoveGroupMember.mockReturnValue(makeMutation(removeMutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Trigger remove' }));
+            expect(screen.getByTestId('remove-member-sheet')).not.toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Submit remove' }));
+
+            await waitFor(() => expect(removeMutateAsync).toHaveBeenCalledWith({ groupId: 'group-1', memberId: 'member-1' }));
+            expect(notify.success).toHaveBeenCalledWith('Anna Schmidt removed from the group');
+            await waitFor(() => expect(screen.queryByTestId('remove-member-sheet')).toBeNull());
+        });
+
+        it('shows an error toast when removing a member fails', async () => {
+            const error = new Error('failed');
+            mockUseRemoveGroupMember.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Trigger remove' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Submit remove' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to remove member'));
         });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
@@ -15,19 +15,35 @@
  */
 import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { GroupDetailPage } from './GroupDetailPage';
+import { useCurrentUserIsGroupAdmin } from '../features/groups/hooks/useCurrentUserGroupAdmin';
 import {
     useGroupApis,
     useGroupApplications,
     useGroupApiProducts,
     useGroupDetail,
+    useGroupInvitations,
     useGroupMembers,
 } from '../features/groups/hooks/useGroupDetail';
-import { useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
-import { useGroupApiProductRoles, useGroupApiRoles, useGroupApplicationRoles } from '../features/groups/hooks/useGroupRoles';
-import type { Group, GroupMembershipItem } from '../features/groups/types/group';
+import {
+    useAddGroupMembers,
+    useDeleteGroup,
+    useDeleteGroupInvitation,
+    useInviteGroupMember,
+    useRemoveGroupMember,
+    useUpdateGroup,
+} from '../features/groups/hooks/useGroupMutations';
+import {
+    useGroupApiProductRoles,
+    useGroupApiRoles,
+    useGroupApplicationRoles,
+    useGroupClusterRoles,
+    useGroupIntegrationRoles,
+} from '../features/groups/hooks/useGroupRoles';
+import type { Group, GroupMember, GroupMembershipItem, GroupMembershipPayload } from '../features/groups/types/group';
 import { notify } from '../shared/notify';
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
@@ -36,16 +52,37 @@ jest.mock('@gravitee/gamma-modules-sdk', () => ({
 jest.mock('../features/groups/hooks/useGroupDetail');
 jest.mock('../features/groups/hooks/useGroupRoles');
 jest.mock('../features/groups/hooks/useGroupMutations');
+jest.mock('../features/groups/hooks/useCurrentUserGroupAdmin');
 jest.mock('../shared/notify', () => ({
     notify: { success: jest.fn(), error: jest.fn() },
 }));
 
 // Stub the nested DataTable-backed components to avoid jsdom/Radix DataTable complexity;
 // exposes the fetched rows as plain text so orchestration (what data flows in) stays covered.
-// GroupMembersTable's own spec covers its columns/search internals.
+// GroupMembersTable's own spec covers its columns/search/actions-menu internals — here we only need
+// buttons that let us trigger the onEditRoles/onRemove callbacks the page wires up, plus a visible
+// readout of `canManageMembers` so this spec can assert on the permission gate it's computed from.
 jest.mock('../features/groups/components/GroupMembersTable', () => ({
-    GroupMembersTable: ({ members }: { members: { id: string; displayName: string }[] }) => (
-        <div data-testid="members-table">{members.map(m => m.displayName).join(', ')}</div>
+    GroupMembersTable: ({
+        members,
+        canManageMembers,
+        onEditRoles,
+        onRemove,
+    }: {
+        members: GroupMember[];
+        canManageMembers: boolean;
+        onEditRoles: (member: GroupMember) => void;
+        onRemove: (member: GroupMember) => void;
+    }) => (
+        <div data-testid="members-table" data-can-manage-members={canManageMembers}>
+            {members.map(m => m.displayName).join(', ')}
+            <button type="button" onClick={() => onEditRoles(members[0])}>
+                Trigger edit roles
+            </button>
+            <button type="button" onClick={() => onRemove(members[0])}>
+                Trigger remove
+            </button>
+        </div>
     ),
 }));
 jest.mock('../features/groups/components/GroupMembershipTable', () => ({
@@ -53,9 +90,59 @@ jest.mock('../features/groups/components/GroupMembershipTable', () => ({
         <div data-testid={`membership-table-${ariaLabel}`}>{items.map(i => i.name).join(', ')}</div>
     ),
 }));
+// GroupAddMembersSheet / GroupInviteMemberSheet each have their own dedicated spec covering internals
+// (search, role selects, validation); here we only need to verify the page wires them correctly.
+jest.mock('../features/groups/components/GroupAddMembersSheet', () => ({
+    GroupAddMembersSheet: ({ open, onSubmit }: { open: boolean; onSubmit: (m: GroupMembershipPayload[]) => void }) =>
+        open ? (
+            <div data-testid="add-members-sheet">
+                <button type="button" onClick={() => onSubmit([{ id: 'user-1', roles: [{ scope: 'GROUP', name: 'ADMIN' }] }])}>
+                    Submit add members
+                </button>
+            </div>
+        ) : null,
+}));
+jest.mock('../features/groups/components/GroupInviteMemberSheet', () => ({
+    GroupInviteMemberSheet: ({
+        open,
+        onSubmit,
+    }: {
+        open: boolean;
+        onSubmit: (v: { email: string; apiRole: string; applicationRole: string }) => void;
+    }) =>
+        open ? (
+            <div data-testid="invite-member-sheet">
+                <button type="button" onClick={() => onSubmit({ email: 'anna@lufthansa.com', apiRole: '', applicationRole: '' })}>
+                    Submit invite
+                </button>
+            </div>
+        ) : null,
+}));
+// GroupEditMemberSheet / GroupRemoveMemberSheet each have their own dedicated spec covering internals;
+// here we only need to verify the page wires them correctly to the right mutations.
+jest.mock('../features/groups/components/GroupEditMemberSheet', () => ({
+    GroupEditMemberSheet: ({ open, onSubmit }: { open: boolean; onSubmit: (memberships: GroupMembershipPayload[]) => void }) =>
+        open ? (
+            <div data-testid="edit-member-sheet">
+                <button type="button" onClick={() => onSubmit([{ id: 'member-1', roles: [{ scope: 'GROUP', name: 'ADMIN' }] }])}>
+                    Submit edit roles
+                </button>
+            </div>
+        ) : null,
+}));
+jest.mock('../features/groups/components/GroupRemoveMemberSheet', () => ({
+    GroupRemoveMemberSheet: ({ open, onConfirm }: { open: boolean; onConfirm: () => void }) =>
+        open ? (
+            <div data-testid="remove-member-sheet">
+                <button type="button" onClick={onConfirm}>
+                    Submit remove
+                </button>
+            </div>
+        ) : null,
+}));
 
-// Radix Switch (rendered inside the real GroupSheet, mounted unconditionally so Edit can open it) measures
-// its thumb via ResizeObserver, which jsdom lacks.
+// Radix Switch/Select (rendered inside the real GroupSheet, mounted unconditionally so Edit can open it)
+// measure via ResizeObserver, which jsdom lacks.
 beforeAll(() => {
     global.ResizeObserver = class ResizeObserver {
         observe() {}
@@ -67,16 +154,30 @@ beforeAll(() => {
 const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseGroupDetail = jest.mocked(useGroupDetail);
 const mockUseGroupMembers = jest.mocked(useGroupMembers);
+const mockUseGroupInvitations = jest.mocked(useGroupInvitations);
 const mockUseGroupApis = jest.mocked(useGroupApis);
 const mockUseGroupApplications = jest.mocked(useGroupApplications);
 const mockUseGroupApiProducts = jest.mocked(useGroupApiProducts);
 const mockUseGroupApiRoles = jest.mocked(useGroupApiRoles);
 const mockUseGroupApplicationRoles = jest.mocked(useGroupApplicationRoles);
 const mockUseGroupApiProductRoles = jest.mocked(useGroupApiProductRoles);
+const mockUseGroupIntegrationRoles = jest.mocked(useGroupIntegrationRoles);
+const mockUseGroupClusterRoles = jest.mocked(useGroupClusterRoles);
 const mockUseUpdateGroup = jest.mocked(useUpdateGroup);
 const mockUseDeleteGroup = jest.mocked(useDeleteGroup);
+const mockUseAddGroupMembers = jest.mocked(useAddGroupMembers);
+const mockUseInviteGroupMember = jest.mocked(useInviteGroupMember);
+const mockUseRemoveGroupMember = jest.mocked(useRemoveGroupMember);
+const mockUseDeleteGroupInvitation = jest.mocked(useDeleteGroupInvitation);
+const mockUseCurrentUserIsGroupAdmin = jest.mocked(useCurrentUserIsGroupAdmin);
 
-const GROUP: Group = { id: 'group-1', name: 'Support Team', event_rules: [{ event: 'API_CREATE' }] };
+const GROUP: Group = {
+    id: 'group-1',
+    name: 'Support Team',
+    event_rules: [{ event: 'API_CREATE' }],
+    system_invitation: true,
+    email_invitation: true,
+};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeMutation(mutateAsync = jest.fn()): any {
@@ -116,6 +217,7 @@ describe('GroupDetailPage', () => {
             isError: false,
         } as ReturnType<typeof useGroupApplications>);
         mockUseGroupApiProducts.mockReturnValue({ data: [], isLoading: false, isError: false } as ReturnType<typeof useGroupApiProducts>);
+        mockUseGroupInvitations.mockReturnValue({ data: [], isLoading: false, isError: false } as ReturnType<typeof useGroupInvitations>);
         mockUseGroupApiRoles.mockReturnValue({ data: [{ name: 'USER', scope: 'API', default: true }], isLoading: false } as ReturnType<
             typeof useGroupApiRoles
         >);
@@ -127,8 +229,15 @@ describe('GroupDetailPage', () => {
             data: [{ name: 'USER', scope: 'API_PRODUCT', default: true }],
             isLoading: false,
         } as ReturnType<typeof useGroupApiProductRoles>);
+        mockUseGroupIntegrationRoles.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupIntegrationRoles>);
+        mockUseGroupClusterRoles.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupClusterRoles>);
         mockUseUpdateGroup.mockReturnValue(makeMutation());
         mockUseDeleteGroup.mockReturnValue(makeMutation());
+        mockUseAddGroupMembers.mockReturnValue(makeMutation());
+        mockUseInviteGroupMember.mockReturnValue(makeMutation());
+        mockUseRemoveGroupMember.mockReturnValue(makeMutation());
+        mockUseDeleteGroupInvitation.mockReturnValue(makeMutation());
+        mockUseCurrentUserIsGroupAdmin.mockReturnValue(false);
     });
 
     afterEach(() => {
@@ -367,6 +476,348 @@ describe('GroupDetailPage', () => {
             expect(screen.queryByText('Auto APIs')).not.toBeNull();
             expect(screen.queryByText('Auto API Products')).not.toBeNull();
             expect(screen.queryByText('Auto Applications')).not.toBeNull();
+        });
+    });
+
+    describe('Add members', () => {
+        it('hides the Add members trigger without permission', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: /Add members/i })).toBeNull();
+        });
+
+        it('offers User search and Email invitation from the dropdown', async () => {
+            const user = userEvent.setup();
+            renderPage();
+
+            await user.click(screen.getByRole('button', { name: /Add members/i }));
+
+            expect(await screen.findByRole('menuitem', { name: /User search/i })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: /Email invitation/i })).not.toBeNull();
+        });
+
+        it('opens GroupAddMembersSheet from the User search option, submits, and shows a success toast', async () => {
+            const addMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseAddGroupMembers.mockReturnValue(makeMutation(addMutateAsync));
+            const user = userEvent.setup();
+            renderPage();
+
+            await user.click(screen.getByRole('button', { name: /Add members/i }));
+            await user.click(await screen.findByRole('menuitem', { name: /User search/i }));
+
+            expect(screen.getByTestId('add-members-sheet')).not.toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Submit add members' }));
+
+            await waitFor(() =>
+                expect(addMutateAsync).toHaveBeenCalledWith({
+                    groupId: 'group-1',
+                    memberships: [{ id: 'user-1', roles: [{ scope: 'GROUP', name: 'ADMIN' }] }],
+                }),
+            );
+            expect(notify.success).toHaveBeenCalledWith('Member added successfully');
+            await waitFor(() => expect(screen.queryByTestId('add-members-sheet')).toBeNull());
+        });
+
+        it('opens GroupInviteMemberSheet from the Email invitation option, submits, and shows a success toast', async () => {
+            const inviteMutateAsync = jest.fn().mockResolvedValue({ ambiguous: false });
+            mockUseInviteGroupMember.mockReturnValue(makeMutation(inviteMutateAsync));
+            const user = userEvent.setup();
+            renderPage();
+
+            await user.click(screen.getByRole('button', { name: /Add members/i }));
+            await user.click(await screen.findByRole('menuitem', { name: /Email invitation/i }));
+
+            expect(screen.getByTestId('invite-member-sheet')).not.toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Submit invite' }));
+
+            await waitFor(() =>
+                expect(inviteMutateAsync).toHaveBeenCalledWith({
+                    groupId: 'group-1',
+                    data: { reference_id: 'group-1', email: 'anna@lufthansa.com', api_role: undefined, application_role: undefined },
+                }),
+            );
+            expect(notify.success).toHaveBeenCalledWith('Invitation sent to anna@lufthansa.com');
+            await waitFor(() => expect(screen.queryByTestId('invite-member-sheet')).toBeNull());
+        });
+
+        it('shows the "many users found" dialog instead of a success toast when the email is ambiguous', async () => {
+            const inviteMutateAsync = jest.fn().mockResolvedValue({ ambiguous: true });
+            mockUseInviteGroupMember.mockReturnValue(makeMutation(inviteMutateAsync));
+            const user = userEvent.setup();
+            renderPage();
+
+            await user.click(screen.getByRole('button', { name: /Add members/i }));
+            await user.click(await screen.findByRole('menuitem', { name: /Email invitation/i }));
+            fireEvent.click(screen.getByRole('button', { name: 'Submit invite' }));
+
+            await waitFor(() => expect(screen.getByRole('heading', { name: 'Many Users Found' })).not.toBeNull());
+            expect(notify.success).not.toHaveBeenCalled();
+            expect(screen.queryByTestId('invite-member-sheet')).toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+            expect(screen.getByTestId('add-members-sheet')).not.toBeNull();
+        });
+
+        it('shows an error toast when adding members fails', async () => {
+            const error = new Error('failed');
+            mockUseAddGroupMembers.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            const user = userEvent.setup();
+            renderPage();
+
+            await user.click(screen.getByRole('button', { name: /Add members/i }));
+            await user.click(await screen.findByRole('menuitem', { name: /User search/i }));
+            fireEvent.click(screen.getByRole('button', { name: 'Submit add members' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to add members'));
+        });
+    });
+
+    describe('Edit roles', () => {
+        it('opens GroupEditMemberSheet, submits, and shows a success toast', async () => {
+            const editMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseAddGroupMembers.mockReturnValue(makeMutation(editMutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Trigger edit roles' }));
+            expect(screen.getByTestId('edit-member-sheet')).not.toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Submit edit roles' }));
+
+            await waitFor(() =>
+                expect(editMutateAsync).toHaveBeenCalledWith({
+                    groupId: 'group-1',
+                    memberships: [{ id: 'member-1', roles: [{ scope: 'GROUP', name: 'ADMIN' }] }],
+                }),
+            );
+            expect(notify.success).toHaveBeenCalledWith('Member roles updated successfully');
+            await waitFor(() => expect(screen.queryByTestId('edit-member-sheet')).toBeNull());
+        });
+
+        it('shows an error toast when editing roles fails', async () => {
+            const error = new Error('failed');
+            mockUseAddGroupMembers.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Trigger edit roles' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Submit edit roles' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to update member roles'));
+        });
+    });
+
+    describe('Remove member', () => {
+        it('opens GroupRemoveMemberSheet, confirms, and shows a success toast', async () => {
+            const removeMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseRemoveGroupMember.mockReturnValue(makeMutation(removeMutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Trigger remove' }));
+            expect(screen.getByTestId('remove-member-sheet')).not.toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Submit remove' }));
+
+            await waitFor(() => expect(removeMutateAsync).toHaveBeenCalledWith({ groupId: 'group-1', memberId: 'member-1' }));
+            expect(notify.success).toHaveBeenCalledWith('Anna Schmidt removed from the group');
+            await waitFor(() => expect(screen.queryByTestId('remove-member-sheet')).toBeNull());
+        });
+
+        it('shows an error toast when removing a member fails', async () => {
+            const error = new Error('failed');
+            mockUseRemoveGroupMember.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Trigger remove' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Submit remove' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to remove member'));
+        });
+    });
+
+    describe('Invitations tab', () => {
+        it('switches to the Invitations tab and lists pending invitations', async () => {
+            const user = userEvent.setup();
+            mockUseGroupInvitations.mockReturnValue({
+                data: [{ id: 'invitation-1', reference_id: 'group-1', email: 'anna@lufthansa.com', api_role: 'USER' }],
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupInvitations>);
+            renderPage();
+
+            await user.click(screen.getByRole('tab', { name: 'Invitations' }));
+
+            expect(screen.getByText('anna@lufthansa.com')).not.toBeNull();
+        });
+
+        it('shows a section error instead of the invitations table when invitations fail to load', async () => {
+            const user = userEvent.setup();
+            mockUseGroupInvitations.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<
+                typeof useGroupInvitations
+            >);
+            renderPage();
+
+            await user.click(screen.getByRole('tab', { name: 'Invitations' }));
+
+            expect(screen.getByText('Failed to load invitations. Please refresh and try again.')).not.toBeNull();
+        });
+
+        it('deletes an invitation after confirming, and shows a success toast', async () => {
+            const user = userEvent.setup();
+            const deleteMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseDeleteGroupInvitation.mockReturnValue(makeMutation(deleteMutateAsync));
+            mockUseGroupInvitations.mockReturnValue({
+                data: [{ id: 'invitation-1', reference_id: 'group-1', email: 'anna@lufthansa.com' }],
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupInvitations>);
+            renderPage();
+
+            await user.click(screen.getByRole('tab', { name: 'Invitations' }));
+            await user.click(screen.getByRole('button', { name: 'Delete invitation sent to anna@lufthansa.com' }));
+
+            expect(screen.getByRole('heading', { name: 'Delete Invitation' })).not.toBeNull();
+            expect(
+                screen.getByText('You are trying to delete an invitation sent to anna@lufthansa.com. Do you want to continue?'),
+            ).not.toBeNull();
+
+            await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+            await waitFor(() => expect(deleteMutateAsync).toHaveBeenCalledWith({ groupId: 'group-1', invitationId: 'invitation-1' }));
+            expect(notify.success).toHaveBeenCalledWith('Successfully deleted the invitation.');
+        });
+
+        it('shows an error toast when deleting an invitation fails', async () => {
+            const user = userEvent.setup();
+            const error = new Error('failed');
+            mockUseDeleteGroupInvitation.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            mockUseGroupInvitations.mockReturnValue({
+                data: [{ id: 'invitation-1', reference_id: 'group-1', email: 'anna@lufthansa.com' }],
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupInvitations>);
+            renderPage();
+
+            await user.click(screen.getByRole('tab', { name: 'Invitations' }));
+            await user.click(screen.getByRole('button', { name: 'Delete invitation sent to anna@lufthansa.com' }));
+            await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Error occurred while deleting the invitation.'));
+        });
+    });
+
+    // Mirrors classic group.component.ts's shouldAllowAddMembers(): environment-group-u always allows
+    // adding members, but a group's own GROUP/ADMIN member (manageable) can self-service too, as long as
+    // the group permits at least one invitation method — independent of the broader org permission.
+    describe('self-service group admin (manageable)', () => {
+        it('shows Add members via manageable + system_invitation even without environment-group-u', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, manageable: true, system_invitation: true, email_invitation: false },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: /Add members/i })).not.toBeNull();
+        });
+
+        it('hides Add members when manageable but the group allows no invitation method', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, manageable: true, system_invitation: false, email_invitation: false },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: /Add members/i })).toBeNull();
+        });
+
+        it('hides Add members when not manageable and lacking environment-group-u', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, manageable: false },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: /Add members/i })).toBeNull();
+        });
+
+        it('disables the User search item when the group does not allow system_invitation', async () => {
+            const user = userEvent.setup();
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, system_invitation: false },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            await user.click(screen.getByRole('button', { name: /Add members/i }));
+            expect((await screen.findByRole('menuitem', { name: /User search/i })).getAttribute('aria-disabled')).toBe('true');
+        });
+
+        it('disables the Email invitation item when the group does not allow email_invitation', async () => {
+            const user = userEvent.setup();
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, email_invitation: false },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            await user.click(screen.getByRole('button', { name: /Add members/i }));
+            expect((await screen.findByRole('menuitem', { name: /Email invitation/i })).getAttribute('aria-disabled')).toBe('true');
+        });
+
+        it('shows the actions column for a group’s own GROUP/ADMIN member even without environment-group-u', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            mockUseCurrentUserIsGroupAdmin.mockReturnValue(true);
+            renderPage();
+
+            expect(screen.getByTestId('members-table').getAttribute('data-can-manage-members')).toBe('true');
+        });
+
+        it('hides the actions column without environment-group-u and without being the group’s own admin', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            mockUseCurrentUserIsGroupAdmin.mockReturnValue(false);
+            renderPage();
+
+            expect(screen.getByTestId('members-table').getAttribute('data-can-manage-members')).toBe('false');
+        });
+    });
+
+    describe('member limit', () => {
+        it('shows an info banner and hides Add members once the group has reached max_invitation', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, max_invitation: 1 },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            mockUseGroupMembers.mockReturnValue({
+                data: [{ id: 'member-1', displayName: 'Anna Schmidt', roles: {} }],
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupMembers>);
+            renderPage();
+
+            expect(
+                screen.getByText(
+                    'The number of members in this group has reached maximum allowed. Adding users via search and email invitation have been disabled.',
+                ),
+            ).not.toBeNull();
+            expect(screen.queryByRole('button', { name: /Add members/i })).toBeNull();
+        });
+
+        it('does not show the banner below the limit', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, max_invitation: 5 },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByText(/reached maximum allowed/)).toBeNull();
+            expect(screen.queryByRole('button', { name: /Add members/i })).not.toBeNull();
         });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
@@ -108,10 +108,10 @@ jest.mock('../features/groups/components/GroupInviteMemberSheet', () => ({
 // GroupEditMemberSheet / GroupRemoveMemberSheet each have their own dedicated spec covering internals;
 // here we only need to verify the page wires them correctly to the right mutations.
 jest.mock('../features/groups/components/GroupEditMemberSheet', () => ({
-    GroupEditMemberSheet: ({ open, onSubmit }: { open: boolean; onSubmit: (payload: GroupMembershipPayload) => void }) =>
+    GroupEditMemberSheet: ({ open, onSubmit }: { open: boolean; onSubmit: (memberships: GroupMembershipPayload[]) => void }) =>
         open ? (
             <div data-testid="edit-member-sheet">
-                <button type="button" onClick={() => onSubmit({ id: 'member-1', roles: [{ scope: 'GROUP', name: 'ADMIN' }] })}>
+                <button type="button" onClick={() => onSubmit([{ id: 'member-1', roles: [{ scope: 'GROUP', name: 'ADMIN' }] }])}>
                     Submit edit roles
                 </button>
             </div>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -35,6 +35,7 @@ import { GroupInviteMemberSheet } from '../features/groups/components/GroupInvit
 import { GroupMembershipTable } from '../features/groups/components/GroupMembershipTable';
 import { GroupMembersTable } from '../features/groups/components/GroupMembersTable';
 import { GroupRemoveMemberSheet } from '../features/groups/components/GroupRemoveMemberSheet';
+import { GroupTooManyUsersDialog } from '../features/groups/components/GroupTooManyUsersDialog';
 import {
     useGroupApis,
     useGroupApplications,
@@ -78,6 +79,7 @@ export function GroupDetailPage() {
     const [memberSheet, setMemberSheet] = useState<MemberSheetState>('closed');
     const [editingMember, setEditingMember] = useState<GroupMember | null>(null);
     const [removingMember, setRemovingMember] = useState<GroupMember | null>(null);
+    const [tooManyUsersEmail, setTooManyUsersEmail] = useState<string | null>(null);
 
     const { data: group, isLoading, isError } = useGroupDetail(groupId);
     const { data: members = [], isLoading: membersLoading, isError: membersError } = useGroupMembers(groupId);
@@ -112,7 +114,7 @@ export function GroupDetailPage() {
     async function handleInviteMember(values: { email: string; apiRole: string; applicationRole: string }) {
         if (!groupId) return;
         try {
-            await inviteMemberMutation.mutateAsync({
+            const result = await inviteMemberMutation.mutateAsync({
                 groupId,
                 data: {
                     reference_id: groupId,
@@ -121,11 +123,23 @@ export function GroupDetailPage() {
                     application_role: values.applicationRole || undefined,
                 },
             });
+            if (result.ambiguous) {
+                // No invitation was actually sent — more than one platform user shares this email, so
+                // redirect to user search instead of claiming success (mirrors classic's 202 branch).
+                closeMemberSheet();
+                setTooManyUsersEmail(values.email);
+                return;
+            }
             notify.success(`Invitation sent to ${values.email}`);
             closeMemberSheet();
         } catch (error) {
             notify.error(error, 'Failed to send invitation');
         }
+    }
+
+    function handleTooManyUsersContinue() {
+        setTooManyUsersEmail(null);
+        setMemberSheet('search');
     }
 
     async function handleEditMemberRoles(memberships: GroupMembershipPayload[]) {
@@ -141,15 +155,27 @@ export function GroupDetailPage() {
         }
     }
 
-    async function handleRemoveMember() {
+    async function handleRemoveMember(transferMembership?: GroupMembershipPayload) {
         if (!groupId || !removingMember) return;
         try {
             await removeMemberMutation.mutateAsync({ groupId, memberId: removingMember.id });
-            notify.success(`${removingMember.displayName} removed from the group`);
-            setRemovingMember(null);
         } catch (error) {
             notify.error(error, 'Failed to remove member');
+            return;
         }
+
+        if (transferMembership) {
+            try {
+                await addMembersMutation.mutateAsync({ groupId, memberships: [transferMembership] });
+            } catch (error) {
+                notify.error(error, `${removingMember.displayName} was removed, but primary ownership could not be transferred`);
+                setRemovingMember(null);
+                return;
+            }
+        }
+
+        notify.success(`${removingMember.displayName} removed from the group`);
+        setRemovingMember(null);
     }
 
     if (isLoading) {
@@ -404,10 +430,18 @@ export function GroupDetailPage() {
             <GroupRemoveMemberSheet
                 open={removingMember !== null}
                 member={removingMember ?? undefined}
+                members={members}
                 groupName={group.name}
                 onClose={() => setRemovingMember(null)}
                 onConfirm={handleRemoveMember}
                 isRemoving={removeMemberMutation.isPending}
+            />
+
+            <GroupTooManyUsersDialog
+                open={tooManyUsersEmail !== null}
+                email={tooManyUsersEmail}
+                onClose={() => setTooManyUsersEmail(null)}
+                onContinue={handleTooManyUsersContinue}
             />
         </div>
     );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -180,6 +180,11 @@ export function GroupDetailPage() {
         }
     }
 
+    function handleDeleteInvitationDialogOpenChange(isOpen: boolean) {
+        if (isOpen || deleteInvitationMutation.isPending) return;
+        setDeletingInvitation(null);
+    }
+
     if (isLoading) {
         return (
             <div className="space-y-4">
@@ -482,7 +487,7 @@ export function GroupDetailPage() {
 
             <ConfirmDialog
                 open={deletingInvitation !== null}
-                onOpenChange={isOpen => !isOpen && !deleteInvitationMutation.isPending && setDeletingInvitation(null)}
+                onOpenChange={handleDeleteInvitationDialogOpenChange}
                 title="Delete Invitation"
                 description={`You are trying to delete an invitation sent to ${deletingInvitation?.email}. Do you want to continue?`}
                 confirmLabel="Continue"

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -105,10 +105,16 @@ export function GroupDetailPage() {
     const [removingMember, setRemovingMember] = useState<GroupMember | null>(null);
     const [tooManyUsersEmail, setTooManyUsersEmail] = useState<string | null>(null);
     const [deletingInvitation, setDeletingInvitation] = useState<GroupInvitation | null>(null);
+    const [memberTab, setMemberTab] = useState<'members' | 'invitations'>('members');
 
     const { data: group, isLoading, isError } = useGroupDetail(groupId);
     const { data: members = [], isLoading: membersLoading, isError: membersError } = useGroupMembers(groupId);
-    const { data: invitations = [], isLoading: invitationsLoading, isError: invitationsError } = useGroupInvitations(groupId);
+    // Invitations only render inside the Invitations tab — skip the fetch until it's actually opened.
+    const {
+        data: invitations = [],
+        isLoading: invitationsLoading,
+        isError: invitationsError,
+    } = useGroupInvitations(memberTab === 'invitations' ? groupId : undefined);
     const { data: apis = [], isLoading: apisLoading, isError: apisError } = useGroupApis(groupId);
     const { data: applications = [], isLoading: applicationsLoading, isError: applicationsError } = useGroupApplications(groupId);
     const { data: apiProducts = [], isLoading: apiProductsLoading, isError: apiProductsError } = useGroupApiProducts(groupId);
@@ -400,7 +406,7 @@ export function GroupDetailPage() {
                             </AlertDescription>
                         </Alert>
                     )}
-                    <Tabs defaultValue="members">
+                    <Tabs value={memberTab} onValueChange={value => setMemberTab(value as 'members' | 'invitations')}>
                         <TabsList variant="line">
                             <TabsTrigger value="members">Members</TabsTrigger>
                             <TabsTrigger value="invitations">Invitations</TabsTrigger>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -14,12 +14,27 @@
  * limitations under the License.
  */
 
-import { Badge, Button, DateCell, Skeleton } from '@gravitee/graphene-core';
-import { ArrowLeftIcon, TriangleAlertIcon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import {
+    Badge,
+    Button,
+    DateCell,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+    Skeleton,
+} from '@gravitee/graphene-core';
+import { ArrowLeftIcon, MailIcon, PlusIcon, SearchIcon, TriangleAlertIcon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
+import { GroupAddMembersSheet } from '../features/groups/components/GroupAddMembersSheet';
+import { GroupEditMemberSheet } from '../features/groups/components/GroupEditMemberSheet';
+import { GroupInviteMemberSheet } from '../features/groups/components/GroupInviteMemberSheet';
 import { GroupMembershipTable } from '../features/groups/components/GroupMembershipTable';
 import { GroupMembersTable } from '../features/groups/components/GroupMembersTable';
+import { GroupRemoveMemberSheet } from '../features/groups/components/GroupRemoveMemberSheet';
 import {
     useGroupApis,
     useGroupApplications,
@@ -27,7 +42,20 @@ import {
     useGroupDetail,
     useGroupMembers,
 } from '../features/groups/hooks/useGroupDetail';
+import { useAddGroupMembers, useInviteGroupMember, useRemoveGroupMember } from '../features/groups/hooks/useGroupMutations';
+import {
+    useGroupApiProductRoles,
+    useGroupApiRoles,
+    useGroupApplicationRoles,
+    useGroupClusterRoles,
+    useGroupIntegrationRoles,
+} from '../features/groups/hooks/useGroupRoles';
+import type { GroupMember, GroupMembershipPayload } from '../features/groups/types/group';
 import { hasEventRule } from '../features/groups/utils/groupPayload';
+import { ENVIRONMENT_GROUP_UPDATE_PERMISSION } from '../features/groups/utils/groupPermissions';
+import { notify } from '../shared/notify';
+
+type MemberSheetState = 'closed' | 'search' | 'invite';
 
 function SectionError({ message }: Readonly<{ message: string }>) {
     return (
@@ -40,18 +68,87 @@ function SectionError({ message }: Readonly<{ message: string }>) {
 
 // Classic Console's group.component.ts has no delete action on this screen at all — a group can only be
 // deleted from the list (groups.component.ts). Editing group settings (name, default roles, invitation
-// rules) also only happens from the list's Edit action, not this page — the detail page is read-only.
-// Member management (add/invite/edit roles/remove) is added on top of this read-only view in a
-// follow-up PR (FOUND-106/FOUND-107).
+// rules) also only happens from the list's Edit action, not this page — the detail page is read-only
+// plus member management.
 export function GroupDetailPage() {
     const { groupId } = useParams<{ groupId: string }>();
     const navigate = useNavigate();
+    const canManageMembers = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_UPDATE_PERMISSION] });
+
+    const [memberSheet, setMemberSheet] = useState<MemberSheetState>('closed');
+    const [editingMember, setEditingMember] = useState<GroupMember | null>(null);
+    const [removingMember, setRemovingMember] = useState<GroupMember | null>(null);
 
     const { data: group, isLoading, isError } = useGroupDetail(groupId);
     const { data: members = [], isLoading: membersLoading, isError: membersError } = useGroupMembers(groupId);
     const { data: apis = [], isLoading: apisLoading, isError: apisError } = useGroupApis(groupId);
     const { data: applications = [], isLoading: applicationsLoading, isError: applicationsError } = useGroupApplications(groupId);
     const { data: apiProducts = [], isLoading: apiProductsLoading, isError: apiProductsError } = useGroupApiProducts(groupId);
+    const { data: apiRoles = [] } = useGroupApiRoles();
+    const { data: applicationRoles = [] } = useGroupApplicationRoles();
+    const { data: apiProductRoles = [] } = useGroupApiProductRoles();
+    const { data: integrationRoles = [] } = useGroupIntegrationRoles();
+    const { data: clusterRoles = [] } = useGroupClusterRoles();
+
+    const addMembersMutation = useAddGroupMembers();
+    const inviteMemberMutation = useInviteGroupMember();
+    const removeMemberMutation = useRemoveGroupMember();
+
+    function closeMemberSheet() {
+        setMemberSheet('closed');
+    }
+
+    async function handleAddMembers(memberships: GroupMembershipPayload[]) {
+        if (!groupId) return;
+        try {
+            await addMembersMutation.mutateAsync({ groupId, memberships });
+            notify.success(memberships.length > 1 ? `${memberships.length} members added successfully` : 'Member added successfully');
+            closeMemberSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to add members');
+        }
+    }
+
+    async function handleInviteMember(values: { email: string; apiRole: string; applicationRole: string }) {
+        if (!groupId) return;
+        try {
+            await inviteMemberMutation.mutateAsync({
+                groupId,
+                data: {
+                    reference_id: groupId,
+                    email: values.email,
+                    api_role: values.apiRole || undefined,
+                    application_role: values.applicationRole || undefined,
+                },
+            });
+            notify.success(`Invitation sent to ${values.email}`);
+            closeMemberSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to send invitation');
+        }
+    }
+
+    async function handleEditMemberRoles(payload: GroupMembershipPayload) {
+        if (!groupId) return;
+        try {
+            await addMembersMutation.mutateAsync({ groupId, memberships: [payload] });
+            notify.success('Member roles updated successfully');
+            setEditingMember(null);
+        } catch (error) {
+            notify.error(error, 'Failed to update member roles');
+        }
+    }
+
+    async function handleRemoveMember() {
+        if (!groupId || !removingMember) return;
+        try {
+            await removeMemberMutation.mutateAsync({ groupId, memberId: removingMember.id });
+            notify.success(`${removingMember.displayName} removed from the group`);
+            setRemovingMember(null);
+        } catch (error) {
+            notify.error(error, 'Failed to remove member');
+        }
+    }
 
     if (isLoading) {
         return (
@@ -172,14 +269,42 @@ export function GroupDetailPage() {
             </section>
 
             <section className="space-y-4 rounded-xl border bg-card p-5">
-                <div>
-                    <h2 className="text-base font-semibold">Members</h2>
-                    <p className="text-sm text-muted-foreground">Direct members of this group and their scoped roles.</p>
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <h2 className="text-base font-semibold">Members</h2>
+                        <p className="text-sm text-muted-foreground">Direct members of this group and their scoped roles.</p>
+                    </div>
+                    {canManageMembers && (
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button type="button" className="shrink-0 gap-1.5">
+                                    <PlusIcon className="size-4" aria-hidden />
+                                    Add members
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                                <DropdownMenuItem onSelect={() => setMemberSheet('search')}>
+                                    <SearchIcon className="size-4 mr-2" aria-hidden />
+                                    User search
+                                </DropdownMenuItem>
+                                <DropdownMenuItem onSelect={() => setMemberSheet('invite')}>
+                                    <MailIcon className="size-4 mr-2" aria-hidden />
+                                    Email invitation
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    )}
                 </div>
                 {membersError ? (
                     <SectionError message="Failed to load members. Please refresh and try again." />
                 ) : (
-                    <GroupMembersTable members={members} loading={membersLoading} />
+                    <GroupMembersTable
+                        members={members}
+                        loading={membersLoading}
+                        canManageMembers={canManageMembers}
+                        onEditRoles={setEditingMember}
+                        onRemove={setRemovingMember}
+                    />
                 )}
             </section>
 
@@ -231,6 +356,55 @@ export function GroupDetailPage() {
                     />
                 )}
             </section>
+
+            <GroupAddMembersSheet
+                open={memberSheet === 'search'}
+                groupName={group.name}
+                members={members}
+                apiRoles={apiRoles}
+                applicationRoles={applicationRoles}
+                apiProductRoles={apiProductRoles}
+                integrationRoles={integrationRoles}
+                clusterRoles={clusterRoles}
+                onClose={closeMemberSheet}
+                onSubmit={handleAddMembers}
+                isSaving={addMembersMutation.isPending}
+            />
+
+            <GroupInviteMemberSheet
+                open={memberSheet === 'invite'}
+                groupName={group.name}
+                apiRoles={apiRoles}
+                applicationRoles={applicationRoles}
+                onClose={closeMemberSheet}
+                onSubmit={handleInviteMember}
+                isSaving={inviteMemberMutation.isPending}
+            />
+
+            <GroupEditMemberSheet
+                open={editingMember !== null}
+                groupName={group.name}
+                member={editingMember ?? undefined}
+                members={members}
+                apiRoles={apiRoles}
+                applicationRoles={applicationRoles}
+                apiProductRoles={apiProductRoles}
+                integrationRoles={integrationRoles}
+                clusterRoles={clusterRoles}
+                groupAllowsGroupAdmin={Boolean(group.system_invitation)}
+                onClose={() => setEditingMember(null)}
+                onSubmit={handleEditMemberRoles}
+                isSaving={addMembersMutation.isPending}
+            />
+
+            <GroupRemoveMemberSheet
+                open={removingMember !== null}
+                member={removingMember ?? undefined}
+                groupName={group.name}
+                onClose={() => setRemovingMember(null)}
+                onConfirm={handleRemoveMember}
+                isRemoving={removeMemberMutation.isPending}
+            />
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -377,6 +377,7 @@ export function GroupDetailPage() {
             <GroupInviteMemberSheet
                 open={memberSheet === 'invite'}
                 groupName={group.name}
+                groupRoles={group.roles}
                 apiRoles={apiRoles}
                 applicationRoles={applicationRoles}
                 onClose={closeMemberSheet}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -235,21 +235,25 @@ export function GroupDetailPage() {
 
     async function handleRemoveMember(transferMembership?: GroupMembershipPayload) {
         if (!groupId || !removingMember) return;
+
+        // Transfer ownership before removing — removing the primary owner first would leave the group
+        // ownerless for the window between the two calls, and if the transfer then failed, there'd be no
+        // way back. Doing it in this order means a failed transfer just aborts with nothing removed yet.
+        if (transferMembership) {
+            try {
+                await addMembersMutation.mutateAsync({ groupId, memberships: [transferMembership] });
+            } catch (error) {
+                notify.error(error, 'Primary ownership could not be transferred');
+                setRemovingMember(null);
+                return;
+            }
+        }
+
         try {
             await removeMemberMutation.mutateAsync({ groupId, memberId: removingMember.id });
         } catch (error) {
             notify.error(error, 'Failed to remove member');
             return;
-        }
-
-        if (transferMembership) {
-            try {
-                await addMembersMutation.mutateAsync({ groupId, memberships: [transferMembership] });
-            } catch (error) {
-                notify.error(error, `${removingMember.displayName} was removed, but primary ownership could not be transferred`);
-                setRemovingMember(null);
-                return;
-            }
         }
 
         notify.success(`${removingMember.displayName} removed from the group`);

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -395,8 +395,6 @@ export function GroupDetailPage() {
                 integrationRoles={integrationRoles}
                 clusterRoles={clusterRoles}
                 groupAllowsGroupAdmin={Boolean(group.system_invitation)}
-                groupHasApis={apis.length > 0}
-                groupHasApiProducts={apiProducts.length > 0}
                 onClose={() => setEditingMember(null)}
                 onSubmit={handleEditMemberRoles}
                 isSaving={addMembersMutation.isPending}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -395,6 +395,8 @@ export function GroupDetailPage() {
                 integrationRoles={integrationRoles}
                 clusterRoles={clusterRoles}
                 groupAllowsGroupAdmin={Boolean(group.system_invitation)}
+                groupHasApis={apis.length > 0}
+                groupHasApiProducts={apiProducts.length > 0}
                 onClose={() => setEditingMember(null)}
                 onSubmit={handleEditMemberRoles}
                 isSaving={addMembersMutation.isPending}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -15,29 +15,82 @@
  */
 
 import { useHasPermission } from '@gravitee/gamma-modules-sdk';
-import { Badge, Button, DateCell, Skeleton } from '@gravitee/graphene-core';
-import { ArrowLeftIcon, PencilIcon, Trash2Icon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
+import {
+    Alert,
+    AlertDescription,
+    Badge,
+    Button,
+    DateCell,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+    Skeleton,
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+} from '@gravitee/graphene-core';
+import {
+    ArrowLeftIcon,
+    InfoIcon,
+    MailIcon,
+    PencilIcon,
+    PlusIcon,
+    SearchIcon,
+    Trash2Icon,
+    UsersRoundIcon,
+} from '@gravitee/graphene-core/icons';
 import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
+import { GroupAddMembersSheet } from '../features/groups/components/GroupAddMembersSheet';
 import { GroupAssociationSection } from '../features/groups/components/GroupAssociationSection';
 import { GroupDeleteSheet } from '../features/groups/components/GroupDeleteSheet';
+import { GroupEditMemberSheet } from '../features/groups/components/GroupEditMemberSheet';
+import { GroupInvitationsTable } from '../features/groups/components/GroupInvitationsTable';
+import { GroupInviteMemberSheet } from '../features/groups/components/GroupInviteMemberSheet';
 import { GroupMembersTable } from '../features/groups/components/GroupMembersTable';
+import { GroupRemoveMemberSheet } from '../features/groups/components/GroupRemoveMemberSheet';
 import { GroupSettingsSection } from '../features/groups/components/GroupSettingsSection';
 import { GroupSheet, type GroupFormValues } from '../features/groups/components/GroupSheet';
+import { GroupTooManyUsersDialog } from '../features/groups/components/GroupTooManyUsersDialog';
 import { SectionError } from '../features/groups/components/SectionError';
+import { useCurrentUserIsGroupAdmin } from '../features/groups/hooks/useCurrentUserGroupAdmin';
 import {
     useGroupApis,
     useGroupApplications,
     useGroupApiProducts,
     useGroupDetail,
+    useGroupInvitations,
     useGroupMembers,
 } from '../features/groups/hooks/useGroupDetail';
-import { useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
-import { useGroupApiProductRoles, useGroupApiRoles, useGroupApplicationRoles } from '../features/groups/hooks/useGroupRoles';
+import {
+    useAddGroupMembers,
+    useDeleteGroup,
+    useDeleteGroupInvitation,
+    useInviteGroupMember,
+    useRemoveGroupMember,
+    useUpdateGroup,
+} from '../features/groups/hooks/useGroupMutations';
+import {
+    useGroupApiProductRoles,
+    useGroupApiRoles,
+    useGroupApplicationRoles,
+    useGroupClusterRoles,
+    useGroupIntegrationRoles,
+} from '../features/groups/hooks/useGroupRoles';
+import type { GroupInvitation, GroupMember, GroupMembershipPayload } from '../features/groups/types/group';
 import { buildEventRules, buildRolesMap, hasEventRule, parseMaxInvitation } from '../features/groups/utils/groupPayload';
-import { ENVIRONMENT_GROUP_DELETE_PERMISSION, ENVIRONMENT_GROUP_UPDATE_PERMISSION } from '../features/groups/utils/groupPermissions';
+import {
+    canInviteToGroup,
+    ENVIRONMENT_GROUP_DELETE_PERMISSION,
+    ENVIRONMENT_GROUP_UPDATE_PERMISSION,
+} from '../features/groups/utils/groupPermissions';
+import { ConfirmDialog } from '../shared/components/ConfirmDialog';
 import { notify } from '../shared/notify';
+
+type MemberSheetState = 'closed' | 'search' | 'invite';
 
 export function GroupDetailPage() {
     const { groupId } = useParams<{ groupId: string }>();
@@ -47,20 +100,34 @@ export function GroupDetailPage() {
 
     const [editOpen, setEditOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
+    const [memberSheet, setMemberSheet] = useState<MemberSheetState>('closed');
+    const [editingMember, setEditingMember] = useState<GroupMember | null>(null);
+    const [removingMember, setRemovingMember] = useState<GroupMember | null>(null);
+    const [tooManyUsersEmail, setTooManyUsersEmail] = useState<string | null>(null);
+    const [deletingInvitation, setDeletingInvitation] = useState<GroupInvitation | null>(null);
 
     const { data: group, isLoading, isError } = useGroupDetail(groupId);
     const { data: members = [], isLoading: membersLoading, isError: membersError } = useGroupMembers(groupId);
+    const { data: invitations = [], isLoading: invitationsLoading, isError: invitationsError } = useGroupInvitations(groupId);
     const { data: apis = [], isLoading: apisLoading, isError: apisError } = useGroupApis(groupId);
     const { data: applications = [], isLoading: applicationsLoading, isError: applicationsError } = useGroupApplications(groupId);
     const { data: apiProducts = [], isLoading: apiProductsLoading, isError: apiProductsError } = useGroupApiProducts(groupId);
-    const { data: apiRoles = [], isLoading: apiRolesLoading } = useGroupApiRoles({ enabled: canEdit && editOpen });
-    const { data: applicationRoles = [], isLoading: applicationRolesLoading } = useGroupApplicationRoles({
-        enabled: canEdit && editOpen,
-    });
-    const { data: apiProductRoles = [], isLoading: apiProductRolesLoading } = useGroupApiProductRoles({ enabled: canEdit && editOpen });
+    // Roles feed both the Edit Group sheet and the Add/Invite/Edit member sheets — deferred until
+    // whichever of those is actually open, not just canEdit, since member management doesn't require it.
+    const rolesNeeded = editOpen || memberSheet !== 'closed' || editingMember !== null;
+    const { data: apiRoles = [], isLoading: apiRolesLoading } = useGroupApiRoles({ enabled: rolesNeeded });
+    const { data: applicationRoles = [], isLoading: applicationRolesLoading } = useGroupApplicationRoles({ enabled: rolesNeeded });
+    const { data: apiProductRoles = [], isLoading: apiProductRolesLoading } = useGroupApiProductRoles({ enabled: rolesNeeded });
+    const { data: integrationRoles = [] } = useGroupIntegrationRoles();
+    const { data: clusterRoles = [] } = useGroupClusterRoles();
+    const isCurrentUserGroupAdmin = useCurrentUserIsGroupAdmin(members);
 
     const updateMutation = useUpdateGroup();
     const deleteMutation = useDeleteGroup();
+    const addMembersMutation = useAddGroupMembers();
+    const inviteMemberMutation = useInviteGroupMember();
+    const removeMemberMutation = useRemoveGroupMember();
+    const deleteInvitationMutation = useDeleteGroupInvitation();
 
     async function handleUpdate(values: GroupFormValues) {
         if (!group) return;
@@ -103,6 +170,97 @@ export function GroupDetailPage() {
         }
     }
 
+    function closeMemberSheet() {
+        setMemberSheet('closed');
+    }
+
+    async function handleAddMembers(memberships: GroupMembershipPayload[]) {
+        if (!groupId) return;
+        try {
+            await addMembersMutation.mutateAsync({ groupId, memberships });
+            notify.success(memberships.length > 1 ? `${memberships.length} members added successfully` : 'Member added successfully');
+            closeMemberSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to add members');
+        }
+    }
+
+    async function handleInviteMember(values: { email: string; apiRole: string; applicationRole: string }) {
+        if (!groupId) return;
+        try {
+            const result = await inviteMemberMutation.mutateAsync({
+                groupId,
+                data: {
+                    reference_id: groupId,
+                    email: values.email,
+                    api_role: values.apiRole || undefined,
+                    application_role: values.applicationRole || undefined,
+                },
+            });
+            if (result.ambiguous) {
+                closeMemberSheet();
+                setTooManyUsersEmail(values.email);
+                return;
+            }
+            notify.success(`Invitation sent to ${values.email}`);
+            closeMemberSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to send invitation');
+        }
+    }
+
+    function handleTooManyUsersContinue() {
+        setTooManyUsersEmail(null);
+        setMemberSheet('search');
+    }
+
+    async function handleEditMemberRoles(memberships: GroupMembershipPayload[]) {
+        if (!groupId) return;
+        try {
+            await addMembersMutation.mutateAsync({ groupId, memberships });
+            notify.success(
+                memberships.length > 1 ? 'Member roles updated and primary ownership transferred' : 'Member roles updated successfully',
+            );
+            setEditingMember(null);
+        } catch (error) {
+            notify.error(error, 'Failed to update member roles');
+        }
+    }
+
+    async function handleRemoveMember(transferMembership?: GroupMembershipPayload) {
+        if (!groupId || !removingMember) return;
+        try {
+            await removeMemberMutation.mutateAsync({ groupId, memberId: removingMember.id });
+        } catch (error) {
+            notify.error(error, 'Failed to remove member');
+            return;
+        }
+
+        if (transferMembership) {
+            try {
+                await addMembersMutation.mutateAsync({ groupId, memberships: [transferMembership] });
+            } catch (error) {
+                notify.error(error, `${removingMember.displayName} was removed, but primary ownership could not be transferred`);
+                setRemovingMember(null);
+                return;
+            }
+        }
+
+        notify.success(`${removingMember.displayName} removed from the group`);
+        setRemovingMember(null);
+    }
+
+    async function handleDeleteInvitation() {
+        if (!groupId || !deletingInvitation) return;
+        try {
+            await deleteInvitationMutation.mutateAsync({ groupId, invitationId: deletingInvitation.id });
+            notify.success('Successfully deleted the invitation.');
+            setDeletingInvitation(null);
+        } catch (error) {
+            notify.error(error, 'Error occurred while deleting the invitation.');
+        }
+    }
+
     if (isLoading) {
         return (
             <div className="space-y-4">
@@ -126,6 +284,10 @@ export function GroupDetailPage() {
             </div>
         );
     }
+
+    const maxInvitationsLimitReached = typeof group.max_invitation === 'number' && group.max_invitation <= members.length;
+    const canAddMembers = (canEdit || canInviteToGroup(group)) && !maxInvitationsLimitReached;
+    const canManageMemberActions = canEdit || isCurrentUserGroupAdmin;
 
     return (
         <>
@@ -203,15 +365,72 @@ export function GroupDetailPage() {
                 <GroupSettingsSection group={group} />
 
                 <section className="space-y-4 rounded-xl border bg-card p-5">
-                    <div>
-                        <h2 className="text-base font-semibold">Members</h2>
-                        <p className="text-sm text-muted-foreground">Direct members of this group and their scoped roles.</p>
+                    <div className="flex items-start justify-between gap-4">
+                        <div>
+                            <h2 className="text-base font-semibold">Members</h2>
+                            <p className="text-sm text-muted-foreground">Direct members of this group and their scoped roles.</p>
+                        </div>
+                        {canAddMembers && (
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button type="button" className="shrink-0 gap-1.5">
+                                        <PlusIcon className="size-4" aria-hidden />
+                                        Add members
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end">
+                                    <DropdownMenuItem onSelect={() => setMemberSheet('search')} disabled={!group.system_invitation}>
+                                        <SearchIcon className="size-4 mr-2" aria-hidden />
+                                        User search
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem onSelect={() => setMemberSheet('invite')} disabled={!group.email_invitation}>
+                                        <MailIcon className="size-4 mr-2" aria-hidden />
+                                        Email invitation
+                                    </DropdownMenuItem>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        )}
                     </div>
-                    {membersError ? (
-                        <SectionError message="Failed to load members. Please refresh and try again." />
-                    ) : (
-                        <GroupMembersTable members={members} loading={membersLoading} />
+                    {maxInvitationsLimitReached && (
+                        <Alert variant="default">
+                            <InfoIcon className="size-4" aria-hidden />
+                            <AlertDescription>
+                                The number of members in this group has reached maximum allowed. Adding users via search and email
+                                invitation have been disabled.
+                            </AlertDescription>
+                        </Alert>
                     )}
+                    <Tabs defaultValue="members">
+                        <TabsList variant="line">
+                            <TabsTrigger value="members">Members</TabsTrigger>
+                            <TabsTrigger value="invitations">Invitations</TabsTrigger>
+                        </TabsList>
+                        <TabsContent value="members">
+                            {membersError ? (
+                                <SectionError message="Failed to load members. Please refresh and try again." />
+                            ) : (
+                                <GroupMembersTable
+                                    members={members}
+                                    loading={membersLoading}
+                                    canManageMembers={canManageMemberActions}
+                                    onEditRoles={setEditingMember}
+                                    onRemove={setRemovingMember}
+                                />
+                            )}
+                        </TabsContent>
+                        <TabsContent value="invitations">
+                            {invitationsError ? (
+                                <SectionError message="Failed to load invitations. Please refresh and try again." />
+                            ) : (
+                                <GroupInvitationsTable
+                                    invitations={invitations}
+                                    loading={invitationsLoading}
+                                    canManageMembers={canManageMemberActions}
+                                    onDelete={setDeletingInvitation}
+                                />
+                            )}
+                        </TabsContent>
+                    </Tabs>
                 </section>
 
                 <GroupAssociationSection
@@ -268,6 +487,89 @@ export function GroupDetailPage() {
                 onClose={() => setDeleteOpen(false)}
                 onConfirm={handleDelete}
                 isDeleting={deleteMutation.isPending}
+            />
+
+            <GroupAddMembersSheet
+                open={memberSheet === 'search'}
+                groupName={group.name}
+                groupRoles={group.roles}
+                members={members}
+                apiRoles={apiRoles}
+                applicationRoles={applicationRoles}
+                apiProductRoles={apiProductRoles}
+                integrationRoles={integrationRoles}
+                clusterRoles={clusterRoles}
+                lockApiRole={Boolean(group.lock_api_role)}
+                lockApiProductRole={Boolean(group.lock_api_product_role)}
+                lockApplicationRole={Boolean(group.lock_application_role)}
+                canOverrideLocks={canEdit}
+                maxInvitation={group.max_invitation ?? null}
+                onClose={closeMemberSheet}
+                onSubmit={handleAddMembers}
+                isSaving={addMembersMutation.isPending}
+            />
+
+            <GroupInviteMemberSheet
+                open={memberSheet === 'invite'}
+                groupName={group.name}
+                groupRoles={group.roles}
+                members={members}
+                apiRoles={apiRoles}
+                applicationRoles={applicationRoles}
+                lockApiRole={Boolean(group.lock_api_role)}
+                lockApplicationRole={Boolean(group.lock_application_role)}
+                canOverrideLocks={canEdit}
+                onClose={closeMemberSheet}
+                onSubmit={handleInviteMember}
+                isSaving={inviteMemberMutation.isPending}
+            />
+
+            <GroupEditMemberSheet
+                open={editingMember !== null}
+                groupName={group.name}
+                member={editingMember ?? undefined}
+                members={members}
+                apiRoles={apiRoles}
+                applicationRoles={applicationRoles}
+                apiProductRoles={apiProductRoles}
+                integrationRoles={integrationRoles}
+                clusterRoles={clusterRoles}
+                lockApiRole={Boolean(group.lock_api_role)}
+                lockApiProductRole={Boolean(group.lock_api_product_role)}
+                lockApplicationRole={Boolean(group.lock_application_role)}
+                canOverrideLocks={canEdit}
+                groupAllowsGroupAdmin={Boolean(group.system_invitation)}
+                onClose={() => setEditingMember(null)}
+                onSubmit={handleEditMemberRoles}
+                isSaving={addMembersMutation.isPending}
+            />
+
+            <GroupRemoveMemberSheet
+                open={removingMember !== null}
+                member={removingMember ?? undefined}
+                members={members}
+                groupName={group.name}
+                onClose={() => setRemovingMember(null)}
+                onConfirm={handleRemoveMember}
+                isRemoving={removeMemberMutation.isPending}
+            />
+
+            <GroupTooManyUsersDialog
+                open={tooManyUsersEmail !== null}
+                email={tooManyUsersEmail}
+                onClose={() => setTooManyUsersEmail(null)}
+                onContinue={handleTooManyUsersContinue}
+            />
+
+            <ConfirmDialog
+                open={deletingInvitation !== null}
+                onOpenChange={isOpen => !isOpen && !deleteInvitationMutation.isPending && setDeletingInvitation(null)}
+                title="Delete Invitation"
+                description={`You are trying to delete an invitation sent to ${deletingInvitation?.email}. Do you want to continue?`}
+                confirmLabel="Continue"
+                pendingLabel="Deleting…"
+                isPending={deleteInvitationMutation.isPending}
+                onConfirm={handleDeleteInvitation}
             />
         </>
     );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -128,11 +128,13 @@ export function GroupDetailPage() {
         }
     }
 
-    async function handleEditMemberRoles(payload: GroupMembershipPayload) {
+    async function handleEditMemberRoles(memberships: GroupMembershipPayload[]) {
         if (!groupId) return;
         try {
-            await addMembersMutation.mutateAsync({ groupId, memberships: [payload] });
-            notify.success('Member roles updated successfully');
+            await addMembersMutation.mutateAsync({ groupId, memberships });
+            notify.success(
+                memberships.length > 1 ? 'Member roles updated and primary ownership transferred' : 'Member roles updated successfully',
+            );
             setEditingMember(null);
         } catch (error) {
             notify.error(error, 'Failed to update member roles');

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -62,17 +62,10 @@ import {
     useGroupApplications,
     useGroupApiProducts,
     useGroupDetail,
-    useGroupInvitations,
     useGroupMembers,
 } from '../features/groups/hooks/useGroupDetail';
-import {
-    useAddGroupMembers,
-    useDeleteGroup,
-    useDeleteGroupInvitation,
-    useInviteGroupMember,
-    useRemoveGroupMember,
-    useUpdateGroup,
-} from '../features/groups/hooks/useGroupMutations';
+import { useGroupMemberActions } from '../features/groups/hooks/useGroupMemberActions';
+import { useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
 import {
     useGroupApiProductRoles,
     useGroupApiRoles,
@@ -80,7 +73,6 @@ import {
     useGroupClusterRoles,
     useGroupIntegrationRoles,
 } from '../features/groups/hooks/useGroupRoles';
-import type { GroupInvitation, GroupMember, GroupMembershipPayload } from '../features/groups/types/group';
 import { buildEventRules, buildRolesMap, hasEventRule, parseMaxInvitation } from '../features/groups/utils/groupPayload';
 import {
     canInviteToGroup,
@@ -90,8 +82,6 @@ import {
 import { ConfirmDialog } from '../shared/components/ConfirmDialog';
 import { notify } from '../shared/notify';
 
-type MemberSheetState = 'closed' | 'search' | 'invite';
-
 export function GroupDetailPage() {
     const { groupId } = useParams<{ groupId: string }>();
     const navigate = useNavigate();
@@ -100,24 +90,42 @@ export function GroupDetailPage() {
 
     const [editOpen, setEditOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
-    const [memberSheet, setMemberSheet] = useState<MemberSheetState>('closed');
-    const [editingMember, setEditingMember] = useState<GroupMember | null>(null);
-    const [removingMember, setRemovingMember] = useState<GroupMember | null>(null);
-    const [tooManyUsersEmail, setTooManyUsersEmail] = useState<string | null>(null);
-    const [deletingInvitation, setDeletingInvitation] = useState<GroupInvitation | null>(null);
-    const [memberTab, setMemberTab] = useState<'members' | 'invitations'>('members');
 
     const { data: group, isLoading, isError } = useGroupDetail(groupId);
     const { data: members = [], isLoading: membersLoading, isError: membersError } = useGroupMembers(groupId);
-    // Invitations only render inside the Invitations tab — skip the fetch until it's actually opened.
-    const {
-        data: invitations = [],
-        isLoading: invitationsLoading,
-        isError: invitationsError,
-    } = useGroupInvitations(memberTab === 'invitations' ? groupId : undefined);
     const { data: apis = [], isLoading: apisLoading, isError: apisError } = useGroupApis(groupId);
     const { data: applications = [], isLoading: applicationsLoading, isError: applicationsError } = useGroupApplications(groupId);
     const { data: apiProducts = [], isLoading: apiProductsLoading, isError: apiProductsError } = useGroupApiProducts(groupId);
+
+    const {
+        memberTab,
+        setMemberTab,
+        memberSheet,
+        setMemberSheet,
+        closeMemberSheet,
+        editingMember,
+        setEditingMember,
+        removingMember,
+        setRemovingMember,
+        tooManyUsersEmail,
+        setTooManyUsersEmail,
+        deletingInvitation,
+        setDeletingInvitation,
+        invitations,
+        invitationsLoading,
+        invitationsError,
+        addMembersMutation,
+        inviteMemberMutation,
+        removeMemberMutation,
+        deleteInvitationMutation,
+        handleAddMembers,
+        handleInviteMember,
+        handleTooManyUsersContinue,
+        handleEditMemberRoles,
+        handleRemoveMember,
+        handleDeleteInvitation,
+    } = useGroupMemberActions(groupId);
+
     // Roles feed both the Edit Group sheet and the Add/Invite/Edit member sheets — deferred until
     // whichever of those is actually open, not just canEdit, since member management doesn't require it.
     const rolesNeeded = editOpen || memberSheet !== 'closed' || editingMember !== null;
@@ -130,10 +138,6 @@ export function GroupDetailPage() {
 
     const updateMutation = useUpdateGroup();
     const deleteMutation = useDeleteGroup();
-    const addMembersMutation = useAddGroupMembers();
-    const inviteMemberMutation = useInviteGroupMember();
-    const removeMemberMutation = useRemoveGroupMember();
-    const deleteInvitationMutation = useDeleteGroupInvitation();
 
     async function handleUpdate(values: GroupFormValues) {
         if (!group) return;
@@ -173,101 +177,6 @@ export function GroupDetailPage() {
             navigate('..');
         } catch (error) {
             notify.error(error, 'Failed to delete group');
-        }
-    }
-
-    function closeMemberSheet() {
-        setMemberSheet('closed');
-    }
-
-    async function handleAddMembers(memberships: GroupMembershipPayload[]) {
-        if (!groupId) return;
-        try {
-            await addMembersMutation.mutateAsync({ groupId, memberships });
-            notify.success(memberships.length > 1 ? `${memberships.length} members added successfully` : 'Member added successfully');
-            closeMemberSheet();
-        } catch (error) {
-            notify.error(error, 'Failed to add members');
-        }
-    }
-
-    async function handleInviteMember(values: { email: string; apiRole: string; applicationRole: string }) {
-        if (!groupId) return;
-        try {
-            const result = await inviteMemberMutation.mutateAsync({
-                groupId,
-                data: {
-                    reference_id: groupId,
-                    email: values.email,
-                    api_role: values.apiRole || undefined,
-                    application_role: values.applicationRole || undefined,
-                },
-            });
-            if (result.ambiguous) {
-                closeMemberSheet();
-                setTooManyUsersEmail(values.email);
-                return;
-            }
-            notify.success(`Invitation sent to ${values.email}`);
-            closeMemberSheet();
-        } catch (error) {
-            notify.error(error, 'Failed to send invitation');
-        }
-    }
-
-    function handleTooManyUsersContinue() {
-        setTooManyUsersEmail(null);
-        setMemberSheet('search');
-    }
-
-    async function handleEditMemberRoles(memberships: GroupMembershipPayload[]) {
-        if (!groupId) return;
-        try {
-            await addMembersMutation.mutateAsync({ groupId, memberships });
-            notify.success(
-                memberships.length > 1 ? 'Member roles updated and primary ownership transferred' : 'Member roles updated successfully',
-            );
-            setEditingMember(null);
-        } catch (error) {
-            notify.error(error, 'Failed to update member roles');
-        }
-    }
-
-    async function handleRemoveMember(transferMembership?: GroupMembershipPayload) {
-        if (!groupId || !removingMember) return;
-
-        // Transfer ownership before removing — removing the primary owner first would leave the group
-        // ownerless for the window between the two calls, and if the transfer then failed, there'd be no
-        // way back. Doing it in this order means a failed transfer just aborts with nothing removed yet.
-        if (transferMembership) {
-            try {
-                await addMembersMutation.mutateAsync({ groupId, memberships: [transferMembership] });
-            } catch (error) {
-                notify.error(error, 'Primary ownership could not be transferred');
-                setRemovingMember(null);
-                return;
-            }
-        }
-
-        try {
-            await removeMemberMutation.mutateAsync({ groupId, memberId: removingMember.id });
-        } catch (error) {
-            notify.error(error, 'Failed to remove member');
-            return;
-        }
-
-        notify.success(`${removingMember.displayName} removed from the group`);
-        setRemovingMember(null);
-    }
-
-    async function handleDeleteInvitation() {
-        if (!groupId || !deletingInvitation) return;
-        try {
-            await deleteInvitationMutation.mutateAsync({ groupId, invitationId: deletingInvitation.id });
-            notify.success('Successfully deleted the invitation.');
-            setDeletingInvitation(null);
-        } catch (error) {
-            notify.error(error, 'Error occurred while deleting the invitation.');
         }
     }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -360,6 +360,7 @@ export function GroupDetailPage() {
             <GroupAddMembersSheet
                 open={memberSheet === 'search'}
                 groupName={group.name}
+                groupRoles={group.roles}
                 members={members}
                 apiRoles={apiRoles}
                 applicationRoles={applicationRoles}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
@@ -88,6 +88,12 @@ jest.mock('../features/groups/components/GroupsTable', () => ({
         ),
 }));
 
+// Has its own dedicated spec (mocking the ConsoleSettingsProvider context it reads/writes); stubbing it
+// here avoids needing that context just to render this page's own wiring.
+jest.mock('../features/groups/components/GroupsRequireGroupSetting', () => ({
+    GroupsRequireGroupSetting: () => <div data-testid="require-group-setting" />,
+}));
+
 // Radix Switch (rendered inside the real GroupSheet) measures its thumb via ResizeObserver, which jsdom lacks.
 beforeAll(() => {
     global.ResizeObserver = class ResizeObserver {
@@ -169,6 +175,17 @@ describe('GroupsPage', () => {
             mockUseHasPermission.mockReturnValue(false);
             renderPage();
             expect(screen.queryByRole('button', { name: /Create Group/i })).toBeNull();
+        });
+
+        it('shows the require-group org setting when the user can read organization settings', () => {
+            renderPage();
+            expect(screen.queryByTestId('require-group-setting')).not.toBeNull();
+        });
+
+        it('hides the require-group org setting without organization-settings-r', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            renderPage();
+            expect(screen.queryByTestId('require-group-setting')).toBeNull();
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.tsx
@@ -22,6 +22,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { GroupDeleteSheet } from '../features/groups/components/GroupDeleteSheet';
 import { GroupSheet, type GroupFormValues } from '../features/groups/components/GroupSheet';
+import { GroupsRequireGroupSetting } from '../features/groups/components/GroupsRequireGroupSetting';
 import { GroupsTable } from '../features/groups/components/GroupsTable';
 import { useCreateGroup, useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
 import { useGroupApiProductRoles, useGroupApiRoles, useGroupApplicationRoles } from '../features/groups/hooks/useGroupRoles';
@@ -32,6 +33,7 @@ import {
     ENVIRONMENT_GROUP_CREATE_PERMISSION,
     ENVIRONMENT_GROUP_DELETE_PERMISSION,
     ENVIRONMENT_GROUP_UPDATE_PERMISSION,
+    ORGANIZATION_SETTINGS_READ_PERMISSION,
 } from '../features/groups/utils/groupPermissions';
 import { DEFAULT_GROUP_LIST_PAGE_SIZE, GROUP_SEARCH_DEBOUNCE_MS } from '../features/groups/utils/paginationConstants';
 import { notify } from '../shared/notify';
@@ -43,6 +45,7 @@ export function GroupsPage() {
     const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_CREATE_PERMISSION] });
     const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_UPDATE_PERMISSION] });
     const canDelete = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_DELETE_PERMISSION] });
+    const canReadOrgSettings = useHasPermission({ anyOf: [ORGANIZATION_SETTINGS_READ_PERMISSION] });
 
     const [search, setSearch] = useState('');
     const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -200,6 +203,8 @@ export function GroupsPage() {
                     </Button>
                 ) : null}
             </div>
+
+            {canReadOrgSettings && <GroupsRequireGroupSetting />}
 
             <GroupsTable
                 groups={groups}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/MemberAvatar.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/MemberAvatar.tsx
@@ -13,6 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type { ConsoleSettings } from './types';
-export { ConsoleSettingsProvider, useConsoleSettings, useConsoleSettingsReady, useSetConsoleSettings } from './ConsoleSettingsProvider';
-export { isUserGroupRequired } from './isUserGroupRequired';
+
+export function MemberAvatar({ name }: Readonly<{ name: string }>) {
+    const initials = name
+        .split(' ')
+        .map(part => part[0] ?? '')
+        .join('')
+        .toUpperCase()
+        .slice(0, 2);
+    return (
+        <div className="size-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+            <span className="text-xs font-semibold text-primary">{initials || '?'}</span>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/ConsoleSettingsProvider.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/ConsoleSettingsProvider.tsx
@@ -23,6 +23,10 @@ const LOAD_ERROR_MESSAGE = 'Management API unreachable or error occurs, please c
 interface ConsoleSettingsContextValue {
     settings: ConsoleSettings | null;
     isReady: boolean;
+    /** Updates the cached settings after a successful save elsewhere (e.g. GroupsPage's userGroupRequired
+     *  toggle) — mirrors classic's `merge(this.constants.org.settings, consoleSettings)`, keeping every
+     *  reader of `useConsoleSettings()` in sync for the rest of the session without a page reload. */
+    setSettings: (settings: ConsoleSettings) => void;
 }
 
 const ConsoleSettingsContext = createContext<ConsoleSettingsContextValue | null>(null);
@@ -66,7 +70,7 @@ export function ConsoleSettingsProvider({ children }: ConsoleSettingsProviderPro
         };
     }, []);
 
-    const value = useMemo(() => ({ settings, isReady }), [settings, isReady]);
+    const value = useMemo(() => ({ settings, isReady, setSettings }), [settings, isReady]);
 
     if (isLoading) {
         return (
@@ -101,4 +105,8 @@ export function useConsoleSettings(): ConsoleSettings | null {
 
 export function useConsoleSettingsReady(): boolean {
     return useConsoleSettingsContext().isReady;
+}
+
+export function useSetConsoleSettings(): (settings: ConsoleSettings) => void {
+    return useConsoleSettingsContext().setSettings;
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 export type { ConsoleSettings } from './types';
-export { ConsoleSettingsProvider, useConsoleSettings, useConsoleSettingsReady } from './ConsoleSettingsProvider';
+export { ConsoleSettingsProvider, useConsoleSettings, useConsoleSettingsReady, useSetConsoleSettings } from './ConsoleSettingsProvider';
 export { isUserGroupRequired } from './isUserGroupRequired';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/services/orgConsoleSettings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/services/orgConsoleSettings.ts
@@ -20,3 +20,16 @@ import type { ConsoleSettings } from '../console-settings';
 export async function fetchOrgConsoleSettings(): Promise<ConsoleSettings> {
     return apimFetchJsonOrg<ConsoleSettings>('/console');
 }
+
+/**
+ * POST /organizations/{orgId}/console (Angular ConsoleSettingsService.save()). The backend replaces the
+ * whole settings document, so callers must pass the complete object (spread the currently-loaded settings
+ * and override only the field being changed) — sending a partial object would wipe out every other console
+ * setting (authentication providers, CORS, etc.), not just merge the one field.
+ */
+export async function saveOrgConsoleSettings(settings: ConsoleSettings): Promise<ConsoleSettings> {
+    return apimFetchJsonOrg<ConsoleSettings>('/console', {
+        method: 'POST',
+        body: JSON.stringify(settings),
+    });
+}


### PR DESCRIPTION
Covers FOUND-106 (Add Member to Group), FOUND-107 (Remove Member from Group), and the member-edit portion of FOUND-104 (Edit User Group), plus a partial slice of FOUND-109 (Manage Group Invitations — sending only).

Stacked on the read-only group detail page: adds a "+ Add members" dropdown (user search / email invitation), a per-row actions menu (Edit roles / Remove member), and disables PRIMARY_OWNER assignment or removal once a scope already has a primary owner.

## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

