### PR TITLE
feat(portal-next): add auto-fetch scheduler for sourced portal pages

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
@@ -24,8 +24,10 @@ export interface PortalNavigationItemSource {
   configuration: unknown;
   useAutoFetch?: boolean;
   fetchCron?: string;
-  /** Read-only, server-managed. */
+  /** Read-only, server-managed. Date of the last successful fetch. */
   lastFetchedAt?: string;
+  /** Read-only, server-managed. Date of the last fetch attempt, successful or not. Dates lastFetchError. */
+  lastFetchAttemptAt?: string;
   /** Read-only, server-managed. Absent when the last fetch succeeded. */
   lastFetchError?: string;
 }

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/pom.xml
@@ -212,6 +212,20 @@
 
         <dependency>
             <groupId>io.gravitee.apim.rest.api.services</groupId>
+            <artifactId>gravitee-apim-rest-api-services-portal-auto-fetch</artifactId>
+            <version>${apim.server.version}</version>
+            <scope>runtime</scope>
+            <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.rest.api.services</groupId>
             <artifactId>gravitee-apim-rest-api-services-audit</artifactId>
             <version>${apim.server.version}</version>
             <scope>runtime</scope>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/config/gravitee.yml
@@ -439,6 +439,15 @@ services:
     enabled: true
     cron: "0 */5 * * * *"
 
+  # Portal Navigation AutoFetch service.
+  # Use to fetch periodically the portal navigation pages backed by an external source.
+  # Runs independently from the auto_fetch service above, and only on the primary node of a cluster.
+  # The cron below paces the whole job: a page whose own fetch cron is finer than this value is only
+  # refreshed at this pace. Lower it if pages need to be re-synchronized more often.
+  portal_navigation_auto_fetch:
+    enabled: true
+    cron: "0 */5 * * * *"
+
   # Subscription service
   subscription:
     enabled: true

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PortalNavigationItemCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PortalNavigationItemCriteria.java
@@ -36,4 +36,5 @@ public class PortalNavigationItemCriteria {
     private Set<String> apiIds;
     private Set<String> apiProductIds;
     private String type;
+    private Boolean useAutoFetch;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
@@ -310,6 +310,10 @@ public class JdbcPortalNavigationItemRepository
                     log.warn("Invalid portal navigation item type value: {}", criteria.getType());
                 }
             }
+            if (criteria.getUseAutoFetch() != null) {
+                clauses.add("use_auto_fetch = ?");
+                params.add(criteria.getUseAutoFetch());
+            }
         }
 
         return new CriteriaClauses(clauses, params);

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/13_add_use_auto_fetch_index_to_portal_navigation_items.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/13_add_use_auto_fetch_index_to_portal_navigation_items.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_13_add_use_auto_fetch_index_to_portal_navigation_items
+      author: GraviteeSource Team
+      changes:
+        - createIndex:
+            indexName: idx_${gravitee_prefix}portal_navigation_items_use_auto_fetch
+            tableName: ${gravitee_prefix}portal_navigation_items
+            columns:
+              - column:
+                  name: use_auto_fetch
+                  type: boolean

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -411,3 +411,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_13_0/11_add_analytics_to_api_products.yml
     - include:
         - file: liquibase/changelogs/v4_13_0/12_add_portal_navigation_item_categories_table.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/13_add_use_auto_fetch_index_to_portal_navigation_items.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNavigationItemRepository.java
@@ -139,6 +139,9 @@ public class MongoPortalNavigationItemRepository implements PortalNavigationItem
                     log.warn("Invalid portal navigation item type value: {}", criteria.getType());
                 }
             }
+            if (criteria.getUseAutoFetch() != null) {
+                query.addCriteria(where("useAutoFetch").is(criteria.getUseAutoFetch()));
+            }
         }
         return query;
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portalnavigationindex/PortalNavigationItemUseAutoFetchIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portalnavigationindex/PortalNavigationItemUseAutoFetchIndexUpgrader.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.portalnavigationindex;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PortalNavigationItemUseAutoFetchIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("portal_navigation_items")
+            .key("useAutoFetch", ascending())
+            .name("uaf1")
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
@@ -836,6 +836,67 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         }
     }
 
+    //////////////////////////////////////
+    ////   SEARCH BY AUTO FETCH
+    //////////////////////////////////////
+
+    @Test
+    public void should_search_items_with_auto_fetch_enabled_across_environments() throws Exception {
+        PortalNavigationItem autoFetched = PortalNavigationItemFixtures.aSourcedPage(
+            "auto-fetch-search-1",
+            "00f8c9e7-78fc-4907-b8c9-e778fc790750"
+        )
+            .environmentId("env-auto-fetch-search")
+            .build();
+        PortalNavigationItem notAutoFetched = PortalNavigationItemFixtures.aSourcedPage(
+            "auto-fetch-search-2",
+            "00f8c9e7-78fc-4907-b8c9-e778fc790751"
+        )
+            .environmentId("env-auto-fetch-search")
+            .useAutoFetch(false)
+            .build();
+
+        try {
+            portalNavigationItemRepository.create(autoFetched);
+            portalNavigationItemRepository.create(notAutoFetched);
+
+            PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder().useAutoFetch(true).build();
+
+            List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+            assertThat(items).extracting("id").contains("auto-fetch-search-1").doesNotContain("auto-fetch-search-2");
+            assertThat(items).allMatch(PortalNavigationItem::isUseAutoFetch);
+        } finally {
+            portalNavigationItemRepository.delete("auto-fetch-search-1");
+            portalNavigationItemRepository.delete("auto-fetch-search-2");
+        }
+    }
+
+    @Test
+    public void should_search_items_with_auto_fetch_disabled() throws Exception {
+        PortalNavigationItem autoFetched = PortalNavigationItemFixtures.aSourcedPage(
+            "auto-fetch-search-3",
+            "00f8c9e7-78fc-4907-b8c9-e778fc790752"
+        )
+            .environmentId("env-auto-fetch-search")
+            .build();
+
+        try {
+            portalNavigationItemRepository.create(autoFetched);
+
+            PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+                .environmentId("env-auto-fetch-search")
+                .useAutoFetch(false)
+                .build();
+
+            List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+            assertThat(items).isEmpty();
+        } finally {
+            portalNavigationItemRepository.delete("auto-fetch-search-3");
+        }
+    }
+
     @Test
     public void should_find_all_navigation_items_by_root_id() throws Exception {
         // "Resources" folder and its 3 children all share rootId 5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/pom.xml
@@ -160,6 +160,12 @@
 
         <dependency>
             <groupId>io.gravitee.apim.rest.api.services</groupId>
+            <artifactId>gravitee-apim-rest-api-services-portal-auto-fetch</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.rest.api.services</groupId>
             <artifactId>gravitee-apim-rest-api-services-dictionary</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -166,8 +166,8 @@ public interface PortalNavigationItemsMapper {
 
     FetchPortalNavigationItemResponse map(FetchPortalNavigationItemUseCase.Output output);
 
-    // Hand-built because lastFetchedAt/lastFetchError are readOnly in the OpenAPI spec: the generated
-    // model only exposes them through its @JsonCreator constructor, which MapStruct cannot target.
+    // Hand-built because the fetch state is readOnly in the OpenAPI spec: the generated model only
+    // exposes it through its @JsonCreator constructor, which MapStruct cannot target.
     default io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemSource map(
         io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource source
     ) {
@@ -176,6 +176,7 @@ public interface PortalNavigationItemsMapper {
         }
         return new io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemSource(
             DateMapper.INSTANCE.map(source.getLastFetchedAt()),
+            DateMapper.INSTANCE.map(source.getLastFetchAttemptAt()),
             source.getLastFetchError()
         )
             .type(source.getSourceType())
@@ -188,6 +189,7 @@ public interface PortalNavigationItemsMapper {
     @Mapping(target = "sourceType", source = "type")
     @Mapping(target = "sourceConfiguration", source = "configuration", qualifiedByName = "serializeConfiguration")
     @Mapping(target = "lastFetchedAt", ignore = true)
+    @Mapping(target = "lastFetchAttemptAt", ignore = true)
     @Mapping(target = "lastFetchError", ignore = true)
     io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource map(
         io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemSource source

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -2443,6 +2443,14 @@ components:
           readOnly: true
           description: Date of the last successful fetch.
           example: 2026-07-17T00:00:00.000Z
+        lastFetchAttemptAt:
+          type: string
+          format: date-time
+          readOnly: true
+          description: >
+            Date of the last fetch attempt, successful or not. This is the date the auto-fetch schedule
+            is computed from, and it dates lastFetchError when the last attempt failed.
+          example: 2026-07-17T00:00:00.000Z
         lastFetchError:
           type: string
           readOnly: true

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -190,6 +190,7 @@ class PortalNavigationItemsMapperTest {
                         .useAutoFetch(true)
                         .fetchCron("0 */10 * * * *")
                         .lastFetchedAt(Instant.parse("2026-07-17T10:00:00Z"))
+                        .lastFetchAttemptAt(Instant.parse("2026-07-17T11:00:00Z"))
                         .lastFetchError("boom")
                         .build()
                 )
@@ -204,6 +205,7 @@ class PortalNavigationItemsMapperTest {
             assertThat(source.getUseAutoFetch()).isTrue();
             assertThat(source.getFetchCron()).isEqualTo("0 */10 * * * *");
             assertThat(source.getLastFetchedAt()).isEqualTo(OffsetDateTime.parse("2026-07-17T10:00:00Z"));
+            assertThat(source.getLastFetchAttemptAt()).isEqualTo(OffsetDateTime.parse("2026-07-17T11:00:00Z"));
             assertThat(source.getLastFetchError()).isEqualTo("boom");
         }
 
@@ -385,6 +387,7 @@ class PortalNavigationItemsMapperTest {
             page.setSource(
                 new io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemSource(
                     OffsetDateTime.parse("2026-07-17T10:00:00Z"),
+                    OffsetDateTime.parse("2026-07-17T11:00:00Z"),
                     "injected error"
                 )
                     .type("github-fetcher")
@@ -396,6 +399,8 @@ class PortalNavigationItemsMapperTest {
             var source = result.getSource();
             assertThat(source).isNotNull();
             assertThat(source.getLastFetchedAt()).isNull();
+            // a forged attempt date would let a client push its page's next auto-fetch arbitrarily far out
+            assertThat(source.getLastFetchAttemptAt()).isNull();
             assertThat(source.getLastFetchError()).isNull();
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_CreateTest.java
@@ -175,6 +175,7 @@ class PortalNavigationItemsResource_CreateTest extends AbstractResourceTest {
                         .useAutoFetch(true)
                         .fetchCron("0 */10 * * * *")
                         .lastFetchedAt(Instant.parse("2026-07-17T10:00:00Z"))
+                        .lastFetchAttemptAt(Instant.parse("2026-07-17T11:00:00Z"))
                         .build()
                 )
                 .build();
@@ -208,6 +209,7 @@ class PortalNavigationItemsResource_CreateTest extends AbstractResourceTest {
         assertThat(item.getSource().getUseAutoFetch()).isTrue();
         assertThat(item.getSource().getFetchCron()).isEqualTo("0 */10 * * * *");
         assertThat(item.getSource().getLastFetchedAt()).isEqualTo(java.time.OffsetDateTime.parse("2026-07-17T10:00:00Z"));
+        assertThat(item.getSource().getLastFetchAttemptAt()).isEqualTo(java.time.OffsetDateTime.parse("2026-07-17T11:00:00Z"));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
@@ -508,7 +508,11 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         // @JsonCreator constructor, exactly how Jackson materializes them from a request body)
         BaseUpdatePortalNavigationItem payload = new UpdatePortalNavigationPage()
             .source(
-                new PortalNavigationItemSource(OffsetDateTime.parse("2026-07-17T10:00:00Z"), "forged error")
+                new PortalNavigationItemSource(
+                    OffsetDateTime.parse("2026-07-17T10:00:00Z"),
+                    OffsetDateTime.parse("2026-07-17T11:00:00Z"),
+                    "forged error"
+                )
                     .type("github-fetcher")
                     .configuration(Map.of("repository", "docs"))
                     .useAutoFetch(true)
@@ -529,6 +533,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(body.getSource().getConfiguration()).isEqualTo(Map.of("repository", "docs"));
         assertThat(body.getSource().getUseAutoFetch()).isTrue();
         assertThat(body.getSource().getLastFetchedAt()).isNull();
+        assertThat(body.getSource().getLastFetchAttemptAt()).isNull();
         assertThat(body.getSource().getLastFetchError()).isNull();
 
         // And storage reflects the same
@@ -536,6 +541,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(updated.getSource()).isNotNull();
         assertThat(updated.getSource().getSourceType()).isEqualTo("github-fetcher");
         assertThat(updated.getSource().getLastFetchedAt()).isNull();
+        assertThat(updated.getSource().getLastFetchAttemptAt()).isNull();
         assertThat(updated.getSource().getLastFetchError()).isNull();
     }
 
@@ -557,6 +563,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
                         }"""
                     )
                     .lastFetchedAt(Instant.parse("2026-07-17T10:00:00Z"))
+                    .lastFetchAttemptAt(Instant.parse("2026-07-17T11:00:00Z"))
                     .lastFetchError("boom")
                     .build()
             )
@@ -566,7 +573,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
 
         // When: PUT keeping the same source origin (clients never send the readOnly fields back)
         BaseUpdatePortalNavigationItem payload = new UpdatePortalNavigationPage()
-            .source(new PortalNavigationItemSource(null, null).type("github-fetcher").configuration(Map.of("repository", "docs")))
+            .source(new PortalNavigationItemSource(null, null, null).type("github-fetcher").configuration(Map.of("repository", "docs")))
             .title("Sourced Page")
             .order(0)
             .type(PortalNavigationItemType.PAGE)
@@ -579,11 +586,13 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         PortalNavigationPage body = response.readEntity(PortalNavigationPage.class);
         assertThat(body.getSource()).isNotNull();
         assertThat(body.getSource().getLastFetchedAt()).isEqualTo(OffsetDateTime.parse("2026-07-17T10:00:00Z"));
+        assertThat(body.getSource().getLastFetchAttemptAt()).isEqualTo(OffsetDateTime.parse("2026-07-17T11:00:00Z"));
         assertThat(body.getSource().getLastFetchError()).isEqualTo("boom");
 
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, sourcedPage.getId());
         assertThat(updated.getSource()).isNotNull();
         assertThat(updated.getSource().getLastFetchedAt()).isEqualTo(Instant.parse("2026-07-17T10:00:00Z"));
+        assertThat(updated.getSource().getLastFetchAttemptAt()).isEqualTo(Instant.parse("2026-07-17T11:00:00Z"));
         assertThat(updated.getSource().getLastFetchError()).isEqualTo("boom");
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
@@ -128,15 +128,21 @@ public class PortalNavigationItemDomainService {
      * Fetches the sourced content and overwrites the page content with it. A failed fetch is recorded
      * in {@code lastFetchError} instead of failing the operation. A missing page content is an
      * internal inconsistency, not a fetch failure, and is propagated.
+     * <p>
+     * {@code lastFetchAttemptAt} is stamped on every attempt, {@code lastFetchedAt} only on success.
      */
     public PortalNavigationItem fetchPageContent(PortalNavigationPage page) {
         final var source = page.getSource();
         if (source == null) {
             throw InvalidPortalNavigationItemDataException.noSourceConfigured(page.getId().json());
         }
-        final var pageContent = pageContentQueryService
-            .findById(page.getPortalPageContentId())
-            .orElseThrow(() -> new PageContentNotFoundException(page.getPortalPageContentId().toString()));
+        source.registerFetchAttempt();
+        // Stamped and persisted before surfacing the inconsistency: without it the broken page is retried on every tick
+        final var pageContent = pageContentQueryService.findById(page.getPortalPageContentId()).orElse(null);
+        if (pageContent == null) {
+            crudService.update(page);
+            throw new PageContentNotFoundException(page.getPortalPageContentId().toString());
+        }
         try {
             final var fetchedContent = sourceDomainService.fetchContent(source);
             pageContent.update(UpdatePortalPageContent.builder().content(fetchedContent).build());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemSourceDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemSourceDomainService.java
@@ -25,4 +25,11 @@ public interface PortalNavigationItemSourceDomainService {
     void mergeSensitiveData(PortalNavigationItemSource oldSource, PortalNavigationItemSource newSource);
 
     void validateSourceConfiguration(PortalNavigationItemSource source);
+
+    /**
+     * Whether the auto-fetch cron has elapsed since the last fetch attempt, successful or not.
+     *
+     * @return {@code false} when auto-fetch is off, when no cron is configured, or when the cron cannot be parsed
+     */
+    boolean isAutoFetchDue(PortalNavigationItemSource source);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -227,9 +227,12 @@ public abstract sealed class PortalNavigationItem
             this.source = null;
             return;
         }
-        var builder = newSource.toBuilder().lastFetchedAt(null).lastFetchError(null);
+        var builder = newSource.toBuilder().lastFetchedAt(null).lastFetchAttemptAt(null).lastFetchError(null);
         if (this.source != null && this.source.sameOriginAs(newSource)) {
-            builder.lastFetchedAt(this.source.getLastFetchedAt()).lastFetchError(this.source.getLastFetchError());
+            builder
+                .lastFetchedAt(this.source.getLastFetchedAt())
+                .lastFetchAttemptAt(this.source.getLastFetchAttemptAt())
+                .lastFetchError(this.source.getLastFetchError());
         }
         this.source = builder.build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemQueryCriteria.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemQueryCriteria.java
@@ -32,4 +32,6 @@ public class PortalNavigationItemQueryCriteria {
     private Set<String> apiIds;
     private Set<String> apiProductIds;
     private PortalNavigationItemType type;
+
+    private Boolean useAutoFetch;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemSource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemSource.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.utils.TimeProvider;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.time.Instant;
@@ -46,7 +47,24 @@ public class PortalNavigationItemSource {
     private Instant lastFetchedAt;
 
     @Nullable
+    private Instant lastFetchAttemptAt;
+
+    @Nullable
     private String lastFetchError;
+
+    public void registerFetchAttempt() {
+        this.lastFetchAttemptAt = TimeProvider.instantNow();
+    }
+
+    public boolean canUseAutoFetch() {
+        return useAutoFetch && fetchCron != null;
+    }
+
+    /** Falls back on the last success for items stored before attempts were recorded. */
+    @Nullable
+    public Instant lastAttempt() {
+        return lastFetchAttemptAt != null ? lastFetchAttemptAt : lastFetchedAt;
+    }
 
     /** Two sources share an origin when they point at the same thing, whatever the fetch state around them. */
     public boolean sameOriginAs(@Nullable PortalNavigationItemSource other) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryService.java
@@ -43,6 +43,16 @@ public interface PortalNavigationItemsQueryService {
 
     List<PortalNavigationItem> findAllByRootId(String environmentId, PortalNavigationItemId rootId);
 
+    /**
+     * Every item whose source has auto-fetch enabled, across all environments: the auto-fetch scheduler
+     * is a node-wide job and does not run inside an environment context.
+     */
+    default List<PortalNavigationItem> findAllWithAutoFetchEnabled() {
+        // Restricted to PAGE in the query rather than in the caller: only a PAGE owns content that the
+        // scheduler knows how to refresh.
+        return search(PortalNavigationItemQueryCriteria.builder().useAutoFetch(true).type(PortalNavigationItemType.PAGE).build());
+    }
+
     default Optional<PortalNavigationPage> findNavigationPageByPortalPageContentId(String environmentId, PortalPageContentId contentId) {
         final var criteria = PortalNavigationItemQueryCriteria.builder()
             .environmentId(environmentId)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/AutoFetchPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/AutoFetchPortalNavigationItemsUseCase.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Re-fetches every sourced portal navigation page whose auto-fetch cron has elapsed. Meant to be
+ * triggered by the auto-fetch scheduler, across all environments. A page failing to fetch never stops
+ * the others: the failure is recorded on the page itself.
+ */
+@UseCase
+@CustomLog
+@RequiredArgsConstructor
+public class AutoFetchPortalNavigationItemsUseCase {
+
+    private final PortalNavigationItemsQueryService queryService;
+    private final PortalNavigationItemSourceDomainService sourceDomainService;
+    private final PortalNavigationItemDomainService domainService;
+
+    public Output execute() {
+        var duePages = queryService
+            .findAllWithAutoFetchEnabled()
+            .stream()
+            .filter(PortalNavigationPage.class::isInstance)
+            .map(PortalNavigationPage.class::cast)
+            .filter(page -> page.getSource() != null)
+            .filter(page -> sourceDomainService.isAutoFetchDue(page.getSource()))
+            .toList();
+
+        int succeeded = 0;
+        int failed = 0;
+        for (var page : duePages) {
+            if (fetch(page)) {
+                succeeded++;
+            } else {
+                failed++;
+            }
+        }
+        return new Output(succeeded, failed);
+    }
+
+    /** Never throws: one failing page must not stop the ones after it. */
+    private boolean fetch(PortalNavigationPage page) {
+        try {
+            log.debug(
+                "Auto-fetching portal navigation page [id={}, title={}, environmentId={}]",
+                page.getId().json(),
+                page.getTitle(),
+                page.getEnvironmentId()
+            );
+            var updated = domainService.fetchPageContent(page);
+            return updated.getSource() != null && updated.getSource().getLastFetchError() == null;
+        } catch (Exception e) {
+            log.warn(
+                "Failed to auto-fetch portal navigation page [id={}, title={}, environmentId={}, sourceType={}]",
+                page.getId().json(),
+                page.getTitle(),
+                page.getEnvironmentId(),
+                page.getSource() == null ? null : page.getSource().getSourceType(),
+                e
+            );
+            return false;
+        }
+    }
+
+    public record Output(int succeeded, int failed) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
@@ -40,6 +40,7 @@ public interface PortalNavigationItemAdapter {
     String SOURCE_CONFIGURATION = "configuration";
     String FETCH_CRON = "fetchCron";
     String LAST_FETCHED_AT = "lastFetchedAt";
+    String LAST_FETCH_ATTEMPT_AT = "lastFetchAttemptAt";
     String LAST_FETCH_ERROR = "lastFetchError";
 
     default PortalNavigationItem toEntity(io.gravitee.repository.management.model.PortalNavigationItem portalNavigationItem) {
@@ -163,6 +164,9 @@ public interface PortalNavigationItemAdapter {
         if (source.getLastFetchedAt() != null) {
             sourceNode.put(LAST_FETCHED_AT, source.getLastFetchedAt().toString());
         }
+        if (source.getLastFetchAttemptAt() != null) {
+            sourceNode.put(LAST_FETCH_ATTEMPT_AT, source.getLastFetchAttemptAt().toString());
+        }
         if (source.getLastFetchError() != null) {
             sourceNode.put(LAST_FETCH_ERROR, source.getLastFetchError());
         }
@@ -213,6 +217,11 @@ public interface PortalNavigationItemAdapter {
                 .fetchCron(sourceNode.hasNonNull(FETCH_CRON) ? sourceNode.get(FETCH_CRON).asText() : null)
                 .lastFetchedAt(
                     sourceNode.hasNonNull(LAST_FETCHED_AT) ? java.time.Instant.parse(sourceNode.get(LAST_FETCHED_AT).asText()) : null
+                )
+                .lastFetchAttemptAt(
+                    sourceNode.hasNonNull(LAST_FETCH_ATTEMPT_AT)
+                        ? java.time.Instant.parse(sourceNode.get(LAST_FETCH_ATTEMPT_AT).asText())
+                        : null
                 )
                 .lastFetchError(sourceNode.hasNonNull(LAST_FETCH_ERROR) ? sourceNode.get(LAST_FETCH_ERROR).asText() : null)
                 .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationItemSourceDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationItemSourceDomainServiceImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.fetcher.api.Fetcher;
 import io.gravitee.fetcher.api.FetcherConfiguration;
 import io.gravitee.fetcher.api.FetcherException;
@@ -31,6 +32,8 @@ import io.gravitee.rest.api.fetcher.FetcherConfigurationFactory;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -172,6 +175,28 @@ public class PortalNavigationItemSourceDomainServiceImpl implements PortalNaviga
         }
         if (source.getFetchCron() != null && !CronExpression.isValidExpression(source.getFetchCron())) {
             throw InvalidPortalNavigationItemSourceException.invalidCronExpression(source.getFetchCron());
+        }
+    }
+
+    @Override
+    public boolean isAutoFetchDue(PortalNavigationItemSource source) {
+        if (!source.canUseAutoFetch()) {
+            return false;
+        }
+        try {
+            var cronExpression = CronExpression.parse(source.getFetchCron());
+            var lastAttempt = source.lastAttempt();
+            // Never attempted: due right away
+            if (lastAttempt == null) {
+                return true;
+            }
+            var zone = ZoneId.systemDefault();
+            var nextRun = cronExpression.next(LocalDateTime.ofInstant(lastAttempt, zone));
+            return nextRun != null && !nextRun.isAfter(LocalDateTime.ofInstant(TimeProvider.instantNow(), zone));
+        } catch (IllegalArgumentException e) {
+            // Cron was validated on write; a stored one that no longer parses must not stop the whole run
+            log.warn("Skipping auto-fetch of portal page source [type={}]: unparseable cron expression", source.getSourceType(), e);
+            return false;
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemSourceDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemSourceDomainServiceInMemory.java
@@ -18,6 +18,9 @@ package inmemory;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import org.springframework.scheduling.support.CronExpression;
 
 public class PortalNavigationItemSourceDomainServiceInMemory implements PortalNavigationItemSourceDomainService {
@@ -25,6 +28,8 @@ public class PortalNavigationItemSourceDomainServiceInMemory implements PortalNa
     public static final String MARKDOWN = "# In memory markdown";
     public static final String SENSITIVE_DATA = "I'm a sensitive data";
     public static final String SENSITIVE_DATA_REPLACEMENT = "********";
+
+    private final Set<PortalNavigationItemSource> notDueSources = Collections.newSetFromMap(new IdentityHashMap<>());
 
     private RuntimeException fetchFailure;
     private String lastValidatedConfiguration;
@@ -80,5 +85,19 @@ public class PortalNavigationItemSourceDomainServiceInMemory implements PortalNa
         if (source.getFetchCron() != null && !CronExpression.isValidExpression(source.getFetchCron())) {
             throw InvalidPortalNavigationItemSourceException.invalidCronExpression(source.getFetchCron());
         }
+    }
+
+    /**
+     * Every auto-fetch source is due, unless the test marked it otherwise. Cron evaluation itself belongs
+     * to the real implementation and is covered by its own test.
+     */
+    @Override
+    public boolean isAutoFetchDue(PortalNavigationItemSource source) {
+        return source.canUseAutoFetch() && !notDueSources.contains(source);
+    }
+
+    /** Marks a source as not yet due, i.e. its cron has not elapsed since the last fetch. */
+    public void markAutoFetchNotDue(PortalNavigationItemSource source) {
+        notDueSources.add(source);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemsQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemsQueryServiceInMemory.java
@@ -88,9 +88,14 @@ public class PortalNavigationItemsQueryServiceInMemory
                     (criteria.getApiProductIds() == null ||
                         criteria.getApiProductIds().isEmpty() ||
                         (item instanceof PortalNavigationApiProduct apiProduct &&
-                            criteria.getApiProductIds().contains(apiProduct.getApiProductId())))
+                            criteria.getApiProductIds().contains(apiProduct.getApiProductId()))) &&
+                    (criteria.getUseAutoFetch() == null || criteria.getUseAutoFetch() == usesAutoFetch(item))
             )
             .toList();
+    }
+
+    private boolean usesAutoFetch(PortalNavigationItem item) {
+        return item.getSource() != null && item.getSource().isUseAutoFetch();
     }
 
     private boolean matchesType(PortalNavigationItem item, PortalNavigationItemType type) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainServiceTest.java
@@ -36,9 +36,14 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import io.gravitee.common.utils.TimeProvider;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -78,6 +83,18 @@ public class PortalNavigationItemDomainServiceTest {
     @Nested
     class CreateWithSource {
 
+        private static final Instant NOW = Instant.parse("2026-08-05T12:34:56Z");
+
+        @BeforeEach
+        void freezeTime() {
+            TimeProvider.overrideClock(Clock.fixed(NOW, ZoneId.systemDefault()));
+        }
+
+        @AfterEach
+        void unfreezeTime() {
+            TimeProvider.overrideClock(Clock.systemDefaultZone());
+        }
+
         private PortalNavigationItemSource.PortalNavigationItemSourceBuilder aSource() {
             return PortalNavigationItemSource.builder()
                 .sourceType("http-fetcher")
@@ -104,7 +121,8 @@ public class PortalNavigationItemDomainServiceTest {
             );
 
             assertThat(created.getSource()).isNotNull();
-            assertThat(created.getSource().getLastFetchedAt()).isNotNull();
+            assertThat(created.getSource().getLastFetchedAt()).isEqualTo(NOW);
+            assertThat(created.getSource().getLastFetchAttemptAt()).isEqualTo(NOW);
             assertThat(created.getSource().getLastFetchError()).isNull();
             assertThat(portalPageContentCrudService.storage())
                 .singleElement()
@@ -129,6 +147,40 @@ public class PortalNavigationItemDomainServiceTest {
             assertThat(created.getSource().getLastFetchedAt()).isNull();
             assertThat(created.getSource().getLastFetchError()).isEqualTo("Unable to fetch content from source type http-fetcher.");
             assertThat(portalNavigationItemsCrudService.storage()).hasSize(1);
+        }
+
+        /** The attempt is what the auto-fetch schedule counts, so it is stamped even when the fetch fails. */
+        @Test
+        void should_record_the_fetch_attempt_when_the_fetch_fails() {
+            sourceDomainService.failNextFetchWith(new TechnicalDomainException("initial fetch failed"));
+
+            var created = domainService.create(
+                PortalNavigationItemFixtures.ORG_ID,
+                PortalNavigationItemFixtures.ENV_ID,
+                aPageToCreate(aSource().build())
+            );
+
+            assertThat(created.getSource().getLastFetchAttemptAt()).isEqualTo(NOW);
+            assertThat(created.getSource().getLastFetchedAt()).isNull();
+        }
+
+        @Test
+        void should_persist_the_fetch_attempt_of_a_failed_fetch() {
+            sourceDomainService.failNextFetchWith(new TechnicalDomainException("initial fetch failed"));
+
+            var created = domainService.create(
+                PortalNavigationItemFixtures.ORG_ID,
+                PortalNavigationItemFixtures.ENV_ID,
+                aPageToCreate(aSource().build())
+            );
+
+            assertThat(portalNavigationItemsCrudService.storage())
+                .singleElement()
+                .isInstanceOfSatisfying(PortalNavigationPage.class, stored -> {
+                    assertThat(stored.getId()).isEqualTo(created.getId());
+                    assertThat(stored.getSource().getLastFetchAttemptAt()).isEqualTo(NOW);
+                    assertThat(stored.getSource().getLastFetchedAt()).isNull();
+                });
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemSourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemSourceTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 class PortalNavigationItemSourceTest {
 
     private static final Instant LAST_FETCHED_AT = Instant.parse("2026-07-17T10:00:00Z");
+    private static final Instant LAST_FETCH_ATTEMPT_AT = Instant.parse("2026-07-17T11:00:00Z");
 
     private PortalNavigationItem aPageWithSource(PortalNavigationItemSource source) {
         var item = PortalNavigationItem.from(
@@ -98,6 +99,7 @@ class PortalNavigationItemSourceTest {
                 .sourceType("http-fetcher")
                 .sourceConfiguration("{\"url\":\"https://example.com/a.md\"}")
                 .lastFetchedAt(LAST_FETCHED_AT)
+                .lastFetchAttemptAt(LAST_FETCH_ATTEMPT_AT)
                 .lastFetchError("boom")
                 .build()
         );
@@ -120,6 +122,7 @@ class PortalNavigationItemSourceTest {
         assertThat(source.isUseAutoFetch()).isTrue();
         assertThat(source.getFetchCron()).isEqualTo("0 */10 * * * *");
         assertThat(source.getLastFetchedAt()).isEqualTo(LAST_FETCHED_AT);
+        assertThat(source.getLastFetchAttemptAt()).isEqualTo(LAST_FETCH_ATTEMPT_AT);
         assertThat(source.getLastFetchError()).isEqualTo("boom");
     }
 
@@ -130,6 +133,7 @@ class PortalNavigationItemSourceTest {
                 .sourceType("http-fetcher")
                 .sourceConfiguration("{\n  \"url\" : \"https://example.com/a.md\",\n  \"useAuth\" : true\n}")
                 .lastFetchedAt(LAST_FETCHED_AT)
+                .lastFetchAttemptAt(LAST_FETCH_ATTEMPT_AT)
                 .build()
         );
 
@@ -146,6 +150,7 @@ class PortalNavigationItemSourceTest {
 
         assertThat(item.getSource()).isNotNull();
         assertThat(item.getSource().getLastFetchedAt()).isEqualTo(LAST_FETCHED_AT);
+        assertThat(item.getSource().getLastFetchAttemptAt()).isEqualTo(LAST_FETCH_ATTEMPT_AT);
     }
 
     @Test
@@ -155,6 +160,7 @@ class PortalNavigationItemSourceTest {
                 .sourceType("http-fetcher")
                 .sourceConfiguration("{\"url\":\"https://example.com/a.md\"}")
                 .lastFetchedAt(LAST_FETCHED_AT)
+                .lastFetchAttemptAt(LAST_FETCH_ATTEMPT_AT)
                 .lastFetchError("boom")
                 .build()
         );
@@ -174,6 +180,7 @@ class PortalNavigationItemSourceTest {
         assertThat(source).isNotNull();
         assertThat(source.getSourceConfiguration()).isEqualTo("{\"url\":\"https://example.com/b.md\"}");
         assertThat(source.getLastFetchedAt()).isNull();
+        assertThat(source.getLastFetchAttemptAt()).isNull();
         assertThat(source.getLastFetchError()).isNull();
     }
 
@@ -184,6 +191,7 @@ class PortalNavigationItemSourceTest {
                 .sourceType("http-fetcher")
                 .sourceConfiguration("{}")
                 .lastFetchedAt(LAST_FETCHED_AT)
+                .lastFetchAttemptAt(LAST_FETCH_ATTEMPT_AT)
                 .lastFetchError("boom")
                 .build()
         );
@@ -195,6 +203,7 @@ class PortalNavigationItemSourceTest {
         var source = item.getSource();
         assertThat(source).isNotNull();
         assertThat(source.getLastFetchedAt()).isNull();
+        assertThat(source.getLastFetchAttemptAt()).isNull();
         assertThat(source.getLastFetchError()).isNull();
     }
 
@@ -209,6 +218,7 @@ class PortalNavigationItemSourceTest {
                         .sourceType("http-fetcher")
                         .sourceConfiguration("{}")
                         .lastFetchedAt(LAST_FETCHED_AT)
+                        .lastFetchAttemptAt(LAST_FETCH_ATTEMPT_AT)
                         .lastFetchError("forged")
                         .build()
                 )
@@ -218,6 +228,7 @@ class PortalNavigationItemSourceTest {
         var source = item.getSource();
         assertThat(source).isNotNull();
         assertThat(source.getLastFetchedAt()).isNull();
+        assertThat(source.getLastFetchAttemptAt()).isNull();
         assertThat(source.getLastFetchError()).isNull();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/AutoFetchPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/AutoFetchPortalNavigationItemsUseCaseTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.common.utils.TimeProvider;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AutoFetchPortalNavigationItemsUseCaseTest {
+
+    private static final String ORG_ID = "org-id";
+    private static final String ENV_ID = "env-id";
+    private static final String OTHER_ENV_ID = "other-env-id";
+    private static final String DEFAULT_CONTENT = "# Default content";
+    private static final Instant NOW = Instant.parse("2026-08-05T12:34:56Z");
+
+    private PortalNavigationItemsCrudServiceInMemory crudService;
+    private PortalPageContentCrudServiceInMemory pageContentCrudService;
+    private PortalNavigationItemSourceDomainServiceInMemory sourceDomainService;
+    private AutoFetchPortalNavigationItemsUseCase useCase;
+
+    @AfterEach
+    void unfreezeTime() {
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void setUp() {
+        TimeProvider.overrideClock(Clock.fixed(NOW, ZoneId.systemDefault()));
+        var storage = new ArrayList<PortalNavigationItem>();
+        crudService = new PortalNavigationItemsCrudServiceInMemory(storage);
+        var queryService = new PortalNavigationItemsQueryServiceInMemory(storage);
+        pageContentCrudService = new PortalPageContentCrudServiceInMemory();
+        sourceDomainService = new PortalNavigationItemSourceDomainServiceInMemory();
+
+        var domainService = new PortalNavigationItemDomainService(
+            crudService,
+            queryService,
+            pageContentCrudService,
+            PortalPageContentQueryServiceInMemory.sharing(pageContentCrudService.storage()),
+            new ApiCrudServiceInMemory(),
+            sourceDomainService
+        );
+        useCase = new AutoFetchPortalNavigationItemsUseCase(queryService, sourceDomainService, domainService);
+    }
+
+    @Test
+    void should_fetch_pages_with_auto_fetch_enabled_across_environments() {
+        var page = aPage("Sourced Page", ENV_ID, autoFetchSource().build());
+        var pageInOtherEnvironment = aPage("Other Sourced Page", OTHER_ENV_ID, autoFetchSource().build());
+
+        var output = useCase.execute();
+
+        assertThat(output.succeeded()).isEqualTo(2);
+        assertThat(output.failed()).isZero();
+        assertThat(fetchedContentOf(page)).isEqualTo(PortalNavigationItemSourceDomainServiceInMemory.MARKDOWN);
+        assertThat(fetchedContentOf(pageInOtherEnvironment)).isEqualTo(PortalNavigationItemSourceDomainServiceInMemory.MARKDOWN);
+    }
+
+    @Test
+    void should_update_last_fetched_at_after_a_successful_fetch() {
+        var page = aPage("Sourced Page", ENV_ID, autoFetchSource().lastFetchError("previous error").build());
+
+        useCase.execute();
+
+        assertThat(page.getSource().getLastFetchedAt()).isEqualTo(NOW);
+        assertThat(page.getSource().getLastFetchAttemptAt()).isEqualTo(NOW);
+        assertThat(page.getSource().getLastFetchError()).isNull();
+    }
+
+    @Test
+    void should_not_fetch_pages_whose_cron_is_not_due_yet() {
+        var notDue = aPage("Not Due Page", ENV_ID, autoFetchSource().build());
+        var due = aPage("Due Page", ENV_ID, autoFetchSource().build());
+        sourceDomainService.markAutoFetchNotDue(notDue.getSource());
+
+        var output = useCase.execute();
+
+        assertThat(output.succeeded()).isEqualTo(1);
+        assertThat(notDue.getSource().getLastFetchedAt()).isNull();
+        assertThat(notDue.getSource().getLastFetchAttemptAt()).isNull();
+        assertThat(fetchedContentOf(notDue)).isEqualTo(DEFAULT_CONTENT);
+        assertThat(fetchedContentOf(due)).isEqualTo(PortalNavigationItemSourceDomainServiceInMemory.MARKDOWN);
+    }
+
+    @Test
+    void should_ignore_pages_without_auto_fetch_and_items_that_are_not_pages() {
+        var withoutAutoFetch = aPage("Manual Page", ENV_ID, manualSource().build());
+        aPage("Inline Page", ENV_ID, null);
+        aFolder("Sourced Folder", autoFetchSource().build());
+
+        var output = useCase.execute();
+
+        assertThat(output.succeeded()).isZero();
+        assertThat(output.failed()).isZero();
+        assertThat(withoutAutoFetch.getSource().getLastFetchedAt()).isNull();
+        assertThat(withoutAutoFetch.getSource().getLastFetchAttemptAt()).isNull();
+    }
+
+    @Test
+    void should_keep_fetching_other_pages_when_one_fetch_fails() {
+        var failing = aPage("Failing Page", ENV_ID, autoFetchSource().build());
+        var working = aPage("Working Page", ENV_ID, autoFetchSource().build());
+        sourceDomainService.failNextFetchWith(new TechnicalDomainException("fetch went wrong"));
+
+        var output = useCase.execute();
+
+        assertThat(output.succeeded()).isEqualTo(1);
+        assertThat(output.failed()).isEqualTo(1);
+        assertThat(failing.getSource().getLastFetchError()).isEqualTo("Unable to fetch content from source type http-fetcher.");
+        assertThat(failing.getSource().getLastFetchError()).doesNotContain("example.com");
+        assertThat(failing.getSource().getLastFetchedAt()).isNull();
+        // The failed attempt is still stamped, so the next run waits for the cron instead of retrying at once
+        assertThat(failing.getSource().getLastFetchAttemptAt()).isEqualTo(NOW);
+        assertThat(working.getSource().getLastFetchedAt()).isEqualTo(NOW);
+        assertThat(fetchedContentOf(working)).isEqualTo(PortalNavigationItemSourceDomainServiceInMemory.MARKDOWN);
+    }
+
+    @Test
+    void should_keep_fetching_other_pages_when_one_page_content_is_missing() {
+        var orphan = aPage("Orphan Page", ENV_ID, autoFetchSource().build());
+        pageContentCrudService.delete(orphan.getPortalPageContentId());
+        var working = aPage("Working Page", ENV_ID, autoFetchSource().build());
+
+        var output = useCase.execute();
+
+        assertThat(output.succeeded()).isEqualTo(1);
+        assertThat(output.failed()).isEqualTo(1);
+        assertThat(working.getSource().getLastFetchedAt()).isEqualTo(NOW);
+        // Stamped even though the fetch never ran, otherwise the broken page is picked up on every tick
+        assertThat(orphan.getSource().getLastFetchAttemptAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    void should_report_nothing_when_no_item_uses_auto_fetch() {
+        var output = useCase.execute();
+
+        assertThat(output.succeeded()).isZero();
+        assertThat(output.failed()).isZero();
+    }
+
+    private PortalNavigationItemSource.PortalNavigationItemSourceBuilder autoFetchSource() {
+        return manualSource().useAutoFetch(true).fetchCron("0 */10 * * * *");
+    }
+
+    private PortalNavigationItemSource.PortalNavigationItemSourceBuilder manualSource() {
+        return PortalNavigationItemSource.builder()
+            .sourceType("http-fetcher")
+            .sourceConfiguration("{\"url\":\"https://example.com/doc.md\"}");
+    }
+
+    private PortalNavigationFolder aFolder(String title, PortalNavigationItemSource source) {
+        var folder = PortalNavigationFolder.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title(title)
+            .segment(PortalNavigationItem.slugify(title).value())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .source(source)
+            .build();
+        crudService.create(folder);
+        return folder;
+    }
+
+    private PortalNavigationPage aPage(String title, String environmentId, PortalNavigationItemSource source) {
+        var content = GraviteeMarkdownPageContent.create(ORG_ID, environmentId, DEFAULT_CONTENT);
+        pageContentCrudService.create(content);
+
+        var page = PortalNavigationPage.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(ORG_ID)
+            .environmentId(environmentId)
+            .title(title)
+            .segment(PortalNavigationItem.slugify(title).value())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .portalPageContentId(content.getId())
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .source(source)
+            .build();
+        crudService.create(page);
+        return page;
+    }
+
+    private String fetchedContentOf(PortalNavigationPage page) {
+        return pageContentCrudService
+            .storage()
+            .stream()
+            .filter(content -> content.getId().equals(page.getPortalPageContentId()))
+            .findFirst()
+            .map(content -> ((GraviteeMarkdownPageContent) content).getContent().value())
+            .orElseThrow();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
@@ -431,6 +431,8 @@ class PortalNavigationItemAdapterTest {
     class SourceMapping {
 
         private static final Instant LAST_FETCHED_AT = Instant.parse("2026-07-17T10:00:00Z");
+        // Deliberately after the last success: the last attempt failed
+        private static final Instant LAST_FETCH_ATTEMPT_AT = Instant.parse("2026-07-17T11:00:00Z");
 
         private PortalNavigationItemSource aSource() {
             return PortalNavigationItemSource.builder()
@@ -439,6 +441,7 @@ class PortalNavigationItemAdapterTest {
                 .useAutoFetch(true)
                 .fetchCron("0 */10 * * * *")
                 .lastFetchedAt(LAST_FETCHED_AT)
+                .lastFetchAttemptAt(LAST_FETCH_ATTEMPT_AT)
                 .lastFetchError("boom")
                 .build();
         }
@@ -462,6 +465,7 @@ class PortalNavigationItemAdapterTest {
             assertThat(source.get("configuration").asText()).isEqualTo("{\"repository\":\"docs\"}");
             assertThat(source.get("fetchCron").asText()).isEqualTo("0 */10 * * * *");
             assertThat(source.get("lastFetchedAt").asText()).isEqualTo(LAST_FETCHED_AT.toString());
+            assertThat(source.get("lastFetchAttemptAt").asText()).isEqualTo(LAST_FETCH_ATTEMPT_AT.toString());
             assertThat(source.get("lastFetchError").asText()).isEqualTo("boom");
         }
 
@@ -515,6 +519,7 @@ class PortalNavigationItemAdapterTest {
                     "configuration": "{\\"repository\\":\\"docs\\"}",
                     "fetchCron": "0 */10 * * * *",
                     "lastFetchedAt": "2026-07-17T10:00:00Z",
+                    "lastFetchAttemptAt": "2026-07-17T11:00:00Z",
                     "lastFetchError": "boom"
                   }
                 }
@@ -532,7 +537,41 @@ class PortalNavigationItemAdapterTest {
             assertThat(entity.getSource().isUseAutoFetch()).isTrue();
             assertThat(entity.getSource().getFetchCron()).isEqualTo("0 */10 * * * *");
             assertThat(entity.getSource().getLastFetchedAt()).isEqualTo(LAST_FETCHED_AT);
+            assertThat(entity.getSource().getLastFetchAttemptAt()).isEqualTo(LAST_FETCH_ATTEMPT_AT);
             assertThat(entity.getSource().getLastFetchError()).isEqualTo("boom");
+        }
+
+        /** Items stored before the key existed: no migration, the field simply reads as absent. */
+        @Test
+        void should_map_configuration_without_last_fetch_attempt_at_to_null() {
+            // Given
+            var repositoryItem = PortalNavigationItemsRepositoryFixtures.aPage(
+                "550e8400-e29b-41d4-a716-446655440026",
+                "My Page",
+                "550e8400-e29b-41d4-a716-446655440013",
+                null
+            );
+            repositoryItem.setConfiguration(
+                """
+                {
+                  "portalPageContentId": "550e8400-e29b-41d4-a716-446655440013",
+                  "source": {
+                    "type": "github-fetcher",
+                    "configuration": "{\\"repository\\":\\"docs\\"}",
+                    "fetchCron": "0 */10 * * * *",
+                    "lastFetchedAt": "2026-07-17T10:00:00Z"
+                  }
+                }
+                """
+            );
+            repositoryItem.setUseAutoFetch(true);
+
+            // When
+            var entity = adapter.toEntity(repositoryItem);
+
+            // Then
+            assertThat(entity.getSource().getLastFetchAttemptAt()).isNull();
+            assertThat(entity.getSource().getLastFetchedAt()).isEqualTo(LAST_FETCHED_AT);
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationItemSourceDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationItemSourceDomainServiceImplTest.java
@@ -31,12 +31,18 @@ import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSo
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
 import io.gravitee.apim.infra.domain_service.documentation.DummyFetcher;
 import io.gravitee.apim.infra.domain_service.documentation.DummyFetcherConfiguration;
+import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.plugin.core.api.PluginManager;
 import io.gravitee.plugin.fetcher.FetcherPlugin;
 import io.gravitee.rest.api.fetcher.FetcherConfigurationFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -366,6 +372,119 @@ class PortalNavigationItemSourceDomainServiceImplTest {
             var source = dummySource().toBuilder().useAutoFetch(true).fetchCron("0 */5 * * * *").build();
 
             cut.validateSourceConfiguration(source);
+        }
+    }
+
+    @Nested
+    class IsAutoFetchDue {
+
+        private static final Instant NOW = Instant.parse("2026-08-05T12:34:56Z");
+
+        @BeforeEach
+        void freezeTime() {
+            TimeProvider.overrideClock(Clock.fixed(NOW, ZoneId.systemDefault()));
+        }
+
+        @AfterEach
+        void unfreezeTime() {
+            TimeProvider.overrideClock(Clock.systemDefaultZone());
+        }
+
+        @Test
+        void should_be_due_when_the_cron_elapsed_since_the_last_attempt() {
+            var source = autoFetchSource("0 */10 * * * *", NOW.minus(11, ChronoUnit.MINUTES));
+
+            assertThat(cut.isAutoFetchDue(source)).isTrue();
+        }
+
+        @Test
+        void should_not_be_due_when_the_cron_has_not_elapsed_yet() {
+            var source = autoFetchSource("0 0 * * * *", NOW.minus(5, ChronoUnit.MINUTES));
+
+            assertThat(cut.isAutoFetchDue(source)).isFalse();
+        }
+
+        /**
+         * The point of lastFetchAttemptAt: a source that keeps failing never updates lastFetchedAt, and
+         * counting from it would make the page due on every scheduler run instead of on its own cron.
+         */
+        @Test
+        void should_not_be_due_when_the_last_attempt_failed_before_the_cron_elapsed() {
+            var source = dummySource()
+                .toBuilder()
+                .useAutoFetch(true)
+                .fetchCron("0 0 * * * *")
+                .lastFetchedAt(null)
+                .lastFetchAttemptAt(NOW.minus(5, ChronoUnit.MINUTES))
+                .lastFetchError("Unable to fetch content from source type dummy-fetcher.")
+                .build();
+
+            assertThat(cut.isAutoFetchDue(source)).isFalse();
+        }
+
+        @Test
+        void should_be_due_again_once_the_cron_elapsed_since_a_failed_attempt() {
+            var source = dummySource()
+                .toBuilder()
+                .useAutoFetch(true)
+                .fetchCron("0 0 * * * *")
+                .lastFetchedAt(null)
+                .lastFetchAttemptAt(NOW.minus(2, ChronoUnit.HOURS))
+                .lastFetchError("Unable to fetch content from source type dummy-fetcher.")
+                .build();
+
+            assertThat(cut.isAutoFetchDue(source)).isTrue();
+        }
+
+        /** Items stored before lastFetchAttemptAt existed still honour their cron via lastFetchedAt. */
+        @Test
+        void should_fall_back_on_last_fetched_at_when_no_attempt_was_ever_recorded() {
+            var source = dummySource()
+                .toBuilder()
+                .useAutoFetch(true)
+                .fetchCron("0 0 * * * *")
+                .lastFetchedAt(NOW.minus(5, ChronoUnit.MINUTES))
+                .lastFetchAttemptAt(null)
+                .build();
+
+            assertThat(cut.isAutoFetchDue(source)).isFalse();
+        }
+
+        @Test
+        void should_be_due_when_the_page_was_never_fetched() {
+            var source = autoFetchSource("0 0 1 1 1 *", null);
+
+            assertThat(cut.isAutoFetchDue(source)).isTrue();
+        }
+
+        @Test
+        void should_not_be_due_when_auto_fetch_is_disabled() {
+            var source = dummySource()
+                .toBuilder()
+                .useAutoFetch(false)
+                .fetchCron("0 */10 * * * *")
+                .lastFetchAttemptAt(Instant.EPOCH)
+                .build();
+
+            assertThat(cut.isAutoFetchDue(source)).isFalse();
+        }
+
+        @Test
+        void should_not_be_due_when_no_cron_is_configured() {
+            var source = dummySource().toBuilder().useAutoFetch(true).fetchCron(null).lastFetchAttemptAt(Instant.EPOCH).build();
+
+            assertThat(cut.isAutoFetchDue(source)).isFalse();
+        }
+
+        @Test
+        void should_not_be_due_when_the_stored_cron_cannot_be_parsed() {
+            var source = autoFetchSource("not-a-cron", Instant.EPOCH);
+
+            assertThat(cut.isAutoFetchDue(source)).isFalse();
+        }
+
+        private PortalNavigationItemSource autoFetchSource(String cron, Instant lastFetchAttemptAt) {
+            return dummySource().toBuilder().useAutoFetch(true).fetchCron(cron).lastFetchAttemptAt(lastFetchAttemptAt).build();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_page/PortalNavigationItemsQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_page/PortalNavigationItemsQueryServiceImplTest.java
@@ -303,6 +303,40 @@ class PortalNavigationItemsQueryServiceImplTest {
     }
 
     @Nested
+    class FindAllWithAutoFetchEnabled {
+
+        @Test
+        void should_search_on_the_auto_fetch_flag_only() throws TechnicalException {
+            var repoItem = PortalNavigationItemsRepositoryFixtures.aPage(
+                "00000000-0000-0000-0000-000000000030",
+                "Sourced page",
+                "00000000-0000-0000-0000-000000000031",
+                null
+            );
+            ArgumentCaptor<PortalNavigationItemCriteria> criteriaCaptor = ArgumentCaptor.forClass(PortalNavigationItemCriteria.class);
+            when(repository.searchByCriteria(criteriaCaptor.capture())).thenReturn(List.of(repoItem));
+
+            var result = service.findAllWithAutoFetchEnabled();
+
+            assertThat(result).hasSize(1);
+            var capturedCriteria = criteriaCaptor.getValue();
+            assertThat(capturedCriteria.getUseAutoFetch()).isTrue();
+            // node-wide job, so no environment restriction, but only a PAGE owns content to refresh
+            assertThat(capturedCriteria.getEnvironmentId()).isNull();
+            assertThat(capturedCriteria.getType()).isEqualTo("PAGE");
+        }
+
+        @Test
+        void should_throw_technical_domain_exception_when_repository_throws_technical_exception() throws TechnicalException {
+            when(repository.searchByCriteria(any())).thenThrow(new TechnicalException("Database error"));
+
+            assertThatThrownBy(() -> service.findAllWithAutoFetchEnabled())
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasCauseInstanceOf(TechnicalException.class);
+        }
+    }
+
+    @Nested
     class FindNavigationPageByPortalPageContentId {
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-portal-auto-fetch/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-portal-auto-fetch/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.apim.rest.api.services</groupId>
+        <artifactId>gravitee-apim-rest-api-services</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>gravitee-apim-rest-api-services-portal-auto-fetch</artifactId>
+    <name>Gravitee.io APIM - Management API - Services - Portal Auto Fetch</name>
+
+    <dependencies>
+        <!-- Spring dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-portal-auto-fetch/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-portal-auto-fetch/src/main/assembly/plugin-assembly.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+	<id>plugin</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!-- Include the main plugin Jar file -->
+	<files>
+		<file>
+			<source>${project.build.directory}/${project.build.finalName}.jar</source>
+		</file>
+	</files>
+
+	<!-- Finally include plugin dependencies -->
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>lib</outputDirectory>
+			<useProjectArtifact>false</useProjectArtifact>
+		</dependencySet>
+	</dependencySets>
+</assembly>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-portal-auto-fetch/src/main/java/io/gravitee/rest/api/services/portal/autofetch/ScheduledPortalPageAutoFetchService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-portal-auto-fetch/src/main/java/io/gravitee/rest/api/services/portal/autofetch/ScheduledPortalPageAutoFetchService.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.portal.autofetch;
+
+import io.gravitee.apim.core.portal_page.use_case.AutoFetchPortalNavigationItemsUseCase;
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.api.cluster.ClusterManager;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+
+/**
+ * Re-synchronizes the portal navigation pages backed by an external source. Runs independently from the
+ * v1 {@code ScheduledAutoFetchService}, which fetches the v1 documentation pages: both have their own
+ * enablement flag, their own cron and their own scheduler thread.
+ */
+@CustomLog
+public class ScheduledPortalPageAutoFetchService extends AbstractService implements Runnable {
+
+    private final TaskScheduler scheduler;
+    private final String cronTrigger;
+    private final boolean enabled;
+    private final AutoFetchPortalNavigationItemsUseCase autoFetchPortalNavigationItemsUseCase;
+    private final ClusterManager clusterManager;
+    private final AtomicLong counter = new AtomicLong(0);
+
+    public ScheduledPortalPageAutoFetchService(
+        @Qualifier("portalAutoFetchTaskScheduler") TaskScheduler scheduler,
+        @Value("${services.portal_navigation_auto_fetch.cron:0 */5 * * * *}") String cronTrigger,
+        @Value("${services.portal_navigation_auto_fetch.enabled:true}") boolean enabled,
+        AutoFetchPortalNavigationItemsUseCase autoFetchPortalNavigationItemsUseCase,
+        ClusterManager clusterManager
+    ) {
+        this.scheduler = scheduler;
+        this.cronTrigger = cronTrigger;
+        this.enabled = enabled;
+        this.autoFetchPortalNavigationItemsUseCase = autoFetchPortalNavigationItemsUseCase;
+        this.clusterManager = clusterManager;
+    }
+
+    @Override
+    protected String name() {
+        return "Portal Page Auto Fetch Service";
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        if (!enabled) {
+            log.warn("Portal Page Auto Fetch service has been disabled");
+            return;
+        }
+        super.doStart();
+        try {
+            scheduler.schedule(this, new CronTrigger(cronTrigger));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                "Invalid cron expression [%s] in property 'services.portal_navigation_auto_fetch.cron'".formatted(cronTrigger),
+                e
+            );
+        }
+        log.info("Portal Page Auto Fetch service has been initialized with cron [{}]", cronTrigger);
+    }
+
+    /**
+     * Only the primary node runs the job. Without this guard every node of a cluster fetches the same
+     * pages on the same tick: N times the outbound calls to the remote sources, and concurrent writes
+     * on the same items where the whole item is persisted, so the last writer wins.
+     */
+    @Override
+    public void run() {
+        if (!clusterManager.self().primary()) {
+            log.debug("Portal page auto fetch is not the primary node, skipping execution");
+            return;
+        }
+        var run = counter.incrementAndGet();
+        log.debug("Portal page auto fetch #{} started at {}", run, Instant.now());
+        try {
+            var output = autoFetchPortalNavigationItemsUseCase.execute();
+            // Kept at debug when there was nothing to do: the job ticks every 5 minutes on every
+            // installation, including those that use no external source at all.
+            if (output.succeeded() + output.failed() > 0) {
+                log.info("Portal page auto fetch #{}: {} navigation page(s) fetched, {} failed", run, output.succeeded(), output.failed());
+            } else {
+                log.debug("Portal page auto fetch #{}: no navigation page was due", run);
+            }
+        } catch (Exception e) {
+            log.error("Portal page auto fetch #{} failed: no portal navigation page was fetched during this run", run, e);
+        }
+        log.debug("Portal page auto fetch #{} ended at {}", run, Instant.now());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-portal-auto-fetch/src/main/java/io/gravitee/rest/api/services/portal/autofetch/spring/PortalPageAutoFetchConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-portal-auto-fetch/src/main/java/io/gravitee/rest/api/services/portal/autofetch/spring/PortalPageAutoFetchConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.portal.autofetch.spring;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * Dedicated scheduler thread, so that a slow portal fetch never delays the v1 auto-fetch service.
+ */
+@Configuration
+public class PortalPageAutoFetchConfiguration {
+
+    @Bean
+    @Qualifier("portalAutoFetchTaskScheduler")
+    public TaskScheduler portalAutoFetchTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setThreadNamePrefix("portal-auto-fetch-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        return scheduler;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-portal-auto-fetch/src/main/resources/plugin.properties
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-portal-auto-fetch/src/main/resources/plugin.properties
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+id=portal-navigation-auto-fetch
+name=${project.name}
+version=${project.version}
+description=${project.description}
+class=io.gravitee.rest.api.services.portal.autofetch.ScheduledPortalPageAutoFetchService
+type=service

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-portal-auto-fetch/src/test/java/io/gravitee/rest/api/services/portal/autofetch/ScheduledPortalPageAutoFetchServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-portal-auto-fetch/src/test/java/io/gravitee/rest/api/services/portal/autofetch/ScheduledPortalPageAutoFetchServiceTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.portal.autofetch;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.portal_page.use_case.AutoFetchPortalNavigationItemsUseCase;
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.cluster.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ScheduledPortalPageAutoFetchServiceTest {
+
+    private static final String CRON = "0 */5 * * * *";
+
+    @Mock
+    private TaskScheduler scheduler;
+
+    @Mock
+    private AutoFetchPortalNavigationItemsUseCase useCase;
+
+    @Mock
+    private ClusterManager clusterManager;
+
+    private ScheduledPortalPageAutoFetchService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ScheduledPortalPageAutoFetchService(scheduler, CRON, true, useCase, clusterManager);
+    }
+
+    private void givenPrimaryNode(boolean primary) {
+        Member member = mock(Member.class);
+        when(member.primary()).thenReturn(primary);
+        when(clusterManager.self()).thenReturn(member);
+    }
+
+    @Test
+    void should_schedule_the_auto_fetch_when_enabled() throws Exception {
+        service.doStart();
+
+        verify(scheduler).schedule(eq(service), any(CronTrigger.class));
+    }
+
+    @Test
+    void should_not_schedule_anything_when_disabled() throws Exception {
+        service = new ScheduledPortalPageAutoFetchService(scheduler, CRON, false, useCase, clusterManager);
+
+        service.doStart();
+
+        verify(scheduler, never()).schedule(any(Runnable.class), any(CronTrigger.class));
+    }
+
+    @Test
+    void should_fail_to_start_when_the_configured_cron_is_invalid() {
+        service = new ScheduledPortalPageAutoFetchService(scheduler, "not-a-cron", true, useCase, clusterManager);
+
+        assertThatThrownBy(() -> service.doStart()).isInstanceOf(IllegalArgumentException.class);
+
+        verify(scheduler, never()).schedule(any(Runnable.class), any(CronTrigger.class));
+    }
+
+    @Test
+    void should_run_the_auto_fetch_of_portal_navigation_items() {
+        givenPrimaryNode(true);
+        when(useCase.execute()).thenReturn(new AutoFetchPortalNavigationItemsUseCase.Output(2, 1));
+
+        service.run();
+
+        verify(useCase, times(1)).execute();
+    }
+
+    @Test
+    void should_not_propagate_a_failure_of_the_whole_run() {
+        givenPrimaryNode(true);
+        when(useCase.execute()).thenThrow(new RuntimeException("DB connection failed"));
+
+        assertThatCode(() -> service.run()).doesNotThrowAnyException();
+
+        verify(useCase, times(1)).execute();
+    }
+
+    @Test
+    void should_skip_the_run_when_the_node_is_not_primary() {
+        givenPrimaryNode(false);
+
+        service.run();
+
+        verify(useCase, never()).execute();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
@@ -37,6 +37,7 @@
     <modules>
         <module>gravitee-apim-rest-api-services-audit</module>
         <module>gravitee-apim-rest-api-services-auto-fetch</module>
+        <module>gravitee-apim-rest-api-services-portal-auto-fetch</module>
         <module>gravitee-apim-rest-api-services-dictionary</module>
         <module>gravitee-apim-rest-api-services-dynamic-properties</module>
         <module>gravitee-apim-rest-api-services-events</module>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-88

## Description

Portal navigation pages backed by an external source are now re-fetched automatically on their own cron, without anyone hitting `_fetch`.

### How it works.

A dedicated service plugin (`portal-navigation-auto-fetch`) ticks on `services.portal_navigation_auto_fetch.cron` (`default 0 */5 * * * *, enabled: true`), loads every PAGE with `useAutoFetch = true` across all environments, and fetches those whose own fetchCron has elapsed. The service cron paces the whole job: a page cron finer than it is only honoured at that pace. In a cluster, only the primary node runs it.

Design point worth reviewing. The schedule is computed from a new `lastFetchAttemptAt`, not from `lastFetchedAt`. A failed fetch leaves `lastFetchedAt` untouched, so counting from it would make an unreachable source due on every tick and hammer it. `lastFetchAttemptAt` is stamped on every attempt, `lastFetchedAt` only on success. Both are read-only in the API; items stored before the field existed fall back to `lastFetchedAt`.

