### PR TITLE
feat(observability): add Gamma dashboards write endpoints

### DIFF
--- a/gravitee-gamma/gravitee-gamma-rest-api/AGENTS.md
+++ b/gravitee-gamma/gravitee-gamma-rest-api/AGENTS.md
@@ -110,6 +110,18 @@ Allowed dependencies:
 
 Only exception: `@UseCase` uses `@Transactional` (accepted trade-off).
 
+**The core layer does not log.** Two guardrails overlap to forbid both logger annotations here, and neither
+fires during `mvn test`:
+
+- `@CustomLog` resolves to `io.gravitee.node.logging.NodeLoggerFactory` (see the root `lombok.config`), which
+  is not in the allowlist above — caught by `CoreRulesTest`.
+- `@Slf4j` resolves to `org.slf4j.LoggerFactory`, forbidden repo-wide by the `gravitee-archrules-maven-plugin`
+  `global-logging-check` goal. The allowlist entry `org.slf4j.*` above therefore only covers types like
+  `Logger` passed around, never the factory.
+
+Log from the REST or infra layer instead, with `@CustomLog`. Run `mvn verify -pl <module> -DskipTests` before
+pushing: the plugin check runs after `test`, so a green `mvn test` proves nothing about it.
+
 ## 6. Infrastructure Layer
 
 - Generate adapters to convert between repository / SPI models and core domain models (Anticorruption Layer).

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/DashboardContent.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/DashboardContent.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The author-editable part of a {@link Dashboard} — what POST and PUT both carry (OBS-16). Server-owned
+ * fields ({@code version}, {@code createdBy}, timestamps, {@code environmentId}) are deliberately
+ * absent: the write use cases derive them, so a request can never smuggle them in.
+ *
+ * <p>{@link #validate()} holds the structural write guardrails and nothing semantic: {@code widgets}
+ * stays opaque apart from the caps and per-widget {@code id} checks below — the dangerous surface
+ * (the analytics query) is validated server-side at read time, so a malformed widget yields a 400 at
+ * query time rather than an arbitrary query. It is separate from {@link Dashboard}'s compact
+ * constructor on purpose: the constructor also runs when re-hydrating persisted rows, where a
+ * pre-guardrail row must keep loading.
+ *
+ * @author GraviteeSource Team
+ */
+public record DashboardContent(String title, String description, List<DashboardFilter> filters, TimeRange timeRange, JsonNode widgets) {
+    /** React keys and grid identities on the frontend — a duplicate breaks rendering, so reject early. */
+    private static final int MAX_WIDGETS = 50;
+
+    /** Order-of-magnitude cap on the serialized widgets payload — the column is otherwise unbounded. */
+    private static final int MAX_WIDGETS_PAYLOAD_LENGTH = 1_048_576;
+
+    public DashboardContent {
+        filters = filters == null ? List.of() : List.copyOf(filters);
+    }
+
+    public void validate() {
+        if (title == null || title.isBlank()) {
+            throw new InvalidDashboardException("Dashboard title is required");
+        }
+        validateWidgets();
+        validateTimeRange();
+    }
+
+    private void validateWidgets() {
+        if (widgets == null || widgets.isNull()) {
+            return;
+        }
+        if (!widgets.isArray()) {
+            throw new InvalidDashboardException("Dashboard widgets must be an array");
+        }
+        if (widgets.size() > MAX_WIDGETS) {
+            throw new InvalidDashboardException("Dashboard cannot hold more than %d widgets".formatted(MAX_WIDGETS));
+        }
+        if (widgets.toString().length() > MAX_WIDGETS_PAYLOAD_LENGTH) {
+            throw new InvalidDashboardException("Dashboard widgets payload exceeds the maximum allowed size");
+        }
+        Set<String> seenIds = new HashSet<>();
+        for (JsonNode widget : widgets) {
+            String id = widget.path("id").asText("");
+            if (id.isBlank()) {
+                throw new InvalidDashboardException("Every dashboard widget requires a non-blank id");
+            }
+            if (!seenIds.add(id)) {
+                throw new InvalidDashboardException("Duplicate widget id '%s'".formatted(id));
+            }
+        }
+    }
+
+    private void validateTimeRange() {
+        if (timeRange == null) {
+            return;
+        }
+        if (timeRange.type() == TimeRangeType.RELATIVE && (timeRange.period() == null || timeRange.period().isBlank())) {
+            throw new InvalidDashboardException("A relative time range requires a period");
+        }
+        if (timeRange.type() == TimeRangeType.ABSOLUTE) {
+            if (timeRange.from() == null || timeRange.to() == null) {
+                throw new InvalidDashboardException("An absolute time range requires both from and to");
+            }
+            if (timeRange.from() >= timeRange.to()) {
+                throw new InvalidDashboardException("An absolute time range requires from to be before to");
+            }
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/DashboardContent.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/DashboardContent.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The author-editable part of a {@link Dashboard} — what POST and PUT both carry (OBS-16). Server-owned
+ * fields ({@code version}, {@code createdBy}, timestamps, {@code environmentId}) are deliberately
+ * absent: the write use cases derive them, so a request can never smuggle them in.
+ *
+ * <p>{@link #validate()} holds the structural write guardrails and nothing semantic: {@code widgets}
+ * stays opaque apart from the caps and per-widget {@code id} checks below — the dangerous surface
+ * (the analytics query) is validated server-side at read time, so a malformed widget yields a 400 at
+ * query time rather than an arbitrary query. It is separate from {@link Dashboard}'s compact
+ * constructor on purpose: the constructor also runs when re-hydrating persisted rows, where a
+ * pre-guardrail row must keep loading.
+ *
+ * @author GraviteeSource Team
+ */
+public record DashboardContent(String title, String description, List<DashboardFilter> filters, TimeRange timeRange, JsonNode widgets) {
+    /** React keys and grid identities on the frontend — a duplicate breaks rendering, so reject early. */
+    private static final int MAX_WIDGETS = 50;
+
+    /** Order-of-magnitude cap on the serialized widgets payload — the column is otherwise unbounded. */
+    private static final int MAX_WIDGETS_PAYLOAD_LENGTH = 1_048_576;
+
+    public DashboardContent {
+        filters = filters == null ? List.of() : List.copyOf(filters);
+    }
+
+    public void validate() {
+        if (title == null || title.isBlank()) {
+            throw new InvalidDashboardException("Dashboard title is required");
+        }
+        validateWidgets();
+        validateTimeRange();
+    }
+
+    private void validateWidgets() {
+        if (widgets == null || widgets.isNull()) {
+            return;
+        }
+        if (!widgets.isArray()) {
+            throw new InvalidDashboardException("Dashboard widgets must be an array");
+        }
+        if (widgets.size() > MAX_WIDGETS) {
+            throw new InvalidDashboardException("Dashboard cannot hold more than " + MAX_WIDGETS + " widgets");
+        }
+        if (widgets.toString().length() > MAX_WIDGETS_PAYLOAD_LENGTH) {
+            throw new InvalidDashboardException("Dashboard widgets payload exceeds the maximum allowed size");
+        }
+        Set<String> seenIds = new HashSet<>();
+        for (JsonNode widget : widgets) {
+            String id = widget.path("id").asText("");
+            if (id.isBlank()) {
+                throw new InvalidDashboardException("Every dashboard widget requires a non-blank id");
+            }
+            if (!seenIds.add(id)) {
+                throw new InvalidDashboardException("Duplicate widget id '" + id + "'");
+            }
+        }
+    }
+
+    private void validateTimeRange() {
+        if (timeRange == null) {
+            return;
+        }
+        if (timeRange.type() == TimeRangeType.RELATIVE && (timeRange.period() == null || timeRange.period().isBlank())) {
+            throw new InvalidDashboardException("A relative time range requires a period");
+        }
+        if (timeRange.type() == TimeRangeType.ABSOLUTE) {
+            if (timeRange.from() == null || timeRange.to() == null) {
+                throw new InvalidDashboardException("An absolute time range requires both from and to");
+            }
+            if (timeRange.from() >= timeRange.to()) {
+                throw new InvalidDashboardException("An absolute time range requires from to be before to");
+            }
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/port/repository/DashboardRepository.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/port/repository/DashboardRepository.java
@@ -42,4 +42,15 @@ public interface DashboardRepository {
      * remember to perform.
      */
     Optional<Dashboard> findByIdAndEnvironmentId(String id, String environmentId);
+
+    Dashboard create(Dashboard dashboard);
+
+    Dashboard update(Dashboard dashboard);
+
+    /**
+     * Takes a bare id because environment scoping happens before deletion: the delete use case
+     * resolves the dashboard through {@link #findByIdAndEnvironmentId} first, so a cross-environment
+     * id 404s without ever reaching this method.
+     */
+    void delete(String id);
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/CreateObservabilityDashboardUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/CreateObservabilityDashboardUseCase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardContent;
+import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.DashboardRepository;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+
+/**
+ * Creates a dashboard from author-supplied {@link DashboardContent} (OBS-16). The id is
+ * client-supplied (AGENTS.md §9 — resource-creation ids come from the request); every server-owned
+ * field is derived here: {@code version} starts at 1, {@code createdBy} is the authenticated caller,
+ * {@code createdAt}/{@code updatedAt} are stamped now. Version is maintained but not enforced — the
+ * optimistic-locking guard is OBS-17.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@AllArgsConstructor
+public class CreateObservabilityDashboardUseCase {
+
+    private static final int INITIAL_VERSION = 1;
+
+    private final DashboardRepository dashboardRepository;
+
+    public record Input(String environmentId, String createdBy, String dashboardId, DashboardContent content) {}
+
+    public record Output(Dashboard dashboard) {}
+
+    public Output execute(Input input) {
+        input.content().validate();
+        Instant now = TimeProvider.instantNow();
+        Dashboard dashboard = new Dashboard(
+            input.dashboardId(),
+            input.environmentId(),
+            input.content().title(),
+            input.content().description(),
+            input.content().filters(),
+            input.content().timeRange(),
+            input.content().widgets(),
+            INITIAL_VERSION,
+            input.createdBy(),
+            now,
+            now
+        );
+        return new Output(dashboardRepository.create(dashboard));
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/DeleteObservabilityDashboardUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/DeleteObservabilityDashboardUseCase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.DashboardNotFoundException;
+import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.DashboardRepository;
+import lombok.AllArgsConstructor;
+
+/**
+ * Deletes a dashboard (OBS-16). Resolves the id through the environment-scoped lookup first, so a
+ * dashboard belonging to another environment throws {@link DashboardNotFoundException} — 404, not
+ * 403 — and never reaches the unscoped {@link DashboardRepository#delete}.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@AllArgsConstructor
+public class DeleteObservabilityDashboardUseCase {
+
+    private final DashboardRepository dashboardRepository;
+
+    public record Input(String environmentId, String dashboardId) {}
+
+    public record Output() {}
+
+    public Output execute(Input input) {
+        dashboardRepository
+            .findByIdAndEnvironmentId(input.dashboardId(), input.environmentId())
+            .orElseThrow(() -> new DashboardNotFoundException(input.dashboardId()));
+        dashboardRepository.delete(input.dashboardId());
+        return new Output();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/UpdateObservabilityDashboardUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/UpdateObservabilityDashboardUseCase.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.DashboardNotFoundException;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardContent;
+import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.DashboardRepository;
+import lombok.AllArgsConstructor;
+
+/**
+ * Replaces a dashboard's author-editable content (OBS-16). Starts from the existing aggregate so the
+ * server-owned fields survive the write: {@code createdAt} and {@code createdBy} are carried over,
+ * {@code updatedAt} is stamped now and {@code version} is incremented. A stale version is not
+ * rejected here — behaviour stays last-write-wins until OBS-17 lands the guard; a partial check
+ * would advertise a guarantee that still has a TOCTOU hole on the Mongo path.
+ *
+ * <p>A dashboard id from another environment throws {@link DashboardNotFoundException} — 404, not
+ * 403 — via the same environment-scoped lookup as the read path, so cross-environment existence
+ * cannot be probed.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@AllArgsConstructor
+public class UpdateObservabilityDashboardUseCase {
+
+    private final DashboardRepository dashboardRepository;
+
+    public record Input(String environmentId, String dashboardId, DashboardContent content) {}
+
+    public record Output(Dashboard dashboard) {}
+
+    public Output execute(Input input) {
+        input.content().validate();
+        Dashboard existing = dashboardRepository
+            .findByIdAndEnvironmentId(input.dashboardId(), input.environmentId())
+            .orElseThrow(() -> new DashboardNotFoundException(input.dashboardId()));
+        Dashboard updated = new Dashboard(
+            existing.id(),
+            existing.environmentId(),
+            input.content().title(),
+            input.content().description(),
+            input.content().filters(),
+            input.content().timeRange(),
+            input.content().widgets(),
+            nextVersion(existing),
+            existing.createdBy(),
+            existing.createdAt(),
+            TimeProvider.instantNow()
+        );
+        return new Output(dashboardRepository.update(updated));
+    }
+
+    /**
+     * Rows written before OBS-16 may carry a {@code null} version (the OBS-14 repository persists it
+     * verbatim, never initialises it) — treat them as unversioned and (re)start the counter.
+     */
+    private static int nextVersion(Dashboard existing) {
+        return existing.version() == null ? 1 : existing.version() + 1;
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapter.java
@@ -28,6 +28,7 @@ import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.Dashb
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
 import io.gravitee.repository.management.model.GammaDashboard;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -53,7 +54,7 @@ public class GammaDashboardRepositoryAdapter implements DashboardRepository {
         return RepositoryCalls.wrap(
             () ->
                 gammaDashboardRepository.findByEnvironmentId(environmentId).stream().map(GammaDashboardRepositoryAdapter::toCore).toList(),
-            "Failed to list dashboards for environment '" + environmentId + "'"
+            "Failed to list dashboards for environment '%s'".formatted(environmentId)
         );
     }
 
@@ -61,7 +62,34 @@ public class GammaDashboardRepositoryAdapter implements DashboardRepository {
     public Optional<Dashboard> findByIdAndEnvironmentId(String id, String environmentId) {
         return RepositoryCalls.wrap(
             () -> gammaDashboardRepository.findByIdAndEnvironmentId(id, environmentId).map(GammaDashboardRepositoryAdapter::toCore),
-            "Failed to fetch dashboard '" + id + "' for environment '" + environmentId + "'"
+            "Failed to fetch dashboard '%s' for environment '%s'".formatted(id, environmentId)
+        );
+    }
+
+    @Override
+    public Dashboard create(Dashboard dashboard) {
+        return RepositoryCalls.wrap(
+            () -> toCore(gammaDashboardRepository.create(toRepository(dashboard))),
+            "Failed to create dashboard '%s'".formatted(dashboard.id())
+        );
+    }
+
+    @Override
+    public Dashboard update(Dashboard dashboard) {
+        return RepositoryCalls.wrap(
+            () -> toCore(gammaDashboardRepository.update(toRepository(dashboard))),
+            "Failed to update dashboard '%s'".formatted(dashboard.id())
+        );
+    }
+
+    @Override
+    public void delete(String id) {
+        RepositoryCalls.wrap(
+            () -> {
+                gammaDashboardRepository.delete(id);
+                return null;
+            },
+            "Failed to delete dashboard '%s'".formatted(id)
         );
     }
 
@@ -95,7 +123,7 @@ public class GammaDashboardRepositoryAdapter implements DashboardRepository {
             return FilterOperator.valueOf(operator.toUpperCase());
         } catch (NullPointerException | IllegalArgumentException e) {
             throw new TechnicalDomainException(
-                "Persisted dashboard filter '" + field + "' has an unsupported operator '" + operator + "'",
+                "Persisted dashboard filter '%s' has an unsupported operator '%s'".formatted(field, operator),
                 e
             );
         }
@@ -112,7 +140,7 @@ public class GammaDashboardRepositoryAdapter implements DashboardRepository {
         try {
             return TimeRangeType.valueOf(type.toUpperCase());
         } catch (NullPointerException | IllegalArgumentException e) {
-            throw new TechnicalDomainException("Persisted dashboard has an unsupported time range type '" + type + "'", e);
+            throw new TechnicalDomainException("Persisted dashboard has an unsupported time range type '%s'".formatted(type), e);
         }
     }
 
@@ -125,5 +153,55 @@ public class GammaDashboardRepositoryAdapter implements DashboardRepository {
         } catch (JsonProcessingException e) {
             throw new TechnicalDomainException("Persisted dashboard widgets payload is not valid JSON", e);
         }
+    }
+
+    /**
+     * Reverse of {@link #toCore(GammaDashboard)}: lowercases the operator and time-range type back
+     * to the persisted vocabulary, and flattens the opaque widgets node to the stored JSON string.
+     *
+     * <p>Nulls are carried through rather than defaulted — the caller owns them. An absent
+     * {@code widgets} node is stored as {@code null} (not {@code "null"}), which {@code toCore}
+     * reads back as a JSON null, so an empty dashboard round-trips unchanged.
+     */
+    private static GammaDashboard toRepository(Dashboard source) {
+        return GammaDashboard.builder()
+            .id(source.id())
+            .environmentId(source.environmentId())
+            .title(source.title())
+            .description(source.description())
+            .filters(source.filters().stream().map(GammaDashboardRepositoryAdapter::toRepository).toList())
+            .timeRange(toRepository(source.timeRange()))
+            .widgets(serializeWidgets(source.widgets()))
+            .version(source.version())
+            .createdBy(source.createdBy())
+            .createdAt(source.createdAt() == null ? null : Date.from(source.createdAt()))
+            .updatedAt(source.updatedAt() == null ? null : Date.from(source.updatedAt()))
+            .build();
+    }
+
+    private static GammaDashboard.Filter toRepository(DashboardFilter source) {
+        return GammaDashboard.Filter.builder()
+            .field(source.condition().name())
+            .label(source.label())
+            .operator(source.condition().operator().name().toLowerCase())
+            .value(source.condition().values())
+            .editable(source.editable())
+            .build();
+    }
+
+    private static GammaDashboard.TimeRange toRepository(TimeRange source) {
+        if (source == null) {
+            return null;
+        }
+        return GammaDashboard.TimeRange.builder()
+            .type(source.type().name().toLowerCase())
+            .period(source.period())
+            .from(source.from())
+            .to(source.to())
+            .build();
+    }
+
+    private static String serializeWidgets(JsonNode widgets) {
+        return widgets == null || widgets.isNull() ? null : widgets.toString();
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapter.java
@@ -28,6 +28,7 @@ import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.Dashb
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
 import io.gravitee.repository.management.model.GammaDashboard;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -62,6 +63,33 @@ public class GammaDashboardRepositoryAdapter implements DashboardRepository {
         return RepositoryCalls.wrap(
             () -> gammaDashboardRepository.findByIdAndEnvironmentId(id, environmentId).map(GammaDashboardRepositoryAdapter::toCore),
             "Failed to fetch dashboard '" + id + "' for environment '" + environmentId + "'"
+        );
+    }
+
+    @Override
+    public Dashboard create(Dashboard dashboard) {
+        return RepositoryCalls.wrap(
+            () -> toCore(gammaDashboardRepository.create(toRepository(dashboard))),
+            "Failed to create dashboard '" + dashboard.id() + "'"
+        );
+    }
+
+    @Override
+    public Dashboard update(Dashboard dashboard) {
+        return RepositoryCalls.wrap(
+            () -> toCore(gammaDashboardRepository.update(toRepository(dashboard))),
+            "Failed to update dashboard '" + dashboard.id() + "'"
+        );
+    }
+
+    @Override
+    public void delete(String id) {
+        RepositoryCalls.wrap(
+            () -> {
+                gammaDashboardRepository.delete(id);
+                return null;
+            },
+            "Failed to delete dashboard '" + id + "'"
         );
     }
 
@@ -125,5 +153,47 @@ public class GammaDashboardRepositoryAdapter implements DashboardRepository {
         } catch (JsonProcessingException e) {
             throw new TechnicalDomainException("Persisted dashboard widgets payload is not valid JSON", e);
         }
+    }
+
+    private static GammaDashboard toRepository(Dashboard source) {
+        return GammaDashboard.builder()
+            .id(source.id())
+            .environmentId(source.environmentId())
+            .title(source.title())
+            .description(source.description())
+            .filters(source.filters().stream().map(GammaDashboardRepositoryAdapter::toRepository).toList())
+            .timeRange(toRepository(source.timeRange()))
+            .widgets(serializeWidgets(source.widgets()))
+            .version(source.version())
+            .createdBy(source.createdBy())
+            .createdAt(source.createdAt() == null ? null : Date.from(source.createdAt()))
+            .updatedAt(source.updatedAt() == null ? null : Date.from(source.updatedAt()))
+            .build();
+    }
+
+    private static GammaDashboard.Filter toRepository(DashboardFilter source) {
+        return GammaDashboard.Filter.builder()
+            .field(source.condition().name())
+            .label(source.label())
+            .operator(source.condition().operator().name().toLowerCase())
+            .value(source.condition().values())
+            .editable(source.editable())
+            .build();
+    }
+
+    private static GammaDashboard.TimeRange toRepository(TimeRange source) {
+        if (source == null) {
+            return null;
+        }
+        return GammaDashboard.TimeRange.builder()
+            .type(source.type().name().toLowerCase())
+            .period(source.period())
+            .from(source.from())
+            .to(source.to())
+            .build();
+    }
+
+    private static String serializeWidgets(JsonNode widgets) {
+        return widgets == null || widgets.isNull() ? null : widgets.toString();
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardResource.java
@@ -16,25 +16,36 @@
 package io.gravitee.gamma.rest.resources.observability.dashboards;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import io.gravitee.gamma.rest.core.observability.dashboard.use_case.DeleteObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.core.observability.dashboard.use_case.GetObservabilityDashboardUseCase;
+import io.gravitee.gamma.rest.core.observability.dashboard.use_case.UpdateObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.resources.observability.dashboards.dto.DashboardDto;
+import io.gravitee.gamma.rest.resources.observability.dashboards.dto.SaveDashboardRequestDto;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
 
 /**
- * Single saved-dashboard endpoint, reached via {@link ObservabilityDashboardsResource}'s
- * {@code {dashboardId}} locator.
+ * Single saved-dashboard endpoints (GET / PUT / DELETE), reached via
+ * {@link ObservabilityDashboardsResource}'s {@code {dashboardId}} locator.
  *
- * <p>Environment isolation: a dashboard id from another environment resolves to 404, not 403 (see
- * {@code GetObservabilityDashboardUseCase} / {@code DashboardRepository#findByIdAndEnvironmentId}),
- * so cross-environment existence cannot be probed.
+ * <p>Environment isolation: a dashboard id from another environment resolves to 404, not 403, on
+ * every verb (see {@code DashboardRepository#findByIdAndEnvironmentId}), so cross-environment
+ * existence cannot be probed.
+ *
+ * <p>On PUT the id comes from the path — a different id in the request body is ignored, like every
+ * other server-owned field (see {@link SaveDashboardRequestDto}).
  *
  * @author GraviteeSource Team
  */
@@ -44,11 +55,39 @@ public class ObservabilityDashboardResource {
     @Inject
     private GetObservabilityDashboardUseCase getDashboardUseCase;
 
+    @Inject
+    private UpdateObservabilityDashboardUseCase updateDashboardUseCase;
+
+    @Inject
+    private DeleteObservabilityDashboardUseCase deleteDashboardUseCase;
+
     @GET
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = { RolePermissionAction.READ }) })
     public DashboardDto get(@PathParam("dashboardId") String dashboardId) {
         var ctx = GraviteeContext.getExecutionContext();
         var output = getDashboardUseCase.execute(new GetObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), dashboardId));
         return DashboardDto.from(output.dashboard());
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = { RolePermissionAction.UPDATE }) })
+    public DashboardDto update(@PathParam("dashboardId") String dashboardId, SaveDashboardRequestDto request) {
+        if (request == null) {
+            throw new InvalidDashboardException("Request body is required");
+        }
+        var ctx = GraviteeContext.getExecutionContext();
+        var output = updateDashboardUseCase.execute(
+            new UpdateObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), dashboardId, request.toContent())
+        );
+        return DashboardDto.from(output.dashboard());
+    }
+
+    @DELETE
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = { RolePermissionAction.DELETE }) })
+    public Response delete(@PathParam("dashboardId") String dashboardId) {
+        var ctx = GraviteeContext.getExecutionContext();
+        deleteDashboardUseCase.execute(new DeleteObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), dashboardId));
+        return Response.noContent().build();
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResource.java
@@ -16,22 +16,32 @@
 package io.gravitee.gamma.rest.resources.observability.dashboards;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import io.gravitee.gamma.rest.core.observability.dashboard.use_case.CreateObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.core.observability.dashboard.use_case.ListObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.resources.observability.dashboards.dto.DashboardDto;
+import io.gravitee.gamma.rest.resources.observability.dashboards.dto.SaveDashboardRequestDto;
 import io.gravitee.gamma.rest.resources.tracing.dto.PaginatedResponseDto;
+import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import java.util.List;
+import lombok.CustomLog;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Saved-dashboard endpoints, mounted under
@@ -43,21 +53,31 @@ import java.util.List;
  *   <li>{@code GET /?page=&perPage=} — dashboards saved in the context environment, paginated
  *       (1-based, {@code perPage} capped server-side at 100). See {@link ListObservabilityDashboardUseCase}
  *       for why pagination is applied by slicing rather than a native repository query.</li>
- *   <li>{@code GET /{dashboardId}} — see {@link ObservabilityDashboardResource}.</li>
+ *   <li>{@code POST /} — creates a dashboard from a client-supplied id (AGENTS.md §9), returns
+ *       {@code 201} with a {@code Location} header.</li>
+ *   <li>{@code GET /{dashboardId}}, {@code PUT}, {@code DELETE} — see {@link ObservabilityDashboardResource}.</li>
  * </ul>
  *
  * <h2>Authorization</h2>
- * Declarative {@code ENVIRONMENT_DASHBOARD:READ} — a CRUD resource, unlike the deliberately lax
- * {@code ENVIRONMENT_DASHBOARD:READ || ENVIRONMENT_API:READ} check used by {@code LogsResource} /
- * {@code ObservabilityFiltersResource} for metadata discovery.
+ * Declarative {@code ENVIRONMENT_DASHBOARD} with per-verb ACLs — a CRUD resource, unlike the
+ * deliberately lax {@code ENVIRONMENT_DASHBOARD:READ || ENVIRONMENT_API:READ} check used by
+ * {@code LogsResource} / {@code ObservabilityFiltersResource} for metadata discovery. POST and PUT
+ * stay separate verbs (no PUT upsert): {@code @Permissions} is per method and CREATE / UPDATE are
+ * distinct ACLs, so collapsing them would silently grant creation to anyone holding update rights.
  *
  * @author GraviteeSource Team
  */
 @Produces(MediaType.APPLICATION_JSON)
+@CustomLog
 public class ObservabilityDashboardsResource {
+
+    private static final String UNKNOWN_USER = "unknown";
 
     @Inject
     private ListObservabilityDashboardUseCase listDashboardUseCase;
+
+    @Inject
+    private CreateObservabilityDashboardUseCase createDashboardUseCase;
 
     @Context
     private ResourceContext resourceContext;
@@ -69,6 +89,43 @@ public class ObservabilityDashboardsResource {
         var output = listDashboardUseCase.execute(new ListObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), page, perPage));
         List<DashboardDto> data = output.dashboards().stream().map(DashboardDto::from).toList();
         return PaginatedResponseDto.of(data, output.totalCount(), output.page(), output.perPage());
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = { RolePermissionAction.CREATE }) })
+    public Response create(@Context UriInfo uriInfo, SaveDashboardRequestDto request) {
+        if (request == null) {
+            throw new InvalidDashboardException("Request body is required");
+        }
+        var ctx = GraviteeContext.getExecutionContext();
+        var output = createDashboardUseCase.execute(
+            new CreateObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), currentUserId(), request.id(), request.toContent())
+        );
+        DashboardDto dto = DashboardDto.from(output.dashboard());
+        return Response.created(uriInfo.getAbsolutePathBuilder().path(dto.id()).build()).entity(dto).build();
+    }
+
+    /**
+     * Id of the authenticated caller, for {@code createdBy}.
+     *
+     * <p>Kept local on purpose: the observability adapters derive the same id when they build their
+     * {@code AuditInfo}, but they live under {@code infra} and the onion rules forbid
+     * {@code resources} and {@code infra} from seeing each other, so the two copies have no shared
+     * home short of a new top-level package or a core port — a call worth making on its own rather
+     * than inside this feature.
+     */
+    private static String currentUserId() {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof UserDetails user) {
+            return user.getUsername();
+        }
+        if (authentication != null && authentication.getPrincipal() != null) {
+            log.debug("Authenticated principal is not a UserDetails, falling back to its string form for createdBy");
+            return authentication.getPrincipal().toString();
+        }
+        log.warn("No authenticated principal while creating a dashboard, recording createdBy as '{}'", UNKNOWN_USER);
+        return UNKNOWN_USER;
     }
 
     @Path("/{dashboardId}")

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResource.java
@@ -16,22 +16,31 @@
 package io.gravitee.gamma.rest.resources.observability.dashboards;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import io.gravitee.gamma.rest.core.observability.dashboard.use_case.CreateObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.core.observability.dashboard.use_case.ListObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.resources.observability.dashboards.dto.DashboardDto;
+import io.gravitee.gamma.rest.resources.observability.dashboards.dto.SaveDashboardRequestDto;
 import io.gravitee.gamma.rest.resources.tracing.dto.PaginatedResponseDto;
+import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import java.util.List;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Saved-dashboard endpoints, mounted under
@@ -43,13 +52,17 @@ import java.util.List;
  *   <li>{@code GET /?page=&perPage=} — dashboards saved in the context environment, paginated
  *       (1-based, {@code perPage} capped server-side at 100). See {@link ListObservabilityDashboardUseCase}
  *       for why pagination is applied by slicing rather than a native repository query.</li>
- *   <li>{@code GET /{dashboardId}} — see {@link ObservabilityDashboardResource}.</li>
+ *   <li>{@code POST /} — creates a dashboard from a client-supplied id (AGENTS.md §9), returns
+ *       {@code 201} with a {@code Location} header.</li>
+ *   <li>{@code GET /{dashboardId}}, {@code PUT}, {@code DELETE} — see {@link ObservabilityDashboardResource}.</li>
  * </ul>
  *
  * <h2>Authorization</h2>
- * Declarative {@code ENVIRONMENT_DASHBOARD:READ} — a CRUD resource, unlike the deliberately lax
- * {@code ENVIRONMENT_DASHBOARD:READ || ENVIRONMENT_API:READ} check used by {@code LogsResource} /
- * {@code ObservabilityFiltersResource} for metadata discovery.
+ * Declarative {@code ENVIRONMENT_DASHBOARD} with per-verb ACLs — a CRUD resource, unlike the
+ * deliberately lax {@code ENVIRONMENT_DASHBOARD:READ || ENVIRONMENT_API:READ} check used by
+ * {@code LogsResource} / {@code ObservabilityFiltersResource} for metadata discovery. POST and PUT
+ * stay separate verbs (no PUT upsert): {@code @Permissions} is per method and CREATE / UPDATE are
+ * distinct ACLs, so collapsing them would silently grant creation to anyone holding update rights.
  *
  * @author GraviteeSource Team
  */
@@ -58,6 +71,9 @@ public class ObservabilityDashboardsResource {
 
     @Inject
     private ListObservabilityDashboardUseCase listDashboardUseCase;
+
+    @Inject
+    private CreateObservabilityDashboardUseCase createDashboardUseCase;
 
     @Context
     private ResourceContext resourceContext;
@@ -69,6 +85,34 @@ public class ObservabilityDashboardsResource {
         var output = listDashboardUseCase.execute(new ListObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), page, perPage));
         List<DashboardDto> data = output.dashboards().stream().map(DashboardDto::from).toList();
         return PaginatedResponseDto.of(data, output.totalCount(), output.page(), output.perPage());
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = { RolePermissionAction.CREATE }) })
+    public Response create(@Context UriInfo uriInfo, SaveDashboardRequestDto request) {
+        if (request == null) {
+            throw new InvalidDashboardException("Request body is required");
+        }
+        var ctx = GraviteeContext.getExecutionContext();
+        var output = createDashboardUseCase.execute(
+            new CreateObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), currentUsername(), request.id(), request.toContent())
+        );
+        DashboardDto dto = DashboardDto.from(output.dashboard());
+        return Response.created(uriInfo.getAbsolutePathBuilder().path(dto.id()).build()).entity(dto).build();
+    }
+
+    /**
+     * Same resolution as {@code ObservabilityFilterDataPortAdapter#currentAuditInfo()} — the
+     * authenticated principal set by the security filter chain; only {@code createdBy} is needed
+     * here, so the full {@code AuditInfo} is not built.
+     */
+    private static String currentUsername() {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof UserDetails user) {
+            return user.getUsername();
+        }
+        return authentication != null && authentication.getPrincipal() != null ? authentication.getPrincipal().toString() : "unknown";
     }
 
     @Path("/{dashboardId}")

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/DashboardTimeRangeDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/DashboardTimeRangeDto.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.gamma.rest.resources.observability.dashboards.dto;
 
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRange;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRangeType;
 
 /**
  * Wire shape for a dashboard's time range. {@code type} is lowercase ({@code relative} /
@@ -27,5 +29,18 @@ public record DashboardTimeRangeDto(String type, String period, Long from, Long 
             return null;
         }
         return new DashboardTimeRangeDto(timeRange.type().name().toLowerCase(), timeRange.period(), timeRange.from(), timeRange.to());
+    }
+
+    public TimeRange toCore() {
+        if (type == null || type.isBlank()) {
+            throw new InvalidDashboardException("Dashboard time range type is required");
+        }
+        TimeRangeType timeRangeType;
+        try {
+            timeRangeType = TimeRangeType.valueOf(type.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidDashboardException("Unsupported dashboard time range type '" + type + "'");
+        }
+        return new TimeRange(timeRangeType, period, from, to);
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/DashboardTimeRangeDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/DashboardTimeRangeDto.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.gamma.rest.resources.observability.dashboards.dto;
 
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRange;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRangeType;
 
 /**
  * Wire shape for a dashboard's time range. {@code type} is lowercase ({@code relative} /
@@ -27,5 +29,18 @@ public record DashboardTimeRangeDto(String type, String period, Long from, Long 
             return null;
         }
         return new DashboardTimeRangeDto(timeRange.type().name().toLowerCase(), timeRange.period(), timeRange.from(), timeRange.to());
+    }
+
+    public TimeRange toCore() {
+        if (type == null || type.isBlank()) {
+            throw new InvalidDashboardException("Dashboard time range type is required");
+        }
+        TimeRangeType timeRangeType;
+        try {
+            timeRangeType = TimeRangeType.valueOf(type.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidDashboardException("Unsupported dashboard time range type '%s'".formatted(type));
+        }
+        return new TimeRange(timeRangeType, period, from, to);
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/SaveDashboardFilterDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/SaveDashboardFilterDto.java
@@ -13,22 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gamma.rest.resources.observability.logs.dto;
+package io.gravitee.gamma.rest.resources.observability.dashboards.dto;
 
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardFilter;
 import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
 import io.gravitee.gamma.rest.resources.observability.dto.FilterValues;
 
 /**
- * Wire shape for one filter condition on the POST search body. Same polymorphic {@code value}
- * contract as the tracing endpoint's {@code FilterConditionDto}: scalar for
- * {@code EQ}/{@code GTE}/{@code LTE}, array for {@code IN}. Operator is UPPERCASE on the wire.
+ * Request shape for one dashboard filter (OBS-16). {@code value} is polymorphic — scalar or array,
+ * normalized by {@link FilterValues}; an empty array is the legal "all values" placeholder.
+ * {@code editable} is a boxed {@link Boolean} defaulting to {@code false} (locked) when absent — the
+ * restrictive default, which can never widen a scope by accident — then narrowed to the primitive
+ * the core model carries. The name is deliberately not checked against the filter catalogue: a
+ * dashboard is declarative configuration, validated at query time, and catalogue coupling would make
+ * dashboards non-importable across environments.
  */
-public record FilterConditionDto(String name, String operator, Object value) {
-    public FilterCondition toCore() {
+public record SaveDashboardFilterDto(String name, String label, String operator, Object value, Boolean editable) {
+    public DashboardFilter toCore() {
         if (name == null || name.isBlank()) {
-            throw UnsupportedObservabilityFilterException.unknownName(name);
+            throw new InvalidDashboardException("Dashboard filter name is required");
         }
         if (operator == null || operator.isBlank()) {
             throw UnsupportedObservabilityFilterException.unsupportedOperator(name, "(missing)");
@@ -39,6 +45,6 @@ public record FilterConditionDto(String name, String operator, Object value) {
         } catch (IllegalArgumentException e) {
             throw UnsupportedObservabilityFilterException.unsupportedOperator(name, operator);
         }
-        return new FilterCondition(name, op, FilterValues.normalize(value));
+        return new DashboardFilter(new FilterCondition(name, op, FilterValues.normalize(value)), label, editable != null && editable);
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/SaveDashboardRequestDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/SaveDashboardRequestDto.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.dashboards.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardContent;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardFilter;
+import java.util.List;
+
+/**
+ * Request shape shared by POST and PUT (OBS-16). {@code id} is read on POST only (client-supplied,
+ * AGENTS.md §9) — PUT takes the id from the path. Server-owned fields ({@code version},
+ * {@code createdAt}, {@code updatedAt}, {@code createdBy}, {@code environmentId}) are not declared
+ * here and are silently dropped by Jackson ({@code GraviteeMapper} disables
+ * {@code FAIL_ON_UNKNOWN_PROPERTIES}), so a client sending them cannot influence the write.
+ */
+public record SaveDashboardRequestDto(
+    String id,
+    String title,
+    String description,
+    List<SaveDashboardFilterDto> filters,
+    DashboardTimeRangeDto timeRange,
+    JsonNode widgets
+) {
+    public DashboardContent toContent() {
+        return new DashboardContent(title, description, toCoreFilters(), timeRange == null ? null : timeRange.toCore(), widgets);
+    }
+
+    /**
+     * A literal {@code null} element in the JSON array deserializes to a null entry — reject it as a
+     * 400 rather than letting it surface as an NPE-driven 500.
+     */
+    private List<DashboardFilter> toCoreFilters() {
+        if (filters == null) {
+            return List.of();
+        }
+        return filters
+            .stream()
+            .map(filter -> {
+                if (filter == null) {
+                    throw new InvalidDashboardException("Dashboard filters must not contain null entries");
+                }
+                return filter.toCore();
+            })
+            .toList();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dto/FilterValues.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dto/FilterValues.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.dto;
+
+import java.util.List;
+
+/**
+ * Shared normalization for the polymorphic filter {@code value} the observability wire contracts
+ * accept: a scalar for single-value operators ({@code EQ}, {@code GTE}, {@code LTE}), an array for
+ * {@code IN}/{@code NOT_IN} — either shape collapses to the {@code List<String>} the core
+ * {@code FilterCondition} carries. Promoted out of the logs {@code FilterConditionDto} (OBS-16) so
+ * the dashboards write DTOs reuse it instead of copying it. {@code null} and {@code []} both
+ * normalize to an empty list — the "all values" placeholder, which is legal and carries no query
+ * constraint.
+ *
+ * @author GraviteeSource Team
+ */
+public final class FilterValues {
+
+    private FilterValues() {}
+
+    public static List<String> normalize(Object value) {
+        if (value == null) {
+            return List.of();
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(FilterValues::asString).toList();
+        }
+        return List.of(asString(value));
+    }
+
+    private static String asString(Object v) {
+        return v == null ? "" : v.toString();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -1135,6 +1135,69 @@ paths:
                             example:
                                 httpStatus: 403
                                 message: "Insufficient permissions to access dashboards."
+        post:
+            tags:
+                - Dashboards
+            summary: Create a dashboard
+            description: |
+                Creates a dashboard from a client-supplied `id`. Server-owned fields (`version`,
+                `createdBy`, `createdAt`, `updatedAt`, `environmentId`) sent in the body are
+                ignored: `version` starts at 1, `createdBy` is the authenticated caller and the
+                timestamps are stamped server-side. A dashboard holds at most 50 widgets.
+            operationId: createObservabilityDashboard
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/SaveDashboardRequest"
+                        example:
+                            id: "d7e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+                            title: "Performance overview"
+                            description: "MCP traffic health"
+                            filters:
+                                - name: "API_TYPE"
+                                  label: "API Type"
+                                  operator: "EQ"
+                                  value: ["MCP"]
+                                  editable: false
+                            timeRange:
+                                type: "relative"
+                                period: "24h"
+                            widgets: [{ id: "w1", type: "metric" }]
+            responses:
+                "201":
+                    description: The dashboard was created. `Location` points at the new resource.
+                    headers:
+                        Location:
+                            description: URL of the created dashboard.
+                            schema:
+                                type: string
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Dashboard"
+                "400":
+                    description: |
+                        Structurally invalid dashboard — blank title, more than 50 widgets, an
+                        oversized widgets payload, a blank or duplicate widget id, an incoherent
+                        time range, or an unknown filter operator.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 400
+                                message: "Dashboard cannot hold more than 50 widgets"
+                "403":
+                    description: The caller cannot create dashboards in this environment.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 403
+                                message: "Insufficient permissions to create dashboards."
 
     /organizations/{orgId}/environments/{envId}/observability/dashboards/{dashboardId}:
         parameters:
@@ -1203,6 +1266,120 @@ paths:
                         No dashboard with this id exists in the context environment — either it
                         doesn't exist at all, or it belongs to a different environment. Both cases
                         collapse to this response so cross-environment existence cannot be probed.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 404
+                                message: "Dashboard 'd7e246cb-ab02-4da4-8f47-f9fa3e061d6b' not found"
+        put:
+            tags:
+                - Dashboards
+            summary: Update a dashboard
+            description: |
+                Replaces the author-editable content of a dashboard. The id comes from the path —
+                an `id` in the body is ignored, like every other server-owned field (`version`,
+                `createdBy`, `createdAt`, `updatedAt`, `environmentId`): `createdAt` and
+                `createdBy` are preserved, `updatedAt` is stamped now and `version` is incremented
+                server-side. A stale `version` is not rejected (last-write-wins); the
+                optimistic-locking guard is a separate change. A dashboard holds at most 50
+                widgets. A dashboard id belonging to another environment returns 404, so
+                cross-environment existence cannot be probed.
+            operationId: updateObservabilityDashboard
+            parameters:
+                - name: dashboardId
+                  in: path
+                  required: true
+                  description: Unique identifier of the dashboard.
+                  example: d7e246cb-ab02-4da4-8f47-f9fa3e061d6b
+                  schema:
+                      type: string
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/SaveDashboardRequest"
+                        example:
+                            title: "Performance overview (renamed)"
+                            filters: []
+                            timeRange:
+                                type: "absolute"
+                                from: 1730000000000
+                                to: 1730600000000
+                            widgets: [{ id: "w1", type: "metric" }]
+            responses:
+                "200":
+                    description: The updated dashboard, with the incremented `version`.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Dashboard"
+                "400":
+                    description: |
+                        Structurally invalid dashboard — blank title, more than 50 widgets, an
+                        oversized widgets payload, a blank or duplicate widget id, an incoherent
+                        time range, or an unknown filter operator.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 400
+                                message: "Dashboard title is required"
+                "403":
+                    description: The caller cannot update dashboards in this environment.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 403
+                                message: "Insufficient permissions to update dashboards."
+                "404":
+                    description: |
+                        No dashboard with this id exists in the context environment — either it
+                        doesn't exist at all, or it belongs to a different environment.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 404
+                                message: "Dashboard 'd7e246cb-ab02-4da4-8f47-f9fa3e061d6b' not found"
+        delete:
+            tags:
+                - Dashboards
+            summary: Delete a dashboard
+            description: |
+                Deletes a dashboard. A dashboard id belonging to another environment returns 404,
+                so cross-environment existence cannot be probed.
+            operationId: deleteObservabilityDashboard
+            parameters:
+                - name: dashboardId
+                  in: path
+                  required: true
+                  description: Unique identifier of the dashboard.
+                  example: d7e246cb-ab02-4da4-8f47-f9fa3e061d6b
+                  schema:
+                      type: string
+            responses:
+                "204":
+                    description: The dashboard was deleted.
+                "403":
+                    description: The caller cannot delete dashboards in this environment.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 403
+                                message: "Insufficient permissions to delete dashboards."
+                "404":
+                    description: |
+                        No dashboard with this id exists in the context environment — either it
+                        doesn't exist at all, or it belongs to a different environment.
                     content:
                         application/json:
                             schema:
@@ -2292,6 +2469,73 @@ components:
                         $ref: "#/components/schemas/Dashboard"
                 pagination:
                     $ref: "#/components/schemas/Pagination"
+
+        SaveDashboardFilter:
+            type: object
+            description: |
+                Request shape for one dashboard filter. `operator` is UPPERCASE; `value` accepts a
+                scalar (single-value operators) or an array (`IN`/`NOT_IN`) — an empty array is the
+                legal "all values" placeholder. `editable` defaults to `false` (locked) when
+                absent. The name is not checked against the filter catalogue at write time; the
+                analytics query path validates it at read time.
+            required: [name, operator]
+            properties:
+                name:
+                    type: string
+                    description: Canonical filter name from the shared filter catalog.
+                    example: API_TYPE
+                label:
+                    type: string
+                    description: Human-readable display name, persisted verbatim (not derivable).
+                    example: API Type
+                operator:
+                    $ref: "#/components/schemas/FilterOperator"
+                value:
+                    description: Scalar or array of values. An empty array is the "all values" placeholder.
+                    oneOf:
+                        - type: string
+                        - type: array
+                          items:
+                              type: string
+                    example: ["MCP"]
+                editable:
+                    type: boolean
+                    default: false
+                    description: Whether the viewer may change the value. Absent means `false` (locked).
+
+        SaveDashboardRequest:
+            type: object
+            description: |
+                Request shape shared by POST and PUT. `id` is read on POST only (client-supplied) —
+                PUT takes the id from the path. Server-owned fields (`version`, `createdBy`,
+                `createdAt`, `updatedAt`, `environmentId`) sent in the body are ignored.
+            required: [id, title]
+            properties:
+                id:
+                    type: string
+                    description: Client-supplied identifier. Required on POST; ignored on PUT.
+                    example: d7e246cb-ab02-4da4-8f47-f9fa3e061d6b
+                title:
+                    type: string
+                    example: Performance overview
+                description:
+                    type: string
+                    nullable: true
+                filters:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/SaveDashboardFilter"
+                timeRange:
+                    $ref: "#/components/schemas/DashboardTimeRange"
+                widgets:
+                    type: array
+                    maxItems: 50
+                    description: |
+                        Opaque widget definitions, stored verbatim (at most 50). Each entry must
+                        carry a non-blank `id`, unique within the dashboard; the rest of the shape
+                        is owned by the frontend and never parsed by the backend.
+                    items:
+                        type: object
 
         Error:
             type: object

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -1058,7 +1058,11 @@ paths:
                 - Dashboards
             summary: List every dashboard saved in the environment
             description: |
-                Paginated dashboards saved in the context environment, most recently created first.
+                Returns the dashboards saved in this environment, oldest first, in pages.
+
+                Walk the collection with `page` and `perPage`; `pagination.totalCount` in the
+                response tells you how many dashboards exist in total. Each entry is a complete
+                dashboard — no extra call is needed to render one from this list.
             operationId: listObservabilityDashboards
             parameters:
                 - name: page
@@ -1147,6 +1151,75 @@ paths:
                             example:
                                 httpStatus: 403
                                 message: "Insufficient permissions to access dashboards."
+        post:
+            tags:
+                - Dashboards
+            summary: Create a dashboard
+            description: |
+                Creates a dashboard in this environment.
+
+                You choose the `id` — generate one client-side (a UUID is the usual choice) and
+                reuse it to fetch, update or delete the dashboard afterwards. The URL of the new
+                dashboard is also returned in the `Location` header.
+
+                A dashboard carries at most 50 widgets. Their content is stored exactly as sent and
+                returned unchanged, so you are free to evolve their shape without a server change;
+                the only requirement is that every widget has an `id`, unique within the dashboard.
+            operationId: createObservabilityDashboard
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/SaveDashboardRequest"
+                        example:
+                            id: "d7e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+                            title: "Performance overview"
+                            description: "MCP traffic health"
+                            filters:
+                                - name: "API_TYPE"
+                                  label: "API Type"
+                                  operator: "EQ"
+                                  value: ["MCP"]
+                                  editable: false
+                            timeRange:
+                                type: "relative"
+                                period: "24h"
+                            widgets: [{ id: "w1", type: "metric" }]
+            responses:
+                "201":
+                    description: The dashboard was created. `Location` points at the new resource.
+                    headers:
+                        Location:
+                            description: URL of the created dashboard.
+                            schema:
+                                type: string
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Dashboard"
+                "400":
+                    description: |
+                        The dashboard could not be saved. The message names the problem: a missing
+                        title, more than 50 widgets, a widgets payload above 1 MB, a widget with a
+                        missing or duplicated `id`, a time range without the fields its `type`
+                        requires, or an unknown filter operator.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 400
+                                message: "Dashboard cannot hold more than 50 widgets"
+                "403":
+                    description: The caller cannot create dashboards in this environment.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 403
+                                message: "Insufficient permissions to create dashboards."
 
     /organizations/{orgId}/environments/{envId}/observability/dashboards/{dashboardId}:
         parameters:
@@ -1157,9 +1230,8 @@ paths:
                 - Dashboards
             summary: Get a single saved dashboard
             description: |
-                Returns one dashboard, with filters, time range and widgets restored verbatim. A
-                dashboard id belonging to another environment returns 404 (not 403, not 200), so
-                cross-environment existence cannot be probed.
+                Returns one dashboard with its filters, time range and widgets exactly as they were
+                saved — enough to render it without any further call.
             operationId: getObservabilityDashboard
             parameters:
                 - name: dashboardId
@@ -1211,10 +1283,119 @@ paths:
                                 httpStatus: 403
                                 message: "Insufficient permissions to access dashboards."
                 "404":
+                    description: No dashboard with this id exists in this environment.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 404
+                                message: "Dashboard 'd7e246cb-ab02-4da4-8f47-f9fa3e061d6b' not found"
+        put:
+            tags:
+                - Dashboards
+            summary: Update a dashboard
+            description: |
+                Replaces the content of an existing dashboard.
+
+                This is a full replacement, not a partial update: anything you leave out is
+                cleared. The usual sequence is to `GET` the dashboard, change what you need and
+                send the whole object back.
+
+                The response carries a new `version`. Concurrent updates are applied in the order
+                they reach the server and the last one wins — if several people can edit the same
+                dashboard, re-read it before saving rather than holding a copy open for a long time.
+            operationId: updateObservabilityDashboard
+            parameters:
+                - name: dashboardId
+                  in: path
+                  required: true
+                  description: Unique identifier of the dashboard.
+                  example: d7e246cb-ab02-4da4-8f47-f9fa3e061d6b
+                  schema:
+                      type: string
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/SaveDashboardRequest"
+                        example:
+                            title: "Performance overview (renamed)"
+                            filters: []
+                            timeRange:
+                                type: "absolute"
+                                from: 1730000000000
+                                to: 1730600000000
+                            widgets: [{ id: "w1", type: "metric" }]
+            responses:
+                "200":
+                    description: The updated dashboard, with the incremented `version`.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Dashboard"
+                "400":
                     description: |
-                        No dashboard with this id exists in the context environment — either it
-                        doesn't exist at all, or it belongs to a different environment. Both cases
-                        collapse to this response so cross-environment existence cannot be probed.
+                        The dashboard could not be saved. The message names the problem: a missing
+                        title, more than 50 widgets, a widgets payload above 1 MB, a widget with a
+                        missing or duplicated `id`, a time range without the fields its `type`
+                        requires, or an unknown filter operator.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 400
+                                message: "Dashboard title is required"
+                "403":
+                    description: The caller cannot update dashboards in this environment.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 403
+                                message: "Insufficient permissions to update dashboards."
+                "404":
+                    description: No dashboard with this id exists in this environment.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 404
+                                message: "Dashboard 'd7e246cb-ab02-4da4-8f47-f9fa3e061d6b' not found"
+        delete:
+            tags:
+                - Dashboards
+            summary: Delete a dashboard
+            description: |
+                Permanently deletes a dashboard. There is no undo and no soft delete — recreate it
+                with `POST` if you need it back.
+            operationId: deleteObservabilityDashboard
+            parameters:
+                - name: dashboardId
+                  in: path
+                  required: true
+                  description: Unique identifier of the dashboard.
+                  example: d7e246cb-ab02-4da4-8f47-f9fa3e061d6b
+                  schema:
+                      type: string
+            responses:
+                "204":
+                    description: The dashboard was deleted.
+                "403":
+                    description: The caller cannot delete dashboards in this environment.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 403
+                                message: "Insufficient permissions to delete dashboards."
+                "404":
+                    description: No dashboard with this id exists in this environment.
                     content:
                         application/json:
                             schema:
@@ -2342,9 +2523,8 @@ components:
         Dashboard:
             type: object
             description: |
-                A dashboard saved by a Gamma Observability user. `widgets` is opaque JSON, never
-                parsed by the backend — returned verbatim. `version` is an optimistic-locking
-                counter; nothing enforces it yet but it must round-trip for a future write to use.
+                A saved dashboard. `widgets` is returned exactly as it was sent — its shape is
+                yours to define.
             required: [id, title, filters, widgets, version, createdAt, updatedAt]
             properties:
                 id:
@@ -2363,17 +2543,23 @@ components:
                 timeRange:
                     $ref: "#/components/schemas/DashboardTimeRange"
                 widgets:
-                    description: Opaque, returned verbatim. Shape is owned by the frontend.
+                    description: Returned exactly as sent. Shape is defined by the client.
                 version:
                     type: integer
+                    readOnly: true
+                    description: |
+                        Starts at 1 and increases by 1 on every successful update. Useful to detect
+                        that a dashboard changed since you last read it.
                     example: 3
                 createdAt:
                     type: integer
                     format: int64
+                    readOnly: true
                     description: Epoch milliseconds.
                 updatedAt:
                     type: integer
                     format: int64
+                    readOnly: true
                     description: Epoch milliseconds.
 
         DashboardsResponse:
@@ -2386,6 +2572,74 @@ components:
                         $ref: "#/components/schemas/Dashboard"
                 pagination:
                     $ref: "#/components/schemas/Pagination"
+
+        SaveDashboardFilter:
+            type: object
+            description: |
+                One filter applied to every widget of the dashboard.
+
+                Filter names are accepted as given, so a dashboard can be moved between
+                environments where the available filters differ; a name that no environment
+                recognises is reported when the dashboard is queried, not when it is saved.
+            required: [name, operator]
+            properties:
+                name:
+                    type: string
+                    description: Canonical filter name from the shared filter catalog.
+                    example: API_TYPE
+                label:
+                    type: string
+                    description: Human-readable display name, persisted verbatim (not derivable).
+                    example: API Type
+                operator:
+                    $ref: "#/components/schemas/FilterOperator"
+                value:
+                    description: Scalar or array of values. An empty array is the "all values" placeholder.
+                    oneOf:
+                        - type: string
+                        - type: array
+                          items:
+                              type: string
+                    example: ["MCP"]
+                editable:
+                    type: boolean
+                    default: false
+                    description: Whether the viewer may change the value. Absent means `false` (locked).
+
+        SaveDashboardRequest:
+            type: object
+            description: |
+                Everything you can set on a dashboard. Used by both `POST` and `PUT`; on `PUT` it
+                replaces the dashboard's content wholesale, so send the complete object.
+            required: [id, title]
+            properties:
+                id:
+                    type: string
+                    description: |
+                        Identifier you choose, typically a UUID. Required when creating; on update
+                        the identifier comes from the URL and this field is not used.
+                    example: d7e246cb-ab02-4da4-8f47-f9fa3e061d6b
+                title:
+                    type: string
+                    example: Performance overview
+                description:
+                    type: string
+                    nullable: true
+                filters:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/SaveDashboardFilter"
+                timeRange:
+                    $ref: "#/components/schemas/DashboardTimeRange"
+                widgets:
+                    type: array
+                    maxItems: 50
+                    description: |
+                        Up to 50 widgets, stored and returned exactly as sent. Each entry must
+                        carry a non-blank `id`, unique within the dashboard; every other property
+                        is yours to define.
+                    items:
+                        type: object
 
         Error:
             type: object

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/inmemory/InMemoryDashboardRepository.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/inmemory/InMemoryDashboardRepository.java
@@ -54,4 +54,29 @@ public class InMemoryDashboardRepository implements DashboardRepository {
             .filter(d -> Objects.equals(d.id(), id) && Objects.equals(d.environmentId(), environmentId))
             .findFirst();
     }
+
+    @Override
+    public Dashboard create(Dashboard dashboard) {
+        dashboards.add(dashboard);
+        return dashboard;
+    }
+
+    @Override
+    public Dashboard update(Dashboard dashboard) {
+        // Replaces in place: the real backends order by creation date, so an update must not
+        // reshuffle the list the way remove-then-add would.
+        for (int i = 0; i < dashboards.size(); i++) {
+            if (Objects.equals(dashboards.get(i).id(), dashboard.id())) {
+                dashboards.set(i, dashboard);
+                return dashboard;
+            }
+        }
+        dashboards.add(dashboard);
+        return dashboard;
+    }
+
+    @Override
+    public void delete(String id) {
+        dashboards.removeIf(d -> Objects.equals(d.id(), id));
+    }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/model/DashboardContentTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/model/DashboardContentTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.model;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the structural write guardrails of OBS-16 — and only those: widgets stay opaque beyond the
+ * caps and id checks, semantic validation belongs to the analytics read path.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DashboardContentTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void should_accept_a_minimal_content_with_only_a_title() {
+        assertThatCode(() -> new DashboardContent("Perf", null, null, null, null).validate()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_reject_a_blank_title() {
+        assertThatThrownBy(() -> new DashboardContent("  ", null, List.of(), null, null).validate())
+            .isInstanceOf(InvalidDashboardException.class)
+            .hasMessageContaining("title");
+    }
+
+    @Test
+    void should_accept_fifty_widgets_and_reject_fifty_one() throws Exception {
+        assertThatCode(() -> content(widgetArray(50)).validate()).doesNotThrowAnyException();
+
+        assertThatThrownBy(() -> content(widgetArray(51)).validate())
+            .isInstanceOf(InvalidDashboardException.class)
+            .hasMessageContaining("50");
+    }
+
+    @Test
+    void should_reject_widgets_that_are_not_an_array() throws Exception {
+        assertThatThrownBy(() -> content(MAPPER.readTree("{\"type\":\"metric\"}")).validate())
+            .isInstanceOf(InvalidDashboardException.class)
+            .hasMessageContaining("array");
+    }
+
+    @Test
+    void should_reject_a_widget_without_an_id() throws Exception {
+        assertThatThrownBy(() -> content(MAPPER.readTree("[{\"type\":\"metric\"}]")).validate())
+            .isInstanceOf(InvalidDashboardException.class)
+            .hasMessageContaining("id");
+    }
+
+    @Test
+    void should_reject_duplicate_widget_ids() throws Exception {
+        assertThatThrownBy(() -> content(MAPPER.readTree("[{\"id\":\"w1\"},{\"id\":\"w1\"}]")).validate())
+            .isInstanceOf(InvalidDashboardException.class)
+            .hasMessageContaining("w1");
+    }
+
+    @Test
+    void should_reject_an_oversized_widgets_payload() throws Exception {
+        String bigValue = "x".repeat(1_100_000);
+        JsonNode widgets = MAPPER.readTree("[{\"id\":\"w1\",\"blob\":\"" + bigValue + "\"}]");
+
+        assertThatThrownBy(() -> content(widgets).validate())
+            .isInstanceOf(InvalidDashboardException.class)
+            .hasMessageContaining("size");
+    }
+
+    @Test
+    void should_reject_a_relative_time_range_without_period() {
+        TimeRange timeRange = new TimeRange(TimeRangeType.RELATIVE, null, null, null);
+
+        assertThatThrownBy(() -> new DashboardContent("Perf", null, List.of(), timeRange, null).validate())
+            .isInstanceOf(InvalidDashboardException.class)
+            .hasMessageContaining("period");
+    }
+
+    @Test
+    void should_reject_an_absolute_time_range_with_from_not_before_to() {
+        TimeRange timeRange = new TimeRange(TimeRangeType.ABSOLUTE, null, 2000L, 1000L);
+
+        assertThatThrownBy(() -> new DashboardContent("Perf", null, List.of(), timeRange, null).validate())
+            .isInstanceOf(InvalidDashboardException.class)
+            .hasMessageContaining("before");
+    }
+
+    @Test
+    void should_reject_an_absolute_time_range_missing_a_bound() {
+        TimeRange timeRange = new TimeRange(TimeRangeType.ABSOLUTE, null, 1000L, null);
+
+        assertThatThrownBy(() -> new DashboardContent("Perf", null, List.of(), timeRange, null).validate())
+            .isInstanceOf(InvalidDashboardException.class)
+            .hasMessageContaining("from and to");
+    }
+
+    private static DashboardContent content(JsonNode widgets) {
+        return new DashboardContent("Perf", null, List.of(), null, widgets);
+    }
+
+    private static JsonNode widgetArray(int count) throws Exception {
+        StringBuilder json = new StringBuilder("[");
+        for (int i = 0; i < count; i++) {
+            if (i > 0) {
+                json.append(',');
+            }
+            json.append("{\"id\":\"w").append(i).append("\"}");
+        }
+        return MAPPER.readTree(json.append(']').toString());
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/CreateObservabilityDashboardUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/CreateObservabilityDashboardUseCaseTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import io.gravitee.gamma.rest.core.observability.dashboard.inmemory.InMemoryDashboardRepository;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardContent;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardFilter;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRange;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRangeType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CreateObservabilityDashboardUseCaseTest {
+
+    private static final String ENV = "env-1";
+    private static final String USER = "user-1";
+    private static final String DASHBOARD_ID = "dash-1";
+    private static final Instant NOW = Instant.parse("2026-08-07T10:00:00Z");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final InMemoryDashboardRepository dashboardRepository = new InMemoryDashboardRepository();
+    private final CreateObservabilityDashboardUseCase useCase = new CreateObservabilityDashboardUseCase(dashboardRepository);
+
+    @BeforeAll
+    static void freezeClock() {
+        TimeProvider.overrideClock(Clock.fixed(NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void restoreClock() {
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void reset() {
+        dashboardRepository.reset();
+    }
+
+    @Test
+    void should_create_the_dashboard_with_server_owned_fields_derived() throws Exception {
+        var content = new DashboardContent(
+            "Performance overview",
+            "desc",
+            List.of(new DashboardFilter(new FilterCondition("API_TYPE", FilterOperator.EQ, List.of("MCP")), "API Type", false)),
+            new TimeRange(TimeRangeType.RELATIVE, "24h", null, null),
+            MAPPER.readTree("[{\"id\":\"w1\",\"type\":\"metric\"}]")
+        );
+
+        var output = useCase.execute(new CreateObservabilityDashboardUseCase.Input(ENV, USER, DASHBOARD_ID, content));
+
+        assertThat(output.dashboard().id()).isEqualTo(DASHBOARD_ID);
+        assertThat(output.dashboard().environmentId()).isEqualTo(ENV);
+        assertThat(output.dashboard().version()).isEqualTo(1);
+        assertThat(output.dashboard().createdBy()).isEqualTo(USER);
+        assertThat(output.dashboard().createdAt()).isEqualTo(NOW);
+        assertThat(output.dashboard().updatedAt()).isEqualTo(NOW);
+        assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENV)).contains(output.dashboard());
+    }
+
+    @Test
+    void should_reject_invalid_content_before_touching_the_repository() {
+        var content = new DashboardContent(" ", null, List.of(), null, null);
+
+        assertThatThrownBy(() ->
+            useCase.execute(new CreateObservabilityDashboardUseCase.Input(ENV, USER, DASHBOARD_ID, content))
+        ).isInstanceOf(InvalidDashboardException.class);
+        assertThat(dashboardRepository.findByEnvironmentId(ENV)).isEmpty();
+    }
+
+    @Test
+    void should_reject_a_blank_dashboard_id() {
+        var content = new DashboardContent("Performance overview", null, List.of(), null, null);
+
+        assertThatThrownBy(() -> useCase.execute(new CreateObservabilityDashboardUseCase.Input(ENV, USER, " ", content))).isInstanceOf(
+            InvalidDashboardException.class
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/DeleteObservabilityDashboardUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/DeleteObservabilityDashboardUseCaseTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.node.NullNode;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.DashboardNotFoundException;
+import io.gravitee.gamma.rest.core.observability.dashboard.inmemory.InMemoryDashboardRepository;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DeleteObservabilityDashboardUseCaseTest {
+
+    private static final String ENV = "env-1";
+    private static final String OTHER_ENV = "env-2";
+    private static final String DASHBOARD_ID = "dash-1";
+
+    private final InMemoryDashboardRepository dashboardRepository = new InMemoryDashboardRepository();
+    private final DeleteObservabilityDashboardUseCase useCase = new DeleteObservabilityDashboardUseCase(dashboardRepository);
+
+    @BeforeEach
+    void reset() {
+        dashboardRepository.reset();
+    }
+
+    @Test
+    void should_delete_the_dashboard() {
+        dashboardRepository.givenDashboard(dashboard(ENV));
+
+        useCase.execute(new DeleteObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID));
+
+        assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENV)).isEmpty();
+    }
+
+    @Test
+    void should_throw_not_found_when_dashboard_does_not_exist() {
+        assertThatThrownBy(() -> useCase.execute(new DeleteObservabilityDashboardUseCase.Input(ENV, "unknown"))).isInstanceOf(
+            DashboardNotFoundException.class
+        );
+    }
+
+    @Test
+    void should_throw_not_found_and_keep_the_dashboard_when_it_belongs_to_another_environment() {
+        dashboardRepository.givenDashboard(dashboard(OTHER_ENV));
+
+        assertThatThrownBy(() -> useCase.execute(new DeleteObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID))).isInstanceOf(
+            DashboardNotFoundException.class
+        );
+        assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, OTHER_ENV)).isPresent();
+    }
+
+    private static Dashboard dashboard(String environmentId) {
+        return new Dashboard(
+            DASHBOARD_ID,
+            environmentId,
+            "Performance overview",
+            null,
+            List.of(),
+            null,
+            NullNode.getInstance(),
+            1,
+            "user-1",
+            Instant.parse("2026-06-10T00:00:00Z"),
+            Instant.parse("2026-06-10T00:00:00Z")
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/UpdateObservabilityDashboardUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/UpdateObservabilityDashboardUseCaseTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.node.NullNode;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.DashboardNotFoundException;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import io.gravitee.gamma.rest.core.observability.dashboard.inmemory.InMemoryDashboardRepository;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardContent;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRange;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRangeType;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UpdateObservabilityDashboardUseCaseTest {
+
+    private static final String ENV = "env-1";
+    private static final String OTHER_ENV = "env-2";
+    private static final String DASHBOARD_ID = "dash-1";
+    private static final Instant CREATED_AT = Instant.parse("2026-06-10T00:00:00Z");
+    private static final Instant NOW = Instant.parse("2026-08-07T10:00:00Z");
+
+    private final InMemoryDashboardRepository dashboardRepository = new InMemoryDashboardRepository();
+    private final UpdateObservabilityDashboardUseCase useCase = new UpdateObservabilityDashboardUseCase(dashboardRepository);
+
+    @BeforeAll
+    static void freezeClock() {
+        TimeProvider.overrideClock(Clock.fixed(NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void restoreClock() {
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void reset() {
+        dashboardRepository.reset();
+    }
+
+    @Test
+    void should_replace_content_preserve_creation_fields_bump_updated_at_and_increment_version() {
+        dashboardRepository.givenDashboard(existingDashboard(3));
+        var content = new DashboardContent(
+            "New title",
+            "new desc",
+            List.of(),
+            new TimeRange(TimeRangeType.RELATIVE, "7d", null, null),
+            null
+        );
+
+        var output = useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, content));
+
+        assertThat(output.dashboard().title()).isEqualTo("New title");
+        assertThat(output.dashboard().description()).isEqualTo("new desc");
+        assertThat(output.dashboard().timeRange().period()).isEqualTo("7d");
+        assertThat(output.dashboard().version()).isEqualTo(4);
+        assertThat(output.dashboard().createdBy()).isEqualTo("user-1");
+        assertThat(output.dashboard().createdAt()).isEqualTo(CREATED_AT);
+        assertThat(output.dashboard().updatedAt()).isEqualTo(NOW);
+        assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENV)).contains(output.dashboard());
+    }
+
+    @Test
+    void should_restart_the_version_counter_when_the_existing_row_predates_versioning() {
+        dashboardRepository.givenDashboard(existingDashboard(null));
+        var content = new DashboardContent("New title", null, List.of(), null, null);
+
+        var output = useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, content));
+
+        assertThat(output.dashboard().version()).isEqualTo(1);
+    }
+
+    @Test
+    void should_throw_not_found_when_dashboard_does_not_exist() {
+        var content = new DashboardContent("New title", null, List.of(), null, null);
+
+        assertThatThrownBy(() -> useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, "unknown", content))).isInstanceOf(
+            DashboardNotFoundException.class
+        );
+    }
+
+    @Test
+    void should_throw_not_found_when_dashboard_belongs_to_another_environment() {
+        dashboardRepository.givenDashboard(existingDashboard(1));
+        var content = new DashboardContent("New title", null, List.of(), null, null);
+
+        assertThatThrownBy(() ->
+            useCase.execute(new UpdateObservabilityDashboardUseCase.Input(OTHER_ENV, DASHBOARD_ID, content))
+        ).isInstanceOf(DashboardNotFoundException.class);
+    }
+
+    @Test
+    void should_reject_invalid_content_before_touching_the_repository() {
+        Dashboard existing = existingDashboard(3);
+        dashboardRepository.givenDashboard(existing);
+        var content = new DashboardContent(" ", null, List.of(), null, null);
+
+        assertThatThrownBy(() -> useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, content))).isInstanceOf(
+            InvalidDashboardException.class
+        );
+        assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENV)).contains(existing);
+    }
+
+    private static Dashboard existingDashboard(Integer version) {
+        return new Dashboard(
+            DASHBOARD_ID,
+            ENV,
+            "Performance overview",
+            "desc",
+            List.of(),
+            new TimeRange(TimeRangeType.RELATIVE, "24h", null, null),
+            NullNode.getInstance(),
+            version,
+            "user-1",
+            CREATED_AT,
+            CREATED_AT
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapterTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapterTest.java
@@ -17,13 +17,24 @@ package io.gravitee.gamma.rest.infra.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardFilter;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRange;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRangeType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.GammaDashboardRepository;
 import io.gravitee.repository.management.model.GammaDashboard;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -31,6 +42,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -141,5 +153,81 @@ class GammaDashboardRepositoryAdapterTest {
             .orElseThrow();
 
         assertThat(dashboard.widgets().isNull()).isTrue();
+    }
+
+    @Test
+    void should_map_the_domain_shape_back_to_the_persisted_shape_on_create() throws Exception {
+        Instant createdAt = Instant.parse("2026-08-07T10:00:00Z");
+        Dashboard dashboard = new Dashboard(
+            "dash-1",
+            "env-1",
+            "Performance overview",
+            "desc",
+            List.of(new DashboardFilter(new FilterCondition("API_TYPE", FilterOperator.NOT_IN, List.of("MCP")), "API Type", true)),
+            new TimeRange(TimeRangeType.RELATIVE, "24h", null, null),
+            new ObjectMapper().readTree("[{\"id\":\"w1\",\"type\":\"metric\"}]"),
+            1,
+            "user-1",
+            createdAt,
+            createdAt
+        );
+        when(gammaDashboardRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        new GammaDashboardRepositoryAdapter(gammaDashboardRepository).create(dashboard);
+
+        var captor = ArgumentCaptor.forClass(GammaDashboard.class);
+        verify(gammaDashboardRepository).create(captor.capture());
+        GammaDashboard persisted = captor.getValue();
+        assertThat(persisted.getId()).isEqualTo("dash-1");
+        assertThat(persisted.getEnvironmentId()).isEqualTo("env-1");
+        assertThat(persisted.getTitle()).isEqualTo("Performance overview");
+        var filter = persisted.getFilters().get(0);
+        assertThat(filter.getField()).isEqualTo("API_TYPE");
+        assertThat(filter.getLabel()).isEqualTo("API Type");
+        assertThat(filter.getOperator()).isEqualTo("not_in");
+        assertThat(filter.getValue()).containsExactly("MCP");
+        assertThat(filter.isEditable()).isTrue();
+        assertThat(persisted.getTimeRange().getType()).isEqualTo("relative");
+        assertThat(persisted.getTimeRange().getPeriod()).isEqualTo("24h");
+        assertThat(persisted.getWidgets()).isEqualTo("[{\"id\":\"w1\",\"type\":\"metric\"}]");
+        assertThat(persisted.getVersion()).isEqualTo(1);
+        assertThat(persisted.getCreatedBy()).isEqualTo("user-1");
+        assertThat(persisted.getCreatedAt()).isEqualTo(Date.from(createdAt));
+        assertThat(persisted.getUpdatedAt()).isEqualTo(Date.from(createdAt));
+    }
+
+    @Test
+    void should_persist_absent_widgets_as_null_on_update() throws Exception {
+        Dashboard dashboard = new Dashboard(
+            "dash-1",
+            "env-1",
+            "Performance overview",
+            null,
+            List.of(),
+            null,
+            NullNode.getInstance(),
+            2,
+            "user-1",
+            Instant.parse("2026-08-07T10:00:00Z"),
+            Instant.parse("2026-08-07T11:00:00Z")
+        );
+        when(gammaDashboardRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        new GammaDashboardRepositoryAdapter(gammaDashboardRepository).update(dashboard);
+
+        var captor = ArgumentCaptor.forClass(GammaDashboard.class);
+        verify(gammaDashboardRepository).update(captor.capture());
+        assertThat(captor.getValue().getWidgets()).isNull();
+        assertThat(captor.getValue().getTimeRange()).isNull();
+        assertThat(captor.getValue().getVersion()).isEqualTo(2);
+    }
+
+    @Test
+    void should_wrap_a_delete_failure_as_a_technical_exception() throws Exception {
+        doThrow(new TechnicalException("boom")).when(gammaDashboardRepository).delete("dash-1");
+
+        assertThatThrownBy(() -> new GammaDashboardRepositoryAdapter(gammaDashboardRepository).delete("dash-1")).isInstanceOf(
+            TechnicalDomainException.class
+        );
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResourceTest.java
@@ -28,8 +28,11 @@ import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardFilter
 import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRange;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRangeType;
 import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.DashboardRepository;
+import io.gravitee.gamma.rest.core.observability.dashboard.use_case.CreateObservabilityDashboardUseCase;
+import io.gravitee.gamma.rest.core.observability.dashboard.use_case.DeleteObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.core.observability.dashboard.use_case.GetObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.core.observability.dashboard.use_case.ListObservabilityDashboardUseCase;
+import io.gravitee.gamma.rest.core.observability.dashboard.use_case.UpdateObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
 import io.gravitee.gamma.rest.resource.AbstractResourceTest;
@@ -37,6 +40,7 @@ import io.gravitee.gamma.rest.resources.observability.dashboards.ObservabilityDa
 import io.gravitee.gamma.rest.spring.ResourceContextConfiguration;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
 import java.time.Instant;
 import java.util.List;
@@ -206,6 +210,272 @@ class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
         }
     }
 
+    @Nested
+    class CreateDashboard {
+
+        @Test
+        void should_return_201_with_location_and_the_created_dashboard() {
+            Response response = rootTarget()
+                .request()
+                .post(
+                    Entity.json(
+                        """
+                        {
+                          "id": "dash-new",
+                          "title": "Performance overview",
+                          "description": "desc",
+                          "filters": [
+                            { "name": "API_TYPE", "label": "API Type", "operator": "eq", "value": "MCP" },
+                            { "name": "HTTP_STATUS", "label": "Status Code", "operator": "IN", "value": [], "editable": true }
+                          ],
+                          "timeRange": { "type": "relative", "period": "24h" },
+                          "widgets": [{ "id": "w1", "type": "metric" }]
+                        }
+                        """
+                    )
+                );
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.CREATED_201);
+            assertThat(response.getHeaderString("Location")).endsWith("/observability/dashboards/dash-new");
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("id").asText()).isEqualTo("dash-new");
+            assertThat(body.get("version").asInt()).isEqualTo(1);
+            assertThat(body.get("createdAt").isNumber()).isTrue();
+            assertThat(body.get("updatedAt").isNumber()).isTrue();
+            JsonNode firstFilter = body.get("filters").get(0);
+            assertThat(firstFilter.get("operator").asText()).isEqualTo("EQ");
+            assertThat(firstFilter.get("value").get(0).asText()).isEqualTo("MCP");
+            assertThat(firstFilter.get("editable").asBoolean()).isFalse();
+            JsonNode secondFilter = body.get("filters").get(1);
+            assertThat(secondFilter.get("value")).isEmpty();
+            assertThat(secondFilter.get("editable").asBoolean()).isTrue();
+            assertThat(body.get("widgets").get(0).get("type").asText()).isEqualTo("metric");
+
+            var persisted = dashboardRepository.findByIdAndEnvironmentId("dash-new", ENVIRONMENT).orElseThrow();
+            assertThat(persisted.createdBy()).isEqualTo(USER_NAME);
+
+            JsonNode listed = rootTarget().request().get().readEntity(JsonNode.class);
+            assertThat(listed.get("data")).hasSize(1);
+            assertThat(listed.get("data").get(0).get("id").asText()).isEqualTo("dash-new");
+        }
+
+        @Test
+        void should_ignore_server_owned_fields_sent_in_the_body() {
+            Response response = rootTarget()
+                .request()
+                .post(
+                    Entity.json(
+                        """
+                        {
+                          "id": "dash-new",
+                          "title": "Performance overview",
+                          "version": 42,
+                          "createdBy": "someone-else",
+                          "createdAt": 1,
+                          "updatedAt": 1,
+                          "environmentId": "other-env"
+                        }
+                        """
+                    )
+                );
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.CREATED_201);
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("version").asInt()).isEqualTo(1);
+            assertThat(dashboardRepository.findByIdAndEnvironmentId("dash-new", ENVIRONMENT)).isPresent();
+        }
+
+        @Test
+        void should_return_400_when_title_is_blank() {
+            Response response = rootTarget().request().post(Entity.json("{ \"id\": \"dash-new\", \"title\": \"  \" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_accept_fifty_widgets_and_reject_fifty_one() {
+            Response accepted = rootTarget().request().post(Entity.json(payloadWithWidgets(50)));
+            assertThat(accepted.getStatus()).isEqualTo(HttpStatusCode.CREATED_201);
+
+            Response rejected = rootTarget().request().post(Entity.json(payloadWithWidgets(51)));
+            assertThat(rejected.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_400_on_duplicate_widget_ids() {
+            Response response = rootTarget()
+                .request()
+                .post(Entity.json("{ \"id\": \"dash-new\", \"title\": \"Perf\", \"widgets\": [{ \"id\": \"w1\" }, { \"id\": \"w1\" }] }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_400_on_an_incoherent_time_range() {
+            Response response = rootTarget()
+                .request()
+                .post(Entity.json("{ \"id\": \"dash-new\", \"title\": \"Perf\", \"timeRange\": { \"type\": \"relative\" } }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_400_on_a_null_filter_entry() {
+            Response response = rootTarget()
+                .request()
+                .post(Entity.json("{ \"id\": \"dash-new\", \"title\": \"Perf\", \"filters\": [null] }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_400_on_an_unknown_filter_operator() {
+            Response response = rootTarget()
+                .request()
+                .post(
+                    Entity.json(
+                        "{ \"id\": \"dash-new\", \"title\": \"Perf\", \"filters\": [{ \"name\": \"API_TYPE\", \"operator\": \"between\", \"value\": \"x\" }] }"
+                    )
+                );
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_403_when_caller_cannot_create_dashboards() {
+            when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
+
+            Response response = rootTarget().request().post(Entity.json("{ \"id\": \"dash-new\", \"title\": \"Perf\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+        }
+
+        private static String payloadWithWidgets(int count) {
+            StringBuilder widgets = new StringBuilder("[");
+            for (int i = 0; i < count; i++) {
+                if (i > 0) {
+                    widgets.append(',');
+                }
+                widgets.append("{\"id\":\"w").append(i).append("\"}");
+            }
+            widgets.append(']');
+            return "{ \"id\": \"dash-new\", \"title\": \"Perf\", \"widgets\": " + widgets + " }";
+        }
+    }
+
+    @Nested
+    class UpdateDashboard {
+
+        @Test
+        void should_return_200_preserve_creation_fields_bump_version_and_updated_at() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .put(
+                    Entity.json(
+                        """
+                        {
+                          "title": "Renamed",
+                          "description": "new desc",
+                          "version": 42,
+                          "timeRange": { "type": "absolute", "from": 1000, "to": 2000 },
+                          "widgets": [{ "id": "w1", "type": "chart" }]
+                        }
+                        """
+                    )
+                );
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("title").asText()).isEqualTo("Renamed");
+            assertThat(body.get("version").asInt()).isEqualTo(4);
+            assertThat(body.get("createdAt").asLong()).isEqualTo(Instant.parse("2026-06-10T00:00:00Z").toEpochMilli());
+            assertThat(body.get("updatedAt").asLong()).isGreaterThan(Instant.parse("2026-06-11T00:00:00Z").toEpochMilli());
+            assertThat(body.get("timeRange").get("type").asText()).isEqualTo("absolute");
+            assertThat(body.get("widgets").get(0).get("type").asText()).isEqualTo("chart");
+
+            var persisted = dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENVIRONMENT).orElseThrow();
+            assertThat(persisted.createdBy()).isEqualTo("user-1");
+            assertThat(persisted.version()).isEqualTo(4);
+        }
+
+        @Test
+        void should_return_404_when_dashboard_does_not_exist() {
+            Response response = rootTarget("unknown").request().put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_404_when_dashboard_belongs_to_another_environment() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, OTHER_ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID).request().put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_400_when_title_is_blank() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID).request().put(Entity.json("{ \"title\": \" \" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_403_when_caller_cannot_update_dashboards() {
+            when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
+
+            Response response = rootTarget(DASHBOARD_ID).request().put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+        }
+    }
+
+    @Nested
+    class DeleteDashboard {
+
+        @Test
+        void should_return_204_and_remove_the_dashboard() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID).request().delete();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NO_CONTENT_204);
+            JsonNode listed = rootTarget().request().get().readEntity(JsonNode.class);
+            assertThat(listed.get("data")).isEmpty();
+        }
+
+        @Test
+        void should_return_404_when_dashboard_does_not_exist() {
+            Response response = rootTarget("unknown").request().delete();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_404_and_keep_the_dashboard_when_it_belongs_to_another_environment() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, OTHER_ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID).request().delete();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+            assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, OTHER_ENVIRONMENT)).isPresent();
+        }
+
+        @Test
+        void should_return_403_when_caller_cannot_delete_dashboards() {
+            when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
+
+            Response response = rootTarget(DASHBOARD_ID).request().delete();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+        }
+    }
+
     private static Dashboard dashboard(String id, String environmentId) {
         try {
             return new Dashboard(
@@ -242,6 +512,21 @@ class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
         @Bean
         GetObservabilityDashboardUseCase getObservabilityDashboardUseCase(DashboardRepository dashboardRepository) {
             return new GetObservabilityDashboardUseCase(dashboardRepository);
+        }
+
+        @Bean
+        CreateObservabilityDashboardUseCase createObservabilityDashboardUseCase(DashboardRepository dashboardRepository) {
+            return new CreateObservabilityDashboardUseCase(dashboardRepository);
+        }
+
+        @Bean
+        UpdateObservabilityDashboardUseCase updateObservabilityDashboardUseCase(DashboardRepository dashboardRepository) {
+            return new UpdateObservabilityDashboardUseCase(dashboardRepository);
+        }
+
+        @Bean
+        DeleteObservabilityDashboardUseCase deleteObservabilityDashboardUseCase(DashboardRepository dashboardRepository) {
+            return new DeleteObservabilityDashboardUseCase(dashboardRepository);
         }
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResourceTest.java
@@ -21,15 +21,13 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.UseCase;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gamma.rest.core.observability.dashboard.inmemory.InMemoryDashboardRepository;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardFilter;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRange;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRangeType;
-import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.DashboardRepository;
-import io.gravitee.gamma.rest.core.observability.dashboard.use_case.GetObservabilityDashboardUseCase;
-import io.gravitee.gamma.rest.core.observability.dashboard.use_case.ListObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
 import io.gravitee.gamma.rest.resource.AbstractResourceTest;
@@ -37,6 +35,7 @@ import io.gravitee.gamma.rest.resources.observability.dashboards.ObservabilityDa
 import io.gravitee.gamma.rest.spring.ResourceContextConfiguration;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
 import java.time.Instant;
 import java.util.List;
@@ -45,12 +44,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * Drives the resources through the <em>real</em> use cases, wired to an in-memory
- * {@link DashboardRepository}. Only the platform boundaries the resource can't run without
+ * {@code DashboardRepository}. Only the platform boundaries the resource can't run without
  * ({@code PermissionService}, {@code EnvironmentService}) stay mocked, via
  * {@link ResourceContextConfiguration} — so behaviour like environment isolation and pagination is
  * exercised end-to-end rather than stubbed at the use-case boundary.
@@ -206,6 +207,272 @@ class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
         }
     }
 
+    @Nested
+    class CreateDashboard {
+
+        @Test
+        void should_return_201_with_location_and_the_created_dashboard() {
+            Response response = rootTarget()
+                .request()
+                .post(
+                    Entity.json(
+                        """
+                        {
+                          "id": "dash-new",
+                          "title": "Performance overview",
+                          "description": "desc",
+                          "filters": [
+                            { "name": "API_TYPE", "label": "API Type", "operator": "eq", "value": "MCP" },
+                            { "name": "HTTP_STATUS", "label": "Status Code", "operator": "IN", "value": [], "editable": true }
+                          ],
+                          "timeRange": { "type": "relative", "period": "24h" },
+                          "widgets": [{ "id": "w1", "type": "metric" }]
+                        }
+                        """
+                    )
+                );
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.CREATED_201);
+            assertThat(response.getHeaderString("Location")).endsWith("/observability/dashboards/dash-new");
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("id").asText()).isEqualTo("dash-new");
+            assertThat(body.get("version").asInt()).isEqualTo(1);
+            assertThat(body.get("createdAt").isNumber()).isTrue();
+            assertThat(body.get("updatedAt").isNumber()).isTrue();
+            JsonNode firstFilter = body.get("filters").get(0);
+            assertThat(firstFilter.get("operator").asText()).isEqualTo("EQ");
+            assertThat(firstFilter.get("value").get(0).asText()).isEqualTo("MCP");
+            assertThat(firstFilter.get("editable").asBoolean()).isFalse();
+            JsonNode secondFilter = body.get("filters").get(1);
+            assertThat(secondFilter.get("value")).isEmpty();
+            assertThat(secondFilter.get("editable").asBoolean()).isTrue();
+            assertThat(body.get("widgets").get(0).get("type").asText()).isEqualTo("metric");
+
+            var persisted = dashboardRepository.findByIdAndEnvironmentId("dash-new", ENVIRONMENT).orElseThrow();
+            assertThat(persisted.createdBy()).isEqualTo(USER_NAME);
+
+            JsonNode listed = rootTarget().request().get().readEntity(JsonNode.class);
+            assertThat(listed.get("data")).hasSize(1);
+            assertThat(listed.get("data").get(0).get("id").asText()).isEqualTo("dash-new");
+        }
+
+        @Test
+        void should_ignore_server_owned_fields_sent_in_the_body() {
+            Response response = rootTarget()
+                .request()
+                .post(
+                    Entity.json(
+                        """
+                        {
+                          "id": "dash-new",
+                          "title": "Performance overview",
+                          "version": 42,
+                          "createdBy": "someone-else",
+                          "createdAt": 1,
+                          "updatedAt": 1,
+                          "environmentId": "other-env"
+                        }
+                        """
+                    )
+                );
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.CREATED_201);
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("version").asInt()).isEqualTo(1);
+            assertThat(dashboardRepository.findByIdAndEnvironmentId("dash-new", ENVIRONMENT)).isPresent();
+        }
+
+        @Test
+        void should_return_400_when_title_is_blank() {
+            Response response = rootTarget().request().post(Entity.json("{ \"id\": \"dash-new\", \"title\": \"  \" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_accept_fifty_widgets_and_reject_fifty_one() {
+            Response accepted = rootTarget().request().post(Entity.json(payloadWithWidgets(50)));
+            assertThat(accepted.getStatus()).isEqualTo(HttpStatusCode.CREATED_201);
+
+            Response rejected = rootTarget().request().post(Entity.json(payloadWithWidgets(51)));
+            assertThat(rejected.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_400_on_duplicate_widget_ids() {
+            Response response = rootTarget()
+                .request()
+                .post(Entity.json("{ \"id\": \"dash-new\", \"title\": \"Perf\", \"widgets\": [{ \"id\": \"w1\" }, { \"id\": \"w1\" }] }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_400_on_an_incoherent_time_range() {
+            Response response = rootTarget()
+                .request()
+                .post(Entity.json("{ \"id\": \"dash-new\", \"title\": \"Perf\", \"timeRange\": { \"type\": \"relative\" } }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_400_on_a_null_filter_entry() {
+            Response response = rootTarget()
+                .request()
+                .post(Entity.json("{ \"id\": \"dash-new\", \"title\": \"Perf\", \"filters\": [null] }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_400_on_an_unknown_filter_operator() {
+            Response response = rootTarget()
+                .request()
+                .post(
+                    Entity.json(
+                        "{ \"id\": \"dash-new\", \"title\": \"Perf\", \"filters\": [{ \"name\": \"API_TYPE\", \"operator\": \"between\", \"value\": \"x\" }] }"
+                    )
+                );
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_403_when_caller_cannot_create_dashboards() {
+            when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
+
+            Response response = rootTarget().request().post(Entity.json("{ \"id\": \"dash-new\", \"title\": \"Perf\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+        }
+
+        private static String payloadWithWidgets(int count) {
+            StringBuilder widgets = new StringBuilder("[");
+            for (int i = 0; i < count; i++) {
+                if (i > 0) {
+                    widgets.append(',');
+                }
+                widgets.append("{\"id\":\"w").append(i).append("\"}");
+            }
+            widgets.append(']');
+            return "{ \"id\": \"dash-new\", \"title\": \"Perf\", \"widgets\": " + widgets + " }";
+        }
+    }
+
+    @Nested
+    class UpdateDashboard {
+
+        @Test
+        void should_return_200_preserve_creation_fields_bump_version_and_updated_at() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .put(
+                    Entity.json(
+                        """
+                        {
+                          "title": "Renamed",
+                          "description": "new desc",
+                          "version": 42,
+                          "timeRange": { "type": "absolute", "from": 1000, "to": 2000 },
+                          "widgets": [{ "id": "w1", "type": "chart" }]
+                        }
+                        """
+                    )
+                );
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("title").asText()).isEqualTo("Renamed");
+            assertThat(body.get("version").asInt()).isEqualTo(4);
+            assertThat(body.get("createdAt").asLong()).isEqualTo(Instant.parse("2026-06-10T00:00:00Z").toEpochMilli());
+            assertThat(body.get("updatedAt").asLong()).isGreaterThan(Instant.parse("2026-06-11T00:00:00Z").toEpochMilli());
+            assertThat(body.get("timeRange").get("type").asText()).isEqualTo("absolute");
+            assertThat(body.get("widgets").get(0).get("type").asText()).isEqualTo("chart");
+
+            var persisted = dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENVIRONMENT).orElseThrow();
+            assertThat(persisted.createdBy()).isEqualTo("user-1");
+            assertThat(persisted.version()).isEqualTo(4);
+        }
+
+        @Test
+        void should_return_404_when_dashboard_does_not_exist() {
+            Response response = rootTarget("unknown").request().put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_404_when_dashboard_belongs_to_another_environment() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, OTHER_ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID).request().put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_400_when_title_is_blank() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID).request().put(Entity.json("{ \"title\": \" \" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_403_when_caller_cannot_update_dashboards() {
+            when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
+
+            Response response = rootTarget(DASHBOARD_ID).request().put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+        }
+    }
+
+    @Nested
+    class DeleteDashboard {
+
+        @Test
+        void should_return_204_and_remove_the_dashboard() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID).request().delete();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NO_CONTENT_204);
+            JsonNode listed = rootTarget().request().get().readEntity(JsonNode.class);
+            assertThat(listed.get("data")).isEmpty();
+        }
+
+        @Test
+        void should_return_404_when_dashboard_does_not_exist() {
+            Response response = rootTarget("unknown").request().delete();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_404_and_keep_the_dashboard_when_it_belongs_to_another_environment() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, OTHER_ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID).request().delete();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+            assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, OTHER_ENVIRONMENT)).isPresent();
+        }
+
+        @Test
+        void should_return_403_when_caller_cannot_delete_dashboards() {
+            when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
+
+            Response response = rootTarget(DASHBOARD_ID).request().delete();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+        }
+    }
+
     private static Dashboard dashboard(String id, String environmentId) {
         try {
             return new Dashboard(
@@ -226,22 +493,23 @@ class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
         }
     }
 
+    /**
+     * Mirrors the production wiring of {@code GammaDashboardsConfiguration}: the use cases come from
+     * the same {@code @UseCase}-filtered scan rather than being declared one by one, so this test
+     * keeps exercising whatever the real context would build. Only the port is substituted —
+     * production derives it from the {@code GammaDashboardRepository} SPI, which the repository
+     * plugin registers at runtime and which does not exist in a unit-test context.
+     */
     @Configuration
+    @ComponentScan(
+        basePackages = "io.gravitee.gamma.rest.core.observability.dashboard",
+        includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, value = UseCase.class)
+    )
     static class DashboardsTestConfiguration {
 
         @Bean
         InMemoryDashboardRepository dashboardRepository() {
             return new InMemoryDashboardRepository();
-        }
-
-        @Bean
-        ListObservabilityDashboardUseCase listObservabilityDashboardUseCase(DashboardRepository dashboardRepository) {
-            return new ListObservabilityDashboardUseCase(dashboardRepository);
-        }
-
-        @Bean
-        GetObservabilityDashboardUseCase getObservabilityDashboardUseCase(DashboardRepository dashboardRepository) {
-            return new GetObservabilityDashboardUseCase(dashboardRepository);
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds the three write verbs (POST / PUT / DELETE) to the Gamma dashboards API so a dashboard author's work is stored server-side and shared with their team rather than trapped in one browser. Builds on the read endpoints from OBS-15 and the persistence layer from OBS-14.

Jira: [OBS-16](https://gravitee.atlassian.net/browse/OBS-16)

## Changes
- Three new use cases (`Create`/`Update`/`Delete ObservabilityDashboardUseCase`) deriving every server-owned field: `version` starts at 1 and increments on update, `createdBy` comes from the authenticated principal, timestamps are stamped server-side; anything a client sends for them is ignored.
- `DashboardContent` core model carrying the author-editable part of a dashboard, with structural write guardrails: blank title, more than 50 widgets, oversized (~1 MiB) widgets payload, blank/duplicate widget ids, incoherent time range → 400.
- `DashboardRepository` port extended with `create`/`update`/`delete` (OBS-15 shipped it read-only) and `GammaDashboardRepositoryAdapter` gains the reverse anticorruption mapping core `Dashboard` → persisted `GammaDashboard` (lowercase operators, serialized widgets, `Instant` → `Date`).
- Request DTOs (`SaveDashboardRequestDto`, `SaveDashboardFilterDto`): polymorphic filter `value` (scalar or array) normalized by the new shared `FilterValues` helper (promoted from the logs `FilterConditionDto` instead of copied), `editable` defaulting to `false` (locked) when absent.
- OpenAPI: the three paths plus `SaveDashboardRequest`/`SaveDashboardFilter` schemas, `maxItems: 50` documented on `widgets`.

### Endpoints
| Endpoint | Method | Change | Request example | Response example |
| --- | --- | --- | --- | --- |
| `/gamma/organizations/{orgId}/environments/{envId}/observability/dashboards` | POST | New — `ENVIRONMENT_DASHBOARD:CREATE` | `{ "id": "d7e2…", "title": "Perf", "widgets": [{"id":"w1"}] }` | `201` + `Location`, body with `version: 1` |
| `…/dashboards/{dashboardId}` | PUT | New — `ENVIRONMENT_DASHBOARD:UPDATE` | `{ "title": "Renamed", "timeRange": {"type":"absolute","from":1000,"to":2000} }` | `200`, body with incremented `version`, preserved `createdAt` |
| `…/dashboards/{dashboardId}` | DELETE | New — `ENVIRONMENT_DASHBOARD:DELETE` | — | `204` |

## Reviewer notes
- **POST and PUT, not a PUT upsert**: `@Permissions` is per method and CREATE / UPDATE are distinct ACLs — collapsing them would silently grant creation to anyone holding update rights.
- **Version is maintained, not enforced**: a stale `version` does not fail — behaviour stays last-write-wins. The 409 guard (and turning the Mongo read-then-save into a single conditional operation) is OBS-17; a partial check here would advertise a guarantee that still has a TOCTOU hole.
- **Filter names are deliberately not validated against the `StaticFilters` catalogue at write time**: a dashboard is declarative configuration, the analytics query path already validates at read time, and catalogue coupling would make dashboards non-importable across environments.
- Cross-environment ids resolve to **404 (not 403)** on every verb, so existence cannot be probed.

## Test plan
- [ ] `mvn test -pl gravitee-gamma-rest-api` from `gravitee-gamma/` — 316 tests green (45 new: use cases, `DashboardContent` validation matrix, adapter write mapping, Jersey resource tests)
- [ ] POST a dashboard with a client-supplied id → `201`, `Location` header, `version: 1`, then `GET /` lists it
- [ ] POST the body with `version: 42` / `createdBy` → both ignored in the response
- [ ] PUT → `200`, `createdAt`/`createdBy` preserved, `updatedAt` bumped, `version` incremented; PUT/DELETE with an id from another environment → `404`
- [ ] 51 widgets, blank title, duplicate widget ids, `{"type":"relative"}` without period → `400`; 50 widgets and `"value": []` filters → accepted
- [ ] Each verb without its ACL → `403`

[OBS-16]: https://gravitee.atlassian.net/browse/OBS-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ