### PR TITLE
feat(portal-next): unify nav-item validation across console and automation writes

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/GraviteeAutomationApplication.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/GraviteeAutomationApplication.java
@@ -37,6 +37,7 @@ import io.gravitee.rest.api.management.v2.rest.exceptionmapper.ConstraintValidat
 import io.gravitee.rest.api.management.v2.rest.exceptionmapper.JsonMappingExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionmapper.ManagementExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionmapper.NotAllowedExceptionMapper;
+import io.gravitee.rest.api.management.v2.rest.exceptionmapper.domain.ConflictDomainExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.provider.ObjectMapperResolver;
 import jakarta.inject.Inject;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -67,6 +68,7 @@ public class GraviteeAutomationApplication extends ResourceConfig {
         register(PortalResource.class);
 
         register(ValidationDomainMapper.class);
+        register(ConflictDomainExceptionMapper.class);
         register(HRIDNotFoundMapper.class);
         register(ManagementExceptionMapper.class);
         register(ConstraintValidationExceptionMapper.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiDocumentationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiDocumentationsResource.java
@@ -18,10 +18,12 @@ package io.gravitee.apim.rest.api.automation.resource;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
 
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdateApiDocumentationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ValidateApiDocumentationUseCase;
 import io.gravitee.apim.rest.api.automation.mapper.ApiDocumentationMapper;
+import io.gravitee.apim.rest.api.automation.model.DocumentationArea;
 import io.gravitee.apim.rest.api.automation.model.DocumentationSpec;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -69,6 +71,9 @@ public class ApiDocumentationsResource extends AbstractResource {
         @Valid @NotNull DocumentationSpec spec,
         @QueryParam("dryRun") boolean dryRun
     ) {
+        if (spec.getArea() != null && spec.getArea() != DocumentationArea.TOP_NAVBAR) {
+            throw new ValidationDomainException("API documentation must be under TOP_NAVBAR area");
+        }
         var auditInfo = getAuditInfo();
         var apiId = HRIDToUUID.api().context(auditInfo).hrid(apiHrid).id();
         var documentationId = PortalPageContentId.of(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiDocumentationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiDocumentationsResourceTest.java
@@ -139,6 +139,21 @@ class ApiDocumentationsResourceTest extends AbstractResourceTest {
                 verifyNoInteractions(createOrUpdateApiDocumentationUseCase);
             }
         }
+
+        @Test
+        void should_return_400_when_area_is_not_top_navbar() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("api-documentation-homepage.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+                verifyNoInteractions(validateApiDocumentationUseCase);
+                verifyNoInteractions(createOrUpdateApiDocumentationUseCase);
+            }
+        }
     }
 
     @Nested
@@ -182,6 +197,20 @@ class ApiDocumentationsResourceTest extends AbstractResourceTest {
                     .put(Entity.json(readJSON("api-documentation.json")))
             ) {
                 assertThat(response.getStatus()).isEqualTo(400);
+            }
+        }
+
+        @Test
+        void should_return_400_when_area_is_not_top_navbar() {
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("api-documentation-homepage.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+                verifyNoInteractions(createOrUpdateApiDocumentationUseCase);
+                verifyNoInteractions(validateApiDocumentationUseCase);
             }
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/api-documentation-homepage.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/api-documentation-homepage.json
@@ -1,0 +1,9 @@
+{
+  "hrid": "getting-started",
+  "name": "Getting Started",
+  "type": "GRAVITEE_MARKDOWN",
+  "content": "# Hello\n\nThis is markdown.",
+  "location": "/getting-started",
+  "order": 1,
+  "area": "HOMEPAGE"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainService.java
@@ -31,6 +31,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.slug.model.Slug;
@@ -60,10 +61,15 @@ public class ApiDocumentationSyncDomainService {
 
     private static final int MAX_CASCADE_DEPTH = 50;
     private static final PortalArea API_DOCUMENTATION_AREA = PortalArea.TOP_NAVBAR;
+    private static final PortalNavigationItemType TYPE = PortalNavigationItemType.PAGE;
+    private static final PortalVisibility DEFAULT_VISIBILITY = PortalVisibility.PUBLIC;
+    private static final int DEFAULT_ORDER = 0;
+    private static final boolean DEFAULT_PUBLISHED = true;
 
     private final PortalNavigationItemCrudService navigationItemCrudService;
     private final PortalNavigationItemsQueryService navigationItemsQueryService;
     private final PortalPageContentQueryService portalPageContentQueryService;
+    private final PortalNavigationItemValidatorService validatorService;
 
     public void materialize(AuditInfo auditInfo, PortalPageContent<?> pageContent) {
         var meta = pageContent.getAutomationMetadata();
@@ -172,33 +178,48 @@ public class ApiDocumentationSyncDomainService {
         PortalNavigationItemContainer parent,
         AutomationMetadata meta
     ) {
-        var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), pageId);
+        final var envId = auditInfo.environmentId();
+        final var orgId = auditInfo.organizationId();
+        var existing = navigationItemsQueryService.findByIdAndEnvironmentId(envId, pageId);
         var parentId = parent == null ? null : parent.getId();
 
-        if (existing instanceof PortalNavigationPage page) {
-            var segment = Slug.from(meta.name(), siblingSlugs(auditInfo.environmentId(), parentId, pageId));
-            page.update(meta, parent, segment);
+        if (existing instanceof PortalNavigationPage page && page.getArea() == API_DOCUMENTATION_AREA) {
+            var segment = Slug.from(meta.name(), siblingSlugs(envId, parentId, pageId));
+            var update = UpdatePortalNavigationItem.builder()
+                .title(meta.name())
+                .segment(segment.value())
+                .type(TYPE)
+                .order(meta.order().orElse(DEFAULT_ORDER))
+                .parentId(parentId)
+                .visibility(DEFAULT_VISIBILITY)
+                .published(DEFAULT_PUBLISHED)
+                .build();
+            validatorService.validateToUpdate(update, page);
+            page.update(update, meta.trimmedForNavItem());
+            page.attachTo(parent);
             navigationItemCrudService.update(page);
             return;
         }
         if (existing != null) {
             navigationItemCrudService.delete(pageId);
         }
-        var segment = Slug.from(meta.name(), siblingSlugs(auditInfo.environmentId(), parentId, null));
+        var segment = Slug.from(meta.name(), siblingSlugs(envId, parentId, null));
         var create = CreatePortalNavigationItem.builder()
             .id(pageId)
             .title(meta.name())
             .segment(segment.value())
             .area(API_DOCUMENTATION_AREA)
-            .type(PortalNavigationItemType.PAGE)
-            .order(meta.order().orElse(0))
+            .type(TYPE)
+            .order(meta.order().orElse(DEFAULT_ORDER))
             .portalPageContentId(contentId)
+            .parentId(parentId)
             .reference(meta.reference())
+            .visibility(DEFAULT_VISIBILITY)
+            .published(DEFAULT_PUBLISHED)
             .automationMetadata(meta.trimmedForNavItem())
-            .visibility(PortalVisibility.PUBLIC)
-            .published(true)
             .build();
-        navigationItemCrudService.create(PortalNavigationItem.from(create, auditInfo.organizationId(), auditInfo.environmentId(), parent));
+        validatorService.validateOne(create, envId);
+        navigationItemCrudService.create(PortalNavigationItem.from(create, orgId, envId, parent));
     }
 
     private Set<Slug> siblingSlugs(String environmentId, PortalNavigationItemId parentId, PortalNavigationItemId excludeId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainService.java
@@ -29,6 +29,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.slug.model.Slug;
 import java.util.Set;
@@ -39,9 +40,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PortalDocumentationSyncDomainService {
 
+    private static final PortalNavigationItemType TYPE = PortalNavigationItemType.PAGE;
+    private static final PortalVisibility DEFAULT_VISIBILITY = PortalVisibility.PUBLIC;
+    private static final int DEFAULT_ORDER = 0;
+    private static final boolean DEFAULT_PUBLISHED = true;
+
     private final PortalNavigationItemCrudService navigationItemCrudService;
     private final PortalNavigationItemsQueryService navigationItemsQueryService;
     private final HomepageReconciler homepageReconciler;
+    private final PortalNavigationItemValidatorService validatorService;
 
     public void materialize(AuditInfo auditInfo, PortalPageContent<?> pageContent, PortalArea targetArea) {
         var navigationItemId = PortalNavigationItemId.forPortalDocumentationContent(auditInfo, pageContent);
@@ -71,14 +78,27 @@ public class PortalDocumentationSyncDomainService {
         PortalNavigationItem existing,
         PortalArea targetArea
     ) {
+        final var envId = auditInfo.environmentId();
+        final var orgId = auditInfo.organizationId();
         final var meta = pageContent.getAutomationMetadata();
         final var parent = resolveParent(auditInfo, meta.location().orElse(null), meta.referenceId());
         final var parentId = parent == null ? null : parent.getId();
 
         if (isUpdatableInPlace(existing, targetArea)) {
             var page = (PortalNavigationPage) existing;
-            final var segment = Slug.from(meta.name(), siblingsSlugs(auditInfo.environmentId(), parentId, navigationItemId));
-            page.update(meta, parent, segment);
+            final var segment = Slug.from(meta.name(), siblingsSlugs(envId, parentId, navigationItemId));
+            var update = UpdatePortalNavigationItem.builder()
+                .title(meta.name())
+                .segment(segment.value())
+                .type(TYPE)
+                .order(meta.order().orElse(DEFAULT_ORDER))
+                .parentId(parentId)
+                .visibility(DEFAULT_VISIBILITY)
+                .published(DEFAULT_PUBLISHED)
+                .build();
+            validatorService.validateToUpdate(update, page);
+            page.update(update, meta.trimmedForNavItem());
+            page.attachTo(parent);
             navigationItemCrudService.update(page);
             return;
         }
@@ -86,23 +106,25 @@ public class PortalDocumentationSyncDomainService {
             navigationItemCrudService.delete(navigationItemId);
         }
         if (targetArea == PortalArea.HOMEPAGE) {
-            homepageReconciler.dropStaleHomepages(auditInfo.environmentId(), meta.referenceId(), navigationItemId);
+            homepageReconciler.dropStaleHomepages(envId, meta.referenceId(), navigationItemId);
         }
-        final var segment = Slug.from(meta.name(), siblingsSlugs(auditInfo.environmentId(), parentId, null));
+        final var segment = Slug.from(meta.name(), siblingsSlugs(envId, parentId, null));
         var create = CreatePortalNavigationItem.builder()
             .id(navigationItemId)
             .title(meta.name())
             .segment(segment.value())
             .area(targetArea)
-            .type(PortalNavigationItemType.PAGE)
-            .order(meta.order().orElse(0))
+            .type(TYPE)
+            .order(meta.order().orElse(DEFAULT_ORDER))
             .portalPageContentId(pageContent.getId())
+            .parentId(parentId)
             .reference(meta.reference())
+            .visibility(DEFAULT_VISIBILITY)
+            .published(DEFAULT_PUBLISHED)
             .automationMetadata(meta.trimmedForNavItem())
-            .visibility(PortalVisibility.PUBLIC)
-            .published(true)
             .build();
-        navigationItemCrudService.create(PortalNavigationItem.from(create, auditInfo.organizationId(), auditInfo.environmentId(), parent));
+        validatorService.validateOne(create, envId);
+        navigationItemCrudService.create(PortalNavigationItem.from(create, orgId, envId, parent));
     }
 
     private static boolean isUpdatableInPlace(PortalNavigationItem existing, PortalArea targetArea) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.domain_service;
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.portal_page.domain_service.validation.ApiDocumentationAreaRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.ApiItemCreateRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.ApiItemUpdateRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.ApiProductItemCreateRule;
@@ -87,6 +88,7 @@ public class PortalNavigationItemValidatorService {
             titleRequiredRule,
             new ApiItemCreateRule(apiProductQueryService),
             new ApiProductItemCreateRule(apiProductQueryService),
+            new ApiDocumentationAreaRule(),
             linkUrlRule,
             parentRule,
             externalSourceItemTypeRule,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/reconciliation/HomepageReconciler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/reconciliation/HomepageReconciler.java
@@ -49,6 +49,7 @@ public class HomepageReconciler {
         var itemsToDelete = stale
             .stream()
             .filter(item -> !item.getId().equals(activeHomepageId))
+            .filter(item -> item.getAutomationMetadata() == null)
             .toList();
         itemsToDelete.forEach(this::deleteItemAndContent);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiDocumentationAreaRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiDocumentationAreaRule.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+
+public class ApiDocumentationAreaRule implements CreatePortalNavigationItemValidationRule {
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getType() == PortalNavigationItemType.PAGE && item.getReference() instanceof NavigationItemReference.ApiReference;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        if (item.getArea() != PortalArea.TOP_NAVBAR) {
+            throw InvalidPortalNavigationItemDataException.apiDocumentationMustBeInTopNavbar();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRule.java
@@ -58,7 +58,8 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
             item.getArea(),
             environmentId,
             item.getPublished() != null ? item.getPublished() : false,
-            item.getVisibility()
+            item.getVisibility(),
+            item.getAutomationMetadata() != null
         );
     }
 
@@ -110,7 +111,8 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
             existingItem.getArea(),
             existingItem.getEnvironmentId(),
             toUpdate.getPublished() != null ? toUpdate.getPublished() : false,
-            toUpdate.getVisibility()
+            toUpdate.getVisibility(),
+            existingItem.getAutomationMetadata() != null
         );
     }
 
@@ -122,7 +124,8 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
         PortalArea itemArea,
         String environmentId,
         boolean itemPublished,
-        PortalVisibility itemVisibility
+        PortalVisibility itemVisibility,
+        boolean automation
     ) {
         if (parentId == null) {
             return;
@@ -131,6 +134,10 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
             .map(parentIdVal -> navigationItemsQueryService.findByIdAndEnvironmentId(environmentId, parentIdVal))
             .orElse(null);
         if (parentItem == null) {
+            if (automation) {
+                // Phantom-parent tolerance: automation may declare a parent that hasn't materialized yet.
+                return;
+            }
             throw new ParentNotFoundException(parentId.toString());
         }
         if (!(parentItem instanceof PortalNavigationItemContainer)) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
@@ -41,6 +41,10 @@ public class InvalidPortalNavigationItemDataException extends ValidationDomainEx
         return new InvalidPortalNavigationItemDataException("API Product items can only be added to TOP_NAVBAR area.");
     }
 
+    public static InvalidPortalNavigationItemDataException apiDocumentationMustBeInTopNavbar() {
+        return new InvalidPortalNavigationItemDataException("API-attached documentation can only be added to TOP_NAVBAR area.");
+    }
+
     public static InvalidPortalNavigationItemDataException sourceNotAllowedForType(String type) {
         return new InvalidPortalNavigationItemDataException(
             "An external source can only be configured on PAGE and FOLDER navigation items (got %s).".formatted(type)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -133,6 +133,14 @@ public abstract sealed class PortalNavigationItem
         this.rootId = parent.getRootId();
     }
 
+    public void attachTo(@Nullable PortalNavigationItemContainer parent) {
+        if (parent == null) {
+            markAsRoot();
+        } else {
+            updateParent(parent);
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationPage.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationPage.java
@@ -16,9 +16,7 @@
 package io.gravitee.apim.core.portal_page.model;
 
 import io.gravitee.apim.core.portal.model.PortalArea;
-import io.gravitee.apim.core.slug.model.Slug;
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
@@ -28,7 +26,6 @@ import lombok.experimental.SuperBuilder;
 public final class PortalNavigationPage extends PortalNavigationItem {
 
     private static final PortalNavigationItemType TYPE = PortalNavigationItemType.PAGE;
-    private static final int DEFAULT_AUTOMATION_ORDER = 0;
 
     @Setter
     @Nonnull
@@ -52,17 +49,5 @@ public final class PortalNavigationPage extends PortalNavigationItem {
     @Override
     public PortalNavigationItemType getType() {
         return TYPE;
-    }
-
-    public void update(@Nonnull AutomationMetadata meta, @Nullable PortalNavigationItemContainer parent, @Nonnull Slug segment) {
-        setTitle(meta.name());
-        setSegment(segment.value());
-        setOrder(meta.order().orElse(DEFAULT_AUTOMATION_ORDER));
-        this.automationMetadata = meta.trimmedForNavItem();
-        if (parent == null) {
-            markAsRoot();
-        } else {
-            updateParent(parent);
-        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdateApiDocumentationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdateApiDocumentationUseCase.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.open_api.OpenApi;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.ApiDocumentationSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.ValidateApiDocumentationDomainService;
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
@@ -47,6 +48,7 @@ public class CreateOrUpdateApiDocumentationUseCase {
     private final ValidateApiDocumentationDomainService validator;
     private final PortalPageContentCrudService portalPageContentCrudService;
     private final PortalPageContentQueryService portalPageContentQueryService;
+    private final PortalPageContentValidatorService pageContentValidatorService;
     private final ApiDocumentationSyncDomainService syncDomainService;
 
     public record Input(
@@ -101,7 +103,9 @@ public class CreateOrUpdateApiDocumentationUseCase {
                 portalPageContentCrudService.delete(current.getId());
                 saved = portalPageContentCrudService.create(buildNew(sanitized, meta));
             } else {
-                current.update(new UpdatePortalPageContent(sanitized.content(), null), meta);
+                var updateContent = new UpdatePortalPageContent(sanitized.content(), null);
+                pageContentValidatorService.validateForUpdate(current, updateContent);
+                current.update(updateContent, meta);
                 saved = portalPageContentCrudService.update(current);
             }
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCase.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.ValidatePortalDocumentationDomainService;
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
@@ -50,6 +51,7 @@ public class CreateOrUpdatePortalDocumentationUseCase {
     private final ValidatePortalDocumentationDomainService validator;
     private final PortalPageContentCrudService portalPageContentCrudService;
     private final PortalPageContentQueryService portalPageContentQueryService;
+    private final PortalPageContentValidatorService pageContentValidatorService;
     private final PortalDocumentationSyncDomainService syncDomainService;
     private final PortalAutomationScopeDomainService portalAutomationScopeEnforcer;
 
@@ -107,7 +109,9 @@ public class CreateOrUpdatePortalDocumentationUseCase {
                 portalPageContentCrudService.delete(current.getId());
                 saved = portalPageContentCrudService.create(buildNew(sanitized, meta));
             } else {
-                current.update(new UpdatePortalPageContent(sanitized.content(), null), meta);
+                var updateContent = new UpdatePortalPageContent(sanitized.content(), null);
+                pageContentValidatorService.validateForUpdate(current, updateContent);
+                current.update(updateContent, meta);
                 saved = portalPageContentCrudService.update(current);
             }
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import fixtures.core.model.PortalFixtures;
 import inmemory.PortalCrudServiceInMemory;
@@ -38,6 +39,7 @@ import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalNavigationStructure;
 import io.gravitee.apim.core.portal.query_service.AutomationManagedNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.reconciliation.HomepageReconciler;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import java.util.List;
@@ -82,7 +84,8 @@ class CreateOrUpdatePortalUseCaseTest {
             new PortalDocumentationSyncDomainService(
                 navCrudService,
                 navQueryService,
-                new HomepageReconciler(navQueryService, navCrudService, pageContentCrudService)
+                new HomepageReconciler(navQueryService, navCrudService, pageContentCrudService),
+                mock(PortalNavigationItemValidatorService.class)
             ),
             scopeEnforcer
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
 
 import fixtures.core.model.PortalFixtures;
 import inmemory.PortalCrudServiceInMemory;
@@ -39,6 +40,7 @@ import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal.model.PortalNavigationStructure;
 import io.gravitee.apim.core.portal.query_service.AutomationManagedNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.reconciliation.HomepageReconciler;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
@@ -91,7 +93,8 @@ class DeletePortalUseCaseTest {
             new PortalDocumentationSyncDomainService(
                 navCrudService,
                 navQueryService,
-                new HomepageReconciler(navQueryService, navCrudService, pageContentCrudService)
+                new HomepageReconciler(navQueryService, navCrudService, pageContentCrudService),
+                mock(PortalNavigationItemValidatorService.class)
             ),
             scopeEnforcer
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal_listing.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.PortalListingCrudServiceInMemory;
@@ -33,6 +34,7 @@ import io.gravitee.apim.core.portal_listing.model.PortalListing;
 import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
 import io.gravitee.apim.core.portal_listing.model.PortalListingId;
 import io.gravitee.apim.core.portal_page.domain_service.ApiDocumentationSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
@@ -80,7 +82,12 @@ class PortalListingSyncDomainServiceTest {
         pageContentCrud.reset();
         apiCrud.reset();
         var portalListingCrud = new PortalListingCrudServiceInMemory();
-        var apiDocSync = new ApiDocumentationSyncDomainService(navItemCrud, navItemQuery, pageContentQuery);
+        var apiDocSync = new ApiDocumentationSyncDomainService(
+            navItemCrud,
+            navItemQuery,
+            pageContentQuery,
+            mock(PortalNavigationItemValidatorService.class)
+        );
         var automationManaged = new AutomationManagedNavigationItemsQueryService(portalListingCrud, pageContentQuery, navItemQuery);
         syncService = new PortalListingSyncDomainService(
             pageContentQuery,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainServiceTest.java
@@ -16,6 +16,10 @@
 package io.gravitee.apim.core.portal_page.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
@@ -59,12 +63,14 @@ class ApiDocumentationSyncDomainServiceTest {
     private final PortalPageContentQueryServiceInMemory pageContentQuery = new PortalPageContentQueryServiceInMemory();
 
     private ApiDocumentationSyncDomainService syncService;
+    private PortalNavigationItemValidatorService validatorService;
 
     @BeforeEach
     void setUp() {
         navItemCrud.reset();
         pageContentQuery.reset();
-        syncService = new ApiDocumentationSyncDomainService(navItemCrud, navItemQuery, pageContentQuery);
+        validatorService = mock(PortalNavigationItemValidatorService.class);
+        syncService = new ApiDocumentationSyncDomainService(navItemCrud, navItemQuery, pageContentQuery, validatorService);
     }
 
     @Test
@@ -112,6 +118,25 @@ class ApiDocumentationSyncDomainServiceTest {
         var pageIdOurs = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, ours.getId(), DOC_ID);
         var pageIdTheirs = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, theirs.getId(), DOC_ID);
         assertThat(navItemCrud.storage()).extracting(PortalNavigationItem::getId).contains(pageIdOurs).doesNotContain(pageIdTheirs);
+    }
+
+    @Test
+    void materialize_invokes_nav_item_validator_on_create_path() {
+        seedNavApi(PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+
+        syncService.materialize(AUDIT_INFO, aDocumentation());
+
+        verify(validatorService).validateOne(any(), eq(AUDIT_INFO.environmentId()));
+    }
+
+    @Test
+    void materialize_invokes_nav_item_validator_on_update_path() {
+        seedNavApi(PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+        syncService.materialize(AUDIT_INFO, aDocumentation());
+
+        syncService.materialize(AUDIT_INFO, aDocumentation());
+
+        verify(validatorService).validateToUpdate(any(), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainServiceTest.java
@@ -16,20 +16,25 @@
 package io.gravitee.apim.core.portal_page.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_page.domain_service.reconciliation.HomepageReconciler;
+import io.gravitee.apim.core.portal_page.exception.HomepageAlreadyExistsException;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
@@ -221,6 +226,31 @@ class PortalDocumentationSyncDomainServiceTest {
     }
 
     @Test
+    void materialize_rejects_second_automation_owned_homepage_for_same_portal() {
+        var syncWithRealValidator = new PortalDocumentationSyncDomainService(
+            navItemCrud,
+            navItemQuery,
+            new HomepageReconciler(navItemQuery, navItemCrud, pageContentCrud),
+            new PortalNavigationItemValidatorService(
+                navItemQuery,
+                new PortalPageContentQueryServiceInMemory(pageContentCrud.storage()),
+                new ApiProductQueryServiceInMemory(),
+                new PortalNavigationItemSourceDomainServiceInMemory()
+            )
+        );
+        var existing = automationOwnedHomepagePage();
+        navItemCrud.create(existing);
+        pageContentCrud.create(staleContent(existing));
+
+        assertThatThrownBy(() ->
+            syncWithRealValidator.materialize(AUDIT_INFO, homepageDoc("Home", "/homepage"), PortalArea.HOMEPAGE)
+        ).isInstanceOf(HomepageAlreadyExistsException.class);
+
+        assertThat(navItemCrud.storage()).hasSize(1);
+        assertThat(navItemCrud.storage().get(0).getId()).isEqualTo(existing.getId());
+    }
+
+    @Test
     void materialize_does_not_touch_homepage_of_a_different_portal() {
         var otherPortalId = "00000000-0000-0000-0000-0000000000ff";
         var otherHomepage = PortalNavigationPage.builder()
@@ -272,6 +302,31 @@ class PortalDocumentationSyncDomainServiceTest {
             .portalPageContentId(PortalPageContentId.of("00000000-0000-0000-0000-00000000c0de"))
             .published(true)
             .visibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    private static PortalNavigationPage automationOwnedHomepagePage() {
+        return PortalNavigationPage.builder()
+            .id(PortalNavigationItemId.of("00000000-0000-0000-0000-00000000c0d3"))
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .reference(new NavigationItemReference.PortalReference(PortalId.of(PORTAL_ID.toString())))
+            .title("Existing")
+            .segment("existing")
+            .area(PortalArea.HOMEPAGE)
+            .order(0)
+            .portalPageContentId(PortalPageContentId.of("00000000-0000-0000-0000-00000000c0da"))
+            .published(true)
+            .visibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PUBLIC)
+            .automationMetadata(
+                new AutomationMetadata(
+                    AutomationMetadata.ReferenceType.PORTAL,
+                    PORTAL_ID.toString(),
+                    null,
+                    Optional.empty(),
+                    Optional.empty()
+                )
+            )
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainServiceTest.java
@@ -16,6 +16,10 @@
 package io.gravitee.apim.core.portal_page.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
@@ -58,15 +62,18 @@ class PortalDocumentationSyncDomainServiceTest {
     private final PortalPageContentCrudServiceInMemory pageContentCrud = new PortalPageContentCrudServiceInMemory();
 
     private PortalDocumentationSyncDomainService syncService;
+    private PortalNavigationItemValidatorService validatorService;
 
     @BeforeEach
     void setUp() {
         navItemCrud.reset();
         pageContentCrud.reset();
+        validatorService = mock(PortalNavigationItemValidatorService.class);
         syncService = new PortalDocumentationSyncDomainService(
             navItemCrud,
             navItemQuery,
-            new HomepageReconciler(navItemQuery, navItemCrud, pageContentCrud)
+            new HomepageReconciler(navItemQuery, navItemCrud, pageContentCrud),
+            validatorService
         );
     }
 
@@ -90,6 +97,22 @@ class PortalDocumentationSyncDomainServiceTest {
         // trimmed: name/order already live natively on the nav item as title/order
         assertThat(page.getAutomationMetadata().name()).isNull();
         assertThat(page.getAutomationMetadata().order()).isEmpty();
+    }
+
+    @Test
+    void materialize_invokes_nav_item_validator_on_create_path() {
+        syncService.materialize(AUDIT_INFO, markdownDoc("Getting Started", "/projects/alpha", 1));
+
+        verify(validatorService).validateOne(any(), eq(AUDIT_INFO.environmentId()));
+    }
+
+    @Test
+    void materialize_invokes_nav_item_validator_on_update_path() {
+        syncService.materialize(AUDIT_INFO, markdownDoc("Getting Started", "/projects/alpha", 1));
+
+        syncService.materialize(AUDIT_INFO, markdownDoc("Renamed", "/projects/alpha", 2));
+
+        verify(validatorService).validateToUpdate(any(), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiDocumentationAreaRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiDocumentationAreaRuleTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiDocumentationAreaRuleTest {
+
+    private final ApiDocumentationAreaRule rule = new ApiDocumentationAreaRule();
+
+    @Test
+    void applies_to_page_with_api_reference() {
+        assertThat(rule.appliesTo(item(PortalNavigationItemType.PAGE, PortalArea.TOP_NAVBAR, apiRef()))).isTrue();
+    }
+
+    @Test
+    void does_not_apply_to_page_with_portal_reference() {
+        assertThat(rule.appliesTo(item(PortalNavigationItemType.PAGE, PortalArea.TOP_NAVBAR, portalRef()))).isFalse();
+    }
+
+    @Test
+    void does_not_apply_to_non_page_types() {
+        assertThat(rule.appliesTo(item(PortalNavigationItemType.FOLDER, PortalArea.TOP_NAVBAR, apiRef()))).isFalse();
+        assertThat(rule.appliesTo(item(PortalNavigationItemType.API, PortalArea.TOP_NAVBAR, apiRef()))).isFalse();
+    }
+
+    @Test
+    void accepts_top_navbar() {
+        assertThatCode(() ->
+            rule.validate(item(PortalNavigationItemType.PAGE, PortalArea.TOP_NAVBAR, apiRef()), "env-1", null)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejects_homepage() {
+        assertThatThrownBy(() -> rule.validate(item(PortalNavigationItemType.PAGE, PortalArea.HOMEPAGE, apiRef()), "env-1", null))
+            .isInstanceOf(InvalidPortalNavigationItemDataException.class)
+            .hasMessageContaining("TOP_NAVBAR");
+    }
+
+    private static CreatePortalNavigationItem item(PortalNavigationItemType type, PortalArea area, NavigationItemReference reference) {
+        return CreatePortalNavigationItem.builder()
+            .type(type)
+            .title("Doc")
+            .segment("doc")
+            .area(area)
+            .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .reference(reference)
+            .build();
+    }
+
+    private static NavigationItemReference apiRef() {
+        return new NavigationItemReference.ApiReference("api-1");
+    }
+
+    private static NavigationItemReference portalRef() {
+        return new NavigationItemReference.PortalReference(PortalId.of("11111111-1111-1111-1111-1111111111a1"));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRuleTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_page.exception.ParentAreaMismatchException;
+import io.gravitee.apim.core.portal_page.exception.ParentNotFoundException;
+import io.gravitee.apim.core.portal_page.exception.ParentTypeMismatchException;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ParentRuleTest {
+
+    private static final String ENV_ID = "env-1";
+    private static final String ORG_ID = "org-1";
+    private static final PortalNavigationItemId FOLDER_ID = PortalNavigationItemId.of("11111111-1111-1111-1111-111111111a11");
+    private static final PortalNavigationItemId ITEM_ID = PortalNavigationItemId.of("22222222-2222-2222-2222-2222222222a2");
+    private static final PortalNavigationItemId MISSING_ID = PortalNavigationItemId.of("33333333-3333-3333-3333-3333333333a3");
+
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+    private ParentRule rule;
+
+    @BeforeEach
+    void setUp() {
+        navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
+        rule = new ParentRule(navigationItemsQueryService);
+    }
+
+    @Test
+    void appliesTo_create_returns_true_when_parent_id_set_and_false_when_null() {
+        assertThat(rule.appliesTo(pageCreate(FOLDER_ID, PortalArea.TOP_NAVBAR, null))).isTrue();
+        assertThat(rule.appliesTo(pageCreate(null, PortalArea.TOP_NAVBAR, null))).isFalse();
+    }
+
+    @Test
+    void create_passes_when_parent_exists_in_db_and_matches_area() {
+        navigationItemsQueryService.storage().add(publicPublishedFolder(FOLDER_ID, PortalArea.TOP_NAVBAR));
+
+        assertThatCode(() ->
+            rule.validate(pageCreate(FOLDER_ID, PortalArea.TOP_NAVBAR, null), ENV_ID, CreateValidationContext.empty())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void create_throws_when_parent_missing_in_db_and_not_automation() {
+        assertThatThrownBy(() ->
+            rule.validate(pageCreate(MISSING_ID, PortalArea.TOP_NAVBAR, null), ENV_ID, CreateValidationContext.empty())
+        ).isInstanceOf(ParentNotFoundException.class);
+    }
+
+    @Test
+    void create_tolerates_phantom_parent_when_automation() {
+        var item = pageCreate(MISSING_ID, PortalArea.TOP_NAVBAR, automationMeta());
+
+        assertThatCode(() -> rule.validate(item, ENV_ID, CreateValidationContext.empty())).doesNotThrowAnyException();
+    }
+
+    @Test
+    void create_throws_when_parent_exists_but_area_mismatches() {
+        navigationItemsQueryService.storage().add(publicPublishedFolder(FOLDER_ID, PortalArea.HOMEPAGE));
+
+        assertThatThrownBy(() ->
+            rule.validate(pageCreate(FOLDER_ID, PortalArea.TOP_NAVBAR, null), ENV_ID, CreateValidationContext.empty())
+        ).isInstanceOf(ParentAreaMismatchException.class);
+    }
+
+    @Test
+    void create_throws_when_parent_exists_but_is_not_a_container() {
+        navigationItemsQueryService
+            .storage()
+            .add(
+                PortalNavigationPage.builder()
+                    .id(FOLDER_ID)
+                    .organizationId(ORG_ID)
+                    .environmentId(ENV_ID)
+                    .title("Not a folder")
+                    .segment("not-a-folder")
+                    .area(PortalArea.TOP_NAVBAR)
+                    .order(0)
+                    .portalPageContentId(PortalPageContentId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+                    .published(true)
+                    .visibility(PortalVisibility.PUBLIC)
+                    .build()
+            );
+
+        assertThatThrownBy(() ->
+            rule.validate(pageCreate(FOLDER_ID, PortalArea.TOP_NAVBAR, null), ENV_ID, CreateValidationContext.empty())
+        ).isInstanceOf(ParentTypeMismatchException.class);
+    }
+
+    @Test
+    void create_uses_pending_parent_from_same_batch() {
+        var pendingParent = folderCreate(FOLDER_ID, PortalArea.TOP_NAVBAR);
+        var child = pageCreate(FOLDER_ID, PortalArea.TOP_NAVBAR, null);
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent));
+
+        assertThatCode(() -> rule.validate(child, ENV_ID, ctx)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void create_pending_parent_area_mismatch_throws() {
+        var pendingParent = folderCreate(FOLDER_ID, PortalArea.HOMEPAGE);
+        var child = pageCreate(FOLDER_ID, PortalArea.TOP_NAVBAR, null);
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent));
+
+        assertThatThrownBy(() -> rule.validate(child, ENV_ID, ctx)).isInstanceOf(ParentAreaMismatchException.class);
+    }
+
+    @Test
+    void update_passes_when_parent_exists_in_db() {
+        navigationItemsQueryService.storage().add(publicPublishedFolder(FOLDER_ID, PortalArea.TOP_NAVBAR));
+        var existing = pageExisting(ITEM_ID, PortalArea.TOP_NAVBAR, null);
+
+        assertThatCode(() -> rule.validate(pageUpdate(FOLDER_ID), existing, UpdateValidationContext.empty())).doesNotThrowAnyException();
+    }
+
+    @Test
+    void update_throws_when_parent_missing_in_db_and_existing_is_not_automation_owned() {
+        var existing = pageExisting(ITEM_ID, PortalArea.TOP_NAVBAR, null);
+
+        assertThatThrownBy(() -> rule.validate(pageUpdate(MISSING_ID), existing, UpdateValidationContext.empty())).isInstanceOf(
+            ParentNotFoundException.class
+        );
+    }
+
+    @Test
+    void update_tolerates_phantom_parent_when_existing_is_automation_owned() {
+        var existing = pageExisting(ITEM_ID, PortalArea.TOP_NAVBAR, automationMeta());
+
+        assertThatCode(() -> rule.validate(pageUpdate(MISSING_ID), existing, UpdateValidationContext.empty())).doesNotThrowAnyException();
+    }
+
+    private static CreatePortalNavigationItem pageCreate(PortalNavigationItemId parentId, PortalArea area, AutomationMetadata meta) {
+        return CreatePortalNavigationItem.builder()
+            .id(ITEM_ID)
+            .title("Doc")
+            .segment("doc")
+            .type(PortalNavigationItemType.PAGE)
+            .area(area)
+            .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .parentId(parentId)
+            .visibility(PortalVisibility.PUBLIC)
+            .published(true)
+            .automationMetadata(meta)
+            .build();
+    }
+
+    private static CreatePortalNavigationItem folderCreate(PortalNavigationItemId id, PortalArea area) {
+        return CreatePortalNavigationItem.builder()
+            .id(id)
+            .title("Folder")
+            .segment("folder")
+            .type(PortalNavigationItemType.FOLDER)
+            .area(area)
+            .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .visibility(PortalVisibility.PUBLIC)
+            .published(true)
+            .build();
+    }
+
+    private static UpdatePortalNavigationItem pageUpdate(PortalNavigationItemId parentId) {
+        return UpdatePortalNavigationItem.builder()
+            .title("Doc")
+            .segment("doc")
+            .type(PortalNavigationItemType.PAGE)
+            .order(0)
+            .parentId(parentId)
+            .visibility(PortalVisibility.PUBLIC)
+            .published(true)
+            .build();
+    }
+
+    private static PortalNavigationFolder publicPublishedFolder(PortalNavigationItemId id, PortalArea area) {
+        return PortalNavigationFolder.builder()
+            .id(id)
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title("Folder")
+            .segment("folder")
+            .area(area)
+            .order(0)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    private static PortalNavigationPage pageExisting(PortalNavigationItemId id, PortalArea area, AutomationMetadata meta) {
+        return PortalNavigationPage.builder()
+            .id(id)
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title("Doc")
+            .segment("doc")
+            .area(area)
+            .order(0)
+            .portalPageContentId(PortalPageContentId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .automationMetadata(meta)
+            .build();
+    }
+
+    private static AutomationMetadata automationMeta() {
+        return new AutomationMetadata(
+            AutomationMetadata.ReferenceType.PORTAL,
+            PortalId.ZERO.toString(),
+            "Doc",
+            Optional.empty(),
+            Optional.empty()
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdateApiDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdateApiDocumentationUseCaseTest.java
@@ -16,21 +16,33 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
 
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
+import io.gravitee.apim.core.gravitee_markdown.exception.GraviteeMarkdownContentEmptyException;
 import io.gravitee.apim.core.portal_page.domain_service.ApiDocumentationSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.GraviteePortalPageContentValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.ValidateApiDocumentationDomainService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -63,11 +75,25 @@ class CreateOrUpdateApiDocumentationUseCaseTest {
 
     @BeforeEach
     void setUp() {
+        var gmdContentValidator = new GraviteePortalPageContentValidatorService(
+            new GraviteeMarkdownValidator(),
+            navQueryService,
+            mock(PortalNavigationEnclosingApiDomainService.class),
+            mock(PortalNavigationTemplatingService.class),
+            mock(ApiTemplateModelProvider.class),
+            mock(EnvironmentTemplateModelProvider.class)
+        );
         useCase = new CreateOrUpdateApiDocumentationUseCase(
             validator,
             crudService,
             queryService,
-            new ApiDocumentationSyncDomainService(navCrudService, navQueryService, queryService)
+            new PortalPageContentValidatorService(List.of(gmdContentValidator)),
+            new ApiDocumentationSyncDomainService(
+                navCrudService,
+                navQueryService,
+                queryService,
+                mock(PortalNavigationItemValidatorService.class)
+            )
         );
     }
 
@@ -107,6 +133,16 @@ class CreateOrUpdateApiDocumentationUseCaseTest {
         assertThat(stored.getType()).isEqualTo(PortalPageContentType.OPENAPI);
         assertThat(meta.location()).contains("/getting-started/v2");
         assertThat(meta.order()).contains(5);
+    }
+
+    @Test
+    void should_reject_update_when_content_becomes_blank() {
+        useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/getting-started", 1));
+        queryService.initWith(crudService.storage());
+
+        assertThatThrownBy(() ->
+            useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "   ", "/getting-started", 1))
+        ).isInstanceOf(GraviteeMarkdownContentEmptyException.class);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCaseTest.java
@@ -16,25 +16,36 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
 
 import inmemory.PortalCrudServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
+import io.gravitee.apim.core.gravitee_markdown.exception.GraviteeMarkdownContentEmptyException;
 import io.gravitee.apim.core.portal.domain_service.PortalAutomationScopeDomainService;
 import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_page.domain_service.GraviteePortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.ValidatePortalDocumentationDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.reconciliation.HomepageReconciler;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.rest.api.service.common.HRIDToUUID;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -71,14 +82,24 @@ class CreateOrUpdatePortalDocumentationUseCaseTest {
 
     @BeforeEach
     void setUp() {
+        var gmdContentValidator = new GraviteePortalPageContentValidatorService(
+            new GraviteeMarkdownValidator(),
+            navQueryService,
+            mock(PortalNavigationEnclosingApiDomainService.class),
+            mock(PortalNavigationTemplatingService.class),
+            mock(ApiTemplateModelProvider.class),
+            mock(EnvironmentTemplateModelProvider.class)
+        );
         useCase = new CreateOrUpdatePortalDocumentationUseCase(
             validator,
             crudService,
             queryService,
+            new PortalPageContentValidatorService(List.of(gmdContentValidator)),
             new PortalDocumentationSyncDomainService(
                 navCrudService,
                 navQueryService,
-                new HomepageReconciler(navQueryService, navCrudService, crudService)
+                new HomepageReconciler(navQueryService, navCrudService, crudService),
+                mock(PortalNavigationItemValidatorService.class)
             ),
             scopeEnforcer
         );
@@ -120,6 +141,16 @@ class CreateOrUpdatePortalDocumentationUseCaseTest {
         assertThat(stored.getType()).isEqualTo(PortalPageContentType.OPENAPI);
         assertThat(meta.location()).contains("/projects/alpha/v2");
         assertThat(meta.order()).contains(5);
+    }
+
+    @Test
+    void should_reject_update_when_content_becomes_blank() {
+        useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1));
+        queryService.initWith(crudService.storage());
+
+        assertThatThrownBy(() ->
+            useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "   ", "/projects/alpha", 1))
+        ).isInstanceOf(GraviteeMarkdownContentEmptyException.class);
     }
 
     @Test
@@ -214,10 +245,12 @@ class CreateOrUpdatePortalDocumentationUseCaseTest {
             new ValidatePortalDocumentationDomainService(restrictedEnforcer),
             crudService,
             queryService,
+            mock(PortalPageContentValidatorService.class),
             new PortalDocumentationSyncDomainService(
                 navCrudService,
                 navQueryService,
-                new HomepageReconciler(navQueryService, navCrudService, crudService)
+                new HomepageReconciler(navQueryService, navCrudService, crudService),
+                mock(PortalNavigationItemValidatorService.class)
             ),
             restrictedEnforcer
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeleteApiDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeleteApiDocumentationUseCaseTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
 
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
@@ -26,6 +27,7 @@ import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_page.domain_service.ApiDocumentationSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
@@ -62,7 +64,12 @@ class DeleteApiDocumentationUseCaseTest {
         useCase = new DeleteApiDocumentationUseCase(
             crudService,
             queryService,
-            new ApiDocumentationSyncDomainService(navCrudService, navQueryService, queryService)
+            new ApiDocumentationSyncDomainService(
+                navCrudService,
+                navQueryService,
+                queryService,
+                mock(PortalNavigationItemValidatorService.class)
+            )
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalDocumentationUseCaseTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
 
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
@@ -27,6 +28,7 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_documentation.exception.PortalDocumentationNotFoundException;
 import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.reconciliation.HomepageReconciler;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
@@ -65,7 +67,8 @@ class DeletePortalDocumentationUseCaseTest {
             new PortalDocumentationSyncDomainService(
                 navCrudService,
                 navQueryService,
-                new HomepageReconciler(navQueryService, navCrudService, crudService)
+                new HomepageReconciler(navQueryService, navCrudService, crudService),
+                mock(PortalNavigationItemValidatorService.class)
             )
         );
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-174

## Description

## Summary
  
Routes automation-driven documentation writes through the shared navigation-item validator before they reach the CRUD layer.

Also adds:
- a new validation rule that rejects API-attached documentation on any area other than TOP_NAVBAR
- adjust homepage reconciliation logic - drop stale homepage that is not automation owned (if automation api creates two homepages it gets rejected on validation rule that is now available)



