### PR TITLE
fix: avoid N+1 certificate lookup when listing applications

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -571,7 +571,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 notificationConfigEntity.setConfig(userEntity.getEmail());
                 genericNotificationConfigService.create(notificationConfigEntity);
             }
-            return convert(executionContext, createdApplication, userEntity);
+            return convert(executionContext, createdApplication, userEntity, true);
         } catch (TechnicalException ex) {
             throw new TechnicalManagementException(
                 "An error occurs while trying create " +
@@ -695,7 +695,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             );
 
             updateActiveSubscriptions(executionContext, applicationId, application);
-            return convertApplication(executionContext, Collections.singleton(updatedApplication)).iterator().next();
+            return convertApplication(executionContext, Collections.singleton(updatedApplication), true).iterator().next();
         } catch (TechnicalException ex) {
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to update application %s", applicationId),
@@ -963,7 +963,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 updatedApplication
             );
 
-            return convertApplication(executionContext, Collections.singleton(updatedApplication)).iterator().next();
+            return convertApplication(executionContext, Collections.singleton(updatedApplication), true).iterator().next();
         } catch (TechnicalException ex) {
             String error = String.format(
                 "An error occurs while trying to update application %s with apiKeyMode %s",
@@ -1067,7 +1067,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                     updatedApplication
                 );
 
-                return convertApplication(executionContext, Collections.singleton(updatedApplication)).iterator().next();
+                return convertApplication(executionContext, Collections.singleton(updatedApplication), true).iterator().next();
             }
 
             throw new ApplicationRenewClientSecretException(applicationToUpdate.getName());
@@ -1135,7 +1135,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             // Audit
             createAuditLog(executionContext, APPLICATION_RESTORED, restoredApplication.getUpdatedAt(), application, restoredApplication);
 
-            return convert(executionContext, restoredApplication, userEntity);
+            return convert(executionContext, restoredApplication, userEntity, true);
         } catch (TechnicalException ex) {
             throw new TechnicalManagementException(String.format("An error occurs while trying to restore %s", applicationId), ex);
         }
@@ -1223,7 +1223,11 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         }
     }
 
-    private Set<ApplicationEntity> convertApplication(ExecutionContext executionContext, Collection<Application> applications) {
+    private Set<ApplicationEntity> convertApplication(
+        ExecutionContext executionContext,
+        Collection<Application> applications,
+        boolean fetchCertificate
+    ) {
         if (applications == null || applications.isEmpty()) {
             return Collections.emptySet();
         }
@@ -1276,7 +1280,12 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         return applications
             .stream()
             .map(publicApplication ->
-                convert(executionContext, publicApplication, userIdToUserEntity.get(applicationToUser.get(publicApplication.getId())))
+                convert(
+                    executionContext,
+                    publicApplication,
+                    userIdToUserEntity.get(applicationToUser.get(publicApplication.getId())),
+                    fetchCertificate
+                )
             )
             .collect(Collectors.toCollection(LinkedHashSet::new));
     }
@@ -1324,7 +1333,8 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     private Set<ApplicationListItem> convertToList(final ExecutionContext executionContext, Collection<Application> applications) {
-        Set<ApplicationEntity> entities = convertApplication(executionContext, applications);
+        // fetchCertificate=false: certificates are resolved in bulk below, resolving them per-application here would be N+1 and wasted work
+        Set<ApplicationEntity> entities = convertApplication(executionContext, applications, false);
 
         Set<ApplicationListItem> apps = entities
             .stream()
@@ -1385,7 +1395,12 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         return apps;
     }
 
-    private ApplicationEntity convert(final ExecutionContext executionContext, Application application, UserEntity primaryOwner) {
+    private ApplicationEntity convert(
+        final ExecutionContext executionContext,
+        Application application,
+        UserEntity primaryOwner,
+        boolean fetchCertificate
+    ) {
         if (primaryOwner == null) {
             // add a default unknown user
             primaryOwner = new UserEntity();
@@ -1413,7 +1428,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         applicationEntity.setUpdatedAt(application.getUpdatedAt());
         applicationEntity.setPrimaryOwner(new PrimaryOwnerEntity(primaryOwner));
 
-        applicationEntity.setSettings(getSettings(executionContext, application, true));
+        applicationEntity.setSettings(getSettings(executionContext, application, fetchCertificate));
         applicationEntity.setDisableMembershipNotifications(application.isDisableMembershipNotifications());
         if (application.getApiKeyMode() != null) {
             applicationEntity.setApiKeyMode(ApiKeyMode.valueOf(application.getApiKeyMode().name()));
@@ -1722,9 +1737,9 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             if (!ApplicationStatus.ARCHIVED.equals(application.getStatus())) {
                 log.error("The Application {} doesn't have any primary owner.", application.getId());
             }
-            return convert(executionContext, application, null);
+            return convert(executionContext, application, null, true);
         }
 
-        return convert(executionContext, application, userService.findById(executionContext, primaryOwnerMemberEntity.getMemberId()));
+        return convert(executionContext, application, userService.findById(executionContext, primaryOwnerMemberEntity.getMemberId()), true);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationServiceImplTest.java
@@ -19,15 +19,36 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.search.ApplicationCriteria;
+import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.ApplicationStatus;
+import io.gravitee.repository.management.model.ApplicationType;
+import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.application.ApplicationQuery;
+import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
@@ -44,6 +65,83 @@ public class ApplicationServiceImplTest {
 
     @Mock
     private MembershipService membershipService;
+
+    @Mock
+    private RoleService roleService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Mock
+    private ClientCertificateCrudService clientCertificateCrudService;
+
+    @Test
+    public void findByIdsAndStatus_shouldNotFetchCertificatesPerApplication() throws TechnicalException {
+        ExecutionContext executionContext = new ExecutionContext("org1", "env1");
+
+        Application app1 = Application.builder().id("app1").status(ApplicationStatus.ACTIVE).type(ApplicationType.SIMPLE).build();
+        Application app2 = Application.builder().id("app2").status(ApplicationStatus.ACTIVE).type(ApplicationType.SIMPLE).build();
+
+        when(applicationRepository.search(any(ApplicationCriteria.class), isNull())).thenReturn(new Page<>(List.of(app1, app2), 0, 2, 2));
+
+        RoleEntity primaryOwnerRole = new RoleEntity();
+        primaryOwnerRole.setId("role1");
+        when(roleService.findPrimaryOwnerRoleByOrganization("org1", RoleScope.APPLICATION)).thenReturn(primaryOwnerRole);
+
+        MembershipEntity membership1 = MembershipEntity.builder().id("m1").referenceId("app1").memberId("user1").build();
+        MembershipEntity membership2 = MembershipEntity.builder().id("m2").referenceId("app2").memberId("user2").build();
+        when(
+            membershipService.getMembershipsByReferencesAndRole(MembershipReferenceType.APPLICATION, List.of("app1", "app2"), "role1")
+        ).thenReturn(Set.of(membership1, membership2));
+
+        when(userService.findByIds(eq(executionContext), any(), eq(false))).thenReturn(Set.of());
+
+        ClientCertificate app1Certificate = new ClientCertificate(
+            "cert1",
+            null,
+            "app1",
+            "cert-name",
+            null,
+            null,
+            new Date(),
+            null,
+            "app1-certificate-pem",
+            null,
+            null,
+            null,
+            null,
+            null,
+            ClientCertificateStatus.ACTIVE
+        );
+        when(clientCertificateCrudService.findByApplicationIdsAndStatuses(any(), any(ClientCertificateStatus[].class))).thenReturn(
+            List.of(app1Certificate)
+        );
+
+        Set<ApplicationListItem> result = applicationService.findByIdsAndStatus(executionContext, List.of("app1", "app2"), null);
+
+        assertThat(result).hasSize(2);
+        ApplicationListItem app1Item = result
+            .stream()
+            .filter(item -> "app1".equals(item.getId()))
+            .findFirst()
+            .orElseThrow();
+        ApplicationListItem app2Item = result
+            .stream()
+            .filter(item -> "app2".equals(item.getId()))
+            .findFirst()
+            .orElseThrow();
+        // Locks the actual contract, not just "no N+1": the batched certificate must still land on the right list item.
+        assertThat(app1Item.getSettings().getTls().getClientCertificate()).isEqualTo("app1-certificate-pem");
+        assertThat(app2Item.getSettings().getTls()).isNull();
+
+        // any(ClientCertificateStatus[].class) matches the vararg's underlying array regardless of how many
+        // statuses are passed, so a regression can't slip past never() just by changing call arity.
+        verify(clientCertificateCrudService, never()).findByApplicationIdAndStatuses(anyString(), any(ClientCertificateStatus[].class));
+        verify(clientCertificateCrudService).findByApplicationIdsAndStatuses(any(), any(ClientCertificateStatus[].class));
+    }
 
     @Test
     public void buildSearchCriteria() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14337

## Description

`GET /applications` regressed from ~500ms to 10-20s in 4.11.x, scaling with app count. Multiple customers affected (APIM-14337).

Initial theory was a missing MongoDB index on `page_revisions` — turned out to be wrong. On the customer's actual DB, the index already existed and `$indexStats`/profiler showed the DB doing 1ms of work for a 3s response. The bottleneck isn't the database.

### Root cause

`convert()` (called once per application from `convertToList`) unconditionally fetches that app's client certificate:

```java
applicationEntity.setSettings(getSettings(executionContext, application, true)); // always true
```

### Fix
Threaded a `fetchCertificate` flag through `convert()/convertApplication()`. List path passes `false` (batched fetch covers it); `create/update/restore/renewClientSecret/findById` still pass `true` — those are single-item lookups where the per-item fetch is correct.

### Test
Added `findByIdsAndStatus_shouldNotFetchCertificatesPerApplication`: asserts the list path calls the batched `findByApplicationIdsAndStatuses` and never the singular `findByApplicationIdAndStatuses`.

### Note
Supersedes #18772 (index-based fix) — that addressed a symptom, not the actual bottleneck.



