### PR TITLE
feat(gamma): gamma reset password

### DIFF
--- a/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/PasswordRequirements.tsx
+++ b/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/PasswordRequirements.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cn } from '@gravitee/graphene-core';
+import { CheckIcon } from '@gravitee/graphene-core/icons';
+
+import type { PasswordPolicyRule } from './types';
+import { evaluatePasswordPolicyRule, resolvePasswordStrengthLabel, resolvePasswordStrengthLevel } from './passwordPolicyRules';
+
+interface PasswordRequirementsProps {
+    readonly rules: PasswordPolicyRule[];
+    readonly password?: string;
+    readonly showStrengthMeter?: boolean;
+    readonly className?: string;
+}
+
+const STRENGTH_BAR_CLASS: Record<ReturnType<typeof resolvePasswordStrengthLevel>, string> = {
+    weak: 'bg-destructive',
+    fair: 'bg-orange-500',
+    good: 'bg-lime-500',
+    strong: 'bg-green-600',
+};
+
+const STRENGTH_TEXT_CLASS: Record<ReturnType<typeof resolvePasswordStrengthLevel>, string> = {
+    weak: 'text-destructive',
+    fair: 'text-orange-500',
+    good: 'text-lime-600',
+    strong: 'text-green-700',
+};
+
+const STRENGTH_FILLED_BARS: Record<ReturnType<typeof resolvePasswordStrengthLevel>, number> = {
+    weak: 1,
+    fair: 2,
+    good: 3,
+    strong: 4,
+};
+
+export function PasswordRequirements({ rules, password = '', showStrengthMeter = false, className }: PasswordRequirementsProps) {
+    const strengthLevel = resolvePasswordStrengthLevel(password, rules);
+    const strengthLabel = resolvePasswordStrengthLabel(strengthLevel);
+    const filledBars = showStrengthMeter ? STRENGTH_FILLED_BARS[strengthLevel] : 0;
+
+    return (
+        <div className={cn('space-y-3', className)}>
+            {showStrengthMeter && password ? (
+                <div className="space-y-1">
+                    <div className="flex gap-1" aria-hidden>
+                        {Array.from({ length: 4 }, (_, index) => (
+                            <span
+                                key={index}
+                                className={cn(
+                                    'h-1.5 flex-1 rounded-full bg-muted',
+                                    index < filledBars && STRENGTH_BAR_CLASS[strengthLevel],
+                                )}
+                            />
+                        ))}
+                    </div>
+                    <p className={cn('text-sm font-medium', STRENGTH_TEXT_CLASS[strengthLevel])}>{strengthLabel}</p>
+                </div>
+            ) : null}
+
+            <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Requirements</p>
+                <ul className="space-y-1.5">
+                    {rules.map(rule => {
+                        const satisfied = password ? evaluatePasswordPolicyRule(rule, password) : false;
+                        return (
+                            <li key={rule.id} className="flex items-start gap-2 text-sm">
+                                <span
+                                    className={cn(
+                                        'mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border',
+                                        satisfied ? 'border-green-600 bg-green-600 text-white' : 'border-muted-foreground/40',
+                                    )}
+                                    aria-hidden
+                                >
+                                    {satisfied ? <CheckIcon className="size-3" /> : null}
+                                </span>
+                                <span className={cn(satisfied && password ? 'text-foreground' : 'text-muted-foreground')}>
+                                    {rule.label}
+                                </span>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/index.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { PasswordRequirements } from './PasswordRequirements';
+export * from './passwordPolicyRules';
+export type { PasswordPolicy, PasswordPolicyRule } from './types';

--- a/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/passwordPolicyRules.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/passwordPolicyRules.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { PasswordPolicyRule } from './types';
+
+export function evaluatePasswordPolicyRule(rule: PasswordPolicyRule, password: string): boolean {
+    if (!password || !rule.pattern) {
+        return false;
+    }
+
+    try {
+        return new RegExp(rule.pattern).test(password);
+    } catch {
+        return false;
+    }
+}
+
+export function countSatisfiedPasswordRules(password: string, rules: PasswordPolicyRule[]): number {
+    return rules.filter(rule => evaluatePasswordPolicyRule(rule, password)).length;
+}
+
+export function isPasswordPolicySatisfied(password: string, rules: PasswordPolicyRule[]): boolean {
+    return rules.length === 0 || countSatisfiedPasswordRules(password, rules) === rules.length;
+}
+
+export type PasswordStrengthLevel = 'weak' | 'fair' | 'good' | 'strong';
+
+export function resolvePasswordStrengthLevel(password: string, rules: PasswordPolicyRule[]): PasswordStrengthLevel {
+    if (!password || rules.length === 0) {
+        return 'weak';
+    }
+
+    const satisfiedCount = countSatisfiedPasswordRules(password, rules);
+    const ratio = satisfiedCount / rules.length;
+
+    if (ratio >= 1) {
+        return 'strong';
+    }
+    if (ratio >= 0.83) {
+        return 'good';
+    }
+    if (ratio >= 0.5) {
+        return 'fair';
+    }
+    return 'weak';
+}
+
+export function resolvePasswordStrengthLabel(level: PasswordStrengthLevel): string {
+    switch (level) {
+        case 'fair':
+            return 'Fair';
+        case 'good':
+            return 'Good';
+        case 'strong':
+            return 'Strong';
+        default:
+            return 'Weak';
+    }
+}

--- a/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/passwordPolicyRules.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/passwordPolicyRules.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { PasswordPolicyRule } from './types';
+
+export function evaluatePasswordPolicyRule(rule: PasswordPolicyRule, password: string): boolean {
+    if (!password || !rule.pattern) {
+        return false;
+    }
+
+    try {
+        return new RegExp(rule.pattern).test(password);
+    } catch {
+        return false;
+    }
+}
+
+export function countSatisfiedPasswordRules(password: string, rules: PasswordPolicyRule[]): number {
+    return rules.filter(rule => evaluatePasswordPolicyRule(rule, password)).length;
+}
+
+export function isPasswordPolicySatisfied(password: string, rules: PasswordPolicyRule[]): boolean {
+    if (!password || rules.length === 0) {
+        return false;
+    }
+
+    return countSatisfiedPasswordRules(password, rules) === rules.length;
+}
+
+const PASSWORD_STRENGTH_FAIR_THRESHOLD = 0.5;
+const PASSWORD_STRENGTH_GOOD_THRESHOLD = 0.83;
+
+export type PasswordStrengthLevel = 'weak' | 'fair' | 'good' | 'strong';
+
+export function resolvePasswordStrengthLevel(password: string, rules: PasswordPolicyRule[]): PasswordStrengthLevel {
+    if (!password || rules.length === 0) {
+        return 'weak';
+    }
+
+    const satisfiedCount = countSatisfiedPasswordRules(password, rules);
+    const ratio = satisfiedCount / rules.length;
+
+    if (ratio >= 1) {
+        return 'strong';
+    }
+    if (ratio >= PASSWORD_STRENGTH_GOOD_THRESHOLD) {
+        return 'good';
+    }
+    if (ratio >= PASSWORD_STRENGTH_FAIR_THRESHOLD) {
+        return 'fair';
+    }
+    return 'weak';
+}
+
+export function resolvePasswordStrengthLabel(level: PasswordStrengthLevel): string {
+    switch (level) {
+        case 'fair':
+            return 'Fair';
+        case 'good':
+            return 'Good';
+        case 'strong':
+            return 'Strong';
+        default:
+            return 'Weak';
+    }
+}

--- a/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/types.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/types.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface PasswordPolicyRule {
+    id: string;
+    label: string;
+    pattern?: string;
+}
+
+export interface PasswordPolicy {
+    description?: string;
+    pattern?: string;
+    rules: PasswordPolicyRule[];
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.tsx
@@ -15,7 +15,7 @@
  */
 import { Navigate, Route, Routes } from 'react-router-dom';
 
-import { LoginPage, ProtectedRoute, PublicOnlyRoute } from '../features/auth';
+import { LoginPage, ProtectedRoute, PublicOnlyRoute, ResetPasswordPage } from '../features/auth';
 import { EnvironmentGuard, RootRedirect } from '../features/environment';
 import { type GammaModule, RemoteModuleRoute, useGammaModules } from '../features/modules';
 import { HomePage } from '../pages/home';
@@ -30,6 +30,7 @@ export function AppRoutes() {
     if (loading && modules.length === 0) {
         return (
             <Routes>
+                <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
                 <Route element={<PublicOnlyRoute />}>
                     <Route path="/login" element={<LoginPage />} />
                 </Route>
@@ -48,6 +49,7 @@ export function AppRoutes() {
 
     return (
         <Routes>
+            <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
             <Route element={<PublicOnlyRoute />}>
                 <Route path="/login" element={<LoginPage />} />
             </Route>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/PasswordRequirements.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/PasswordRequirements.spec.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { screen } from '@testing-library/react';
+
+import { PasswordRequirements } from '../../../../../gamma-ui-shared/src/passwordPolicy';
+
+const TEST_RULES = [
+    { id: 'minLength', label: 'At least 12 characters', pattern: '.{12,}' },
+    { id: 'uppercase', label: 'Contains uppercase letter', pattern: '[A-Z]' },
+    { id: 'lowercase', label: 'Contains lowercase letter', pattern: '[a-z]' },
+    { id: 'digit', label: 'Contains a number', pattern: '[0-9]' },
+    { id: 'special', label: 'Contains a special character', pattern: '[!@#$]' },
+    { id: 'noConsecutive', label: 'No more than 2 consecutive equal characters', pattern: '^(?!.*(.)\\1{2,}).+$' },
+];
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
+});
+
+describe('PasswordRequirements', () => {
+    it('renders policy rules and marks satisfied requirements when a password is provided', () => {
+        renderWithGraphene(<PasswordRequirements rules={TEST_RULES} password="LongEnough1!a" showStrengthMeter />);
+
+        expect(screen.getByText('Requirements')).toBeTruthy();
+        expect(screen.getByText('Strong')).toBeTruthy();
+        expect(screen.getByText('At least 12 characters')).toBeTruthy();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.spec.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { ResetPasswordPage } from './ResetPasswordPage';
+import { useBootstrapStore } from '../../../shared/config/bootstrap.store';
+import { buildBootstrapConfig, TEST_MANAGEMENT_BASE } from '../../../testing/factories';
+import { trackHandler } from '../../../testing/helpers';
+import { server } from '../../../testing/server';
+
+const VALID_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+    'eyJzdWIiOiJ1c2VyLTEiLCJlbWFpbCI6Im5vcm0xQGdtYWlsLmNvbSIsImZpcnN0bmFtZSI6Im5vcm0xIiwibGFzdG5hbWUiOiJub3JtMSIsImV4cCI6OTk5OTk5OTk5OTk5fQ.' +
+    'signature';
+
+const EXPIRED_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+    'eyJzdWIiOiJ1c2VyLTEiLCJlbWFpbCI6Im5vcm0xQGdtYWlsLmNvbSIsImZpcnN0bmFtZSI6Im5vcm0xIiwibGFzdG5hbWUiOiJub3JtMSIsImV4cCI6MTAwMDAwMDAwMH0.' +
+    'signature';
+
+function renderResetPasswordPage(token = VALID_TOKEN) {
+    useBootstrapStore.setState({
+        config: buildBootstrapConfig(),
+        loading: false,
+        error: null,
+    });
+
+    return render(
+        <MemoryRouter initialEntries={[`/reset-password/${token}`]}>
+            <Routes>
+                <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('ResetPasswordPage', () => {
+    it('renders user details from the token and submits the new password', async () => {
+        const user = userEvent.setup();
+        const changePasswordTracker = trackHandler('post', `${TEST_MANAGEMENT_BASE}/users/user-1/changePassword`, null, 204);
+
+        renderResetPasswordPage();
+
+        await waitFor(() => {
+            expect(screen.getByText('At least 12 characters')).toBeTruthy();
+        });
+
+        expect((screen.getByLabelText('First name') as HTMLInputElement).value).toBe('norm1');
+        expect((screen.getByLabelText('Last name') as HTMLInputElement).value).toBe('norm1');
+        expect((screen.getByLabelText('Email') as HTMLInputElement).value).toBe('norm1@gmail.com');
+
+        await user.type(screen.getByLabelText('Password'), 'NewPassword1!a');
+        await user.type(screen.getByLabelText('Confirm password'), 'NewPassword1!a');
+
+        const submitButton = screen.getByRole('button', { name: 'Reset password' }) as HTMLButtonElement;
+        expect(submitButton.disabled).toBe(false);
+        await user.click(submitButton);
+
+        await waitFor(() => expect(changePasswordTracker.callCount).toBe(1));
+        expect(screen.getByText('Password successfully reset')).toBeTruthy();
+    });
+
+    it('shows an error when the token is invalid', () => {
+        renderResetPasswordPage('invalid-token');
+
+        expect(screen.getByText('Invalid password reset token!')).toBeTruthy();
+    });
+
+    it('shows an error when the token is expired', () => {
+        renderResetPasswordPage(EXPIRED_TOKEN);
+
+        expect(screen.getByText('Your password reset token has expired!')).toBeTruthy();
+    });
+
+    it('keeps submit disabled when passwords do not match', async () => {
+        const user = userEvent.setup();
+
+        renderResetPasswordPage();
+
+        await waitFor(() => {
+            expect(screen.getByText('At least 12 characters')).toBeTruthy();
+        });
+
+        await user.type(screen.getByLabelText('Password'), 'NewPassword1!a');
+        await user.type(screen.getByLabelText('Confirm password'), 'DifferentPassword1!a');
+
+        expect(screen.getByText('Password and confirm password must be the same.')).toBeTruthy();
+        expect((screen.getByRole('button', { name: 'Reset password' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('shows the API error message when password reset fails', async () => {
+        const user = userEvent.setup();
+        server.use(
+            http.post(`${TEST_MANAGEMENT_BASE}/users/user-1/changePassword`, () =>
+                HttpResponse.json({ message: 'Password does not meet policy requirements.' }, { status: 400 }),
+            ),
+        );
+
+        renderResetPasswordPage();
+
+        await waitFor(() => {
+            expect(screen.getByText('At least 12 characters')).toBeTruthy();
+        });
+
+        await user.type(screen.getByLabelText('Password'), 'NewPassword1!a');
+        await user.type(screen.getByLabelText('Confirm password'), 'NewPassword1!a');
+        await user.click(screen.getByRole('button', { name: 'Reset password' }));
+
+        expect(await screen.findByText('Password does not meet policy requirements.')).toBeTruthy();
+    });
+
+    it('blocks submit when password policy cannot be loaded', async () => {
+        server.use(
+            http.get(`${TEST_MANAGEMENT_BASE}/configuration/password-policy`, () =>
+                HttpResponse.json({ message: 'Service unavailable' }, { status: 503 }),
+            ),
+        );
+
+        renderResetPasswordPage();
+
+        expect(await screen.findByText('Unable to load password requirements. Please refresh the page and try again.')).toBeTruthy();
+        expect((screen.getByRole('button', { name: 'Reset password' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.spec.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { ResetPasswordPage } from './ResetPasswordPage';
+import { useBootstrapStore } from '../../../shared/config/bootstrap.store';
+import { buildBootstrapConfig, TEST_MANAGEMENT_BASE } from '../../../testing/factories';
+import { trackHandler } from '../../../testing/helpers';
+import { server } from '../../../testing/server';
+
+const VALID_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+    'eyJzdWIiOiJ1c2VyLTEiLCJlbWFpbCI6Im5vcm0xQGdtYWlsLmNvbSIsImZpcnN0bmFtZSI6Im5vcm0xIiwibGFzdG5hbWUiOiJub3JtMSIsImV4cCI6OTk5OTk5OTk5OTk5fQ.' +
+    'signature';
+
+const EXPIRED_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+    'eyJzdWIiOiJ1c2VyLTEiLCJlbWFpbCI6Im5vcm0xQGdtYWlsLmNvbSIsImZpcnN0bmFtZSI6Im5vcm0xIiwibGFzdG5hbWUiOiJub3JtMSIsImV4cCI6MTAwMDAwMDAwMH0.' +
+    'signature';
+
+function renderResetPasswordPage(token = VALID_TOKEN) {
+    useBootstrapStore.setState({
+        config: buildBootstrapConfig(),
+        loading: false,
+        error: null,
+    });
+
+    return render(
+        <MemoryRouter initialEntries={[`/reset-password/${token}`]}>
+            <Routes>
+                <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('ResetPasswordPage', () => {
+    it('renders user details from the token and submits the new password', async () => {
+        const user = userEvent.setup();
+        const changePasswordTracker = trackHandler('post', `${TEST_MANAGEMENT_BASE}/users/user-1/changePassword`, null, 204);
+
+        renderResetPasswordPage();
+
+        await waitFor(() => {
+            expect(screen.getByText('At least 12 characters')).toBeTruthy();
+        });
+
+        expect((screen.getByLabelText('First name') as HTMLInputElement).value).toBe('norm1');
+        expect((screen.getByLabelText('Last name') as HTMLInputElement).value).toBe('norm1');
+        expect((screen.getByLabelText('Email') as HTMLInputElement).value).toBe('norm1@gmail.com');
+
+        await user.type(screen.getByLabelText('Password'), 'NewPassword1!a');
+        await user.type(screen.getByLabelText('Confirm password'), 'NewPassword1!a');
+
+        const submitButton = screen.getByRole('button', { name: 'Reset password' }) as HTMLButtonElement;
+        expect(submitButton.disabled).toBe(false);
+        await user.click(submitButton);
+
+        await waitFor(() => expect(changePasswordTracker.callCount).toBe(1));
+        expect(screen.getByText('Password successfully reset')).toBeTruthy();
+    });
+
+    it('shows an error when the token is invalid', () => {
+        renderResetPasswordPage('invalid-token');
+
+        expect(screen.getByText('Invalid password reset token!')).toBeTruthy();
+    });
+
+    it('shows an error when the token is expired', () => {
+        renderResetPasswordPage(EXPIRED_TOKEN);
+
+        expect(screen.getByText('Your password reset token has expired!')).toBeTruthy();
+    });
+
+    it('keeps submit disabled when passwords do not match', async () => {
+        const user = userEvent.setup();
+
+        renderResetPasswordPage();
+
+        await waitFor(() => {
+            expect(screen.getByText('At least 12 characters')).toBeTruthy();
+        });
+
+        await user.type(screen.getByLabelText('Password'), 'NewPassword1!a');
+        await user.type(screen.getByLabelText('Confirm password'), 'DifferentPassword1!a');
+
+        expect(screen.getByText('Password and confirm password must be the same.')).toBeTruthy();
+        expect((screen.getByRole('button', { name: 'Reset password' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('shows the API error message when password reset fails', async () => {
+        const user = userEvent.setup();
+        server.use(
+            http.post(`${TEST_MANAGEMENT_BASE}/users/user-1/changePassword`, () =>
+                HttpResponse.json({ message: 'Password does not meet policy requirements.' }, { status: 400 }),
+            ),
+        );
+
+        renderResetPasswordPage();
+
+        await waitFor(() => {
+            expect(screen.getByText('At least 12 characters')).toBeTruthy();
+        });
+
+        await user.type(screen.getByLabelText('Password'), 'NewPassword1!a');
+        await user.type(screen.getByLabelText('Confirm password'), 'NewPassword1!a');
+        await user.click(screen.getByRole('button', { name: 'Reset password' }));
+
+        expect(await screen.findByText('Password does not meet policy requirements.')).toBeTruthy();
+    });
+
+    it('blocks submit when password policy cannot be loaded', async () => {
+        server.use(
+            http.get(`${TEST_MANAGEMENT_BASE}/configuration/password-policy`, () =>
+                HttpResponse.json({ message: 'Service unavailable' }, { status: 503 }),
+            ),
+        );
+
+        renderResetPasswordPage();
+
+        expect(await screen.findByText('Unable to load password requirements. Please refresh the page and try again.')).toBeTruthy();
+        expect((screen.getByRole('button', { name: 'Reset password' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('blocks submit when password policy returns no rules', async () => {
+        server.use(
+            http.get(`${TEST_MANAGEMENT_BASE}/configuration/password-policy`, () =>
+                HttpResponse.json({ description: 'Policy', pattern: '.*', rules: [] }),
+            ),
+        );
+
+        renderResetPasswordPage();
+
+        expect(await screen.findByText('Unable to load password requirements. Please refresh the page and try again.')).toBeTruthy();
+        expect((screen.getByRole('button', { name: 'Reset password' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.tsx
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    AlertTitle,
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Field,
+    FieldLabel,
+    Input,
+    Spinner,
+    cn,
+} from '@gravitee/graphene-core';
+import { useMemo, useState, type SubmitEvent } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { PasswordRequirements, isPasswordPolicySatisfied } from '../../../shared/password-policy';
+import { usePasswordPolicy } from '../hooks/usePasswordPolicy';
+import { finalizeResetPassword } from '../services/resetPassword.service';
+import { isResetPasswordTokenExpired, parseResetPasswordToken } from '../utils/resetPasswordToken';
+
+function passwordsMatch(password: string, confirmPassword: string): boolean {
+    return password.length > 0 && password === confirmPassword;
+}
+
+export function ResetPasswordPage() {
+    const { token = '' } = useParams<{ token: string }>();
+    const tokenClaims = useMemo(() => parseResetPasswordToken(token), [token]);
+    const tokenError = useMemo(() => {
+        if (!token) {
+            return 'Invalid password reset token!';
+        }
+        if (!tokenClaims) {
+            return 'Invalid password reset token!';
+        }
+        if (isResetPasswordTokenExpired(tokenClaims)) {
+            return 'Your password reset token has expired!';
+        }
+        if (!tokenClaims.sub) {
+            return 'Invalid password reset token!';
+        }
+        return null;
+    }, [token, tokenClaims]);
+
+    const [password, setPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [error, setError] = useState('');
+    const [success, setSuccess] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const { policy: passwordPolicy, loading: passwordPolicyLoading, error: passwordPolicyError } = usePasswordPolicy();
+
+    const passwordMismatch = confirmPassword.length > 0 && password !== confirmPassword;
+    const passwordPolicySatisfied = isPasswordPolicySatisfied(password, passwordPolicy.rules);
+    const canSubmit =
+        Boolean(tokenClaims?.sub) &&
+        password.length > 0 &&
+        confirmPassword.length > 0 &&
+        passwordsMatch(password, confirmPassword) &&
+        passwordPolicySatisfied &&
+        !passwordPolicyLoading &&
+        !passwordPolicyError &&
+        !loading &&
+        !tokenError;
+
+    async function handleSubmit(event: SubmitEvent) {
+        event.preventDefault();
+        if (
+            !tokenClaims?.sub ||
+            tokenError ||
+            passwordPolicyError ||
+            passwordPolicyLoading ||
+            loading ||
+            !passwordsMatch(password, confirmPassword) ||
+            !isPasswordPolicySatisfied(password, passwordPolicy.rules)
+        ) {
+            return;
+        }
+
+        setError('');
+        setLoading(true);
+        try {
+            await finalizeResetPassword(tokenClaims.sub, {
+                token,
+                password,
+                firstname: tokenClaims.firstname ?? '',
+                lastname: tokenClaims.lastname ?? '',
+            });
+            setSuccess(true);
+        } catch (submitError) {
+            if (process.env.NODE_ENV !== 'production') {
+                console.error('Password reset failed', submitError);
+            }
+            const message = submitError instanceof Error ? submitError.message : 'An error occurred while resetting your password.';
+            setError(message);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <div className={cn('flex min-h-screen flex-col items-center justify-center p-4', 'font-sans text-foreground')}>
+            <Card className="w-full max-w-md shadow-md">
+                <CardHeader className="space-y-1 text-center">
+                    <CardTitle className="text-2xl">Reset password</CardTitle>
+                    <CardDescription>to access Gravitee Gamma</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {tokenError ? (
+                        <Alert variant="destructive" role="alert">
+                            <AlertTitle>Could not reset password</AlertTitle>
+                            <AlertDescription>{tokenError}</AlertDescription>
+                        </Alert>
+                    ) : null}
+
+                    {success ? (
+                        <Alert role="status">
+                            <AlertTitle>Password successfully reset</AlertTitle>
+                            <AlertDescription>You can now sign in with your new password.</AlertDescription>
+                        </Alert>
+                    ) : null}
+
+                    {!tokenError && !success ? (
+                        <form onSubmit={handleSubmit} className="space-y-4">
+                            {passwordPolicyError ? (
+                                <Alert variant="destructive" role="alert">
+                                    <AlertTitle>Could not load password requirements</AlertTitle>
+                                    <AlertDescription>{passwordPolicyError}</AlertDescription>
+                                </Alert>
+                            ) : null}
+
+                            {error ? (
+                                <Alert variant="destructive" role="alert">
+                                    <AlertTitle>Reset failed</AlertTitle>
+                                    <AlertDescription>{error}</AlertDescription>
+                                </Alert>
+                            ) : null}
+
+                            <Field orientation="vertical" className="gap-2">
+                                <FieldLabel htmlFor="reset-first-name">First name</FieldLabel>
+                                <Input id="reset-first-name" value={tokenClaims?.firstname ?? ''} disabled readOnly />
+                            </Field>
+
+                            <Field orientation="vertical" className="gap-2">
+                                <FieldLabel htmlFor="reset-last-name">Last name</FieldLabel>
+                                <Input id="reset-last-name" value={tokenClaims?.lastname ?? ''} disabled readOnly />
+                            </Field>
+
+                            <Field orientation="vertical" className="gap-2">
+                                <FieldLabel htmlFor="reset-email">Email</FieldLabel>
+                                <Input id="reset-email" type="email" value={tokenClaims?.email ?? ''} disabled readOnly />
+                            </Field>
+
+                            <Field orientation="vertical" className="gap-2">
+                                <FieldLabel htmlFor="reset-password">Password</FieldLabel>
+                                <Input
+                                    id="reset-password"
+                                    type="password"
+                                    value={password}
+                                    onChange={event => setPassword(event.target.value)}
+                                    required
+                                    autoComplete="new-password"
+                                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                                    autoFocus
+                                />
+                                <PasswordRequirements rules={passwordPolicy.rules} password={password} showStrengthMeter />
+                            </Field>
+
+                            <Field orientation="vertical" className="gap-2">
+                                <FieldLabel htmlFor="reset-confirm-password">Confirm password</FieldLabel>
+                                <Input
+                                    id="reset-confirm-password"
+                                    type="password"
+                                    value={confirmPassword}
+                                    onChange={event => setConfirmPassword(event.target.value)}
+                                    required
+                                    autoComplete="new-password"
+                                />
+                                {passwordMismatch ? (
+                                    <p className="text-sm text-destructive">Password and confirm password must be the same.</p>
+                                ) : null}
+                            </Field>
+
+                            <Button type="submit" className="w-full" size="lg" disabled={!canSubmit}>
+                                {loading ? (
+                                    <span className="inline-flex items-center justify-center gap-2">
+                                        <Spinner className="size-4 shrink-0" aria-hidden />
+                                        Resetting password…
+                                    </span>
+                                ) : (
+                                    'Reset password'
+                                )}
+                            </Button>
+                        </form>
+                    ) : null}
+
+                    <p className="mt-4 text-center text-sm text-muted-foreground">
+                        Go to{' '}
+                        <Link to="/login" className="text-primary underline-offset-4 hover:underline">
+                            Sign in
+                        </Link>
+                    </p>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.tsx
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    AlertTitle,
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Field,
+    FieldLabel,
+    Input,
+    Spinner,
+    cn,
+} from '@gravitee/graphene-core';
+import { useMemo, useState, type SubmitEvent } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { PasswordRequirements, isPasswordPolicySatisfied } from '../../../../../gamma-ui-shared/src/passwordPolicy';
+import { usePasswordPolicy } from '../hooks/usePasswordPolicy';
+import { finalizeResetPassword } from '../services/resetPassword.service';
+import { isResetPasswordTokenExpired, parseResetPasswordToken } from '../utils/resetPasswordToken';
+
+function passwordsMatch(password: string, confirmPassword: string): boolean {
+    return password.length > 0 && password === confirmPassword;
+}
+
+export function ResetPasswordPage() {
+    const { token = '' } = useParams<{ token: string }>();
+    const tokenClaims = useMemo(() => parseResetPasswordToken(token), [token]);
+    const tokenError = useMemo(() => {
+        if (!token) {
+            return 'Invalid password reset token!';
+        }
+        if (!tokenClaims) {
+            return 'Invalid password reset token!';
+        }
+        if (isResetPasswordTokenExpired(tokenClaims)) {
+            return 'Your password reset token has expired!';
+        }
+        if (!tokenClaims.sub) {
+            return 'Invalid password reset token!';
+        }
+        return null;
+    }, [token, tokenClaims]);
+
+    const [password, setPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [error, setError] = useState('');
+    const [success, setSuccess] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const { policy: passwordPolicy, loading: passwordPolicyLoading, error: passwordPolicyError } = usePasswordPolicy();
+
+    const passwordMismatch = confirmPassword.length > 0 && password !== confirmPassword;
+    const passwordPolicySatisfied = isPasswordPolicySatisfied(password, passwordPolicy.rules);
+    const canSubmit =
+        Boolean(tokenClaims?.sub) &&
+        password.length > 0 &&
+        confirmPassword.length > 0 &&
+        passwordsMatch(password, confirmPassword) &&
+        passwordPolicySatisfied &&
+        !passwordPolicyLoading &&
+        !passwordPolicyError &&
+        !loading &&
+        !tokenError;
+
+    async function handleSubmit(event: SubmitEvent) {
+        event.preventDefault();
+        if (!tokenClaims?.sub || tokenError || passwordPolicyError) {
+            return;
+        }
+
+        setError('');
+        setLoading(true);
+        try {
+            await finalizeResetPassword(tokenClaims.sub, {
+                token,
+                password,
+                firstname: tokenClaims.firstname ?? '',
+                lastname: tokenClaims.lastname ?? '',
+            });
+            setSuccess(true);
+        } catch (submitError) {
+            if (process.env.NODE_ENV !== 'production') {
+                console.error('Password reset failed', submitError);
+            }
+            const message = submitError instanceof Error ? submitError.message : 'An error occurred while resetting your password.';
+            setError(message);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <div className={cn('flex min-h-screen flex-col items-center justify-center p-4', 'font-sans text-foreground')}>
+            <Card className="w-full max-w-md shadow-md">
+                <CardHeader className="space-y-1 text-center">
+                    <CardTitle className="text-2xl">Reset password</CardTitle>
+                    <CardDescription>to access Gravitee Gamma</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {tokenError ? (
+                        <Alert variant="destructive" role="alert">
+                            <AlertTitle>Could not reset password</AlertTitle>
+                            <AlertDescription>{tokenError}</AlertDescription>
+                        </Alert>
+                    ) : null}
+
+                    {success ? (
+                        <Alert role="status">
+                            <AlertTitle>Password successfully reset</AlertTitle>
+                            <AlertDescription>You can now sign in with your new password.</AlertDescription>
+                        </Alert>
+                    ) : null}
+
+                    {!tokenError && !success ? (
+                        <form onSubmit={handleSubmit} className="space-y-4">
+                            {passwordPolicyError ? (
+                                <Alert variant="destructive" role="alert">
+                                    <AlertTitle>Could not load password requirements</AlertTitle>
+                                    <AlertDescription>{passwordPolicyError}</AlertDescription>
+                                </Alert>
+                            ) : null}
+
+                            {error ? (
+                                <Alert variant="destructive" role="alert">
+                                    <AlertTitle>Reset failed</AlertTitle>
+                                    <AlertDescription>{error}</AlertDescription>
+                                </Alert>
+                            ) : null}
+
+                            <Field orientation="vertical" className="gap-2">
+                                <FieldLabel htmlFor="reset-first-name">First name</FieldLabel>
+                                <Input id="reset-first-name" value={tokenClaims?.firstname ?? ''} disabled readOnly />
+                            </Field>
+
+                            <Field orientation="vertical" className="gap-2">
+                                <FieldLabel htmlFor="reset-last-name">Last name</FieldLabel>
+                                <Input id="reset-last-name" value={tokenClaims?.lastname ?? ''} disabled readOnly />
+                            </Field>
+
+                            <Field orientation="vertical" className="gap-2">
+                                <FieldLabel htmlFor="reset-email">Email</FieldLabel>
+                                <Input id="reset-email" type="email" value={tokenClaims?.email ?? ''} disabled readOnly />
+                            </Field>
+
+                            <Field orientation="vertical" className="gap-2">
+                                <FieldLabel htmlFor="reset-password">Password</FieldLabel>
+                                <Input
+                                    id="reset-password"
+                                    type="password"
+                                    value={password}
+                                    onChange={event => setPassword(event.target.value)}
+                                    required
+                                    autoComplete="new-password"
+                                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                                    autoFocus
+                                />
+                                <PasswordRequirements rules={passwordPolicy.rules} password={password} showStrengthMeter />
+                            </Field>
+
+                            <Field orientation="vertical" className="gap-2">
+                                <FieldLabel htmlFor="reset-confirm-password">Confirm password</FieldLabel>
+                                <Input
+                                    id="reset-confirm-password"
+                                    type="password"
+                                    value={confirmPassword}
+                                    onChange={event => setConfirmPassword(event.target.value)}
+                                    required
+                                    autoComplete="new-password"
+                                />
+                                {passwordMismatch ? (
+                                    <p className="text-sm text-destructive">Password and confirm password must be the same.</p>
+                                ) : null}
+                            </Field>
+
+                            <Button type="submit" className="w-full" size="lg" disabled={!canSubmit}>
+                                {loading ? (
+                                    <span className="inline-flex items-center justify-center gap-2">
+                                        <Spinner className="size-4 shrink-0" aria-hidden />
+                                        Resetting password…
+                                    </span>
+                                ) : (
+                                    'Reset password'
+                                )}
+                            </Button>
+                        </form>
+                    ) : null}
+
+                    <p className="mt-4 text-center text-sm text-muted-foreground">
+                        Go to{' '}
+                        <Link to="/login" className="text-primary underline-offset-4 hover:underline">
+                            Sign in
+                        </Link>
+                    </p>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/hooks/usePasswordPolicy.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/hooks/usePasswordPolicy.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useState } from 'react';
+
+import type { PasswordPolicy } from '../../../shared/password-policy';
+import { getPasswordPolicy } from '../services/passwordPolicy.service';
+
+const EMPTY_POLICY: PasswordPolicy = { rules: [] };
+
+export function usePasswordPolicy() {
+    const [policy, setPolicy] = useState<PasswordPolicy>(EMPTY_POLICY);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        getPasswordPolicy()
+            .then(fetchedPolicy => {
+                if (!cancelled) {
+                    const rules = fetchedPolicy.rules ?? [];
+                    if (rules.length === 0) {
+                        setPolicy(EMPTY_POLICY);
+                        setError('Unable to load password requirements. Please refresh the page and try again.');
+                        return;
+                    }
+
+                    setPolicy({
+                        description: fetchedPolicy.description,
+                        pattern: fetchedPolicy.pattern,
+                        rules,
+                    });
+                    setError(null);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setPolicy(EMPTY_POLICY);
+                    setError('Unable to load password requirements. Please refresh the page and try again.');
+                }
+            })
+            .finally(() => {
+                if (!cancelled) {
+                    setLoading(false);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    return { policy, loading, error };
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/hooks/usePasswordPolicy.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/hooks/usePasswordPolicy.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useState } from 'react';
+
+import type { PasswordPolicy } from '../../../../../gamma-ui-shared/src/passwordPolicy';
+import { getPasswordPolicy } from '../services/passwordPolicy.service';
+
+const EMPTY_POLICY: PasswordPolicy = { rules: [] };
+
+export function usePasswordPolicy() {
+    const [policy, setPolicy] = useState<PasswordPolicy>(EMPTY_POLICY);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        getPasswordPolicy()
+            .then(fetchedPolicy => {
+                if (!cancelled) {
+                    setPolicy({
+                        description: fetchedPolicy.description,
+                        pattern: fetchedPolicy.pattern,
+                        rules: fetchedPolicy.rules ?? [],
+                    });
+                    setError(null);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setPolicy(EMPTY_POLICY);
+                    setError('Unable to load password requirements. Please refresh the page and try again.');
+                }
+            })
+            .finally(() => {
+                if (!cancelled) {
+                    setLoading(false);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    return { policy, loading, error };
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/passwordPolicy.service.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/passwordPolicy.service.ts
@@ -13,9 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { useUser, useIsAuthenticated, useLogin, useLogout, useIdentityProviders } from './auth.selectors';
-export { useAuthStore } from './auth.store';
-export type { CurrentUser as User, SocialIdentityProvider, IdentityProviderType } from './auth.types';
-export { LoginPage } from './components/LoginPage';
-export { ResetPasswordPage } from './components/ResetPasswordPage';
-export { ProtectedRoute, PublicOnlyRoute } from './components/ProtectedRoute';
+import type { PasswordPolicy } from '../../../../../gamma-ui-shared/src/passwordPolicy';
+import { managementApi } from '../../../shared/api/api-client';
+
+export async function getPasswordPolicy(): Promise<PasswordPolicy> {
+    const policy = await managementApi.get<PasswordPolicy>('/configuration/password-policy');
+    return {
+        ...policy,
+        rules: policy.rules ?? [],
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/passwordPolicy.service.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/passwordPolicy.service.ts
@@ -13,9 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { useUser, useIsAuthenticated, useLogin, useLogout, useIdentityProviders } from './auth.selectors';
-export { useAuthStore } from './auth.store';
-export type { CurrentUser as User, SocialIdentityProvider, IdentityProviderType } from './auth.types';
-export { LoginPage } from './components/LoginPage';
-export { ResetPasswordPage } from './components/ResetPasswordPage';
-export { ProtectedRoute, PublicOnlyRoute } from './components/ProtectedRoute';
+import { managementApi } from '../../../shared/api/api-client';
+import type { PasswordPolicy } from '../../../shared/password-policy';
+
+export async function getPasswordPolicy(): Promise<PasswordPolicy> {
+    const policy = await managementApi.get<PasswordPolicy>('/configuration/password-policy');
+    return {
+        ...policy,
+        rules: policy.rules ?? [],
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/recaptcha.service.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/recaptcha.service.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { http, HttpResponse } from 'msw';
+
+import { getReCaptchaHeaderName, resetReCaptchaConfigCacheForTests, resolveReCaptchaToken } from './recaptcha.service';
+import { useBootstrapStore } from '../../../shared/config/bootstrap.store';
+import { buildBootstrapConfig, TEST_MANAGEMENT_BASE } from '../../../testing/factories';
+import { server } from '../../../testing/server';
+
+describe('recaptcha.service', () => {
+    beforeEach(() => {
+        resetReCaptchaConfigCacheForTests();
+        useBootstrapStore.setState({
+            config: buildBootstrapConfig(),
+            loading: false,
+            error: null,
+        });
+    });
+
+    it('returns null when reCAPTCHA is disabled in console config', async () => {
+        server.use(http.get(`${TEST_MANAGEMENT_BASE}/console`, () => HttpResponse.json({ reCaptcha: { enabled: false } })));
+
+        await expect(resolveReCaptchaToken('register')).resolves.toBeNull();
+    });
+
+    it('exposes the management API header name used by changePassword', () => {
+        expect(getReCaptchaHeaderName()).toBe('X-Recaptcha-Token');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/recaptcha.service.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/recaptcha.service.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { managementApi } from '../../../shared/api/api-client';
+
+const RECAPTCHA_HEADER = 'X-Recaptcha-Token';
+const RECAPTCHA_SCRIPT_ID = 'gamma-recaptcha';
+
+interface ConsoleReCaptchaConfig {
+    enabled?: boolean;
+    siteKey?: string;
+}
+
+interface GRecaptcha {
+    ready: (callback: () => void) => void;
+    execute: (siteKey: string, options: { action: string }) => Promise<string>;
+}
+
+declare global {
+    interface Window {
+        grecaptcha?: GRecaptcha;
+    }
+}
+
+let cachedConfig: ConsoleReCaptchaConfig | null | undefined;
+let scriptLoadPromise: Promise<void> | null = null;
+
+async function fetchReCaptchaConfig(): Promise<ConsoleReCaptchaConfig | null> {
+    if (cachedConfig !== undefined) {
+        return cachedConfig;
+    }
+
+    try {
+        const consoleConfig = await managementApi.get<{ reCaptcha?: ConsoleReCaptchaConfig }>('/console');
+        const reCaptcha = consoleConfig.reCaptcha;
+        cachedConfig = reCaptcha?.enabled && reCaptcha.siteKey ? reCaptcha : null;
+    } catch {
+        cachedConfig = null;
+    }
+
+    return cachedConfig;
+}
+
+function loadReCaptchaScript(siteKey: string): Promise<void> {
+    if (scriptLoadPromise) {
+        return scriptLoadPromise;
+    }
+
+    scriptLoadPromise = new Promise((resolve, reject) => {
+        if (document.getElementById(RECAPTCHA_SCRIPT_ID)) {
+            resolve();
+            return;
+        }
+
+        const script = document.createElement('script');
+        script.id = RECAPTCHA_SCRIPT_ID;
+        script.src = `https://www.google.com/recaptcha/api.js?render=${encodeURIComponent(siteKey)}`;
+        script.async = true;
+        script.onload = () => {
+            window.grecaptcha?.ready(() => resolve());
+        };
+        script.onerror = () => {
+            scriptLoadPromise = null;
+            reject(new Error('Failed to load reCAPTCHA'));
+        };
+        document.head.appendChild(script);
+    });
+
+    return scriptLoadPromise;
+}
+
+export async function resolveReCaptchaToken(action: string): Promise<string | null> {
+    const config = await fetchReCaptchaConfig();
+    if (!config?.enabled || !config.siteKey) {
+        return null;
+    }
+
+    await loadReCaptchaScript(config.siteKey);
+    if (!window.grecaptcha) {
+        throw new Error('reCAPTCHA is not available');
+    }
+
+    return window.grecaptcha.execute(config.siteKey, { action });
+}
+
+export function getReCaptchaHeaderName(): string {
+    return RECAPTCHA_HEADER;
+}
+
+export function resetReCaptchaConfigCacheForTests(): void {
+    cachedConfig = undefined;
+    scriptLoadPromise = null;
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/resetPassword.service.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/resetPassword.service.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useBootstrapStore } from '../../../shared/config/bootstrap.store';
+
+export interface FinalizeResetPasswordPayload {
+    token: string;
+    password: string;
+    firstname: string;
+    lastname: string;
+}
+
+const RESET_PASSWORD_FALLBACK_ERROR = 'An error occurred while resetting your password.';
+
+function getCsrfToken(): string | null {
+    return localStorage.getItem('XSRF-TOKEN');
+}
+
+function setCsrfToken(value: string) {
+    localStorage.setItem('XSRF-TOKEN', value);
+}
+
+function resolveManagementErrorMessage(text: string, fallback: string): string {
+    if (!text) {
+        return fallback;
+    }
+
+    try {
+        const parsed = JSON.parse(text) as { message?: string };
+        return parsed.message?.trim() || fallback;
+    } catch {
+        return text.trim() || fallback;
+    }
+}
+
+export async function finalizeResetPassword(userId: string, payload: FinalizeResetPasswordPayload): Promise<void> {
+    const config = useBootstrapStore.getState().config;
+    if (!config) {
+        throw new Error('Bootstrap not initialized');
+    }
+
+    const path = `/users/${encodeURIComponent(userId)}/changePassword`;
+    const url = `${config.managementBaseURL}/organizations/${config.organizationId}${path}`;
+    const headers = new Headers({
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+    });
+    const csrf = getCsrfToken();
+    if (csrf) {
+        headers.set('X-Xsrf-Token', csrf);
+    }
+
+    const res = await fetch(url, {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+        body: JSON.stringify({
+            token: payload.token,
+            password: payload.password,
+            firstname: payload.firstname,
+            lastname: payload.lastname,
+        }),
+    });
+
+    const newCsrf = res.headers.get('X-Xsrf-Token');
+    if (newCsrf) {
+        setCsrfToken(newCsrf);
+    }
+
+    if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(resolveManagementErrorMessage(text, RESET_PASSWORD_FALLBACK_ERROR));
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/resetPassword.service.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/resetPassword.service.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getReCaptchaHeaderName, resolveReCaptchaToken } from './recaptcha.service';
+import { ApiError, managementApi } from '../../../shared/api/api-client';
+
+export interface FinalizeResetPasswordPayload {
+    token: string;
+    password: string;
+    firstname: string;
+    lastname: string;
+}
+
+const RESET_PASSWORD_FALLBACK_ERROR = 'An error occurred while resetting your password.';
+
+export async function finalizeResetPassword(userId: string, payload: FinalizeResetPasswordPayload): Promise<void> {
+    const reCaptchaToken = await resolveReCaptchaToken('register');
+    const extraHeaders: Record<string, string> = {};
+    if (reCaptchaToken) {
+        extraHeaders[getReCaptchaHeaderName()] = reCaptchaToken;
+    }
+
+    try {
+        await managementApi.post<void>(
+            `/users/${encodeURIComponent(userId)}/changePassword`,
+            {
+                token: payload.token,
+                password: payload.password,
+                firstname: payload.firstname,
+                lastname: payload.lastname,
+            },
+            extraHeaders,
+        );
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw new Error(error.message || RESET_PASSWORD_FALLBACK_ERROR);
+        }
+        throw error;
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/utils/passwordPolicyRules.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/utils/passwordPolicyRules.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    countSatisfiedPasswordRules,
+    evaluatePasswordPolicyRule,
+    isPasswordPolicySatisfied,
+    resolvePasswordStrengthLevel,
+    type PasswordPolicyRule,
+} from '../../../../../gamma-ui-shared/src/passwordPolicy';
+
+const TEST_RULES: PasswordPolicyRule[] = [
+    { id: 'minLength', label: 'At least 12 characters', pattern: '.{12,}' },
+    { id: 'uppercase', label: 'Contains uppercase letter', pattern: '[A-Z]' },
+    { id: 'lowercase', label: 'Contains lowercase letter', pattern: '[a-z]' },
+    { id: 'digit', label: 'Contains a number', pattern: '[0-9]' },
+    { id: 'special', label: 'Contains a special character', pattern: '[!@#$]' },
+    { id: 'noConsecutive', label: 'No more than 2 consecutive equal characters', pattern: '^(?!.*(.)\\1{2,}).+$' },
+];
+
+describe('passwordPolicyRules', () => {
+    it('evaluates rules using patterns returned by the API', () => {
+        expect(evaluatePasswordPolicyRule(TEST_RULES[0], 'Short1!a')).toBe(false);
+        expect(evaluatePasswordPolicyRule(TEST_RULES[0], 'LongEnough1!a')).toBe(true);
+        expect(evaluatePasswordPolicyRule(TEST_RULES[1], 'longenough1!a')).toBe(false);
+        expect(evaluatePasswordPolicyRule(TEST_RULES[3], 'LongEnough!abc')).toBe(false);
+        expect(evaluatePasswordPolicyRule(TEST_RULES[4], 'LongEnough1abc')).toBe(false);
+        expect(evaluatePasswordPolicyRule(TEST_RULES[5], 'LongEnough111!a')).toBe(false);
+    });
+
+    it('resolves password strength from satisfied rule count', () => {
+        expect(resolvePasswordStrengthLevel('', TEST_RULES)).toBe('weak');
+        expect(resolvePasswordStrengthLevel('LongEnough1!a', TEST_RULES)).toBe('strong');
+        expect(countSatisfiedPasswordRules('LongEnough1!a', TEST_RULES)).toBe(TEST_RULES.length);
+    });
+
+    it('treats empty rules as satisfied only when no rules are configured', () => {
+        expect(isPasswordPolicySatisfied('any', [])).toBe(true);
+        expect(isPasswordPolicySatisfied('Short1!a', TEST_RULES)).toBe(false);
+        expect(isPasswordPolicySatisfied('LongEnough1!a', TEST_RULES)).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/utils/resetPasswordToken.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/utils/resetPasswordToken.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isResetPasswordTokenExpired, parseResetPasswordToken } from './resetPasswordToken';
+
+const VALID_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+    'eyJzdWIiOiJ1c2VyLTEiLCJlbWFpbCI6Im5vcm0xQGdtYWlsLmNvbSIsImZpcnN0bmFtZSI6Im5vcm0xIiwibGFzdG5hbWUiOiJub3JtMSIsImV4cCI6OTk5OTk5OTk5OTk5fQ.' +
+    'signature';
+
+describe('resetPasswordToken', () => {
+    it('parses user claims from a reset token', () => {
+        const claims = parseResetPasswordToken(VALID_TOKEN);
+
+        expect(claims).toEqual(
+            expect.objectContaining({
+                sub: 'user-1',
+                email: 'norm1@gmail.com',
+                firstname: 'norm1',
+                lastname: 'norm1',
+            }),
+        );
+    });
+
+    it('returns null for invalid tokens', () => {
+        expect(parseResetPasswordToken('not-a-jwt')).toBeNull();
+    });
+
+    it('detects expired tokens', () => {
+        const expiredToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' + 'eyJzdWIiOiJ1c2VyLTEiLCJleHAiOjF9.' + 'signature';
+
+        const claims = parseResetPasswordToken(expiredToken);
+        expect(claims).not.toBeNull();
+        expect(isResetPasswordTokenExpired(claims!)).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/utils/resetPasswordToken.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/utils/resetPasswordToken.ts
@@ -13,9 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { useUser, useIsAuthenticated, useLogin, useLogout, useIdentityProviders } from './auth.selectors';
-export { useAuthStore } from './auth.store';
-export type { CurrentUser as User, SocialIdentityProvider, IdentityProviderType } from './auth.types';
-export { LoginPage } from './components/LoginPage';
-export { ResetPasswordPage } from './components/ResetPasswordPage';
-export { ProtectedRoute, PublicOnlyRoute } from './components/ProtectedRoute';
+import { jwtDecode, type JwtPayload } from 'jwt-decode';
+
+export interface ResetPasswordTokenClaims extends JwtPayload {
+    email?: string;
+    firstname?: string;
+    lastname?: string;
+}
+
+export function parseResetPasswordToken(token: string): ResetPasswordTokenClaims | null {
+    try {
+        return jwtDecode<ResetPasswordTokenClaims>(token);
+    } catch {
+        return null;
+    }
+}
+
+export function isResetPasswordTokenExpired(claims: ResetPasswordTokenClaims): boolean {
+    return typeof claims.exp === 'number' && claims.exp * 1000 < Date.now();
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/api/api-client.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/api/api-client.spec.ts
@@ -48,6 +48,15 @@ describe('managementApi', () => {
         await expect(managementApi.get('/user')).rejects.toThrow(ApiError);
     });
 
+    it('should surface backend message from json error responses', async () => {
+        respondWithError('get', `${TEST_MANAGEMENT_BASE}/user`, 400);
+
+        await expect(managementApi.get('/user')).rejects.toMatchObject({
+            message: 'Error 400',
+            status: 400,
+        });
+    });
+
     it('should send json body on post', async () => {
         const tracker = trackHandler('post', `${TEST_MANAGEMENT_BASE}/apis`, { id: '123' });
 

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/api/api-client.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/api/api-client.ts
@@ -41,6 +41,20 @@ function setCsrfToken(value: string) {
     localStorage.setItem('XSRF-TOKEN', value);
 }
 
+async function resolveErrorMessage(res: Response, fallback: string): Promise<string> {
+    const text = await res.text().catch(() => '');
+    if (!text) {
+        return fallback;
+    }
+
+    try {
+        const parsed = JSON.parse(text) as { message?: string };
+        return parsed.message?.trim() || fallback;
+    } catch {
+        return text.trim() || fallback;
+    }
+}
+
 export async function request<T>(backend: Backend, path: string, init?: RequestInit): Promise<T> {
     const headers = new Headers(init?.headers);
     headers.set('X-Requested-With', 'XMLHttpRequest');
@@ -57,7 +71,8 @@ export async function request<T>(backend: Backend, path: string, init?: RequestI
     if (newCsrf) setCsrfToken(newCsrf);
 
     if (!res.ok) {
-        throw new ApiError(res.status, `${init?.method ?? 'GET'} ${path} failed`);
+        const fallback = `${init?.method ?? 'GET'} ${path} failed`;
+        throw new ApiError(res.status, await resolveErrorMessage(res, fallback));
     }
 
     if (res.status === 204) return undefined as T;

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/password-policy/PasswordRequirements.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/password-policy/PasswordRequirements.spec.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { screen } from '@testing-library/react';
+
+import { PasswordRequirements } from './index';
+
+const TEST_RULES = [
+    { id: 'minLength', label: 'At least 12 characters', pattern: '.{12,}' },
+    { id: 'uppercase', label: 'Contains uppercase letter', pattern: '[A-Z]' },
+    { id: 'lowercase', label: 'Contains lowercase letter', pattern: '[a-z]' },
+    { id: 'digit', label: 'Contains a number', pattern: '[0-9]' },
+    { id: 'special', label: 'Contains a special character', pattern: '[!@#$]' },
+    { id: 'noConsecutive', label: 'No more than 2 consecutive equal characters', pattern: '^(?!.*(.)\\1{2,}).+$' },
+];
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
+});
+
+describe('PasswordRequirements', () => {
+    it('renders policy rules and marks satisfied requirements when a password is provided', () => {
+        renderWithGraphene(<PasswordRequirements rules={TEST_RULES} password="LongEnough1!a" showStrengthMeter />);
+
+        expect(screen.getByText('Requirements')).toBeTruthy();
+        expect(screen.getByText('Strong')).toBeTruthy();
+        expect(screen.getByText('At least 12 characters')).toBeTruthy();
+    });
+
+    it('shows a weaker strength label when only some rules are satisfied', () => {
+        renderWithGraphene(<PasswordRequirements rules={TEST_RULES} password="LongEnough1" showStrengthMeter />);
+
+        expect(screen.getByText('Fair')).toBeTruthy();
+        expect(screen.queryByText('Strong')).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/password-policy/index.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/password-policy/index.ts
@@ -13,9 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { useUser, useIsAuthenticated, useLogin, useLogout, useIdentityProviders } from './auth.selectors';
-export { useAuthStore } from './auth.store';
-export type { CurrentUser as User, SocialIdentityProvider, IdentityProviderType } from './auth.types';
-export { LoginPage } from './components/LoginPage';
-export { ResetPasswordPage } from './components/ResetPasswordPage';
-export { ProtectedRoute, PublicOnlyRoute } from './components/ProtectedRoute';
+
+export * from '../../../../gamma-ui-shared/src/passwordPolicy/index';

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/password-policy/passwordPolicyRules.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/password-policy/passwordPolicyRules.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    countSatisfiedPasswordRules,
+    evaluatePasswordPolicyRule,
+    isPasswordPolicySatisfied,
+    resolvePasswordStrengthLevel,
+    type PasswordPolicyRule,
+} from './index';
+
+const TEST_RULES: PasswordPolicyRule[] = [
+    { id: 'minLength', label: 'At least 12 characters', pattern: '.{12,}' },
+    { id: 'uppercase', label: 'Contains uppercase letter', pattern: '[A-Z]' },
+    { id: 'lowercase', label: 'Contains lowercase letter', pattern: '[a-z]' },
+    { id: 'digit', label: 'Contains a number', pattern: '[0-9]' },
+    { id: 'special', label: 'Contains a special character', pattern: '[!@#$]' },
+    { id: 'noConsecutive', label: 'No more than 2 consecutive equal characters', pattern: '^(?!.*(.)\\1{2,}).+$' },
+];
+
+describe('passwordPolicyRules', () => {
+    it('evaluates rules using patterns returned by the API', () => {
+        expect(evaluatePasswordPolicyRule(TEST_RULES[0], 'Short1!a')).toBe(false);
+        expect(evaluatePasswordPolicyRule(TEST_RULES[0], 'LongEnough1!a')).toBe(true);
+        expect(evaluatePasswordPolicyRule(TEST_RULES[1], 'longenough1!a')).toBe(false);
+        expect(evaluatePasswordPolicyRule(TEST_RULES[3], 'LongEnough!abc')).toBe(false);
+        expect(evaluatePasswordPolicyRule(TEST_RULES[4], 'LongEnough1abc')).toBe(false);
+        expect(evaluatePasswordPolicyRule(TEST_RULES[5], 'LongEnough111!a')).toBe(false);
+    });
+
+    it('resolves password strength from satisfied rule count', () => {
+        expect(resolvePasswordStrengthLevel('', TEST_RULES)).toBe('weak');
+        expect(resolvePasswordStrengthLevel('LongEnough1!a', TEST_RULES)).toBe('strong');
+        expect(countSatisfiedPasswordRules('LongEnough1!a', TEST_RULES)).toBe(TEST_RULES.length);
+    });
+
+    it('treats empty rules as unsatisfied', () => {
+        expect(isPasswordPolicySatisfied('any', [])).toBe(false);
+        expect(isPasswordPolicySatisfied('', TEST_RULES)).toBe(false);
+        expect(isPasswordPolicySatisfied('Short1!a', TEST_RULES)).toBe(false);
+        expect(isPasswordPolicySatisfied('LongEnough1!a', TEST_RULES)).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/handlers/auth.handlers.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/handlers/auth.handlers.ts
@@ -27,4 +27,21 @@ export const authHandlers = [
     ),
     http.post(`${TEST_MANAGEMENT_BASE}/user/login`, () => new HttpResponse(null, { status: 200 })),
     http.post(`${TEST_MANAGEMENT_BASE}/user/logout`, () => new HttpResponse(null, { status: 200 })),
+    http.get(`${TEST_MANAGEMENT_BASE}/configuration/password-policy`, () =>
+        HttpResponse.json({
+            description:
+                'Password must be at least 12 characters long, contain at least one digit, one upper case letter, one lower case letter, one special character, and no more than 2 consecutive equal characters.',
+            pattern: '^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!~<>.,;:_=?/*+\\-#\\"\'&§`£€%°()|\\[\\]$^@])(?!.*(.)\\1{2,}).{12,128}$',
+            rules: [
+                { id: 'minLength', label: 'At least 12 characters', pattern: '^.{12,}$' },
+                { id: 'maxLength', label: 'At most 128 characters', pattern: '^.{0,128}$' },
+                { id: 'digit', label: 'Contains a number', pattern: '[0-9]' },
+                { id: 'uppercase', label: 'Contains uppercase letter', pattern: '[A-Z]' },
+                { id: 'lowercase', label: 'Contains lowercase letter', pattern: '[a-z]' },
+                { id: 'special', label: 'Contains a special character', pattern: '[!~<>.,;:_=?/*+\\-#\\"\'&§`£€%°()|\\[\\]$^@]' },
+                { id: 'noConsecutive', label: 'No more than 2 consecutive equal characters', pattern: '^(?!.*(.)\\1{2,}).+$' },
+            ],
+        }),
+    ),
+    http.get(`${TEST_MANAGEMENT_BASE}/console`, () => HttpResponse.json({ reCaptcha: { enabled: false } })),
 ];

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/handlers/auth.handlers.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/handlers/auth.handlers.ts
@@ -27,4 +27,19 @@ export const authHandlers = [
     ),
     http.post(`${TEST_MANAGEMENT_BASE}/user/login`, () => new HttpResponse(null, { status: 200 })),
     http.post(`${TEST_MANAGEMENT_BASE}/user/logout`, () => new HttpResponse(null, { status: 200 })),
+    http.get(`${TEST_MANAGEMENT_BASE}/configuration/password-policy`, () =>
+        HttpResponse.json({
+            description:
+                'Password must be at least 12 characters long, contain at least one digit, one upper case letter, one lower case letter, one special character, and no more than 2 consecutive equal characters.',
+            pattern: '^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!~<>.,;:_=?/*+\\-#\\"\'&§`£€%°()|\\[\\]$^@])(?!.*(.)\\1{2,}).{12,128}$',
+            rules: [
+                { id: 'minLength', label: 'At least 12 characters', pattern: '.{12,}' },
+                { id: 'digit', label: 'Contains a number', pattern: '[0-9]' },
+                { id: 'uppercase', label: 'Contains uppercase letter', pattern: '[A-Z]' },
+                { id: 'lowercase', label: 'Contains lowercase letter', pattern: '[a-z]' },
+                { id: 'special', label: 'Contains a special character', pattern: '[!~<>.,;:_=?/*+\\-#\\"\'&§`£€%°()|\\[\\]$^@]' },
+                { id: 'noConsecutive', label: 'No more than 2 consecutive equal characters', pattern: '^(?!.*(.)\\1{2,}).+$' },
+            ],
+        }),
+    ),
 ];

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useUserMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/hooks/useUserMutations.ts
@@ -24,6 +24,7 @@ import {
     deleteOrganizationUser,
     processUserRegistration,
     removeUserFromGroup,
+    resetOrganizationUserPassword,
     revokeOrganizationUserToken,
     updateOrganizationUserRoles,
     updateOrganizationUserServiceAccount,
@@ -184,5 +185,11 @@ export function useUpdateOrganizationUserRoles(userId: string | undefined) {
                 void queryClient.invalidateQueries({ queryKey: organizationUserKeys.detail(userId) });
             }
         },
+    });
+}
+
+export function useResetOrganizationUserPassword(userId: string | undefined) {
+    return useMutation({
+        mutationFn: () => resetOrganizationUserPassword(userId!),
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.spec.ts
@@ -13,6 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonOrg: jest.fn(),
+    apimFetchJsonV1Env: jest.fn(),
+    apimFetchJsonV2: jest.fn(),
+    apimFetchJsonV2Org: jest.fn(),
+    resolveOrganizationId: jest.fn(),
+}));
+
 import {
     addUserToGroup,
     createOrganizationUser,
@@ -32,6 +40,7 @@ import {
     listOrganizationUsers,
     listOrganizationUserTokens,
     processUserRegistration,
+    resetOrganizationUserPassword,
     revokeOrganizationUserToken,
     removeUserFromGroup,
     updateOrganizationUserRoles,
@@ -45,14 +54,6 @@ import {
     apimFetchJsonV2Org,
     resolveOrganizationId,
 } from '../../../shared/api/apimClient';
-
-jest.mock('../../../shared/api/apimClient', () => ({
-    apimFetchJsonOrg: jest.fn(),
-    apimFetchJsonV1Env: jest.fn(),
-    apimFetchJsonV2: jest.fn(),
-    apimFetchJsonV2Org: jest.fn(),
-    resolveOrganizationId: jest.fn(),
-}));
 
 const mockApimFetchJsonOrg = jest.mocked(apimFetchJsonOrg);
 const mockApimFetchJsonV1Env = jest.mocked(apimFetchJsonV1Env);
@@ -350,6 +351,16 @@ describe('organizationUsers service', () => {
                 referenceId: 'DEFAULT',
                 roles: ['org-user'],
             }),
+        });
+    });
+
+    it('resets an organization user password', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue(undefined);
+
+        await resetOrganizationUserPassword('user-1');
+
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/users/user-1/resetPassword?resetTarget=gamma', {
+            method: 'POST',
         });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/services/organizationUsers.ts
@@ -258,3 +258,9 @@ export async function updateOrganizationUserRoles(userId: string, payload: Updat
         }),
     });
 }
+
+export async function resetOrganizationUserPassword(userId: string): Promise<void> {
+    await apimFetchJsonOrg<void>(`/users/${encodeURIComponent(userId)}/resetPassword?resetTarget=gamma`, {
+        method: 'POST',
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.spec.ts
@@ -15,6 +15,7 @@
  */
 import {
     canConvertToServiceAccount,
+    canResetPassword,
     formatCustomFieldValue,
     formatUserDisplayName,
     formatUserTimestamp,
@@ -66,5 +67,13 @@ describe('userDetailDisplay utilities', () => {
         expect(canConvertToServiceAccount({ isServiceAccount: undefined, hasPassword: true, source: 'gravitee' })).toBe(false);
         expect(canConvertToServiceAccount({ isServiceAccount: undefined, hasPassword: false, source: 'ldap' })).toBe(false);
         expect(canConvertToServiceAccount({ isServiceAccount: true, hasPassword: false, source: 'gravitee' })).toBe(false);
+    });
+
+    it('allows password reset for active gravitee users that are not service accounts', () => {
+        expect(canResetPassword({ source: 'gravitee', hasPassword: true, isServiceAccount: false, status: 'ACTIVE' })).toBe(true);
+        expect(canResetPassword({ source: 'gravitee', hasPassword: false, isServiceAccount: false, status: 'ACTIVE' })).toBe(true);
+        expect(canResetPassword({ source: 'ldap', hasPassword: true, isServiceAccount: false, status: 'ACTIVE' })).toBe(false);
+        expect(canResetPassword({ source: 'gravitee', hasPassword: true, isServiceAccount: true, status: 'ACTIVE' })).toBe(false);
+        expect(canResetPassword({ source: 'gravitee', hasPassword: true, isServiceAccount: false, status: 'PENDING' })).toBe(false);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.ts
@@ -82,3 +82,11 @@ export function canConvertToServiceAccount(user: Pick<OrganizationUser, 'isServi
         (user.isServiceAccount === null || user.isServiceAccount === undefined) && user.hasPassword !== true && user.source === 'gravitee'
     );
 }
+
+export function isServiceAccountUser(user: Pick<OrganizationUser, 'isServiceAccount'>): boolean {
+    return user.isServiceAccount === true;
+}
+
+export function canResetPassword(user: Pick<OrganizationUser, 'source' | 'hasPassword' | 'isServiceAccount' | 'status'>): boolean {
+    return user.source === 'gravitee' && !isServiceAccountUser(user) && user.status?.toUpperCase() === 'ACTIVE';
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDetailDisplay.ts
@@ -82,3 +82,11 @@ export function canConvertToServiceAccount(user: Pick<OrganizationUser, 'isServi
         (user.isServiceAccount === null || user.isServiceAccount === undefined) && user.hasPassword !== true && user.source === 'gravitee'
     );
 }
+
+export function isServiceAccountUser(user: Pick<OrganizationUser, 'isServiceAccount'>): boolean {
+    return user.isServiceAccount === true;
+}
+
+export function canResetPassword(user: Pick<OrganizationUser, 'source' | 'isServiceAccount' | 'status'>): boolean {
+    return user.source === 'gravitee' && !isServiceAccountUser(user) && user.status?.toUpperCase() === 'ACTIVE';
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.spec.tsx
@@ -29,6 +29,7 @@ import {
 } from '../features/users/hooks/useOrganizationUser';
 import {
     useProcessUserRegistration,
+    useResetOrganizationUserPassword,
     useUpdateOrganizationUserRoles,
     useUpdateOrganizationUserServiceAccount,
 } from '../features/users/hooks/useUserMutations';
@@ -89,6 +90,7 @@ jest.mock('../features/users/hooks/useUserMutations', () => ({
     useProcessUserRegistration: jest.fn(),
     useUpdateOrganizationUserRoles: jest.fn(),
     useUpdateOrganizationUserServiceAccount: jest.fn(),
+    useResetOrganizationUserPassword: jest.fn(),
 }));
 
 const mockUseHasPermission = jest.mocked(useHasPermission);
@@ -99,6 +101,7 @@ const mockUseEnvironmentRoleCatalog = jest.mocked(useEnvironmentRoleCatalog);
 const mockUseProcessUserRegistration = jest.mocked(useProcessUserRegistration);
 const mockUseUpdateOrganizationUserServiceAccount = jest.mocked(useUpdateOrganizationUserServiceAccount);
 const mockUseUpdateOrganizationUserRoles = jest.mocked(useUpdateOrganizationUserRoles);
+const mockUseResetOrganizationUserPassword = jest.mocked(useResetOrganizationUserPassword);
 
 async function commitOrganizationRoleChange(user: ReturnType<typeof userEvent.setup>, roleLabel: string) {
     await user.click(screen.getByRole('button', { name: 'Organization roles' }));
@@ -207,6 +210,10 @@ describe('UserDetailPage', () => {
             mutate: jest.fn(),
             isPending: false,
         } as unknown as ReturnType<typeof useUpdateOrganizationUserRoles>);
+        mockUseResetOrganizationUserPassword.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as unknown as ReturnType<typeof useResetOrganizationUserPassword>);
     });
 
     afterEach(() => {
@@ -601,5 +608,121 @@ describe('UserDetailPage', () => {
         renderUserDetailPage();
 
         expect(await screen.findByText('User not found or failed to load.')).toBeTruthy();
+    });
+
+    it('shows reset password for active gravitee users with a local password', async () => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUser.mockReturnValue({
+            data: {
+                ...DETAIL_USER,
+                status: 'ACTIVE',
+                source: 'gravitee',
+                hasPassword: true,
+                isServiceAccount: false,
+            },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+
+        renderUserDetailPage();
+
+        expect(await screen.findByRole('button', { name: 'Reset password' })).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Convert to service account' })).toBeNull();
+    });
+
+    it('shows reset password for SSO-only gravitee users like classic console', async () => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUser.mockReturnValue({
+            data: {
+                ...DETAIL_USER,
+                status: 'ACTIVE',
+                source: 'gravitee',
+                hasPassword: false,
+                isServiceAccount: undefined,
+            },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+
+        renderUserDetailPage();
+
+        expect(await screen.findByRole('button', { name: 'Reset password' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Convert to service account' })).toBeTruthy();
+    });
+
+    it('calls reset password for SSO-only gravitee users like classic console', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn((_value: undefined, options?: { onSuccess?: () => void }) => options?.onSuccess?.());
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUser.mockReturnValue({
+            data: {
+                ...DETAIL_USER,
+                status: 'ACTIVE',
+                source: 'gravitee',
+                hasPassword: false,
+                isServiceAccount: undefined,
+            },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+        mockUseResetOrganizationUserPassword.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useResetOrganizationUserPassword>);
+
+        renderUserDetailPage();
+
+        await user.click(await screen.findByRole('button', { name: 'Reset password' }));
+        await user.click(within(await screen.findByRole('dialog')).getByRole('button', { name: 'Reset' }));
+
+        expect(mutate).toHaveBeenCalled();
+    });
+
+    it('hides reset password for external identity provider users', async () => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUser.mockReturnValue({
+            data: {
+                ...DETAIL_USER,
+                status: 'ACTIVE',
+                source: 'ldap',
+                hasPassword: true,
+                isServiceAccount: false,
+            },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+
+        renderUserDetailPage();
+
+        await screen.findByRole('heading', { name: 'Anna Schmidt' });
+        expect(screen.queryByRole('button', { name: 'Reset password' })).toBeNull();
+    });
+
+    it('shows a success toast after password reset', async () => {
+        const user = userEvent.setup();
+        const mutate = jest.fn((_value: undefined, options?: { onSuccess?: () => void }) => options?.onSuccess?.());
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationUser.mockReturnValue({
+            data: {
+                ...DETAIL_USER,
+                status: 'ACTIVE',
+                source: 'gravitee',
+                hasPassword: true,
+                isServiceAccount: false,
+            },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrganizationUser>);
+        mockUseResetOrganizationUserPassword.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useResetOrganizationUserPassword>);
+
+        renderUserDetailPage();
+
+        await user.click(await screen.findByRole('button', { name: 'Reset password' }));
+        await user.click(within(await screen.findByRole('dialog')).getByRole('button', { name: 'Reset' }));
+
+        await waitFor(() => expect(notify.success).toHaveBeenCalledWith('The password of user "Anna Schmidt" has been successfully reset'));
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/UserDetailPage.tsx
@@ -33,10 +33,16 @@ import {
 } from '../features/users/hooks/useOrganizationUser';
 import {
     useProcessUserRegistration,
+    useResetOrganizationUserPassword,
     useUpdateOrganizationUserRoles,
     useUpdateOrganizationUserServiceAccount,
 } from '../features/users/hooks/useUserMutations';
-import { canConvertToServiceAccount, formatUserDisplayName, roleLabelsForIds } from '../features/users/utils/userDetailDisplay';
+import {
+    canConvertToServiceAccount,
+    canResetPassword,
+    formatUserDisplayName,
+    roleLabelsForIds,
+} from '../features/users/utils/userDetailDisplay';
 import {
     ORGANIZATION_USER_CREATE_PERMISSION,
     ORGANIZATION_USER_DELETE_PERMISSION,
@@ -55,6 +61,7 @@ export function UserDetailPage() {
     const canDelete = useHasPermission({ anyOf: [ORGANIZATION_USER_DELETE_PERMISSION] });
     const [registrationConfirm, setRegistrationConfirm] = useState<RegistrationConfirmAction | null>(null);
     const [convertToServiceAccountConfirmOpen, setConvertToServiceAccountConfirmOpen] = useState(false);
+    const [resetPasswordConfirmOpen, setResetPasswordConfirmOpen] = useState(false);
 
     const { data: user, isLoading: userLoading, isError: userError } = useOrganizationUser(userId);
     const { data: environments = [], isLoading: environmentsLoading } = useOrganizationEnvironments();
@@ -62,6 +69,7 @@ export function UserDetailPage() {
     const { data: environmentRoles = [], isLoading: environmentRolesLoading } = useEnvironmentRoleCatalog();
     const processRegistration = useProcessUserRegistration(userId);
     const convertToServiceAccount = useUpdateOrganizationUserServiceAccount(userId);
+    const resetPassword = useResetOrganizationUserPassword(userId);
     const updateUserRoles = useUpdateOrganizationUserRoles(userId);
     const shellEnvironment = useEnvironment();
 
@@ -102,6 +110,22 @@ export function UserDetailPage() {
             },
             onError: error => {
                 notify.error(error, 'Failed to convert user to a service account.');
+            },
+        });
+    }
+
+    function handleResetPasswordConfirm() {
+        if (!user) {
+            return;
+        }
+
+        resetPassword.mutate(undefined, {
+            onSuccess: () => {
+                setResetPasswordConfirmOpen(false);
+                notify.success(`The password of user "${formatUserDisplayName(user)}" has been successfully reset`);
+            },
+            onError: error => {
+                notify.error(error, 'Failed to reset user password.');
             },
         });
     }
@@ -172,8 +196,39 @@ export function UserDetailPage() {
 
     const showRegistrationBanner = canUpdate && user.status?.toUpperCase() === 'PENDING';
     const showConvertToServiceAccount = canUpdate && canConvertToServiceAccount(user);
+    const showResetPassword = canUpdate && canResetPassword(user);
+    const hasProfileHeaderActions = showResetPassword || showConvertToServiceAccount;
     const userDisplayName = formatUserDisplayName(user);
     const tokenEnvironmentId = shellEnvironment?.id ?? environments[0]?.id ?? 'DEFAULT';
+
+    const profileHeaderActions = (
+        <>
+            {showResetPassword ? (
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    aria-label="Reset password"
+                    disabled={resetPassword.isPending}
+                    onClick={() => setResetPasswordConfirmOpen(true)}
+                >
+                    Reset password
+                </Button>
+            ) : null}
+            {showConvertToServiceAccount ? (
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    aria-label="Convert to service account"
+                    disabled={convertToServiceAccount.isPending}
+                    onClick={() => setConvertToServiceAccountConfirmOpen(true)}
+                >
+                    Convert to service account
+                </Button>
+            ) : null}
+        </>
+    );
 
     return (
         <div className="space-y-6">
@@ -184,23 +239,7 @@ export function UserDetailPage() {
                 </Link>
             </Button>
 
-            <UserProfileCard
-                user={user}
-                headerActions={
-                    showConvertToServiceAccount ? (
-                        <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            aria-label="Convert to service account"
-                            disabled={convertToServiceAccount.isPending}
-                            onClick={() => setConvertToServiceAccountConfirmOpen(true)}
-                        >
-                            Convert to service account
-                        </Button>
-                    ) : undefined
-                }
-            />
+            <UserProfileCard user={user} headerActions={hasProfileHeaderActions ? profileHeaderActions : undefined} />
 
             {showRegistrationBanner ? (
                 <UserRegistrationPendingBanner
@@ -243,6 +282,25 @@ export function UserDetailPage() {
                     pendingLabel="Converting…"
                     isPending={convertToServiceAccount.isPending}
                     onConfirm={handleConvertToServiceAccountConfirm}
+                />
+            ) : null}
+
+            {resetPasswordConfirmOpen ? (
+                <ConfirmDialog
+                    open
+                    onOpenChange={open => !open && !resetPassword.isPending && setResetPasswordConfirmOpen(open)}
+                    title="Reset user password"
+                    description={
+                        <>
+                            Are you sure you want to reset the password of user <strong>{userDisplayName}</strong>?
+                            <br />
+                            The user will receive an email with a link to set a new password.
+                        </>
+                    }
+                    confirmLabel="Reset"
+                    pendingLabel="Resetting…"
+                    isPending={resetPassword.isPending}
+                    onConfirm={handleResetPasswordConfirm}
                 />
             ) : null}
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-87

## Description
Adds Gamma password reset end-to-end: platform admins can trigger reset from the user detail page; users complete the flow on a new public Gamma reset page. Matches classic APIM Console behavior for user gating and token handling. Password requirements come from the backend policy API as a checklist 

**Platform module — admin reset (gravitee-gamma-module-platform)**
UserDetailPage — “Reset password” action with confirm dialog and success toast (classic parity)
canResetPassword() — button shown only for ACTIVE, source=gravitee, non–service-account users
resetOrganizationUserPassword() — POST /users/{id}/resetPassword?resetTarget=gamma
useResetOrganizationUserPassword mutation hook

**Control plane — public reset page (gravitee-gamma-control-plane-webui)**
Route /reset-password/:token 
ResetPasswordPage — read-only user fields from JWT, password + confirm, requirements checklist + strength meter
Token handling — decode + expiry check on UI (classic pattern); full token sent to backend for verification
resetPassword.service.ts — reset flow uses managementApi from api-client, not a separate fetch/CSRF client 
usePasswordPolicy — loads rules from GET /configuration/password-policy
Submit blocked when policy fails to load or rules are not satisfied
API validation errors surfaced inline (e.g. policy violations)


https://github.com/user-attachments/assets/e23f338f-ed98-42a6-9f72-47dce9e6e0c4
