### PR TITLE
feat: expose API Product subscription prerequisites

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -176,6 +176,7 @@ import io.gravitee.apim.core.plan.domain_service.PlanValidatorDomainService;
 import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.ValidatePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.VerifyPlanPortRangesDomainService;
+import io.gravitee.apim.core.plan.query_service.PlanSearchQueryService;
 import io.gravitee.apim.core.plan.use_case.CreateApiProductPlanUseCase;
 import io.gravitee.apim.core.plan.use_case.CreatePlanUseCase;
 import io.gravitee.apim.core.plan.use_case.GetPlansUseCase;
@@ -469,6 +470,11 @@ public class ResourceContextConfiguration {
     @Bean
     public PlanSearchService planSearchService() {
         return mock(PlanSearchService.class);
+    }
+
+    @Bean
+    public PlanSearchQueryService planSearchQueryService() {
+        return mock(PlanSearchQueryService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApiProductPlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApiProductPlanMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
+import io.gravitee.rest.api.portal.rest.model.ApiProductPlan;
+import io.gravitee.rest.api.portal.rest.model.ApiProductPlan.SecurityEnum;
+import io.gravitee.rest.api.portal.rest.model.ApiProductPlan.ValidationEnum;
+import io.gravitee.rest.api.portal.rest.model.PlanMode;
+
+public final class ApiProductPlanMapper {
+
+    public static final ApiProductPlanMapper INSTANCE = new ApiProductPlanMapper();
+
+    private ApiProductPlanMapper() {}
+
+    public ApiProductPlan map(Plan plan) {
+        var result = new ApiProductPlan();
+
+        result.setId(plan.getId());
+        result.setName(plan.getName());
+        result.setDescription(plan.getDescription());
+        result.setCharacteristics(plan.getCharacteristics());
+        result.setOrder(plan.getOrder());
+        result.setCommentRequired(plan.isCommentRequired());
+        result.setCommentQuestion(plan.getCommentMessage());
+        if (plan.getPlanSecurity() != null && plan.getPlanSecurity().getType() != null) {
+            var securityType = PlanSecurityType.valueOfLabel(plan.getPlanSecurity().getType());
+            result.setSecurity(SecurityEnum.fromValue(securityType.name()));
+        }
+        result.setValidation(ValidationEnum.fromValue(plan.getPlanValidation().name()));
+        result.setMode(PlanMode.valueOf(plan.getPlanMode().name()));
+
+        return result;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiProductPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiProductPlansResource.java
@@ -17,50 +17,41 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static io.gravitee.rest.api.service.common.GraviteeContext.getExecutionContext;
 
-import io.gravitee.apim.core.api_product.use_case.GetPortalApiProductUseCase;
+import io.gravitee.apim.core.plan.use_case.GetPortalApiProductPlansUseCase;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
 import io.gravitee.common.http.MediaType;
-import io.gravitee.rest.api.portal.rest.mapper.ApiProductMapper;
+import io.gravitee.rest.api.portal.rest.mapper.ApiProductPlanMapper;
+import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.container.ResourceContext;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import java.util.UUID;
 
-public class ApiProductResource extends AbstractResource {
-
-    private static final ApiProductMapper apiProductMapper = ApiProductMapper.INSTANCE;
+public class ApiProductPlansResource extends AbstractResource {
 
     @Inject
-    private GetPortalApiProductUseCase getPortalApiProductUseCase;
+    private GetPortalApiProductPlansUseCase getPortalApiProductPlansUseCase;
 
-    @Context
-    private ResourceContext resourceContext;
+    private static final ApiProductPlanMapper apiProductPlanMapper = ApiProductPlanMapper.INSTANCE;
 
     @GET
-    @Path("{apiProductId}")
     @Produces(MediaType.APPLICATION_JSON)
     @RequirePortalAuth
-    public Response getApiProductByApiProductId(@PathParam("apiProductId") UUID apiProductId) {
+    public Response getApiProductPlans(@PathParam("apiProductId") UUID apiProductId, @BeanParam PaginationParam paginationParam) {
         var executionContext = getExecutionContext();
-        var output = getPortalApiProductUseCase.execute(
-            new GetPortalApiProductUseCase.Input(
-                executionContext.getEnvironmentId(),
-                apiProductId.toString(),
-                PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull())
-            )
+        var output = getPortalApiProductPlansUseCase.execute(
+            new GetPortalApiProductPlansUseCase.Input(executionContext.getEnvironmentId(), apiProductId.toString(), viewerContext())
         );
+        var plans = output.plans().stream().map(apiProductPlanMapper::map).toList();
 
-        return Response.ok(apiProductMapper.map(output.apiProduct())).build();
+        return createListResponse(executionContext, plans, paginationParam);
     }
 
-    @Path("{apiProductId}/plans")
-    public ApiProductPlansResource getApiProductPlansResource() {
-        return resourceContext.getResource(ApiProductPlansResource.class);
+    private PortalNavigationItemViewerContext viewerContext() {
+        return PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -241,13 +241,7 @@ paths:
                     $ref: "#/components/responses/InternalServerError"
     /api-products/{apiProductId}:
         parameters:
-            - name: apiProductId
-              in: path
-              required: true
-              description: Unique identifier of an API Product.
-              schema:
-                  type: string
-                  format: uuid
+            - $ref: "#/components/parameters/apiProductIdParam"
         get:
             tags:
                 - Api Product
@@ -269,6 +263,37 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/PortalApiProductDetails"
+                404:
+                    $ref: "#/components/responses/ApiProductNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+    /api-products/{apiProductId}/plans:
+        parameters:
+            - $ref: "#/components/parameters/apiProductIdParam"
+        get:
+            tags:
+                - Api Product
+            parameters:
+                - $ref: "#/components/parameters/pageNumberParam"
+                - $ref: "#/components/parameters/pageSizeParam"
+            summary: List plans for an API Product
+            description: |
+                List published plans of an API Product available to the current user.
+
+                The API Product must be exposed by an accessible, published Portal navigation item,
+                otherwise a 404 is returned.
+            operationId: getApiProductPlans
+            security:
+                - {}
+                - BasicAuth: []
+                - CookieAuth: []
+            responses:
+                200:
+                    description: List of accessible API Product plans
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiProductPlansResponse"
                 404:
                     $ref: "#/components/responses/ApiProductNotFoundError"
                 500:
@@ -4116,6 +4141,14 @@ components:
             description: Id of an API.
             schema:
                 type: string
+        apiProductIdParam:
+            name: apiProductId
+            in: path
+            required: true
+            description: Unique identifier of an API Product.
+            schema:
+                type: string
+                format: uuid
         applicationIdParam:
             name: applicationId
             in: path
@@ -4948,6 +4981,17 @@ components:
                     $ref: "#/components/schemas/MetadataMap"
                 links:
                     $ref: "#/components/schemas/Links"
+        ApiProductPlansResponse:
+            properties:
+                data:
+                    description: List of API Product plans available to the current viewer.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ApiProductPlan"
+                metadata:
+                    $ref: "#/components/schemas/MetadataMap"
+                links:
+                    $ref: "#/components/schemas/Links"
         MembersResponse:
             properties:
                 data:
@@ -5607,6 +5651,58 @@ components:
                     $ref: "#/components/schemas/PlanMode"
                 usage_configuration:
                     $ref: "#/components/schemas/PlanUsageConfiguration"
+
+        ApiProductPlan:
+            required:
+                - id
+                - name
+                - description
+                - security
+                - validation
+                - order
+                - comment_required
+                - mode
+            properties:
+                id:
+                    description: Unique identifier of the plan.
+                    type: string
+                name:
+                    description: Name of the plan.
+                    type: string
+                description:
+                    description: Description of the plan.
+                    type: string
+                characteristics:
+                    description: List of additional terms describing the plan.
+                    type: array
+                    items:
+                        type: string
+                order:
+                    description: Priority order.
+                    type: integer
+                security:
+                    description: Security used with this plan.
+                    type: string
+                    enum:
+                        - API_KEY
+                        - KEY_LESS
+                        - JWT
+                        - OAUTH2
+                        - MTLS
+                validation:
+                    description: Type of validation for subscription requests.
+                    type: string
+                    enum:
+                        - AUTO
+                        - MANUAL
+                mode:
+                    $ref: "#/components/schemas/PlanMode"
+                comment_required:
+                    description: True if a comment is required when a subscription is created.
+                    type: boolean
+                comment_question:
+                    description: Content of the message sent to a user creating a subscription.
+                    type: string
 
         PlanUsageConfiguration:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApiProductPlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApiProductPlanMapperTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.portal.rest.model.ApiProductPlan.SecurityEnum;
+import io.gravitee.rest.api.portal.rest.model.ApiProductPlan.ValidationEnum;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiProductPlanMapperTest {
+
+    @Test
+    void should_map_only_api_product_supported_fields() throws JsonProcessingException {
+        var plan = Plan.builder()
+            .id("plan-id")
+            .name("API Key plan")
+            .description("API Product plan")
+            .characteristics(List.of("featured"))
+            .order(2)
+            .commentRequired(true)
+            .commentMessage("Why do you need access?")
+            .generalConditions("terms-page-id")
+            .definitionVersion(DefinitionVersion.V4)
+            .validation(Plan.PlanValidationType.MANUAL)
+            .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .planDefinitionHttpV4(
+                io.gravitee.definition.model.v4.plan.Plan.builder()
+                    .mode(PlanMode.STANDARD)
+                    .status(PlanStatus.PUBLISHED)
+                    .security(PlanSecurity.builder().type("api-key").build())
+                    .build()
+            )
+            .build();
+
+        var result = ApiProductPlanMapper.INSTANCE.map(plan);
+
+        assertThat(result.getId()).isEqualTo("plan-id");
+        assertThat(result.getName()).isEqualTo("API Key plan");
+        assertThat(result.getDescription()).isEqualTo("API Product plan");
+        assertThat(result.getCharacteristics()).containsExactly("featured");
+        assertThat(result.getOrder()).isEqualTo(2);
+        assertThat(result.getSecurity()).isEqualTo(SecurityEnum.API_KEY);
+        assertThat(result.getValidation()).isEqualTo(ValidationEnum.MANUAL);
+        assertThat(result.getMode()).isEqualTo(io.gravitee.rest.api.portal.rest.model.PlanMode.STANDARD);
+        assertThat(result.getCommentRequired()).isTrue();
+        assertThat(result.getCommentQuestion()).isEqualTo("Why do you need access?");
+
+        var json = new ObjectMapper().writeValueAsString(result);
+        assertThat(json).doesNotContain("general_conditions", "generalConditions", "usage_configuration", "usageConfiguration");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiProductPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiProductPlansResourceTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import inmemory.ApiProductCrudServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.plan.query_service.PlanSearchQueryService;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.model.v4.plan.PlanQuery;
+import io.gravitee.rest.api.portal.rest.model.ApiProductPlan;
+import io.gravitee.rest.api.portal.rest.model.ApiProductPlansResponse;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.UUID;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiProductPlansResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT_ID = "DEFAULT";
+    private static final UUID API_PRODUCT_ID = UUID.fromString("00000000-0000-0000-0000-000000000101");
+
+    @Autowired
+    private ApiProductQueryServiceInMemory apiProductQueryService;
+
+    @Autowired
+    private ApiProductCrudServiceInMemory apiProductCrudService;
+
+    @Autowired
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+
+    @Autowired
+    private PlanSearchQueryService planSearchQueryService;
+
+    @Override
+    protected String contextPath() {
+        return "api-products/";
+    }
+
+    @Override
+    protected void decorate(ResourceConfig resourceConfig) {
+        resourceConfig.register(NotAuthenticatedAuthenticationFilter.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+        reset(planSearchQueryService);
+        var apiProduct = apiProduct();
+        apiProductQueryService.initWith(List.of(apiProduct));
+        apiProductCrudService.initWith(List.of(apiProduct));
+        navigationItemsQueryService.initWith(List.of(apiProductNavigationItem()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        GraviteeContext.cleanContext();
+        apiProductQueryService.reset();
+        apiProductCrudService.reset();
+        navigationItemsQueryService.reset();
+        reset(planSearchQueryService);
+    }
+
+    @Test
+    void should_return_product_plans_ordered_by_plan_order() {
+        var second = plan("plan-2", "Second", 2);
+        var first = plan("plan-1", "First", 1);
+        givenPlans(second, first);
+
+        var response = target(API_PRODUCT_ID + "/plans").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        var result = response.readEntity(ApiProductPlansResponse.class);
+        assertThat(result.getData()).extracting(ApiProductPlan::getId).containsExactly("plan-1", "plan-2");
+    }
+
+    @Test
+    void should_exclude_restricted_plan_for_anonymous_viewer() {
+        var available = plan("available", "Available", 1);
+        var restricted = plan("restricted", "Restricted", 2).toBuilder().excludedGroups(List.of("excluded-group")).build();
+        givenPlans(available, restricted);
+
+        var response = target(API_PRODUCT_ID + "/plans").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        assertThat(response.readEntity(ApiProductPlansResponse.class).getData())
+            .extracting(ApiProductPlan::getId)
+            .containsExactly("available");
+    }
+
+    @Test
+    void should_return_empty_list_when_no_plan_is_available() {
+        givenPlans();
+
+        var response = target(API_PRODUCT_ID + "/plans").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        assertThat(response.readEntity(ApiProductPlansResponse.class).getData()).isEmpty();
+    }
+
+    @Test
+    void should_return_not_found_when_product_is_not_exposed() {
+        navigationItemsQueryService.reset();
+        givenPlans(plan("plan-id", "Plan", 1));
+
+        var response = target(API_PRODUCT_ID + "/plans").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
+    }
+
+    private void givenPlans(io.gravitee.apim.core.plan.model.Plan... plans) {
+        when(
+            planSearchQueryService.searchPlans(
+                eq(API_PRODUCT_ID.toString()),
+                eq(GenericPlanEntity.ReferenceType.API_PRODUCT),
+                any(PlanQuery.class),
+                isNull(),
+                eq(false)
+            )
+        ).thenReturn(List.of(plans));
+    }
+
+    private static Plan plan(String id, String name, int order) {
+        return Plan.builder()
+            .id(id)
+            .name(name)
+            .order(order)
+            .definitionVersion(DefinitionVersion.V4)
+            .validation(Plan.PlanValidationType.AUTO)
+            .referenceId(API_PRODUCT_ID.toString())
+            .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .planDefinitionHttpV4(
+                io.gravitee.definition.model.v4.plan.Plan.builder().mode(PlanMode.STANDARD).status(PlanStatus.PUBLISHED).build()
+            )
+            .build();
+    }
+
+    private static ApiProduct apiProduct() {
+        return ApiProduct.builder().id(API_PRODUCT_ID.toString()).environmentId(ENVIRONMENT_ID).name("AI Workspace").build();
+    }
+
+    private static PortalNavigationApiProduct apiProductNavigationItem() {
+        return PortalNavigationApiProduct.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId("organization-id")
+            .environmentId(ENVIRONMENT_ID)
+            .title("AI Workspace")
+            .segment("ai-workspace")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .apiProductId(API_PRODUCT_ID.toString())
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetPortalApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetPortalApiProductUseCase.java
@@ -20,18 +20,12 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.ApiFieldFilter;
 import io.gravitee.apim.core.api.model.ApiSearchCriteria;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
-import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.model.PortalApiProductDetails;
-import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalApiProductAccessDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
-import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -45,19 +39,17 @@ public class GetPortalApiProductUseCase {
     private static final Comparator<String> NULL_SAFE_STRING_COMPARATOR = Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER);
     private static final ApiFieldFilter API_FIELD_FILTER = ApiFieldFilter.builder().definitionExcluded(true).pictureExcluded(true).build();
 
-    private final ApiProductQueryService apiProductQueryService;
-    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
-    private final PortalNavigationApiProductVisibilityDomainService apiProductVisibilityDomainService;
+    private final PortalApiProductAccessDomainService portalApiProductAccessDomainService;
     private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
     private final ApiQueryService apiQueryService;
 
     public Output execute(Input input) {
-        var apiProduct = apiProductQueryService
-            .findById(input.apiProductId())
-            .filter(product -> input.environmentId().equals(product.getEnvironmentId()))
-            .orElseThrow(() -> new ApiProductNotFoundException(input.apiProductId()));
-
-        var navigationItem = findAccessibleNavigationItem(input);
+        var accessibleApiProduct = portalApiProductAccessDomainService.findAccessible(
+            input.environmentId(),
+            input.apiProductId(),
+            input.viewerContext()
+        );
+        var apiProduct = accessibleApiProduct.apiProduct();
         var apis = findAccessibleApis(apiProduct, input);
         var tags = apiProduct.getTags() == null
             ? List.<String>of()
@@ -70,44 +62,11 @@ public class GetPortalApiProductUseCase {
                 apiProduct.getDescription(),
                 apiProduct.getVersion(),
                 apiProduct.getKind(),
-                navigationItem.getId().json(),
+                accessibleApiProduct.navigationItem().getId().json(),
                 tags,
                 apis
             )
         );
-    }
-
-    private PortalNavigationApiProduct findAccessibleNavigationItem(Input input) {
-        Set<String> accessibleApiProductIds = apiProductVisibilityDomainService.resolveAccessibleApiProductIds(
-            input.environmentId(),
-            input.viewerContext()
-        );
-
-        return portalNavigationItemsQueryService
-            .search(
-                PortalNavigationItemQueryCriteria.builder()
-                    .environmentId(input.environmentId())
-                    .published(true)
-                    .type(PortalNavigationItemType.API_PRODUCT)
-                    .apiProductIds(Set.of(input.apiProductId()))
-                    .build()
-            )
-            .stream()
-            .filter(PortalNavigationApiProduct.class::isInstance)
-            .map(PortalNavigationApiProduct.class::cast)
-            .filter(item -> !input.viewerContext().shouldNotShow(item))
-            .filter(item -> !apiProductVisibilityDomainService.isApiProductItemHidden(item, input.viewerContext(), accessibleApiProductIds))
-            .filter(item ->
-                !apiProductVisibilityDomainService.hasHiddenApiProductAncestor(
-                    input.environmentId(),
-                    item,
-                    input.viewerContext(),
-                    accessibleApiProductIds
-                )
-            )
-            .filter(item -> !apiVisibilityDomainService.hasHiddenApiAncestor(input.environmentId(), item, input.viewerContext()))
-            .findFirst()
-            .orElseThrow(() -> new ApiProductNotFoundException(input.apiProductId()));
     }
 
     private List<PortalApiProductDetails.ApiSummary> findAccessibleApis(ApiProduct apiProduct, Input input) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/GetPortalApiProductPlansUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/GetPortalApiProductPlansUseCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.portal_page.domain_service.PortalApiProductPlanDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetPortalApiProductPlansUseCase {
+
+    private final PortalApiProductPlanDomainService portalApiProductPlanDomainService;
+
+    public Output execute(Input input) {
+        return new Output(
+            portalApiProductPlanDomainService.findAccessiblePlans(input.environmentId(), input.apiProductId(), input.viewerContext())
+        );
+    }
+
+    public record Input(String environmentId, String apiProductId, PortalNavigationItemViewerContext viewerContext) {}
+
+    public record Output(List<Plan> plans) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalApiProductAccessDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalApiProductAccessDomainService.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class PortalApiProductAccessDomainService {
+
+    private final ApiProductQueryService apiProductQueryService;
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalNavigationApiProductVisibilityDomainService apiProductVisibilityDomainService;
+    private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
+
+    public AccessibleApiProduct findAccessible(String environmentId, String apiProductId, PortalNavigationItemViewerContext viewerContext) {
+        var apiProduct = apiProductQueryService
+            .findById(apiProductId)
+            .filter(product -> environmentId.equals(product.getEnvironmentId()))
+            .orElseThrow(() -> new ApiProductNotFoundException(apiProductId));
+
+        Set<String> accessibleApiProductIds = apiProductVisibilityDomainService.resolveAccessibleApiProductIds(
+            environmentId,
+            viewerContext
+        );
+
+        var navigationItem = portalNavigationItemsQueryService
+            .search(
+                PortalNavigationItemQueryCriteria.builder()
+                    .environmentId(environmentId)
+                    .published(true)
+                    .type(PortalNavigationItemType.API_PRODUCT)
+                    .apiProductIds(Set.of(apiProductId))
+                    .build()
+            )
+            .stream()
+            .filter(PortalNavigationApiProduct.class::isInstance)
+            .map(PortalNavigationApiProduct.class::cast)
+            .filter(item -> !viewerContext.shouldNotShow(item))
+            .filter(item -> !apiProductVisibilityDomainService.isApiProductItemHidden(item, viewerContext, accessibleApiProductIds))
+            .filter(item ->
+                !apiProductVisibilityDomainService.hasHiddenApiProductAncestor(environmentId, item, viewerContext, accessibleApiProductIds)
+            )
+            .filter(item -> !apiVisibilityDomainService.hasHiddenApiAncestor(environmentId, item, viewerContext))
+            .findFirst()
+            .orElseThrow(() -> new ApiProductNotFoundException(apiProductId));
+
+        return new AccessibleApiProduct(apiProduct, navigationItem);
+    }
+
+    public record AccessibleApiProduct(ApiProduct apiProduct, PortalNavigationApiProduct navigationItem) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalApiProductPlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalApiProductPlanDomainService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import static java.util.Comparator.comparingInt;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.plan.domain_service.PlanExcludedGroupsDomainService;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.plan.query_service.PlanSearchQueryService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.model.v4.plan.PlanQuery;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class PortalApiProductPlanDomainService {
+
+    private final PortalApiProductAccessDomainService portalApiProductAccessDomainService;
+    private final PlanSearchQueryService planSearchQueryService;
+    private final PlanExcludedGroupsDomainService planExcludedGroupsDomainService;
+
+    public List<Plan> findAccessiblePlans(String environmentId, String apiProductId, PortalNavigationItemViewerContext viewerContext) {
+        var accessibleApiProduct = portalApiProductAccessDomainService.findAccessible(environmentId, apiProductId, viewerContext);
+        var userId = viewerContext.userId().orElse(null);
+        var query = PlanQuery.builder()
+            .referenceId(apiProductId)
+            .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .status(List.of(PlanStatus.PUBLISHED))
+            .build();
+
+        return planSearchQueryService
+            .searchPlans(apiProductId, GenericPlanEntity.ReferenceType.API_PRODUCT, query, userId, false)
+            .stream()
+            .filter(plan ->
+                planExcludedGroupsDomainService.isUserAuthorizedToAccessApiProductPlan(
+                    accessibleApiProduct.apiProduct(),
+                    plan.getExcludedGroups(),
+                    userId
+                )
+            )
+            .sorted(comparingInt(Plan::getOrder))
+            .toList();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetPortalApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetPortalApiProductUseCaseTest.java
@@ -31,6 +31,7 @@ import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.model.ApiProductKind;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.portal_page.domain_service.PortalApiProductAccessDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
@@ -84,13 +85,13 @@ class GetPortalApiProductUseCaseTest {
             navigationItemsQueryService,
             new ApiProductAccessibleIdsDomainService(apiProductQueryService, membershipQueryService)
         );
-        useCase = new GetPortalApiProductUseCase(
+        var portalApiProductAccessDomainService = new PortalApiProductAccessDomainService(
             apiProductQueryService,
             navigationItemsQueryService,
             apiProductVisibilityDomainService,
-            apiVisibilityDomainService,
-            apiQueryService
+            apiVisibilityDomainService
         );
+        useCase = new GetPortalApiProductUseCase(portalApiProductAccessDomainService, apiVisibilityDomainService, apiQueryService);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/GetPortalApiProductPlansUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/GetPortalApiProductPlansUseCaseTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.PlanFixtures;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.portal_page.domain_service.PortalApiProductPlanDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class GetPortalApiProductPlansUseCaseTest {
+
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String API_PRODUCT_ID = "api-product-id";
+    private static final PortalNavigationItemViewerContext VIEWER_CONTEXT = PortalNavigationItemViewerContext.forPortal("user-id");
+
+    @Mock
+    private PortalApiProductPlanDomainService portalApiProductPlanDomainService;
+
+    private GetPortalApiProductPlansUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetPortalApiProductPlansUseCase(portalApiProductPlanDomainService);
+    }
+
+    @Test
+    void should_return_published_api_product_plans_for_current_user() {
+        var first = PlanFixtures.HttpV4.anApiKey().toBuilder().id("plan-1").order(1).build();
+        var second = PlanFixtures.HttpV4.anApiKey().toBuilder().id("plan-2").order(2).build();
+        var input = input();
+        when(portalApiProductPlanDomainService.findAccessiblePlans(ENVIRONMENT_ID, API_PRODUCT_ID, VIEWER_CONTEXT)).thenReturn(
+            List.of(first, second)
+        );
+
+        var output = useCase.execute(input);
+
+        assertThat(output.plans()).containsExactly(first, second);
+    }
+
+    @Test
+    void should_not_load_plans_when_api_product_is_inaccessible() {
+        var input = input();
+        when(portalApiProductPlanDomainService.findAccessiblePlans(ENVIRONMENT_ID, API_PRODUCT_ID, VIEWER_CONTEXT)).thenThrow(
+            new ApiProductNotFoundException(API_PRODUCT_ID)
+        );
+
+        assertThatThrownBy(() -> useCase.execute(input)).isInstanceOf(ApiProductNotFoundException.class);
+    }
+
+    private static GetPortalApiProductPlansUseCase.Input input() {
+        return new GetPortalApiProductPlansUseCase.Input(ENVIRONMENT_ID, API_PRODUCT_ID, VIEWER_CONTEXT);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalApiProductAccessDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalApiProductAccessDomainServiceTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalApiProductAccessDomainServiceTest {
+
+    private static final String ENVIRONMENT_ID = PortalNavigationItemFixtures.ENV_ID;
+    private static final String API_PRODUCT_ID = "00000000-0000-0000-0000-000000000101";
+    private static final String NAVIGATION_ITEM_ID = "00000000-0000-0000-0000-000000000102";
+    private static final String USER_ID = "user-id";
+
+    private ApiProductQueryServiceInMemory apiProductQueryService;
+    private MembershipQueryServiceInMemory membershipQueryService;
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+    private PortalApiProductAccessDomainService service;
+
+    @BeforeEach
+    void setUp() {
+        apiProductQueryService = new ApiProductQueryServiceInMemory();
+        membershipQueryService = new MembershipQueryServiceInMemory();
+        navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
+
+        var apiQueryService = new ApiQueryServiceInMemory();
+        var apiVisibilityDomainService = new PortalNavigationApiVisibilityDomainService(
+            navigationItemsQueryService,
+            new ApiPortalMembershipDomainService(membershipQueryService, new SubscriptionQueryServiceInMemory(), apiQueryService)
+        );
+        var apiProductVisibilityDomainService = new PortalNavigationApiProductVisibilityDomainService(
+            navigationItemsQueryService,
+            new ApiProductAccessibleIdsDomainService(apiProductQueryService, membershipQueryService)
+        );
+        service = new PortalApiProductAccessDomainService(
+            apiProductQueryService,
+            navigationItemsQueryService,
+            apiProductVisibilityDomainService,
+            apiVisibilityDomainService
+        );
+    }
+
+    @Test
+    void should_return_public_product_and_navigation_item_for_anonymous_viewer() {
+        givenProductAndNavigation(apiProduct(), apiProductNavigation());
+
+        var result = service.findAccessible(ENVIRONMENT_ID, API_PRODUCT_ID, viewer(null));
+
+        assertThat(result.apiProduct().getId()).isEqualTo(API_PRODUCT_ID);
+        assertThat(result.navigationItem().getId()).isEqualTo(PortalNavigationItemId.of(NAVIGATION_ITEM_ID));
+    }
+
+    @Test
+    void should_return_private_product_for_direct_member() {
+        var navigationItem = apiProductNavigation();
+        navigationItem.setVisibility(PortalVisibility.PRIVATE);
+        givenProductAndNavigation(apiProduct(), navigationItem);
+        membershipQueryService.initWith(List.of(apiProductMembership()));
+
+        var result = service.findAccessible(ENVIRONMENT_ID, API_PRODUCT_ID, viewer(USER_ID));
+
+        assertThat(result.apiProduct().getId()).isEqualTo(API_PRODUCT_ID);
+    }
+
+    @Test
+    void should_reject_private_product_for_anonymous_viewer() {
+        var navigationItem = apiProductNavigation();
+        navigationItem.setVisibility(PortalVisibility.PRIVATE);
+        givenProductAndNavigation(apiProduct(), navigationItem);
+
+        assertThatThrownBy(() -> service.findAccessible(ENVIRONMENT_ID, API_PRODUCT_ID, viewer(null))).isInstanceOf(
+            ApiProductNotFoundException.class
+        );
+    }
+
+    @Test
+    void should_reject_product_from_another_environment() {
+        var apiProduct = apiProduct();
+        apiProduct.setEnvironmentId("other-environment");
+        givenProductAndNavigation(apiProduct, apiProductNavigation());
+
+        assertThatThrownBy(() -> service.findAccessible(ENVIRONMENT_ID, API_PRODUCT_ID, viewer(null))).isInstanceOf(
+            ApiProductNotFoundException.class
+        );
+    }
+
+    @Test
+    void should_reject_product_without_published_navigation_item() {
+        var navigationItem = apiProductNavigation();
+        navigationItem.setPublished(false);
+        givenProductAndNavigation(apiProduct(), navigationItem);
+
+        assertThatThrownBy(() -> service.findAccessible(ENVIRONMENT_ID, API_PRODUCT_ID, viewer(null))).isInstanceOf(
+            ApiProductNotFoundException.class
+        );
+    }
+
+    @Test
+    void should_reject_product_below_hidden_api_product_ancestor() {
+        var parent = PortalNavigationItemFixtures.anApiProduct(
+            "00000000-0000-0000-0000-000000000201",
+            "Parent product",
+            null,
+            "00000000-0000-0000-0000-000000000202"
+        );
+        parent.setVisibility(PortalVisibility.PRIVATE);
+        var navigationItem = apiProductNavigation(parent.getId());
+        apiProductQueryService.initWith(List.of(apiProduct()));
+        navigationItemsQueryService.initWith(List.of(parent, navigationItem));
+
+        assertThatThrownBy(() -> service.findAccessible(ENVIRONMENT_ID, API_PRODUCT_ID, viewer(USER_ID))).isInstanceOf(
+            ApiProductNotFoundException.class
+        );
+    }
+
+    @Test
+    void should_reject_product_below_hidden_api_ancestor() {
+        var parent = PortalNavigationItemFixtures.anApi("00000000-0000-0000-0000-000000000301", "Parent API", null, "api-id");
+        parent.setVisibility(PortalVisibility.PRIVATE);
+        var navigationItem = apiProductNavigation(parent.getId());
+        apiProductQueryService.initWith(List.of(apiProduct()));
+        navigationItemsQueryService.initWith(List.of(parent, navigationItem));
+
+        assertThatThrownBy(() -> service.findAccessible(ENVIRONMENT_ID, API_PRODUCT_ID, viewer(USER_ID))).isInstanceOf(
+            ApiProductNotFoundException.class
+        );
+    }
+
+    private void givenProductAndNavigation(ApiProduct apiProduct, PortalNavigationApiProduct navigationItem) {
+        apiProductQueryService.initWith(List.of(apiProduct));
+        navigationItemsQueryService.initWith(List.of(navigationItem));
+    }
+
+    private static ApiProduct apiProduct() {
+        return ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENVIRONMENT_ID).name("Product").build();
+    }
+
+    private static PortalNavigationApiProduct apiProductNavigation() {
+        return apiProductNavigation(null);
+    }
+
+    private static PortalNavigationApiProduct apiProductNavigation(PortalNavigationItemId parentId) {
+        return PortalNavigationItemFixtures.anApiProduct(NAVIGATION_ITEM_ID, "Product", parentId, API_PRODUCT_ID);
+    }
+
+    private static Membership apiProductMembership() {
+        return Membership.builder()
+            .id("membership-id")
+            .memberId(USER_ID)
+            .memberType(Membership.Type.USER)
+            .referenceType(Membership.ReferenceType.API_PRODUCT)
+            .referenceId(API_PRODUCT_ID)
+            .build();
+    }
+
+    private static PortalNavigationItemViewerContext viewer(String userId) {
+        return PortalNavigationItemViewerContext.forPortal(userId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalApiProductPlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalApiProductPlanDomainServiceTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.PlanFixtures;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.plan.domain_service.PlanExcludedGroupsDomainService;
+import io.gravitee.apim.core.plan.query_service.PlanSearchQueryService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.model.v4.plan.PlanQuery;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class PortalApiProductPlanDomainServiceTest {
+
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String API_PRODUCT_ID = "api-product-id";
+    private static final String USER_ID = "user-id";
+    private static final PortalNavigationItemViewerContext VIEWER_CONTEXT = PortalNavigationItemViewerContext.forPortal(USER_ID);
+
+    @Mock
+    private PortalApiProductAccessDomainService portalApiProductAccessDomainService;
+
+    @Mock
+    private PlanSearchQueryService planSearchQueryService;
+
+    @Mock
+    private PlanExcludedGroupsDomainService planExcludedGroupsDomainService;
+
+    private PortalApiProductPlanDomainService domainService;
+
+    @BeforeEach
+    void setUp() {
+        domainService = new PortalApiProductPlanDomainService(
+            portalApiProductAccessDomainService,
+            planSearchQueryService,
+            planExcludedGroupsDomainService
+        );
+    }
+
+    @Test
+    void should_return_authorized_published_plans_ordered_by_plan_order() {
+        var second = PlanFixtures.HttpV4.anApiKey().toBuilder().id("plan-2").order(2).build();
+        var first = PlanFixtures.HttpV4.anApiKey().toBuilder().id("plan-1").order(1).build();
+        var restricted = PlanFixtures.HttpV4.anApiKey()
+            .toBuilder()
+            .id("restricted")
+            .order(0)
+            .excludedGroups(List.of("restricted-group"))
+            .build();
+        var apiProduct = accessibleApiProduct();
+        when(portalApiProductAccessDomainService.findAccessible(ENVIRONMENT_ID, API_PRODUCT_ID, VIEWER_CONTEXT)).thenReturn(
+            new PortalApiProductAccessDomainService.AccessibleApiProduct(apiProduct, null)
+        );
+        when(
+            planSearchQueryService.searchPlans(
+                eq(API_PRODUCT_ID),
+                eq(GenericPlanEntity.ReferenceType.API_PRODUCT),
+                any(PlanQuery.class),
+                eq(USER_ID),
+                eq(false)
+            )
+        ).thenReturn(List.of(second, restricted, first));
+        when(planExcludedGroupsDomainService.isUserAuthorizedToAccessApiProductPlan(apiProduct, List.of(), USER_ID)).thenReturn(true);
+        when(
+            planExcludedGroupsDomainService.isUserAuthorizedToAccessApiProductPlan(apiProduct, restricted.getExcludedGroups(), USER_ID)
+        ).thenReturn(false);
+
+        var result = domainService.findAccessiblePlans(ENVIRONMENT_ID, API_PRODUCT_ID, VIEWER_CONTEXT);
+
+        assertThat(result).containsExactly(first, second);
+        var queryCaptor = ArgumentCaptor.forClass(PlanQuery.class);
+        verify(planSearchQueryService).searchPlans(
+            eq(API_PRODUCT_ID),
+            eq(GenericPlanEntity.ReferenceType.API_PRODUCT),
+            queryCaptor.capture(),
+            eq(USER_ID),
+            eq(false)
+        );
+        assertThat(queryCaptor.getValue().getStatus()).containsExactly(PlanStatus.PUBLISHED);
+    }
+
+    @Test
+    void should_not_search_plans_when_api_product_is_inaccessible() {
+        when(portalApiProductAccessDomainService.findAccessible(ENVIRONMENT_ID, API_PRODUCT_ID, VIEWER_CONTEXT)).thenThrow(
+            new ApiProductNotFoundException(API_PRODUCT_ID)
+        );
+
+        assertThatThrownBy(() -> domainService.findAccessiblePlans(ENVIRONMENT_ID, API_PRODUCT_ID, VIEWER_CONTEXT)).isInstanceOf(
+            ApiProductNotFoundException.class
+        );
+        verifyNoInteractions(planSearchQueryService, planExcludedGroupsDomainService);
+    }
+
+    private static ApiProduct accessibleApiProduct() {
+        return ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENVIRONMENT_ID).build();
+    }
+}


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/PORTAL-109

## Description

Expose published API Product plans through the Portal API.

This PR adds:

- `GET /api-products/{apiProductId}/plans`
- API Product visibility validation for anonymous and authenticated users
- filtering based on excluded groups
- deterministic plan ordering
- a dedicated `ApiProductPlan` response containing only fields supported by API Products



