### PR TITLE
feat(portal-next): support API products in documentation navigation

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
@@ -376,6 +376,63 @@ describe('DocumentationFolderComponent', () => {
     });
   });
 
+  describe('api product', () => {
+    it('should redirect an API Product selection to its first readable descendant', async () => {
+      const apiProduct = makeItem('product1', 'API_PRODUCT', 'API Product 1', 0, undefined, 'root1');
+      const productFolder = makeItem('product-folder1', 'FOLDER', 'Product Documentation', 0, 'product1', 'root1');
+      const overviewPage = makeItem('product-overview1', 'PAGE', 'Product Overview', 0, 'product-folder1', 'root1');
+      const laterPage = makeItem('product-page2', 'PAGE', 'Later Product Page', 1, 'product1', 'root1');
+
+      await init({
+        items: [apiProduct, productFolder, overviewPage, laterPage],
+        queryParams: { selectedId: 'product1' },
+        content: MOCK_CONTENT,
+      });
+
+      expect(routerSpy.navigate).toHaveBeenCalledWith([], {
+        relativeTo: expect.anything(),
+        queryParams: { selectedId: 'product-overview1' },
+      });
+      expect(navigationServiceSpy.getNavigationItemContent).not.toHaveBeenCalledWith('product1');
+      expect(navigationServiceSpy.getNavigationItemContent).toHaveBeenCalledWith('product-overview1');
+
+      const breadcrumbs = await harness.getBreadcrumbs();
+      expect(await breadcrumbs?.getText()).toEqual('Test item/API Product 1/Product Documentation/Product Overview');
+    });
+
+    it('should keep the existing empty state when an API Product has no readable descendant', async () => {
+      const apiProduct = makeItem('product1', 'API_PRODUCT', 'API Product 1', 0, undefined, 'root1');
+      const productFolder = makeItem('product-folder1', 'FOLDER', 'Product Documentation', 0, 'product1', 'root1');
+      const productLink = makeItem('product-link1', 'LINK', 'External Documentation', 0, 'product-folder1', 'root1');
+
+      await init({
+        items: [apiProduct, productFolder, productLink],
+        queryParams: { selectedId: 'product1' },
+        content: MOCK_CONTENT,
+      });
+
+      expect(routerSpy.navigate).not.toHaveBeenCalled();
+      expect(navigationServiceSpy.getNavigationItemContent).not.toHaveBeenCalled();
+
+      const contentEmptyState = await harness.getContentEmptyState();
+      expect(await contentEmptyState?.getText()).toEqual('No content to show');
+    });
+
+    it('should preserve API behavior for documentation nested under an API Product', async () => {
+      const apiProduct = makeItem('product1', 'API_PRODUCT', 'API Product 1', 0, undefined, 'root1');
+      const apiItem = makeItem('api1', 'API', 'API 1', 0, 'product1', 'root1');
+      const apiPage = makeItem('p-api1', 'PAGE', 'API 1 Documentation', 0, 'api1', 'root1');
+
+      await init({ items: [apiProduct, apiItem, apiPage], queryParams: { selectedId: 'p-api1' }, content: MOCK_CONTENT });
+
+      expect(routerSpy.navigate).not.toHaveBeenCalled();
+      expect(await harness.getSubscribeButton()).not.toBeNull();
+
+      const breadcrumbs = await harness.getBreadcrumbs();
+      expect(await breadcrumbs?.getText()).toEqual('Test item/API Product 1/API 1/API 1 Documentation');
+    });
+  });
+
   describe('api', () => {
     it('should show subscribe button when api documentation is clicked', async () => {
       const apiItem = makeItem('api1', 'API', 'API 1', 0, undefined);

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
@@ -162,8 +162,8 @@ export class DocumentationFolderComponent {
       return of({ children, selectedPageContent: null }).pipe(tap(() => this.navigateToNotFound()));
     }
 
-    if (child.type === 'API' || child.type === 'FOLDER') {
-      // APIs and folders are not selectable, so we need to navigate to the first page within the API or folder
+    if (child.type === 'API' || child.type === 'API_PRODUCT' || child.type === 'FOLDER') {
+      // APIs, API Products, and folders are not selectable, so navigate to their first page.
       const firstPageId = this.treeService.findFirstPageIdWithinNode(selectedId);
       return of({ children, selectedPageContent: null }).pipe(tap(() => firstPageId && this.navigateToPage(firstPageId)));
     }

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.harness.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BaseHarnessFilters, ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+import { BaseHarnessFilters, ComponentHarness, HarnessPredicate, TestKey } from '@angular/cdk/testing';
 
 import { DivHarness } from '../../../../../testing/div.harness';
 
@@ -38,6 +38,18 @@ export class TreeRowHarness extends ComponentHarness {
   async isExpanded(): Promise<boolean> {
     const icon = await this.locatorForOptional('.tree__icon')();
     return icon ? icon.hasClass('expanded') : false;
+  }
+
+  async getAriaExpanded(): Promise<string | null> {
+    return (await this.host()).getAttribute('aria-expanded');
+  }
+
+  async click(): Promise<void> {
+    return (await this.host()).click();
+  }
+
+  async sendKeys(...keys: (string | TestKey)[]): Promise<void> {
+    return (await this.host()).sendKeys(...keys);
   }
 }
 
@@ -71,5 +83,21 @@ export class TreeNodeComponentHarness extends ComponentHarness {
     const host = await container?.host();
     const selected = await host?.getAttribute('aria-selected');
     return selected === 'true';
+  }
+
+  async isExpanded(): Promise<boolean> {
+    return (await this.contentContainer())?.isExpanded() ?? false;
+  }
+
+  async getAriaExpanded(): Promise<string | null> {
+    return (await this.contentContainer())?.getAriaExpanded() ?? null;
+  }
+
+  async click(): Promise<void> {
+    await (await this.contentContainer())?.click();
+  }
+
+  async sendKeys(...keys: (string | TestKey)[]): Promise<void> {
+    await (await this.contentContainer())?.sendKeys(...keys);
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.html
@@ -33,7 +33,7 @@
     <span class="material-icons tree__link__icon" aria-hidden="true">open_in_new</span>
   </a>
 } @else {
-  @let isContainer = node().type === 'FOLDER' || node().type === 'API';
+  @let isContainer = node().type === 'FOLDER' || node().type === 'API' || node().type === 'API_PRODUCT';
 
   <button
     class="tree__row nav-button next-gen-small"
@@ -41,6 +41,7 @@
     mat-stroked-button
     [class.folder]="node().type === 'FOLDER'"
     [class.api]="node().type === 'API'"
+    [class.api-product]="node().type === 'API_PRODUCT'"
     [class.selected]="isSelected()"
     [class.child]="level() > 0"
     [style.--level]="level()"

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.scss
@@ -42,7 +42,8 @@ $folder-indent-step: $indent-step;
     height: fit-content;
 
     &.folder,
-    &.api {
+    &.api,
+    &.api-product {
       padding-left: calc(#{$indent-base} + (var(--level) * #{$indent-step}));
 
       &.child {

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.spec.ts
@@ -13,16 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { TestKey } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { TreeNodeComponent } from './tree-node.component';
+import { TreeNodeComponentHarness } from './tree-node.component.harness';
 import { AppTestingModule } from '../../../../../testing/app-testing.module';
 import { TreeNode } from '../../../services/tree.service';
 
 describe('TreeNodeComponent', () => {
   let fixture: ComponentFixture<TreeNodeComponent>;
   let component: TreeNodeComponent;
+  let harness: TreeNodeComponentHarness;
 
   const init = async (params: Partial<{ node: TreeNode }> = {}) => {
     await TestBed.configureTestingModule({
@@ -35,6 +39,7 @@ describe('TreeNodeComponent', () => {
     fixture.componentRef.setInput('node', params.node);
     fixture.componentRef.setInput('level', 0);
     fixture.componentRef.setInput('selectedId', null);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, TreeNodeComponentHarness);
     fixture.detectChanges();
   };
 
@@ -159,6 +164,52 @@ describe('TreeNodeComponent', () => {
 
       const icon = fixture.debugElement.query(By.css('.tree__icon'));
       expect(icon.nativeElement.classList).not.toContain('expanded');
+    });
+  });
+
+  describe('test API Product node', () => {
+    const node: TreeNode = {
+      id: 'product1',
+      label: 'API Product 1',
+      type: 'API_PRODUCT',
+      children: [
+        {
+          id: 'product-page1',
+          label: 'Product Overview',
+          type: 'PAGE',
+        },
+      ],
+    };
+
+    it('should render as an expanded container', async () => {
+      await init({ node });
+
+      expect(await harness.getText()).toBe(node.label);
+      expect(await harness.getChildren()).toHaveLength(1);
+      expect(await harness.getAriaExpanded()).toBe('true');
+      expect(await harness.isExpanded()).toBe(true);
+    });
+
+    it('should toggle expansion without selecting the node', async () => {
+      await init({ node });
+      const nodeSelected = jest.fn();
+      component.nodeSelected.subscribe(nodeSelected);
+
+      await harness.click();
+
+      expect(await harness.getAriaExpanded()).toBe('false');
+      expect(await harness.isExpanded()).toBe(false);
+      expect(nodeSelected).not.toHaveBeenCalled();
+    });
+
+    it('should support keyboard expansion', async () => {
+      await init({ node });
+
+      await harness.sendKeys(TestKey.LEFT_ARROW);
+      expect(await harness.getAriaExpanded()).toBe('false');
+
+      await harness.sendKeys(TestKey.RIGHT_ARROW);
+      expect(await harness.getAriaExpanded()).toBe('true');
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/tree/tree-node.component.ts
@@ -69,6 +69,7 @@ export class TreeNodeComponent {
     switch (this.node().type) {
       case 'FOLDER':
       case 'API':
+      case 'API_PRODUCT':
         this.toggleNode();
         break;
       case 'PAGE':


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-103

## Description

Adds API Product support to the existing Portal Next documentation navigation.

API Products now behave like documentation containers, using the same route pattern as APIs:

`/documentation/{rootId}?selectedId={apiProductNavigationItemId}`

When an API Product is selected, Portal resolves its first readable page while preserving the current documentation root.

## Changes

- Treat `API_PRODUCT` as an expandable documentation container.
- Resolve the first readable descendant when an API Product is selected.
- Preserve product and linked API documentation within the same navigation root.
- Support mouse and keyboard expansion with the appropriate accessibility attributes.
- Preserve the existing empty-content behavior when no readable page exists.
- Keep existing `FOLDER`, `PAGE`, `LINK`, and `API` behavior unchanged.
- Add focused component and navigation tests.





