### PR TITLE
feat(observability): read one authz decision by its event id

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/MetricsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/MetricsRepository.java
@@ -48,4 +48,10 @@ public interface MetricsRepository {
     LogResponse<NativeApiMetrics> searchNativeApiMetrics(QueryContext queryContext, NativeApiMetricsQuery query) throws AnalyticsException;
 
     LogResponse<AuthzDecisionLog> searchAuthzDecisionLogs(QueryContext queryContext, AuthzDecisionLogQuery query) throws AnalyticsException;
+
+    /**
+     * Reads one decision by its event id, scoped to an api. A batch stamps every decision with the
+     * same request id, so the event id is the only key that identifies a single one.
+     */
+    Optional<AuthzDecisionLog> findAuthzDecisionLog(QueryContext queryContext, String apiId, String eventId) throws AnalyticsException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepository.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepository;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.utils.ClusterUtils;
+import io.gravitee.repository.elasticsearch.v4.log.adapter.authz.FindAuthzDecisionLogQueryAdapter;
 import io.gravitee.repository.elasticsearch.v4.log.adapter.authz.SearchAuthzDecisionLogsQueryAdapter;
 import io.gravitee.repository.elasticsearch.v4.log.adapter.authz.SearchAuthzDecisionLogsResponseAdapter;
 import io.gravitee.repository.elasticsearch.v4.log.adapter.connection.SearchConnectionLogErrorKeysQueryAdapter;
@@ -157,6 +158,21 @@ public class MetricsElasticsearchRepository extends AbstractElasticsearchReposit
                 .blockingGet();
         } catch (RuntimeException e) {
             throw new AnalyticsException("Failed to search authz decision logs for apis " + query.getApiIds(), e);
+        }
+    }
+
+    @Override
+    public Optional<AuthzDecisionLog> findAuthzDecisionLog(QueryContext queryContext, String apiId, String eventId)
+        throws AnalyticsException {
+        var clusters = ClusterUtils.extractClusterIndexPrefixes(configuration);
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.EVENT_METRICS, clusters);
+
+        try {
+            return this.client.search(index, null, FindAuthzDecisionLogQueryAdapter.adapt(apiId, eventId))
+                .map(SearchAuthzDecisionLogsResponseAdapter::adaptFirst)
+                .blockingGet();
+        } catch (RuntimeException e) {
+            throw new AnalyticsException("Failed to find authz decision " + eventId + " for api " + apiId, e);
         }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/FindAuthzDecisionLogQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/FindAuthzDecisionLogQueryAdapter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.log.adapter.authz;
+
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Keys.BOOL;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Keys.FILTER;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Keys.QUERY;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Keys.SIZE;
+import static io.gravitee.repository.elasticsearch.utils.ElasticsearchDsl.Query.TERM;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Reads one decision by its event id. The api id is part of the predicate rather than a
+ * post-filter: it scopes the lookup the same way the caller's permission does, so a known event id
+ * from another api cannot be read through this path.
+ *
+ * @author GraviteeSource Team
+ */
+public final class FindAuthzDecisionLogQueryAdapter {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private FindAuthzDecisionLogQueryAdapter() {}
+
+    public static String adapt(String apiId, String eventId) {
+        ArrayNode filters = MAPPER.createArrayNode();
+        filters.add(MAPPER.createObjectNode().set(TERM, MAPPER.createObjectNode().put(AuthzDecisionLogFields.DOC_TYPE, "authz")));
+        filters.add(MAPPER.createObjectNode().set(TERM, MAPPER.createObjectNode().put(AuthzDecisionLogFields.API_ID, apiId)));
+        filters.add(MAPPER.createObjectNode().set(TERM, MAPPER.createObjectNode().put(AuthzDecisionLogFields.EVENT_ID, eventId)));
+
+        ObjectNode root = MAPPER.createObjectNode();
+        root.set(QUERY, MAPPER.createObjectNode().set(BOOL, MAPPER.createObjectNode().set(FILTER, filters)));
+        root.put(SIZE, 1);
+
+        return root.toString();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsResponseAdapter.java
@@ -19,6 +19,7 @@ import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.repository.log.v4.model.LogResponse;
 import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLog;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author GraviteeSource Team
@@ -26,6 +27,15 @@ import java.util.List;
 public final class SearchAuthzDecisionLogsResponseAdapter {
 
     private SearchAuthzDecisionLogsResponseAdapter() {}
+
+    /** First hit of a by-id lookup; empty when no decision matches within the caller's api scope. */
+    public static Optional<AuthzDecisionLog> adaptFirst(SearchResponse response) {
+        var hits = response.getSearchHits();
+        if (hits == null || hits.getHits() == null || hits.getHits().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(AuthzDecisionLogSourceMapper.from(hits.getHits().getFirst().getSource()));
+    }
 
     public static LogResponse<AuthzDecisionLog> adapt(SearchResponse response) {
         var hits = response.getSearchHits();

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepositoryTest_FindAuthzDecisionLog.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepositoryTest_FindAuthzDecisionLog.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.index.IndexNameGenerator;
+import io.gravitee.elasticsearch.model.SearchHit;
+import io.gravitee.elasticsearch.model.SearchHits;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.elasticsearch.model.TotalHits;
+import io.gravitee.elasticsearch.utils.Type;
+import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class MetricsElasticsearchRepositoryTest_FindAuthzDecisionLog {
+
+    private static final QueryContext QUERY_CONTEXT = new QueryContext("org#1", "env#1");
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private Client client;
+    private IndexNameGenerator indexNameGenerator;
+    private MetricsElasticsearchRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        client = mock(Client.class);
+        indexNameGenerator = mock(IndexNameGenerator.class);
+        when(indexNameGenerator.getWildcardIndexName(any(), any(), any())).thenReturn("gravitee-event-metrics-*");
+
+        repository = new MetricsElasticsearchRepository(mock(RepositoryConfiguration.class));
+        ReflectionTestUtils.setField(repository, "client", client);
+        ReflectionTestUtils.setField(repository, "indexNameGenerator", indexNameGenerator);
+    }
+
+    @Test
+    @SneakyThrows
+    void reads_the_decision_from_the_event_metrics_data_stream() {
+        when(client.search(any(), any(), any())).thenReturn(
+            Single.just(
+                responseWith(
+                    """
+                    { "event-id": "evt-1", "api-id": "api-1", "request-id": "req-1", "decision": "PERMIT" }
+                    """
+                )
+            )
+        );
+
+        var decision = repository.findAuthzDecisionLog(QUERY_CONTEXT, "api-1", "evt-1");
+
+        assertThat(decision).isPresent();
+        assertThat(decision.get().eventId()).isEqualTo("evt-1");
+        assertThat(decision.get().decision()).isEqualTo("PERMIT");
+        // Decisions live in the event-metrics data stream, not in the request-shaped v4 metrics index.
+        verify(indexNameGenerator).getWildcardIndexName(any(), eq(Type.EVENT_METRICS), any());
+    }
+
+    @Test
+    @SneakyThrows
+    void looks_the_decision_up_by_event_id_within_the_api() {
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        repository.findAuthzDecisionLog(QUERY_CONTEXT, "api-1", "evt-1");
+
+        var query = ArgumentCaptor.forClass(String.class);
+        verify(client).search(eq("gravitee-event-metrics-*"), eq(null), query.capture());
+        assertThat(query.getValue()).contains("evt-1").contains("api-1");
+    }
+
+    @Test
+    @SneakyThrows
+    void finds_nothing_when_no_decision_matches() {
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        assertThat(repository.findAuthzDecisionLog(QUERY_CONTEXT, "api-1", "missing")).isEmpty();
+    }
+
+    @Test
+    void reports_a_failed_lookup_as_an_analytics_exception() {
+        when(client.search(any(), any(), any())).thenThrow(new RuntimeException("cluster unreachable"));
+
+        assertThatThrownBy(() -> repository.findAuthzDecisionLog(QUERY_CONTEXT, "api-1", "evt-1"))
+            .isInstanceOf(AnalyticsException.class)
+            .hasMessageContaining("evt-1")
+            .hasMessageContaining("api-1");
+    }
+
+    @SneakyThrows
+    private SearchResponse responseWith(String source) {
+        var response = new SearchResponse();
+        var hits = new SearchHits();
+        var hit = new SearchHit();
+        hit.setSource(MAPPER.readTree(source));
+        hits.setHits(List.of(hit));
+        hits.setTotal(new TotalHits(1));
+        response.setSearchHits(hits);
+        return response;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/FindAuthzDecisionLogQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/FindAuthzDecisionLogQueryAdapterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.log.adapter.authz;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FindAuthzDecisionLogQueryAdapterTest {
+
+    @Test
+    void builds_a_single_hit_query_pinned_to_doc_type_api_and_event_id() {
+        var result = FindAuthzDecisionLogQueryAdapter.adapt("api-1", "evt-9");
+
+        assertThatJson(result).isEqualTo(
+            """
+            {
+              "query": {
+                "bool": {
+                  "filter": [
+                    { "term": { "doc-type": "authz" } },
+                    { "term": { "api-id": "api-1" } },
+                    { "term": { "event-id": "evt-9" } }
+                  ]
+                }
+              },
+              "size": 1
+            }
+            """
+        );
+    }
+
+    @Test
+    void scopes_by_api_so_an_event_id_from_another_api_cannot_be_read() {
+        var result = FindAuthzDecisionLogQueryAdapter.adapt("api-1", "evt-9");
+
+        assertThatJson(result).inPath("$.query.bool.filter[1].term.api-id").isEqualTo("api-1");
+    }
+
+    @Test
+    void keys_on_event_id_because_a_batch_shares_one_request_id() {
+        var result = FindAuthzDecisionLogQueryAdapter.adapt("api-1", "evt-9");
+
+        assertThatJson(result).inPath("$.query.bool.filter[2].term.event-id").isEqualTo("evt-9");
+        assertThatJson(result).node("query.bool.filter").isArray().hasSize(3);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsResponseAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsResponseAdapterTest.java
@@ -195,6 +195,54 @@ class SearchAuthzDecisionLogsResponseAdapterTest {
         assertThat(decision.eventId()).isEqualTo("evt-5");
     }
 
+    @Test
+    void finds_no_decision_when_the_lookup_came_back_without_hits() {
+        assertThat(SearchAuthzDecisionLogsResponseAdapter.adaptFirst(new SearchResponse())).isEmpty();
+    }
+
+    @Test
+    void finds_no_decision_when_the_hit_list_is_absent_or_empty() {
+        var withoutHitList = new SearchResponse();
+        withoutHitList.setSearchHits(new SearchHits());
+
+        var withEmptyHitList = new SearchResponse();
+        var emptyHits = new SearchHits();
+        emptyHits.setHits(List.of());
+        emptyHits.setTotal(new TotalHits(0));
+        withEmptyHitList.setSearchHits(emptyHits);
+
+        assertThat(SearchAuthzDecisionLogsResponseAdapter.adaptFirst(withoutHitList)).isEmpty();
+        assertThat(SearchAuthzDecisionLogsResponseAdapter.adaptFirst(withEmptyHitList)).isEmpty();
+    }
+
+    @Test
+    @SneakyThrows
+    void reads_the_one_decision_a_by_id_lookup_returns() {
+        var response = responseOf(
+            """
+            {
+              "event-id": "evt-9",
+              "api-id": "api-9",
+              "request-id": "req-9",
+              "decision": "DENY",
+              "reasons": ["No policy matched"]
+            }
+            """,
+            1L
+        );
+
+        var decision = SearchAuthzDecisionLogsResponseAdapter.adaptFirst(response);
+
+        assertThat(decision).isPresent();
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(decision.get().eventId()).isEqualTo("evt-9");
+            soft.assertThat(decision.get().apiId()).isEqualTo("api-9");
+            soft.assertThat(decision.get().requestId()).isEqualTo("req-9");
+            soft.assertThat(decision.get().decision()).isEqualTo("DENY");
+            soft.assertThat(decision.get().reasons()).containsExactly("No policy matched");
+        });
+    }
+
     @SneakyThrows
     private SearchResponse responseOf(String source, long total) {
         var response = new SearchResponse();

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpMetricsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpMetricsRepository.java
@@ -62,4 +62,9 @@ public class NoOpMetricsRepository implements MetricsRepository {
     public LogResponse<AuthzDecisionLog> searchAuthzDecisionLogs(QueryContext queryContext, AuthzDecisionLogQuery query) {
         return new LogResponse<>(0, List.of());
     }
+
+    @Override
+    public Optional<AuthzDecisionLog> findAuthzDecisionLog(QueryContext queryContext, String apiId, String eventId) {
+        return Optional.empty();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/crud_service/AuthzDecisionLogsCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/crud_service/AuthzDecisionLogsCrudService.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.log.model.AuthzDecisionLogFilters;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Optional;
 
 /**
  * Reads authorization outcomes from the event-metrics data stream. Separate from
@@ -34,4 +35,10 @@ public interface AuthzDecisionLogsCrudService {
         AuthzDecisionLogFilters filters,
         Pageable pageable
     );
+
+    /**
+     * One decision by its event id. Batched decisions share a request id, so that is not a key here;
+     * the event id is.
+     */
+    Optional<AuthzDecisionLog> findDecisionLog(ExecutionContext executionContext, String apiId, String eventId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/domain_service/UserContextLoader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/domain_service/UserContextLoader.java
@@ -22,4 +22,11 @@ import io.gravitee.apim.core.user.model.UserContext;
  */
 public interface UserContextLoader {
     UserContext loadApis(UserContext context);
+
+    /**
+     * Same scoping as {@link #loadApis}, narrowed to one api. A caller that needs a single api by id
+     * should not pay for the whole environment: this keeps the membership check and fetches one row.
+     * Yields no api when the caller cannot see it, which is indistinguishable from it not existing.
+     */
+    UserContext loadApi(UserContext context, String apiId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/AuthzDecisionLogsCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/AuthzDecisionLogsCrudServiceImpl.java
@@ -27,6 +27,7 @@ import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import lombok.CustomLog;
 import org.springframework.context.annotation.Lazy;
@@ -74,6 +75,22 @@ class AuthzDecisionLogsCrudServiceImpl implements AuthzDecisionLogsCrudService {
         } catch (AnalyticsException e) {
             log.error("An error occurs while trying to search authz decision logs [apiIds={}]", apiIds, e);
             throw new TechnicalManagementException("Unable to search authz decision logs", e);
+        }
+    }
+
+    @Override
+    public Optional<AuthzDecisionLog> findDecisionLog(ExecutionContext executionContext, String apiId, String eventId) {
+        try {
+            return metricsRepository
+                .findAuthzDecisionLog(
+                    new QueryContext(executionContext.getOrganizationId(), executionContext.getEnvironmentId()),
+                    apiId,
+                    eventId
+                )
+                .map(AuthzDecisionLogsCrudServiceImpl::toDomain);
+        } catch (AnalyticsException e) {
+            log.error("An error occurs while trying to find authz decision [apiId={}, eventId={}]", apiId, eventId, e);
+            throw new TechnicalManagementException("Unable to find authz decision " + eventId, e);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/UserContextLoaderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/UserContextLoaderImpl.java
@@ -81,6 +81,26 @@ public class UserContextLoaderImpl implements UserContextLoader {
         return context.withApis(apis).withApiNamesById(apiIdsToNames);
     }
 
+    @Override
+    public UserContext loadApi(UserContext context, String apiId) {
+        var organizationId = context.auditInfo().organizationId();
+        var environmentId = context.auditInfo().environmentId();
+        var userId = context.auditInfo().actor().userId();
+
+        if (!isAdmin()) {
+            ExecutionContext executionContext = new ExecutionContext(organizationId, environmentId);
+            Set<String> userApiIds = apiAuthorizationService.findApiIdsByUserId(executionContext, userId, null, true);
+            if (!userApiIds.contains(apiId)) {
+                return context.withApis(Collections.emptyList()).withApiNamesById(Collections.emptyMap());
+            }
+        }
+
+        var criteria = new ApiCriteria.Builder().environmentId(environmentId).ids(Set.of(apiId)).build();
+        var apis = ApiMapper.INSTANCE.map(apiRepository.search(criteria, ApiFieldFilter.defaultFields()));
+
+        return context.withApis(apis).withApiNamesById(mapApiIdsToNames(apis));
+    }
+
     private static Map<String, String> mapApiIdsToNames(Collection<Api> apis) {
         return apis.stream().collect(Collectors.toMap(Api::getId, Api::getName));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/log/AuthzDecisionLogsCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/log/AuthzDecisionLogsCrudServiceImplTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.infra.crud_service.log;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -34,6 +35,7 @@ import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -179,6 +181,45 @@ class AuthzDecisionLogsCrudServiceImplTest {
         var captor = ArgumentCaptor.forClass(AuthzDecisionLogQuery.class);
         verify(metricsRepository).searchAuthzDecisionLogs(any(), captor.capture());
         assertThat(captor.getValue().getDecisions()).containsExactly("FORBID");
+    }
+
+    @Test
+    void finds_one_decision_by_event_id_within_the_api() throws Exception {
+        when(metricsRepository.findAuthzDecisionLog(any(), any(), any())).thenReturn(
+            Optional.of(
+                io.gravitee.repository.log.v4.model.authz.AuthzDecisionLog.builder()
+                    .eventId("evt-1")
+                    .apiId("api-1")
+                    .decision("PERMIT")
+                    .build()
+            )
+        );
+
+        var decision = service.findDecisionLog(CONTEXT, "api-1", "evt-1");
+
+        assertThat(decision).isPresent();
+        assertThat(decision.get().eventId()).isEqualTo("evt-1");
+        assertThat(decision.get().decision()).isEqualTo("PERMIT");
+
+        var contextCaptor = ArgumentCaptor.forClass(QueryContext.class);
+        verify(metricsRepository).findAuthzDecisionLog(contextCaptor.capture(), eq("api-1"), eq("evt-1"));
+        assertThat(contextCaptor.getValue().placeholder()).containsEntry("orgId", "org-1").containsEntry("envId", "env-1");
+    }
+
+    @Test
+    void finds_no_decision_when_the_event_id_is_unknown() throws Exception {
+        when(metricsRepository.findAuthzDecisionLog(any(), any(), any())).thenReturn(Optional.empty());
+
+        assertThat(service.findDecisionLog(CONTEXT, "api-1", "gone")).isEmpty();
+    }
+
+    @Test
+    void turns_a_failed_decision_lookup_into_a_technical_management_exception() throws Exception {
+        when(metricsRepository.findAuthzDecisionLog(any(), any(), any())).thenThrow(new AnalyticsException("index unavailable"));
+
+        assertThatThrownBy(() -> service.findDecisionLog(CONTEXT, "api-1", "evt-1"))
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessageContaining("evt-1");
     }
 
     private static AuthzDecisionLogFilters filters(Set<String> apiIds, Long from, Long to) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/UserContextLoaderImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/UserContextLoaderImplTest.java
@@ -194,4 +194,52 @@ class UserContextLoaderImplTest {
             verify(apiRepository, never()).search(any(), any());
         }
     }
+
+    @Nested
+    class LoadOneApi {
+
+        @Test
+        void should_narrow_the_query_to_the_single_api_for_an_admin() {
+            setUpSecurityContext("ORGANIZATION:ADMIN");
+            auditInfo = auditInfo(ADMIN_USER_ID);
+            when(apiRepository.search(any(), any())).thenReturn(List.of(API_2));
+
+            var context = userContextLoader.loadApi(new UserContext(auditInfo), API_2.getId());
+
+            var criteria = ArgumentCaptor.forClass(ApiCriteria.class);
+            verify(apiRepository).search(criteria.capture(), any());
+            assertThat(criteria.getValue().getIds()).containsExactly(API_2.getId());
+            assertThat(criteria.getValue().getEnvironmentId()).isEqualTo("DEFAULT");
+            assertThat(context.apis()).hasValue(ApiMapper.INSTANCE.map(List.of(API_2)));
+            verify(apiAuthorizationService, never()).findApiIdsByUserId(any(), any(), any(), anyBoolean());
+        }
+
+        @Test
+        void should_keep_the_membership_check_for_a_non_admin() {
+            setUpSecurityContext("ORGANIZATION:USER");
+            auditInfo = auditInfo(NON_ADMIN_USER_ID);
+            when(apiAuthorizationService.findApiIdsByUserId(any(), any(), any(), anyBoolean())).thenReturn(NON_ADMIN_API_IDS);
+            when(apiRepository.search(any(), any())).thenReturn(List.of(API_2));
+
+            var context = userContextLoader.loadApi(new UserContext(auditInfo), API_2.getId());
+
+            verify(apiAuthorizationService).findApiIdsByUserId(any(), eq(NON_ADMIN_USER_ID), any(), eq(true));
+            assertThat(context.apis()).hasValue(ApiMapper.INSTANCE.map(List.of(API_2)));
+        }
+
+        @Test
+        void should_yield_nothing_when_a_non_admin_is_not_a_member_of_the_api() {
+            setUpSecurityContext("ORGANIZATION:USER");
+            auditInfo = auditInfo(NON_ADMIN_USER_ID);
+            when(apiAuthorizationService.findApiIdsByUserId(any(), any(), any(), anyBoolean())).thenReturn(NON_ADMIN_API_IDS);
+
+            // API_1 exists in the environment but this user is not a member: narrowing the query by id
+            // must not become "anything in the environment".
+            var context = userContextLoader.loadApi(new UserContext(auditInfo), API_1.getId());
+
+            assertThat(context.apis()).hasValue(Collections.emptyList());
+            assertThat(context.apiNameById()).hasValue(Collections.emptyMap());
+            verify(apiRepository, never()).search(any(), any());
+        }
+    }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/port/service_provider/ObservabilityLogsDataPort.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/port/service_provider/ObservabilityLogsDataPort.java
@@ -17,6 +17,7 @@ package io.gravitee.gamma.rest.core.observability.logs.port.service_provider;
 
 import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogDetail;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
 import java.util.List;
@@ -43,6 +44,13 @@ public interface ObservabilityLogsDataPort {
     List<AccessibleApi> loadAccessibleApis(String organizationId, String environmentId);
 
     /**
+     * Same scoping as {@link #loadAccessibleApis} for a single api. Empty when the caller cannot read
+     * it, so a by-id read collapses into the same "not found" as a missing record. Separate from the
+     * list form because resolving one api should not cost a fetch of the whole environment.
+     */
+    Optional<AccessibleApi> loadAccessibleApi(String organizationId, String environmentId, String apiId);
+
+    /**
      * Searches the {@code v4-metrics} index with the pre-scoped query and returns enriched log
      * entries (plan/application/gateway/apiProduct names resolved). Only V4 definition versions are
      * queried.
@@ -55,4 +63,11 @@ public interface ObservabilityLogsDataPort {
      * {@code v4-log} index. Returns empty when neither index contains a matching document.
      */
     Optional<LogDetail> getLogDetail(String organizationId, String environmentId, String apiId, String requestId);
+
+    /**
+     * Fetches one authorization decision by its event id. Separate from {@link #getLogDetail}
+     * because a decision is not an HTTP exchange, and its key is not the request id — a batch stamps
+     * every decision it contains with the same one.
+     */
+    Optional<LogEntry> getDecision(String organizationId, String environmentId, String apiId, String eventId);
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/GetAuthzDecisionUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/GetAuthzDecisionUseCase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+
+/**
+ * Fetches one authorization decision by its event id, for the detail view opened from a decision
+ * row. Returns the same shape the search returns, so the caller renders one row's worth of data
+ * rather than a second contract.
+ *
+ * <p>Authorization ({@code API_LOG[READ]} with 404 collapse) is enforced at the REST layer, and the
+ * data port additionally resolves the api through the caller's accessible set.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@AllArgsConstructor
+public class GetAuthzDecisionUseCase {
+
+    private final ObservabilityLogsDataPort logsDataPort;
+
+    public record Input(String organizationId, String environmentId, String apiId, String eventId) {}
+
+    public record Output(Optional<LogEntry> decision) {}
+
+    public Output execute(Input input) {
+        return new Output(logsDataPort.getDecision(input.organizationId, input.environmentId, input.apiId, input.eventId));
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
@@ -123,6 +123,19 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
     }
 
     @Override
+    public Optional<AccessibleApi> loadAccessibleApi(String organizationId, String environmentId, String apiId) {
+        var auditInfo = currentAuditInfo(organizationId, environmentId);
+        var userContext = userContextLoader.loadApi(new UserContext(auditInfo), apiId);
+
+        return userContext
+            .apis()
+            .orElseGet(Collections::emptyList)
+            .stream()
+            .findFirst()
+            .map(api -> new AccessibleApi(api.getId(), api.getName(), toGammaApiType(api.getType())));
+    }
+
+    @Override
     public LogsPage searchLogs(String organizationId, String environmentId, LogsSearchQuery query) {
         var executionContext = new ExecutionContext(organizationId, environmentId);
         var pageable = new PageableImpl(query.page(), query.perPage());
@@ -418,6 +431,22 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
             .map(decision -> mapDecisionToLogEntry(decision, query.apisById()))
             .toList();
         return new LogsPage(entries, result.total());
+    }
+
+    @Override
+    public Optional<LogEntry> getDecision(String organizationId, String environmentId, String apiId, String eventId) {
+        // Resolving the api through the accessible set is what scopes this read: an api the caller
+        // cannot see yields empty, which the resource collapses into the same 404 as "no such decision".
+        return loadAccessibleApi(organizationId, environmentId, apiId).flatMap(api ->
+            authzDecisionLogsCrudService
+                .findDecisionLog(new ExecutionContext(organizationId, environmentId), apiId, eventId)
+                .map(decision ->
+                    mapDecisionToLogEntry(
+                        decision,
+                        Map.of(apiId, new ApiReference(api.name(), api.type() == null ? null : api.type().name()))
+                    )
+                )
+        );
     }
 
     private static Set<String> valuesOf(List<FilterCondition> conditions, String filterName) {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/LogsResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/LogsResource.java
@@ -19,6 +19,7 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.logs.exception.LogDetailNotFoundException;
 import io.gravitee.gamma.rest.core.observability.logs.exception.MissingLogScopeException;
+import io.gravitee.gamma.rest.core.observability.logs.use_case.GetAuthzDecisionUseCase;
 import io.gravitee.gamma.rest.core.observability.logs.use_case.GetObservabilityLogDetailUseCase;
 import io.gravitee.gamma.rest.core.observability.logs.use_case.SearchObservabilityLogsUseCase;
 import io.gravitee.gamma.rest.resources.observability.logs.dto.FilterConditionDto;
@@ -79,6 +80,9 @@ public class LogsResource {
     private GetObservabilityLogDetailUseCase getLogDetailUseCase;
 
     @Inject
+    private GetAuthzDecisionUseCase getAuthzDecisionUseCase;
+
+    @Inject
     private PermissionService permissionService;
 
     @POST
@@ -135,6 +139,29 @@ public class LogsResource {
             .detail()
             .map(detail -> Response.ok(LogDetailDto.from(detail)).build())
             .orElseThrow(() -> new LogDetailNotFoundException(requestId, apiId));
+    }
+
+    /**
+     * Fetches one authorization decision by its event id. Its own path rather than the
+     * {@code /{requestId}} detail: a batch stamps every decision it contains with the same request
+     * id, so that is not a key here, and a decision is not an HTTP exchange so the merged log detail
+     * shape does not fit. Same {@code apiId} defense and 404 collapse.
+     */
+    @GET
+    @Path("/decisions/{eventId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getDecision(@PathParam("eventId") String eventId, @QueryParam("apiId") String apiId) {
+        requireParam("apiId", apiId);
+        checkApiLogReadPermissionOrCollapse(apiId, eventId);
+
+        var ctx = GraviteeContext.getExecutionContext();
+        var output = getAuthzDecisionUseCase.execute(
+            new GetAuthzDecisionUseCase.Input(ctx.getOrganizationId(), ctx.getEnvironmentId(), apiId, eventId)
+        );
+        return output
+            .decision()
+            .map(decision -> Response.ok(LogEntryDto.from(decision)).build())
+            .orElseThrow(() -> new LogDetailNotFoundException(eventId, apiId));
     }
 
     private static void requireParam(String name, String value) {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -393,6 +393,57 @@ paths:
                                 http_status: 403
                                 message: "Insufficient permissions to access observability metadata."
 
+    /organizations/{orgId}/environments/{envId}/observability/logs/decisions/{eventId}:
+        parameters:
+            - $ref: "#/components/parameters/orgIdParam"
+            - $ref: "#/components/parameters/envIdParam"
+        get:
+            tags:
+                - Logs
+            summary: Get a single authorization decision
+            description: |
+                Returns one decision, in the same shape a row of the search response has, so a client
+                renders it with the translation it already uses for the table.
+
+                **Keyed by event id, not request id.** A batch evaluation stamps every decision it
+                contains with the same request id — the table renders those as `1/2`, `2/2` — so the
+                request id cannot address a single one. This is also why the decision detail is not
+                served by `/observability/logs/{requestId}`, which resolves a connection log: a
+                different record, in a different index, and often absent entirely for a decision
+                taken over AuthZEN rather than in front of an HTTP call.
+
+                **`apiId` is required** as a security defense, same as the connection-log detail. The
+                server verifies `API_LOG[READ]` on that API, and additionally resolves the API
+                through the caller's accessible set; both failures collapse into 404, so a known
+                event id from another API cannot be probed.
+            operationId: getAuthzDecision
+            parameters:
+                - name: eventId
+                  in: path
+                  required: true
+                  description: Identifier of the decision event.
+                  schema:
+                      type: string
+                - name: apiId
+                  in: query
+                  required: true
+                  description: API the decision belongs to. Required — see the security note above.
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: The decision.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/LogEntry"
+                "400":
+                    description: '`apiId` is missing or blank.'
+                "404":
+                    description: |
+                        No such decision for that API — or the caller cannot read its logs. The two
+                        are deliberately indistinguishable.
+
     /organizations/{orgId}/environments/{envId}/observability/logs/{requestId}:
         parameters:
             - $ref: "#/components/parameters/orgIdParam"

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/GetAuthzDecisionUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/GetAuthzDecisionUseCaseTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetAuthzDecisionUseCaseTest {
+
+    private static final String ORG = "org-1";
+    private static final String ENV = "env-1";
+    private static final String API_ID = "api-1";
+    private static final String EVENT_ID = "evt-1";
+
+    private ObservabilityLogsDataPort logsDataPort;
+    private GetAuthzDecisionUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        logsDataPort = mock(ObservabilityLogsDataPort.class);
+        useCase = new GetAuthzDecisionUseCase(logsDataPort);
+    }
+
+    @Test
+    void returns_the_decision_the_data_port_resolved() {
+        var decision = LogEntry.builder().apiId(API_ID).requestId("req-1").build();
+        when(logsDataPort.getDecision(ORG, ENV, API_ID, EVENT_ID)).thenReturn(Optional.of(decision));
+
+        var output = useCase.execute(new GetAuthzDecisionUseCase.Input(ORG, ENV, API_ID, EVENT_ID));
+
+        assertThat(output.decision()).contains(decision);
+    }
+
+    @Test
+    void identifies_the_decision_by_event_id_within_one_api_and_the_caller_scope() {
+        when(logsDataPort.getDecision(ORG, ENV, API_ID, EVENT_ID)).thenReturn(Optional.empty());
+
+        useCase.execute(new GetAuthzDecisionUseCase.Input(ORG, ENV, API_ID, EVENT_ID));
+
+        verify(logsDataPort).getDecision(ORG, ENV, API_ID, EVENT_ID);
+    }
+
+    @Test
+    void reports_no_decision_rather_than_failing_when_the_event_is_absent_or_out_of_scope() {
+        when(logsDataPort.getDecision(ORG, ENV, API_ID, "gone")).thenReturn(Optional.empty());
+
+        var output = useCase.execute(new GetAuthzDecisionUseCase.Input(ORG, ENV, API_ID, "gone"));
+
+        assertThat(output.decision()).isEmpty();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
@@ -18,11 +18,14 @@ package io.gravitee.gamma.rest.infra.adapter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
@@ -33,7 +36,9 @@ import io.gravitee.apim.core.log.model.AuthzDecisionLog;
 import io.gravitee.apim.core.log.model.AuthzDecisionLogFilters;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
+import io.gravitee.apim.core.user.model.UserContext;
 import io.gravitee.common.http.HttpMethod;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
@@ -47,6 +52,7 @@ import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -732,6 +738,62 @@ class ObservabilityLogsDataPortAdapterTest {
             var captor = ArgumentCaptor.forClass(AuthzDecisionLogFilters.class);
             verify(authzDecisionLogsCrudService).searchDecisionLogs(any(), captor.capture(), any());
             assertThat(captor.getValue().decisions()).isEmpty();
+        }
+
+        @Test
+        void should_not_read_a_decision_for_an_api_the_caller_cannot_access() {
+            when(userContextLoader.loadApi(any(), eq("api-1"))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            var decision = adapter.getDecision(ORG, ENV, "api-1", "evt-1");
+
+            assertThat(decision).isEmpty();
+            // The scoping has to happen before the store is touched, otherwise the guard is decorative.
+            verifyNoInteractions(authzDecisionLogsCrudService);
+        }
+
+        @Test
+        void should_resolve_the_api_by_id_rather_than_loading_the_whole_environment() {
+            grantAccessToApi1();
+            when(authzDecisionLogsCrudService.findDecisionLog(any(), eq("api-1"), eq("evt-1"))).thenReturn(
+                Optional.of(AuthzDecisionLog.builder().eventId("evt-1").apiId("api-1").build())
+            );
+
+            adapter.getDecision(ORG, ENV, "api-1", "evt-1");
+
+            // Opening one decision must not pay for every api in the environment.
+            verify(userContextLoader).loadApi(any(), eq("api-1"));
+            verify(userContextLoader, never()).loadApis(any());
+        }
+
+        @Test
+        void should_read_the_decision_of_an_accessible_api_and_enrich_it_with_the_api_identity() {
+            grantAccessToApi1();
+            when(authzDecisionLogsCrudService.findDecisionLog(any(), eq("api-1"), eq("evt-1"))).thenReturn(
+                Optional.of(AuthzDecisionLog.builder().eventId("evt-1").apiId("api-1").requestId("req-1").decision("PERMIT").build())
+            );
+
+            var decision = adapter.getDecision(ORG, ENV, "api-1", "evt-1");
+
+            assertThat(decision).isPresent();
+            assertThat(decision.get().requestId()).isEqualTo("req-1");
+            assertThat(decision.get().apiName()).isEqualTo("API 1");
+            assertThat(decision.get().apiType()).isEqualTo("AUTHZ");
+        }
+
+        @Test
+        void should_report_no_decision_when_the_accessible_api_has_no_such_event() {
+            grantAccessToApi1();
+            when(authzDecisionLogsCrudService.findDecisionLog(any(), eq("api-1"), eq("gone"))).thenReturn(Optional.empty());
+
+            assertThat(adapter.getDecision(ORG, ENV, "api-1", "gone")).isEmpty();
+        }
+
+        private void grantAccessToApi1() {
+            when(userContextLoader.loadApi(any(), eq("api-1"))).thenAnswer(invocation ->
+                ((UserContext) invocation.getArgument(0)).withApis(
+                    List.of(Api.builder().id("api-1").name("API 1").type(ApiType.AUTHZ).build())
+                )
+            );
         }
 
         private LogsSearchQuery decisionQuery() {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/observability/logs/LogsResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/observability/logs/LogsResourceTest.java
@@ -26,10 +26,12 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.gamma.rest.core.observability.logs.model.AuthzDecision;
 import io.gravitee.gamma.rest.core.observability.logs.model.HttpPayload;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogDetail;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
+import io.gravitee.gamma.rest.core.observability.logs.use_case.GetAuthzDecisionUseCase;
 import io.gravitee.gamma.rest.core.observability.logs.use_case.GetObservabilityLogDetailUseCase;
 import io.gravitee.gamma.rest.core.observability.logs.use_case.SearchObservabilityLogsUseCase;
 import io.gravitee.gamma.rest.resource.AbstractResourceTest;
@@ -67,6 +69,9 @@ class LogsResourceTest extends AbstractResourceTest {
     @Inject
     private GetObservabilityLogDetailUseCase getLogDetailUseCase;
 
+    @Inject
+    private GetAuthzDecisionUseCase getAuthzDecisionUseCase;
+
     @Override
     protected String contextPath() {
         return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/observability/logs";
@@ -82,7 +87,7 @@ class LogsResourceTest extends AbstractResourceTest {
 
     @AfterEach
     void resetUseCases() {
-        reset(searchLogsUseCase, getLogDetailUseCase);
+        reset(searchLogsUseCase, getLogDetailUseCase, getAuthzDecisionUseCase);
     }
 
     @Nested
@@ -261,6 +266,75 @@ class LogsResourceTest extends AbstractResourceTest {
         }
     }
 
+    @Nested
+    class GetDecision {
+
+        private static final String EVENT_ID = "evt-1";
+        private static final String API_ID = "api-1";
+        private static final String REQUEST_ID = "req-123";
+
+        @Test
+        void should_return_the_decision_in_the_same_shape_a_row_has() {
+            var decision = LogEntry.builder()
+                .apiId(API_ID)
+                .requestId(REQUEST_ID)
+                .timestamp(Instant.parse("2026-06-10T14:32:01Z"))
+                .authz(AuthzDecision.builder().eventId(EVENT_ID).decision("FORBID").subjectId("alice").policyGeneration(3L).build())
+                .build();
+            when(getAuthzDecisionUseCase.execute(any())).thenReturn(new GetAuthzDecisionUseCase.Output(Optional.of(decision)));
+
+            Response response = rootTarget("decisions/" + EVENT_ID).queryParam("apiId", API_ID).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("apiId").asText()).isEqualTo(API_ID);
+            assertThat(body.get("authz").get("eventId").asText()).isEqualTo(EVENT_ID);
+            assertThat(body.get("authz").get("decision").asText()).isEqualTo("FORBID");
+            assertThat(body.get("authz").get("policyGeneration").asLong()).isEqualTo(3L);
+        }
+
+        @Test
+        void should_forward_apiId_and_eventId_to_the_use_case() {
+            when(getAuthzDecisionUseCase.execute(any())).thenReturn(new GetAuthzDecisionUseCase.Output(Optional.empty()));
+
+            rootTarget("decisions/" + EVENT_ID).queryParam("apiId", API_ID).request().get();
+
+            var captor = ArgumentCaptor.forClass(GetAuthzDecisionUseCase.Input.class);
+            verify(getAuthzDecisionUseCase).execute(captor.capture());
+            assertThat(captor.getValue().apiId()).isEqualTo(API_ID);
+            assertThat(captor.getValue().eventId()).isEqualTo(EVENT_ID);
+        }
+
+        @Test
+        void should_return_400_when_apiId_is_missing() {
+            Response response = rootTarget("decisions/" + EVENT_ID).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+            verifyNoInteractions(getAuthzDecisionUseCase);
+        }
+
+        @Test
+        void should_return_404_when_the_decision_does_not_exist() {
+            when(getAuthzDecisionUseCase.execute(any())).thenReturn(new GetAuthzDecisionUseCase.Output(Optional.empty()));
+
+            Response response = rootTarget("decisions/" + EVENT_ID).queryParam("apiId", API_ID).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_collapse_a_permission_denial_into_the_same_404() {
+            when(permissionService.hasPermission(any(), eq(RolePermission.API_LOG), eq(API_ID), eq(RolePermissionAction.READ))).thenReturn(
+                false
+            );
+
+            Response response = rootTarget("decisions/" + EVENT_ID).queryParam("apiId", API_ID).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+            verifyNoInteractions(getAuthzDecisionUseCase);
+        }
+    }
+
     @Configuration
     static class LogsTestConfiguration {
 
@@ -272,6 +346,11 @@ class LogsResourceTest extends AbstractResourceTest {
         @Bean
         GetObservabilityLogDetailUseCase getObservabilityLogDetailUseCase() {
             return mock(GetObservabilityLogDetailUseCase.class);
+        }
+
+        @Bean
+        GetAuthzDecisionUseCase getAuthzDecisionUseCase() {
+            return mock(GetAuthzDecisionUseCase.class);
         }
     }
 }


### PR DESCRIPTION
> Stacked on #19044 — base is `authz-decision-filter`, so this diff is only the delta. Merge that one first.
>
> Console counterpart: [gravitee-gamma-module-authz#118](https://github.com/gravitee-io/gravitee-gamma-module-authz/pull/118).

## Summary

Clicking a decision row opens a drawer that errors:

> Log detail is not supported. The data source does not implement getById.

The panel it would render is already written in full — `config/log-detail.tsx` in the
console describes decision and search sections, reasons, matched policies and search
results. It has never had anything to show, because nothing serves a single decision.
This adds that read.

## Why not the existing detail endpoint

`GET /observability/logs/{requestId}` resolves a **connection log**. For a decision that is
the wrong record, in the wrong index, and often absent entirely — an AuthZEN call has no
HTTP exchange behind it.

More fundamentally, **the request id is not a key here**. A batch stamps every decision it
contains with the same one; the decisions screen renders those as `1/2` and `2/2`. The key
is the event id, which is already what the table uses for its row id. Hence its own path
rather than a parameter bolted onto the request-log detail.

## Changes

- `MetricsRepository.findAuthzDecisionLog(queryContext, apiId, eventId)`, with a term query
  on `event-id` reusing the existing source mapper. Implemented for elasticsearch and noop.
- `AuthzDecisionLogsCrudService.findDecisionLog` over the core-owned record.
- `ObservabilityLogsDataPort.getDecision` and `GetAuthzDecisionUseCase`.
- `GET /observability/logs/decisions/{eventId}?apiId=`, returning the same `LogEntryDto` a
  row has — so the console maps the response through the same translation it uses for the
  table rather than keeping a second contract that can drift.

## API surface

| Endpoint | Method | Change | Request | Response |
|---|---|---|---|---|
| `/environments/{envId}/observability/logs/decisions/{eventId}` | `GET` | New. `apiId` is required. | `?apiId=api-1` | `200` with a `LogEntryDto` carrying the `authz` object; `404` when absent or not permitted; `400` without `apiId` |

Additive: a new path under an existing resource, nothing else moves.

## Reviewer notes

**The api scope is the security control.** The adapter resolves the api through the caller's
accessible set before reading, so an api they cannot see yields empty, and the resource
collapses that into the same `404` as "no such decision". A known event id from another api
cannot be probed through this path — same posture as the request-log detail, which is why
`apiId` is required rather than inferred.

**Null versus throw, on the console side.** A `404` becomes `null` so the drawer can say the
decision is gone; any other status throws, so it never renders a decision assembled from an
error body.

## Test plan

- [ ] On *Observability → Decisions*, click a row: the drawer opens and shows the decision —
      outcome, subject, action, resource, caller, PDP, eval time, request id.
- [ ] Click a row belonging to a batch (`1/2`): the drawer shows that decision, and clicking
      `2/2` shows the *other* one. Before this change the request id could not tell them apart.
- [ ] Click a search record: the drawer opens on its Search section with the result list.
- [ ] Reload the page with a drawer open: it still resolves, since the read is server-side.
- [ ] As a user without `API_LOG[READ]` on that api: `404`, indistinguishable from a missing
      decision.

## Verification

`LogsResourceTest` (14, five new: response shape, forwarding, missing `apiId`, absent
decision, permission denial collapsing to the same 404), plus the modules it touches green:
repository-api, repository-elasticsearch, repository-noop, rest-api-service, gamma-rest-api.
Console side 1,189 with four new for the source, typecheck and eslint clean.

Not yet clicked in a running console — the endpoint and the mapping are covered by the tests
above, but the drawer itself has not been opened against a live stack.
