### PR TITLE
feat(portal): filter catalog by category with shareable deep link

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
@@ -19,6 +19,7 @@
   <div class="api-list__header" [appIsMobile]="'api-list__header--mobile'">
     <div class="next-gen-h1" i18n="@@catalogTitle">Catalog</div>
     <div class="api-list__header__controls">
+      <app-category-select [categories]="categories()" [value]="categoryId()" (valueChange)="onCategorySelect($event)" />
       <app-button-toggle-group [(value)]="viewMode">
         <app-button-toggle-option value="grid" icon="grid_view" i18n-label label="Cards" />
         <app-button-toggle-option value="list" icon="view_list" i18n-label label="List" />
@@ -67,6 +68,19 @@
               </td>
             </ng-container>
 
+            <ng-container matColumnDef="category">
+              <th mat-header-cell *matHeaderCellDef i18n="@@tableHeaderCategory">Category</th>
+              <td mat-cell *matCellDef="let api">
+                @if (api.categoryIds) {
+                  @for (categoryId of api.categoryIds; track categoryId) {
+                    @if (categoryNameById().get(categoryId); as categoryName) {
+                      <mat-chip>{{ categoryName }}</mat-chip>
+                    }
+                  }
+                }
+              </td>
+            </ng-container>
+
             <ng-container matColumnDef="version">
               <th mat-header-cell *matHeaderCellDef i18n="@@tableHeaderVersion">Version</th>
               <td mat-cell *matCellDef="let api">{{ api.version }}</td>
@@ -107,6 +121,12 @@
         (selectPage)="onPageChange($event)"
         (selectPageSize)="onPageSizeChange($event)"
       />
+    } @else if (!loadingPage() && apiPaginator().error) {
+      <div class="api-list__empty-state">
+        <span class="material-icons icon-with-background" aria-hidden="true">error_outline</span>
+        <h2 class="next-gen-h5" i18n="@@catalogErrorTitle">Something went wrong</h2>
+        <p i18n="@@catalogErrorDescription">We couldn't load the catalog. Please try again later.</p>
+      </div>
     } @else if (!loadingPage()) {
       <div class="api-list__empty-state">
         <span class="material-icons icon-with-background" aria-hidden="true">search</span>

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.scss
@@ -52,12 +52,16 @@ $empty-state-height: 400px;
       app-search-bar {
         width: 300px;
       }
+
+      app-category-select {
+        width: 200px;
+      }
     }
 
     &--mobile {
       display: grid;
       grid-template-columns: 1fr auto;
-      grid-template-rows: auto auto;
+      grid-template-rows: auto auto auto;
       gap: 16px;
 
       .next-gen-h1 {
@@ -74,9 +78,15 @@ $empty-state-height: 400px;
         grid-row: 1 / 2;
       }
 
-      app-search-bar {
+      app-category-select {
         grid-column: 1 / 3;
         grid-row: 2 / 3;
+        width: 100%;
+      }
+
+      app-search-bar {
+        grid-column: 1 / 3;
+        grid-row: 3 / 4;
         width: 100%;
       }
     }

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
@@ -17,12 +17,17 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
 
 import { CatalogComponent } from './catalog.component';
 import { ApiCardHarness } from '../../components/api-card/api-card.harness';
+import { CategorySelectHarness } from '../../components/category-select/category-select.component.harness';
 import { PaginationHarness } from '../../components/pagination/pagination.harness';
 import { fakeApi, fakeApisResponse } from '../../entities/api/api.fixtures';
 import { ApisResponse } from '../../entities/api/apis-response';
+import { PortalCategory } from '../../entities/categories/portal-category';
+import { fakePortalCategory } from '../../entities/categories/portal-category.fixture';
 import { PortalNavigationItemsSearchResponse } from '../../entities/portal-navigation/portal-navigation-apis-search';
 import { AppTestingModule, TESTING_BASE_URL } from '../../testing/app-testing.module';
 
@@ -40,6 +45,8 @@ describe('CatalogComponent', () => {
 
     httpTestingController = TestBed.inject(HttpTestingController);
     harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+
+    flushCategories();
 
     fixture.detectChanges();
   };
@@ -60,6 +67,20 @@ describe('CatalogComponent', () => {
     await initBase();
     expectApiList(params.apisResponse, params.page ?? 1, params.size ?? 20, params.hasNextPage ?? false);
     fixture.detectChanges();
+  };
+
+  const initWithQueryParams = async (queryParams: Record<string, string>) => {
+    await TestBed.configureTestingModule({
+      imports: [CatalogComponent, AppTestingModule],
+    })
+      .overrideProvider(ActivatedRoute, {
+        useValue: { snapshot: { queryParams }, queryParams: of(queryParams) },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(CatalogComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture);
   };
 
   afterEach(() => {
@@ -161,7 +182,7 @@ describe('CatalogComponent', () => {
     });
 
     describe('when error occurs', () => {
-      it('should show empty API list', async () => {
+      it('should show a generic error state', async () => {
         await initBase();
         httpTestingController
           .expectOne(portalSearchUrl(1, 20))
@@ -170,7 +191,75 @@ describe('CatalogComponent', () => {
 
         const emptyState = fixture.nativeElement.querySelector('.api-list__empty-state');
         expect(emptyState).toBeTruthy();
-        expect(emptyState.textContent).toContain('No APIs available yet');
+        expect(emptyState.textContent).toContain('Something went wrong');
+      });
+    });
+  });
+
+  describe('category filtering', () => {
+    const categories = [
+      fakePortalCategory({ id: 'cat-1', title: 'Category One' }),
+      fakePortalCategory({ id: 'cat-2', title: 'Category Two' }),
+    ];
+
+    it('should send categoryId to the search endpoint and hydrate the selector from the URL', async () => {
+      await initWithQueryParams({ category: 'cat-1' });
+
+      const req = httpTestingController.expectOne(
+        r => r.url === `${TESTING_BASE_URL}/portal-navigation-items/_search` && r.params.get('categoryId') === 'cat-1',
+      );
+      req.flush(toPortalSearchResponse(fakeApisResponse({ data: [] }), 1, 20));
+
+      flushCategories(categories);
+      fixture.detectChanges();
+
+      const categorySelect = await harnessLoader.getHarness(CategorySelectHarness);
+      expect(await categorySelect.getSelectedText()).toEqual('Category One');
+    });
+
+    it('should show a generic error state for an unknown or hidden category id', async () => {
+      await initWithQueryParams({ category: 'unknown-id' });
+
+      // the initial search fires before the visible categories have loaded, since validity isn't known yet
+      httpTestingController
+        .expectOne(r => r.url === `${TESTING_BASE_URL}/portal-navigation-items/_search`)
+        .flush(toPortalSearchResponse(fakeApisResponse({ data: [] }), 1, 20));
+
+      flushCategories(categories);
+      fixture.detectChanges();
+
+      const emptyState = fixture.nativeElement.querySelector('.api-list__empty-state');
+      expect(emptyState).toBeTruthy();
+      expect(emptyState.textContent).toContain('Something went wrong');
+    });
+
+    it('should navigate with the selected category and clear the search query', async () => {
+      await init();
+      const router = TestBed.inject(Router);
+      const route = TestBed.inject(ActivatedRoute);
+      const navigateSpy = jest.spyOn(router, 'navigate');
+
+      fixture.componentInstance.onCategorySelect('cat-1');
+
+      expect(navigateSpy).toHaveBeenCalledWith([], {
+        relativeTo: route,
+        queryParams: { category: 'cat-1', query: null },
+        queryParamsHandling: 'merge',
+      });
+    });
+
+    it('should preserve the selected category when the search query changes', async () => {
+      await init();
+      const router = TestBed.inject(Router);
+      const route = TestBed.inject(ActivatedRoute);
+      const navigateSpy = jest.spyOn(router, 'navigate');
+
+      fixture.componentInstance.onSearchResults('weather');
+
+      expect(navigateSpy).toHaveBeenCalledWith([], {
+        relativeTo: route,
+        queryParams: { query: 'weather' },
+        queryParamsHandling: 'merge',
       });
     });
   });
@@ -216,5 +305,9 @@ describe('CatalogComponent', () => {
     const url = `${TESTING_BASE_URL}/portal-navigation-items/_search?type=api&include=api&page=${page}&size=${size}`;
     const req = httpTestingController.expectOne(url);
     req.flush(toPortalSearchResponse(apisResponse, page, size, hasNextPage));
+  }
+
+  function flushCategories(categories: PortalCategory[] = []) {
+    httpTestingController.expectOne(`${TESTING_BASE_URL}/portal-categories`).flush({ data: categories });
   }
 });

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
@@ -205,32 +205,49 @@ describe('CatalogComponent', () => {
     it('should send categoryId to the search endpoint and hydrate the selector from the URL', async () => {
       await initWithQueryParams({ category: 'cat-1' });
 
+      // the search is held back until the visible categories have loaded, so categoryId is only ever sent once validated
+      flushCategories(categories);
+      fixture.detectChanges();
+
       const req = httpTestingController.expectOne(
         r => r.url === `${TESTING_BASE_URL}/portal-navigation-items/_search` && r.params.get('categoryId') === 'cat-1',
       );
       req.flush(toPortalSearchResponse(fakeApisResponse({ data: [] }), 1, 20));
-
-      flushCategories(categories);
       fixture.detectChanges();
 
       const categorySelect = await harnessLoader.getHarness(CategorySelectHarness);
       expect(await categorySelect.getSelectedText()).toEqual('Category One');
     });
 
-    it('should show a generic error state for an unknown or hidden category id', async () => {
+    it('should show a generic error state for an unknown or hidden category id, without calling search', async () => {
       await initWithQueryParams({ category: 'unknown-id' });
-
-      // the initial search fires before the visible categories have loaded, since validity isn't known yet
-      httpTestingController
-        .expectOne(r => r.url === `${TESTING_BASE_URL}/portal-navigation-items/_search`)
-        .flush(toPortalSearchResponse(fakeApisResponse({ data: [] }), 1, 20));
 
       flushCategories(categories);
       fixture.detectChanges();
 
+      httpTestingController.expectNone(r => r.url === `${TESTING_BASE_URL}/portal-navigation-items/_search`);
+
       const emptyState = fixture.nativeElement.querySelector('.api-list__empty-state');
       expect(emptyState).toBeTruthy();
       expect(emptyState.textContent).toContain('Something went wrong');
+    });
+
+    it('should still run the search when the categories list fails to load while a category is selected', async () => {
+      await initWithQueryParams({ category: 'cat-1' });
+
+      httpTestingController
+        .expectOne(`${TESTING_BASE_URL}/portal-categories`)
+        .flush({ error: { message: 'Error occurred' } }, { status: 500, statusText: 'Internal Error' });
+      fixture.detectChanges();
+
+      const req = httpTestingController.expectOne(
+        r => r.url === `${TESTING_BASE_URL}/portal-navigation-items/_search` && r.params.get('categoryId') === 'cat-1',
+      );
+      req.flush(toPortalSearchResponse(fakeApisResponse(), 1, 20));
+      fixture.detectChanges();
+
+      const apiCard = await harnessLoader.getHarness(ApiCardHarness);
+      expect(apiCard).toBeDefined();
     });
 
     it('should navigate with the selected category and clear the search query', async () => {

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
@@ -181,15 +181,16 @@ export class CatalogComponent {
         unknownCategory: this.unknownCategory(),
       })),
       distinctUntilChanged((previous, current) => isEqual(previous, current)),
-      tap(_ => this.loadingPage.set(true)),
-      switchMap(({ page, pageSize, query, categoryId, unknownCategory }) =>
-        unknownCategory
-          ? of({ data: [], metadata: undefined, error: true })
-          : this.portalNavigationItemsService.searchNavigationItemsWithApis(page, query, pageSize, categoryId ?? undefined).pipe(
-              map(resp => ({ ...resp, error: false })),
-              catchError(_ => of({ data: [], metadata: undefined, error: true })),
-            ),
-      ),
+      switchMap(({ page, pageSize, query, categoryId, unknownCategory }) => {
+        if (unknownCategory) {
+          return of({ data: [], metadata: undefined, error: true });
+        }
+        this.loadingPage.set(true);
+        return this.portalNavigationItemsService.searchNavigationItemsWithApis(page, query, pageSize, categoryId ?? undefined).pipe(
+          map(resp => ({ ...resp, error: false })),
+          catchError(_ => of({ data: [], metadata: undefined, error: true })),
+        );
+      }),
       map(resp => {
         const data = resp.data.map(item => ({
           id: item.id,

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
@@ -21,7 +21,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
 import { isEqual } from 'lodash';
-import { BehaviorSubject, catchError, distinctUntilChanged, map, Observable, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, catchError, distinctUntilChanged, filter, map, Observable, switchMap, tap } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
 
 import { ApiCardComponent } from '../../components/api-card/api-card.component';
@@ -57,6 +57,11 @@ interface ApiPaginatorVM {
   page: number;
   totalResults: number;
   error: boolean;
+}
+
+interface CategoriesState {
+  categories: PortalCategory[];
+  status: 'loading' | 'loaded' | 'error';
 }
 
 @Component({
@@ -99,18 +104,18 @@ export class CatalogComponent {
   protected readonly categoryId = toSignal(this.route.queryParams.pipe(map(p => p['category'] ?? null)), {
     initialValue: null as string | null,
   });
-  private readonly categoriesState = toSignal(
+  private readonly categoriesState = toSignal<CategoriesState, CategoriesState>(
     this.portalCategoriesService.getCategories().pipe(
-      map(categories => ({ categories, loaded: true })),
-      catchError(_ => of({ categories: [] as PortalCategory[], loaded: true })),
+      map((categories): CategoriesState => ({ categories, status: 'loaded' })),
+      catchError((): Observable<CategoriesState> => of({ categories: [], status: 'error' })),
     ),
-    { initialValue: { categories: [] as PortalCategory[], loaded: false } },
+    { initialValue: { categories: [] as PortalCategory[], status: 'loading' as const } },
   );
   protected readonly categories = computed(() => this.categoriesState().categories);
   protected readonly unknownCategory = computed(() => {
     const categoryId = this.categoryId();
-    const { categories, loaded } = this.categoriesState();
-    return !!categoryId && loaded && !categories.some(category => category.id === categoryId);
+    const { categories, status } = this.categoriesState();
+    return !!categoryId && status === 'loaded' && !categories.some(category => category.id === categoryId);
   });
   protected readonly categoryNameById = computed(() => new Map(this.categories().map(category => [category.id, category.title])));
   protected readonly tableColumns = computed(() =>
@@ -178,8 +183,11 @@ export class CatalogComponent {
         pageSize: this.pageSize,
         query: this.query(),
         categoryId: this.categoryId(),
+        status: this.categoriesState().status,
         unknownCategory: this.unknownCategory(),
       })),
+      filter(({ categoryId, status }) => !categoryId || status !== 'loading'),
+      map(({ status: _status, ...rest }) => rest),
       distinctUntilChanged((previous, current) => isEqual(previous, current)),
       switchMap(({ page, pageSize, query, categoryId, unknownCategory }) => {
         if (unknownCategory) {

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
@@ -29,11 +29,14 @@ import { BadgeComponent } from '../../components/badge/badge.component';
 import { ButtonToggleGroupComponent } from '../../components/button-toggle-group/button-toggle-group.component';
 import { ButtonToggleOptionComponent } from '../../components/button-toggle-group/button-toggle-option.component';
 import { CardsGridComponent } from '../../components/cards-grid/cards-grid.component';
+import { CategorySelectComponent } from '../../components/category-select/category-select.component';
 import { LoaderComponent } from '../../components/loader/loader.component';
 import { PaginationComponent } from '../../components/pagination/pagination.component';
 import { SearchBarComponent } from '../../components/search-bar/search-bar.component';
 import { MobileClassDirective } from '../../directives/mobile-class.directive';
+import { PortalCategory } from '../../entities/categories/portal-category';
 import { ObservabilityBreakpointService } from '../../services/observability-breakpoint.service';
+import { PortalCategoriesService } from '../../services/portal-categories.service';
 import { PortalNavigationItemsService } from '../../services/portal-navigation-items.service';
 
 interface ApiVM {
@@ -44,6 +47,7 @@ interface ApiVM {
   isEnabledMcpServer: boolean;
   picture?: string;
   labels?: string[];
+  categoryIds?: string[];
   rootId: string;
   navItemId: string;
 }
@@ -52,6 +56,7 @@ interface ApiPaginatorVM {
   data: ApiVM[];
   page: number;
   totalResults: number;
+  error: boolean;
 }
 
 @Component({
@@ -63,6 +68,7 @@ interface ApiPaginatorVM {
     ButtonToggleGroupComponent,
     ButtonToggleOptionComponent,
     CardsGridComponent,
+    CategorySelectComponent,
     LoaderComponent,
     MobileClassDirective,
     PaginationComponent,
@@ -82,6 +88,7 @@ export class CatalogComponent {
   viewMode = signal<'grid' | 'list'>('grid');
 
   private readonly portalNavigationItemsService = inject(PortalNavigationItemsService);
+  private readonly portalCategoriesService = inject(PortalCategoriesService);
   private readonly breakpointService = inject(ObservabilityBreakpointService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
@@ -89,16 +96,36 @@ export class CatalogComponent {
 
   private readonly page$ = new BehaviorSubject<number>(1);
   protected readonly query = toSignal(this.route.queryParams.pipe(map(p => p['query'] ?? '')), { initialValue: '' });
-  protected readonly tableColumns = computed(() => (this.isMobile() ? ['name', 'version', 'mcp'] : ['name', 'labels', 'version', 'mcp']));
+  protected readonly categoryId = toSignal(this.route.queryParams.pipe(map(p => p['category'] ?? null)), {
+    initialValue: null as string | null,
+  });
+  private readonly categoriesState = toSignal(
+    this.portalCategoriesService.getCategories().pipe(
+      map(categories => ({ categories, loaded: true })),
+      catchError(_ => of({ categories: [] as PortalCategory[], loaded: true })),
+    ),
+    { initialValue: { categories: [] as PortalCategory[], loaded: false } },
+  );
+  protected readonly categories = computed(() => this.categoriesState().categories);
+  protected readonly unknownCategory = computed(() => {
+    const categoryId = this.categoryId();
+    const { categories, loaded } = this.categoriesState();
+    return !!categoryId && loaded && !categories.some(category => category.id === categoryId);
+  });
+  protected readonly categoryNameById = computed(() => new Map(this.categories().map(category => [category.id, category.title])));
+  protected readonly tableColumns = computed(() =>
+    this.isMobile() ? ['name', 'version', 'mcp'] : ['name', 'labels', 'category', 'version', 'mcp'],
+  );
   protected apiPaginator: Signal<ApiPaginatorVM> = toSignal(this.loadNavigationItemsWithApis$(), {
-    initialValue: { data: [], page: 1, totalResults: 0 },
+    initialValue: { data: [], page: 1, totalResults: 0, error: false },
   });
 
   constructor() {
     effect(() => {
-      if (this.query() || this.query() === '') {
-        this.page$.next(1);
-      }
+      this.query();
+      this.categoryId();
+      this.categoriesState();
+      this.page$.next(1);
     });
   }
 
@@ -116,6 +143,17 @@ export class CatalogComponent {
       this.router.navigate([], {
         relativeTo: this.route,
         queryParams: { query: searchInput },
+        queryParamsHandling: 'merge',
+      });
+    }
+  }
+
+  onCategorySelect(categoryId: string | null) {
+    if (categoryId !== this.categoryId()) {
+      this.router.navigate([], {
+        relativeTo: this.route,
+        queryParams: { category: categoryId, query: null },
+        queryParamsHandling: 'merge',
       });
     }
   }
@@ -135,13 +173,22 @@ export class CatalogComponent {
 
   private loadNavigationItemsWithApis$(): Observable<ApiPaginatorVM> {
     return this.page$.pipe(
-      map(page => ({ page, pageSize: this.pageSize, query: this.query() })),
+      map(page => ({
+        page,
+        pageSize: this.pageSize,
+        query: this.query(),
+        categoryId: this.categoryId(),
+        unknownCategory: this.unknownCategory(),
+      })),
       distinctUntilChanged((previous, current) => isEqual(previous, current)),
       tap(_ => this.loadingPage.set(true)),
-      switchMap(({ page, pageSize, query }) =>
-        this.portalNavigationItemsService
-          .searchNavigationItemsWithApis(page, query, pageSize)
-          .pipe(catchError(_ => of({ data: [], metadata: undefined }))),
+      switchMap(({ page, pageSize, query, categoryId, unknownCategory }) =>
+        unknownCategory
+          ? of({ data: [], metadata: undefined, error: true })
+          : this.portalNavigationItemsService.searchNavigationItemsWithApis(page, query, pageSize, categoryId ?? undefined).pipe(
+              map(resp => ({ ...resp, error: false })),
+              catchError(_ => of({ data: [], metadata: undefined, error: true })),
+            ),
       ),
       map(resp => {
         const data = resp.data.map(item => ({
@@ -152,6 +199,7 @@ export class CatalogComponent {
           picture: item._links?.picture,
           isEnabledMcpServer: !!item.mcp,
           labels: item.labels,
+          categoryIds: item.categoryIds,
           rootId: item.rootId,
           navItemId: item.navItemId,
         }));
@@ -162,6 +210,7 @@ export class CatalogComponent {
           data,
           page,
           totalResults,
+          error: resp.error,
         };
       }),
       tap(_ => this.loadingPage.set(false)),

--- a/gravitee-apim-portal-webui-next/src/components/category-select/category-select.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/category-select/category-select.component.harness.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatMenuHarness } from '@angular/material/menu/testing';
+
+export class CategorySelectHarness extends ComponentHarness {
+  public static readonly hostSelector = 'app-category-select';
+
+  protected locateMenu = this.locatorFor(MatMenuHarness);
+  protected locateTriggerValue = this.locatorFor('.category-select__value');
+
+  async getSelectedText(): Promise<string> {
+    return (await this.locateTriggerValue()).text();
+  }
+
+  async selectCategory(text: string): Promise<void> {
+    const menu = await this.locateMenu();
+    await menu.open();
+    const [item] = await menu.getItems({ text });
+    await item.click();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/category-select/category-select.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/category-select/category-select.component.html
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<button class="category-select" type="button" [matMenuTriggerFor]="menu">
+  <span class="category-select__label" i18n="@@catalogCategorySelectLabel">Category:</span>
+  <span class="category-select__value">{{ selectedLabel() }}</span>
+  <span class="material-icons category-select__icon" aria-hidden="true">arrow_drop_down</span>
+</button>
+
+<mat-menu #menu="matMenu">
+  <button mat-menu-item (click)="select(null)" i18n="@@catalogCategorySelectAllOption">All categories</button>
+  @for (category of categories(); track category.id) {
+    <button mat-menu-item (click)="select(category.id)">{{ category.title }}</button>
+  }
+</mat-menu>

--- a/gravitee-apim-portal-webui-next/src/components/category-select/category-select.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/category-select/category-select.component.scss
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/theme' as app-theme;
+
+.category-select {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 40px;
+  padding: 0 16px;
+  border: app-theme.$border-width solid app-theme.$border-color;
+  border-radius: app-theme.$element-shape;
+  background-color: app-theme.$card-background-color;
+  box-sizing: border-box;
+  cursor: pointer;
+  font-family: app-theme.$font-family;
+  color: app-theme.$default-text-color;
+
+  &__label {
+    font-weight: 700;
+    white-space: nowrap;
+  }
+
+  &__value {
+    color: app-theme.$primary-main-color;
+    white-space: nowrap;
+  }
+
+  &__icon {
+    margin-left: auto;
+    color: app-theme.$paragraph-color;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/category-select/category-select.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/category-select/category-select.component.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { CategorySelectComponent } from './category-select.component';
+import { CategorySelectHarness } from './category-select.component.harness';
+import { fakePortalCategory } from '../../entities/categories/portal-category.fixture';
+
+describe('CategorySelectComponent', () => {
+  let fixture: ComponentFixture<CategorySelectComponent>;
+  let harness: CategorySelectHarness;
+
+  const categories = [
+    fakePortalCategory({ id: 'cat-1', title: 'Category One' }),
+    fakePortalCategory({ id: 'cat-2', title: 'Category Two' }),
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CategorySelectComponent],
+      providers: [provideNoopAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CategorySelectComponent);
+    fixture.componentRef.setInput('categories', categories);
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, CategorySelectHarness);
+  });
+
+  it('should default to "All"', async () => {
+    expect(await harness.getSelectedText()).toEqual('All');
+  });
+
+  it('should reflect the bound value', async () => {
+    fixture.componentRef.setInput('categories', categories);
+    fixture.componentInstance.value.set('cat-2');
+    fixture.detectChanges();
+
+    expect(await harness.getSelectedText()).toEqual('Category Two');
+  });
+
+  it('should update the value model when an option is selected', async () => {
+    await harness.selectCategory('Category One');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.value()).toEqual('cat-1');
+  });
+
+  it('should clear the value model when "All categories" is selected', async () => {
+    fixture.componentInstance.value.set('cat-2');
+    fixture.detectChanges();
+
+    await harness.selectCategory('All categories');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.value()).toBeNull();
+    expect(await harness.getSelectedText()).toEqual('All');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/category-select/category-select.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/category-select/category-select.component.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, input, model } from '@angular/core';
+import { MatMenuModule } from '@angular/material/menu';
+
+import { PortalCategory } from '../../entities/categories/portal-category';
+
+const ALL_LABEL = $localize`:@@catalogCategorySelectAllValue:All`;
+
+@Component({
+  selector: 'app-category-select',
+  standalone: true,
+  imports: [MatMenuModule],
+  templateUrl: './category-select.component.html',
+  styleUrl: './category-select.component.scss',
+})
+export class CategorySelectComponent {
+  readonly categories = input.required<PortalCategory[]>();
+  readonly value = model<string | null>(null);
+
+  protected readonly selectedLabel = computed(() => this.categories().find(category => category.id === this.value())?.title ?? ALL_LABEL);
+
+  select(categoryId: string | null): void {
+    this.value.set(categoryId);
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/entities/categories/portal-category.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/categories/portal-category.fixture.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isFunction } from 'lodash';
+
+import { PortalCategory } from './portal-category';
+
+export function fakePortalCategory(overrides?: Partial<PortalCategory> | ((base: PortalCategory) => PortalCategory)): PortalCategory {
+  const base: PortalCategory = {
+    id: 'category-1',
+    title: 'Category 1',
+    description: 'My first category',
+  };
+
+  if (isFunction(overrides)) {
+    return overrides(base);
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/entities/categories/portal-category.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/categories/portal-category.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface PortalCategory {
+  id: string;
+  title: string;
+  description?: string;
+}
+
+export interface PortalCategoriesResponse {
+  data: PortalCategory[];
+}

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-apis-search.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-apis-search.ts
@@ -29,6 +29,7 @@ export interface PortalNavigationApiSearchItem {
   labels?: string[];
   rootId: string;
   navItemId: string;
+  categoryIds?: string[];
 }
 
 export interface PortalNavigationSearchMetadata {

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.ts
@@ -48,6 +48,7 @@ export interface PortalNavigationLink extends BasePortalNavigationItem {
 export interface PortalNavigationApi extends BasePortalNavigationItem {
   type: 'API';
   apiId: string;
+  categoryIds?: string[];
 }
 
 export interface PortalNavigationApiProduct extends BasePortalNavigationItem {

--- a/gravitee-apim-portal-webui-next/src/services/portal-categories.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-categories.service.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { PortalCategoriesService } from './portal-categories.service';
+import { fakePortalCategory } from '../entities/categories/portal-category.fixture';
+import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
+
+describe('PortalCategoriesService', () => {
+  let service: PortalCategoriesService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(PortalCategoriesService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should return the list of visible portal categories', done => {
+    const categories = [fakePortalCategory(), fakePortalCategory({ id: 'category-2', title: 'Category 2' })];
+
+    service.getCategories().subscribe(response => {
+      expect(response).toEqual(categories);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/portal-categories`);
+    expect(req.request.method).toEqual('GET');
+
+    req.flush({ data: categories });
+  });
+
+  it('should return an empty array when data is missing', done => {
+    service.getCategories().subscribe(response => {
+      expect(response).toEqual([]);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/portal-categories`);
+    req.flush({});
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/portal-categories.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-categories.service.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { map, Observable } from 'rxjs';
+
+import { ConfigService } from './config.service';
+import { PortalCategoriesResponse, PortalCategory } from '../entities/categories/portal-category';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PortalCategoriesService {
+  constructor(
+    private readonly http: HttpClient,
+    private readonly configService: ConfigService,
+  ) {}
+
+  getCategories(): Observable<PortalCategory[]> {
+    return this.http.get<PortalCategoriesResponse>(`${this.configService.baseURL}/portal-categories`).pipe(map(res => res.data ?? []));
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
@@ -228,4 +228,21 @@ describe('PortalNavigationItemsService', () => {
     );
     req.flush(rawResponse);
   });
+
+  it('should pass categoryId when searching APIs within a category', done => {
+    service.searchNavigationItemsWithApis(1, '', 10, 'category-1').subscribe(() => done());
+
+    const req = httpMock.expectOne(
+      r => r.method === 'GET' && r.url === `${baseURL}/portal-navigation-items/_search` && r.params.get('categoryId') === 'category-1',
+    );
+    req.flush({ data: [], apis: [] });
+  });
+
+  it('should not send categoryId when not provided', done => {
+    service.searchNavigationItemsWithApis(1, '', 10).subscribe(() => done());
+
+    const req = httpMock.expectOne(r => r.method === 'GET' && r.url === `${baseURL}/portal-navigation-items/_search`);
+    expect(req.request.params.has('categoryId')).toBe(false);
+    req.flush({ data: [], apis: [] });
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.ts
@@ -72,7 +72,7 @@ export class PortalNavigationItemsService {
     );
   }
 
-  searchNavigationItemsWithApis(page = 1, query = '', size = 8): Observable<PortalNavigationApisSearchResponse> {
+  searchNavigationItemsWithApis(page = 1, query = '', size = 8, categoryId?: string): Observable<PortalNavigationApisSearchResponse> {
     const params: Record<string, string | number> = {
       type: 'api',
       include: 'api',
@@ -80,6 +80,7 @@ export class PortalNavigationItemsService {
       size,
     };
     if (query) params['query'] = query;
+    if (categoryId) params['categoryId'] = categoryId;
 
     return this.http
       .get<PortalNavigationItemsSearchResponse>(`${this.configService.baseURL}/portal-navigation-items/_search`, { params })
@@ -107,6 +108,7 @@ export class PortalNavigationItemsService {
                 labels: api.labels,
                 rootId: item.rootId,
                 navItemId: item.id,
+                categoryIds: item.categoryIds,
               },
             ]
           : [];


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PORTAL-23

**Purpose**

Let a portal consumer filter the API catalog by category and share/bookmark the filtered view as a deep link.

**Summary of changes**

- `PortalNavigationApi.categoryIds?: string[]` added to the nav-item entity; threaded through the search response mapping into the catalog's row view model.
- New `PortalCategory` entity + `PortalCategoriesService` (`GET /portal-categories`) to list visible categories.
- `PortalNavigationItemsService.searchNavigationItemsWithApis()` takes an optional `categoryId` and forwards it to `_search`.
- New `CategorySelectComponent`: a compact "Category: All ▾" dropdown (styled to match the Figma spec), placed left of the grid/list toggle in the catalog header.
- Catalog page: hydrates the selected category from the `category` query param on load; selecting/clearing syncs the URL via `Router.navigate` with `queryParamsHandling: 'merge'` and resets the search query + pagination.
- Fixed the search box's navigation to merge query params instead of replacing them, so an active category filter no longer gets wiped out by typing a search term.
- Added a generic inline error state (distinct from the existing "no results" empty state) for both backend search failures and an unknown/hidden `category` id in the URL.
- List view gained a **Category** column (chip badges), matching the Figma mockup.

**Out of scope**

- The `/portal-categories` and `categoryId` search-filter backend support (already shipped in the PORTAL-22 PR this stacks on).
- Category management/admin UI (pre-existing, unrelated).

**Testing**

- Full `portal-webui-next` unit test suite (1171 tests) passes, including new/updated specs for `CatalogComponent`, `CategorySelectComponent`, `PortalCategoriesService`, and `PortalNavigationItemsService`.
- `lint-eslint`, `lint-prettier`, `lint-license`, and a production `build` all pass.
- Not yet manually verified in a running browser — follow-up before merge.

**Additional context**

Stacked on #19062 (PORTAL-22) — base branch is `portal-22-nav-category-filter`, not `master`. Figma reference: the "Categories - Next Gen Portal" file (node 1:4800 / catalog header).