### PR TITLE
chore(4.10.x): bump gravitee-reactor-native-kafka from 5.0.5 to 5.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.0.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>9.0.1</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>5.0.5</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>5.0.7</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.2.0</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>1.4.3</gravitee-reactor-llm-proxy.version>
         <gravitee-apim-repository-bridge.version>7.1.1</gravitee-apim-repository-bridge.version>


### PR DESCRIPTION
## Issue

- https://gravitee.atlassian.net/browse/ESM-119
- https://gravitee.atlassian.net/browse/ESM-125

## Description

Bumps [gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka) from `5.0.5` to `5.0.7` on `4.10.x`.

Picks up two Native Kafka fixes:

- **ESM-119** — `NullPointerException: records should not be null` while counting records for metrics on a Fetch response when a partition carries `null` (or non-`MemoryRecords`) records. The gateway could not return the Fetch response to the downstream client.
- **ESM-125** — a policy dropping a record mid-fetch (e.g. `kafka-message-filtering`) renumbered the offsets of the surviving records, so every survivor ahead of the drop was delivered under the wrong offset. Broker offsets are now preserved, with a gap where the record was dropped.

Also includes `5.0.6`, which was superseded the same day by `5.0.7`.


## Additional context

- Reactor release: https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases/tag/5.0.7
