### PR TITLE
fix: derive service-account sourceId from lastname or email

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UsersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UsersResource.java
@@ -91,6 +91,11 @@ public class UsersResource extends AbstractResource {
         description = "List users matching the query criteria",
         content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = UserEntity.class))
     )
+    @ApiResponse(
+        responseCode = "400",
+        description = "Pre-registered user is not valid: a service account must not have a firstname, and must " +
+            "have at least one of sourceId, lastname or email set to derive a unique identifier"
+    )
     @ApiResponse(responseCode = "500", description = "Internal server error")
     public Response createUser(@ValidNewPreRegisterUser NewPreRegisterUserEntity newPreRegisterUserEntity) {
         UserEntity newUser = userService.create(GraviteeContext.getExecutionContext(), newPreRegisterUserEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/UsersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/UsersResourceTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
@@ -59,8 +60,54 @@ public class UsersResourceTest extends AbstractResourceTest {
     }
 
     @Test
-    public void shouldCreateServiceAccountWithoutEmail() {
+    public void shouldNotCreateServiceAccountWithoutEmailLastnameOrSourceId() {
+        // sourceId is resolved as sourceId -> lastname -> email; with none of the three set,
+        // sourceId cannot be derived, so the request must be rejected (APIM-14832)
         NewPreRegisterUserEntity newPreRegisterUserEntity = new NewPreRegisterUserEntity();
+        newPreRegisterUserEntity.setService(true);
+
+        when(userService.create(any(), any())).thenReturn(new UserEntity());
+
+        final Response response = orgTarget().request().post(Entity.json(newPreRegisterUserEntity));
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+        assertTrue(
+            response
+                .readEntity(String.class)
+                .contains("a service account requires a sourceId, lastname or email to derive a unique identifier")
+        );
+    }
+
+    @Test
+    public void shouldNotCreateServiceAccountWithFirstname() {
+        // a service account must not have a firstname, even with a usable identifier present (APIM-14832)
+        NewPreRegisterUserEntity newPreRegisterUserEntity = new NewPreRegisterUserEntity();
+        newPreRegisterUserEntity.setFirstname("SA");
+        newPreRegisterUserEntity.setEmail("mail@fake.fake");
+        newPreRegisterUserEntity.setService(true);
+
+        when(userService.create(any(), any())).thenReturn(new UserEntity());
+
+        final Response response = orgTarget().request().post(Entity.json(newPreRegisterUserEntity));
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+        assertTrue(response.readEntity(String.class).contains("a service account must not have a firstname"));
+    }
+
+    @Test
+    public void shouldCreateServiceAccountWithLastnameOnly() {
+        NewPreRegisterUserEntity newPreRegisterUserEntity = new NewPreRegisterUserEntity();
+        newPreRegisterUserEntity.setLastname("SA_LASTNAME");
+        newPreRegisterUserEntity.setService(true);
+
+        when(userService.create(any(), any())).thenReturn(new UserEntity());
+
+        final Response response = orgTarget().request().post(Entity.json(newPreRegisterUserEntity));
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+    }
+
+    @Test
+    public void shouldCreateServiceAccountWithSourceIdOnly() {
+        NewPreRegisterUserEntity newPreRegisterUserEntity = new NewPreRegisterUserEntity();
+        newPreRegisterUserEntity.setSourceId("SA_SOURCE_ID");
         newPreRegisterUserEntity.setService(true);
 
         when(userService.create(any(), any())).thenReturn(new UserEntity());
@@ -86,5 +133,6 @@ public class UsersResourceTest extends AbstractResourceTest {
 
         final Response response = orgTarget().request().post(Entity.json(newPreRegisterUserEntity));
         assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+        assertTrue(response.readEntity(String.class).contains("email is required"));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewExternalUserEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewExternalUserEntity.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.model;
 
 import io.gravitee.rest.api.sanitizer.HtmlSanitizer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 
@@ -28,17 +29,20 @@ public class NewExternalUserEntity {
     /**
      * The user first name
      */
+    @Schema(description = "The user first name.")
     private String firstname;
 
     /**
      * The user last name
      */
+    @Schema(description = "The user last name.")
     private String lastname;
 
     /**
      * The user email
      */
     @NotNull
+    @Schema(description = "The user email.")
     private String email;
 
     /**
@@ -54,6 +58,7 @@ public class NewExternalUserEntity {
     /**
      * The user source reference
      */
+    @Schema(description = "The unique identifier of the user for the given source.")
     private String sourceId;
 
     private Boolean newsletter;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewPreRegisterUserEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewPreRegisterUserEntity.java
@@ -15,12 +15,18 @@
  */
 package io.gravitee.rest.api.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class NewPreRegisterUserEntity extends NewExternalUserEntity {
 
+    @Schema(
+        description = "Whether this user is a service account. A service account must not have a firstname, and " +
+            "requires at least one of sourceId, lastname or email to derive a unique identifier."
+    )
     private boolean service = false;
 
     public boolean isService() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/NewPreRegisterUserEntityValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/NewPreRegisterUserEntityValidator.java
@@ -18,12 +18,18 @@ package io.gravitee.rest.api.validator;
 import io.gravitee.rest.api.model.NewPreRegisterUserEntity;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class NewPreRegisterUserEntityValidator implements ConstraintValidator<ValidNewPreRegisterUser, NewPreRegisterUserEntity> {
+
+    static final String SERVICE_ACCOUNT_FIRSTNAME_MESSAGE = "a service account must not have a firstname";
+    static final String SERVICE_ACCOUNT_IDENTIFIER_MESSAGE =
+        "a service account requires a sourceId, lastname or email to derive a unique identifier";
+    static final String EMAIL_REQUIRED_MESSAGE = "email is required";
 
     @Override
     public void initialize(ValidNewPreRegisterUser constraintAnnotation) {
@@ -32,15 +38,37 @@ public class NewPreRegisterUserEntityValidator implements ConstraintValidator<Va
 
     /**
      * Is valid when:
-     * - Is service account and firstName is null.
-     * - Is not service account and have an email
+     * - Is service account, firstName is blank, and at least one of sourceId, lastName or email is non-blank
+     *   (the service layer derives sourceId as sourceId -> lastName -> email, so one of the three must be present).
+     * - Is not service account and have a non-blank email
      */
     @Override
     public boolean isValid(NewPreRegisterUserEntity value, ConstraintValidatorContext context) {
         if (Boolean.TRUE.equals(value.isService())) {
-            return value.getFirstname() == null;
+            if (StringUtils.isNotBlank(value.getFirstname())) {
+                addViolation(context, SERVICE_ACCOUNT_FIRSTNAME_MESSAGE);
+                return false;
+            }
+            if (
+                StringUtils.isBlank(value.getSourceId()) &&
+                StringUtils.isBlank(value.getLastname()) &&
+                StringUtils.isBlank(value.getEmail())
+            ) {
+                addViolation(context, SERVICE_ACCOUNT_IDENTIFIER_MESSAGE);
+                return false;
+            }
+            return true;
         } else {
-            return value.getEmail() != null;
+            if (StringUtils.isBlank(value.getEmail())) {
+                addViolation(context, EMAIL_REQUIRED_MESSAGE);
+                return false;
+            }
+            return true;
         }
+    }
+
+    private void addViolation(ConstraintValidatorContext context, String message) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/validator/NewPreRegisterUserEntityValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/validator/NewPreRegisterUserEntityValidatorTest.java
@@ -15,7 +15,12 @@
  */
 package io.gravitee.rest.api.validator;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import io.gravitee.rest.api.model.NewPreRegisterUserEntity;
+import jakarta.validation.ConstraintValidatorContext;
 import java.util.Arrays;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,19 +37,33 @@ public class NewPreRegisterUserEntityValidatorTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NewPreRegisterUserEntityValidatorTest.class);
     private NewPreRegisterUserEntityValidator validator;
+    private ConstraintValidatorContext constraintValidatorContext;
 
     public static Iterable<Object[]> data() {
         return Arrays.asList(
             new Object[][] {
-                // email;firstName;isServiceAccount;shouldBeValid
-                { "", null, true, true },
-                { null, null, true, true },
-                { "mail@mail.mail", null, true, true },
-                { null, "firstName", true, false },
-                { "mail@mail.mail", "firstName", true, false },
-                { "", "firstName", false, true },
-                { null, "firstName", false, false },
-                { "mail@mail.mail", "firstName", false, true },
+                // email;firstName;lastName;sourceId;isServiceAccount;shouldBeValid
+                // sourceId is resolved as sourceId -> lastName -> email, so a service account is only rejected
+                // when none of the three can be used to derive a non-null sourceId (APIM-14832)
+                { "", null, null, null, true, false },
+                { null, null, null, null, true, false },
+                { "mail@mail.mail", null, null, null, true, true },
+                { "", null, "lastName", null, true, true },
+                { null, null, null, "sourceId", true, true },
+                { "mail@mail.mail", null, "lastName", "sourceId", true, true },
+                { null, "firstName", "lastName", "sourceId", true, false },
+                { "mail@mail.mail", "firstName", null, null, true, false },
+                { "", "firstName", null, null, false, false },
+                { null, "firstName", null, null, false, false },
+                { " ", "firstName", null, null, false, false },
+                { "mail@mail.mail", "firstName", null, null, false, true },
+                // whitespace-only values are not usable identifiers, isNotBlank must reject them too
+                { null, null, " ", null, true, false },
+                { null, null, null, " ", true, false },
+                { " ", null, null, null, true, false },
+                // blank firstname is "not set", consistent with isNotBlank used everywhere else
+                { "mail@mail.mail", "", null, null, true, true },
+                { "mail@mail.mail", " ", null, null, true, true },
             }
         );
     }
@@ -52,15 +71,27 @@ public class NewPreRegisterUserEntityValidatorTest {
     @BeforeEach
     public void setUp() {
         this.validator = new NewPreRegisterUserEntityValidator();
+        this.constraintValidatorContext = mock(ConstraintValidatorContext.class);
+        var violationBuilder = mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        when(constraintValidatorContext.buildConstraintViolationWithTemplate(any())).thenReturn(violationBuilder);
     }
 
     @MethodSource("data")
     @ParameterizedTest
-    public void shoultTestNewExternalUserEntityValidation(String email, String firstName, Boolean isServiceAccount, boolean shouldBeValid) {
+    public void shoultTestNewExternalUserEntityValidation(
+        String email,
+        String firstName,
+        String lastName,
+        String sourceId,
+        Boolean isServiceAccount,
+        boolean shouldBeValid
+    ) {
         LOGGER.info(
-            "Execute NewExternalUserEntity validation test for mail: '{}', firstName: '{}', serviceUser: {}, shouldBeValid: {}",
+            "Execute NewExternalUserEntity validation test for mail: '{}', firstName: '{}', lastName: '{}', sourceId: '{}', serviceUser: {}, shouldBeValid: {}",
             email,
             firstName,
+            lastName,
+            sourceId,
             isServiceAccount,
             shouldBeValid
         );
@@ -68,9 +99,11 @@ public class NewPreRegisterUserEntityValidatorTest {
         final NewPreRegisterUserEntity newPreRegisterUserEntity = new NewPreRegisterUserEntity();
         newPreRegisterUserEntity.setService(isServiceAccount);
         newPreRegisterUserEntity.setFirstname(firstName);
+        newPreRegisterUserEntity.setLastname(lastName);
+        newPreRegisterUserEntity.setSourceId(sourceId);
         newPreRegisterUserEntity.setEmail(email);
 
-        final boolean isValid = validator.isValid(newPreRegisterUserEntity, null);
+        final boolean isValid = validator.isValid(newPreRegisterUserEntity, constraintValidatorContext);
 
         Assertions.assertEquals(isValid, shouldBeValid);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -38,6 +38,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
@@ -896,13 +897,10 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     }
 
     private boolean isServiceAccount(User user) {
-        // A service account has the sourceId equals to the lastname or to the email address
-        return (
-            IDP_SOURCE_GRAVITEE.equals(user.getSource()) &&
-            user.getIsServiceAccount() != null &&
-            user.getIsServiceAccount() &&
-            (user.getSourceId().equalsIgnoreCase(user.getEmail()) || user.getSourceId().equalsIgnoreCase(user.getLastname()))
-        );
+        // isServiceAccount is authoritative; a sourceId comparison was a heuristic for records predating the
+        // flag and incorrectly excludes a service account created with an explicit sourceId that differs
+        // from both email and lastname (e.g. sourceId "sa-billing" with email "ops@acme.com").
+        return IDP_SOURCE_GRAVITEE.equals(user.getSource()) && Boolean.TRUE.equals(user.getIsServiceAccount());
     }
 
     /**
@@ -928,13 +926,33 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         if (isBlank(newExternalUserEntity.getSource())) {
             newExternalUserEntity.setSource(IDP_SOURCE_GRAVITEE);
         } else if (!IDP_SOURCE_GRAVITEE.equals(newExternalUserEntity.getSource())) {
-            // check if IDP exists
             identityProviderService.findById(newExternalUserEntity.getSource());
         }
 
-        if (isBlank(newExternalUserEntity.getSourceId())) {
-            newExternalUserEntity.setSourceId(isServiceUser ? newExternalUserEntity.getLastname() : newExternalUserEntity.getEmail());
+        if (isServiceUser && isBlank(newExternalUserEntity.getFirstname())) {
+            newExternalUserEntity.setFirstname(null);
         }
+
+        final String resolvedSourceId;
+        if (isBlank(newExternalUserEntity.getSourceId())) {
+            if (isServiceUser && isNotBlank(newExternalUserEntity.getLastname())) {
+                resolvedSourceId = newExternalUserEntity.getLastname();
+            } else {
+                resolvedSourceId = newExternalUserEntity.getEmail();
+            }
+        } else {
+            resolvedSourceId = newExternalUserEntity.getSourceId();
+        }
+        final String trimmedSourceId = StringUtils.trim(resolvedSourceId);
+        if (isBlank(trimmedSourceId)) {
+            throw new InvalidUserException(
+                "a service account requires a sourceId, lastname or email to derive a unique identifier",
+                newExternalUserEntity.getSource(),
+                null,
+                organizationId
+            );
+        }
+        newExternalUserEntity.setSourceId(trimmedSourceId);
 
         final Optional<User> optionalUser;
         try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -1347,6 +1347,32 @@ public class UserServiceTest {
         });
     }
 
+    @Test
+    public void shouldNotResetPasswordOnServiceAccountWithNullSourceId() throws TechnicalException {
+        // legacy/corrupted service account persisted with a null sourceId (see APIM-14832): must not NPE,
+        // and the isServiceAccount flag alone must still block the reset - a null sourceId must not be
+        // waved through as "not a service account"
+        when(user.getId()).thenReturn(USER_NAME);
+        when(user.getSource()).thenReturn("gravitee");
+        when(user.getSourceId()).thenReturn(null);
+        when(user.getOrganizationId()).thenReturn(ORGANIZATION);
+        when(user.getIsServiceAccount()).thenReturn(true);
+        when(userRepository.findById(USER_NAME)).thenReturn(of(user));
+
+        assertThrows(ServiceAccountNotManageableException.class, () -> userService.resetPassword(EXECUTION_CONTEXT, USER_NAME));
+    }
+
+    @Test
+    public void shouldNotResetPasswordOnServiceAccountWithMismatchedSourceId() throws TechnicalException {
+        when(user.getSource()).thenReturn("gravitee");
+        when(user.getSourceId()).thenReturn("sa-billing");
+        when(user.getOrganizationId()).thenReturn(ORGANIZATION);
+        when(user.getIsServiceAccount()).thenReturn(true);
+        when(userRepository.findById(USER_NAME)).thenReturn(of(user));
+
+        assertThrows(ServiceAccountNotManageableException.class, () -> userService.resetPassword(EXECUTION_CONTEXT, USER_NAME));
+    }
+
     private String createJWT(long expirationSeconds, String action) {
         Algorithm algorithm = Algorithm.HMAC256(JWT_SECRET);
 
@@ -2918,6 +2944,170 @@ public class UserServiceTest {
         userService.create(EXECUTION_CONTEXT, newPreRegisterUserEntity);
 
         verify(userRepository).create(argThat(userToCreate -> Boolean.TRUE.equals(userToCreate.getIsServiceAccount())));
+    }
+
+    @Test
+    public void shouldDeriveSourceIdFromEmailWhenServiceAccountHasNoLastname() throws TechnicalException {
+        // sourceId is resolved as sourceId -> lastname -> email, so a service account with only an
+        // email (the customer's original reproduction in APIM-14832) must never end up with a null sourceId
+        final NewPreRegisterUserEntity newPreRegisterUserEntity = mock(NewPreRegisterUserEntity.class);
+        when(newPreRegisterUserEntity.isService()).thenReturn(true);
+        when(newPreRegisterUserEntity.getEmail()).thenReturn(EMAIL);
+        when(newPreRegisterUserEntity.getSource()).thenReturn("gravitee");
+        when(newPreRegisterUserEntity.getLastname()).thenReturn(null);
+        doCallRealMethod().when(newPreRegisterUserEntity).setSourceId(any());
+        when(newPreRegisterUserEntity.getSourceId()).thenCallRealMethod();
+
+        when(organizationService.findById(ORGANIZATION)).thenReturn(new OrganizationEntity());
+        mockDefaultEnvironment();
+
+        when(user.getId()).thenReturn(USER_NAME);
+        when(user.getEmail()).thenReturn(EMAIL);
+        when(user.getFirstname()).thenReturn(null);
+        when(user.getPassword()).thenReturn(PASSWORD);
+        when(user.getCreatedAt()).thenReturn(date);
+        when(user.getUpdatedAt()).thenReturn(date);
+        when(user.getOrganizationId()).thenReturn(ORGANIZATION);
+        when(userRepository.create(any(User.class))).thenReturn(user);
+        RoleEntity roleEnv = mock(RoleEntity.class);
+        when(roleEnv.getScope()).thenReturn(RoleScope.ENVIRONMENT);
+        when(roleEnv.getName()).thenReturn("USER");
+        when(
+            membershipService.getRoles(MembershipReferenceType.ENVIRONMENT, ENVIRONMENT, MembershipMemberType.USER, user.getId())
+        ).thenReturn(new HashSet<>(List.of(roleEnv)));
+        RoleEntity roleOrg = mock(RoleEntity.class);
+        when(roleOrg.getScope()).thenReturn(RoleScope.ORGANIZATION);
+        when(roleOrg.getName()).thenReturn("USER");
+        when(
+            membershipService.getRoles(MembershipReferenceType.ORGANIZATION, ORGANIZATION, MembershipMemberType.USER, user.getId())
+        ).thenReturn(new HashSet<>(List.of(roleOrg)));
+
+        userService.create(EXECUTION_CONTEXT, newPreRegisterUserEntity);
+
+        verify(userRepository).create(argThat(userToCreate -> EMAIL.equals(userToCreate.getSourceId())));
+    }
+
+    @Test
+    public void shouldNotCreateServiceAccountWhenEmailDerivedSourceIdAlreadyExists() {
+        // ticket step 3 (APIM-14832): a second service account created with the same email must be
+        // rejected as a clean duplicate (InvalidUserException -> 400), not persisted with a colliding
+        // sourceId that later blows up as a 500 - findBySource must catch it because sourceId is now
+        // derived from email instead of being left null
+        assertThrows(InvalidUserException.class, () -> {
+            final NewPreRegisterUserEntity newPreRegisterUserEntity = mock(NewPreRegisterUserEntity.class);
+            when(newPreRegisterUserEntity.isService()).thenReturn(true);
+            when(newPreRegisterUserEntity.getEmail()).thenReturn(EMAIL);
+            when(newPreRegisterUserEntity.getSource()).thenReturn("gravitee");
+            when(newPreRegisterUserEntity.getLastname()).thenReturn(null);
+            doCallRealMethod().when(newPreRegisterUserEntity).setSourceId(any());
+            when(newPreRegisterUserEntity.getSourceId()).thenCallRealMethod();
+
+            when(userRepository.findBySource("gravitee", EMAIL, ORGANIZATION)).thenReturn(Optional.of(new User()));
+
+            userService.create(EXECUTION_CONTEXT, newPreRegisterUserEntity);
+        });
+    }
+
+    @Test
+    public void shouldTrimDerivedSourceId() throws TechnicalException {
+        // " sa " and "sa" must resolve to the same sourceId, otherwise they'd persist as distinct
+        // accounts under the exact-match findBySource lookup (APIM-14832)
+        final NewPreRegisterUserEntity newPreRegisterUserEntity = mock(NewPreRegisterUserEntity.class);
+        when(newPreRegisterUserEntity.isService()).thenReturn(true);
+        when(newPreRegisterUserEntity.getEmail()).thenReturn(EMAIL);
+        when(newPreRegisterUserEntity.getSource()).thenReturn("gravitee");
+        when(newPreRegisterUserEntity.getLastname()).thenReturn(" sa ");
+        doCallRealMethod().when(newPreRegisterUserEntity).setSourceId(any());
+        when(newPreRegisterUserEntity.getSourceId()).thenCallRealMethod();
+
+        when(organizationService.findById(ORGANIZATION)).thenReturn(new OrganizationEntity());
+        mockDefaultEnvironment();
+
+        when(user.getId()).thenReturn(USER_NAME);
+        when(user.getEmail()).thenReturn(EMAIL);
+        when(user.getFirstname()).thenReturn(null);
+        when(user.getPassword()).thenReturn(PASSWORD);
+        when(user.getCreatedAt()).thenReturn(date);
+        when(user.getUpdatedAt()).thenReturn(date);
+        when(user.getOrganizationId()).thenReturn(ORGANIZATION);
+        when(userRepository.create(any(User.class))).thenReturn(user);
+        RoleEntity roleEnv = mock(RoleEntity.class);
+        when(roleEnv.getScope()).thenReturn(RoleScope.ENVIRONMENT);
+        when(roleEnv.getName()).thenReturn("USER");
+        when(
+            membershipService.getRoles(MembershipReferenceType.ENVIRONMENT, ENVIRONMENT, MembershipMemberType.USER, user.getId())
+        ).thenReturn(new HashSet<>(List.of(roleEnv)));
+        RoleEntity roleOrg = mock(RoleEntity.class);
+        when(roleOrg.getScope()).thenReturn(RoleScope.ORGANIZATION);
+        when(roleOrg.getName()).thenReturn("USER");
+        when(
+            membershipService.getRoles(MembershipReferenceType.ORGANIZATION, ORGANIZATION, MembershipMemberType.USER, user.getId())
+        ).thenReturn(new HashSet<>(List.of(roleOrg)));
+
+        userService.create(EXECUTION_CONTEXT, newPreRegisterUserEntity);
+
+        verify(userRepository).create(argThat(userToCreate -> "sa".equals(userToCreate.getSourceId())));
+    }
+
+    @Test
+    public void shouldNotCreateServiceAccountWithNoDerivableSourceId() {
+        // defence in depth: NewPreRegisterUserEntityValidator normally rejects this shape at the API boundary,
+        // but the service layer itself must refuse to silently persist a blank sourceId if that invariant is
+        // ever bypassed by a future caller - a corrupt null-sourceId write is the original APIM-14832 defect,
+        // just one layer deeper, and would still 500 on the next create under the unique-index constraint
+        assertThrows(InvalidUserException.class, () -> {
+            final NewPreRegisterUserEntity newPreRegisterUserEntity = mock(NewPreRegisterUserEntity.class);
+            when(newPreRegisterUserEntity.isService()).thenReturn(true);
+            when(newPreRegisterUserEntity.getEmail()).thenReturn(null);
+            when(newPreRegisterUserEntity.getSource()).thenReturn("gravitee");
+            when(newPreRegisterUserEntity.getLastname()).thenReturn(null);
+            when(newPreRegisterUserEntity.getSourceId()).thenReturn(null);
+
+            userService.create(EXECUTION_CONTEXT, newPreRegisterUserEntity);
+        });
+    }
+
+    @Test
+    public void shouldNormalizeBlankFirstnameToNullForServiceAccount() throws TechnicalException {
+        // the validator allows a blank ("") firstname on a service account, not just a null one - it must
+        // still be persisted as null, since a non-null firstname on a service account is what the rule
+        // that rejects an explicit firstname exists to prevent (APIM-14832)
+        final NewPreRegisterUserEntity newPreRegisterUserEntity = mock(NewPreRegisterUserEntity.class);
+        when(newPreRegisterUserEntity.isService()).thenReturn(true);
+        when(newPreRegisterUserEntity.getEmail()).thenReturn(EMAIL);
+        when(newPreRegisterUserEntity.getSource()).thenReturn("gravitee");
+        doCallRealMethod().when(newPreRegisterUserEntity).setFirstname(any());
+        when(newPreRegisterUserEntity.getFirstname()).thenCallRealMethod();
+        newPreRegisterUserEntity.setFirstname("");
+        doCallRealMethod().when(newPreRegisterUserEntity).setSourceId(any());
+        when(newPreRegisterUserEntity.getSourceId()).thenCallRealMethod();
+
+        when(organizationService.findById(ORGANIZATION)).thenReturn(new OrganizationEntity());
+        mockDefaultEnvironment();
+
+        when(user.getId()).thenReturn(USER_NAME);
+        when(user.getEmail()).thenReturn(EMAIL);
+        when(user.getPassword()).thenReturn(PASSWORD);
+        when(user.getCreatedAt()).thenReturn(date);
+        when(user.getUpdatedAt()).thenReturn(date);
+        when(user.getOrganizationId()).thenReturn(ORGANIZATION);
+        when(userRepository.create(any(User.class))).thenReturn(user);
+        RoleEntity roleEnv = mock(RoleEntity.class);
+        when(roleEnv.getScope()).thenReturn(RoleScope.ENVIRONMENT);
+        when(roleEnv.getName()).thenReturn("USER");
+        when(
+            membershipService.getRoles(MembershipReferenceType.ENVIRONMENT, ENVIRONMENT, MembershipMemberType.USER, user.getId())
+        ).thenReturn(new HashSet<>(List.of(roleEnv)));
+        RoleEntity roleOrg = mock(RoleEntity.class);
+        when(roleOrg.getScope()).thenReturn(RoleScope.ORGANIZATION);
+        when(roleOrg.getName()).thenReturn("USER");
+        when(
+            membershipService.getRoles(MembershipReferenceType.ORGANIZATION, ORGANIZATION, MembershipMemberType.USER, user.getId())
+        ).thenReturn(new HashSet<>(List.of(roleOrg)));
+
+        userService.create(EXECUTION_CONTEXT, newPreRegisterUserEntity);
+
+        verify(userRepository).create(argThat(userToCreate -> userToCreate.getFirstname() == null));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14832

## Description


### Root cause
Three compounding issues:
1. `UserServiceImpl.createAndSendEmail()` derives `sourceId` for a service account from `lastname` only. If `lastname` is missing, `sourceId` is set to `null` — it never falls back further to `email`, even though `email` is the one field realistically guaranteed to be present.
2. `NewPreRegisterUserEntityValidator.isValid()` only checked that `firstname` was null for a service account — it never verified that anything usable for `sourceId` derivation was actually present.
3. `MongoUserRepository.findBySource()` returns `Optional.empty()` for a `null` `sourceId`, so the pre-create duplicate check never caught it — the conflict only surfaced later as a unique-index violation, wrapped into a generic `TechnicalManagementException` (500).

Side effect: a legacy null-`sourceId` service account could also trigger an NPE in `UserServiceImpl.isServiceAccount()` (reachable via the password-reset path), since it called `.equalsIgnoreCase()` on `getSourceId()` with no null guard.

### Fix
Rather than forcing callers to always supply `lastname` (which would break existing integrations — see the PostNord case in the ticket comments, where accounts are created with only `email` + `service: true`), the fix widens the `sourceId` derivation instead of narrowing the request contract:

- **`UserServiceImpl`**: `sourceId` is now resolved as `sourceId → lastname → email`, in that priority order. Since `email` is effectively always present, `sourceId` can no longer end up `null` for a service account.
- **`NewPreRegisterUserEntityValidator`**: a service account request is now rejected (`400`) only when `sourceId`, `lastname`, **and** `email` are all blank — the one case where an identifier truly cannot be derived. Every request shape that used to work (including email-only) keeps working.
- **`UserServiceImpl.isServiceAccount()`**: null-guards `getSourceId()` to prevent the NPE on already-corrupted records from before this fix.

### Behavior after the fix
Walking through the ticket's exact reproduction:
1. `{"email": "sa-one@example.com", "service": true}` → no `lastname`/`sourceId` → `sourceId` derived from email → **succeeds**.
2. `{"email": "sa-two@example.com", "service": true}` → different email → different derived `sourceId` → **succeeds, no 500**.
3. Posting the *same* email twice → same derived `sourceId` on both attempts → the pre-create check now catches it → clean **400 "user already exists"** instead of a raw 500.
4. A service account with **no** `email`, `lastname`, or `sourceId` at all → the only case that still gets a **400** (nothing to derive from).


### Before Fix
https://github.com/user-attachments/assets/70c5654f-b563-40c6-b5f7-a03b4491f2b6

### After Fix
https://github.com/user-attachments/assets/7002f884-a827-44fd-91ae-af317cb54d28



