### PR TITLE
feat(console): add external source editor for portal navigation items

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.html
@@ -1,0 +1,72 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="source-editor">
+  @if (source()?.lastFetchError; as lastFetchError) {
+    <gio-banner-error data-testid="source-fetch-error-banner">
+      Last fetch failed
+      <span gioBannerBody>{{ lastFetchError }}</span>
+    </gio-banner-error>
+  } @else if (source()?.lastFetchedAt; as lastFetchedAt) {
+    <div class="source-editor__last-fetch" data-testid="source-last-fetched-at">
+      Last successful fetch: {{ lastFetchedAt | date: 'medium' }}
+    </div>
+  }
+
+  <mat-form-field appearance="outline" class="source-editor__fetcher">
+    <mat-label>Source type</mat-label>
+    <mat-select data-testid="source-type-select" [formControl]="typeControl">
+      @for (fetcher of fetchers(); track fetcher.id) {
+        <mat-option [value]="fetcher.id">{{ fetcher.name }}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+
+  @if (selectedSchema(); as jsonSchema) {
+    @if (configurationControl) {
+      <gio-form-json-schema
+        data-testid="source-configuration-form"
+        [jsonSchema]="jsonSchema"
+        [formControl]="configurationControl"
+        (ready)="onSchemaFormReady($event)"
+      />
+    }
+  }
+
+  <div class="source-editor__auto-fetch">
+    <mat-slide-toggle data-testid="auto-fetch-toggle" [formControl]="useAutoFetchControl">Auto-fetch</mat-slide-toggle>
+
+    @if (useAutoFetch()) {
+      <mat-form-field appearance="outline" class="source-editor__auto-fetch__cron">
+        <mat-label>Update frequency (cron expression)</mat-label>
+        <input matInput data-testid="fetch-cron-input" [formControl]="fetchCronControl" placeholder="0 */10 * * * *" />
+        <mat-hint>Example: "0 */10 * * * *" fetches every 10 minutes</mat-hint>
+      </mat-form-field>
+    }
+  </div>
+
+  @if (!disabled() && !embedded()) {
+    <div class="source-editor__actions">
+      @if (source()) {
+        <button mat-stroked-button data-testid="remove-source-button" (click)="onRemove()">Remove source</button>
+      }
+      <button mat-flat-button color="primary" data-testid="save-source-button" [disabled]="saveDisabled()" (click)="onSave()">
+        Save source
+      </button>
+    </div>
+  }
+</div>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.scss
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+.source-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &__last-fetch {
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter40);
+  }
+
+  &__auto-fetch {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    &__cron {
+      max-width: 400px;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GioJsonSchema } from '@gravitee/ui-particles-angular';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+import { NavigationItemSourceEditorComponent, stripLegacyAutoFetchFromSchema } from './navigation-item-source-editor.component';
+import { NavigationItemSourceEditorHarness } from './navigation-item-source-editor.harness';
+
+import { fakeFetcherList } from '../../../entities/fetcher/fetcher.fixture';
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { PortalNavigationItemSource } from '../../../entities/management-api-v2';
+
+describe('stripLegacyAutoFetchFromSchema', () => {
+  it('removes the legacy autoFetch and fetchCron properties, required entries and if/then clause', () => {
+    const githubSchema = JSON.parse(fakeFetcherList().find(fetcher => fetcher.id === 'github-fetcher').schema);
+
+    const stripped = stripLegacyAutoFetchFromSchema(githubSchema) as Record<string, unknown>;
+
+    const properties = stripped['properties'] as Record<string, unknown>;
+    expect(properties['autoFetch']).toBeUndefined();
+    expect(properties['fetchCron']).toBeUndefined();
+    expect(properties['owner']).toBeDefined();
+    expect(stripped['required']).toEqual(['githubUrl', 'owner', 'repository']);
+    expect(stripped['if']).toBeUndefined();
+    expect(stripped['then']).toBeUndefined();
+  });
+
+  it('keeps an if/then clause that does not reference autoFetch', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        mode: { type: 'string' },
+        detail: { type: 'string' },
+      },
+      if: { properties: { mode: { const: 'advanced' } } },
+      then: { required: ['detail'] },
+    } as unknown as GioJsonSchema;
+
+    const stripped = stripLegacyAutoFetchFromSchema(schema) as Record<string, unknown>;
+
+    expect(stripped['if']).toEqual({ properties: { mode: { const: 'advanced' } } });
+    expect(stripped['then']).toEqual({ required: ['detail'] });
+  });
+
+  it('leaves schemas without legacy properties untouched', () => {
+    const schema = {
+      type: 'object',
+      properties: { url: { type: 'string' } },
+      required: ['url'],
+    } as unknown as GioJsonSchema;
+
+    expect(stripLegacyAutoFetchFromSchema(schema)).toEqual(schema);
+  });
+});
+
+describe('NavigationItemSourceEditorComponent', () => {
+  let fixture: ComponentFixture<NavigationItemSourceEditorComponent>;
+  let harness: NavigationItemSourceEditorHarness;
+  let httpTestingController: HttpTestingController;
+
+  const githubSource: PortalNavigationItemSource = {
+    type: 'github-fetcher',
+    configuration: { githubUrl: 'https://api.github.com', owner: 'gravitee-io', repository: 'docs' },
+    useAutoFetch: false,
+  };
+
+  async function createComponent(source: PortalNavigationItemSource | null, disabled: boolean) {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioTestingModule, NavigationItemSourceEditorComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NavigationItemSourceEditorComponent);
+    fixture.componentRef.setInput('source', source);
+    fixture.componentRef.setInput('disabled', disabled);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, NavigationItemSourceEditorHarness);
+    fixture.detectChanges();
+
+    httpTestingController
+      .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/fetchers?expand=schema` })
+      .flush(fakeFetcherList());
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('is fully read-only when disabled (no update permission)', async () => {
+    await createComponent(githubSource, true);
+
+    expect(await harness.isTypeSelectDisabled()).toBe(true);
+    expect(await harness.hasSaveButton()).toBe(false);
+    expect(await harness.hasRemoveButton()).toBe(false);
+  });
+
+  it('emits the source built from the form on save', async () => {
+    await createComponent(githubSource, false);
+    const emitted: PortalNavigationItemSource[] = [];
+    fixture.componentInstance.saveSource.subscribe(source => emitted.push(source));
+
+    await harness.toggleAutoFetch();
+    fixture.detectChanges();
+    await harness.setCron('0 0 * * * *');
+    await harness.save();
+
+    expect(emitted).toEqual([
+      expect.objectContaining({
+        type: 'github-fetcher',
+        useAutoFetch: true,
+        fetchCron: '0 0 * * * *',
+        configuration: expect.objectContaining({ owner: 'gravitee-io' }),
+      }),
+    ]);
+  });
+});

--- a/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.ts
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, DestroyRef, effect, inject, input, output, signal } from '@angular/core';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { GioBannerModule, GioFormJsonSchemaModule, GioJsonSchema } from '@gravitee/ui-particles-angular';
+import { catchError, debounceTime, map, tap } from 'rxjs/operators';
+import { of, Subject, Subscription } from 'rxjs';
+import { DatePipe } from '@angular/common';
+import { isEqual } from 'lodash';
+
+import { PortalNavigationItemSource } from '../../../entities/management-api-v2';
+import { FetcherService } from '../../../services-ngx/fetcher.service';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+
+interface FetcherVM {
+  id: string;
+  name: string;
+  schema: GioJsonSchema;
+}
+
+export function stripLegacyAutoFetchFromSchema(schema: GioJsonSchema): GioJsonSchema {
+  const { if: ifClause, then: thenClause, else: elseClause, ...rest } = schema as Record<string, unknown>;
+  const properties = { ...((rest['properties'] as Record<string, unknown>) ?? {}) };
+  delete properties['autoFetch'];
+  delete properties['fetchCron'];
+
+  const required = Array.isArray(rest['required'])
+    ? (rest['required'] as string[]).filter(key => key !== 'autoFetch' && key !== 'fetchCron')
+    : undefined;
+
+  const ifClauseProperties = ((ifClause as Record<string, unknown>)?.['properties'] ?? {}) as Record<string, unknown>;
+  const referencesAutoFetch = !!ifClause && 'autoFetch' in ifClauseProperties;
+
+  return {
+    ...rest,
+    properties,
+    ...(required && required.length > 0 ? { required } : {}),
+    ...(referencesAutoFetch
+      ? {}
+      : {
+          ...(ifClause ? { if: ifClause } : {}),
+          ...(thenClause ? { then: thenClause } : {}),
+          ...(elseClause ? { else: elseClause } : {}),
+        }),
+  } as GioJsonSchema;
+}
+
+@Component({
+  selector: 'navigation-item-source-editor',
+  templateUrl: './navigation-item-source-editor.component.html',
+  styleUrls: ['./navigation-item-source-editor.component.scss'],
+  imports: [
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatSlideToggleModule,
+    GioBannerModule,
+    GioFormJsonSchemaModule,
+    DatePipe,
+  ],
+})
+export class NavigationItemSourceEditorComponent {
+  private readonly fetcherService = inject(FetcherService);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  source = input<PortalNavigationItemSource | null>(null);
+  disabled = input(false);
+  embedded = input(false);
+
+  saveSource = output<PortalNavigationItemSource>();
+  removeSource = output<void>();
+
+  readonly typeControl = new FormControl<string | null>(null, Validators.required);
+  readonly useAutoFetchControl = new FormControl<boolean>(false, { nonNullable: true });
+  readonly fetchCronControl = new FormControl<string | null>(null);
+  configurationControl?: FormControl<unknown>;
+
+  readonly selectedSchema = signal<GioJsonSchema | undefined>(undefined);
+  readonly selectedType = toSignal(this.typeControl.valueChanges, { initialValue: this.typeControl.value });
+  readonly useAutoFetch = toSignal(this.useAutoFetchControl.valueChanges, { initialValue: this.useAutoFetchControl.value });
+  readonly fetchCron = toSignal(this.fetchCronControl.valueChanges, { initialValue: this.fetchCronControl.value });
+  private readonly configurationInvalid = signal(false);
+  private readonly rebuildConfiguration$ = new Subject<string | null>();
+  private configurationSubscription?: Subscription;
+  private lastResetSource: PortalNavigationItemSource | null | undefined = undefined;
+
+  readonly fetchers = toSignal(
+    this.fetcherService.getList().pipe(
+      map(fetchers =>
+        fetchers.map(
+          (fetcher): FetcherVM => ({
+            id: fetcher.id,
+            name: fetcher.name ?? fetcher.id,
+            schema: stripLegacyAutoFetchFromSchema(JSON.parse(fetcher.schema)),
+          }),
+        ),
+      ),
+      catchError(() => {
+        this.snackBarService.error('Failed to load the fetcher plugins');
+        return of([] as FetcherVM[]);
+      }),
+    ),
+    { initialValue: [] as FetcherVM[] },
+  );
+
+  readonly saveDisabled = computed(() => {
+    if (this.disabled() || !this.selectedType() || !this.selectedSchema() || this.configurationInvalid()) {
+      return true;
+    }
+    return this.useAutoFetch() && !this.fetchCron()?.trim();
+  });
+
+  private readonly rebuildConfigurationSubscription = this.rebuildConfiguration$
+    .pipe(
+      tap(() => {
+        this.selectedSchema.set(undefined);
+        this.configurationControl = undefined;
+      }),
+      debounceTime(10),
+      takeUntilDestroyed(this.destroyRef),
+    )
+    .subscribe(type => {
+      const initialConfiguration = type && type === this.source()?.type ? this.source()?.configuration : {};
+      this.createConfigurationControl(initialConfiguration);
+      this.selectedSchema.set(type ? this.fetchers().find(fetcher => fetcher.id === type)?.schema : undefined);
+    });
+
+  private readonly typeChangeSubscription = this.typeControl.valueChanges
+    .pipe(takeUntilDestroyed(this.destroyRef))
+    .subscribe(type => this.rebuildConfiguration$.next(type));
+
+  private readonly resetOnSourceChange = effect(() => {
+    const source = this.source();
+    const fetchers = this.fetchers();
+    if (!isEqual(source ?? null, this.lastResetSource ?? null) || this.lastResetSource === undefined) {
+      this.lastResetSource = source ?? null;
+      this.resetFormFromSource(source);
+    } else if (fetchers.length > 0 && this.selectedType() && !this.selectedSchema()) {
+      this.rebuildConfiguration$.next(this.selectedType());
+    }
+  });
+
+  private readonly applyDisabledState = effect(() => {
+    const disabled = this.disabled();
+    const options = { emitEvent: false };
+    if (disabled) {
+      this.typeControl.disable(options);
+      this.useAutoFetchControl.disable(options);
+      this.fetchCronControl.disable(options);
+      this.configurationControl?.disable(options);
+    } else {
+      this.typeControl.enable(options);
+      this.useAutoFetchControl.enable(options);
+      this.fetchCronControl.enable(options);
+      this.configurationControl?.enable(options);
+    }
+  });
+
+  onSchemaFormReady(ready: boolean) {
+    if (ready) {
+      this.configurationControl?.updateValueAndValidity();
+    }
+  }
+
+  buildSource(): PortalNavigationItemSource | null {
+    const type = this.typeControl.value;
+    if (!type || !this.configurationControl || this.configurationControl.invalid) {
+      return null;
+    }
+    const useAutoFetch = this.useAutoFetchControl.value;
+    const fetchCron = this.fetchCronControl.value;
+    return {
+      type,
+      configuration: this.configurationControl.value,
+      useAutoFetch,
+      ...(useAutoFetch && fetchCron ? { fetchCron } : {}),
+    };
+  }
+
+  onSave() {
+    const source = this.buildSource();
+    if (source) {
+      this.saveSource.emit(source);
+    }
+  }
+
+  onRemove() {
+    this.removeSource.emit();
+  }
+
+  private resetFormFromSource(source: PortalNavigationItemSource | null) {
+    this.typeControl.setValue(source?.type ?? null);
+    this.useAutoFetchControl.setValue(source?.useAutoFetch ?? false);
+    this.fetchCronControl.setValue(source?.fetchCron ?? null);
+  }
+
+  private createConfigurationControl(value: unknown) {
+    this.configurationSubscription?.unsubscribe();
+    const control = new FormControl<unknown>({ value, disabled: this.disabled() });
+    this.configurationControl = control;
+    this.configurationInvalid.set(false);
+    this.configurationSubscription = control.statusChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(status => this.configurationInvalid.set(status === 'INVALID'));
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.harness.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+
+export class NavigationItemSourceEditorHarness extends ComponentHarness {
+  static readonly hostSelector = 'navigation-item-source-editor';
+
+  private readonly locateTypeSelect = this.locatorFor(MatSelectHarness.with({ selector: '[data-testid="source-type-select"]' }));
+  private readonly locateAutoFetchToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-testid="auto-fetch-toggle"]' }));
+  private readonly locateCronInput = this.locatorForOptional(MatInputHarness.with({ selector: '[data-testid="fetch-cron-input"]' }));
+  private readonly locateSaveButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="save-source-button"]' }));
+  private readonly locateRemoveButton = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[data-testid="remove-source-button"]' }),
+  );
+  private readonly locateErrorBanner = this.locatorForOptional('[data-testid="source-fetch-error-banner"]');
+  private readonly locateLastFetchedAt = this.locatorForOptional('[data-testid="source-last-fetched-at"]');
+  private readonly locateSchemaForm = this.locatorForOptional('gio-form-json-schema');
+  private readonly locateSchemaFormInputs = this.locatorForAll(MatInputHarness.with({ ancestor: 'gio-form-json-schema' }));
+
+  async selectType(fetcherName: string): Promise<void> {
+    const select = await this.locateTypeSelect();
+    await select.open();
+    await select.clickOptions({ text: fetcherName });
+  }
+
+  async getSelectedType(): Promise<string> {
+    return (await this.locateTypeSelect()).getValueText();
+  }
+
+  async isTypeSelectDisabled(): Promise<boolean> {
+    return (await this.locateTypeSelect()).isDisabled();
+  }
+
+  async hasSchemaForm(): Promise<boolean> {
+    return !!(await this.locateSchemaForm());
+  }
+
+  async getSchemaFormInputValues(): Promise<string[]> {
+    const inputs = await this.locateSchemaFormInputs();
+    return Promise.all(inputs.map(input => input.getValue()));
+  }
+
+  async setSchemaFormInputValue(value: string, index = 0): Promise<void> {
+    const inputs = await this.locateSchemaFormInputs();
+    await inputs[index]?.setValue(value);
+  }
+
+  async toggleAutoFetch(): Promise<void> {
+    return (await this.locateAutoFetchToggle()).toggle();
+  }
+
+  async isAutoFetchChecked(): Promise<boolean> {
+    return (await this.locateAutoFetchToggle()).isChecked();
+  }
+
+  async setCron(cron: string): Promise<void> {
+    const input = await this.locateCronInput();
+    await input?.setValue(cron);
+  }
+
+  async getCron(): Promise<string | null> {
+    const input = await this.locateCronInput();
+    return input ? input.getValue() : null;
+  }
+
+  async hasCronInput(): Promise<boolean> {
+    return !!(await this.locateCronInput());
+  }
+
+  async save(): Promise<void> {
+    return (await this.locateSaveButton())?.click();
+  }
+
+  async isSaveDisabled(): Promise<boolean> {
+    const button = await this.locateSaveButton();
+    return button ? button.isDisabled() : true;
+  }
+
+  async hasSaveButton(): Promise<boolean> {
+    return !!(await this.locateSaveButton());
+  }
+
+  async remove(): Promise<void> {
+    return (await this.locateRemoveButton())?.click();
+  }
+
+  async hasRemoveButton(): Promise<boolean> {
+    return !!(await this.locateRemoveButton());
+  }
+
+  async getLastFetchErrorText(): Promise<string | null> {
+    const banner = await this.locateErrorBanner();
+    return banner ? banner.text() : null;
+  }
+
+  async getLastFetchedAtText(): Promise<string | null> {
+    const info = await this.locateLastFetchedAt();
+    return info ? info.text() : null;
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -152,6 +152,7 @@
           } @else if (contentLoadError()) {
             <ng-container *ngTemplateOutlet="pageNotFound"></ng-container>
           } @else {
+            <ng-container *ngTemplateOutlet="contentSourceBanners"></ng-container>
             @switch (currentPageContentType()) {
               @case ('OPENAPI') {
                 <openapi-editor
@@ -168,6 +169,15 @@
               }
             }
           }
+        }
+        @case ('FOLDER') {
+          @if (selectedItemSource()) {
+            <div class="source-mention" data-testid="folder-managed-by-source-banner">
+              <mat-icon class="source-mention__icon" svgIcon="gio:link" />
+              <span>Folder content from {{ selectedSourceTypeLabel() }} — read only</span>
+            </div>
+          }
+          <ng-container *ngTemplateOutlet="emptyEditorState"></ng-container>
         }
         @default {
           <ng-container *ngTemplateOutlet="emptyEditorState"></ng-container>
@@ -222,4 +232,24 @@
       </mat-card-content>
     </mat-card>
   </div>
+</ng-template>
+
+<ng-template #contentSourceBanners>
+  @if (parentSourcedFolder(); as parentFolder) {
+    <div class="source-mention" data-testid="content-managed-by-parent-banner">
+      <mat-icon class="source-mention__icon" svgIcon="gio:link" />
+      <span>Managed by parent folder "{{ parentFolder.title }}" — read only</span>
+    </div>
+  } @else if (selectedItemSource(); as source) {
+    <div class="source-mention" data-testid="content-managed-by-source-banner">
+      <mat-icon class="source-mention__icon" svgIcon="gio:link" />
+      <span>Content from {{ selectedSourceTypeLabel() }} — read only</span>
+    </div>
+    @if (source.lastFetchError; as lastFetchError) {
+      <gio-banner-error class="source-banner" data-testid="content-fetch-error-banner">
+        Last fetch failed
+        <span gioBannerBody>{{ lastFetchError }}</span>
+      </gio-banner-error>
+    }
+  }
 </ng-template>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
@@ -151,6 +151,32 @@ $outline-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter80)
     )
   );
 
+  .source-mention {
+    @include mat.m2-typography-level($typography, 'body-2');
+
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-shrink: 0;
+    gap: 8px;
+    margin: 16px 16px 0 16px;
+    padding: 8px 12px;
+    border: 1px solid rgba(mat.m2-get-color-from-palette(gio.$mat-accent-palette, lighter20), 0.32);
+    border-radius: 4px;
+    background-color: rgba(mat.m2-get-color-from-palette(gio.$mat-accent-palette, lighter20), 0.08);
+    color: mat.m2-get-color-from-palette(gio.$mat-accent-palette, darker20);
+
+    &__icon {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+  }
+
+  .source-banner {
+    margin: 16px 16px 0 16px;
+  }
+
   gmd-editor,
   openapi-editor {
     flex-grow: 1;

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -54,13 +54,17 @@ import {
   fakeUpdateApiProductPortalNavigationItem,
   fakeUpdatePagePortalNavigationItem,
   NewPortalNavigationItem,
+  NewPagePortalNavigationItem,
   PortalNavigationItem,
+  PortalNavigationItemSource,
   PortalNavigationItemsResponse,
   PortalPageContentType,
   UpdateFolderPortalNavigationItem,
   UpdateLinkPortalNavigationItem,
+  UpdatePagePortalNavigationItem,
   UpdatePortalNavigationItem,
 } from '../../entities/management-api-v2';
+import { fakeFetcherList } from '../../entities/fetcher/fetcher.fixture';
 import {
   OpenApiDocExpansion,
   OpenApiViewer,
@@ -115,6 +119,7 @@ describe('PortalNavigationItemsComponent', () => {
   afterEach(() => {
     flushPendingLinkedApiSearchRequests();
     flushPendingLinkedApiProductRequests();
+    flushPendingFetcherRequests();
     httpTestingController.verify();
     jest.clearAllMocks();
   });
@@ -231,6 +236,9 @@ describe('PortalNavigationItemsComponent', () => {
       beforeEach(async () => {
         await harness.clickPageMenuItem();
         dialogHarness = await rootLoader.getHarness(SectionEditorDialogHarness);
+        // Skip the content-source choice step (default: Fill in content)
+        await dialogHarness.clickContinueButton();
+        fixture.detectChanges();
       });
       it('opens the dialog when the Add button is clicked and Page is selected', async () => {
         expect(dialogHarness).toBeTruthy();
@@ -510,6 +518,9 @@ describe('PortalNavigationItemsComponent', () => {
       fixture.detectChanges();
 
       const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      // Skip the content-source choice step (default: Fill in content)
+      await dialog.clickContinueButton();
+      fixture.detectChanges();
       expect(dialog).toBeTruthy();
 
       // cancel should not send any POST request
@@ -539,6 +550,9 @@ describe('PortalNavigationItemsComponent', () => {
       fixture.detectChanges();
 
       const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      // Skip the content-source choice step (default: Fill in content)
+      await dialog.clickContinueButton();
+      fixture.detectChanges();
       expect(dialog).toBeTruthy();
 
       const title = 'New Child Page';
@@ -587,6 +601,9 @@ describe('PortalNavigationItemsComponent', () => {
       fixture.detectChanges();
 
       const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      // Skip the content-source choice step (default: Fill in content)
+      await dialog.clickContinueButton();
+      fixture.detectChanges();
       const title = 'New Child Page';
       await dialog.setTitleInputValue(title);
       await dialog.clickSubmitButton();
@@ -641,6 +658,9 @@ describe('PortalNavigationItemsComponent', () => {
       fixture.detectChanges();
 
       const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      // Skip the content-source choice step (default: Fill in content)
+      await dialog.clickContinueButton();
+      fixture.detectChanges();
       expect(dialog).toBeTruthy();
 
       const authToggle = await dialog.getAuthenticationToggle();
@@ -1092,6 +1112,9 @@ describe('PortalNavigationItemsComponent', () => {
 
       it('opens create dialog and does not call backend when cancelled', async () => {
         const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        // Skip the content-source choice step (default: Fill in content)
+        await dialog.clickContinueButton();
+        fixture.detectChanges();
         expect(dialog).toBeTruthy();
 
         // cancel should not send any POST request
@@ -1101,6 +1124,9 @@ describe('PortalNavigationItemsComponent', () => {
       it('calls backend create with parentId when dialog is submitted', async () => {
         const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
         expect(dialog).toBeTruthy();
+        // Skip the content-source choice step (default: Fill in content)
+        await dialog.clickContinueButton();
+        fixture.detectChanges();
 
         const title = 'New Child Page';
         await dialog.setTitleInputValue(title);
@@ -1239,6 +1265,9 @@ describe('PortalNavigationItemsComponent', () => {
       fixture.detectChanges();
 
       const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      // Skip the content-source choice step (default: Fill in content)
+      await dialog.clickContinueButton();
+      fixture.detectChanges();
       const authenticationToggle = await dialog.getAuthenticationToggle();
       expect(await authenticationToggle.isChecked()).toBe(true);
       expect(await authenticationToggle.isDisabled()).toBe(true);
@@ -1379,6 +1408,7 @@ describe('PortalNavigationItemsComponent', () => {
     it('should show empty message when non-PAGE is selected', async () => {
       await harness.selectNavigationItemByTitle('Nav Item 2');
       expect(await harness.isEditorEmptyStateDisplayed()).toBe(true);
+      expect(await harness.getGmdEditor()).toBeFalsy();
     });
 
     it('should disable save button after selecting a PAGE after editing its content', async () => {
@@ -2977,6 +3007,14 @@ describe('PortalNavigationItemsComponent', () => {
     fixture.detectChanges();
   }
 
+  function expectGetFetchers() {
+    httpTestingController
+      .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/fetchers?expand=schema` })
+      .flush(fakeFetcherList());
+
+    fixture.detectChanges();
+  }
+
   function expectCreateNavigationItem(requestBody: NewPortalNavigationItem, result: PortalNavigationItem) {
     const req = httpTestingController.expectOne({
       method: 'POST',
@@ -3105,6 +3143,20 @@ describe('PortalNavigationItemsComponent', () => {
     });
 
     fixture.detectChanges();
+  }
+
+  // The source editor shown for FOLDER items (and the External Source tab) loads the fetcher list on creation
+  function flushPendingFetcherRequests() {
+    const requests = httpTestingController.match(
+      request => request.method === 'GET' && request.url === `${CONSTANTS_TESTING.env.baseURL}/fetchers?expand=schema`,
+    );
+
+    const activeRequests = requests.filter(req => !req.cancelled);
+    activeRequests.forEach(req => req.flush(fakeFetcherList()));
+
+    if (activeRequests.length > 0) {
+      fixture.detectChanges();
+    }
   }
 
   function flushPendingLinkedApiSearchRequests() {
@@ -4023,6 +4075,442 @@ describe('PortalNavigationItemsComponent', () => {
       expectGetPageContent('content-2', 'Page 2 content');
 
       expect(await harness.isPreviewVisible()).toBe(false);
+    });
+  });
+
+  describe('external source', () => {
+    const githubSource: PortalNavigationItemSource = {
+      type: 'github-fetcher',
+      configuration: {
+        githubUrl: 'https://api.github.com',
+        owner: 'gravitee-io',
+        repository: 'docs',
+        personalAccessToken: '********',
+      },
+      useAutoFetch: false,
+    };
+
+    async function openEditDialog(): Promise<SectionEditorDialogHarness> {
+      await harness.clickEditButton();
+      fixture.detectChanges();
+      return rootLoader.getHarness(SectionEditorDialogHarness);
+    }
+
+    function expectPutNavigationItemAndCaptureBody(id: string, response: PortalNavigationItem): UpdatePortalNavigationItem {
+      const req = httpTestingController.expectOne({
+        method: 'PUT',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${id}`,
+      });
+      const body = req.request.body as UpdatePortalNavigationItem;
+      req.flush(response);
+      fixture.detectChanges();
+      return body;
+    }
+
+    describe('page without source', () => {
+      const page = fakePortalNavigationPage({
+        id: 'page-1',
+        title: 'Page 1',
+        area: 'TOP_NAVBAR',
+        portalPageContentId: 'content-1',
+      });
+
+      beforeEach(async () => {
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [page] }));
+        expectGetPageContent('content-1', 'Some content');
+      });
+
+      it('keeps the content editable without banner', async () => {
+        expect(await harness.isContentEditorReadOnly()).toBe(false);
+        expect(await harness.isContentManagedBySourceBannerDisplayed()).toBe(false);
+      });
+
+      it('creates a page bound to an external source from the Add dialog', async () => {
+        await harness.clickAddButton();
+        fixture.detectChanges();
+        await harness.clickPageMenuItem();
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+
+        expect(await dialog.isContentSourceStepVisible()).toBe(true);
+        await dialog.selectContentSource('EXTERNAL');
+        await dialog.clickContinueButton();
+        fixture.detectChanges();
+        expectGetFetchers();
+
+        await dialog.setTitleInputValue('Sourced page');
+        const sourceEditor = await dialog.getSourceEditor();
+        expect(sourceEditor).not.toBeNull();
+        await sourceEditor.selectType('HTTP');
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        // url is required by the http-fetcher schema: an untouched configuration must not be submittable
+        expect(await dialog.isSubmitButtonDisabled()).toBe(true);
+        await sourceEditor.setSchemaFormInputValue('https://example.com/doc.md');
+        expect(await dialog.isSubmitButtonDisabled()).toBe(false);
+        await dialog.clickSubmitButton();
+
+        const req = httpTestingController.expectOne({
+          method: 'POST',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items`,
+        });
+        const body = req.request.body as NewPagePortalNavigationItem;
+        expect(body.type).toBe('PAGE');
+        expect(body.source).toEqual(
+          expect.objectContaining({
+            type: 'http-fetcher',
+            useAutoFetch: false,
+            configuration: expect.objectContaining({ url: 'https://example.com/doc.md' }),
+          }),
+        );
+        const createdPage = fakePortalNavigationPage({
+          id: 'new-page',
+          title: 'Sourced page',
+          area: 'TOP_NAVBAR',
+          portalPageContentId: 'new-content',
+          source: githubSource,
+        });
+        req.flush(createdPage);
+        fixture.detectChanges();
+
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [page, createdPage] }));
+        expectGetPageContent('new-content', 'Fetched content');
+      });
+
+      it('requires a cron expression when auto-fetch is enabled', async () => {
+        await harness.clickAddButton();
+        fixture.detectChanges();
+        await harness.clickPageMenuItem();
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        await dialog.selectContentSource('EXTERNAL');
+        await dialog.clickContinueButton();
+        fixture.detectChanges();
+        expectGetFetchers();
+
+        await dialog.setTitleInputValue('Sourced page');
+        const sourceEditor = await dialog.getSourceEditor();
+        await sourceEditor.selectType('HTTP');
+        await fixture.whenStable();
+        fixture.detectChanges();
+        await sourceEditor.setSchemaFormInputValue('https://example.com/doc.md');
+        expect(await dialog.isSubmitButtonDisabled()).toBe(false);
+
+        await sourceEditor.toggleAutoFetch();
+        fixture.detectChanges();
+        expect(await sourceEditor.hasCronInput()).toBe(true);
+        expect(await dialog.isSubmitButtonDisabled()).toBe(true);
+
+        await sourceEditor.setCron('0 */10 * * * *');
+        expect(await dialog.isSubmitButtonDisabled()).toBe(false);
+        await dialog.clickCancelButton();
+      });
+
+      it('adds a source to an existing page from the Edit dialog', async () => {
+        const dialog = await openEditDialog();
+        expect(await dialog.hasExternalSourceToggle()).toBe(true);
+        expect(await dialog.isExternalSourceToggleChecked()).toBe(false);
+
+        await dialog.toggleExternalSource();
+        fixture.detectChanges();
+        expectGetFetchers();
+
+        const sourceEditor = await dialog.getSourceEditor();
+        await sourceEditor.selectType('HTTP');
+        await fixture.whenStable();
+        fixture.detectChanges();
+        await sourceEditor.setSchemaFormInputValue('https://example.com/doc.md');
+        await dialog.clickSubmitButton();
+
+        const body = expectPutNavigationItemAndCaptureBody('page-1', fakePortalNavigationPage({ ...page, source: githubSource }));
+        expect(body.type).toBe('PAGE');
+        expect((body as UpdatePagePortalNavigationItem).source).toEqual(
+          expect.objectContaining({
+            type: 'http-fetcher',
+            useAutoFetch: false,
+            configuration: expect.objectContaining({ url: 'https://example.com/doc.md' }),
+          }),
+        );
+
+        await expectGetNavigationItems(
+          fakePortalNavigationItemsResponse({ items: [fakePortalNavigationPage({ ...page, source: githubSource })] }),
+        );
+        expectGetPageContent('content-1', 'Some content');
+      });
+    });
+
+    describe('page with source', () => {
+      const sourcedPage = fakePortalNavigationPage({
+        id: 'page-1',
+        title: 'Page 1',
+        area: 'TOP_NAVBAR',
+        portalPageContentId: 'content-1',
+        source: githubSource,
+      });
+
+      beforeEach(async () => {
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedPage] }));
+        expectGetPageContent('content-1', 'Fetched content');
+      });
+
+      it('makes the content read-only with a managed-by-source banner', async () => {
+        expect(await harness.isContentEditorReadOnly()).toBe(true);
+        expect(await harness.isContentManagedBySourceBannerDisplayed()).toBe(true);
+        expect(await harness.getContentManagedBySourceBannerText()).toContain('Content from GitHub — read only');
+      });
+
+      it('pre-fills the source editor in the Edit dialog and locks the title', async () => {
+        const dialog = await openEditDialog();
+        expectGetFetchers();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(await dialog.isExternalSourceToggleChecked()).toBe(true);
+        const sourceEditor = await dialog.getSourceEditor();
+        expect(await sourceEditor.getSelectedType()).toBe('GitHub');
+        expect(await sourceEditor.hasSchemaForm()).toBe(true);
+
+        const titleInput = await dialog.getTitleInput();
+        expect(await titleInput.isDisabled()).toBe(true);
+        await dialog.clickCancelButton();
+      });
+
+      it('keeps masked secrets untouched when saving other changes', async () => {
+        const dialog = await openEditDialog();
+        expectGetFetchers();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const sourceEditor = await dialog.getSourceEditor();
+        expect(await sourceEditor.getSchemaFormInputValues()).toContain('********');
+
+        await sourceEditor.toggleAutoFetch();
+        fixture.detectChanges();
+        await sourceEditor.setCron('0 0 * * * *');
+        expect(await dialog.isSubmitButtonDisabled()).toBe(false);
+        await dialog.clickSubmitButton();
+
+        const body = expectPutNavigationItemAndCaptureBody('page-1', sourcedPage);
+        expect((body as UpdatePagePortalNavigationItem).source).toEqual(
+          expect.objectContaining({
+            type: 'github-fetcher',
+            useAutoFetch: true,
+            fetchCron: '0 0 * * * *',
+            configuration: expect.objectContaining({ personalAccessToken: '********' }),
+          }),
+        );
+
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedPage] }));
+        expectGetPageContent('content-1', 'Fetched content');
+      });
+
+      it('removes the source from the Edit dialog and unlocks the title', async () => {
+        const dialog = await openEditDialog();
+        expectGetFetchers();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        await dialog.toggleExternalSource();
+        fixture.detectChanges();
+
+        expect(await dialog.isSourceRemovalWarningDisplayed()).toBe(true);
+        const titleInput = await dialog.getTitleInput();
+        expect(await titleInput.isDisabled()).toBe(false);
+
+        await dialog.clickSubmitButton();
+        const body = expectPutNavigationItemAndCaptureBody('page-1', fakePortalNavigationPage({ ...sourcedPage, source: undefined }));
+        expect((body as UpdatePagePortalNavigationItem).source).toBeUndefined();
+
+        await expectGetNavigationItems(
+          fakePortalNavigationItemsResponse({ items: [fakePortalNavigationPage({ ...sourcedPage, source: undefined })] }),
+        );
+        expectGetPageContent('content-1', 'Fetched content');
+      });
+
+      it('displays the last fetch error in the Content view when present', async () => {
+        // Re-load with a failing source
+        const failingPage = fakePortalNavigationPage({
+          ...sourcedPage,
+          source: { ...githubSource, lastFetchError: 'Repository not found' },
+        });
+        privateComponent().refreshMenuList.next(1);
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [failingPage] }));
+        expectGetPageContent('content-1', 'Fetched content');
+
+        expect(await harness.getContentFetchErrorBannerText()).toContain('Repository not found');
+      });
+    });
+
+    describe('page with auto-fetch source', () => {
+      const page = fakePortalNavigationPage({
+        id: 'page-1',
+        title: 'Page 1',
+        area: 'TOP_NAVBAR',
+        portalPageContentId: 'content-1',
+      });
+
+      it('pre-fills the auto-fetch toggle and cron from the source', async () => {
+        const autoFetchSource: PortalNavigationItemSource = { ...githubSource, useAutoFetch: true, fetchCron: '0 0 * * * *' };
+        await expectGetNavigationItems(
+          fakePortalNavigationItemsResponse({ items: [fakePortalNavigationPage({ ...page, source: autoFetchSource })] }),
+        );
+        expectGetPageContent('content-1', 'Fetched content');
+        const dialog = await openEditDialog();
+        expectGetFetchers();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const sourceEditor = await dialog.getSourceEditor();
+        expect(await sourceEditor.isAutoFetchChecked()).toBe(true);
+        expect(await sourceEditor.getCron()).toBe('0 0 * * * *');
+        await dialog.clickCancelButton();
+      });
+
+      it('shows the last fetch error in the source editor', async () => {
+        const failingSource: PortalNavigationItemSource = { ...githubSource, lastFetchError: 'Repository not found' };
+        await expectGetNavigationItems(
+          fakePortalNavigationItemsResponse({ items: [fakePortalNavigationPage({ ...page, source: failingSource })] }),
+        );
+        expectGetPageContent('content-1', 'Fetched content');
+        const dialog = await openEditDialog();
+        expectGetFetchers();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const sourceEditor = await dialog.getSourceEditor();
+        expect(await sourceEditor.getLastFetchErrorText()).toContain('Repository not found');
+        await dialog.clickCancelButton();
+      });
+
+      it('shows the last successful fetch date in the source editor', async () => {
+        const fetchedSource: PortalNavigationItemSource = { ...githubSource, lastFetchedAt: '2026-07-17T00:00:00.000Z' };
+        await expectGetNavigationItems(
+          fakePortalNavigationItemsResponse({ items: [fakePortalNavigationPage({ ...page, source: fetchedSource })] }),
+        );
+        expectGetPageContent('content-1', 'Fetched content');
+        const dialog = await openEditDialog();
+        expectGetFetchers();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const sourceEditor = await dialog.getSourceEditor();
+        expect(await sourceEditor.getLastFetchedAtText()).toContain('Last successful fetch');
+        await dialog.clickCancelButton();
+      });
+    });
+
+    describe('child of a sourced folder', () => {
+      const sourcedFolder = fakePortalNavigationFolder({
+        id: 'folder-1',
+        title: 'Docs Folder',
+        area: 'TOP_NAVBAR',
+        source: githubSource,
+      });
+      const childPage = fakePortalNavigationPage({
+        id: 'page-1',
+        title: 'Child Page',
+        area: 'TOP_NAVBAR',
+        parentId: 'folder-1',
+        portalPageContentId: 'content-1',
+        source: undefined,
+      });
+
+      beforeEach(async () => {
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedFolder, childPage] }));
+        expectGetPageContent('content-1', 'Child content');
+      });
+
+      it('makes everything read-only with a managed-by-parent mention', async () => {
+        expect(await harness.isContentEditorReadOnly()).toBe(true);
+        expect(await harness.getContentManagedByParentBannerText()).toContain('Managed by parent folder "Docs Folder"');
+        expect(await harness.isEditButtonDisabled()).toBe(true);
+      });
+    });
+
+    describe('tree context menu on sourced items', () => {
+      const sourcedFolder = fakePortalNavigationFolder({
+        id: 'folder-1',
+        title: 'Docs Folder',
+        area: 'TOP_NAVBAR',
+        source: githubSource,
+      });
+      const childPage = fakePortalNavigationPage({
+        id: 'page-1',
+        title: 'Child Page',
+        area: 'TOP_NAVBAR',
+        parentId: 'folder-1',
+        portalPageContentId: 'content-1',
+        source: undefined,
+      });
+
+      beforeEach(async () => {
+        snackBarErrorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedFolder, childPage] }));
+        expectGetPageContent('content-1', 'Child content');
+      });
+
+      it('blocks editing a child of a sourced folder with an explanation', async () => {
+        await harness.editNodeById('page-1');
+        fixture.detectChanges();
+
+        expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('managed by the external source of folder "Docs Folder"'));
+        expect(await rootLoader.getHarnessOrNull(SectionEditorDialogHarness)).toBeNull();
+      });
+
+      it('blocks deleting the sourced folder itself with an explanation', async () => {
+        await harness.deleteNodeById('folder-1');
+        fixture.detectChanges();
+
+        expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('remove the source before deleting it'));
+        expect(await rootLoader.getHarnessOrNull(GioConfirmAndValidateDialogHarness)).toBeNull();
+      });
+    });
+
+    describe('folder selected', () => {
+      it('shows the empty state without banner for a folder without source', async () => {
+        const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'My Folder', area: 'TOP_NAVBAR' });
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder] }));
+
+        expect(await harness.isEditorEmptyStateDisplayed()).toBe(true);
+        expect(await harness.getFolderManagedBySourceBannerText()).toBeNull();
+      });
+
+      it('shows a read-only mention for a sourced folder', async () => {
+        const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'My Folder', area: 'TOP_NAVBAR', source: githubSource });
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder] }));
+
+        expect(await harness.getFolderManagedBySourceBannerText()).toContain('Folder content from GitHub — read only');
+      });
+
+      it('adds a source on the folder from the Edit dialog', async () => {
+        const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'My Folder', area: 'TOP_NAVBAR' });
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder] }));
+
+        const dialog = await openEditDialog();
+        expect(await dialog.hasExternalSourceToggle()).toBe(true);
+        await dialog.toggleExternalSource();
+        fixture.detectChanges();
+        expectGetFetchers();
+
+        const sourceEditor = await dialog.getSourceEditor();
+        await sourceEditor.selectType('HTTP');
+        await fixture.whenStable();
+        fixture.detectChanges();
+        await sourceEditor.setSchemaFormInputValue('https://example.com/folder');
+        await dialog.clickSubmitButton();
+
+        const body = expectPutNavigationItemAndCaptureBody('folder-1', fakePortalNavigationFolder({ ...folder, source: githubSource }));
+        expect(body.type).toBe('FOLDER');
+        expect((body as UpdateFolderPortalNavigationItem).source).toEqual(
+          expect.objectContaining({
+            type: 'http-fetcher',
+            configuration: expect.objectContaining({ url: 'https://example.com/folder' }),
+          }),
+        );
+
+        await expectGetNavigationItems(
+          fakePortalNavigationItemsResponse({ items: [fakePortalNavigationFolder({ ...folder, source: githubSource })] }),
+        );
+      });
     });
   });
 });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -18,11 +18,12 @@ import { GraviteeMarkdownEditorComponent, GraviteeMarkdownEditorModule } from '@
 import { load, YAMLException } from 'js-yaml';
 import {
   GIO_DIALOG_WIDTH,
+  GioBannerModule,
   GioCardEmptyStateModule,
   GioConfirmAndValidateDialogComponent,
   GioConfirmAndValidateDialogData,
 } from '@gravitee/ui-particles-angular';
-import { Component, computed, DestroyRef, HostListener, inject, NgZone, Signal, signal, viewChild } from '@angular/core';
+import { Component, computed, DestroyRef, effect, HostListener, inject, NgZone, Signal, signal, viewChild } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { AbstractControl, FormControl, ReactiveFormsModule, ValidationErrors, ValidatorFn } from '@angular/forms';
@@ -71,7 +72,9 @@ import {
   PortalArea,
   PortalNavigationApi,
   PortalNavigationApiProduct,
+  PortalNavigationFolder,
   PortalNavigationItem,
+  PortalNavigationItemSource,
   PortalNavigationItemType,
   PortalNavigationLink,
   PortalNavigationPage,
@@ -129,6 +132,7 @@ type ApiProductBulkCreateResult = {
     TitleCasePipe,
     PortalNavigationItemIconPipe,
     CdkScrollable,
+    GioBannerModule,
   ],
 })
 export class PortalNavigationItemsComponent implements HasUnsavedChanges {
@@ -136,13 +140,14 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   private readonly apiProductService = inject(ApiProductV2Service);
 
   // UI State & Forms
-  private isReadOnly = !inject(GioPermissionService).hasAnyMatching(['environment-documentation-u']);
+  protected isReadOnly = !inject(GioPermissionService).hasAnyMatching(['environment-documentation-u']);
   addSectionMenuOpen = false;
   contentControl = new FormControl({
     value: '',
     disabled: this.isReadOnly,
   });
-  readonly actionsDisabled = computed(() => this.contentLoadError() || !this.selectedNavigationItem());
+  // Children of a sourced folder are fully managed by the fetcher: every action is read-only
+  readonly actionsDisabled = computed(() => this.contentLoadError() || !this.selectedNavigationItem() || !!this.parentSourcedFolder());
 
   // Route State
   private readonly navId$ = this.activatedRoute.queryParams.pipe(map(params => params['navId'] ?? null));
@@ -234,6 +239,31 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     return this.selectedNavigationItem()?.data?.published ?? false;
   });
 
+  // --- External source state ---
+  readonly selectedItemSource: Signal<PortalNavigationItemSource | null> = computed(() => {
+    const navItem = this.selectedNavigationItem()?.data;
+    return navItem && (navItem.type === 'PAGE' || navItem.type === 'FOLDER') ? (navItem.source ?? null) : null;
+  });
+  readonly selectedSourceTypeLabel = computed(() => {
+    const sourceType = this.selectedItemSource()?.type;
+    if (!sourceType) {
+      return '';
+    }
+    const KNOWN_FETCHER_LABELS: Record<string, string> = {
+      'github-fetcher': 'GitHub',
+      'gitlab-fetcher': 'GitLab',
+      'git-fetcher': 'Git',
+      'bitbucket-fetcher': 'Bitbucket',
+      'http-fetcher': 'HTTP',
+    };
+    return KNOWN_FETCHER_LABELS[sourceType] ?? sourceType.replace(/-fetcher$/, '');
+  });
+  readonly parentSourcedFolder: Signal<PortalNavigationFolder | null> = computed(() => {
+    const navItem = this.selectedNavigationItem()?.data;
+    return navItem ? this.findSourcedFolderAbove(navItem) : null;
+  });
+  readonly isContentEditingLocked = computed(() => !!this.selectedItemSource() || !!this.parentSourcedFolder());
+
   // --- Resize Configuration ---
   private readonly ngZone = inject(NgZone);
   private readonly MIN_PANEL_WIDTH = 280;
@@ -279,6 +309,59 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   ) {
     this.contentControl.addValidators(this.asyncApiSpecValidator);
     this.setupPageContentSubscription();
+    effect(() => {
+      if (this.isReadOnly) {
+        return;
+      }
+      if (this.isContentEditingLocked()) {
+        this.contentControl.disable({ emitEvent: false });
+      } else {
+        this.contentControl.enable({ emitEvent: false });
+      }
+    });
+  }
+
+  /** The backend keeps sourced subtrees read-only; blocking here avoids a doomed dialog + 400 round-trip. */
+  private blockActionOnSourcedItem(event: NodeMenuActionEvent): boolean {
+    const nodeItem = event.node.data;
+    if (!nodeItem) {
+      return false;
+    }
+    const sourcedParent = this.findSourcedFolderAbove(nodeItem);
+    if (sourcedParent && event.action !== 'create') {
+      this.snackBarService.error(
+        `"${nodeItem.title}" is managed by the external source of folder "${sourcedParent.title}" and is read-only`,
+      );
+      return true;
+    }
+    const sourcedContainer = nodeItem.type === 'FOLDER' && nodeItem.source ? nodeItem : sourcedParent;
+    if (event.action === 'create' && sourcedContainer) {
+      this.snackBarService.error(`Folder "${sourcedContainer.title}" is managed by an external source: items cannot be created inside it`);
+      return true;
+    }
+    if (
+      event.action === 'delete' &&
+      (nodeItem.type === 'PAGE' || nodeItem.type === 'FOLDER') &&
+      (nodeItem as PortalNavigationPage | PortalNavigationFolder).source
+    ) {
+      this.snackBarService.error(`"${nodeItem.title}" is bound to an external source: remove the source before deleting it`);
+      return true;
+    }
+    return false;
+  }
+
+  private findSourcedFolderAbove(navItem: PortalNavigationItem): PortalNavigationFolder | null {
+    const itemsById = new Map(this.menuLinks().map(item => [item.id, item]));
+    const visitedItemIds = new Set<string>();
+    let currentItem = navItem.parentId ? itemsById.get(navItem.parentId) : undefined;
+    while (currentItem && !visitedItemIds.has(currentItem.id)) {
+      visitedItemIds.add(currentItem.id);
+      if (currentItem.type === 'FOLDER' && currentItem.source) {
+        return currentItem;
+      }
+      currentItem = currentItem.parentId ? itemsById.get(currentItem.parentId) : undefined;
+    }
+    return null;
   }
 
   onSelect($event: SectionNode) {
@@ -308,6 +391,9 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
 
   onNodeMenuAction(event: NodeMenuActionEvent) {
     this.checkUnsavedChangesAndRun(() => {
+      if (this.blockActionOnSourcedItem(event)) {
+        return;
+      }
       switch (event.action) {
         case 'delete':
           this.confirmDeleteAction(event);
@@ -488,9 +574,12 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
       });
   }
 
-  private loadPageContent(
-    contentId: string,
-  ): Observable<{ success: boolean; content: string; type?: PortalPageContentType; configuration?: Partial<OpenApiViewerConfiguration> }> {
+  private loadPageContent(contentId: string): Observable<{
+    success: boolean;
+    content: string;
+    type?: PortalPageContentType;
+    configuration?: Partial<OpenApiViewerConfiguration>;
+  }> {
     return this.portalPageContentService.getPageContent(contentId).pipe(
       map(({ content, type, configuration }) => ({ success: true, content, type, configuration })),
       catchError(() => {
@@ -629,7 +718,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         : { mode: 'edit', type, existingItem: existingItem!, parentItem };
     this.matDialog
       .open<SectionEditorDialogComponent, SectionEditorDialogData>(SectionEditorDialogComponent, {
-        width: GIO_DIALOG_WIDTH.SMALL,
+        width: GIO_DIALOG_WIDTH.MEDIUM,
         data,
       })
       .afterClosed()
@@ -645,6 +734,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
               parentId: existingItem?.id,
               visibility: result.visibility,
               ...(type === 'PAGE' && result.contentType ? { contentType: result.contentType } : {}),
+              ...(type === 'PAGE' && result.source ? { source: result.source } : {}),
             });
           } else {
             if (!existingItem) {
@@ -669,6 +759,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
               apiId: (existingItem as PortalNavigationApi).apiId,
               url: result.url,
               visibility: result.visibility,
+              source: result.source,
             });
           }
         }),
@@ -676,8 +767,10 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
           this.refreshMenuList.next(1);
           this.navigateToItemByNavId(id);
         }),
-        catchError(() => {
-          this.snackBarService.error('Failed to update navigation item');
+        catchError(error => {
+          if (!(error instanceof HttpErrorResponse)) {
+            this.snackBarService.error('Failed to update navigation item');
+          }
           return EMPTY;
         }),
         takeUntilDestroyed(this.destroyRef),
@@ -982,13 +1075,17 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
             apiId: (navItem as PortalNavigationApi).apiId,
             parentId: newParentId ?? undefined,
             order: newOrder,
+            source: (navItem as PortalNavigationPage).source,
           };
     return this.update(navItem.id, updateItem).pipe(
       tap(() => {
         this.refreshMenuList.next(1);
       }),
-      catchError(() => {
-        this.snackBarService.error('Failed to move navigation item');
+      catchError(error => {
+        // HTTP errors are already caught by HttpErrorInterceptor and displayed in the snackbar
+        if (!(error instanceof HttpErrorResponse)) {
+          this.snackBarService.error('Failed to move navigation item');
+        }
         return EMPTY;
       }),
     );

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -56,6 +56,10 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
       message: 'Failed to load page content.',
     }),
   );
+  private readonly getContentManagedBySourceBanner = this.locatorForOptional('[data-testid="content-managed-by-source-banner"]');
+  private readonly getContentManagedByParentBanner = this.locatorForOptional('[data-testid="content-managed-by-parent-banner"]');
+  private readonly getContentFetchErrorBanner = this.locatorForOptional('[data-testid="content-fetch-error-banner"]');
+  private readonly getFolderManagedBySourceBanner = this.locatorForOptional('[data-testid="folder-managed-by-source-banner"]');
 
   async getAddButtonHarness(): Promise<MatButtonHarness> {
     return this.getAddButton();
@@ -95,6 +99,11 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   async clickEditButton(): Promise<void> {
     const button = await this.getEditButton();
     return button.click();
+  }
+
+  async isEditButtonDisabled(): Promise<boolean> {
+    const button = await this.getEditButton();
+    return button.isDisabled();
   }
 
   async isConfigureButtonVisible(): Promise<boolean> {
@@ -276,6 +285,35 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   async isPageNotFoundDisplayed(): Promise<boolean> {
     const emptyState = await this.getPageNotFoundEmptyState();
     return emptyState !== null;
+  }
+
+  async isContentManagedBySourceBannerDisplayed(): Promise<boolean> {
+    return (await this.getContentManagedBySourceBanner()) !== null;
+  }
+
+  async getContentManagedBySourceBannerText(): Promise<string | null> {
+    const banner = await this.getContentManagedBySourceBanner();
+    return banner ? banner.text() : null;
+  }
+
+  async getFolderManagedBySourceBannerText(): Promise<string | null> {
+    const banner = await this.getFolderManagedBySourceBanner();
+    return banner ? banner.text() : null;
+  }
+
+  async getContentManagedByParentBannerText(): Promise<string | null> {
+    const banner = await this.getContentManagedByParentBanner();
+    return banner ? banner.text() : null;
+  }
+
+  async getContentFetchErrorBannerText(): Promise<string | null> {
+    const banner = await this.getContentFetchErrorBanner();
+    return banner ? banner.text() : null;
+  }
+
+  async isContentEditorReadOnly(): Promise<boolean> {
+    const editor = await this.getGraviteeMarkdownEditor();
+    return editor.isEditorReadOnly();
   }
 
   async getPageNotFoundMessage(): Promise<string | null> {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
@@ -20,65 +20,129 @@
 </div>
 
 <form [formGroup]="form" (ngSubmit)="onSubmit()">
-  <mat-dialog-content>
-    @if (showPageTypeSelection()) {
-      <div class="form-field-title">Page Type</div>
-      <gio-form-selection-inline class="section-editor-dialog__page-types" formControlName="contentType">
-        @for (option of pageContentTypeOptions; track option.value) {
-          <gio-form-selection-inline-card [value]="option.value" [disabled]="!option.available">
-            <gio-form-selection-inline-card-content [icon]="option.icon">
-              <gio-card-content-title>{{ option.label }}</gio-card-content-title>
-            </gio-form-selection-inline-card-content>
-          </gio-form-selection-inline-card>
-        }
+  @if (isSourceChoiceStep()) {
+    <mat-dialog-content>
+      <gio-form-selection-inline class="section-editor-dialog__content-sources" [formControl]="contentSourceControl">
+        <gio-form-selection-inline-card value="FILL">
+          <gio-form-selection-inline-card-content icon="gio:edit-pencil">
+            <gio-card-content-title>Fill in content</gio-card-content-title>
+            <gio-card-content-subtitle>Write Markdown or OpenAPI directly in the editor</gio-card-content-subtitle>
+          </gio-form-selection-inline-card-content>
+        </gio-form-selection-inline-card>
+        <gio-form-selection-inline-card value="IMPORT_FILE" [disabled]="true">
+          <gio-form-selection-inline-card-content icon="gio:upload">
+            <gio-card-content-title>Import from file</gio-card-content-title>
+            <gio-card-content-subtitle>Upload a .md or .yaml file from your machine (coming soon)</gio-card-content-subtitle>
+          </gio-form-selection-inline-card-content>
+        </gio-form-selection-inline-card>
+        <gio-form-selection-inline-card value="EXTERNAL">
+          <gio-form-selection-inline-card-content icon="gio:link">
+            <gio-card-content-title>Link to external source</gio-card-content-title>
+            <gio-card-content-subtitle>Pull content from GitHub or an HTTP URL with optional auto-refresh</gio-card-content-subtitle>
+          </gio-form-selection-inline-card-content>
+        </gio-form-selection-inline-card>
       </gio-form-selection-inline>
-    }
-    <div class="form-field-title">Title</div>
-    <mat-form-field>
-      <mat-label>{{ titleFieldLabel }}</mat-label>
-      <input matInput formControlName="title" required />
-      @if (form.controls.title.hasError('required')) {
-        <mat-error>Title is required</mat-error>
+    </mat-dialog-content>
+
+    <mat-dialog-actions align="end">
+      <button mat-button type="button" (click)="onCancel()">Cancel</button>
+      <button mat-flat-button color="primary" type="button" data-testid="content-source-continue-button" (click)="continueToDetails()">
+        Continue
+      </button>
+    </mat-dialog-actions>
+  } @else {
+    <mat-dialog-content>
+      @if (showPageTypeSelection()) {
+        <div class="form-field-title">Page Type</div>
+        <gio-form-selection-inline class="section-editor-dialog__page-types" formControlName="contentType">
+          @for (option of pageContentTypeOptions; track option.value) {
+            <gio-form-selection-inline-card [value]="option.value" [disabled]="!option.available">
+              <gio-form-selection-inline-card-content [icon]="option.icon">
+                <gio-card-content-title>{{ option.label }}</gio-card-content-title>
+              </gio-form-selection-inline-card-content>
+            </gio-form-selection-inline-card>
+          }
+        </gio-form-selection-inline>
       }
-    </mat-form-field>
-
-    @if (linkedApiName(); as linkedApiName) {
-      <label class="sr-only" for="linked-api-name">Linked API (read-only)</label>
-      <mat-form-field class="section-editor-dialog__linked-api">
-        <mat-label>Linked API (read-only)</mat-label>
-        <input id="linked-api-name" matInput disabled [value]="linkedApiName" data-testid="linked-api-name" />
-        <mat-hint>This is the original API name and cannot be changed.</mat-hint>
-      </mat-form-field>
-    }
-
-    @if (type === 'LINK') {
-      <div class="form-field-title">Link settings</div>
+      <div class="form-field-title">Title</div>
       <mat-form-field>
-        <mat-label>URL</mat-label>
-        <input matInput formControlName="url" required />
-        @if (form.controls.url.hasError('required')) {
-          <mat-error>URL is required</mat-error>
+        <mat-label>{{ titleFieldLabel }}</mat-label>
+        <input matInput formControlName="title" required />
+        @if (titleLockedBySource) {
+          <mat-hint data-testid="title-locked-by-source-hint"
+            >Managed by an external source — remove the source to rename this item.</mat-hint
+          >
         }
-        @if (form.controls.url.hasError('invalidUrl')) {
-          <mat-error>Invalid URL format</mat-error>
+        @if (form.controls.title.hasError('required')) {
+          <mat-error>Title is required</mat-error>
         }
       </mat-form-field>
-    }
 
-    <div class="form-field-title">Authentication</div>
-    <span [matTooltip]="publicDisabledTooltip()" [matTooltipDisabled]="!publicDisabled()">
-      <mat-slide-toggle formControlName="isPrivate" aria-label="Require authentication to view this AP"
-        >Authentication is required to view this {{ type | lowercase }}.</mat-slide-toggle
-      >
-    </span>
+      @if (linkedApiName(); as linkedApiName) {
+        <label class="sr-only" for="linked-api-name">Linked API (read-only)</label>
+        <mat-form-field class="section-editor-dialog__linked-api">
+          <mat-label>Linked API (read-only)</mat-label>
+          <input id="linked-api-name" matInput disabled [value]="linkedApiName" data-testid="linked-api-name" />
+          <mat-hint>This is the original API name and cannot be changed.</mat-hint>
+        </mat-form-field>
+      }
 
-    <gio-banner-info type="info">
-      This change will not be visible in the Developer Portal until you publish the {{ type | lowercase }}.
-    </gio-banner-info>
-  </mat-dialog-content>
+      @if (type === 'LINK') {
+        <div class="form-field-title">Link settings</div>
+        <mat-form-field>
+          <mat-label>URL</mat-label>
+          <input matInput formControlName="url" required />
+          @if (form.controls.url.hasError('required')) {
+            <mat-error>URL is required</mat-error>
+          }
+          @if (form.controls.url.hasError('invalidUrl')) {
+            <mat-error>Invalid URL format</mat-error>
+          }
+        </mat-form-field>
+      }
 
-  <mat-dialog-actions align="end">
-    <button mat-button type="button" (click)="onCancel()">Cancel</button>
-    <button mat-flat-button color="primary" type="submit" [disabled]="!form.valid || formIsUnchanged()">{{ buttonTitle }}</button>
-  </mat-dialog-actions>
+      @if (isCreatePageFlow() && contentSource() === 'EXTERNAL') {
+        <div class="form-field-title">External source</div>
+        <navigation-item-source-editor [embedded]="true" />
+      }
+
+      @if (canConfigureSourceOnEdit()) {
+        <div class="form-field-title">External source</div>
+        <mat-slide-toggle
+          class="section-editor-dialog__source-toggle"
+          data-testid="external-source-toggle"
+          [formControl]="useExternalSourceControl"
+        >
+          Link to external source
+        </mat-slide-toggle>
+        @if (useExternalSource()) {
+          <navigation-item-source-editor [embedded]="true" [source]="initialSource" />
+        } @else if (initialSource) {
+          <gio-banner-warning data-testid="source-removal-warning">
+            The external source will be removed
+            <span gioBannerBody>The content stops being fetched and becomes editable again.</span>
+          </gio-banner-warning>
+        }
+      }
+
+      <div class="form-field-title">Authentication</div>
+      <span [matTooltip]="publicDisabledTooltip()" [matTooltipDisabled]="!publicDisabled()">
+        <mat-slide-toggle formControlName="isPrivate" aria-label="Require authentication to view this AP"
+          >Authentication is required to view this {{ type | lowercase }}.</mat-slide-toggle
+        >
+      </span>
+
+      <gio-banner-info type="info">
+        This change will not be visible in the Developer Portal until you publish the {{ type | lowercase }}.
+      </gio-banner-info>
+    </mat-dialog-content>
+
+    <mat-dialog-actions align="end">
+      @if (isCreatePageFlow()) {
+        <button mat-button type="button" data-testid="content-source-back-button" (click)="backToSourceChoice()">Back</button>
+      }
+      <button mat-button type="button" (click)="onCancel()">Cancel</button>
+      <button mat-flat-button color="primary" type="submit" [disabled]="isSubmitDisabled()">{{ buttonTitle }}</button>
+    </mat-dialog-actions>
+  }
 </form>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.scss
@@ -24,3 +24,13 @@ mat-dialog-content {
   grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
   gap: 8px;
 }
+
+.section-editor-dialog__content-sources {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(180px, 1fr));
+  gap: 8px;
+}
+
+.section-editor-dialog__source-toggle {
+  margin-bottom: 8px;
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
@@ -113,10 +113,14 @@ describe('SectionEditorDialogComponent', () => {
       fixture.componentRef.setInput('mode', 'create');
     });
     describe('when adding a page', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         fixture.componentRef.setInput('type', 'PAGE');
         fixture.detectChanges();
         component.clicked();
+        fixture.detectChanges();
+        // Skip the content-source choice step (default: Fill in content)
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        await dialog.clickContinueButton();
         fixture.detectChanges();
       });
       it('should not allow empty title', async () => {
@@ -199,11 +203,15 @@ describe('SectionEditorDialogComponent', () => {
       });
     });
     describe('when adding a page with PRIVATE parent', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         fixture.componentRef.setInput('type', 'PAGE');
         fixture.componentRef.setInput('parentItem', fakePortalNavigationFolder({ visibility: 'PRIVATE' }));
         fixture.detectChanges();
         component.clicked();
+        fixture.detectChanges();
+        // Skip the content-source choice step (default: Fill in content)
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        await dialog.clickContinueButton();
         fixture.detectChanges();
       });
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, computed, HostListener, inject, OnInit, Signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, HostListener, inject, OnInit, Signal, signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
@@ -25,21 +25,25 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { LowerCasePipe } from '@angular/common';
 import { DomSanitizer } from '@angular/platform-browser';
 import { GioBannerModule, GioFormSelectionInlineModule } from '@gravitee/ui-particles-angular';
-import { isEqual } from 'lodash';
+import { isEqual, pick } from 'lodash';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { Observable, of } from 'rxjs';
 
 import {
   PortalNavigationApi,
+  PortalNavigationFolder,
   PortalNavigationItem,
+  PortalNavigationItemSource,
   PortalNavigationItemType,
   PortalNavigationLink,
+  PortalNavigationPage,
   PortalPageContentType,
   PortalVisibility,
 } from '../../../entities/management-api-v2';
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { urlValidator } from '../../../shared/validators/url.validator';
 import { getPublicVisibilityDisabledTooltip, isPublicVisibilityDisabled } from '../visibility-toggle.util';
+import { NavigationItemSourceEditorComponent } from '../navigation-item-source-editor/navigation-item-source-editor.component';
 
 export type SectionEditorDialogMode = 'create' | 'edit';
 
@@ -65,7 +69,10 @@ export interface SectionEditorDialogResult {
   visibility: PortalVisibility;
   url?: string;
   contentType?: PortalPageContentType;
+  source?: PortalNavigationItemSource;
 }
+
+export type SectionContentSource = 'FILL' | 'IMPORT_FILE' | 'EXTERNAL';
 
 export interface PortalPageTypeOption {
   value: PortalPageContentType;
@@ -117,6 +124,7 @@ type SectionForm = FormGroup<SectionFormControls>;
     GioFormSelectionInlineModule,
     LowerCasePipe,
     MatTooltipModule,
+    NavigationItemSourceEditorComponent,
   ],
   templateUrl: './section-editor-dialog.component.html',
   styleUrls: ['./section-editor-dialog.component.scss'],
@@ -132,10 +140,35 @@ export class SectionEditorDialogComponent implements OnInit {
   public mode: SectionEditorDialogMode;
   public title: string;
   public titleFieldLabel: string;
+  public titleLockedBySource = false;
   readonly pageContentTypeOptions = PORTAL_PAGE_CONTENT_TYPE_OPTIONS;
+
+  // --- External source state ---
+  readonly contentSourceControl = new FormControl<SectionContentSource>('FILL', { nonNullable: true });
+  readonly contentSource = toSignal(this.contentSourceControl.valueChanges, { initialValue: this.contentSourceControl.value });
+  readonly useExternalSourceControl = new FormControl<boolean>(false, { nonNullable: true });
+  readonly useExternalSource = toSignal(this.useExternalSourceControl.valueChanges, { initialValue: this.useExternalSourceControl.value });
+  readonly isSourceChoiceStep = signal(false);
+  public initialSource: PortalNavigationItemSource | undefined;
+  private readonly sourceEditor = viewChild(NavigationItemSourceEditorComponent);
 
   showPageTypeSelection(): boolean {
     return this.mode === 'create' && this.type === 'PAGE';
+  }
+
+  isCreatePageFlow(): boolean {
+    return this.mode === 'create' && this.type === 'PAGE';
+  }
+
+  canConfigureSourceOnEdit(): boolean {
+    return this.mode === 'edit' && (this.type === 'PAGE' || this.type === 'FOLDER');
+  }
+
+  isExternalSourceActive(): boolean {
+    if (this.isCreatePageFlow()) {
+      return this.contentSource() === 'EXTERNAL';
+    }
+    return this.canConfigureSourceOnEdit() && this.useExternalSource();
   }
 
   private readonly dialogRef = inject(MatDialogRef<SectionEditorDialogComponent, SectionEditorDialogResult>);
@@ -143,6 +176,7 @@ export class SectionEditorDialogComponent implements OnInit {
   private readonly iconRegistry = inject(MatIconRegistry);
   private readonly sanitizer = inject(DomSanitizer);
   private readonly apiService = inject(ApiV2Service);
+  private readonly destroyRef = inject(DestroyRef);
   readonly publicDisabled: Signal<boolean> = computed(() => {
     return isPublicVisibilityDisabled(this.data.parentItem);
   });
@@ -180,7 +214,31 @@ export class SectionEditorDialogComponent implements OnInit {
     this.prefillExistingItem();
     this.syncVisibilityControlState();
 
+    if (this.isCreatePageFlow()) {
+      this.isSourceChoiceStep.set(true);
+    }
+
+    this.useExternalSourceControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(useSource => {
+      if (!this.initialSource) {
+        return;
+      }
+      this.titleLockedBySource = useSource;
+      if (useSource) {
+        this.form.controls.title.disable({ emitEvent: false });
+      } else {
+        this.form.controls.title.enable({ emitEvent: false });
+      }
+    });
+
     this.initialFormValues = this.form.getRawValue();
+  }
+
+  continueToDetails(): void {
+    this.isSourceChoiceStep.set(false);
+  }
+
+  backToSourceChoice(): void {
+    this.isSourceChoiceStep.set(true);
   }
 
   private syncVisibilityControlState(): void {
@@ -217,24 +275,53 @@ export class SectionEditorDialogComponent implements OnInit {
         title: this.data.existingItem.title,
         isPrivate: this.data.existingItem.visibility === 'PRIVATE',
       });
+      const existingItem = this.data.existingItem;
+      if (existingItem.type === 'PAGE' || existingItem.type === 'FOLDER') {
+        this.initialSource = (existingItem as PortalNavigationPage | PortalNavigationFolder).source;
+      }
+      if (this.initialSource) {
+        this.useExternalSourceControl.setValue(true);
+        this.titleLockedBySource = true;
+        this.form.controls.title.disable({ emitEvent: false });
+      }
     }
   }
 
   onSubmit(): void {
-    if (this.form.valid) {
-      const formValues = this.form.getRawValue();
-
-      this.dialogRef.close({
-        title: formValues.title,
-        visibility: formValues.isPrivate ? 'PRIVATE' : 'PUBLIC',
-        ...(this.type === 'LINK' ? { url: formValues.url! } : {}),
-        ...(this.showPageTypeSelection() && formValues.contentType ? { contentType: formValues.contentType } : {}),
-      });
+    if (this.isSubmitDisabled()) {
+      return;
     }
+    const formValues = this.form.getRawValue();
+
+    this.dialogRef.close({
+      title: formValues.title,
+      visibility: formValues.isPrivate ? 'PRIVATE' : 'PUBLIC',
+      ...(this.type === 'LINK' ? { url: formValues.url! } : {}),
+      ...(this.showPageTypeSelection() && formValues.contentType ? { contentType: formValues.contentType } : {}),
+      ...(this.isExternalSourceActive() ? { source: this.sourceEditor()?.buildSource() ?? undefined } : {}),
+    });
   }
 
   onCancel(): void {
     this.dialogRef.close();
+  }
+
+  isSubmitDisabled(): boolean {
+    if (!this.form.valid) {
+      return true;
+    }
+    if (this.isExternalSourceActive()) {
+      const editor = this.sourceEditor();
+      if (!editor || editor.saveDisabled()) {
+        return true;
+      }
+      const comparableInitialSource = this.initialSource
+        ? pick(this.initialSource, ['type', 'configuration', 'useAutoFetch', 'fetchCron'])
+        : null;
+      return this.formIsUnchanged() && isEqual(editor.buildSource(), comparableInitialSource);
+    }
+    const sourceRemoved = !!this.initialSource && this.canConfigureSourceOnEdit() && !this.useExternalSource();
+    return this.formIsUnchanged() && !sourceRemoved;
   }
 
   formIsUnchanged(): boolean {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.harness.ts
@@ -20,6 +20,8 @@ import { DivHarness } from '@gravitee/ui-particles-angular/testing';
 import { GioFormSelectionInlineCardHarness } from '@gravitee/ui-particles-angular';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 
+import { NavigationItemSourceEditorHarness } from '../navigation-item-source-editor/navigation-item-source-editor.harness';
+
 export class SectionEditorDialogHarness extends ComponentHarness {
   static hostSelector = 'section-editor-dialog';
   private locateTitleInput = this.locatorFor(MatInputHarness.with({ selector: '[formcontrolname="title"]' }));
@@ -27,7 +29,21 @@ export class SectionEditorDialogHarness extends ComponentHarness {
   private locateCancelButton = this.locatorFor(MatButtonHarness.with({ text: 'Cancel' }));
   private locateSubmitButton = this.locatorFor(MatButtonHarness.with({ text: /Add|Save/ }));
   private locateFormTitle = this.locatorFor(DivHarness.with({ selector: '[mat-dialog-title]' }));
-  private locateAuthenticationToggle = this.locatorFor(MatSlideToggleHarness);
+  private locateAuthenticationToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formcontrolname="isPrivate"]' }));
+  private readonly locateContentSourceCards = this.locatorForAll(
+    GioFormSelectionInlineCardHarness.with({ ancestor: '.section-editor-dialog__content-sources' }),
+  );
+  private readonly locateContinueButton = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[data-testid="content-source-continue-button"]' }),
+  );
+  private readonly locateBackButton = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[data-testid="content-source-back-button"]' }),
+  );
+  private readonly locateExternalSourceToggle = this.locatorForOptional(
+    MatSlideToggleHarness.with({ selector: '[data-testid="external-source-toggle"]' }),
+  );
+  private readonly locateSourceEditor = this.locatorForOptional(NavigationItemSourceEditorHarness);
+  private readonly locateSourceRemovalWarning = this.locatorForOptional('[data-testid="source-removal-warning"]');
   private readonly locateLinkedApiNameInput = this.locatorForOptional(
     MatInputHarness.with({ selector: '[data-testid="linked-api-name"]' }),
   );
@@ -127,5 +143,53 @@ export class SectionEditorDialogHarness extends ComponentHarness {
       }
     }
     return undefined;
+  }
+
+  // --- External source ---
+
+  async isContentSourceStepVisible(): Promise<boolean> {
+    return (await this.locateContinueButton()) !== null;
+  }
+
+  async selectContentSource(value: 'FILL' | 'IMPORT_FILE' | 'EXTERNAL'): Promise<void> {
+    const cards = await this.locateContentSourceCards();
+    const card = await this.findCardByValue(cards, value);
+    if (!card) {
+      throw new Error(`Content source card with value "${value}" not found`);
+    }
+    const host = await card.host();
+    await host.click();
+  }
+
+  async clickContinueButton(): Promise<void> {
+    const button = await this.locateContinueButton();
+    await button?.click();
+  }
+
+  async clickBackButton(): Promise<void> {
+    const button = await this.locateBackButton();
+    await button?.click();
+  }
+
+  async getSourceEditor(): Promise<NavigationItemSourceEditorHarness | null> {
+    return this.locateSourceEditor();
+  }
+
+  async hasExternalSourceToggle(): Promise<boolean> {
+    return (await this.locateExternalSourceToggle()) !== null;
+  }
+
+  async isExternalSourceToggleChecked(): Promise<boolean> {
+    const toggle = await this.locateExternalSourceToggle();
+    return toggle ? toggle.isChecked() : false;
+  }
+
+  async toggleExternalSource(): Promise<void> {
+    const toggle = await this.locateExternalSourceToggle();
+    await toggle?.toggle();
+  }
+
+  async isSourceRemovalWarningDisplayed(): Promise<boolean> {
+    return (await this.locateSourceRemovalWarning()) !== null;
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-89

## Description

Lets portal administrators bind the content of a navigation PAGE or FOLDER to an external repository (GitHub, HTTP, Git, GitLab, Bitbucket).

### What's included
- **Add a new page** dialog: content-source step (*Fill in content* / *Import from file*, disabled for now / *Link to external source*), with fetcher selection, schema-driven configuration form, auto-fetch toggle and cron field embedded in the dialog.
- **Edit page/folder** dialog: add, edit or remove the external source (toggle + embedded editor). Title is locked while a source is active (backend rejects renaming sourced items); removing the source unlocks it.
- **Editor panel**: sourced pages show a "Content from <Source> — read only" banner over a read-only editor, plus a `lastFetchError` banner when the last fetch failed.
- **Sourced subtrees**: children of a sourced folder are fully read-only (header actions and tree context menu guarded with explanatory messages); deleting a sourced item is blocked until its source is removed.
- Secrets are displayed masked (`********`) and kept server-side when not modified.

## Aditionnal context


https://github.com/user-attachments/assets/01d23c9f-ac4d-4241-8d1d-c717def1f61c
