### PR TITLE
chore(4.12.x): bump gravitee-policy-kafka-acl from 3.0.2 to 3.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
     <gravitee-policy-interops.version>1.1.3</gravitee-policy-interops.version>
     <gravitee-policy-kafka-quota.version>1.2.1</gravitee-policy-kafka-quota.version>
     <gravitee-policy-kafka-topic-mapping.version>2.0.1</gravitee-policy-kafka-topic-mapping.version>
-    <gravitee-policy-kafka-acl.version>3.0.2</gravitee-policy-kafka-acl.version>
+    <gravitee-policy-kafka-acl.version>3.0.3</gravitee-policy-kafka-acl.version>
     <gravitee-policy-kafka-transform-key.version>1.0.0</gravitee-policy-kafka-transform-key.version>
     <gravitee-policy-kafka-message-filtering.version>1.0.0</gravitee-policy-kafka-message-filtering.version>
     <gravitee-policy-kafka-message-encryption-decryption.version>1.0.0</gravitee-policy-kafka-message-encryption-decryption.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-policy-kafka-acl](https://github.com/gravitee-io/gravitee-policy-kafka-acl)** from `3.0.2` to `3.0.3` on branch `4.12.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-policy-kafka-acl/releases) page.

## Jira

[APIM-14879](https://gravitee.atlassian.net/browse/APIM-14879)

## Backport

- `apply-on-4-11-x`
- `apply-on-4-10-x`


[APIM-14879]: https://gravitee.atlassian.net/browse/APIM-14879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ