### PR TITLE
feat: exclude API Product-scoped APIs from Portal catalog

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -3946,7 +3946,10 @@ paths:
             tags:
                 - Portal
             summary: Search portal navigation items.
-            description: When the fuzzy search is enabled, minor typos in the query may still match.
+            description: |
+                When the fuzzy search is enabled, minor typos in the query may still match.
+                For `type=catalog`, an API is returned as a standalone catalog result only when its navigation item has no `API_PRODUCT` ancestor.
+                APIs within an API Product navigation subtree remain available for the API Product summary and documentation tree.
             operationId: searchPortalNavigationItems
             security:
                 - {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalCatalogNavigationVisibilityDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalCatalogNavigationVisibilityDomainService.java
@@ -50,6 +50,28 @@ public class PortalCatalogNavigationVisibilityDomainService {
             .toList();
     }
 
+    public List<PortalNavigationApi> filterStandaloneApis(
+        List<PortalNavigationApi> items,
+        Map<PortalNavigationItemId, PortalNavigationItem> itemsById
+    ) {
+        return items
+            .stream()
+            .filter(item -> !hasApiProductAncestor(item, itemsById))
+            .toList();
+    }
+
+    private boolean hasApiProductAncestor(PortalNavigationItem item, Map<PortalNavigationItemId, PortalNavigationItem> itemsById) {
+        Set<PortalNavigationItemId> visited = new HashSet<>();
+        PortalNavigationItem current = item;
+        while (current != null && current.getParentId() != null && visited.add(current.getId())) {
+            current = itemsById.get(current.getParentId());
+            if (current instanceof PortalNavigationApiProduct) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private boolean hasHiddenAncestor(
         PortalNavigationItem item,
         Map<PortalNavigationItemId, PortalNavigationItem> itemsById,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCase.java
@@ -102,6 +102,10 @@ public class GetVisiblePortalCatalogItemsUseCase {
             accessibleApiNavigationItemIds,
             accessibleApiProductIds
         );
+        List<PortalNavigationApi> catalogApiCandidates = catalogNavigationVisibilityDomainService.filterStandaloneApis(
+            visibleApis,
+            navigationItemsById
+        );
         List<PortalNavigationApiProduct> visibleApiProducts = findVisibleApiProducts(
             navigationItems,
             input,
@@ -114,12 +118,18 @@ public class GetVisiblePortalCatalogItemsUseCase {
             .query()
             .filter(value -> !value.isBlank())
             .map(String::trim);
-        Map<String, Api> matchingApisById = findMatchingApis(input, visibleApis, query)
+        Map<String, Api> matchingApisById = findMatchingApis(input, catalogApiCandidates, query)
             .stream()
             .collect(Collectors.toMap(Api::getId, Function.identity(), (first, ignored) -> first));
         Map<String, ApiProduct> visibleApiProductsById = loadApiProducts(input.environmentId(), visibleApiProducts);
 
-        List<CatalogEntry> entries = createEntries(visibleApis, visibleApiProducts, matchingApisById, visibleApiProductsById, query)
+        List<CatalogEntry> entries = createEntries(
+            catalogApiCandidates,
+            visibleApiProducts,
+            matchingApisById,
+            visibleApiProductsById,
+            query
+        )
             .stream()
             .sorted(CATALOG_ENTRY_COMPARATOR)
             .toList();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalCatalogNavigationVisibilityDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalCatalogNavigationVisibilityDomainServiceTest.java
@@ -121,16 +121,52 @@ class PortalCatalogNavigationVisibilityDomainServiceTest {
         assertThat(visible).containsExactly(api, apiProduct);
     }
 
+    @Test
+    void should_keep_only_apis_without_an_api_product_ancestor() {
+        var apiProduct = apiProduct("api-product-item", null, PortalVisibility.PUBLIC);
+        var folder = folder("folder-item", apiProduct.getId());
+        var directApi = api("direct-api-item", apiProduct.getId(), PortalVisibility.PUBLIC);
+        var nestedApi = api("nested-api-item", folder.getId(), PortalVisibility.PUBLIC);
+        var standaloneApi = api("standalone-api-item", null, PortalVisibility.PUBLIC);
+        var items = List.<PortalNavigationItem>of(apiProduct, folder, directApi, nestedApi, standaloneApi);
+
+        var result = service.filterStandaloneApis(List.of(directApi, nestedApi, standaloneApi), index(items));
+
+        assertThat(result).containsExactly(standaloneApi);
+    }
+
+    @Test
+    void should_keep_standalone_apis_when_a_parent_is_missing_or_ancestors_form_a_cycle() {
+        var missingParentApi = api("missing-parent-api-item", PortalNavigationItemId.random(), PortalVisibility.PUBLIC);
+        var firstParentId = PortalNavigationItemId.random();
+        var secondParentId = PortalNavigationItemId.random();
+        var firstParent = folder(firstParentId, secondParentId);
+        var secondParent = folder(secondParentId, firstParentId);
+        var cycleApi = api("cycle-api-item", firstParentId, PortalVisibility.PUBLIC);
+        var items = List.<PortalNavigationItem>of(missingParentApi, firstParent, secondParent, cycleApi);
+
+        var result = service.filterStandaloneApis(List.of(missingParentApi, cycleApi), index(items));
+
+        assertThat(result).containsExactly(missingParentApi, cycleApi);
+    }
+
     private <T extends PortalNavigationItem> List<T> filter(
         List<T> candidates,
         List<PortalNavigationItem> allItems,
         Set<PortalNavigationItemId> accessibleApiNavigationItemIds,
         Set<String> accessibleApiProductIds
     ) {
-        Map<PortalNavigationItemId, PortalNavigationItem> itemsById = allItems
-            .stream()
-            .collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity()));
-        return service.filterVisibleItems(candidates, itemsById, VIEWER_CONTEXT, accessibleApiNavigationItemIds, accessibleApiProductIds);
+        return service.filterVisibleItems(
+            candidates,
+            index(allItems),
+            VIEWER_CONTEXT,
+            accessibleApiNavigationItemIds,
+            accessibleApiProductIds
+        );
+    }
+
+    private Map<PortalNavigationItemId, PortalNavigationItem> index(List<PortalNavigationItem> items) {
+        return items.stream().collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity()));
     }
 
     private PortalNavigationFolder folder(String id, PortalNavigationItemId parentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCaseTest.java
@@ -33,6 +33,7 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalCatalogNavigationV
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalCatalogApiProductSummary;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
@@ -118,6 +119,74 @@ class GetVisiblePortalCatalogItemsUseCaseTest {
             .containsExactly(PortalNavigationItemType.API_PRODUCT, PortalNavigationItemType.API);
         assertThat(output.includedApis()).isEmpty();
         assertThat(output.includedApiProducts()).isEmpty();
+    }
+
+    @Test
+    void should_exclude_direct_and_nested_product_apis_while_preserving_the_product_summary() {
+        var productItem = apiProductItem("product-item-id", "product-id", null, PortalVisibility.PUBLIC);
+        var folder = folder("folder-id", "Product APIs", productItem.getId());
+        var directApiItem = apiItem("direct-api-item-id", "direct-api-id", productItem.getId(), PortalVisibility.PUBLIC);
+        var nestedApiItem = apiItem("nested-api-item-id", "nested-api-id", folder.getId(), PortalVisibility.PUBLIC);
+        navigationItemsQueryService.initWith(List.of(productItem, folder, directApiItem, nestedApiItem));
+        initApis(List.of(api("direct-api-id", "Direct API", "1.0.0"), api("nested-api-id", "Nested API", "2.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "API Product", Set.of("direct-api-id", "nested-api-id"))));
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(PortalNavigationSearchInclude.API_PRODUCT), 1, 10));
+
+        assertThat(output.items().getTotalElements()).isEqualTo(1);
+        assertThat(output.items().getContent()).containsExactly(productItem);
+        assertThat(output.includedApiProducts())
+            .singleElement()
+            .satisfies(summary ->
+                assertThat(summary.apis())
+                    .extracting(PortalCatalogApiProductSummary.ApiSummary::id)
+                    .containsExactly("direct-api-id", "nested-api-id")
+            );
+    }
+
+    @Test
+    void should_return_a_standalone_api_once_when_the_same_api_is_also_product_scoped() {
+        var productItem = apiProductItem("product-item-id", "product-id", null, PortalVisibility.PUBLIC);
+        var productScopedApiItem = apiItem("product-api-item-id", "api-id", productItem.getId(), PortalVisibility.PUBLIC);
+        var standaloneApiItem = apiItem("standalone-api-item-id", "api-id", null, PortalVisibility.PUBLIC);
+        navigationItemsQueryService.initWith(List.of(productItem, productScopedApiItem, standaloneApiItem));
+        initApis(List.of(api("api-id", "Zebra API", "1.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Apple Product", Set.of("api-id"))));
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(PortalNavigationSearchInclude.API), 1, 10));
+
+        assertThat(output.items().getTotalElements()).isEqualTo(2);
+        assertThat(output.items().getContent()).containsExactly(productItem, standaloneApiItem).doesNotContain(productScopedApiItem);
+        assertThat(output.includedApis()).singleElement().extracting(Api::getId).isEqualTo("api-id");
+    }
+
+    @Test
+    void should_not_match_a_product_scoped_api_as_an_independent_catalog_result() {
+        var productItem = apiProductItem("product-item-id", "product-id", null, PortalVisibility.PUBLIC);
+        var productScopedApiItem = apiItem("product-api-item-id", "api-id", productItem.getId(), PortalVisibility.PUBLIC);
+        navigationItemsQueryService.initWith(List.of(productItem, productScopedApiItem));
+        initApis(List.of(api("api-id", "Payments API", "1.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Commerce Product", Set.of("api-id"))));
+
+        var output = useCase.execute(input(Optional.of("payments"), Set.of(), 1, 10));
+
+        assertThat(output.items().getContent()).isEmpty();
+        assertThat(output.items().getTotalElements()).isZero();
+    }
+
+    @Test
+    void should_paginate_after_excluding_product_scoped_apis() {
+        var productItem = apiProductItem("product-item-id", "product-id", null, PortalVisibility.PUBLIC);
+        var productScopedApiItem = apiItem("product-api-item-id", "product-api-id", productItem.getId(), PortalVisibility.PUBLIC);
+        var standaloneApiItem = apiItem("standalone-api-item-id", "standalone-api-id", null, PortalVisibility.PUBLIC);
+        navigationItemsQueryService.initWith(List.of(productItem, productScopedApiItem, standaloneApiItem));
+        initApis(List.of(api("product-api-id", "Middle API", "1.0.0"), api("standalone-api-id", "Zebra API", "1.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Apple Product", Set.of("product-api-id"))));
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(), 2, 1));
+
+        assertThat(output.items().getTotalElements()).isEqualTo(2);
+        assertThat(output.items().getContent()).containsExactly(standaloneApiItem);
     }
 
     @Test


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/PORTAL-106

## Summary

Exclude APIs located within an API Product navigation subtree from standalone Portal catalog results.

APIs are filtered before search, sorting, and pagination. They remain available through the API Product summary and documentation tree.

A standalone navigation item referencing the same API can still appear independently in the catalog.

## Changes

- Detect direct and nested `API_PRODUCT` ancestors.
- Exclude product-scoped APIs from standalone catalog results.
- Preserve visible APIs in API Product summaries.
- Handle missing parents and navigation cycles safely.
- Document the catalog behavior in the Portal OpenAPI specification.
- Add regression tests for filtering, searching, duplicate references, and pagination.

