### PR TITLE
chore(4.12.x): bump gravitee-reactor-native-kafka from 7.0.4 to 7.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
     <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
-    <gravitee-reactor-native-kafka.version>7.0.4</gravitee-reactor-native-kafka.version>
+    <gravitee-reactor-native-kafka.version>7.0.5</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.1.5</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>3.3.5</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.1.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Issue

- https://gravitee.atlassian.net/browse/ESM-119
- https://gravitee.atlassian.net/browse/ESM-125

## Description

Bumps [gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka) from `7.0.4` to `7.0.5` on `4.12.x`.

Picks up two Native Kafka fixes:

- **ESM-119** — `NullPointerException: records should not be null` while counting records for metrics on a Fetch response when a partition carries `null` (or non-`MemoryRecords`) records. The gateway could not return the Fetch response to the downstream client.
- **ESM-125** — a policy dropping a record mid-fetch (e.g. `kafka-message-filtering`) renumbered the offsets of the surviving records, so every survivor ahead of the drop was delivered under the wrong offset. Broker offsets are now preserved, with a gap where the record was dropped.

Note: `7.0.4` (already on this branch) carried the ESM-125 fix, so this bump effectively adds ESM-119.


## Additional context

- Reactor release: https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases/tag/7.0.5
