### PR TITLE
chore(4.9.x): bump gravitee-reactor-native-kafka from 4.4.3 to 4.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.0.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.0.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>8.0.1</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>4.4.3</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>4.4.4</gravitee-reactor-native-kafka.version>
         <gravitee-apim-repository-bridge.version>7.0.1</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>


### PR DESCRIPTION
## Issue

- https://gravitee.atlassian.net/browse/ESM-119
- https://gravitee.atlassian.net/browse/ESM-125

## Description

Bumps [gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka) from `4.4.3` to `4.4.4` on `4.9.x`.

Picks up two Native Kafka fixes:

- **ESM-119** — `NullPointerException: records should not be null` while counting records for metrics on a Fetch response when a partition carries `null` (or non-`MemoryRecords`) records. The gateway could not return the Fetch response to the downstream client.
- **ESM-125** — a policy dropping a record mid-fetch (e.g. `kafka-message-filtering`) renumbered the offsets of the surviving records, so every survivor ahead of the drop was delivered under the wrong offset. Broker offsets are now preserved, with a gap where the record was dropped.


## Additional context

- Reactor release: https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases/tag/4.4.4
