### PR TITLE
fix: report the reason when a target token deletion fails

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteTargetTokenCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteTargetTokenCommandHandler.java
@@ -54,7 +54,7 @@ public class DeleteTargetTokenCommandHandler implements CommandHandler<DeleteTar
             log.info("User with id [{}] has not been found.", payload.id());
         } catch (Exception e) {
             log.error("Error occurred while deleting target token for user with id [{}].", payload.id(), e);
-            return Single.just(new DeleteTargetTokenReply(command.getId(), CommandStatus.ERROR));
+            return Single.just(new DeleteTargetTokenReply(command.getId(), e.getMessage()));
         }
 
         return Single.just(new DeleteTargetTokenReply(command.getId(), CommandStatus.SUCCEEDED));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteTargetTokenCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteTargetTokenCommandHandlerTest.java
@@ -108,7 +108,8 @@ class DeleteTargetTokenCommandHandlerTest {
             .assertComplete()
             .assertNoErrors()
             .assertValue(reply -> nonNull(reply.getCommandId()))
-            .assertValue(reply -> CommandStatus.ERROR.equals(reply.getCommandStatus()));
+            .assertValue(reply -> CommandStatus.ERROR.equals(reply.getCommandStatus()))
+            .assertValue(reply -> "Error during deletion".equals(reply.getErrorDetails()));
     }
 
     private static DeleteTargetTokenCommandPayload generatePayload() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-5090

## Description

When a target token deletion fails, the reply told cockpit that it failed but not why, so the alert on the cockpit side read `BatchError: null` and the reason was only in the installation logs.

`DeleteTargetTokenReply` already has a constructor taking the error details, it just was not used. The handler now passes the exception message, typically `The user is still primary owner of '0' APIs and '2' Applications`.

Backward compatible: an older cockpit ignores the field.