### PR TITLE
chore(gamma): show slice totals in the center of the http-proxy doughnuts

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/package.json
@@ -2,7 +2,7 @@
     "name": "gravitee-gamma-module-apim",
     "private": true,
     "dependencies": {
-        "@gravitee/gamma-lib-observability": "1.36.0",
+        "@gravitee/gamma-lib-observability": "1.39.1",
         "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/graphene-charts": "3.8.0",
         "@gravitee/graphene-core": "3.8.0",

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/templates/__tests__/coherence.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/templates/__tests__/coherence.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { HTTP_PROXY_DASHBOARD } from '../http-proxy.dashboard';
-import { cartesianSeriesSupportRequestTotal } from '../shared';
+import { cartesianSeriesSupportRequestTotal, doughnutStatesItsScopeInTitle } from '../shared';
 
 const widgets = HTTP_PROXY_DASHBOARD.widgets;
 
@@ -41,6 +41,22 @@ describe('HTTP Proxy dashboard template coherence', () => {
                 expect(series.axisId).toBeDefined();
                 expect(series.unit).toBeDefined();
             }
+        }
+    });
+
+    it('doughnut widgets fill their hole with the total of their slices', () => {
+        for (const widget of widgets) {
+            if (widget.type !== 'doughnut') continue;
+
+            expect(widget.centerTotal).toBe(true);
+        }
+    });
+
+    it('capped doughnut widgets state their scope in the title', () => {
+        for (const widget of widgets) {
+            if (widget.type !== 'doughnut') continue;
+
+            expect(doughnutStatesItsScopeInTitle(widget)).toBe(true);
         }
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/templates/http-proxy.dashboard.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/templates/http-proxy.dashboard.ts
@@ -72,6 +72,7 @@ export const HTTP_PROXY_DASHBOARD: Dashboard = {
             type: 'doughnut',
             by: ['HTTP_STATUS_CODE_GROUP', 'HTTP_STATUS'],
             valueLabel: 'Requests',
+            centerTotal: true,
             layout: { x: 9, y: 1, cols: 3, rows: 2 },
         },
 
@@ -113,6 +114,7 @@ export const HTTP_PROXY_DASHBOARD: Dashboard = {
             type: 'doughnut',
             by: ['APPLICATION'],
             valueLabel: 'Requests',
+            centerTotal: true,
             limit: 5,
             sorts: TOP_BY_COUNT,
             layout: { x: 9, y: 3, cols: 3, rows: 2 },

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/templates/shared.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/templates/shared.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { CartesianWidget, FilterCondition, SeriesDefinition, Widget } from '@gravitee/gamma-lib-observability';
+import type { CartesianWidget, DoughnutWidget, FilterCondition, SeriesDefinition, Widget } from '@gravitee/gamma-lib-observability';
 
 export function apiTypeScope(value: string): FilterCondition {
     return { field: 'API_TYPE', label: 'API Type', operator: 'in', value: [value], valueLabels: [value] };
@@ -34,6 +34,17 @@ export function cartesianSeriesSupportRequestTotal(series: readonly SeriesDefini
     if (representations.has('bar') && representations.has('line')) return false;
 
     return true;
+}
+
+/**
+ * `centerTotal` sums the buckets the backend returned, so a doughnut capped by
+ * `limit` necessarily shows a partial total. The widget has to say so — in its
+ * title, not in the center caption, whose single line carries the measured unit.
+ */
+export function doughnutStatesItsScopeInTitle(widget: DoughnutWidget): boolean {
+    if (widget.limit === undefined) return true;
+
+    return widget.title.includes(`Top ${widget.limit}`);
 }
 
 function stripCartesianTooltipTotal(widget: CartesianWidget): CartesianWidget {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@fontsource/material-icons-two-tone": "5.2.5",
         "@fontsource/montserrat": "5.2.5",
         "@fontsource/roboto": "5.2.5",
-        "@gravitee/gamma-lib-observability": "1.36.0",
+        "@gravitee/gamma-lib-observability": "1.39.1",
         "@gravitee/graphene-charts": "3.8.0",
         "@gravitee/graphene-core": "3.8.0",
         "@gravitee/graphene-policy-studio": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4567,12 +4567,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/gamma-lib-observability@npm:1.36.0":
-  version: 1.36.0
-  resolution: "@gravitee/gamma-lib-observability@npm:1.36.0"
+"@gravitee/gamma-lib-observability@npm:1.39.1":
+  version: 1.39.1
+  resolution: "@gravitee/gamma-lib-observability@npm:1.39.1"
   peerDependencies:
-    "@gravitee/graphene-charts": ^2.57.0
-    "@gravitee/graphene-core": ^2.57.0
+    "@gravitee/graphene-charts": ^3.7.0
+    "@gravitee/graphene-core": ^3.7.0
     "@tanstack/react-query": ^5.0.0
     "@xyflow/react": ^12.0.0
     react: ^19.0.0
@@ -4585,7 +4585,7 @@ __metadata:
       optional: true
     tailwindcss:
       optional: true
-  checksum: 10c0/347cdecbbe14418d6505f205d494fdef9caebb90f2abc22c8d0e50308cb2099a140e8cf234cd3abec91511fbd02f3d0d28a27e756ac48f60f93617de564aed6c
+  checksum: 10c0/5f6d444168ff7824a5f3b44af14e6476e8e8729e44e46e1c7e60a3d4d60dac18f042807eb44b5d0c7fca977e1385deff4f84188b3a709873cc1e6849c641ea49
   languageName: node
   linkType: hard
 
@@ -21519,7 +21519,7 @@ __metadata:
     "@fontsource/material-icons-two-tone": "npm:5.2.5"
     "@fontsource/montserrat": "npm:5.2.5"
     "@fontsource/roboto": "npm:5.2.5"
-    "@gravitee/gamma-lib-observability": "npm:1.36.0"
+    "@gravitee/gamma-lib-observability": "npm:1.39.1"
     "@gravitee/gamma-modules-sdk": "npm:1.2.0"
     "@gravitee/graphene-charts": "npm:3.8.0"
     "@gravitee/graphene-core": "npm:3.8.0"


### PR DESCRIPTION
## Summary

Turns on the doughnut center stat for the two doughnuts of the HTTP Proxy dashboard, so APIM reads the same way as the AIM templates. Second half of [OBS-33](https://gravitee.atlassian.net/browse/OBS-33) — the AIM half is [gravitee-gamma-module-aim#616](https://github.com/gravitee-io/gravitee-gamma-module-aim/pull/616).

The feature itself was delivered in `gamma-lib-observability` ([OBS-31](https://gravitee.atlassian.net/browse/OBS-31)); it is opt-in, so the hole stays empty until a consumer asks for it. This PR is that opt-in, which is why it is a `chore` and not a `feat`.

## Changes

| Widget | Change |
|---|---|
| `http-proxy-status-distribution` (exhaustive) | `centerTotal: true` — caption inherited from the `valueLabel: 'Requests'` it already declares |
| `http-proxy-top-applications` (`limit: 5`) | `centerTotal: true` — title already reads `Top 5 Applications`, nothing else needed |

- Bump `@gravitee/gamma-lib-observability` 1.36.0 → 1.39.1 (workspace + module `package.json`). Graphene is untouched: `master` moved it to 3.8.0 on its own in `1dcbcff72e`, which already satisfies the lib's peers.
- Add `doughnutStatesItsScopeInTitle()` next to `cartesianSeriesSupportRequestTotal` in the template helpers, and assert both new invariants in `coherence.test.ts`.

## Reviewer notes

**Why 1.39.1 and not 1.39.0.** 1.39.0 formats the center value with graphene's `compactTick`, an axis-tick formatter that returns `String(value)` below 1000 — so a fractional total rendered its full float precision and got clipped ([OBS-34](https://gravitee.atlassian.net/browse/OBS-34)). Both doughnuts here are count-based and unaffected, but the two consumers should not sit on different versions of the same feature.

**Why the scope goes in the title, not in the center caption.** `centerTotal` sums the buckets the backend returned, and the facets response carries no grand total nor cardinality — a capped doughnut therefore shows a *partial* total and has to say so. Putting `Top 5 applications` in the caption instead would spend its only line on the scope and cost the reader the unit. This dashboard already titles `Top 5 APIs`, `Top 5 Applications` and `Top 5 Paths`, so the convention is being honoured, not invented. Verified on the AIM side with real data: MCP's `Top 5 Tools` centres 733 against a dashboard total of 1.9k — the title is the only thing that makes that honest.

**A zero-traffic window renders `0` in the hole, not an empty hole.** `HTTP_STATUS_CODE_GROUP` is range-bucketed, so the backend always returns all five groups with `0` counts. Consistent with the rest of the dashboard, and kept.

## Test plan

- [ ] `nx run-many -t lint,test -p gravitee-gamma-module-apim,gravitee-gamma-module-platform` is green (82 suites / 645 tests on apim, 131 / 875 across both).
- [ ] Check the **resolved** versions, not just the declared ones — the lib must resolve to 1.39.1 and graphene to 3.8.0. A stale graphene resolution makes the center stat silently not render at all, which looks like a bug in the feature rather than a dependency problem.
- [ ] HTTP Proxy dashboard: both doughnuts show their total in the hole, captioned `Requests`.
- [ ] Cross-check the Status Distribution center against the dashboard's own request key metric — they are computed independently and must match.
- [ ] Caption readable and untruncated at the widgets' real width (3 columns), no collision with the legend, light **and** dark theme.
- [ ] Non-doughnut widgets on the HTTP Proxy dashboard render unchanged.

> **UI change — remember to attach screenshots** of the HTTP Proxy dashboard (light and dark) before merging.

[OBS-33]: https://gravitee.atlassian.net/browse/OBS-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OBS-31]: https://gravitee.atlassian.net/browse/OBS-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OBS-34]: https://gravitee.atlassian.net/browse/OBS-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ