### PR TITLE
feat(observability): guard Gamma dashboard saves with ETag / If-Match

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/GammaDashboardRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/GammaDashboardRepository.java
@@ -45,5 +45,32 @@ public interface GammaDashboardRepository extends CrudRepository<GammaDashboard,
      */
     Optional<GammaDashboard> findByIdAndEnvironmentId(String id, String environmentId) throws TechnicalException;
 
+    /**
+     * Optimistic-locking write: replaces the dashboard only if the stored {@code version} is still {@code
+     * expectedVersion}, and returns empty when it is not (or when the dashboard no longer exists).
+     *
+     * <p>Separate from {@link #update(Object)} rather than layered on top of it, for two reasons. The comparison and
+     * the write must be the <strong>same</strong> query — comparing in one round trip and writing in another is the
+     * race this method exists to close. And {@code update} comes from the shared {@code CrudRepository} contract, so
+     * making it version-aware here would give one entity a different meaning from every other implementation of it.
+     *
+     * <p>{@code expectedVersion} is a primitive: a dashboard whose stored version is {@code null} (written before the
+     * counter existed) cannot be guarded, and the caller decides what to do about it rather than passing a null
+     * through to a comparison that means something different in each backend — SQL's {@code = NULL} never matches,
+     * Mongo's does.
+     */
+    Optional<GammaDashboard> updateIfVersionMatches(GammaDashboard gammaDashboard, int expectedVersion) throws TechnicalException;
+
+    /**
+     * Replaces the dashboard if it still exists, whatever its version, and returns empty if it does not. Backs a
+     * deliberate overwrite.
+     *
+     * <p>Same operation as {@link #update(Object)} but reporting "nothing was written" as an empty result rather than
+     * an {@link IllegalStateException}: a concurrent delete is an ordinary outcome for a caller that already accepts
+     * losing a race, and it deserves an answer that caller can act on rather than an exception that reaches the client
+     * as a server error.
+     */
+    Optional<GammaDashboard> updateIfPresent(GammaDashboard gammaDashboard) throws TechnicalException;
+
     void deleteByEnvironmentId(String environmentId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcGammaDashboardRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcGammaDashboardRepository.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.repository.jdbc.management;
 
+import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -122,6 +124,43 @@ public class JdbcGammaDashboardRepository extends JdbcAbstractCrudRepository<Gam
                 .findFirst();
         } catch (Exception ex) {
             throw new TechnicalException("Failed to find gamma dashboard by id: " + id + " and environment id: " + environmentId, ex);
+        }
+    }
+
+    /**
+     * The inherited {@code update} issues {@code update … where id = ?} and checks the affected-row count, which proves
+     * the row <em>exists</em> — nothing about its version. Guarding needs the version in the {@code where} clause of
+     * that same statement, so that comparing and writing cannot be interleaved with a competing write.
+     */
+    @Override
+    public Optional<GammaDashboard> updateIfVersionMatches(GammaDashboard gammaDashboard, int expectedVersion) throws TechnicalException {
+        log.debug("JdbcGammaDashboardRepository.updateIfVersionMatches({}, {})", gammaDashboard, expectedVersion);
+        return replaceMatching(gammaDashboard, getOrm().getUpdateSql() + " and " + escapeReservedWord("version") + " = ?", expectedVersion);
+    }
+
+    @Override
+    public Optional<GammaDashboard> updateIfPresent(GammaDashboard gammaDashboard) throws TechnicalException {
+        log.debug("JdbcGammaDashboardRepository.updateIfPresent({})", gammaDashboard);
+        return replaceMatching(gammaDashboard, getOrm().getUpdateSql());
+    }
+
+    /**
+     * Runs {@code sql} — the ORM's update statement, optionally narrowed — binding every column, then the id, then
+     * {@code extraPredicateValues} in the order the added predicates appear.
+     */
+    private Optional<GammaDashboard> replaceMatching(GammaDashboard gammaDashboard, String sql, Object... extraPredicateValues)
+        throws TechnicalException {
+        if (gammaDashboard == null) {
+            throw new IllegalStateException("Unable to update a null gamma dashboard");
+        }
+        Object[] ids = new Object[extraPredicateValues.length + 1];
+        ids[0] = gammaDashboard.getId();
+        System.arraycopy(extraPredicateValues, 0, ids, 1, extraPredicateValues.length);
+        try {
+            int rows = jdbcTemplate.update(getOrm().buildUpdatePreparedStatementCreator(sql, gammaDashboard, ids));
+            return rows == 0 ? Optional.empty() : findById(gammaDashboard.getId());
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to update gamma dashboard: " + gammaDashboard.getId(), ex);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/orm/JdbcObjectMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/orm/JdbcObjectMapper.java
@@ -64,6 +64,13 @@ public class JdbcObjectMapper<T> {
 
     private final String idColumn;
     private final String insertSql;
+
+    /**
+     * Exposed so a repository can derive a narrower write from it — appending an optimistic-locking predicate, for
+     * instance — without restating every column. Pair it with
+     * {@link #buildUpdatePreparedStatementCreator(String, Object, Object...)}.
+     */
+    @Getter
     private final String updateSql;
 
     @Getter
@@ -251,6 +258,15 @@ public class JdbcObjectMapper<T> {
 
     public PreparedStatementCreator buildUpdatePreparedStatementCreator(T item, Object... ids) {
         return new Psc(updateSql, item, ids);
+    }
+
+    /**
+     * Same binding as {@link #buildUpdatePreparedStatementCreator(Object, Object...)} — every column, then {@code ids}
+     * in order — against a caller-supplied statement, for writes that need a predicate beyond the id. Build the
+     * statement from {@link #getUpdateSql()} so the {@code set} clause stays in step with the columns.
+     */
+    public PreparedStatementCreator buildUpdatePreparedStatementCreator(String sql, T item, Object... ids) {
+        return new Psc(sql, item, ids);
     }
 
     public boolean buildInCondition(boolean first, StringBuilder query, String column, Collection args) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoGammaDashboardRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoGammaDashboardRepository.java
@@ -76,9 +76,6 @@ public class MongoGammaDashboardRepository implements GammaDashboardRepository {
      * <p>{@code save()} is an upsert, so with a read-then-write pair a dashboard deleted between the two calls would be
      * silently re-inserted — while the JDBC implementation, guarded by its affected-row count, raises. Matching on
      * {@code _id} folds the existence check into the same round trip and keeps the two backends behaving alike.
-     *
-     * <p>When {@code version} is eventually enforced, the guard is one more criterion on this same query rather than a
-     * new round trip.
      */
     @Override
     public GammaDashboard update(GammaDashboard gammaDashboard) throws TechnicalException {
@@ -86,19 +83,41 @@ public class MongoGammaDashboardRepository implements GammaDashboardRepository {
             throw new IllegalStateException("Unable to update a null gamma dashboard");
         }
 
+        return updateIfPresent(gammaDashboard).orElseThrow(() ->
+            new IllegalStateException(String.format("No gamma dashboard found with id [%s]", gammaDashboard.getId()))
+        );
+    }
+
+    @Override
+    public Optional<GammaDashboard> updateIfPresent(GammaDashboard gammaDashboard) throws TechnicalException {
+        if (gammaDashboard == null) {
+            throw new IllegalStateException("Unable to update a null gamma dashboard");
+        }
+
+        return replaceMatching(Criteria.where("_id").is(gammaDashboard.getId()), gammaDashboard);
+    }
+
+    /**
+     * The version guard is one more criterion on the same {@code findAndReplace} the unguarded update already used, so
+     * comparing and writing stay a single atomic operation.
+     */
+    @Override
+    public Optional<GammaDashboard> updateIfVersionMatches(GammaDashboard gammaDashboard, int expectedVersion) throws TechnicalException {
+        if (gammaDashboard == null) {
+            throw new IllegalStateException("Unable to update a null gamma dashboard");
+        }
+
+        return replaceMatching(Criteria.where("_id").is(gammaDashboard.getId()).and("version").is(expectedVersion), gammaDashboard);
+    }
+
+    private Optional<GammaDashboard> replaceMatching(Criteria criteria, GammaDashboard gammaDashboard) throws TechnicalException {
         try {
             var replaced = mongoTemplate.findAndReplace(
-                Query.query(Criteria.where("_id").is(gammaDashboard.getId())),
+                Query.query(criteria),
                 mapper.map(gammaDashboard),
                 FindAndReplaceOptions.options().returnNew()
             );
-
-            if (replaced == null) {
-                throw new IllegalStateException(String.format("No gamma dashboard found with id [%s]", gammaDashboard.getId()));
-            }
-            return mapper.map(replaced);
-        } catch (IllegalStateException e) {
-            throw e;
+            return Optional.ofNullable(replaced).map(mapper::map);
         } catch (Exception e) {
             throw new TechnicalException("An error occurred when updating gamma dashboard " + gammaDashboard.getId(), e);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/GammaDashboardRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/GammaDashboardRepositoryTest.java
@@ -285,6 +285,120 @@ public class GammaDashboardRepositoryTest extends AbstractManagementRepositoryTe
     }
 
     @Test
+    public void shouldUpdateWhenVersionMatches() throws Exception {
+        var dashboard = gammaDashboardRepository.findById("gd-2").orElseThrow();
+        dashboard.setTitle("Guarded update");
+        dashboard.setVersion(8);
+
+        var updated = gammaDashboardRepository.updateIfVersionMatches(dashboard, 7);
+
+        assertThat(updated).hasValueSatisfying(result -> {
+            assertThat(result.getTitle()).isEqualTo("Guarded update");
+            assertThat(result.getVersion()).isEqualTo(8);
+        });
+        assertThat(gammaDashboardRepository.findById("gd-2")).hasValueSatisfying(result ->
+            assertThat(result.getTitle()).isEqualTo("Guarded update")
+        );
+    }
+
+    /**
+     * The race the guard exists for, played out in one thread: two writers start from version 7, and the second must
+     * come back empty with the first writer's dashboard still in place. Empty rather than an exception — a stale save
+     * is an expected outcome the caller answers with a 409, not a failure.
+     */
+    @Test
+    public void shouldNotUpdateWhenVersionIsStale() throws Exception {
+        var firstWriter = gammaDashboardRepository.findById("gd-2").orElseThrow();
+        var secondWriter = gammaDashboardRepository.findById("gd-2").orElseThrow();
+
+        firstWriter.setTitle("First writer wins");
+        firstWriter.setVersion(8);
+        assertThat(gammaDashboardRepository.updateIfVersionMatches(firstWriter, 7)).isPresent();
+
+        secondWriter.setTitle("Second writer loses");
+        secondWriter.setVersion(8);
+        assertThat(gammaDashboardRepository.updateIfVersionMatches(secondWriter, 7)).isEmpty();
+
+        assertThat(gammaDashboardRepository.findById("gd-2")).hasValueSatisfying(result -> {
+            assertThat(result.getTitle()).isEqualTo("First writer wins");
+            assertThat(result.getVersion()).isEqualTo(8);
+        });
+    }
+
+    /** A dashboard deleted in between is the same non-event as a stale version: empty, and no resurrection. */
+    @Test
+    public void shouldNotUpdateWhenTheDashboardIsGone() throws Exception {
+        var dashboard = gammaDashboardRepository.findById("gd-2").orElseThrow();
+        gammaDashboardRepository.delete("gd-2");
+
+        dashboard.setTitle("Resurrected by the guarded write");
+        assertThat(gammaDashboardRepository.updateIfVersionMatches(dashboard, 7)).isEmpty();
+        assertThat(gammaDashboardRepository.findById("gd-2")).isEmpty();
+    }
+
+    /**
+     * {@code gd-3} carries no version at all. SQL's {@code = NULL} never matches while Mongo's does, so the two
+     * backends would disagree here — the SPI takes a primitive to keep that case away from the query entirely, and
+     * this pins the one behaviour they can both honour: no stored version, no match.
+     */
+    @Test
+    public void shouldNotUpdateWhenTheStoredVersionIsNull() throws Exception {
+        var dashboard = gammaDashboardRepository.findById("gd-3").orElseThrow();
+        assertThat(dashboard.getVersion()).isNull();
+
+        dashboard.setTitle("Guarded against a null version");
+        assertThat(gammaDashboardRepository.updateIfVersionMatches(dashboard, 1)).isEmpty();
+        assertThat(gammaDashboardRepository.findById("gd-3")).hasValueSatisfying(result ->
+            assertThat(result.getTitle()).isNotEqualTo("Guarded against a null version")
+        );
+    }
+
+    @Test
+    public void shouldNotUpdateNullWhenGuardingOnVersion() throws Exception {
+        assertThrows(IllegalStateException.class, () -> gammaDashboardRepository.updateIfVersionMatches(null, 1));
+    }
+
+    /** The deliberate overwrite: it ignores the version, including the row that has none. */
+    @Test
+    public void shouldUpdateIfPresentWhateverTheStoredVersion() throws Exception {
+        var versioned = gammaDashboardRepository.findById("gd-2").orElseThrow();
+        versioned.setTitle("Overwritten");
+        versioned.setVersion(99);
+        assertThat(gammaDashboardRepository.updateIfPresent(versioned)).hasValueSatisfying(result -> {
+            assertThat(result.getTitle()).isEqualTo("Overwritten");
+            assertThat(result.getVersion()).isEqualTo(99);
+        });
+
+        var unversioned = gammaDashboardRepository.findById("gd-3").orElseThrow();
+        assertThat(unversioned.getVersion()).isNull();
+        unversioned.setTitle("Overwritten too");
+        unversioned.setVersion(1);
+        assertThat(gammaDashboardRepository.updateIfPresent(unversioned)).hasValueSatisfying(result ->
+            assertThat(result.getVersion()).isEqualTo(1)
+        );
+    }
+
+    /**
+     * An overwrite still loses to a delete. Reported as empty rather than the {@code IllegalStateException} the
+     * inherited {@code update} raises: the caller already accepts losing a race, so it needs an answer it can turn
+     * into a status code, not one that reaches the client as a server error.
+     */
+    @Test
+    public void shouldNotUpdateIfPresentWhenTheDashboardIsGone() throws Exception {
+        var dashboard = gammaDashboardRepository.findById("gd-2").orElseThrow();
+        gammaDashboardRepository.delete("gd-2");
+
+        dashboard.setTitle("Resurrected by an overwrite");
+        assertThat(gammaDashboardRepository.updateIfPresent(dashboard)).isEmpty();
+        assertThat(gammaDashboardRepository.findById("gd-2")).isEmpty();
+    }
+
+    @Test
+    public void shouldNotUpdateIfPresentNull() throws Exception {
+        assertThrows(IllegalStateException.class, () -> gammaDashboardRepository.updateIfPresent(null));
+    }
+
+    @Test
     public void shouldDelete() throws Exception {
         var nbBefore = gammaDashboardRepository.findByEnvironmentId("DEFAULT").size();
         gammaDashboardRepository.delete("gd-3");

--- a/gravitee-gamma/gravitee-gamma-rest-api/AGENTS.md
+++ b/gravitee-gamma/gravitee-gamma-rest-api/AGENTS.md
@@ -162,6 +162,15 @@ public class GammaTracingConfiguration {
 - Domain exceptions extend these bases with descriptive names (e.g. `TraceNotFoundException`).
 - Map domain exceptions to HTTP status codes in the JAX-RS layer (or rely on the apim management-rest exception mappers, which already cover the base types).
 
+**Check the base type actually has a registered mapper before relying on one.** `GammaModuleApplication`
+registers mappers explicitly, one by one, and management-rest does not ship a mapper for every base
+exception — `ConflictDomainException` has none, so a domain exception extending it falls through to
+`ThrowableMapper` and surfaces as a **500**. Nothing fails at compile time and nothing fails at startup;
+the wrong status only shows up if a test asserts on it. When adding a domain exception, either confirm its
+base is in the `register(...)` list or write a mapper under `resources/<domain>/exception/` and register it
+there. A dedicated mapper is required anyway whenever the response body carries more than
+`message`/`http_status`.
+
 ## 9. REST Layer Conventions
 
 - JAX-RS: `@Path`, `@GET` / `@POST` / etc., `@Produces(MediaType.APPLICATION_JSON)`.

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/GammaModuleApplication.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/GammaModuleApplication.java
@@ -23,6 +23,7 @@ import io.gravitee.gamma.rest.resources.observability.GammaObservabilityResource
 import io.gravitee.gamma.rest.resources.observability.analytics.AnalyticsResource;
 import io.gravitee.gamma.rest.resources.observability.dashboards.ObservabilityDashboardResource;
 import io.gravitee.gamma.rest.resources.observability.dashboards.ObservabilityDashboardsResource;
+import io.gravitee.gamma.rest.resources.observability.dashboards.exception.DashboardVersionConflictExceptionMapper;
 import io.gravitee.gamma.rest.resources.observability.filters.ObservabilityFiltersResource;
 import io.gravitee.gamma.rest.resources.observability.logs.LogsResource;
 import io.gravitee.gamma.rest.resources.tracing.TracingResource;
@@ -85,6 +86,7 @@ public class GammaModuleApplication extends ResourceConfig {
         register(NotFoundDomainExceptionMapper.class);
         register(TechnicalDomainExceptionMapper.class);
         register(JsonMappingExceptionMapper.class);
+        register(DashboardVersionConflictExceptionMapper.class);
 
         register(SecurityContextFilter.class);
         register(PermissionsFilter.class);

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/exception/DashboardVersionConflictException.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/exception/DashboardVersionConflictException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.exception;
+
+import io.gravitee.apim.core.exception.ConflictDomainException;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.VersionPrecondition;
+import lombok.Getter;
+
+/**
+ * The dashboard changed since the caller read it, so the write was refused rather than applied over someone else's
+ * work.
+ *
+ * <p>Carries the whole current dashboard, not just its version: the client has to show the author what they are about
+ * to overwrite, and making it fetch that separately would race with the next editor and give a diff against a third
+ * state.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+public class DashboardVersionConflictException extends ConflictDomainException {
+
+    private final transient Dashboard current;
+
+    public DashboardVersionConflictException(Dashboard current, VersionPrecondition precondition) {
+        super(
+            "Dashboard '%s' has been modified since you loaded it (you required %s, the current version is %s)".formatted(
+                current.id(),
+                describe(precondition),
+                current.version()
+            ),
+            current.id()
+        );
+        this.current = current;
+    }
+
+    /**
+     * An overwrite reaches here only by losing to a concurrent delete-and-recreate, so say that rather than report a
+     * version the caller never claimed.
+     */
+    private static String describe(VersionPrecondition precondition) {
+        return precondition instanceof VersionPrecondition.OneOf oneOf ? "version " + oneOf.versions() : "any current revision";
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/VersionPrecondition.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/model/VersionPrecondition.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.dashboard.model;
+
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * What a writer requires of the stored revision before its write may be applied.
+ *
+ * <p>Two shapes, and the type is sealed so that adding a third forces every decision site to be revisited rather than
+ * silently defaulting. The distinction is deliberately not modelled as "a version, or null": an absent precondition
+ * and a deliberate overwrite are opposite intents, and collapsing them is precisely how last-write-wins creeps back
+ * in — a caller that forgot to state a version would inherit the behaviour of one that explicitly asked to clobber.
+ *
+ * @author GraviteeSource Team
+ */
+public sealed interface VersionPrecondition {
+    /** Whether a write may proceed against {@code storedVersion}. */
+    boolean isSatisfiedBy(Integer storedVersion);
+
+    /**
+     * The stored revision must be one of {@code versions}. Usually a single value; a set because HTTP's
+     * {@code If-Match} accepts a list of validators and any one of them matching is enough.
+     */
+    record OneOf(Set<Integer> versions) implements VersionPrecondition {
+        public OneOf {
+            if (versions == null || versions.isEmpty()) {
+                throw new InvalidDashboardException("At least one version must be stated");
+            }
+            versions = Set.copyOf(versions);
+        }
+
+        public static OneOf of(int version) {
+            return new OneOf(Set.of(version));
+        }
+
+        /**
+         * A dashboard with no stored version satisfies no version — and the null check is not decorative: the
+         * immutable set this holds throws on {@code contains(null)} rather than answering false.
+         */
+        @Override
+        public boolean isSatisfiedBy(Integer storedVersion) {
+            return storedVersion != null && versions.contains(storedVersion);
+        }
+    }
+
+    /**
+     * Any current revision will do — an explicit overwrite. It says nothing about the dashboard <em>existing</em>:
+     * that is still required, so a deliberate overwrite cannot resurrect something another author deleted.
+     */
+    record AnyVersion() implements VersionPrecondition {
+        @Override
+        public boolean isSatisfiedBy(Integer storedVersion) {
+            return true;
+        }
+    }
+
+    static VersionPrecondition oneOf(Set<Integer> versions) {
+        return new OneOf(new LinkedHashSet<>(versions));
+    }
+
+    static VersionPrecondition version(int version) {
+        return OneOf.of(version);
+    }
+
+    static VersionPrecondition anyVersion() {
+        return new AnyVersion();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/port/repository/DashboardRepository.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/port/repository/DashboardRepository.java
@@ -45,7 +45,26 @@ public interface DashboardRepository {
 
     Dashboard create(Dashboard dashboard);
 
-    Dashboard update(Dashboard dashboard);
+    /**
+     * Writes only if the stored version is still {@code expectedVersion}; empty means someone else got there first
+     * (or deleted the dashboard). The comparison belongs to the storage query, not to the caller — a use case that
+     * read the version and then wrote unconditionally would leave the very window this guard exists to close.
+     *
+     * <p>{@code expectedVersion} is a primitive because a stored {@code null} version cannot be guarded at all; a
+     * dashboard in that state is writable only through {@link #updateIfPresent}.
+     */
+    Optional<Dashboard> updateIfVersionMatches(Dashboard dashboard, int expectedVersion);
+
+    /**
+     * Writes whatever the current revision is, provided the dashboard still exists; empty means it does not. Backs a
+     * deliberate overwrite, so it is the one write that does not consult the version.
+     *
+     * <p>There is no unconditional {@code update} on this port on purpose. Every write goes through one of these two
+     * methods, and both make the caller face the case where nothing was written — a plain {@code update} would sit
+     * here as an unguarded path for a future use case to pick up by accident, which is exactly how last-write-wins
+     * would come back.
+     */
+    Optional<Dashboard> updateIfPresent(Dashboard dashboard);
 
     /**
      * Takes a bare id because environment scoping happens before deletion: the delete use case

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/UpdateObservabilityDashboardUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/UpdateObservabilityDashboardUseCase.java
@@ -18,17 +18,39 @@ package io.gravitee.gamma.rest.core.observability.dashboard.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.gamma.rest.core.observability.dashboard.exception.DashboardNotFoundException;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.DashboardVersionConflictException;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardContent;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.VersionPrecondition;
 import io.gravitee.gamma.rest.core.observability.dashboard.port.repository.DashboardRepository;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 
 /**
- * Replaces a dashboard's author-editable content (OBS-16). Starts from the existing aggregate so the
- * server-owned fields survive the write: {@code createdAt} and {@code createdBy} are carried over,
- * {@code updatedAt} is stamped now and {@code version} is incremented. A stale version is not
- * rejected here — behaviour stays last-write-wins until OBS-17 lands the guard; a partial check
- * would advertise a guarantee that still has a TOCTOU hole on the Mongo path.
+ * Replaces a dashboard's author-editable content, under optimistic locking (OBS-17). Starts from the
+ * existing aggregate so the server-owned fields survive the write: {@code createdAt} and
+ * {@code createdBy} are carried over, {@code updatedAt} is stamped now and {@code version} is
+ * incremented.
+ *
+ * <p>The caller must state a {@link VersionPrecondition}, and a stored revision that fails it is
+ * refused with {@link DashboardVersionConflictException} rather than written over. How the
+ * precondition reaches here is the REST layer's business — it arrives as {@code If-Match} and the
+ * refusal leaves as {@code 412} — but the rule is a property of the operation, so it is stated as a
+ * required argument rather than trusted to a single caller. There is no way to express "no
+ * precondition": {@link VersionPrecondition.AnyVersion} is the deliberate overwrite, and a caller
+ * that simply forgot cannot land on it by omission.
+ *
+ * <p>For a version-bearing precondition the comparison happens twice, and both are needed. The one
+ * here reads the dashboard the caller is about to clobber, which is what the refusal has to carry.
+ * The one inside {@link DashboardRepository#updateIfVersionMatches} is the actual guard: between
+ * this use case's read and its write sits a window a competing save fits through, and only a
+ * comparison made by the storage query itself closes it. Losing that second race is rare but not
+ * impossible, hence the re-read below to answer with the state that actually won.
+ *
+ * <p>An overwrite skips the guard by definition, but not the existence check: it goes through
+ * {@link DashboardRepository#updateIfPresent}, so it can still lose to a concurrent delete rather
+ * than resurrect what another author removed.
  *
  * <p>A dashboard id from another environment throws {@link DashboardNotFoundException} — 404, not
  * 403 — via the same environment-scoped lookup as the read path, so cross-environment existence
@@ -42,16 +64,40 @@ public class UpdateObservabilityDashboardUseCase {
 
     private final DashboardRepository dashboardRepository;
 
-    public record Input(String environmentId, String dashboardId, DashboardContent content) {}
+    public record Input(String environmentId, String dashboardId, VersionPrecondition precondition, DashboardContent content) {}
 
     public record Output(Dashboard dashboard) {}
 
     public Output execute(Input input) {
         input.content().validate();
-        Dashboard existing = dashboardRepository
+        if (input.precondition() == null) {
+            throw new InvalidDashboardException("The revision this edit is based on must be stated");
+        }
+        Dashboard existing = findOrThrow(input);
+        if (!input.precondition().isSatisfiedBy(existing.version())) {
+            throw new DashboardVersionConflictException(existing, input.precondition());
+        }
+        Dashboard updated = withContentOf(input, existing);
+
+        // Exhaustive over the sealed precondition rather than an if/else, so a third kind cannot silently inherit one
+        // of these two write paths. Unboxing the version is safe in the OneOf arm: it was just matched against the
+        // stored one, and OneOf is satisfied by no null.
+        Optional<Dashboard> written = switch (input.precondition()) {
+            case VersionPrecondition.AnyVersion ignored -> dashboardRepository.updateIfPresent(updated);
+            case VersionPrecondition.OneOf ignored -> dashboardRepository.updateIfVersionMatches(updated, existing.version());
+        };
+
+        return written.map(Output::new).orElseThrow(() -> new DashboardVersionConflictException(findOrThrow(input), input.precondition()));
+    }
+
+    private Dashboard findOrThrow(Input input) {
+        return dashboardRepository
             .findByIdAndEnvironmentId(input.dashboardId(), input.environmentId())
             .orElseThrow(() -> new DashboardNotFoundException(input.dashboardId()));
-        Dashboard updated = new Dashboard(
+    }
+
+    private static Dashboard withContentOf(Input input, Dashboard existing) {
+        return new Dashboard(
             existing.id(),
             existing.environmentId(),
             input.content().title(),
@@ -64,12 +110,12 @@ public class UpdateObservabilityDashboardUseCase {
             existing.createdAt(),
             TimeProvider.instantNow()
         );
-        return new Output(dashboardRepository.update(updated));
     }
 
     /**
-     * Rows written before OBS-16 may carry a {@code null} version (the OBS-14 repository persists it
-     * verbatim, never initialises it) — treat them as unversioned and (re)start the counter.
+     * A stored {@code null} is reachable only through an overwrite — the repository model still permits the value,
+     * and such a dashboard carries no {@code ETag} for a caller to match on, so an overwrite is the only way to save
+     * it. Starting the counter is what makes it a normally versioned dashboard from then on.
      */
     private static int nextVersion(Dashboard existing) {
         return existing.version() == null ? 1 : existing.version() + 1;

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapter.java
@@ -75,10 +75,21 @@ public class GammaDashboardRepositoryAdapter implements DashboardRepository {
     }
 
     @Override
-    public Dashboard update(Dashboard dashboard) {
+    public Optional<Dashboard> updateIfPresent(Dashboard dashboard) {
         return RepositoryCalls.wrap(
-            () -> toCore(gammaDashboardRepository.update(toRepository(dashboard))),
+            () -> gammaDashboardRepository.updateIfPresent(toRepository(dashboard)).map(GammaDashboardRepositoryAdapter::toCore),
             "Failed to update dashboard '%s'".formatted(dashboard.id())
+        );
+    }
+
+    @Override
+    public Optional<Dashboard> updateIfVersionMatches(Dashboard dashboard, int expectedVersion) {
+        return RepositoryCalls.wrap(
+            () ->
+                gammaDashboardRepository
+                    .updateIfVersionMatches(toRepository(dashboard), expectedVersion)
+                    .map(GammaDashboardRepositoryAdapter::toCore),
+            "Failed to update dashboard '%s' at version %d".formatted(dashboard.id(), expectedVersion)
         );
     }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/DashboardEntityTag.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/DashboardEntityTag.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.dashboards;
+
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import io.gravitee.gamma.rest.resources.observability.dashboards.dto.DashboardDto;
+import jakarta.ws.rs.core.EntityTag;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * The one place a dashboard's {@code ETag} is spelled.
+ *
+ * <p>Every response that names a revision goes through here — create, read, update, and the {@code 412} that refuses a
+ * save. {@code If-Match} only works if the value handed out on one response is the value accepted on the next request,
+ * and independent formatting sites are how that quietly stops being true: the refusal path formatted its own tag for
+ * exactly one commit, and got the no-version case wrong that the read path had already fixed.
+ *
+ * @author GraviteeSource Team
+ */
+public final class DashboardEntityTag {
+
+    private DashboardEntityTag() {}
+
+    /** Attaches the dashboard as the response entity, plus its {@code ETag}. */
+    public static Response.ResponseBuilder withETag(Response.ResponseBuilder builder, Dashboard dashboard) {
+        return withETagOnly(builder.entity(DashboardDto.from(dashboard)), dashboard);
+    }
+
+    /**
+     * Attaches the {@code ETag} alone, for responses carrying something other than the dashboard itself.
+     *
+     * <p>No version, no tag — rather than the string {@code "null"}, which would be a validator this API refuses on
+     * the way back in, leaving the dashboard unsaveable by a client that did exactly what it was told. Omitting the
+     * header states the truth instead: there is nothing to match on, so the only way to save it is {@code If-Match: *}.
+     */
+    public static Response.ResponseBuilder withETagOnly(Response.ResponseBuilder builder, Dashboard dashboard) {
+        return dashboard.version() == null ? builder : builder.tag(new EntityTag(String.valueOf(dashboard.version())));
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardResource.java
@@ -17,11 +17,13 @@ package io.gravitee.gamma.rest.resources.observability.dashboards;
 
 import io.gravitee.common.http.MediaType;
 import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.VersionPrecondition;
 import io.gravitee.gamma.rest.core.observability.dashboard.use_case.DeleteObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.core.observability.dashboard.use_case.GetObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.core.observability.dashboard.use_case.UpdateObservabilityDashboardUseCase;
 import io.gravitee.gamma.rest.resources.observability.dashboards.dto.DashboardDto;
 import io.gravitee.gamma.rest.resources.observability.dashboards.dto.SaveDashboardRequestDto;
+import io.gravitee.rest.api.management.rest.model.ErrorEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.rest.annotation.Permission;
@@ -34,7 +36,14 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Single saved-dashboard endpoints (GET / PUT / DELETE), reached via
@@ -47,10 +56,35 @@ import jakarta.ws.rs.core.Response;
  * <p>On PUT the id comes from the path — a different id in the request body is ignored, like every
  * other server-owned field (see {@link SaveDashboardRequestDto}).
  *
+ * <h2>Concurrency (OBS-17)</h2>
+ * The revision an edit is based on travels as an {@code ETag} / {@code If-Match} pair rather than a
+ * body field: it is the mechanism HTTP already has for this exact problem, so clients, proxies and
+ * generated SDKs recognise it without being taught a Gamma-specific convention, and a future
+ * versioned resource inherits the same vocabulary instead of inventing its own.
+ *
+ * <p>Every response carrying a single dashboard sets {@code ETag} to its version, and PUT requires
+ * that value back in {@code If-Match}. The precondition is enforced, never inferred:
+ *
+ * <ul>
+ *   <li>no {@code If-Match} → {@code 428 Precondition Required} — the request is refused rather than
+ *       treated as an overwrite, since an implicit force is exactly what this feature exists to
+ *       prevent;</li>
+ *   <li>a stale {@code If-Match} → {@code 412 Precondition Failed}, carrying the current dashboard;</li>
+ *   <li>{@code If-Match: *} → the write is applied over whatever revision is current. This is HTTP's
+ *       own spelling of a deliberate overwrite, which is what makes it safe to offer: it cannot be
+ *       reached by forgetting the header, only by choosing a different one. It is the second step of
+ *       the conflict flow — a client that got a 412 and whose user chose "overwrite" can apply the
+ *       edit in one request instead of re-reading and re-submitting, which would race again.
+ *       Existence is still required, so an overwrite cannot resurrect a deleted dashboard.</li>
+ * </ul>
+ *
  * @author GraviteeSource Team
  */
 @Produces(MediaType.APPLICATION_JSON)
 public class ObservabilityDashboardResource {
+
+    private static final int PRECONDITION_REQUIRED_428 = 428;
+    private static final String WILDCARD_VALIDATOR = "*";
 
     @Inject
     private GetObservabilityDashboardUseCase getDashboardUseCase;
@@ -63,24 +97,25 @@ public class ObservabilityDashboardResource {
 
     @GET
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = { RolePermissionAction.READ }) })
-    public DashboardDto get(@PathParam("dashboardId") String dashboardId) {
+    public Response get(@PathParam("dashboardId") String dashboardId) {
         var ctx = GraviteeContext.getExecutionContext();
         var output = getDashboardUseCase.execute(new GetObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), dashboardId));
-        return DashboardDto.from(output.dashboard());
+        return DashboardEntityTag.withETag(Response.ok(), output.dashboard()).build();
     }
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = { RolePermissionAction.UPDATE }) })
-    public DashboardDto update(@PathParam("dashboardId") String dashboardId, SaveDashboardRequestDto request) {
+    public Response update(@PathParam("dashboardId") String dashboardId, @Context HttpHeaders headers, SaveDashboardRequestDto request) {
         if (request == null) {
             throw new InvalidDashboardException("Request body is required");
         }
+        VersionPrecondition precondition = requiredVersionPrecondition(headers.getRequestHeader(HttpHeaders.IF_MATCH));
         var ctx = GraviteeContext.getExecutionContext();
         var output = updateDashboardUseCase.execute(
-            new UpdateObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), dashboardId, request.toContent())
+            new UpdateObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), dashboardId, precondition, request.toContent())
         );
-        return DashboardDto.from(output.dashboard());
+        return DashboardEntityTag.withETag(Response.ok(), output.dashboard()).build();
     }
 
     @DELETE
@@ -89,5 +124,63 @@ public class ObservabilityDashboardResource {
         var ctx = GraviteeContext.getExecutionContext();
         deleteDashboardUseCase.execute(new DeleteObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), dashboardId));
         return Response.noContent().build();
+    }
+
+    /**
+     * Turns {@code If-Match} into the precondition the write is subject to.
+     *
+     * <p>Takes the header's every value rather than one string, because HTTP lets a client spell the same list two
+     * ways — {@code If-Match: "1", "3"} or the field repeated once per validator — and reading only the first would
+     * refuse a request whose precondition holds. Both forms flatten to the same set of validators here.
+     *
+     * <p>Weak forms ({@code W/"4"}) are accepted as equivalent: the validator is a revision counter, so a proxy
+     * rewriting the form does not change which revision it names. A validator that is not a version this API issued
+     * is refused rather than guessed at.
+     */
+    private static VersionPrecondition requiredVersionPrecondition(List<String> ifMatch) {
+        List<String> validators = ifMatch == null
+            ? List.of()
+            : ifMatch
+                .stream()
+                .filter(Objects::nonNull)
+                .flatMap(value -> Arrays.stream(value.split(",")))
+                .map(String::trim)
+                .filter(validator -> !validator.isEmpty())
+                .toList();
+
+        if (validators.isEmpty()) {
+            throw new WebApplicationException(
+                Response.status(PRECONDITION_REQUIRED_428)
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity(
+                        new ErrorEntity(
+                            "If-Match is required on a dashboard update: send back the ETag you received, or `*` to overwrite whatever revision is current",
+                            PRECONDITION_REQUIRED_428
+                        )
+                    )
+                    .build()
+            );
+        }
+        if (validators.contains(WILDCARD_VALIDATOR)) {
+            if (validators.size() > 1) {
+                // `*` already means "any revision", so pairing it with a specific one states two different intents.
+                // Guessing which was meant could silently overwrite; ask instead.
+                throw new InvalidDashboardException("If-Match must be either `*` or a list of ETags, not both");
+            }
+            return VersionPrecondition.anyVersion();
+        }
+        return VersionPrecondition.oneOf(validators.stream().map(ObservabilityDashboardResource::parseVersion).collect(Collectors.toSet()));
+    }
+
+    private static int parseVersion(String validator) {
+        String value = validator.startsWith("W/") ? validator.substring(2) : validator;
+        if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            value = value.substring(1, value.length() - 1);
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new InvalidDashboardException("If-Match '%s' is not a dashboard ETag issued by this API".formatted(validator));
+        }
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResource.java
@@ -54,7 +54,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
  *       (1-based, {@code perPage} capped server-side at 100). See {@link ListObservabilityDashboardUseCase}
  *       for why pagination is applied by slicing rather than a native repository query.</li>
  *   <li>{@code POST /} — creates a dashboard from a client-supplied id (AGENTS.md §9), returns
- *       {@code 201} with a {@code Location} header.</li>
+ *       {@code 201} with a {@code Location} header and the new dashboard's {@code ETag}, so the
+ *       creator can go straight to editing without re-reading it.</li>
  *   <li>{@code GET /{dashboardId}}, {@code PUT}, {@code DELETE} — see {@link ObservabilityDashboardResource}.</li>
  * </ul>
  *
@@ -102,8 +103,8 @@ public class ObservabilityDashboardsResource {
         var output = createDashboardUseCase.execute(
             new CreateObservabilityDashboardUseCase.Input(ctx.getEnvironmentId(), currentUserId(), request.id(), request.toContent())
         );
-        DashboardDto dto = DashboardDto.from(output.dashboard());
-        return Response.created(uriInfo.getAbsolutePathBuilder().path(dto.id()).build()).entity(dto).build();
+        var created = output.dashboard();
+        return DashboardEntityTag.withETag(Response.created(uriInfo.getAbsolutePathBuilder().path(created.id()).build()), created).build();
     }
 
     /**

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/DashboardConflictDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/DashboardConflictDto.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.dashboards.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Body of the {@code 412} returned when a dashboard was modified since the caller read it.
+ *
+ * <p>Extends the standard error shape ({@code message} + {@code http_status}, as produced by the
+ * platform's {@code ErrorEntity}) rather than replacing it, so a client with generic error handling
+ * still gets a usable message, while one that handles the refusal properly finds everything it needs
+ * to offer overwrite / reload / save-as-a-copy without a second round trip.
+ *
+ * <p>{@code currentVersion} duplicates what the response's {@code ETag} already carries. That is
+ * deliberate: the ETag is what a client feeds back into {@code If-Match}, while this stays readable
+ * to anything that only ever parses bodies — and to a human reading the response.
+ */
+public record DashboardConflictDto(
+    String message,
+    @JsonProperty("http_status") int httpStatus,
+    Integer currentVersion,
+    DashboardDto dashboard
+) {
+    public static DashboardConflictDto from(String message, Dashboard current) {
+        return new DashboardConflictDto(
+            message,
+            Response.Status.PRECONDITION_FAILED.getStatusCode(),
+            current.version(),
+            DashboardDto.from(current)
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/SaveDashboardRequestDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/dto/SaveDashboardRequestDto.java
@@ -27,6 +27,10 @@ import java.util.List;
  * {@code createdAt}, {@code updatedAt}, {@code createdBy}, {@code environmentId}) are not declared
  * here and are silently dropped by Jackson ({@code GraviteeMapper} disables
  * {@code FAIL_ON_UNKNOWN_PROPERTIES}), so a client sending them cannot influence the write.
+ *
+ * <p>{@code version} stays out of this shape on purpose (OBS-17): the revision a PUT is based on
+ * travels in the {@code If-Match} header, not the body, so the body remains a pure description of
+ * the dashboard's content and the concurrency token is expressed the way HTTP already expresses it.
  */
 public record SaveDashboardRequestDto(
     String id,

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/exception/DashboardVersionConflictExceptionMapper.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/exception/DashboardVersionConflictExceptionMapper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.dashboards.exception;
+
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.DashboardVersionConflictException;
+import io.gravitee.gamma.rest.resources.observability.dashboards.DashboardEntityTag;
+import io.gravitee.gamma.rest.resources.observability.dashboards.dto.DashboardConflictDto;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * Maps a stale-version save to {@code 412 Precondition Failed}.
+ *
+ * <p>412 rather than 409 because the caller stated a precondition in {@code If-Match} and it did not
+ * hold — which is what 412 means. 409 would describe the same event in a vocabulary the HTTP
+ * mechanism we chose does not use, leaving a client that already understands conditional requests to
+ * special-case this API.
+ *
+ * <p>The response carries the current revision's {@code ETag} — via {@link DashboardEntityTag}, like every other
+ * response that names one — so a client whose user chooses to reload has the validator for its next save without a
+ * second request.
+ *
+ * <p>Domain-specific rather than a generic mapper for the exception's base type, for two reasons.
+ * The platform registers no {@code ConflictDomainException} mapper at all in
+ * {@code GammaModuleApplication} — management-rest ships none — so without this a refused save would
+ * surface through {@code ThrowableMapper} as a 500, telling the author their work failed for an
+ * unknown reason. And the body has to carry the current dashboard, which the shared error shape
+ * cannot express.
+ *
+ * @author GraviteeSource Team
+ */
+@Provider
+public class DashboardVersionConflictExceptionMapper implements ExceptionMapper<DashboardVersionConflictException> {
+
+    @Override
+    public Response toResponse(DashboardVersionConflictException exception) {
+        var current = exception.getCurrent();
+        return DashboardEntityTag.withETagOnly(
+            Response.status(Response.Status.PRECONDITION_FAILED)
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .entity(DashboardConflictDto.from(exception.getMessage(), current)),
+            current
+        ).build();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -159,7 +159,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 400
+                                http_status: 400
                                 message: "Unknown signal value 'INVALID'"
                 "403":
                     description: The caller cannot read observability metadata in this environment.
@@ -168,7 +168,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 403
+                                http_status: 403
                                 message: "Insufficient permissions to access observability metadata."
 
     /organizations/{orgId}/environments/{envId}/observability/filters/{filterName}/values:
@@ -302,7 +302,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 400
+                                http_status: 400
                                 message: "Filter type NUMBER does not support value listing."
                                 technicalCode: "filter.values.unsupported"
                 "403":
@@ -312,7 +312,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 403
+                                http_status: 403
                                 message: "Insufficient permissions to access observability metadata."
                 "404":
                     description: No filter with the given name exists in the catalog.
@@ -321,7 +321,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 404
+                                http_status: 404
                                 message: "Filter 'UNKNOWN_FILTER' not found in the catalog."
 
     /organizations/{orgId}/environments/{envId}/observability/filters/resolve:
@@ -381,7 +381,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 400
+                                http_status: 400
                                 message: "Request exceeds the maximum of 10 entries."
                 "403":
                     description: The caller cannot read observability metadata in this environment.
@@ -390,7 +390,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 403
+                                http_status: 403
                                 message: "Insufficient permissions to access observability metadata."
 
     /organizations/{orgId}/environments/{envId}/observability/logs/{requestId}:
@@ -496,7 +496,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 400
+                                http_status: 400
                                 message: "Required scope dimension 'apiId' is missing"
                                 technicalCode: "observability.log.scope.missing"
                 "404":
@@ -509,7 +509,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 404
+                                http_status: 404
                                 message: "Log req-abc-123 not found for API 67e246cb-ab02-4da4-8f47-f9fa3e061d6b"
 
     /organizations/{orgId}/environments/{envId}/observability/logs/search:
@@ -725,36 +725,36 @@ paths:
                                 unknown-filter:
                                     summary: Unknown filter name
                                     value:
-                                        httpStatus: 400
+                                        http_status: 400
                                         message: "Filter 'UNKNOWN_FILTER' is not supported by this backend"
                                         technicalCode: "observability.filter.unknown_name"
                                 signal-mismatch:
                                     summary: Filter not applicable to LOGS signal
                                     value:
-                                        httpStatus: 400
+                                        http_status: 400
                                         message: "Filter 'GATEWAY' does not apply to signal LOGS"
                                         technicalCode: "observability.filter.signal_mismatch"
                                 unsupported-operator:
                                     summary: Operator not usable for this filter on log search
                                     value:
-                                        httpStatus: 400
+                                        http_status: 400
                                         message: "Operator 'GTE' is not supported for filter 'ERROR_KEY'"
                                         technicalCode: "observability.filter.unsupported_operator"
                                 search-translation-not-supported:
                                     summary: Filter valid for LOGS but not yet translated by log search
                                     value:
-                                        httpStatus: 400
+                                        http_status: 400
                                         message: "Filter 'API_TYPE' is not yet supported for log search"
                                         technicalCode: "observability.filter.search_translation_not_supported"
                                 invalid-filter-value:
                                     summary: Malformed or out-of-range filter value
                                     value:
-                                        httpStatus: 400
+                                        http_status: 400
                                         message: "Invalid HTTP status code: 1000. Must be between 100 and 599."
                                 invalid-time-range:
                                     summary: Invalid time range (from > to)
                                     value:
-                                        httpStatus: 400
+                                        http_status: 400
                                         message: "Invalid time range: 'from' must be before 'to'."
                 "403":
                     description: The caller cannot read observability data in this environment (missing `ENVIRONMENT_DASHBOARD:READ` or `ENVIRONMENT_API:READ` permission).
@@ -763,7 +763,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 403
+                                http_status: 403
                                 message: "Insufficient permissions to access observability data."
 
     /organizations/{orgId}/environments/{envId}/observability/analytics/measures:
@@ -858,7 +858,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 403
+                                http_status: 403
                                 message: "Insufficient permissions to access observability data."
 
     /organizations/{orgId}/environments/{envId}/observability/analytics/facets:
@@ -958,7 +958,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 403
+                                http_status: 403
                                 message: "Insufficient permissions to access observability data."
 
     /organizations/{orgId}/environments/{envId}/observability/analytics/time-series:
@@ -1046,7 +1046,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 403
+                                http_status: 403
                                 message: "Insufficient permissions to access observability data."
 
     /organizations/{orgId}/environments/{envId}/observability/dashboards:
@@ -1149,7 +1149,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 403
+                                http_status: 403
                                 message: "Insufficient permissions to access dashboards."
         post:
             tags:
@@ -1171,7 +1171,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: "#/components/schemas/SaveDashboardRequest"
+                            $ref: "#/components/schemas/CreateDashboardRequest"
                         example:
                             id: "d7e246cb-ab02-4da4-8f47-f9fa3e061d6b"
                             title: "Performance overview"
@@ -1209,7 +1209,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 400
+                                http_status: 400
                                 message: "Dashboard cannot hold more than 50 widgets"
                 "403":
                     description: The caller cannot create dashboards in this environment.
@@ -1218,7 +1218,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 403
+                                http_status: 403
                                 message: "Insufficient permissions to create dashboards."
 
     /organizations/{orgId}/environments/{envId}/observability/dashboards/{dashboardId}:
@@ -1280,7 +1280,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 403
+                                http_status: 403
                                 message: "Insufficient permissions to access dashboards."
                 "404":
                     description: No dashboard with this id exists in this environment.
@@ -1289,7 +1289,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 404
+                                http_status: 404
                                 message: "Dashboard 'd7e246cb-ab02-4da4-8f47-f9fa3e061d6b' not found"
         put:
             tags:
@@ -1319,7 +1319,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: "#/components/schemas/SaveDashboardRequest"
+                            $ref: "#/components/schemas/UpdateDashboardRequest"
                         example:
                             title: "Performance overview (renamed)"
                             filters: []
@@ -1346,7 +1346,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 400
+                                http_status: 400
                                 message: "Dashboard title is required"
                 "403":
                     description: The caller cannot update dashboards in this environment.
@@ -1355,7 +1355,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 403
+                                http_status: 403
                                 message: "Insufficient permissions to update dashboards."
                 "404":
                     description: No dashboard with this id exists in this environment.
@@ -1364,7 +1364,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 404
+                                http_status: 404
                                 message: "Dashboard 'd7e246cb-ab02-4da4-8f47-f9fa3e061d6b' not found"
         delete:
             tags:
@@ -1392,7 +1392,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 403
+                                http_status: 403
                                 message: "Insufficient permissions to delete dashboards."
                 "404":
                     description: No dashboard with this id exists in this environment.
@@ -1401,7 +1401,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                httpStatus: 404
+                                http_status: 404
                                 message: "Dashboard 'd7e246cb-ab02-4da4-8f47-f9fa3e061d6b' not found"
 
 components:
@@ -2611,7 +2611,10 @@ components:
             description: |
                 Everything you can set on a dashboard. Used by both `POST` and `PUT`; on `PUT` it
                 replaces the dashboard's content wholesale, so send the complete object.
-            required: [id, title]
+
+                `id` is only meaningful on one of the two verbs — see `CreateDashboardRequest`
+                and `UpdateDashboardRequest`, which state which.
+            required: [title]
             properties:
                 id:
                     type: string
@@ -2641,12 +2644,25 @@ components:
                     items:
                         type: object
 
+        CreateDashboardRequest:
+            allOf:
+                - $ref: "#/components/schemas/SaveDashboardRequest"
+                - type: object
+                  description: A dashboard being created. You supply the `id`.
+                  required: [id]
+
+        UpdateDashboardRequest:
+            allOf:
+                - $ref: "#/components/schemas/SaveDashboardRequest"
+                - type: object
+                  description: A dashboard being replaced. The `id` comes from the URL and is ignored here.
+
         Error:
             type: object
             description: Standard error response.
-            required: [httpStatus, message]
+            required: [http_status, message]
             properties:
-                httpStatus:
+                http_status:
                     type: integer
                     description: HTTP status code.
                 message:

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -1194,6 +1194,10 @@ paths:
                             description: URL of the created dashboard.
                             schema:
                                 type: string
+                        ETag:
+                            description: Version of the new dashboard, ready for a first `If-Match`.
+                            schema:
+                                type: string
                     content:
                         application/json:
                             schema:
@@ -1244,6 +1248,14 @@ paths:
             responses:
                 "200":
                     description: The saved dashboard.
+                    headers:
+                        ETag:
+                            description: |
+                                Current version — quote it in `If-Match` when you save. Absent on a
+                                dashboard that carries no version, which can then only be saved with
+                                `If-Match: *`.
+                            schema:
+                                type: string
                     content:
                         application/json:
                             schema:
@@ -1300,11 +1312,27 @@ paths:
 
                 This is a full replacement, not a partial update: anything you leave out is
                 cleared. The usual sequence is to `GET` the dashboard, change what you need and
-                send the whole object back.
+                send the whole object back, quoting the `ETag` you received in `If-Match`.
 
-                The response carries a new `version`. Concurrent updates are applied in the order
-                they reach the server and the last one wins — if several people can edit the same
-                dashboard, re-read it before saving rather than holding a copy open for a long time.
+                That header is how concurrent edits are caught. If someone else saved the dashboard
+                after you read it, yours is refused with `412` and their work is left untouched; the
+                response carries the current dashboard so you can show what changed and let the
+                author choose to overwrite, reload, or save a copy. Nothing is lost either way — a
+                refused save changes nothing on the server, and your edits are still in hand.
+
+                `If-Match` is required: without it the request is refused with `428` rather than
+                treated as an overwrite. You may send several validators (`"3", "4"`) — any one
+                matching is enough.
+
+                `If-Match: *` means "whatever revision is current" and applies the write
+                unconditionally. That is the second step of the conflict flow: a client that got a
+                `412` and whose user chose to overwrite can apply the edit in one request, instead of
+                re-reading and re-submitting, which could lose the same race again. It cannot be
+                reached by forgetting the header, only by deliberately choosing a different one. The
+                dashboard must still exist, so an overwrite never resurrects a deleted one.
+
+                On success the stored version is incremented and returned, both in the body and in a
+                fresh `ETag`.
             operationId: updateObservabilityDashboard
             parameters:
                 - name: dashboardId
@@ -1312,6 +1340,18 @@ paths:
                   required: true
                   description: Unique identifier of the dashboard.
                   example: d7e246cb-ab02-4da4-8f47-f9fa3e061d6b
+                  schema:
+                      type: string
+                - name: If-Match
+                  in: header
+                  required: true
+                  description: |
+                      The `ETag` you received when you read this dashboard; the update is applied only
+                      if it still matches the stored revision. A list is accepted, any one matching
+                      being enough, spelled either comma-separated or as a repeated header. `*`
+                      applies the write over whatever revision is current — a deliberate overwrite —
+                      and cannot be combined with a specific validator.
+                  example: "\"3\""
                   schema:
                       type: string
             requestBody:
@@ -1330,24 +1370,71 @@ paths:
                             widgets: [{ id: "w1", type: "metric" }]
             responses:
                 "200":
-                    description: The updated dashboard, with the incremented `version`.
+                    description: The updated dashboard, with the incremented version.
+                    headers:
+                        ETag:
+                            description: The new version, to quote in the next update's `If-Match`.
+                            schema:
+                                type: string
                     content:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Dashboard"
                 "400":
                     description: |
-                        The dashboard could not be saved. The message names the problem: a missing
-                        title, more than 50 widgets, a widgets payload above 1 MB, a widget with a
-                        missing or duplicated `id`, a time range without the fields its `type`
-                        requires, or an unknown filter operator.
+                        The dashboard could not be saved. The message names the problem: an
+                        `If-Match` that is not an ETag this API issued, a missing title, more than 50
+                        widgets, a widgets payload above 1 MB, a widget with a missing or duplicated
+                        `id`, a time range without the fields its `type` requires, or an unknown
+                        filter operator.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            examples:
+                                unreadable-if-match:
+                                    summary: If-Match is not an ETag this API issued
+                                    value:
+                                        http_status: 400
+                                        message: "If-Match 'abc' is not a dashboard ETag issued by this API"
+                                wildcard-mixed-with-etags:
+                                    summary: "`*` combined with a specific validator"
+                                    value:
+                                        http_status: 400
+                                        message: "If-Match must be either `*` or a list of ETags, not both"
+                                invalid-content:
+                                    summary: Invalid content
+                                    value:
+                                        http_status: 400
+                                        message: "Dashboard title is required"
+                "412":
+                    description: |
+                        Someone else saved this dashboard after you read it, so your `If-Match` no
+                        longer matches. Your changes were not applied and the stored dashboard is
+                        unchanged.
+                    headers:
+                        ETag:
+                            description: |
+                                The version stored right now, to retry with. Absent on a dashboard
+                                carrying no version.
+                            schema:
+                                type: string
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DashboardConflict"
+                "428":
+                    description: |
+                        No `If-Match` was sent. The update is refused rather than applied blindly, so
+                        a concurrent edit cannot be overwritten unnoticed. Send the `ETag` you
+                        received, or `*` to overwrite deliberately.
                     content:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Error"
                             example:
-                                http_status: 400
-                                message: "Dashboard title is required"
+                                http_status: 428
+                                message: "If-Match is required on a dashboard update: send back the ETag you received, or `*` to overwrite whatever revision is current"
                 "403":
                     description: The caller cannot update dashboards in this environment.
                     content:
@@ -2648,14 +2735,42 @@ components:
             allOf:
                 - $ref: "#/components/schemas/SaveDashboardRequest"
                 - type: object
-                  description: A dashboard being created. You supply the `id`.
+                  description: |
+                      A dashboard being created. You supply the `id`. The new dashboard starts at
+                      version 1, returned in the response `ETag`.
                   required: [id]
 
         UpdateDashboardRequest:
             allOf:
                 - $ref: "#/components/schemas/SaveDashboardRequest"
                 - type: object
-                  description: A dashboard being replaced. The `id` comes from the URL and is ignored here.
+                  description: |
+                      A dashboard being replaced. The revision your edit was based on travels in the
+                      required `If-Match` header, not in this body. The `id` comes from the URL and
+                      is ignored here.
+
+        DashboardConflict:
+            type: object
+            description: |
+                Returned with `412` when the dashboard changed since you read it. Carries the current
+                dashboard as well as its version, so you can show the author what they were about to
+                overwrite without a second request. The response `ETag` carries that same version,
+                ready to be sent back in `If-Match`.
+            required: [message, http_status, dashboard]
+            properties:
+                message:
+                    type: string
+                    description: Human-readable explanation naming both versions.
+                http_status:
+                    type: integer
+                    description: HTTP status code.
+                    example: 412
+                currentVersion:
+                    type: integer
+                    description: The version stored on the server right now — send it back in `If-Match` to overwrite.
+                    example: 4
+                dashboard:
+                    $ref: "#/components/schemas/Dashboard"
 
         Error:
             type: object

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/inmemory/InMemoryDashboardRepository.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/inmemory/InMemoryDashboardRepository.java
@@ -31,12 +31,18 @@ public class InMemoryDashboardRepository implements DashboardRepository {
 
     private final List<Dashboard> dashboards = new ArrayList<>();
 
+    private Dashboard pendingConcurrentSave;
+
+    private String pendingConcurrentDelete;
+
     public void givenDashboard(Dashboard dashboard) {
         dashboards.add(dashboard);
     }
 
     public void reset() {
         dashboards.clear();
+        pendingConcurrentSave = null;
+        pendingConcurrentDelete = null;
     }
 
     @Override
@@ -62,17 +68,63 @@ public class InMemoryDashboardRepository implements DashboardRepository {
     }
 
     @Override
-    public Dashboard update(Dashboard dashboard) {
-        // Replaces in place: the real backends order by creation date, so an update must not
-        // reshuffle the list the way remove-then-add would.
+    public Optional<Dashboard> updateIfPresent(Dashboard dashboard) {
+        runPendingConcurrentSave();
+        return replaceInPlace(dashboard);
+    }
+
+    /**
+     * Replaces in place: the real backends order by creation date, so an update must not reshuffle the list the way
+     * remove-then-add would. Absent means absent — no upsert, matching both backends, so a test cannot accidentally
+     * assert on a dashboard the real store would have refused to resurrect.
+     */
+    private Optional<Dashboard> replaceInPlace(Dashboard dashboard) {
         for (int i = 0; i < dashboards.size(); i++) {
             if (Objects.equals(dashboards.get(i).id(), dashboard.id())) {
                 dashboards.set(i, dashboard);
-                return dashboard;
+                return Optional.of(dashboard);
             }
         }
-        dashboards.add(dashboard);
-        return dashboard;
+        return Optional.empty();
+    }
+
+    /**
+     * Compares against the <em>stored</em> version, exactly as the real conditional query does, so the guard is
+     * genuinely exercised rather than mocked away.
+     */
+    @Override
+    public Optional<Dashboard> updateIfVersionMatches(Dashboard dashboard, int expectedVersion) {
+        runPendingConcurrentSave();
+        return findByIdAndEnvironmentId(dashboard.id(), dashboard.environmentId())
+            .filter(stored -> Objects.equals(stored.version(), expectedVersion))
+            .flatMap(stored -> replaceInPlace(dashboard));
+    }
+
+    /**
+     * Runs {@code save} inside the next conditional write, i.e. after the caller has read the dashboard and decided
+     * its version still matched. That interleaving is the whole point of the storage-level guard, and it cannot be
+     * reproduced by seeding the store up front — the caller's own read would see it and refuse earlier.
+     */
+    public void givenAConcurrentSaveBeforeTheNextVersionedWrite(Dashboard winner) {
+        this.pendingConcurrentSave = winner;
+    }
+
+    /** Same idea for a delete landing after the caller's read — the case an overwrite must still lose to. */
+    public void givenADeleteBeforeTheNextWrite(String id) {
+        this.pendingConcurrentDelete = id;
+    }
+
+    private void runPendingConcurrentSave() {
+        if (pendingConcurrentSave != null) {
+            Dashboard winner = pendingConcurrentSave;
+            pendingConcurrentSave = null;
+            replaceInPlace(winner);
+        }
+        if (pendingConcurrentDelete != null) {
+            String doomed = pendingConcurrentDelete;
+            pendingConcurrentDelete = null;
+            delete(doomed);
+        }
     }
 
     @Override

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/UpdateObservabilityDashboardUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/dashboard/use_case/UpdateObservabilityDashboardUseCaseTest.java
@@ -21,16 +21,19 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.databind.node.NullNode;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.gamma.rest.core.observability.dashboard.exception.DashboardNotFoundException;
+import io.gravitee.gamma.rest.core.observability.dashboard.exception.DashboardVersionConflictException;
 import io.gravitee.gamma.rest.core.observability.dashboard.exception.InvalidDashboardException;
 import io.gravitee.gamma.rest.core.observability.dashboard.inmemory.InMemoryDashboardRepository;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.Dashboard;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.DashboardContent;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRange;
 import io.gravitee.gamma.rest.core.observability.dashboard.model.TimeRangeType;
+import io.gravitee.gamma.rest.core.observability.dashboard.model.VersionPrecondition;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -76,7 +79,9 @@ class UpdateObservabilityDashboardUseCaseTest {
             null
         );
 
-        var output = useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, content));
+        var output = useCase.execute(
+            new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, VersionPrecondition.version(3), content)
+        );
 
         assertThat(output.dashboard().title()).isEqualTo("New title");
         assertThat(output.dashboard().description()).isEqualTo("new desc");
@@ -88,23 +93,41 @@ class UpdateObservabilityDashboardUseCaseTest {
         assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENV)).contains(output.dashboard());
     }
 
+    /**
+     * A stored version of {@code null} is not reachable through the API — every dashboard is created with 1 — but the
+     * repository model still allows it. Such a dashboard advertises no ETag, so no version can match it and only an
+     * overwrite can save it; that write starts the counter, making it an ordinary versioned dashboard from then on.
+     */
     @Test
-    void should_restart_the_version_counter_when_the_existing_row_predates_versioning() {
+    void should_refuse_a_version_match_against_a_dashboard_whose_stored_version_is_null() {
         dashboardRepository.givenDashboard(existingDashboard(null));
         var content = new DashboardContent("New title", null, List.of(), null, null);
 
-        var output = useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, content));
+        assertThatThrownBy(() ->
+            useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, VersionPrecondition.version(1), content))
+        ).isInstanceOf(DashboardVersionConflictException.class);
+    }
+
+    @Test
+    void should_let_an_overwrite_save_a_dashboard_whose_stored_version_is_null_and_start_the_counter() {
+        dashboardRepository.givenDashboard(existingDashboard(null));
+        var content = new DashboardContent("New title", null, List.of(), null, null);
+
+        var output = useCase.execute(
+            new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, VersionPrecondition.anyVersion(), content)
+        );
 
         assertThat(output.dashboard().version()).isEqualTo(1);
+        assertThat(output.dashboard().title()).isEqualTo("New title");
     }
 
     @Test
     void should_throw_not_found_when_dashboard_does_not_exist() {
         var content = new DashboardContent("New title", null, List.of(), null, null);
 
-        assertThatThrownBy(() -> useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, "unknown", content))).isInstanceOf(
-            DashboardNotFoundException.class
-        );
+        assertThatThrownBy(() ->
+            useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, "unknown", VersionPrecondition.version(1), content))
+        ).isInstanceOf(DashboardNotFoundException.class);
     }
 
     @Test
@@ -113,7 +136,7 @@ class UpdateObservabilityDashboardUseCaseTest {
         var content = new DashboardContent("New title", null, List.of(), null, null);
 
         assertThatThrownBy(() ->
-            useCase.execute(new UpdateObservabilityDashboardUseCase.Input(OTHER_ENV, DASHBOARD_ID, content))
+            useCase.execute(new UpdateObservabilityDashboardUseCase.Input(OTHER_ENV, DASHBOARD_ID, VersionPrecondition.version(1), content))
         ).isInstanceOf(DashboardNotFoundException.class);
     }
 
@@ -123,10 +146,120 @@ class UpdateObservabilityDashboardUseCaseTest {
         dashboardRepository.givenDashboard(existing);
         var content = new DashboardContent(" ", null, List.of(), null, null);
 
-        assertThatThrownBy(() -> useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, content))).isInstanceOf(
-            InvalidDashboardException.class
-        );
+        assertThatThrownBy(() ->
+            useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, VersionPrecondition.version(3), content))
+        ).isInstanceOf(InvalidDashboardException.class);
         assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENV)).contains(existing);
+    }
+
+    @Test
+    void should_reject_a_stale_version_and_leave_the_stored_dashboard_untouched() {
+        Dashboard existing = existingDashboard(3);
+        dashboardRepository.givenDashboard(existing);
+        var content = new DashboardContent("New title", null, List.of(), null, null);
+
+        assertThatThrownBy(() ->
+            useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, VersionPrecondition.version(2), content))
+        ).isInstanceOfSatisfying(DashboardVersionConflictException.class, e -> assertThat(e.getCurrent()).isEqualTo(existing));
+        assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENV)).contains(existing);
+    }
+
+    /**
+     * The version the caller sends is ahead of the stored one — impossible from a well-behaved client, so it means a
+     * fabricated or replayed request. Refuse it for the same reason a stale one is refused: the caller is not editing
+     * the revision it claims to be.
+     */
+    @Test
+    void should_reject_a_version_ahead_of_the_stored_one() {
+        dashboardRepository.givenDashboard(existingDashboard(3));
+        var content = new DashboardContent("New title", null, List.of(), null, null);
+
+        assertThatThrownBy(() ->
+            useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, VersionPrecondition.version(4), content))
+        ).isInstanceOf(DashboardVersionConflictException.class);
+    }
+
+    @Test
+    void should_reject_a_missing_version_rather_than_treat_it_as_a_force_overwrite() {
+        Dashboard existing = existingDashboard(3);
+        dashboardRepository.givenDashboard(existing);
+        var content = new DashboardContent("New title", null, List.of(), null, null);
+
+        assertThatThrownBy(() -> useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, null, content)))
+            .isInstanceOf(InvalidDashboardException.class)
+            .hasMessageContaining("revision this edit is based on must be stated");
+        assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENV)).contains(existing);
+    }
+
+    /**
+     * The race the storage-level guard exists for: the version still matched when this use case read it, and a
+     * competing save landed before the write. The conditional update refuses it, and the 409 must describe the state
+     * that actually won — not the stale one this use case read.
+     */
+    @Test
+    void should_reject_and_report_the_winner_when_a_concurrent_save_lands_between_the_read_and_the_write() {
+        dashboardRepository.givenDashboard(existingDashboard(3));
+        Dashboard winner = new Dashboard(
+            DASHBOARD_ID,
+            ENV,
+            "Someone else's title",
+            "desc",
+            List.of(),
+            null,
+            NullNode.getInstance(),
+            4,
+            "user-1",
+            CREATED_AT,
+            NOW
+        );
+        dashboardRepository.givenAConcurrentSaveBeforeTheNextVersionedWrite(winner);
+        var content = new DashboardContent("New title", null, List.of(), null, null);
+
+        assertThatThrownBy(() ->
+            useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, VersionPrecondition.version(3), content))
+        ).isInstanceOfSatisfying(DashboardVersionConflictException.class, e -> assertThat(e.getCurrent()).isEqualTo(winner));
+    }
+
+    @Test
+    void should_apply_an_overwrite_over_whatever_revision_is_current() {
+        dashboardRepository.givenDashboard(existingDashboard(3));
+        var content = new DashboardContent("Overwritten", null, List.of(), null, null);
+
+        var output = useCase.execute(
+            new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, VersionPrecondition.anyVersion(), content)
+        );
+
+        assertThat(output.dashboard().title()).isEqualTo("Overwritten");
+        assertThat(output.dashboard().version()).as("an overwrite still moves the counter on").isEqualTo(4);
+    }
+
+    /**
+     * An overwrite is not a resurrection: the dashboard has to still exist. Deleting it inside the write reproduces
+     * the only way that can happen — a delete landing after this use case's read.
+     */
+    @Test
+    void should_refuse_an_overwrite_when_the_dashboard_was_deleted_first() {
+        dashboardRepository.givenDashboard(existingDashboard(3));
+        dashboardRepository.givenADeleteBeforeTheNextWrite(DASHBOARD_ID);
+        var content = new DashboardContent("Overwritten", null, List.of(), null, null);
+
+        assertThatThrownBy(() ->
+            useCase.execute(new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, VersionPrecondition.anyVersion(), content))
+        ).isInstanceOf(DashboardNotFoundException.class);
+        assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENV)).isEmpty();
+    }
+
+    /** If-Match accepts a list of validators; any one matching is enough. */
+    @Test
+    void should_accept_a_precondition_listing_several_versions_when_one_of_them_is_stored() {
+        dashboardRepository.givenDashboard(existingDashboard(3));
+        var content = new DashboardContent("New title", null, List.of(), null, null);
+
+        var output = useCase.execute(
+            new UpdateObservabilityDashboardUseCase.Input(ENV, DASHBOARD_ID, VersionPrecondition.oneOf(Set.of(2, 3)), content)
+        );
+
+        assertThat(output.dashboard().version()).isEqualTo(4);
     }
 
     private static Dashboard existingDashboard(Integer version) {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapterTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/GammaDashboardRepositoryAdapterTest.java
@@ -18,6 +18,8 @@ package io.gravitee.gamma.rest.infra.adapter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -197,7 +199,7 @@ class GammaDashboardRepositoryAdapterTest {
     }
 
     @Test
-    void should_persist_absent_widgets_as_null_on_update() throws Exception {
+    void should_persist_absent_widgets_as_null_on_an_overwrite() throws Exception {
         Dashboard dashboard = new Dashboard(
             "dash-1",
             "env-1",
@@ -211,15 +213,73 @@ class GammaDashboardRepositoryAdapterTest {
             Instant.parse("2026-08-07T10:00:00Z"),
             Instant.parse("2026-08-07T11:00:00Z")
         );
-        when(gammaDashboardRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(gammaDashboardRepository.updateIfPresent(any())).thenAnswer(invocation -> Optional.of(invocation.getArgument(0)));
 
-        new GammaDashboardRepositoryAdapter(gammaDashboardRepository).update(dashboard);
+        new GammaDashboardRepositoryAdapter(gammaDashboardRepository).updateIfPresent(dashboard);
 
         var captor = ArgumentCaptor.forClass(GammaDashboard.class);
-        verify(gammaDashboardRepository).update(captor.capture());
+        verify(gammaDashboardRepository).updateIfPresent(captor.capture());
         assertThat(captor.getValue().getWidgets()).isNull();
         assertThat(captor.getValue().getTimeRange()).isNull();
         assertThat(captor.getValue().getVersion()).isEqualTo(2);
+    }
+
+    @Test
+    void should_pass_the_expected_version_through_on_a_guarded_update() throws Exception {
+        Dashboard dashboard = versionedDashboard(4);
+        when(gammaDashboardRepository.updateIfVersionMatches(any(), anyInt())).thenAnswer(invocation ->
+            Optional.of(invocation.getArgument(0))
+        );
+
+        var updated = new GammaDashboardRepositoryAdapter(gammaDashboardRepository).updateIfVersionMatches(dashboard, 3);
+
+        var captor = ArgumentCaptor.forClass(GammaDashboard.class);
+        verify(gammaDashboardRepository).updateIfVersionMatches(captor.capture(), eq(3));
+        assertThat(captor.getValue().getVersion()).as("the write carries the new version, the guard the old one").isEqualTo(4);
+        assertThat(updated).hasValueSatisfying(result -> assertThat(result.version()).isEqualTo(4));
+    }
+
+    /** A refused write is an expected outcome, not a failure — it must not be dressed up as a technical exception. */
+    @Test
+    void should_return_empty_when_the_guarded_update_matched_nothing() throws Exception {
+        when(gammaDashboardRepository.updateIfVersionMatches(any(), anyInt())).thenReturn(Optional.empty());
+
+        assertThat(
+            new GammaDashboardRepositoryAdapter(gammaDashboardRepository).updateIfVersionMatches(versionedDashboard(4), 3)
+        ).isEmpty();
+    }
+
+    @Test
+    void should_wrap_a_guarded_update_failure_as_a_technical_exception() throws Exception {
+        when(gammaDashboardRepository.updateIfVersionMatches(any(), anyInt())).thenThrow(new TechnicalException("boom"));
+
+        assertThatThrownBy(() ->
+            new GammaDashboardRepositoryAdapter(gammaDashboardRepository).updateIfVersionMatches(versionedDashboard(4), 3)
+        ).isInstanceOf(TechnicalDomainException.class);
+    }
+
+    /** A concurrent delete is an ordinary outcome for an overwrite, not a failure to dress up as one. */
+    @Test
+    void should_return_empty_when_an_overwrite_finds_the_dashboard_gone() throws Exception {
+        when(gammaDashboardRepository.updateIfPresent(any())).thenReturn(Optional.empty());
+
+        assertThat(new GammaDashboardRepositoryAdapter(gammaDashboardRepository).updateIfPresent(versionedDashboard(4))).isEmpty();
+    }
+
+    private static Dashboard versionedDashboard(int version) {
+        return new Dashboard(
+            "dash-1",
+            "env-1",
+            "Performance overview",
+            null,
+            List.of(),
+            null,
+            NullNode.getInstance(),
+            version,
+            "user-1",
+            Instant.parse("2026-08-07T10:00:00Z"),
+            Instant.parse("2026-08-07T11:00:00Z")
+        );
     }
 
     @Test

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resources/observability/dashboards/ObservabilityDashboardsResourceTest.java
@@ -36,6 +36,8 @@ import io.gravitee.gamma.rest.spring.ResourceContextConfiguration;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.EntityTag;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import java.time.Instant;
 import java.util.List;
@@ -174,6 +176,7 @@ class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
             Response response = rootTarget(DASHBOARD_ID).request().get();
 
             assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            assertThat(response.getEntityTag()).as("the tag a later If-Match must echo").isEqualTo(new EntityTag("3"));
             JsonNode body = response.readEntity(JsonNode.class);
             assertThat(body.get("id").asText()).isEqualTo(DASHBOARD_ID);
             assertThat(body.get("title").asText()).isEqualTo("Performance overview");
@@ -233,6 +236,7 @@ class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
                 );
 
             assertThat(response.getStatus()).isEqualTo(HttpStatusCode.CREATED_201);
+            assertThat(response.getEntityTag()).as("a creator can edit without re-reading").isEqualTo(new EntityTag("1"));
             assertThat(response.getHeaderString("Location")).endsWith("/observability/dashboards/dash-new");
             JsonNode body = response.readEntity(JsonNode.class);
             assertThat(body.get("id").asText()).isEqualTo("dash-new");
@@ -369,13 +373,13 @@ class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
 
             Response response = rootTarget(DASHBOARD_ID)
                 .request()
+                .header(HttpHeaders.IF_MATCH, "\"3\"")
                 .put(
                     Entity.json(
                         """
                         {
                           "title": "Renamed",
                           "description": "new desc",
-                          "version": 42,
                           "timeRange": { "type": "absolute", "from": 1000, "to": 2000 },
                           "widgets": [{ "id": "w1", "type": "chart" }]
                         }
@@ -384,6 +388,7 @@ class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
                 );
 
             assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            assertThat(response.getEntityTag()).isEqualTo(new EntityTag("4"));
             JsonNode body = response.readEntity(JsonNode.class);
             assertThat(body.get("title").asText()).isEqualTo("Renamed");
             assertThat(body.get("version").asInt()).isEqualTo(4);
@@ -397,9 +402,137 @@ class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
             assertThat(persisted.version()).isEqualTo(4);
         }
 
+        /** A weak validator is what a proxy may hand back; it still identifies the revision unambiguously here. */
+        @Test
+        void should_accept_a_weak_entity_tag() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "W/\"3\"")
+                .put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        }
+
+        @Test
+        void should_return_412_with_the_current_dashboard_when_the_version_is_stale() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "\"2\"")
+                .put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.PRECONDITION_FAILED_412);
+            assertThat(response.getEntityTag()).as("the tag to retry with").isEqualTo(new EntityTag("3"));
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("http_status").asInt()).isEqualTo(HttpStatusCode.PRECONDITION_FAILED_412);
+            assertThat(body.get("message").asText()).contains("modified since you loaded it");
+            assertThat(body.get("currentVersion").asInt()).isEqualTo(3);
+            assertThat(body.get("dashboard").get("title").asText()).isEqualTo("Performance overview");
+            assertThat(body.get("dashboard").get("version").asInt()).isEqualTo(3);
+
+            var persisted = dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENVIRONMENT).orElseThrow();
+            assertThat(persisted.title()).isEqualTo("Performance overview");
+            assertThat(persisted.version()).isEqualTo(3);
+            assertThat(persisted.updatedAt()).isEqualTo(Instant.parse("2026-06-11T00:00:00Z"));
+        }
+
+        @Test
+        void should_return_428_when_if_match_is_absent() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID).request().put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(428);
+            assertThat(response.readEntity(JsonNode.class).get("message").asText()).contains("If-Match is required");
+            assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENVIRONMENT).orElseThrow().title()).isEqualTo(
+                "Performance overview"
+            );
+        }
+
+        /** The deliberate overwrite: applied over whatever revision is current, without a stale-version refusal. */
+        @Test
+        void should_apply_a_wildcard_if_match_over_whatever_revision_is_current() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "*")
+                .put(Entity.json("{ \"title\": \"Overwritten\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            assertThat(response.getEntityTag()).isEqualTo(new EntityTag("4"));
+            assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENVIRONMENT).orElseThrow().title()).isEqualTo(
+                "Overwritten"
+            );
+        }
+
+        /** The whole point of the wildcard: the answer to a 412 is one request, not a re-read that can race again. */
+        @Test
+        void should_let_a_wildcard_overwrite_resolve_a_conflict_in_one_request() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response refused = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "\"2\"")
+                .put(Entity.json("{ \"title\": \"Mine\" }"));
+            assertThat(refused.getStatus()).isEqualTo(HttpStatusCode.PRECONDITION_FAILED_412);
+
+            Response forced = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "*")
+                .put(Entity.json("{ \"title\": \"Mine\" }"));
+
+            assertThat(forced.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENVIRONMENT).orElseThrow().title()).isEqualTo("Mine");
+        }
+
+        /** RFC 9110 allows a list; any one matching is enough. */
+        @Test
+        void should_accept_an_if_match_listing_several_validators() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "\"2\", \"3\"")
+                .put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            assertThat(response.getEntityTag()).isEqualTo(new EntityTag("4"));
+        }
+
+        @Test
+        void should_return_412_when_no_validator_in_the_list_matches() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "\"1\", \"2\"")
+                .put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.PRECONDITION_FAILED_412);
+        }
+
+        @Test
+        void should_return_400_on_an_if_match_that_is_not_a_version() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "\"not-a-version\"")
+                .put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
         @Test
         void should_return_404_when_dashboard_does_not_exist() {
-            Response response = rootTarget("unknown").request().put(Entity.json("{ \"title\": \"Renamed\" }"));
+            Response response = rootTarget("unknown")
+                .request()
+                .header(HttpHeaders.IF_MATCH, "\"3\"")
+                .put(Entity.json("{ \"title\": \"Renamed\" }"));
 
             assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
         }
@@ -408,7 +541,10 @@ class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
         void should_return_404_when_dashboard_belongs_to_another_environment() {
             dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, OTHER_ENVIRONMENT));
 
-            Response response = rootTarget(DASHBOARD_ID).request().put(Entity.json("{ \"title\": \"Renamed\" }"));
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "\"3\"")
+                .put(Entity.json("{ \"title\": \"Renamed\" }"));
 
             assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
         }
@@ -417,16 +553,113 @@ class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
         void should_return_400_when_title_is_blank() {
             dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
 
-            Response response = rootTarget(DASHBOARD_ID).request().put(Entity.json("{ \"title\": \" \" }"));
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "\"3\"")
+                .put(Entity.json("{ \"title\": \" \" }"));
 
             assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        /** The same list, spelled as a repeated field rather than comma-separated. HTTP treats them identically. */
+        @Test
+        void should_accept_if_match_repeated_as_several_headers() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "\"1\"")
+                .header(HttpHeaders.IF_MATCH, "\"3\"")
+                .put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            assertThat(response.getEntityTag()).isEqualTo(new EntityTag("4"));
+        }
+
+        /** `*` and a specific validator state two different intents; guessing could silently overwrite. */
+        @Test
+        void should_return_400_when_the_wildcard_is_mixed_with_a_validator() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "*, \"3\"")
+                .put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+            assertThat(dashboardRepository.findByIdAndEnvironmentId(DASHBOARD_ID, ENVIRONMENT).orElseThrow().title()).isEqualTo(
+                "Performance overview"
+            );
+        }
+
+        @Test
+        void should_return_428_when_if_match_is_present_but_empty() {
+            dashboardRepository.givenDashboard(dashboard(DASHBOARD_ID, ENVIRONMENT));
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "")
+                .put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(428);
+        }
+
+        /**
+         * A dashboard with no stored version can only be saved with `*`, so the refusal must not hand back an ETag
+         * the client would then be refused for echoing. No version, no tag — and no currentVersion in the body.
+         */
+        @Test
+        void should_refuse_without_an_etag_when_the_dashboard_carries_no_version() {
+            dashboardRepository.givenDashboard(unversionedDashboard());
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "\"1\"")
+                .put(Entity.json("{ \"title\": \"Renamed\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.PRECONDITION_FAILED_412);
+            assertThat(response.getEntityTag()).as("nothing to match on, so nothing to hand back").isNull();
+            JsonNode body = response.readEntity(JsonNode.class);
+            // Null fields are omitted, not serialized as null (GraviteeMapper sets NON_NULL).
+            assertThat(body.has("currentVersion")).isFalse();
+            assertThat(body.get("dashboard").get("id").asText()).isEqualTo(DASHBOARD_ID);
+            assertThat(body.get("dashboard").has("version")).isFalse();
+        }
+
+        @Test
+        void should_omit_the_etag_on_a_get_of_a_dashboard_carrying_no_version() {
+            dashboardRepository.givenDashboard(unversionedDashboard());
+
+            Response response = rootTarget(DASHBOARD_ID).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            assertThat(response.getEntityTag()).isNull();
+            assertThat(response.readEntity(JsonNode.class).has("version")).isFalse();
+        }
+
+        /** ...and the wildcard is then the way out: it saves and starts the counter. */
+        @Test
+        void should_let_a_wildcard_save_a_dashboard_carrying_no_version() {
+            dashboardRepository.givenDashboard(unversionedDashboard());
+
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "*")
+                .put(Entity.json("{ \"title\": \"Rescued\" }"));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            assertThat(response.getEntityTag()).isEqualTo(new EntityTag("1"));
+            assertThat(response.readEntity(JsonNode.class).get("version").asInt()).isEqualTo(1);
         }
 
         @Test
         void should_return_403_when_caller_cannot_update_dashboards() {
             when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
 
-            Response response = rootTarget(DASHBOARD_ID).request().put(Entity.json("{ \"title\": \"Renamed\" }"));
+            Response response = rootTarget(DASHBOARD_ID)
+                .request()
+                .header(HttpHeaders.IF_MATCH, "\"3\"")
+                .put(Entity.json("{ \"title\": \"Renamed\" }"));
 
             assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
         }
@@ -471,6 +704,24 @@ class ObservabilityDashboardsResourceTest extends AbstractResourceTest {
 
             assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
         }
+    }
+
+    /** Not reachable through the API — every dashboard is created with version 1 — but the model still allows it. */
+    private static Dashboard unversionedDashboard() {
+        Dashboard versioned = dashboard(DASHBOARD_ID, ENVIRONMENT);
+        return new Dashboard(
+            versioned.id(),
+            versioned.environmentId(),
+            versioned.title(),
+            versioned.description(),
+            versioned.filters(),
+            versioned.timeRange(),
+            versioned.widgets(),
+            null,
+            versioned.createdBy(),
+            versioned.createdAt(),
+            versioned.updatedAt()
+        );
     }
 
     private static Dashboard dashboard(String id, String environmentId) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/OBS-17

## Description

### Summary

Tells a dashboard author when someone else changed a dashboard since they opened it, instead of silently overwriting that person's work. The `version` field has been persisted since OBS-14 and incremented since OBS-16, but was never checked: two people editing the same dashboard meant the second save won and the first author was never told.

The revision an edit is based on now travels as an **`ETag` / `If-Match`** pair rather than a body field — HTTP's own mechanism for the lost-update problem, so clients, proxies and generated SDKs recognise it without being taught a Gamma-specific convention. No client consumes these endpoints yet, so adopting the standard costs nothing today and avoids a breaking change later.

### Changes

- **`ETag` on every response naming a revision** — `GET`, `POST`, `PUT`, and the `412` itself. Produced in one place (`DashboardEntityTag`); omitted when a dashboard carries no version, rather than emitting the string `"null"` that the endpoint's own parser would then reject.
- **`If-Match` required on `PUT`.** Stale → `412` with the current dashboard attached. Absent → `428`, never an implicit overwrite. Accepts what HTTP defines: weak validators, a comma list, and the same list sent as a repeated field.
- **`If-Match: *` applies a deliberate overwrite.** Safe to offer because it cannot be reached by forgetting the header, only by choosing a different one — and it makes the frontend's "overwrite" action a single request instead of a re-read that can lose the race again. Existence is still required, so it never resurrects a deleted dashboard. Combined with a specific validator it is a `400` rather than a guess.
- **The guard lives in the storage query, not only in the use case.** Mongo adds one criterion to the `findAndReplace` OBS-16 already used; JDBC needed its own conditional update, since the inherited affected-rows check proves existence only.
- **The core port exposes only guarded writes** (`updateIfVersionMatches`, `updateIfPresent`). An unconditional `update` would sit there as an unguarded path for a future use case to pick up by accident.
- **`chore` commit**: two OpenAPI inaccuracies inherited from OBS-16 — the error schema documented `httpStatus` while the API sends `http_status`, and the shared request schema required `id` on both verbs though `PUT` ignores it. Documentation only.

### Endpoints

| Endpoint | Method | Change | Request example | Response example |
|---|---|---|---|---|
| `/observability/dashboards` | `POST` | Now returns `ETag` | `{"id":"d-1","title":"Perf","widgets":[]}` | `201` · `ETag: "1"` · `Location: …/d-1` |
| `/observability/dashboards/{id}` | `GET` | Now returns `ETag` | — | `200` · `ETag: "3"` |
| `/observability/dashboards/{id}` | `PUT` | **`If-Match` now required** | `If-Match: "3"` + `{"title":"Renamed","widgets":[]}` | `200` · `ETag: "4"` |
| `/observability/dashboards/{id}` | `PUT` | Stale precondition | `If-Match: "2"` | `412` · `ETag: "3"` · `{"message":…,"http_status":412,"currentVersion":3,"dashboard":{…}}` |
| `/observability/dashboards/{id}` | `PUT` | No precondition | *(no `If-Match`)* | `428` · `{"message":"If-Match is required…","http_status":428}` |
| `/observability/dashboards/{id}` | `PUT` | Deliberate overwrite | `If-Match: *` | `200` · `ETag: "4"` |
| `/observability/dashboards/{id}` | `PUT` | Unreadable / mixed validator | `If-Match: "abc"` or `*, "3"` | `400` |
| `/observability/dashboards/{id}` | `DELETE` | unchanged | — | `204` |

> **Breaking change, deliberately taken now:** `PUT` without `If-Match` was a `200`, it is now a `428`. No in-repo client calls these endpoints (only a `routerLink` in `gio-side-nav.component.ts`), so nothing shipped breaks — but the frontend adapter must send the header from its first commit.

## Test plan

- [ ] `mvn verify -pl gravitee-gamma/gravitee-gamma-rest-api` — 348 tests, ArchUnit and the archrules plugin included.
- [ ] `mvn test -pl gravitee-apim-repository/gravitee-apim-repository-jdbc,gravitee-apim-repository/gravitee-apim-repository-mongodb -Dtest=GammaDashboardRepositoryTest` — 30 tests **per backend**, the shared TCK that pins Mongo/JDBC parity.
- [ ] `GET` a dashboard, save it back with the `ETag` you received → `200`, version incremented, fresh `ETag`.
- [ ] Save again with the now-stale tag → `412`, and confirm via `GET` that `title`, `version` and `updatedAt` are untouched.
- [ ] Same save with `If-Match: *` → `200`, the edit lands.
- [ ] Omit `If-Match` → `428`. Send `If-Match: *, "3"` → `400`.
- [ ] Delete a dashboard, then `PUT` it with `If-Match: *` → `404`, not a resurrection.

<img width="559" height="828" alt="Screenshot 2026-08-11 at 11 26 38" src="https://github.com/user-attachments/assets/8031137f-1660-4c25-97ce-9dd94c7b8a79" />
<img width="551" height="632" alt="Screenshot 2026-08-11 at 11 27 16" src="https://github.com/user-attachments/assets/2a58c9fa-52f6-4123-9e50-0cd55b2eed38" />
<img width="554" height="840" alt="Screenshot 2026-08-11 at 11 26 58" src="https://github.com/user-attachments/assets/3e2129c9-dcf5-4ef0-83c0-8f68a2022de0" />


**Edge cases and regressions to check**

- [ ] **The race:** two concurrent `PUT`s quoting the same tag. Exactly one gets `200`, the other `412`, and the dashboard ends at version *n+1* — not *n+2*. This is the only check that proves the guard is in the storage query rather than the application pre-check.
- [ ] Weak validator `W/"3"`, a comma list `"9", "3"`, and the same list as a repeated `If-Match` field — all accepted when one matches.
- [ ] A dashboard whose stored `version` is `null` (not reachable via the API, but the model allows it): no `ETag` is emitted and `If-Match: *` is the only way to save it.
- [ ] `POST` still ignores a `version` sent in the body; a new dashboard always starts at 1.

## Additional context

**Verified over real HTTP, on both backends.** A local Management API was deployed from this branch and driven through 42 scenarios — twice, once backed by MongoDB and once by PostgreSQL. Identical results, 42/42 each, including the concurrent-writer race and a CORS preflight confirming the browser can read `ETag` and send `If-Match`. Full report with expected vs observed per call: https://claude.ai/code/artifact/84225a7d-1abd-4104-8ca3-0a9851b0444a

### Reviewer notes — where the risk is

- **`JdbcObjectMapper`** (shared JDBC ORM, used by every repository) gains a getter and an overload. Purely additive, but it is the only change outside this feature's blast radius. The full JDBC module suite passes; its one failure (`MySqlChangeLogTableWithPrimaryKeyGeneratorTest`) is **pre-existing and order-dependent** — `origin/master` fails it identically.
- **`JdbcGammaDashboardRepository.replaceMatching`** builds its SQL by appending a predicate to the ORM's update statement. Binding order is columns, then id, then the extra predicate values — worth a careful read.
- **The version is compared twice**, deliberately: once in the use case to read the dashboard the `412` has to carry, once inside the storage query as the actual guard. Please confirm you agree rather than letting it pass unnoticed.
- **`412` rather than `409`**, and **`428` rather than `400`**: these follow from adopting `If-Match`. 409 would describe the same event in a vocabulary the chosen mechanism does not use.

### Not in this PR

The **frontend conflict UX** — keep the author's edits in memory on `412` and offer overwrite / reload / save-a-copy. The backend makes the guarantee possible; that increment is what delivers it. Recorded on OBS-17 so it is not lost.
