### PR TITLE
chore(4.11.x): bump gravitee-reactor-native-kafka from 6.3.3 to 6.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.1.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>10.0.1</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>6.3.3</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>6.3.4</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>2.2.1</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>2.11.3</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.2</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Issue

- https://gravitee.atlassian.net/browse/ESM-119
- https://gravitee.atlassian.net/browse/ESM-125

## Description

Bumps [gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka) from `6.3.3` to `6.3.4` on `4.11.x`.

Picks up two Native Kafka fixes:

- **ESM-119** — `NullPointerException: records should not be null` while counting records for metrics on a Fetch response when a partition carries `null` (or non-`MemoryRecords`) records. The gateway could not return the Fetch response to the downstream client.
- **ESM-125** — a policy dropping a record mid-fetch (e.g. `kafka-message-filtering`) renumbered the offsets of the surviving records, so every survivor ahead of the drop was delivered under the wrong offset. Broker offsets are now preserved, with a gap where the record was dropped.


## Additional context

- Reactor release: https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases/tag/6.3.4
