### PR TITLE
feat(gamma): search field overlap improvement

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/ClientSideTableSearchField.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/ClientSideTableSearchField.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Input } from '@gravitee/graphene-core';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@gravitee/graphene-core';
 import { SearchIcon } from '@gravitee/graphene-core/icons';
 
 interface ClientSideTableSearchFieldProps {
@@ -26,18 +26,16 @@ interface ClientSideTableSearchFieldProps {
 
 export function ClientSideTableSearchField({ id, label, value, onChange, placeholder = 'Search' }: ClientSideTableSearchFieldProps) {
     return (
-        <div className="relative w-64">
-            <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" aria-hidden />
+        <div className="w-64">
             <label htmlFor={id} className="sr-only">
                 {label}
             </label>
-            <Input
-                id={id}
-                placeholder={placeholder}
-                value={value}
-                onChange={event => onChange(event.target.value)}
-                className="h-8 w-64 pl-9"
-            />
+            <InputGroup>
+                <InputGroupAddon align="inline-start">
+                    <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                </InputGroupAddon>
+                <InputGroupInput id={id} placeholder={placeholder} value={value} onChange={event => onChange(event.target.value)} />
+            </InputGroup>
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UsersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UsersTable.tsx
@@ -13,7 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Badge, Button, DataTable, DataTableEmptyState, DateCell, Input, type DataTableProps } from '@gravitee/graphene-core';
+import {
+    Badge,
+    Button,
+    DataTable,
+    DataTableEmptyState,
+    DateCell,
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
 import { SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
 import { useId, useMemo } from 'react';
 import { Link } from 'react-router-dom';
@@ -230,21 +240,21 @@ export function UsersTable({
                 />
             }
             toolbar={
-                <div className="relative w-64">
-                    <SearchIcon
-                        className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none"
-                        aria-hidden
-                    />
+                <div className="w-64">
                     <label htmlFor={searchInputId} className="sr-only">
                         Search users
                     </label>
-                    <Input
-                        id={searchInputId}
-                        placeholder="Search by name, email, or ID..."
-                        value={search}
-                        onChange={e => onSearchChange(e.target.value)}
-                        className="h-8 w-64 pl-9"
-                    />
+                    <InputGroup>
+                        <InputGroupAddon align="inline-start">
+                            <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                        </InputGroupAddon>
+                        <InputGroupInput
+                            id={searchInputId}
+                            placeholder="Search by name, email, or ID..."
+                            value={search}
+                            onChange={e => onSearchChange(e.target.value)}
+                        />
+                    </InputGroup>
                 </div>
             }
         />


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-85

## Description
There was search icon/text overlap on the Users page

Change:
User list
UsersTable toolbar search → InputGroup

User detail (all via ClientSideTableSearchField → InputGroup)
Personal access tokens
Group memberships
Environment roles
Inherited APIs / API products / applications

Before:
<img width="1507" height="232" alt="image" src="https://github.com/user-attachments/assets/8cd7d91a-6964-427e-b0a8-8d6d75570aaf" />

After:
<img width="1507" height="232" alt="image" src="https://github.com/user-attachments/assets/c18eefc6-9971-4598-ad1f-b2f53b413e1e" />
