### PR TITLE
feat(portal): filter navigation search by category and expose visible portal categories

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PortalNavigationItemCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PortalNavigationItemCriteria.java
@@ -37,4 +37,5 @@ public class PortalNavigationItemCriteria {
     private Set<String> apiProductIds;
     private String type;
     private Boolean useAutoFetch;
+    private String categoryId;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
@@ -314,6 +314,10 @@ public class JdbcPortalNavigationItemRepository
                 clauses.add("use_auto_fetch = ?");
                 params.add(criteria.getUseAutoFetch());
             }
+            if (hasText(criteria.getCategoryId())) {
+                clauses.add("id IN (select nav_item_id from " + PORTAL_NAVIGATION_ITEM_CATEGORIES + " where category_id = ?)");
+                params.add(criteria.getCategoryId());
+            }
         }
 
         return new CriteriaClauses(clauses, params);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNavigationItemRepository.java
@@ -142,6 +142,9 @@ public class MongoPortalNavigationItemRepository implements PortalNavigationItem
             if (criteria.getUseAutoFetch() != null) {
                 query.addCriteria(where("useAutoFetch").is(criteria.getUseAutoFetch()));
             }
+            if (hasText(criteria.getCategoryId())) {
+                query.addCriteria(where("categoryIds").is(criteria.getCategoryId()));
+            }
         }
         return query;
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portalnavigationindex/PortalNavigationItemCategoryIdsIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portalnavigationindex/PortalNavigationItemCategoryIdsIndexUpgrader.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.portalnavigationindex;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PortalNavigationItemCategoryIdsIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        // Build a composite index on environmentId + categoryIds to support the _search categoryId filter
+        return Index.builder()
+            .collection("portal_navigation_items")
+            .key("environmentId", ascending())
+            .key("categoryIds", ascending())
+            .name("e1c1")
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
@@ -914,6 +914,74 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
             );
     }
 
+    //////////////////////////////////////
+    ////   SEARCH BY CATEGORY ID TESTS
+    //////////////////////////////////////
+
+    @Test
+    public void should_search_by_category_id() throws Exception {
+        PortalNavigationItem itemInCategory = PortalNavigationItem.builder()
+            .id("category-search-1")
+            .organizationId("org-1")
+            .environmentId("env-category-search")
+            .title("In Category")
+            .segment("in-category")
+            .type(PortalNavigationItem.Type.LINK)
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(1)
+            .published(true)
+            .configuration("{ \"url\": \"https://in-category.example.com\" }")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("category-search-1")
+            .categoryIds(List.of("category-1", "category-2"))
+            .build();
+        PortalNavigationItem itemOutsideCategory = PortalNavigationItem.builder()
+            .id("category-search-2")
+            .organizationId("org-1")
+            .environmentId("env-category-search")
+            .title("Outside Category")
+            .segment("outside-category")
+            .type(PortalNavigationItem.Type.LINK)
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(2)
+            .published(true)
+            .configuration("{ \"url\": \"https://outside-category.example.com\" }")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("category-search-2")
+            .build();
+
+        portalNavigationItemRepository.create(itemInCategory);
+        portalNavigationItemRepository.create(itemOutsideCategory);
+
+        try {
+            PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+                .environmentId("env-category-search")
+                .categoryId("category-1")
+                .build();
+
+            List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+            assertThat(items).hasSize(1);
+            assertThat(items.getFirst().getId()).isEqualTo("category-search-1");
+            assertThat(items.getFirst().getCategoryIds()).containsExactlyInAnyOrder("category-1", "category-2");
+        } finally {
+            portalNavigationItemRepository.delete("category-search-1");
+            portalNavigationItemRepository.delete("category-search-2");
+        }
+    }
+
+    @Test
+    public void should_return_empty_when_category_id_does_not_match() throws Exception {
+        PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+            .environmentId("env-1")
+            .categoryId("unknown-category")
+            .build();
+
+        List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+        assertThat(items).isEmpty();
+    }
+
     @Test
     public void should_delete_navigation_items_by_ids() throws Exception {
         List<String> idsToDelete = List.of("6b1c2d3e-4e5f-6a7b-8c9d-0e1f2a3b4c5d", "7c2d3e4f-5f6a-7b8c-9d0e-1f2a3b4c5d6e");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalCategoryMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalCategoryMapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface PortalCategoryMapper {
+    PortalCategoryMapper INSTANCE = Mappers.getMapper(PortalCategoryMapper.class);
+
+    @Mapping(target = "id", source = "id")
+    io.gravitee.rest.api.portal.rest.model.PortalCategory map(PortalCategory portalCategory);
+
+    List<io.gravitee.rest.api.portal.rest.model.PortalCategory> map(List<PortalCategory> portalCategories);
+
+    default String mapId(PortalCategoryId id) {
+        return id != null ? id.toString() : null;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/EnvironmentsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/EnvironmentsResource.java
@@ -57,6 +57,11 @@ public class EnvironmentsResource extends AbstractResource {
         return resourceContext.getResource(CategoriesResource.class);
     }
 
+    @Path("portal-categories")
+    public PortalCategoriesResource getPortalCategoriesResource() {
+        return resourceContext.getResource(PortalCategoriesResource.class);
+    }
+
     @Path("configuration")
     public ConfigurationResource getConfigurationResource() {
         return resourceContext.getResource(ConfigurationResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalCategoriesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalCategoriesResource.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static io.gravitee.rest.api.service.common.GraviteeContext.getExecutionContext;
+
+import io.gravitee.apim.core.portal_category.use_case.GetVisiblePortalCategoriesUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.portal.rest.mapper.PortalCategoryMapper;
+import io.gravitee.rest.api.portal.rest.model.PortalCategoriesResponse;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+public class PortalCategoriesResource extends AbstractResource {
+
+    @Inject
+    private GetVisiblePortalCategoriesUseCase getVisiblePortalCategoriesUseCase;
+
+    private final PortalCategoryMapper portalCategoryMapper = PortalCategoryMapper.INSTANCE;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getPortalCategories() {
+        var executionContext = getExecutionContext();
+        var output = getVisiblePortalCategoriesUseCase.execute(
+            new GetVisiblePortalCategoriesUseCase.Input(executionContext.getEnvironmentId())
+        );
+
+        var responseBody = new PortalCategoriesResponse().data(portalCategoryMapper.map(output.portalCategories()));
+        return Response.ok(responseBody).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalCategoriesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalCategoriesResource.java
@@ -21,11 +21,13 @@ import io.gravitee.apim.core.portal_category.use_case.GetVisiblePortalCategories
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.portal.rest.mapper.PortalCategoryMapper;
 import io.gravitee.rest.api.portal.rest.model.PortalCategoriesResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
+@Tag(name = "Portal")
 public class PortalCategoriesResource extends AbstractResource {
 
     @Inject

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
@@ -100,6 +100,7 @@ public class PortalNavigationItemsResource extends AbstractResource {
         @QueryParam("query") String query,
         @QueryParam("type") String type,
         @QueryParam("include") Set<String> include,
+        @QueryParam("categoryId") String categoryId,
         @BeanParam PaginationParam paginationParam
     ) {
         if ("catalog".equalsIgnoreCase(type)) {
@@ -119,7 +120,8 @@ public class PortalNavigationItemsResource extends AbstractResource {
                 Optional.ofNullable(getAuthenticatedUserOrNull()),
                 new PageableImpl(paginationParam.getPage(), paginationParam.getSize()),
                 Optional.ofNullable(query),
-                coreIncludes
+                coreIncludes,
+                Optional.ofNullable(categoryId)
             )
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -3880,6 +3880,27 @@ paths:
                                 $ref: "#/components/schemas/ConnectorsResponse"
                 500:
                     $ref: "#/components/responses/InternalServerError"
+    /portal-categories:
+        get:
+            tags:
+                - Portal
+            summary: Get the list of visible portal categories.
+            description: |
+                Get all portal categories that are visible to portal consumers.
+            operationId: getPortalCategories
+            security:
+                - {}
+                - BasicAuth: []
+                - CookieAuth: []
+            responses:
+                200:
+                    description: List of visible portal categories
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/PortalCategoriesResponse"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
     /portal-menu-links:
         get:
             deprecated: true
@@ -3973,6 +3994,12 @@ paths:
                       type: array
                       items:
                           $ref: "#/components/schemas/PortalNavigationSearchInclude"
+                - name: categoryId
+                  in: query
+                  required: false
+                  description: Filter results to navigation items belonging to the given category.
+                  schema:
+                      type: string
                 - name: page
                   in: query
                   required: false
@@ -4974,6 +5001,22 @@ components:
                     $ref: "#/components/schemas/MetadataMap"
                 links:
                     $ref: "#/components/schemas/Links"
+        PortalCategoriesResponse:
+            properties:
+                data:
+                    description: List of visible portal categories.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/PortalCategory"
+        PortalCategory:
+            properties:
+                id:
+                    description: Unique identifier of a portal category.
+                    type: string
+                title:
+                    type: string
+                description:
+                    type: string
         PortalNotificationsResponse:
             properties:
                 data:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalCategoriesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalCategoriesResourceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.PortalCategoryQueryServiceInMemory;
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import io.gravitee.rest.api.portal.rest.model.PortalCategoriesResponse;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PortalCategoriesResourceTest extends AbstractResourceTest {
+
+    private static final String ENV_ID = "DEFAULT";
+
+    @Autowired
+    private PortalCategoryQueryServiceInMemory portalCategoryQueryService;
+
+    @Override
+    protected String contextPath() {
+        return "portal-categories";
+    }
+
+    @BeforeEach
+    public void init() {
+        GraviteeContext.setCurrentEnvironment(ENV_ID);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+        portalCategoryQueryService.reset();
+    }
+
+    @Test
+    void should_return_only_visible_categories() {
+        portalCategoryQueryService.initWith(
+            List.of(
+                PortalCategory.of(PortalCategoryId.random(), ENV_ID, "Weather", "Weather APIs", true),
+                PortalCategory.of(PortalCategoryId.random(), ENV_ID, "Hidden", "Hidden category", false),
+                PortalCategory.of(PortalCategoryId.random(), "other-env", "Banking", "Banking APIs", true)
+            )
+        );
+
+        Response response = target().request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(PortalCategoriesResponse.class);
+        assertThat(result.getData()).extracting(io.gravitee.rest.api.portal.rest.model.PortalCategory::getTitle).containsExactly("Weather");
+    }
+
+    @Test
+    void should_return_empty_list_when_no_visible_categories() {
+        portalCategoryQueryService.initWith(
+            List.of(PortalCategory.of(PortalCategoryId.random(), ENV_ID, "Hidden", "Hidden category", false))
+        );
+
+        Response response = target().request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(PortalCategoriesResponse.class);
+        assertThat(result.getData()).isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceTest.java
@@ -25,6 +25,7 @@ import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
@@ -53,6 +54,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
 
     private static final String ENV_ID = "DEFAULT";
+    private static final String CATEGORY_ID_1 = "11111111-1111-1111-1111-111111111111";
+    private static final String UNKNOWN_CATEGORY_ID = "99999999-9999-9999-9999-999999999999";
 
     @Autowired
     private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
@@ -339,6 +342,106 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
 
         // When - query that doesn't match
         Response response = target("/_search").queryParam("query", "xyz-no-match").queryParam("type", "api").request().get();
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        @SuppressWarnings("unchecked")
+        var data = (List<Object>) result.get("data");
+        assertThat(data).isEmpty();
+    }
+
+    @Test
+    void should_return_all_api_navigation_items_when_no_category_id_param() {
+        // Given
+        var apiItem = PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Auth API")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(1)
+            .apiId("api-uuid-1")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .segment(PortalNavigationItem.slugify("Auth API").value())
+            .categoryIds(List.of(PortalCategoryId.of(CATEGORY_ID_1)))
+            .build();
+        portalNavigationItemsQueryService.initWith(List.of(apiItem));
+
+        // When
+        Response response = target("/_search").queryParam("type", "api").request().get();
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        @SuppressWarnings("unchecked")
+        var data = (List<Object>) result.get("data");
+        assertThat(data).hasSize(1);
+    }
+
+    @Test
+    void should_filter_api_navigation_items_by_known_category_id() {
+        // Given
+        var itemInCategory = PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Auth API")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(1)
+            .apiId("api-uuid-1")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .segment(PortalNavigationItem.slugify("Auth API").value())
+            .categoryIds(List.of(PortalCategoryId.of(CATEGORY_ID_1)))
+            .build();
+        var itemOutsideCategory = PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Other API")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(2)
+            .apiId("api-uuid-2")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .segment(PortalNavigationItem.slugify("Other API").value())
+            .build();
+        portalNavigationItemsQueryService.initWith(List.of(itemInCategory, itemOutsideCategory));
+
+        // When
+        Response response = target("/_search").queryParam("type", "api").queryParam("categoryId", CATEGORY_ID_1).request().get();
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        @SuppressWarnings("unchecked")
+        var data = (List<Map<String, Object>>) result.get("data");
+        assertThat(data).hasSize(1);
+        assertThat(data.getFirst()).containsEntry("id", itemInCategory.getId().toString());
+    }
+
+    @Test
+    void should_return_empty_results_when_category_id_does_not_match() {
+        // Given
+        var apiItem = PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Auth API")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(1)
+            .apiId("api-uuid-1")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .segment(PortalNavigationItem.slugify("Auth API").value())
+            .categoryIds(List.of(PortalCategoryId.of(CATEGORY_ID_1)))
+            .build();
+        portalNavigationItemsQueryService.initWith(List.of(apiItem));
+
+        // When
+        Response response = target("/_search").queryParam("type", "api").queryParam("categoryId", UNKNOWN_CATEGORY_ID).request().get();
 
         // Then
         assertThat(response.getStatus()).isEqualTo(200);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/config/BasicSecurityConfigurerAdapter.java
@@ -289,6 +289,8 @@ public class BasicSecurityConfigurerAdapter implements SecureHeadersConfigurer {
             // Categories
             .requestMatchers(HttpMethod.GET, uriPrefix + "/categories/**")
             .permitAll()
+            .requestMatchers(HttpMethod.GET, uriPrefix + "/portal-categories")
+            .permitAll()
             // GMD pages
             .requestMatchers(HttpMethod.GET, uriPrefix + "/portal-pages")
             .permitAll()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/use_case/GetVisiblePortalCategoriesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_category/use_case/GetVisiblePortalCategoriesUseCase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_category.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.query_service.PortalCategoryQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Lists portal categories visible to portal consumers, excluding categories hidden by administrators.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@RequiredArgsConstructor
+public class GetVisiblePortalCategoriesUseCase {
+
+    private final PortalCategoryQueryService portalCategoryQueryService;
+
+    public Output execute(Input input) {
+        List<PortalCategory> visible = portalCategoryQueryService
+            .findByEnvironmentId(input.environmentId())
+            .stream()
+            .filter(PortalCategory::isVisible)
+            .toList();
+        return new Output(visible);
+    }
+
+    public record Input(String environmentId) {}
+
+    public record Output(List<PortalCategory> portalCategories) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
@@ -106,6 +106,7 @@ public class PortalNavigationApiVisibilityDomainService implements PortalNavigat
     }
 
     private List<PortalNavigationApi> fetchApiItems(String environmentId, @Nullable String categoryId) {
+        PortalCategoryId parsedCategoryId = categoryId != null ? PortalCategoryId.of(categoryId) : null;
         return queryService
             .search(
                 PortalNavigationItemQueryCriteria.builder()
@@ -113,7 +114,7 @@ public class PortalNavigationApiVisibilityDomainService implements PortalNavigat
                     .published(true)
                     .root(false)
                     .type(PortalNavigationItemType.API)
-                    .categoryId(categoryId != null ? PortalCategoryId.of(categoryId) : null)
+                    .categoryId(parsedCategoryId)
                     .build()
             )
             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.domain_service;
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
@@ -55,7 +56,16 @@ public class PortalNavigationApiVisibilityDomainService implements PortalNavigat
      * Resolves visible APIs for unauthenticated portal access where only public APIs should be exposed.
      */
     public List<PortalNavigationApi> resolveVisibleItems(String environmentId) {
-        return fetchApiItems(environmentId)
+        return resolveVisiblePublicItems(environmentId, null);
+    }
+
+    /**
+     * Resolves visible APIs for unauthenticated portal access, restricted to a single category, where only
+     * public APIs should be exposed. Unlike {@link #resolveVisibleItems(String, String, String)}, this performs
+     * no membership/subscription lookups since there is no authenticated user to check access for.
+     */
+    public List<PortalNavigationApi> resolveVisiblePublicItems(String environmentId, @Nullable String categoryId) {
+        return fetchApiItems(environmentId, categoryId)
             .stream()
             .filter(i -> PortalVisibility.PUBLIC.equals(i.getVisibility()))
             .toList();
@@ -65,7 +75,15 @@ public class PortalNavigationApiVisibilityDomainService implements PortalNavigat
      * Enforces portal navigation access control by filtering APIs based on visibility rules and user permissions.
      */
     public List<PortalNavigationApi> resolveVisibleItems(String environmentId, String userId) {
-        List<PortalNavigationApi> apiItems = fetchApiItems(environmentId);
+        return resolveVisibleItems(environmentId, userId, null);
+    }
+
+    /**
+     * Enforces portal navigation access control by filtering APIs based on visibility rules and user permissions,
+     * optionally restricted to a single category.
+     */
+    public List<PortalNavigationApi> resolveVisibleItems(String environmentId, String userId, @Nullable String categoryId) {
+        List<PortalNavigationApi> apiItems = fetchApiItems(environmentId, categoryId);
 
         Set<String> publicIds = new HashSet<>();
         Set<String> privateIds = new HashSet<>();
@@ -87,7 +105,7 @@ public class PortalNavigationApiVisibilityDomainService implements PortalNavigat
             .toList();
     }
 
-    private List<PortalNavigationApi> fetchApiItems(String environmentId) {
+    private List<PortalNavigationApi> fetchApiItems(String environmentId, @Nullable String categoryId) {
         return queryService
             .search(
                 PortalNavigationItemQueryCriteria.builder()
@@ -95,6 +113,7 @@ public class PortalNavigationApiVisibilityDomainService implements PortalNavigat
                     .published(true)
                     .root(false)
                     .type(PortalNavigationItemType.API)
+                    .categoryId(categoryId != null ? PortalCategoryId.of(categoryId) : null)
                     .build()
             )
             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemQueryCriteria.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemQueryCriteria.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import java.util.Set;
 import lombok.Builder;
 import lombok.Data;
@@ -34,4 +35,5 @@ public class PortalNavigationItemQueryCriteria {
     private PortalNavigationItemType type;
 
     private Boolean useAutoFetch;
+    private PortalCategoryId categoryId;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCase.java
@@ -40,9 +40,10 @@ public class GetVisiblePortalNavigationApisUseCase {
     private final CheckTypoToleranceDomainService checkTypoToleranceDomainService;
 
     public Output execute(Input input) {
+        String categoryId = input.categoryId().orElse(null);
         List<PortalNavigationApi> visible = input.userId().isPresent()
-            ? visibilityDomainService.resolveVisibleItems(input.environmentId(), input.userId().get())
-            : visibilityDomainService.resolveVisibleItems(input.environmentId());
+            ? visibilityDomainService.resolveVisibleItems(input.environmentId(), input.userId().get(), categoryId)
+            : visibilityDomainService.resolveVisiblePublicItems(input.environmentId(), categoryId);
 
         List<Api> searchedApis = List.of();
         Optional<String> queryText = input.query().filter(q -> !q.isBlank());
@@ -103,7 +104,8 @@ public class GetVisiblePortalNavigationApisUseCase {
         Optional<String> userId,
         Pageable pageable,
         Optional<String> query,
-        Set<PortalNavigationSearchInclude> includes
+        Set<PortalNavigationSearchInclude> includes,
+        Optional<String> categoryId
     ) {}
 
     public record Output(Page<PortalNavigationApi> apis, List<Api> includedApis) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCase.java
@@ -41,9 +41,12 @@ public class GetVisiblePortalNavigationApisUseCase {
 
     public Output execute(Input input) {
         String categoryId = input.categoryId().orElse(null);
-        List<PortalNavigationApi> visible = input.userId().isPresent()
-            ? visibilityDomainService.resolveVisibleItems(input.environmentId(), input.userId().get(), categoryId)
-            : visibilityDomainService.resolveVisiblePublicItems(input.environmentId(), categoryId);
+        List<PortalNavigationApi> visible;
+        if (input.userId().isPresent()) {
+            visible = visibilityDomainService.resolveVisibleItems(input.environmentId(), input.userId().get(), categoryId);
+        } else {
+            visible = visibilityDomainService.resolveVisiblePublicItems(input.environmentId(), categoryId);
+        }
 
         List<Api> searchedApis = List.of();
         Optional<String> queryText = input.query().filter(q -> !q.isBlank());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
@@ -235,6 +235,22 @@ public class PortalNavigationItemFixtures {
             .build();
     }
 
+    public static PortalNavigationApi anApi(String apiId, PortalVisibility visibility, List<PortalCategoryId> categoryIds) {
+        return PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title("Nav for " + apiId)
+            .segment(PortalNavigationItem.slugify("Nav for " + apiId).value())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .apiId(apiId)
+            .published(true)
+            .visibility(visibility)
+            .categoryIds(categoryIds)
+            .build();
+    }
+
     public static PortalNavigationApi anApi() {
         return PortalNavigationApi.builder()
             .id(PortalNavigationItemId.of(API_ID))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemsQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemsQueryServiceInMemory.java
@@ -89,7 +89,9 @@ public class PortalNavigationItemsQueryServiceInMemory
                         criteria.getApiProductIds().isEmpty() ||
                         (item instanceof PortalNavigationApiProduct apiProduct &&
                             criteria.getApiProductIds().contains(apiProduct.getApiProductId()))) &&
-                    (criteria.getUseAutoFetch() == null || criteria.getUseAutoFetch() == usesAutoFetch(item))
+                    (criteria.getUseAutoFetch() == null || criteria.getUseAutoFetch() == usesAutoFetch(item)) &&
+                    (criteria.getCategoryId() == null ||
+                        (item instanceof PortalNavigationApi api && api.getCategoryIds().contains(criteria.getCategoryId())))
             )
             .toList();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_category/use_case/GetVisiblePortalCategoriesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_category/use_case/GetVisiblePortalCategoriesUseCaseTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_category.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.PortalCategoryQueryServiceInMemory;
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetVisiblePortalCategoriesUseCaseTest {
+
+    private static final String ENVIRONMENT_ID = "env-1";
+
+    private PortalCategoryQueryServiceInMemory portalCategoryQueryServiceInMemory;
+    private GetVisiblePortalCategoriesUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        portalCategoryQueryServiceInMemory = new PortalCategoryQueryServiceInMemory();
+        useCase = new GetVisiblePortalCategoriesUseCase(portalCategoryQueryServiceInMemory);
+    }
+
+    @AfterEach
+    void tearDown() {
+        portalCategoryQueryServiceInMemory.reset();
+    }
+
+    @Test
+    void should_return_only_visible_categories_for_environment() {
+        portalCategoryQueryServiceInMemory.initWith(
+            List.of(
+                PortalCategory.of(PortalCategoryId.random(), ENVIRONMENT_ID, "Weather", null, true),
+                PortalCategory.of(PortalCategoryId.random(), ENVIRONMENT_ID, "Hidden Category", null, false),
+                PortalCategory.of(PortalCategoryId.random(), "other-env", "Banking", null, true)
+            )
+        );
+
+        var output = useCase.execute(new GetVisiblePortalCategoriesUseCase.Input(ENVIRONMENT_ID));
+
+        assertThat(output.portalCategories()).extracting(PortalCategory::getTitle).containsExactly("Weather");
+    }
+
+    @Test
+    void should_return_empty_list_when_no_visible_categories() {
+        portalCategoryQueryServiceInMemory.initWith(
+            List.of(PortalCategory.of(PortalCategoryId.random(), ENVIRONMENT_ID, "Hidden Category", null, false))
+        );
+
+        var output = useCase.execute(new GetVisiblePortalCategoriesUseCase.Input(ENVIRONMENT_ID));
+
+        assertThat(output.portalCategories()).isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainServiceTest.java
@@ -24,6 +24,7 @@ import inmemory.SubscriptionQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
@@ -47,6 +48,10 @@ class PortalNavigationApiVisibilityDomainServiceTest {
 
     private static final String PUBLIC_API_ID = "public-api-1";
     private static final String PRIVATE_API_ID = "private-api-1";
+
+    private static final String CATEGORY_ID_1 = "11111111-1111-1111-1111-111111111111";
+    private static final String CATEGORY_ID_2 = "22222222-2222-2222-2222-222222222222";
+    private static final String UNKNOWN_CATEGORY_ID = "99999999-9999-9999-9999-999999999999";
 
     private PortalNavigationApiVisibilityDomainService domainService;
     private PortalNavigationItemsQueryServiceInMemory navQueryService;
@@ -204,6 +209,47 @@ class PortalNavigationApiVisibilityDomainServiceTest {
         assertThat(result).extracting(PortalNavigationApi::getApiId).containsExactly(PUBLIC_API_ID);
     }
 
+    // --- resolveVisibleItems with categoryId ---
+
+    @Test
+    void anonymous_user_sees_only_apis_in_requested_category() {
+        navQueryService.initWith(
+            List.of(
+                publishedApiNavItemWithCategories(PUBLIC_API_ID, PortalVisibility.PUBLIC, List.of(CATEGORY_ID_1)),
+                publishedApiNavItemWithCategories("other-public-api", PortalVisibility.PUBLIC, List.of(CATEGORY_ID_2))
+            )
+        );
+
+        var result = domainService.resolveVisiblePublicItems(ENV_ID, CATEGORY_ID_1);
+
+        assertThat(result).extracting(PortalNavigationApi::getApiId).containsExactly(PUBLIC_API_ID);
+    }
+
+    @Test
+    void anonymous_user_sees_no_apis_for_unknown_category() {
+        navQueryService.initWith(
+            List.of(publishedApiNavItemWithCategories(PUBLIC_API_ID, PortalVisibility.PUBLIC, List.of(CATEGORY_ID_1)))
+        );
+
+        var result = domainService.resolveVisiblePublicItems(ENV_ID, UNKNOWN_CATEGORY_ID);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void authenticated_user_sees_only_apis_in_requested_category() {
+        navQueryService.initWith(
+            List.of(
+                publishedApiNavItemWithCategories(PUBLIC_API_ID, PortalVisibility.PUBLIC, List.of(CATEGORY_ID_1)),
+                publishedApiNavItemWithCategories("other-public-api", PortalVisibility.PUBLIC, List.of(CATEGORY_ID_2))
+            )
+        );
+
+        var result = domainService.resolveVisibleItems(ENV_ID, USER_ID, CATEGORY_ID_1);
+
+        assertThat(result).extracting(PortalNavigationApi::getApiId).containsExactly(PUBLIC_API_ID);
+    }
+
     // --- isVisibleToUser ---
 
     @Test
@@ -322,6 +368,22 @@ class PortalNavigationApiVisibilityDomainServiceTest {
             .apiId(apiId)
             .published(true)
             .visibility(visibility)
+            .build();
+    }
+
+    private PortalNavigationApi publishedApiNavItemWithCategories(String apiId, PortalVisibility visibility, List<String> categoryIds) {
+        return PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title("Nav for " + apiId)
+            .segment(PortalNavigationItem.slugify("Nav for " + apiId).value())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .apiId(apiId)
+            .published(true)
+            .visibility(visibility)
+            .categoryIds(categoryIds.stream().map(PortalCategoryId::of).toList())
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainServiceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
@@ -215,8 +216,8 @@ class PortalNavigationApiVisibilityDomainServiceTest {
     void anonymous_user_sees_only_apis_in_requested_category() {
         navQueryService.initWith(
             List.of(
-                publishedApiNavItemWithCategories(PUBLIC_API_ID, PortalVisibility.PUBLIC, List.of(CATEGORY_ID_1)),
-                publishedApiNavItemWithCategories("other-public-api", PortalVisibility.PUBLIC, List.of(CATEGORY_ID_2))
+                PortalNavigationItemFixtures.anApi(PUBLIC_API_ID, PortalVisibility.PUBLIC, List.of(PortalCategoryId.of(CATEGORY_ID_1))),
+                PortalNavigationItemFixtures.anApi("other-public-api", PortalVisibility.PUBLIC, List.of(PortalCategoryId.of(CATEGORY_ID_2)))
             )
         );
 
@@ -228,7 +229,7 @@ class PortalNavigationApiVisibilityDomainServiceTest {
     @Test
     void anonymous_user_sees_no_apis_for_unknown_category() {
         navQueryService.initWith(
-            List.of(publishedApiNavItemWithCategories(PUBLIC_API_ID, PortalVisibility.PUBLIC, List.of(CATEGORY_ID_1)))
+            List.of(PortalNavigationItemFixtures.anApi(PUBLIC_API_ID, PortalVisibility.PUBLIC, List.of(PortalCategoryId.of(CATEGORY_ID_1))))
         );
 
         var result = domainService.resolveVisiblePublicItems(ENV_ID, UNKNOWN_CATEGORY_ID);
@@ -240,8 +241,8 @@ class PortalNavigationApiVisibilityDomainServiceTest {
     void authenticated_user_sees_only_apis_in_requested_category() {
         navQueryService.initWith(
             List.of(
-                publishedApiNavItemWithCategories(PUBLIC_API_ID, PortalVisibility.PUBLIC, List.of(CATEGORY_ID_1)),
-                publishedApiNavItemWithCategories("other-public-api", PortalVisibility.PUBLIC, List.of(CATEGORY_ID_2))
+                PortalNavigationItemFixtures.anApi(PUBLIC_API_ID, PortalVisibility.PUBLIC, List.of(PortalCategoryId.of(CATEGORY_ID_1))),
+                PortalNavigationItemFixtures.anApi("other-public-api", PortalVisibility.PUBLIC, List.of(PortalCategoryId.of(CATEGORY_ID_2)))
             )
         );
 
@@ -368,22 +369,6 @@ class PortalNavigationApiVisibilityDomainServiceTest {
             .apiId(apiId)
             .published(true)
             .visibility(visibility)
-            .build();
-    }
-
-    private PortalNavigationApi publishedApiNavItemWithCategories(String apiId, PortalVisibility visibility, List<String> categoryIds) {
-        return PortalNavigationApi.builder()
-            .id(PortalNavigationItemId.random())
-            .organizationId(ORG_ID)
-            .environmentId(ENV_ID)
-            .title("Nav for " + apiId)
-            .segment(PortalNavigationItem.slugify("Nav for " + apiId).value())
-            .area(PortalArea.TOP_NAVBAR)
-            .order(0)
-            .apiId(apiId)
-            .published(true)
-            .visibility(visibility)
-            .categoryIds(categoryIds.stream().map(PortalCategoryId::of).toList())
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
@@ -94,7 +94,8 @@ class GetVisiblePortalNavigationApisUseCaseTest {
                 Optional.empty(),
                 new PageableImpl(1, 10),
                 Optional.empty(),
-                Set.of()
+                Set.of(),
+                Optional.empty()
             )
         );
 
@@ -119,7 +120,8 @@ class GetVisiblePortalNavigationApisUseCaseTest {
                 Optional.of(USER_ID),
                 new PageableImpl(1, 10),
                 Optional.empty(),
-                Set.of()
+                Set.of(),
+                Optional.empty()
             )
         );
 
@@ -146,7 +148,8 @@ class GetVisiblePortalNavigationApisUseCaseTest {
                 Optional.empty(),
                 new PageableImpl(1, 2),
                 Optional.empty(),
-                Set.of()
+                Set.of(),
+                Optional.empty()
             )
         );
 
@@ -171,7 +174,8 @@ class GetVisiblePortalNavigationApisUseCaseTest {
                 Optional.empty(),
                 new PageableImpl(2, 2),
                 Optional.empty(),
-                Set.of()
+                Set.of(),
+                Optional.empty()
             )
         );
 
@@ -221,7 +225,8 @@ class GetVisiblePortalNavigationApisUseCaseTest {
                 Optional.empty(),
                 new PageableImpl(1, 10),
                 Optional.empty(),
-                Set.of()
+                Set.of(),
+                Optional.empty()
             )
         );
 
@@ -243,7 +248,8 @@ class GetVisiblePortalNavigationApisUseCaseTest {
                 Optional.empty(),
                 new PageableImpl(1, 10),
                 Optional.of("auth"),
-                Set.of()
+                Set.of(),
+                Optional.empty()
             )
         );
 
@@ -269,7 +275,8 @@ class GetVisiblePortalNavigationApisUseCaseTest {
                 Optional.empty(),
                 new PageableImpl(1, 10),
                 Optional.of("Catalog"),
-                Set.of()
+                Set.of(),
+                Optional.empty()
             )
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
@@ -200,7 +200,8 @@ class GetVisiblePortalNavigationApisUseCaseTest {
                 Optional.empty(),
                 new PageableImpl(1, -1),
                 Optional.empty(),
-                Set.of()
+                Set.of(),
+                Optional.empty()
             )
         );
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PORTAL-22

**Purpose**

Let portal consumers filter navigation search results by category and discover which categories are visible to them.

**Summary of changes**

- `GET /portal-navigation-items/_search` accepts an optional `categoryId` query param, filtering to items whose `categoryIds` array contains the given value. Implemented at the repository layer (Mongo `where("categoryIds").is(...)`, JDBC subquery against the `portal_navigation_item_categories` join table) and threaded through the domain service and use case.
- New `GET /portal-categories` endpoint returning only visible (`visible = true`) portal categories for the current environment.
- Fixed a bug caught during manual testing: the new `/portal-categories` endpoint was unreachable anonymously because the portal-security module uses a URL allow-list (default-deny) and the new path wasn't added to it — added a `permitAll()` matcher alongside the existing one for `/portal-navigation-items/**`.

**Out of scope**

- Exposing the category `visible` flag itself in the API response (only pre-filtered results are returned).
- Filtering `_search` by more than one category at a time.

**Testing**

Unit + integration tests (repository conformance for Mongo/JDBC, domain service, use case, REST resource) — all passing.

Manually verified against a local Docker Compose stack (Mongo-backed):

```bash
# No categoryId param — unaffected baseline
curl -s "http://localhost:8083/portal/environments/DEFAULT/portal-navigation-items/_search?type=api"
# -> 200, all API nav items returned

# Known categoryId — filters to matching items only
curl -s "http://localhost:8083/portal/environments/DEFAULT/portal-navigation-items/_search?type=api&categoryId=<uuid>"
# -> 200, only items tagged with that category

# Unknown categoryId — empty result
curl -s "http://localhost:8083/portal/environments/DEFAULT/portal-navigation-items/_search?type=api&categoryId=00000000-0000-0000-0000-000000000000"
# -> 200, "data": []

# Visible categories only
curl -s "http://localhost:8083/portal/environments/DEFAULT/portal-categories"
# -> 200, returns visible categories; a category manually set to visible:false in Mongo was confirmed excluded
```

**Additional context**

_None._