### PR TITLE
[4.12.x] chore(deps): bump gravitee-policy-kafka-topic-mapping to 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
     <gravitee-service-secrets.version>3.0.1</gravitee-service-secrets.version>
     <gravitee-policy-interops.version>1.1.3</gravitee-policy-interops.version>
     <gravitee-policy-kafka-quota.version>1.2.1</gravitee-policy-kafka-quota.version>
-    <gravitee-policy-kafka-topic-mapping.version>2.0.1</gravitee-policy-kafka-topic-mapping.version>
+    <gravitee-policy-kafka-topic-mapping.version>2.0.2</gravitee-policy-kafka-topic-mapping.version>
     <gravitee-policy-kafka-acl.version>3.0.3</gravitee-policy-kafka-acl.version>
     <gravitee-policy-kafka-transform-key.version>1.0.0</gravitee-policy-kafka-transform-key.version>
     <gravitee-policy-kafka-message-filtering.version>1.0.0</gravitee-policy-kafka-message-filtering.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-policy-kafka-topic-mapping](https://github.com/gravitee-io/gravitee-policy-kafka-topic-mapping)** `2.0.1` -> `2.0.2`.

## Why

`2.0.2` carries [`88a94e1`](https://github.com/gravitee-io/gravitee-policy-kafka-topic-mapping/commit/88a94e15268565ece6e3fb16a6b74c6815e905d1) — *fix: isolate evaluated topic mapping per connection*.

The policy instance is shared by every connection of the API/plan (policy chains are cached per flow by `AbstractPolicyChainFactory`), but the EL-evaluated mappings were kept in an instance field overwritten by each new connection's `onInitialize`. With connection-dependent expressions (e.g. OAuth claims), a connection could end up using another client's evaluation and consume data from another client's broker-side topic.

Same root cause as **APIM-14219** (intermittent incorrect Kafka topic mapping under load). The fix was released on 2026-06-11 but is still not bundled on any branch — `master`, `4.12.x` and `4.11.x` all pin `2.0.1`. It is being hit again in the field (ZD #17682: intermittent consumer hangs and authorization errors on aliased topics).

## Note

[#18279](https://github.com/gravitee-io/gravitee-api-management/pull/18279) was the equivalent bump on `master`. It was closed on 2026-06-26 with all CI checks green and no stated reason, and its branch predates the move of the property from the root `pom.xml` to `gravitee-apim-distribution/pom.xml`. @callaertanthony — if that close was deliberate, say so and I'll drop these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
