### PR TITLE
chore(4.11.x): bump gravitee-policy-transform-avro-json from 5.2.0 to 5.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
         <gravitee-policy-role-based-access-control.version>2.1.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.6.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>3.0.3</gravitee-policy-traffic-shadowing.version>
-        <gravitee-policy-transform-avro-json.version>5.2.0</gravitee-policy-transform-avro-json.version>
+        <gravitee-policy-transform-avro-json.version>5.2.1</gravitee-policy-transform-avro-json.version>
         <gravitee-policy-transform-avro-protobuf.version>1.0.9</gravitee-policy-transform-avro-protobuf.version>
         <gravitee-policy-transform-protobuf-json.version>2.0.1</gravitee-policy-transform-protobuf-json.version>
         <gravitee-policy-transformheaders.version>5.2.0</gravitee-policy-transformheaders.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-policy-transform-avro-json](https://github.com/gravitee-io/gravitee-policy-transform-avro-json)** from `5.2.0` to `5.2.1` on branch `4.11.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-policy-transform-avro-json/releases) page.

## Backport

- `apply-on-4-10-x`
