### PR TITLE
feat(mapi): gamma reset password

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationConfigurationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationConfigurationResource.java
@@ -74,4 +74,9 @@ public class OrganizationConfigurationResource {
     public FlowsResource getFlowsResource() {
         return resourceContext.getResource(FlowsResource.class);
     }
+
+    @Path("password-policy")
+    public PasswordPolicyResource getPasswordPolicyResource() {
+        return resourceContext.getResource(PasswordPolicyResource.class);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/PasswordPolicyResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/PasswordPolicyResource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource.organization;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.PasswordPolicyEntity;
+import io.gravitee.rest.api.service.PasswordPolicyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag(name = "Configuration")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class PasswordPolicyResource extends AbstractResource {
+
+    @Autowired
+    private PasswordPolicyService passwordPolicyService;
+
+    @GET
+    @Operation(
+        summary = "Get the password policy",
+        description = "Returns the configured password policy for user registration and reset flows"
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Password policy",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PasswordPolicyEntity.class))
+    )
+    public PasswordPolicyEntity getPasswordPolicy() {
+        return passwordPolicyService.getPasswordPolicy();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UserResource.java
@@ -212,7 +212,7 @@ public class UserResource extends AbstractResource {
         description = "User must have the ORGANIZATION_USERS[UPDATE] permission to use this service"
     )
     @ApiResponse(responseCode = "204", description = "User's password reset")
-    @ApiResponse(responseCode = "400", description = "reset page URL must not be null")
+    @ApiResponse(responseCode = "400", description = "Unsupported reset target")
     @ApiResponse(responseCode = "404", description = "User not found")
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions(
@@ -220,8 +220,12 @@ public class UserResource extends AbstractResource {
         // if permission changes or a new one is added, please update io.gravitee.rest.api.service.impl.UserServiceImpl#canResetPassword
     )
     @Path("resetPassword")
-    public Response resetUserPassword() {
-        userService.resetPassword(GraviteeContext.getExecutionContext(), userId);
+    public Response resetUserPassword(
+        @Parameter(
+            description = "Optional reset page target. When set to `gamma`, the password reset email link targets the Gravitee Gamma console reset page. When omitted, the APIM Console reset page is used."
+        ) @QueryParam("resetTarget") String resetTarget
+    ) {
+        userService.resetPasswordWithTarget(GraviteeContext.getExecutionContext(), userId, resetTarget);
         return Response.noContent().build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/config/BasicSecurityConfigurerAdapter.java
@@ -321,6 +321,8 @@ public class BasicSecurityConfigurerAdapter implements SecureHeadersConfigurer {
             .permitAll()
             .requestMatchers(HttpMethod.GET, uriOrgPrefix + "/configuration/custom-user-fields")
             .permitAll()
+            .requestMatchers(HttpMethod.GET, uriOrgPrefix + "/configuration/password-policy")
+            .permitAll()
             .requestMatchers(uriOrgPrefix + "/configuration/**")
             .authenticated()
             // Search for users

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PasswordPolicyEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PasswordPolicyEntity.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordPolicyEntity {
+
+    private String description;
+    private String pattern;
+    private List<PasswordPolicyRuleEntity> rules;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PasswordPolicyRuleEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PasswordPolicyRuleEntity.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordPolicyRuleEntity {
+
+    private String id;
+    private String label;
+    private String pattern;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PasswordPolicyService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PasswordPolicyService.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+import io.gravitee.rest.api.model.PasswordPolicyEntity;
+
+public interface PasswordPolicyService {
+    PasswordPolicyEntity getPasswordPolicy();
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
@@ -82,6 +82,10 @@ public interface UserService {
 
     void resetPassword(ExecutionContext executionContext, String id);
 
+    void resetPassword(ExecutionContext executionContext, String id, String resetPageUrl);
+
+    void resetPasswordWithTarget(ExecutionContext executionContext, String id, String resetTarget);
+
     void updateServiceAccountStatus(ExecutionContext executionContext, String id, boolean serviceAccount);
 
     UserEntity resetPasswordFromSourceId(ExecutionContext executionContext, String sourceId, String resetPageUrl);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PasswordPolicyPatternParser.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PasswordPolicyPatternParser.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import io.gravitee.rest.api.model.PasswordPolicyRuleEntity;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Derives UI password requirement rules from {@code user.password.policy.pattern} in gravitee.yml.
+ */
+public class PasswordPolicyPatternParser {
+
+    private static final String POSITIVE_LOOKAHEAD_PREFIX = "(?=.*[";
+    private static final Pattern LENGTH_QUANTIFIER = Pattern.compile("\\.\\{(\\d+)(?:,(\\d+)?)?\\}\\$?");
+
+    public List<PasswordPolicyRuleEntity> parse(String policyPattern) {
+        if (policyPattern == null || policyPattern.isBlank()) {
+            return List.of();
+        }
+
+        List<PasswordPolicyRuleEntity> rules = new ArrayList<>();
+        Set<String> seenRuleIds = new LinkedHashSet<>();
+
+        Matcher lengthMatcher = LENGTH_QUANTIFIER.matcher(policyPattern);
+        if (lengthMatcher.find()) {
+            int minLength = Integer.parseInt(lengthMatcher.group(1));
+            String maxLengthGroup = lengthMatcher.group(2);
+            addRule(
+                rules,
+                seenRuleIds,
+                PasswordPolicyRuleEntity.builder()
+                    .id("minLength")
+                    .label("At least " + minLength + " characters")
+                    .pattern(String.format("^.{%d,}$", minLength))
+                    .build()
+            );
+            if (maxLengthGroup != null && !maxLengthGroup.isBlank()) {
+                int maxLength = Integer.parseInt(maxLengthGroup);
+                addRule(
+                    rules,
+                    seenRuleIds,
+                    PasswordPolicyRuleEntity.builder()
+                        .id("maxLength")
+                        .label("At most " + maxLength + " characters")
+                        .pattern(String.format("^.{0,%d}$", maxLength))
+                        .build()
+                );
+            }
+        }
+
+        for (String charClass : extractPositiveLookaheadCharClasses(policyPattern)) {
+            classifyLookahead(charClass).ifPresent(rule -> addRule(rules, seenRuleIds, rule));
+        }
+
+        if (policyPattern.contains("(?!.*(.)\\1{2,})")) {
+            addRule(
+                rules,
+                seenRuleIds,
+                PasswordPolicyRuleEntity.builder()
+                    .id("noConsecutive")
+                    .label("No more than 2 consecutive equal characters")
+                    .pattern("^(?!.*(.)\\1{2,}).+$")
+                    .build()
+            );
+        }
+
+        return List.copyOf(rules);
+    }
+
+    private static List<String> extractPositiveLookaheadCharClasses(String policyPattern) {
+        List<String> charClasses = new ArrayList<>();
+        int index = 0;
+
+        while ((index = policyPattern.indexOf(POSITIVE_LOOKAHEAD_PREFIX, index)) >= 0) {
+            int start = index + POSITIVE_LOOKAHEAD_PREFIX.length();
+            int end = findCharClassEnd(policyPattern, start);
+            if (end > start) {
+                charClasses.add(policyPattern.substring(start, end));
+                index = end + 1;
+            } else if (end >= 0) {
+                index = end + 1;
+            } else {
+                index += POSITIVE_LOOKAHEAD_PREFIX.length();
+            }
+        }
+
+        return charClasses;
+    }
+
+    private static int findCharClassEnd(String policyPattern, int start) {
+        for (int i = start; i < policyPattern.length(); i++) {
+            if (policyPattern.charAt(i) == '\\' && i + 1 < policyPattern.length()) {
+                i++;
+                continue;
+            }
+            if (policyPattern.charAt(i) == ']') {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static void addRule(List<PasswordPolicyRuleEntity> rules, Set<String> seenRuleIds, PasswordPolicyRuleEntity rule) {
+        if (seenRuleIds.add(rule.getId())) {
+            rules.add(rule);
+        }
+    }
+
+    private static java.util.Optional<PasswordPolicyRuleEntity> classifyLookahead(String charClass) {
+        if ("0-9".equals(charClass)) {
+            return java.util.Optional.of(
+                PasswordPolicyRuleEntity.builder().id("digit").label("Contains a number").pattern("[0-9]").build()
+            );
+        }
+        if ("A-Z".equals(charClass)) {
+            return java.util.Optional.of(
+                PasswordPolicyRuleEntity.builder().id("uppercase").label("Contains uppercase letter").pattern("[A-Z]").build()
+            );
+        }
+        if ("a-z".equals(charClass)) {
+            return java.util.Optional.of(
+                PasswordPolicyRuleEntity.builder().id("lowercase").label("Contains lowercase letter").pattern("[a-z]").build()
+            );
+        }
+        if (containsSpecialCharacter(charClass)) {
+            return java.util.Optional.of(
+                PasswordPolicyRuleEntity.builder()
+                    .id("special")
+                    .label("Contains a special character")
+                    .pattern("[" + charClass + "]")
+                    .build()
+            );
+        }
+        return java.util.Optional.empty();
+    }
+
+    private static boolean containsSpecialCharacter(String charClass) {
+        for (int i = 0; i < charClass.length(); i++) {
+            char current = charClass.charAt(i);
+            if (current == '\\' && i + 1 < charClass.length()) {
+                i++;
+                continue;
+            }
+            if (!Character.isLetterOrDigit(current) && current != '-') {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PasswordPolicyPatternParser.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PasswordPolicyPatternParser.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import io.gravitee.rest.api.model.PasswordPolicyRuleEntity;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Derives UI password requirement rules from {@code user.password.policy.pattern} in gravitee.yml.
+ */
+public class PasswordPolicyPatternParser {
+
+    private static final String POSITIVE_LOOKAHEAD_PREFIX = "(?=.*[";
+    private static final Pattern LENGTH_QUANTIFIER = Pattern.compile("\\.\\{(\\d+)(?:,(\\d+)?)?\\}\\$?");
+
+    public List<PasswordPolicyRuleEntity> parse(String policyPattern) {
+        if (policyPattern == null || policyPattern.isBlank()) {
+            return List.of();
+        }
+
+        List<PasswordPolicyRuleEntity> rules = new ArrayList<>();
+        Set<String> seenRuleIds = new LinkedHashSet<>();
+
+        Matcher lengthMatcher = LENGTH_QUANTIFIER.matcher(policyPattern);
+        if (lengthMatcher.find()) {
+            int minLength = Integer.parseInt(lengthMatcher.group(1));
+            addRule(
+                rules,
+                seenRuleIds,
+                PasswordPolicyRuleEntity.builder()
+                    .id("minLength")
+                    .label("At least " + minLength + " characters")
+                    .pattern(".{" + minLength + ",}")
+                    .build()
+            );
+        }
+
+        for (String charClass : extractPositiveLookaheadCharClasses(policyPattern)) {
+            classifyLookahead(charClass).ifPresent(rule -> addRule(rules, seenRuleIds, rule));
+        }
+
+        if (policyPattern.contains("(?!.*(.)\\1{2,})")) {
+            addRule(
+                rules,
+                seenRuleIds,
+                PasswordPolicyRuleEntity.builder()
+                    .id("noConsecutive")
+                    .label("No more than 2 consecutive equal characters")
+                    .pattern("^(?!.*(.)\\1{2,}).+$")
+                    .build()
+            );
+        }
+
+        return List.copyOf(rules);
+    }
+
+    private static List<String> extractPositiveLookaheadCharClasses(String policyPattern) {
+        List<String> charClasses = new ArrayList<>();
+        int index = 0;
+
+        while ((index = policyPattern.indexOf(POSITIVE_LOOKAHEAD_PREFIX, index)) >= 0) {
+            int start = index + POSITIVE_LOOKAHEAD_PREFIX.length();
+            int end = findCharClassEnd(policyPattern, start);
+            if (end > start) {
+                charClasses.add(policyPattern.substring(start, end));
+            }
+            index = end + 1;
+        }
+
+        return charClasses;
+    }
+
+    private static int findCharClassEnd(String policyPattern, int start) {
+        for (int i = start; i < policyPattern.length(); i++) {
+            if (policyPattern.charAt(i) == '\\' && i + 1 < policyPattern.length()) {
+                i++;
+                continue;
+            }
+            if (policyPattern.charAt(i) == ']') {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static void addRule(List<PasswordPolicyRuleEntity> rules, Set<String> seenRuleIds, PasswordPolicyRuleEntity rule) {
+        if (seenRuleIds.add(rule.getId())) {
+            rules.add(rule);
+        }
+    }
+
+    private static java.util.Optional<PasswordPolicyRuleEntity> classifyLookahead(String charClass) {
+        if ("0-9".equals(charClass)) {
+            return java.util.Optional.of(
+                PasswordPolicyRuleEntity.builder().id("digit").label("Contains a number").pattern("[0-9]").build()
+            );
+        }
+        if ("A-Z".equals(charClass)) {
+            return java.util.Optional.of(
+                PasswordPolicyRuleEntity.builder().id("uppercase").label("Contains uppercase letter").pattern("[A-Z]").build()
+            );
+        }
+        if ("a-z".equals(charClass)) {
+            return java.util.Optional.of(
+                PasswordPolicyRuleEntity.builder().id("lowercase").label("Contains lowercase letter").pattern("[a-z]").build()
+            );
+        }
+        if (containsSpecialCharacter(charClass)) {
+            return java.util.Optional.of(
+                PasswordPolicyRuleEntity.builder()
+                    .id("special")
+                    .label("Contains a special character")
+                    .pattern("[" + charClass + "]")
+                    .build()
+            );
+        }
+        return java.util.Optional.empty();
+    }
+
+    private static boolean containsSpecialCharacter(String charClass) {
+        for (int i = 0; i < charClass.length(); i++) {
+            char current = charClass.charAt(i);
+            if (current == '\\' && i + 1 < charClass.length()) {
+                i++;
+                continue;
+            }
+            if (!Character.isLetterOrDigit(current) && current != '-') {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PasswordPolicyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PasswordPolicyServiceImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import io.gravitee.rest.api.model.PasswordPolicyEntity;
+import io.gravitee.rest.api.model.PasswordPolicyRuleEntity;
+import io.gravitee.rest.api.service.PasswordPolicyService;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class PasswordPolicyServiceImpl implements PasswordPolicyService {
+
+    private final PasswordPolicyPatternParser patternParser = new PasswordPolicyPatternParser();
+
+    @Value("${user.password.policy.description:}")
+    private String passwordPolicyDescription;
+
+    @Value(
+        "${user.password.policy.pattern:^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!~<>.,;:_=?/*+\\-#\\\"'&§`£€%°()|\\[\\]$^@])(?!.*(.)\\1{2,}).{12,128}$}"
+    )
+    private String passwordPolicyPattern;
+
+    @Override
+    public PasswordPolicyEntity getPasswordPolicy() {
+        String pattern = passwordPolicyPattern == null ? null : passwordPolicyPattern.trim();
+        List<PasswordPolicyRuleEntity> rules = resolveRules(pattern);
+        return PasswordPolicyEntity.builder().description(resolveDescription(rules)).pattern(pattern).rules(rules).build();
+    }
+
+    private List<PasswordPolicyRuleEntity> resolveRules(String policyPattern) {
+        List<PasswordPolicyRuleEntity> rules = patternParser.parse(policyPattern);
+        if (rules.isEmpty() && StringUtils.hasText(policyPattern)) {
+            return List.of(buildFallbackRule(policyPattern));
+        }
+        return rules;
+    }
+
+    private static PasswordPolicyRuleEntity buildFallbackRule(String policyPattern) {
+        return PasswordPolicyRuleEntity.builder()
+            .id("policyPattern")
+            .label("Matches the configured password policy")
+            .pattern(policyPattern)
+            .build();
+    }
+
+    private String resolveDescription(List<PasswordPolicyRuleEntity> rules) {
+        if (StringUtils.hasText(passwordPolicyDescription)) {
+            return passwordPolicyDescription.trim();
+        }
+        if (rules.isEmpty()) {
+            return "";
+        }
+        return rules
+            .stream()
+            .map(PasswordPolicyRuleEntity::getLabel)
+            .collect(Collectors.joining(", ", "Password must meet the following requirements: ", "."));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PasswordPolicyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PasswordPolicyServiceImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import io.gravitee.rest.api.model.PasswordPolicyEntity;
+import io.gravitee.rest.api.service.PasswordPolicyService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class PasswordPolicyServiceImpl implements PasswordPolicyService {
+
+    private static final String DEFAULT_DESCRIPTION =
+        "Password must be at least 12 characters long, contain at least one digit, one upper case letter, one lower case letter, one special character, and no more than 2 consecutive equal characters.";
+
+    private final PasswordPolicyPatternParser patternParser = new PasswordPolicyPatternParser();
+
+    @Value("${user.password.policy.description:}")
+    private String passwordPolicyDescription;
+
+    @Value(
+        "${user.password.policy.pattern:^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!~<>.,;:_=?/*+\\-#\\\"'&§`£€%°()|\\[\\]$^@])(?!.*(.)\\1{2,}).{12,128}$}"
+    )
+    private String passwordPolicyPattern;
+
+    @Override
+    public PasswordPolicyEntity getPasswordPolicy() {
+        return PasswordPolicyEntity.builder()
+            .description(StringUtils.hasText(passwordPolicyDescription) ? passwordPolicyDescription.trim() : DEFAULT_DESCRIPTION)
+            .pattern(passwordPolicyPattern)
+            .rules(patternParser.parse(passwordPolicyPattern))
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -29,6 +29,7 @@ import static io.gravitee.rest.api.service.common.JWTHelper.ACTION.USER_CREATION
 import static io.gravitee.rest.api.service.common.JWTHelper.ACTION.USER_REGISTRATION;
 import static io.gravitee.rest.api.service.common.JWTHelper.DefaultValues.DEFAULT_JWT_EMAIL_REGISTRATION_EXPIRE_AFTER;
 import static io.gravitee.rest.api.service.common.JWTHelper.DefaultValues.DEFAULT_JWT_ISSUER;
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.GAMMA_RESET_PASSWORD_PATH;
 import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.REGISTRATION_PATH;
 import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.RESET_PASSWORD_PATH;
 import static java.util.Collections.emptyList;
@@ -45,6 +46,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.ReadContext;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.apim.core.user.domain_service.AssignUserDefaultRolesDomainService;
 import io.gravitee.common.data.domain.MetadataPage;
@@ -1399,7 +1401,38 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
 
     @Override
     public void resetPassword(ExecutionContext executionContext, final String id) {
-        this.resetPassword(executionContext, id, null);
+        resetPasswordWithTarget(executionContext, id, null);
+    }
+
+    @Override
+    public void resetPassword(ExecutionContext executionContext, final String id, final String resetPageUrl) {
+        if (resetPageUrl != null && !resetPageUrl.isBlank()) {
+            UrlSanitizerUtils.checkAllowed(resetPageUrl, portalWhitelist, true);
+        }
+        doResetPassword(executionContext, id, resetPageUrl);
+    }
+
+    @Override
+    public void resetPasswordWithTarget(ExecutionContext executionContext, final String id, final String resetTarget) {
+        if (resetTarget == null || resetTarget.isBlank()) {
+            resetPassword(executionContext, id, null);
+            return;
+        }
+
+        if ("gamma".equalsIgnoreCase(resetTarget.trim())) {
+            doResetPassword(executionContext, id, buildGammaResetPasswordPageUrl(executionContext.getOrganizationId()));
+            return;
+        }
+
+        throw new ValidationDomainException("Unsupported password reset target: " + resetTarget);
+    }
+
+    private String buildGammaResetPasswordPageUrl(final String organizationId) {
+        String gammaUrl = installationAccessQueryService.getGammaUrl(organizationId);
+        if (gammaUrl.endsWith("/")) {
+            gammaUrl = gammaUrl.substring(0, gammaUrl.length() - 1);
+        }
+        return gammaUrl + GAMMA_RESET_PASSWORD_PATH;
     }
 
     @Override
@@ -1428,11 +1461,9 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             throw new UserNotActiveException(sourceId);
         }
 
-        UrlSanitizerUtils.checkAllowed(resetPageUrl, portalWhitelist, true);
-
         UserEntity foundUser = this.findBySource(executionContext.getOrganizationId(), IDP_SOURCE_GRAVITEE, sourceId, false);
         if ("ACTIVE".equals(foundUser.getStatus())) {
-            this.resetPassword(executionContext, foundUser.getId(), resetPageUrl);
+            resetPassword(executionContext, foundUser.getId(), resetPageUrl);
             return foundUser;
         } else {
             throw new UserNotActiveException(foundUser.getSourceId());
@@ -1443,7 +1474,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         return IDP_SOURCE_GRAVITEE.equals(user.getSource());
     }
 
-    private void resetPassword(ExecutionContext executionContext, final String id, final String resetPageUrl) {
+    private void doResetPassword(ExecutionContext executionContext, final String id, final String resetPageUrl) {
         try {
             log.debug("Resetting password of user id {}", id);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -29,6 +29,7 @@ import static io.gravitee.rest.api.service.common.JWTHelper.ACTION.USER_CREATION
 import static io.gravitee.rest.api.service.common.JWTHelper.ACTION.USER_REGISTRATION;
 import static io.gravitee.rest.api.service.common.JWTHelper.DefaultValues.DEFAULT_JWT_EMAIL_REGISTRATION_EXPIRE_AFTER;
 import static io.gravitee.rest.api.service.common.JWTHelper.DefaultValues.DEFAULT_JWT_ISSUER;
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.GAMMA_RESET_PASSWORD_PATH;
 import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.REGISTRATION_PATH;
 import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.RESET_PASSWORD_PATH;
 import static java.util.Collections.emptyList;
@@ -45,6 +46,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.ReadContext;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.apim.core.user.domain_service.AssignUserDefaultRolesDomainService;
 import io.gravitee.common.data.domain.MetadataPage;
@@ -1399,7 +1401,41 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
 
     @Override
     public void resetPassword(ExecutionContext executionContext, final String id) {
-        this.resetPassword(executionContext, id, null);
+        resetPasswordWithTarget(executionContext, id, null);
+    }
+
+    @Override
+    public void resetPassword(ExecutionContext executionContext, final String id, final String resetPageUrl) {
+        if (resetPageUrl != null && !resetPageUrl.isBlank()) {
+            UrlSanitizerUtils.checkAllowed(resetPageUrl, portalWhitelist, true);
+        }
+        doResetPassword(executionContext, id, resetPageUrl);
+    }
+
+    @Override
+    public void resetPasswordWithTarget(ExecutionContext executionContext, final String id, final String resetTarget) {
+        if (resetTarget == null || resetTarget.isBlank()) {
+            resetPassword(executionContext, id, null);
+            return;
+        }
+
+        if ("gamma".equalsIgnoreCase(resetTarget.trim())) {
+            doResetPassword(executionContext, id, buildGammaResetPasswordPageUrl(executionContext.getOrganizationId()));
+            return;
+        }
+
+        throw new ValidationDomainException("Unsupported password reset target: " + resetTarget);
+    }
+
+    private String buildGammaResetPasswordPageUrl(final String organizationId) {
+        String gammaUrl = installationAccessQueryService.getGammaUrl(organizationId);
+        if (gammaUrl == null || gammaUrl.isBlank()) {
+            throw new ValidationDomainException("Gamma URL is not configured for organization: " + organizationId);
+        }
+        if (gammaUrl.endsWith("/")) {
+            gammaUrl = gammaUrl.substring(0, gammaUrl.length() - 1);
+        }
+        return gammaUrl + GAMMA_RESET_PASSWORD_PATH;
     }
 
     @Override
@@ -1428,11 +1464,9 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             throw new UserNotActiveException(sourceId);
         }
 
-        UrlSanitizerUtils.checkAllowed(resetPageUrl, portalWhitelist, true);
-
         UserEntity foundUser = this.findBySource(executionContext.getOrganizationId(), IDP_SOURCE_GRAVITEE, sourceId, false);
         if ("ACTIVE".equals(foundUser.getStatus())) {
-            this.resetPassword(executionContext, foundUser.getId(), resetPageUrl);
+            resetPassword(executionContext, foundUser.getId(), resetPageUrl);
             return foundUser;
         } else {
             throw new UserNotActiveException(foundUser.getSourceId());
@@ -1443,7 +1477,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         return IDP_SOURCE_GRAVITEE.equals(user.getSource());
     }
 
-    private void resetPassword(ExecutionContext executionContext, final String id, final String resetPageUrl) {
+    private void doResetPassword(ExecutionContext executionContext, final String id, final String resetPageUrl) {
         try {
             log.debug("Resetting password of user id {}", id);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/NotificationParamsBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/NotificationParamsBuilder.java
@@ -49,6 +49,7 @@ public class NotificationParamsBuilder {
     public static final String PARAM_EXPIRATION_DELAY = "expirationDelay";
     public static final String REGISTRATION_PATH = "/#!/_sign-up-confirm/";
     public static final String RESET_PASSWORD_PATH = "/#!/_reset-password/";
+    public static final String GAMMA_RESET_PASSWORD_PATH = "/reset-password";
     private final Map<String, Object> params = new HashMap<>();
 
     public Map<String, Object> build() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PasswordPolicyPatternParserTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PasswordPolicyPatternParserTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PasswordPolicyPatternParserTest {
+
+    private static final String DEFAULT_PATTERN =
+        "^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!~<>.,;:_=?/*+\\-#\\\"'&§`£€%°()|\\[\\]$^@])(?!.*(.)\\1{2,}).{12,128}$";
+
+    private PasswordPolicyPatternParser parser;
+
+    @BeforeEach
+    void setUp() {
+        parser = new PasswordPolicyPatternParser();
+    }
+
+    @Test
+    void should_parse_default_gravitee_pattern() {
+        var rules = parser.parse(DEFAULT_PATTERN);
+
+        assertThat(rules).extracting("id").containsExactly("minLength", "digit", "uppercase", "lowercase", "special", "noConsecutive");
+        assertThat(rules.getFirst().getLabel()).isEqualTo("At least 12 characters");
+        assertThat(rules.getFirst().getPattern()).isEqualTo(".{12,}");
+        assertThat(rules).allMatch(rule -> rule.getPattern() != null && !rule.getPattern().isBlank());
+    }
+
+    @Test
+    void should_parse_custom_minimum_length() {
+        var rules = parser.parse("^(?=.*[0-9]).{8,64}$");
+
+        assertThat(rules).extracting("id").containsExactly("minLength", "digit");
+        assertThat(rules.getFirst().getLabel()).isEqualTo("At least 8 characters");
+    }
+
+    @Test
+    void should_return_empty_rules_when_pattern_is_blank() {
+        assertThat(parser.parse("")).isEmpty();
+        assertThat(parser.parse(null)).isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PasswordPolicyPatternParserTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PasswordPolicyPatternParserTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PasswordPolicyPatternParserTest {
+
+    private static final String DEFAULT_PATTERN =
+        "^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!~<>.,;:_=?/*+\\-#\\\"'&§`£€%°()|\\[\\]$^@])(?!.*(.)\\1{2,}).{12,128}$";
+
+    private PasswordPolicyPatternParser parser;
+
+    @BeforeEach
+    void setUp() {
+        parser = new PasswordPolicyPatternParser();
+    }
+
+    @Test
+    void should_parse_default_gravitee_pattern() {
+        var rules = parser.parse(DEFAULT_PATTERN);
+
+        assertThat(rules)
+            .extracting("id")
+            .containsExactly("minLength", "maxLength", "digit", "uppercase", "lowercase", "special", "noConsecutive");
+        assertThat(rules.getFirst().getLabel()).isEqualTo("At least 12 characters");
+        assertThat(rules.getFirst().getPattern()).isEqualTo("^.{12,}$");
+        assertThat(rules.get(1).getLabel()).isEqualTo("At most 128 characters");
+        assertThat(rules.get(1).getPattern()).isEqualTo("^.{0,128}$");
+        assertThat(rules).allMatch(rule -> rule.getPattern() != null && !rule.getPattern().isBlank());
+    }
+
+    @Test
+    void should_parse_custom_minimum_length() {
+        var rules = parser.parse("^(?=.*[0-9]).{8,64}$");
+
+        assertThat(rules).extracting("id").containsExactly("minLength", "maxLength", "digit");
+        assertThat(rules.getFirst().getLabel()).isEqualTo("At least 8 characters");
+        assertThat(rules.getFirst().getPattern()).isEqualTo("^.{8,}$");
+        assertThat(rules.get(1).getLabel()).isEqualTo("At most 64 characters");
+        assertThat(rules.get(1).getPattern()).isEqualTo("^.{0,64}$");
+    }
+
+    @Test
+    void should_reject_passwords_not_meeting_length_constraints() {
+        var rules = parser.parse("^(?=.*[0-9]).{8,64}$");
+        var minLengthRule = rules
+            .stream()
+            .filter(rule -> "minLength".equals(rule.getId()))
+            .findFirst()
+            .orElseThrow();
+        var maxLengthRule = rules
+            .stream()
+            .filter(rule -> "maxLength".equals(rule.getId()))
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(Pattern.compile(minLengthRule.getPattern()).matcher("a".repeat(7)).matches()).isFalse();
+        assertThat(Pattern.compile(minLengthRule.getPattern()).matcher("a".repeat(8)).matches()).isTrue();
+
+        assertThat(Pattern.compile(maxLengthRule.getPattern()).matcher("a".repeat(65)).matches()).isFalse();
+        assertThat(Pattern.compile(maxLengthRule.getPattern()).matcher("a".repeat(64)).matches()).isTrue();
+    }
+
+    @Test
+    void should_parse_minimum_length_without_maximum() {
+        var rules = parser.parse("^(?=.*[0-9]).{12,}$");
+
+        assertThat(rules).extracting("id").containsExactly("minLength", "digit");
+        assertThat(rules.getFirst().getPattern()).isEqualTo("^.{12,}$");
+    }
+
+    @Test
+    void should_parse_exact_length_as_min_and_max_rules() {
+        var rules = parser.parse("^(?=.*[0-9]).{8,8}$");
+
+        assertThat(rules).extracting("id").containsExactly("minLength", "maxLength", "digit");
+
+        Pattern minLength = Pattern.compile(rules.get(0).getPattern());
+        Pattern maxLength = Pattern.compile(rules.get(1).getPattern());
+
+        assertThat(minLength.matcher("1234567").matches()).isFalse();
+        assertThat(minLength.matcher("12345678").matches()).isTrue();
+        assertThat(minLength.matcher("123456789").matches()).isTrue();
+
+        assertThat(maxLength.matcher("1234567").matches()).isTrue();
+        assertThat(maxLength.matcher("12345678").matches()).isTrue();
+        assertThat(maxLength.matcher("123456789").matches()).isFalse();
+
+        assertThat(allRulesSatisfied("12345678", rules)).isTrue();
+        assertThat(allRulesSatisfied("1234567", rules)).isFalse();
+        assertThat(allRulesSatisfied("123456789", rules)).isFalse();
+    }
+
+    @Test
+    void should_validate_default_pattern_password_against_decomposed_rules() {
+        var rules = parser.parse(DEFAULT_PATTERN);
+        String validPassword = "LongEnough1!abc";
+
+        assertThat(allRulesSatisfied(validPassword, rules)).isTrue();
+        assertThat(Pattern.compile(DEFAULT_PATTERN).matcher(validPassword).matches()).isTrue();
+
+        assertThat(allRulesSatisfied("Short1!a", rules)).isFalse();
+        assertThat(allRulesSatisfied("longenough1!abc", rules)).isFalse();
+        assertThat(allRulesSatisfied("LongEnough1!aaa", rules)).isFalse();
+
+        String maxLengthPassword = buildPasswordWithoutTripleConsecutive(validPassword, 128);
+        assertThat(maxLengthPassword).hasSize(128);
+        assertThat(allRulesSatisfied(maxLengthPassword, rules)).isTrue();
+        assertThat(Pattern.compile(DEFAULT_PATTERN).matcher(maxLengthPassword).matches()).isTrue();
+
+        String tooLongPassword = buildPasswordWithoutTripleConsecutive(validPassword, 129);
+        assertThat(tooLongPassword).hasSize(129);
+        assertThat(allRulesSatisfied(tooLongPassword, rules)).isFalse();
+        assertThat(Pattern.compile(DEFAULT_PATTERN).matcher(tooLongPassword).matches()).isFalse();
+    }
+
+    @Test
+    void should_not_emit_duplicate_rule_ids() {
+        var rules = parser.parse(DEFAULT_PATTERN);
+
+        assertThat(
+            rules
+                .stream()
+                .map(rule -> rule.getId())
+                .distinct()
+        ).hasSameSizeAs(rules);
+    }
+
+    @Test
+    void should_ignore_unrecognized_lookaheads_without_length_quantifier() {
+        assertThat(parser.parse("(?=.*[unclosed")).isEmpty();
+        assertThat(parser.parse("^(?=.*\\d).+$")).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_rules_when_pattern_is_blank() {
+        assertThat(parser.parse("")).isEmpty();
+        assertThat(parser.parse(null)).isEmpty();
+    }
+
+    @Test
+    void should_not_hang_on_unbalanced_char_class() {
+        assertThat(parser.parse("^(?=.*[0-9])(?=.*[unclosed")).extracting("id").containsExactly("digit");
+        assertThat(parser.parse("(?=.*[unclosed")).isEmpty();
+    }
+
+    private static String buildPasswordWithoutTripleConsecutive(String prefix, int targetLength) {
+        StringBuilder password = new StringBuilder(prefix);
+        char[] alternates = { 'y', 'z' };
+        int index = 0;
+        while (password.length() < targetLength) {
+            password.append(alternates[index % alternates.length]);
+            index++;
+        }
+        return password.toString();
+    }
+
+    private static boolean allRulesSatisfied(String password, java.util.List<io.gravitee.rest.api.model.PasswordPolicyRuleEntity> rules) {
+        return rules.stream().allMatch(rule -> Pattern.compile(rule.getPattern()).matcher(password).find());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PasswordPolicyServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PasswordPolicyServiceImplTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.model.PasswordPolicyEntity;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class PasswordPolicyServiceImplTest {
+
+    private PasswordPolicyServiceImpl passwordPolicyService;
+
+    @BeforeEach
+    void setUp() {
+        passwordPolicyService = new PasswordPolicyServiceImpl();
+    }
+
+    @Test
+    void should_return_rules_parsed_from_configured_pattern() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "   ");
+        ReflectionTestUtils.setField(
+            passwordPolicyService,
+            "passwordPolicyPattern",
+            "^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!@#$])(?!.*(.)\\1{2,}).{10,64}$"
+        );
+
+        PasswordPolicyEntity policy = passwordPolicyService.getPasswordPolicy();
+
+        assertThat(policy.getDescription()).contains("At least 10 characters");
+        assertThat(policy.getDescription()).contains("At most 64 characters");
+        assertThat(policy.getDescription()).doesNotContain("At least 12 characters");
+        assertThat(policy.getPattern()).contains(".{10,64}");
+        assertThat(policy.getRules())
+            .extracting("id")
+            .containsExactly("minLength", "maxLength", "digit", "uppercase", "lowercase", "special", "noConsecutive");
+        assertThat(policy.getRules().getFirst().getLabel()).isEqualTo("At least 10 characters");
+    }
+
+    @Test
+    void should_fallback_to_full_pattern_when_parser_yields_no_rules() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "   ");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", "^\\d{8,}$");
+
+        PasswordPolicyEntity policy = passwordPolicyService.getPasswordPolicy();
+
+        assertThat(policy.getRules()).hasSize(1);
+        assertThat(policy.getRules().getFirst().getId()).isEqualTo("policyPattern");
+        assertThat(policy.getRules().getFirst().getPattern()).isEqualTo("^\\d{8,}$");
+        assertThat(policy.getDescription()).contains("Matches the configured password policy");
+    }
+
+    @Test
+    void should_fallback_to_full_pattern_for_non_standard_pattern() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "   ");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", "^\\w{8,}$");
+
+        PasswordPolicyEntity policy = passwordPolicyService.getPasswordPolicy();
+
+        assertThat(policy.getRules()).hasSize(1);
+        assertThat(policy.getRules().getFirst().getId()).isEqualTo("policyPattern");
+        assertThat(policy.getRules().getFirst().getPattern()).isEqualTo("^\\w{8,}$");
+
+        Pattern compiledPattern = Pattern.compile(policy.getRules().getFirst().getPattern());
+        assertThat(compiledPattern.matcher("Password1").matches()).isTrue();
+        assertThat(compiledPattern.matcher("short").matches()).isFalse();
+    }
+
+    @Test
+    void should_return_empty_rules_for_whitespace_only_pattern() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "   ");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", "   ");
+
+        PasswordPolicyEntity policy = passwordPolicyService.getPasswordPolicy();
+
+        assertThat(policy.getPattern()).isEmpty();
+        assertThat(policy.getRules()).isEmpty();
+        assertThat(policy.getDescription()).isEmpty();
+    }
+
+    @Test
+    void should_trim_pattern_before_parsing() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "   ");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", "  ^(?=.*[0-9]).{8,64}$  ");
+
+        PasswordPolicyEntity policy = passwordPolicyService.getPasswordPolicy();
+
+        assertThat(policy.getPattern()).isEqualTo("^(?=.*[0-9]).{8,64}$");
+        assertThat(policy.getRules()).extracting("id").containsExactly("minLength", "maxLength", "digit");
+    }
+
+    @Test
+    void should_not_fallback_when_parser_returns_partial_rules() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "   ");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", "^(?=.*[0-9])(?=.*[unclosed).{8,64}$");
+
+        PasswordPolicyEntity policy = passwordPolicyService.getPasswordPolicy();
+
+        assertThat(policy.getRules()).extracting("id").containsExactly("minLength", "maxLength", "digit");
+    }
+
+    @Test
+    void should_return_configured_description_when_present() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "Custom password policy description.");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", "^(?=.*[0-9]).{8,64}$");
+
+        PasswordPolicyEntity policy = passwordPolicyService.getPasswordPolicy();
+
+        assertThat(policy.getDescription()).isEqualTo("Custom password policy description.");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PasswordPolicyServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PasswordPolicyServiceImplTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.model.PasswordPolicyEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class PasswordPolicyServiceImplTest {
+
+    private PasswordPolicyServiceImpl passwordPolicyService;
+
+    @BeforeEach
+    void setUp() {
+        passwordPolicyService = new PasswordPolicyServiceImpl();
+    }
+
+    @Test
+    void should_return_rules_parsed_from_configured_pattern() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "   ");
+        ReflectionTestUtils.setField(
+            passwordPolicyService,
+            "passwordPolicyPattern",
+            "^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!@#$])(?!.*(.)\\1{2,}).{10,64}$"
+        );
+
+        PasswordPolicyEntity policy = passwordPolicyService.getPasswordPolicy();
+
+        assertThat(policy.getDescription()).contains("at least 12 characters");
+        assertThat(policy.getPattern()).contains(".{10,64}");
+        assertThat(policy.getRules())
+            .extracting("id")
+            .containsExactly("minLength", "digit", "uppercase", "lowercase", "special", "noConsecutive");
+        assertThat(policy.getRules().getFirst().getLabel()).isEqualTo("At least 10 characters");
+    }
+
+    @Test
+    void should_return_configured_description_when_present() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "Custom password policy description.");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", "^(?=.*[0-9]).{8,64}$");
+
+        PasswordPolicyEntity policy = passwordPolicyService.getPasswordPolicy();
+
+        assertThat(policy.getDescription()).isEqualTo("Custom password policy description.");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceResetPasswordTargetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceResetPasswordTargetTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static io.gravitee.rest.api.service.common.JWTHelper.DefaultValues.DEFAULT_JWT_EMAIL_REGISTRATION_EXPIRE_AFTER;
+import static io.gravitee.rest.api.service.common.JWTHelper.DefaultValues.DEFAULT_JWT_ISSUER;
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.PARAM_REGISTRATION_URL;
+import static java.util.Optional.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.common.data.domain.MetadataPage;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.UserRepository;
+import io.gravitee.repository.management.model.User;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EmailService;
+import io.gravitee.rest.api.service.NotifierService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.converter.UserConverter;
+import io.gravitee.rest.api.service.notification.PortalHook;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceResetPasswordTargetTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("DEFAULT", "DEFAULT");
+    private static final String JWT_SECRET = "test-jwt-secret-key-min-32-characters";
+
+    private UserServiceImpl userService;
+
+    @Mock
+    private InstallationAccessQueryService installationAccessQueryService;
+
+    @Mock
+    private ConfigurableEnvironment environment;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    private NotifierService notifierService;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private UserConverter userConverter;
+
+    @Mock
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        userService = new UserServiceImpl();
+        ReflectionTestUtils.setField(userService, "installationAccessQueryService", installationAccessQueryService);
+        ReflectionTestUtils.setField(userService, "environment", environment);
+        ReflectionTestUtils.setField(userService, "userRepository", userRepository);
+        ReflectionTestUtils.setField(userService, "auditService", auditService);
+        ReflectionTestUtils.setField(userService, "notifierService", notifierService);
+        ReflectionTestUtils.setField(userService, "emailService", emailService);
+        ReflectionTestUtils.setField(userService, "userConverter", userConverter);
+    }
+
+    @Test
+    void should_build_gamma_reset_password_page_url_from_installation_config() {
+        when(installationAccessQueryService.getGammaUrl("DEFAULT")).thenReturn("http://gamma.example.com/");
+
+        String resetPageUrl = ReflectionTestUtils.invokeMethod(userService, "buildGammaResetPasswordPageUrl", "DEFAULT");
+
+        assertThat(resetPageUrl).isEqualTo("http://gamma.example.com/reset-password");
+    }
+
+    @Test
+    void should_reject_reset_when_gamma_url_is_not_configured() {
+        when(installationAccessQueryService.getGammaUrl("DEFAULT")).thenReturn(null);
+
+        assertThatThrownBy(() -> userService.resetPasswordWithTarget(EXECUTION_CONTEXT, "user-id", "gamma"))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("Gamma URL is not configured");
+    }
+
+    @Test
+    void should_reject_unknown_reset_target() {
+        assertThatThrownBy(() -> userService.resetPasswordWithTarget(EXECUTION_CONTEXT, "user-id", "portal"))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("portal");
+    }
+
+    @Test
+    void should_reset_password_with_gamma_target_and_build_registration_url() throws TechnicalException {
+        when(installationAccessQueryService.getGammaUrl("DEFAULT")).thenReturn("http://gamma.example.com");
+        when(environment.getProperty("jwt.secret")).thenReturn(JWT_SECRET);
+        when(
+            environment.getProperty("user.creation.token.expire-after", Integer.class, DEFAULT_JWT_EMAIL_REGISTRATION_EXPIRE_AFTER)
+        ).thenReturn(3600);
+        when(environment.getProperty("jwt.issuer", DEFAULT_JWT_ISSUER)).thenReturn(DEFAULT_JWT_ISSUER);
+        when(user.getId()).thenReturn("user-1");
+        when(user.getSource()).thenReturn("gravitee");
+        when(user.getOrganizationId()).thenReturn("DEFAULT");
+        when(user.getEmail()).thenReturn("user@example.com");
+        when(user.getIsServiceAccount()).thenReturn(false);
+        when(userRepository.findById("user-1")).thenReturn(of(user));
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId("user-1");
+        userEntity.setEmail("user@example.com");
+        when(userConverter.toUserEntity(eq(user), any())).thenReturn(userEntity);
+        when(auditService.search(eq(EXECUTION_CONTEXT), any())).thenReturn(mock(MetadataPage.class));
+
+        userService.resetPasswordWithTarget(EXECUTION_CONTEXT, "user-1", "gamma");
+
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notifierService).trigger(eq(EXECUTION_CONTEXT), eq(PortalHook.PASSWORD_RESET), paramsCaptor.capture());
+
+        String registrationUrl = (String) paramsCaptor.getValue().get(PARAM_REGISTRATION_URL);
+        assertThat(registrationUrl).startsWith("http://gamma.example.com/reset-password/");
+        assertThat(registrationUrl.substring("http://gamma.example.com/reset-password/".length())).isNotBlank();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceResetPasswordTargetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceResetPasswordTargetTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceResetPasswordTargetTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("DEFAULT", "DEFAULT");
+
+    private UserServiceImpl userService;
+
+    @Mock
+    private InstallationAccessQueryService installationAccessQueryService;
+
+    @BeforeEach
+    void setUp() {
+        userService = new UserServiceImpl();
+        ReflectionTestUtils.setField(userService, "installationAccessQueryService", installationAccessQueryService);
+    }
+
+    @Test
+    void should_build_gamma_reset_password_page_url_from_installation_config() {
+        when(installationAccessQueryService.getGammaUrl("DEFAULT")).thenReturn("http://gamma.example.com/");
+
+        String resetPageUrl = ReflectionTestUtils.invokeMethod(userService, "buildGammaResetPasswordPageUrl", "DEFAULT");
+
+        assertThat(resetPageUrl).isEqualTo("http://gamma.example.com/reset-password");
+    }
+
+    @Test
+    void should_reject_unknown_reset_target() {
+        assertThatThrownBy(() -> userService.resetPasswordWithTarget(EXECUTION_CONTEXT, "user-id", "portal"))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("portal");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-87

## Description
Adds backward-compatible Management API support for the Gamma password reset flow. Classic console behavior is unchanged when resetTarget is omitted.

**Changes**
Password policy endpoint — GET /management/organizations/{orgId}/configuration/password-policy
Returns description from user.password.policy.description in gravitee.yml
Returns pattern and a structured rules[] array parsed from user.password.policy.pattern
Public (unauthenticated) access, same pattern as other registration config endpoints
Admin reset email target — POST /management/organizations/{orgId}/users/{userId}/resetPassword?resetTarget=gamma
Optional resetTarget query parameter (replaces request-body entity)
When resetTarget=gamma, password reset emails link to the Gamma console reset page (/reset-password/:token)
When omitted, existing classic APIM Console reset URL is used (no breaking change)
Unknown resetTarget values return HTTP 400 via ValidationDomainException
Service layer — UserServiceImpl.resetPasswordWithTarget() builds the Gamma reset URL from trusted installation settings
Existing guards unchanged — UserNotInternallyManagedException for external IDP users, ServiceAccountNotManageableException for service accounts, PASSWORD_RESET audit event, email notification

https://github.com/user-attachments/assets/6308368e-52c6-4eb9-947f-d05b8518b7bc
