### PR TITLE
chore(4.9.x): bump gravitee-policy-kafka-acl from 2.0.2 to 2.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
 
         <gravitee-policy-kafka-quota.version>1.2.1</gravitee-policy-kafka-quota.version>
         <gravitee-policy-kafka-topic-mapping.version>2.0.1</gravitee-policy-kafka-topic-mapping.version>
-        <gravitee-policy-kafka-acl.version>2.0.2</gravitee-policy-kafka-acl.version>
+        <gravitee-policy-kafka-acl.version>2.0.3</gravitee-policy-kafka-acl.version>
         <gravitee-policy-kafka-transform-key.version>1.0.0</gravitee-policy-kafka-transform-key.version>
         <gravitee-policy-kafka-message-filtering.version>1.0.0</gravitee-policy-kafka-message-filtering.version>
         <gravitee-policy-offloading.version>1.1.0</gravitee-policy-offloading.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-policy-kafka-acl](https://github.com/gravitee-io/gravitee-policy-kafka-acl)** from `2.0.2` to `2.0.3` on branch `4.9.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-policy-kafka-acl/releases) page.