### PR TITLE
feat(console): batch-resolve category API summaries via portal-navigation-items includes

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItemsResponse.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItemsResponse.ts
@@ -15,6 +15,18 @@
  */
 import { PortalNavigationItem } from './portalNavigationItem';
 
+export interface PortalNavigationItemApiSummary {
+  id: string;
+  name: string;
+  apiVersion: string;
+  contextPath?: string;
+}
+
+export interface PortalNavigationItemsResponseMetadata {
+  apis?: Record<string, PortalNavigationItemApiSummary>;
+}
+
 export interface PortalNavigationItemsResponse {
   items: PortalNavigationItem[];
+  metadata?: PortalNavigationItemsResponseMetadata;
 }

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.spec.ts
@@ -30,13 +30,12 @@ import { AddApiToCategoryDialogHarness } from './add-api-to-category-dialog/add-
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import {
-  Api,
-  fakeApiV2,
   fakePortalCategory,
   fakePortalNavigationApi,
   fakePortalNavigationItemsResponse,
   PortalCategory,
   PortalNavigationApi,
+  PortalNavigationItemApiSummary,
   UpdateApiPortalNavigationItem,
 } from '../../../entities/management-api-v2';
 import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
@@ -105,12 +104,15 @@ describe('CategoryCatalogComponent', () => {
     req.flush(fakePortalNavigationItemsResponse({ items }));
   };
 
-  const expectGetApi = (api: Api) => {
+  const expectGetPortalNavigationItemsWithApis = (
+    items: PortalNavigationApi[] = [],
+    apisById: Record<string, PortalNavigationItemApiSummary> = {},
+  ) => {
     const req = httpTestingController.expectOne({
       method: 'GET',
-      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`,
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items?area=TOP_NAVBAR&includes=apis`,
     });
-    req.flush(api);
+    req.flush(fakePortalNavigationItemsResponse({ items, metadata: { apis: apisById } }));
   };
 
   const expectUpdateNavigationItem = (navItemId: string, expectedBody: UpdateApiPortalNavigationItem, response: PortalNavigationApi) => {
@@ -160,7 +162,7 @@ describe('CategoryCatalogComponent', () => {
       await init(CATEGORY.id);
       expectListPortalCategoriesRequest(httpTestingController, [CATEGORY]);
       fixture.detectChanges();
-      expectGetPortalNavigationItems([]);
+      expectGetPortalNavigationItemsWithApis([]);
 
       expect(component.mode).toEqual('edit');
     });
@@ -191,7 +193,7 @@ describe('CategoryCatalogComponent', () => {
       await init(CATEGORY.id);
       expectListPortalCategoriesRequest(httpTestingController, [CATEGORY]);
       fixture.detectChanges();
-      expectGetPortalNavigationItems([]);
+      expectGetPortalNavigationItemsWithApis([]);
     });
 
     it('should require title', async () => {
@@ -234,7 +236,7 @@ describe('CategoryCatalogComponent', () => {
     });
 
     it('should show empty APIs when none are assigned to the category', async () => {
-      expectGetPortalNavigationItems([]);
+      expectGetPortalNavigationItemsWithApis([]);
       fixture.detectChanges();
 
       const table = await harnessLoader.getHarness(MatTableHarness);
@@ -243,7 +245,7 @@ describe('CategoryCatalogComponent', () => {
     });
 
     it('should have the add API button enabled', async () => {
-      expectGetPortalNavigationItems([]);
+      expectGetPortalNavigationItemsWithApis([]);
       fixture.detectChanges();
 
       const addApiButton = await componentHarness.getAddApiButton(harnessLoader);
@@ -258,10 +260,10 @@ describe('CategoryCatalogComponent', () => {
         title: 'Planets API',
         categoryIds: [CATEGORY.id],
       });
-      const api = fakeApiV2({ id: 'api-1', name: 'Planets API', apiVersion: '1.0' });
 
-      expectGetPortalNavigationItems([navItem]);
-      expectGetApi(api);
+      expectGetPortalNavigationItemsWithApis([navItem], {
+        'nav-api-1': { id: 'api-1', name: 'Planets API', apiVersion: '1.0', contextPath: '/planets' },
+      });
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
@@ -273,7 +275,7 @@ describe('CategoryCatalogComponent', () => {
 
     describe('Add API to Category', () => {
       beforeEach(async () => {
-        expectGetPortalNavigationItems([]);
+        expectGetPortalNavigationItemsWithApis([]);
         fixture.detectChanges();
       });
 
@@ -312,9 +314,9 @@ describe('CategoryCatalogComponent', () => {
 
         expect(successSpy).toHaveBeenCalledWith('API [Planets API] has been added to the category.');
 
-        const api = fakeApiV2({ id: 'api-1', name: 'Planets API' });
-        expectGetPortalNavigationItems([updatedNavItem]);
-        expectGetApi(api);
+        expectGetPortalNavigationItemsWithApis([updatedNavItem], {
+          'nav-api-1': { id: 'api-1', name: 'Planets API', apiVersion: '1.0', contextPath: '/planets' },
+        });
       });
 
       it('should not offer APIs already assigned to the category', async () => {
@@ -347,11 +349,11 @@ describe('CategoryCatalogComponent', () => {
         title: 'Planets API',
         categoryIds: [CATEGORY.id],
       });
-      const api = fakeApiV2({ id: 'api-1', name: 'Planets API' });
 
       beforeEach(async () => {
-        expectGetPortalNavigationItems([navItem]);
-        expectGetApi(api);
+        expectGetPortalNavigationItemsWithApis([navItem], {
+          'nav-api-1': { id: 'api-1', name: 'Planets API', apiVersion: '1.0', contextPath: '/planets' },
+        });
         fixture.detectChanges();
         await fixture.whenStable();
         fixture.detectChanges();
@@ -384,7 +386,7 @@ describe('CategoryCatalogComponent', () => {
 
         expect(successSpy).toHaveBeenCalledWith(`'Planets API' removed successfully`);
 
-        expectGetPortalNavigationItems([]);
+        expectGetPortalNavigationItemsWithApis([]);
       });
 
       it('should not remove the API when cancelling the confirmation', async () => {

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.spec.ts
@@ -273,6 +273,25 @@ describe('CategoryCatalogComponent', () => {
       expect(await componentHarness.getTextByColumnNameAndRowIndex(harnessLoader, 'contextPath', 0)).toEqual('/planets');
     });
 
+    it('should still list an API assigned to the category after it was unpublished', async () => {
+      const navItem = fakePortalNavigationApi({
+        id: 'nav-api-1',
+        apiId: 'api-1',
+        title: 'Planets API',
+        categoryIds: [CATEGORY.id],
+        published: false,
+      });
+
+      expectGetPortalNavigationItemsWithApis([navItem], {
+        'nav-api-1': { id: 'api-1', name: 'Planets API', apiVersion: '1.0', contextPath: '/planets' },
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(await componentHarness.getNameByRowIndex(harnessLoader, 0)).toEqual('Planets API');
+    });
+
     describe('Add API to Category', () => {
       beforeEach(async () => {
         expectGetPortalNavigationItemsWithApis([]);

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.ts
@@ -15,7 +15,7 @@
  */
 import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
-import { BehaviorSubject, forkJoin, Observable, of } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { catchError, filter, map, switchMap, tap } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -51,15 +51,14 @@ import { GioPermissionService } from '../../../shared/components/gio-permission/
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { PortalCategoryService } from '../../../services-ngx/portal-category.service';
 import { PortalNavigationItemService } from '../../../services-ngx/portal-navigation-item.service';
-import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import {
   CreatePortalCategory,
   PortalCategory,
   PortalNavigationApi,
+  PortalNavigationItemApiSummary,
   UpdateApiPortalNavigationItem,
   UpdatePortalCategory,
 } from '../../../entities/management-api-v2';
-import { getApiContextPath } from '../../../shared/utils';
 
 interface ApiVM {
   id: string;
@@ -118,7 +117,6 @@ export class CategoryCatalogComponent implements OnInit {
   private refreshApis = new BehaviorSubject(1);
   private destroyRef = inject(DestroyRef);
   private readonly portalNavigationItemService = inject(PortalNavigationItemService);
-  private readonly apiService = inject(ApiV2Service);
   private readonly matDialog = inject(MatDialog);
 
   constructor(
@@ -164,8 +162,13 @@ export class CategoryCatalogComponent implements OnInit {
         if (this.mode !== 'edit') {
           return of([]);
         }
-        return this.publishedApiNavigationItemsInCategory$().pipe(
-          switchMap(navItems => this.loadApiVMs(navItems)),
+        return this.publishedApiNavigationItemsWithSummaries$().pipe(
+          map(({ navItems, apisById }) =>
+            navItems
+              .filter(navItem => (navItem.categoryIds ?? []).includes(this.categoryId))
+              .map(navItem => this.toApiVM(navItem, apisById[navItem.id]))
+              .filter((apiVM): apiVM is ApiVM => !!apiVM),
+          ),
           catchError(() => of([])),
         );
       }),
@@ -290,41 +293,36 @@ export class CategoryCatalogComponent implements OnInit {
     return this.activatedRoute.snapshot.params.categoryId;
   }
 
-  private publishedApiNavigationItems$(): Observable<PortalNavigationApi[]> {
-    return this.portalNavigationItemService
-      .getNavigationItems('TOP_NAVBAR')
-      .pipe(map(response => response.items.filter((item): item is PortalNavigationApi => item.type === 'API' && item.published)));
-  }
-
-  private publishedApiNavigationItemsInCategory$(): Observable<PortalNavigationApi[]> {
-    return this.publishedApiNavigationItems$().pipe(
-      map(navItems => navItems.filter(navItem => (navItem.categoryIds ?? []).includes(this.categoryId))),
-    );
-  }
-
   private selectableApiNavigationItems$(): Observable<PortalNavigationApi[]> {
-    return this.publishedApiNavigationItems$().pipe(
+    return this.portalNavigationItemService.getNavigationItems('TOP_NAVBAR').pipe(
+      map(response => response.items.filter((item): item is PortalNavigationApi => item.type === 'API' && item.published)),
       map(navItems => navItems.filter(navItem => !(navItem.categoryIds ?? []).includes(this.categoryId))),
     );
   }
 
-  private loadApiVMs(navItems: PortalNavigationApi[]): Observable<ApiVM[]> {
-    if (navItems.length === 0) {
-      return of([]);
-    }
-    return forkJoin(
-      navItems.map(navItem =>
-        this.apiService.get(navItem.apiId).pipe(
-          map(api => ({
-            id: api.id,
-            name: api.name,
-            version: api.apiVersion,
-            contextPath: getApiContextPath(api) ?? '',
-            navigationItem: navItem,
-          })),
-        ),
-      ),
+  private publishedApiNavigationItemsWithSummaries$(): Observable<{
+    navItems: PortalNavigationApi[];
+    apisById: Record<string, PortalNavigationItemApiSummary>;
+  }> {
+    return this.portalNavigationItemService.getNavigationItems('TOP_NAVBAR', ['apis']).pipe(
+      map(response => ({
+        navItems: response.items.filter((item): item is PortalNavigationApi => item.type === 'API' && item.published),
+        apisById: response.metadata?.apis ?? {},
+      })),
     );
+  }
+
+  private toApiVM(navItem: PortalNavigationApi, summary: PortalNavigationItemApiSummary | undefined): ApiVM | null {
+    if (!summary) {
+      return null;
+    }
+    return {
+      id: summary.id,
+      name: summary.name,
+      version: summary.apiVersion,
+      contextPath: summary.contextPath ?? '',
+      navigationItem: navItem,
+    };
   }
 
   private toUpdatePayload(navItem: PortalNavigationApi, categoryIds: string[]): UpdateApiPortalNavigationItem {

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.ts
@@ -162,7 +162,7 @@ export class CategoryCatalogComponent implements OnInit {
         if (this.mode !== 'edit') {
           return of([]);
         }
-        return this.publishedApiNavigationItemsWithSummaries$().pipe(
+        return this.apiNavigationItemsWithSummaries$().pipe(
           map(({ navItems, apisById }) =>
             navItems
               .filter(navItem => (navItem.categoryIds ?? []).includes(this.categoryId))
@@ -300,13 +300,17 @@ export class CategoryCatalogComponent implements OnInit {
     );
   }
 
-  private publishedApiNavigationItemsWithSummaries$(): Observable<{
+  /**
+   * Not filtered by `published`: an API assigned to this category before being unpublished must
+   * still appear here so its association can be seen and removed.
+   */
+  private apiNavigationItemsWithSummaries$(): Observable<{
     navItems: PortalNavigationApi[];
     apisById: Record<string, PortalNavigationItemApiSummary>;
   }> {
     return this.portalNavigationItemService.getNavigationItems('TOP_NAVBAR', ['apis']).pipe(
       map(response => ({
-        navItems: response.items.filter((item): item is PortalNavigationApi => item.type === 'API' && item.published),
+        navItems: response.items.filter((item): item is PortalNavigationApi => item.type === 'API'),
         apisById: response.metadata?.apis ?? {},
       })),
     );

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
@@ -62,6 +62,18 @@ describe('PortalNavigationItemService', () => {
         .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items?area=TOP_NAVBAR` })
         .flush(fakeResponse);
     });
+
+    it('should add the includes query param when provided', done => {
+      const fakeResponse = fakePortalNavigationItemsResponse();
+      service.getNavigationItems('TOP_NAVBAR', ['apis']).subscribe(response => {
+        expect(response).toMatchObject(fakeResponse);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items?area=TOP_NAVBAR&includes=apis` })
+        .flush(fakeResponse);
+    });
   });
 
   describe('createNavigationItem', () => {

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.ts
@@ -35,8 +35,11 @@ export class PortalNavigationItemService {
     @Inject(Constants) private readonly constants: Constants,
   ) {}
 
-  public getNavigationItems(portalArea: PortalArea): Observable<PortalNavigationItemsResponse> {
-    return this.http.get<PortalNavigationItemsResponse>(`${this.constants.env.v2BaseURL}/portal-navigation-items?area=${portalArea}`);
+  public getNavigationItems(portalArea: PortalArea, includes?: string[]): Observable<PortalNavigationItemsResponse> {
+    const includesParam = includes?.length ? `&includes=${includes.join(',')}` : '';
+    return this.http.get<PortalNavigationItemsResponse>(
+      `${this.constants.env.v2BaseURL}/portal-navigation-items?area=${portalArea}${includesParam}`,
+    );
   }
 
   public createNavigationItem(newPortalNavigationItem: NewPortalNavigationItem): Observable<PortalNavigationItem> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -324,15 +324,19 @@ public interface PortalNavigationItemsMapper {
             return tcpHost;
         }
 
-        String kafkaHost = listeners
+        String kafkaAddress = listeners
             .stream()
             .filter(listener -> listener.getType() == ListenerType.KAFKA)
             .map(KafkaListener.class::cast)
-            .map(KafkaListener::getHost)
+            .map(
+                kafkaListener ->
+                    (kafkaListener.getHost() != null ? kafkaListener.getHost() : "") +
+                    (kafkaListener.getPort() != null ? ":" + kafkaListener.getPort() : "")
+            )
             .findFirst()
             .orElse(null);
-        if (kafkaHost != null) {
-            return kafkaHost;
+        if (kafkaAddress != null) {
+            return kafkaAddress;
         }
 
         return listeners

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -20,6 +20,11 @@ import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.use_case.FetchPortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForPortalNavigationItemsUseCase;
+import io.gravitee.definition.model.VirtualHost;
+import io.gravitee.definition.model.v4.listener.ListenerType;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
+import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.BaseUpdatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi;
@@ -29,6 +34,7 @@ import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
 import io.gravitee.rest.api.management.v2.rest.model.FetchPortalNavigationItemResponse;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItem;
+import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemApiSummary;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemFetchResult;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemsFetchSummary;
 import io.gravitee.rest.api.management.v2.rest.model.PortalPageContentType;
@@ -38,7 +44,9 @@ import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApiPr
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationPage;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -262,5 +270,78 @@ public interface PortalNavigationItemsMapper {
             return null;
         }
         return id.id();
+    }
+
+    /**
+     * Maps the domain APIs already resolved by the use case (via {@code ApiPortalSearchQueryService},
+     * version-agnostic) to the REST summary DTO, keyed by navigation item id.
+     */
+    default Map<String, PortalNavigationItemApiSummary> mapApisMetadata(
+        Map<PortalNavigationItemId, io.gravitee.apim.core.api.model.Api> apisByNavigationItemId
+    ) {
+        Map<String, PortalNavigationItemApiSummary> summariesByNavigationItemId = new HashMap<>();
+        apisByNavigationItemId.forEach((navigationItemId, api) ->
+            summariesByNavigationItemId.put(navigationItemId.json(), mapApiSummary(api))
+        );
+        return summariesByNavigationItemId;
+    }
+
+    default PortalNavigationItemApiSummary mapApiSummary(io.gravitee.apim.core.api.model.Api api) {
+        return new PortalNavigationItemApiSummary()
+            .id(api.getId())
+            .name(api.getName())
+            .apiVersion(api.getVersion())
+            .contextPath(resolveApiContextPath(api));
+    }
+
+    /**
+     * Mirrors the frontend's {@code getApiAccess}/{@code getApiContextPath} utilities
+     * (gravitee-apim-console-webui/src/shared/utils/api-access.util.ts): returns the API's primary
+     * access path for display, or {@code null} for API versions with no gateway-managed endpoint
+     * (federated, federated agent).
+     */
+    private String resolveApiContextPath(io.gravitee.apim.core.api.model.Api api) {
+        var v2Definition = api.getApiDefinition();
+        if (v2Definition != null) {
+            var virtualHosts = v2Definition.getProxy() != null ? v2Definition.getProxy().getVirtualHosts() : null;
+            if (virtualHosts == null || virtualHosts.isEmpty()) {
+                return null;
+            }
+            VirtualHost virtualHost = virtualHosts.get(0);
+            return (virtualHost.getHost() != null ? virtualHost.getHost() : "") + virtualHost.getPath();
+        }
+
+        var listeners = api.getApiListeners();
+
+        String tcpHost = listeners
+            .stream()
+            .filter(listener -> listener.getType() == ListenerType.TCP)
+            .map(TcpListener.class::cast)
+            .flatMap(listener -> listener.getHosts().stream())
+            .findFirst()
+            .orElse(null);
+        if (tcpHost != null) {
+            return tcpHost;
+        }
+
+        String kafkaHost = listeners
+            .stream()
+            .filter(listener -> listener.getType() == ListenerType.KAFKA)
+            .map(KafkaListener.class::cast)
+            .map(KafkaListener::getHost)
+            .findFirst()
+            .orElse(null);
+        if (kafkaHost != null) {
+            return kafkaHost;
+        }
+
+        return listeners
+            .stream()
+            .filter(listener -> listener.getType() == ListenerType.HTTP)
+            .map(HttpListener.class::cast)
+            .flatMap(listener -> listener.getPaths().stream())
+            .findFirst()
+            .map(path -> (path.getHost() != null ? path.getHost() : "") + path.getPath())
+            .orElse(null);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource.java
@@ -26,7 +26,9 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.PortalNavigationItemsMapper;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItems;
+import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemApiSummary;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemsResponseMetadata;
 import io.gravitee.rest.api.management.v2.rest.model.SeedDefaultPagesRequest;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -48,7 +50,9 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import lombok.CustomLog;
 
 /**
@@ -80,7 +84,8 @@ public class PortalNavigationItemsResource extends AbstractResource {
     public PortalNavigationItemsResponse getPortalNavigationItems(
         @QueryParam("area") @DefaultValue("TOP_NAVBAR") String area,
         @QueryParam("parentId") String parentId,
-        @QueryParam("loadChildren") @DefaultValue("true") boolean loadChildren
+        @QueryParam("loadChildren") @DefaultValue("true") boolean loadChildren,
+        @QueryParam("includes") Set<String> includes
     ) {
         final PortalArea portalArea;
         try {
@@ -89,17 +94,28 @@ public class PortalNavigationItemsResource extends AbstractResource {
             throw new BadRequestException("Invalid value '" + area + "' for query parameter 'area'");
         }
 
+        boolean includeApis = includes != null && includes.contains("apis");
+
         var result = listPortalNavigationItemsUseCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 GraviteeContext.getCurrentEnvironment(),
+                GraviteeContext.getCurrentOrganization(),
                 portalArea,
                 Optional.ofNullable(parentId).map(PortalNavigationItemId::of),
                 loadChildren,
-                PortalNavigationItemViewerContext.forConsole()
+                PortalNavigationItemViewerContext.forConsole(),
+                includeApis
             )
         );
 
-        return new PortalNavigationItemsResponse().items(mapper.map(result.items()));
+        var response = new PortalNavigationItemsResponse().items(mapper.map(result.items()));
+
+        Map<String, PortalNavigationItemApiSummary> apisMetadata = mapper.mapApisMetadata(result.apis());
+        if (!apisMetadata.isEmpty()) {
+            response.metadata(new PortalNavigationItemsResponseMetadata().apis(apisMetadata));
+        }
+
+        return response;
     }
 
     @POST

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1005,6 +1005,16 @@ paths:
           schema:
             type: boolean
             default: true
+        - name: includes
+          in: query
+          description: Additional data to include in the response, returned as a separate `metadata` map rather than inlined onto each item.
+          required: false
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [ apis ]
       responses:
         "200":
           $ref: "#/components/responses/PortalNavigationItemsResponse"
@@ -2569,6 +2579,31 @@ components:
           LINK: "#/components/schemas/PortalNavigationLink"
           API: "#/components/schemas/PortalNavigationApi"
           API_PRODUCT: "#/components/schemas/PortalNavigationApiProduct"
+    PortalNavigationItemsResponseMetadata:
+      type: object
+      description: Sidecar data resolved for the returned navigation items, present only when requested via the `includes` query parameter.
+      properties:
+        apis:
+          type: object
+          description: Map of navigation item ID to a summary of its resolved Api, present only when `includes=apis` was requested.
+          additionalProperties:
+            $ref: "#/components/schemas/PortalNavigationItemApiSummary"
+    PortalNavigationItemApiSummary:
+      type: object
+      description: A minimal summary of an Api, used to populate the `metadata.apis` map without requiring the full Api schema.
+      properties:
+        id:
+          type: string
+          description: API's uuid.
+        name:
+          type: string
+          description: API's name.
+        apiVersion:
+          type: string
+          description: API's version.
+        contextPath:
+          type: string
+          description: The API's primary access path for display, if any (context path, listener path/host, or similar depending on API type).
     BaseCreatePortalNavigationItem:
       type: object
       description: Base portal navigation item. Newly created items are unpublished by default.
@@ -3661,6 +3696,8 @@ components:
                 description: List of portal navigation items
                 items:
                   $ref: "#/components/schemas/PortalNavigationItem"
+              metadata:
+                $ref: "#/components/schemas/PortalNavigationItemsResponseMetadata"
     PortalPageContentResponse:
       description: Portal page content
       content:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -433,4 +433,17 @@ class PortalNavigationItemsMapperTest {
             assertThat(source.isUseAutoFetch()).isFalse();
         }
     }
+
+    @Nested
+    class ApisMetadataMapping {
+
+        @Test
+        void should_include_the_port_in_a_native_kafka_api_context_path() {
+            var api = fixtures.core.model.ApiFixtures.aNativeApi();
+
+            var summary = mapper.mapApiSummary(api);
+
+            assertThat(summary.getContextPath()).isEqualTo("native.kafka:1000");
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_GetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_GetTest.java
@@ -21,6 +21,7 @@ import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.ApiPortalSearchQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemsResponse;
@@ -56,6 +57,9 @@ class PortalNavigationItemsResource_GetTest extends AbstractResourceTest {
     @Autowired
     private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
 
+    @Autowired
+    private ApiPortalSearchQueryServiceInMemory apiPortalSearchQueryService;
+
     private WebTarget target;
 
     @Override
@@ -79,6 +83,7 @@ class PortalNavigationItemsResource_GetTest extends AbstractResourceTest {
     public void tearDown() {
         GraviteeContext.cleanContext();
         portalNavigationItemsQueryService.reset();
+        apiPortalSearchQueryService.reset();
     }
 
     @Test
@@ -331,5 +336,71 @@ class PortalNavigationItemsResource_GetTest extends AbstractResourceTest {
             .contains("Invalid value")
             .contains("invalidArea")
             .contains("area");
+    }
+
+    @Test
+    void should_not_include_apis_metadata_by_default() {
+        // Given
+        var apiNavItem = PortalNavigationItemFixtures.anApi("00000000-0000-0000-0000-000000000030", "API 1", null, "api-1");
+        apiNavItem.setEnvironmentId(ENVIRONMENT);
+        portalNavigationItemsQueryService.initWith(java.util.List.of(apiNavItem));
+
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_DOCUMENTATION,
+                ENVIRONMENT,
+                RolePermissionAction.READ
+            )
+        ).thenReturn(true);
+
+        // When
+        Response response = target.queryParam("area", PortalArea.TOP_NAVBAR).queryParam("loadChildren", true).request().get();
+
+        // Then
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(PortalNavigationItemsResponse.class)
+            .satisfies(entity -> assertThat(entity.getMetadata()).isNull());
+    }
+
+    @Test
+    void should_include_apis_metadata_when_includes_apis_is_requested() {
+        // Given
+        var api = fixtures.core.model.ApiFixtures.aProxyApiV4().toBuilder().environmentId(ENVIRONMENT).build();
+        var apiNavItem = PortalNavigationItemFixtures.anApi("00000000-0000-0000-0000-000000000030", "API 1", null, api.getId());
+        apiNavItem.setEnvironmentId(ENVIRONMENT);
+        portalNavigationItemsQueryService.initWith(java.util.List.of(apiNavItem));
+        apiPortalSearchQueryService.initWith(java.util.List.of(api));
+
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_DOCUMENTATION,
+                ENVIRONMENT,
+                RolePermissionAction.READ
+            )
+        ).thenReturn(true);
+
+        // When
+        Response response = target
+            .queryParam("area", PortalArea.TOP_NAVBAR)
+            .queryParam("loadChildren", true)
+            .queryParam("includes", "apis")
+            .request()
+            .get();
+
+        // Then
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(PortalNavigationItemsResponse.class)
+            .satisfies(entity -> {
+                assertThat(entity.getMetadata()).isNotNull();
+                assertThat(entity.getMetadata().getApis()).containsKey(apiNavItem.getId().toString());
+                var summary = entity.getMetadata().getApis().get(apiNavItem.getId().toString());
+                assertThat(summary.getId()).isEqualTo(api.getId());
+                assertThat(summary.getName()).isEqualTo(api.getName());
+                assertThat(summary.getContextPath()).isEqualTo("/http_proxy");
+            });
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -74,6 +74,7 @@ import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
+import io.gravitee.apim.core.api.query_service.ApiPortalSearchQueryService;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
@@ -1501,12 +1502,14 @@ public class ResourceContextConfiguration {
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService,
         PortalNavigationApiProductVisibilityDomainService portalNavigationApiProductVisibilityDomainService,
-        PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService
+        PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService,
+        ApiPortalSearchQueryService apiPortalSearchQueryService
     ) {
         return new ListPortalNavigationItemsUseCase(
             portalNavigationItemsQueryService,
             List.of(portalNavigationApiVisibilityDomainService, portalNavigationApiProductVisibilityDomainService),
-            portalNavigationItemSourceDomainService
+            portalNavigationItemSourceDomainService,
+            apiPortalSearchQueryService
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
@@ -84,10 +84,12 @@ public class PortalNavigationItemsResource extends AbstractResource {
         var executionContext = getExecutionContext();
         var input = new ListPortalNavigationItemsUseCase.Input(
             executionContext.getEnvironmentId(),
+            executionContext.getOrganizationId(),
             portalNavigationItemMapper.map(area),
             Optional.ofNullable(parentId).map(PortalNavigationItemId::of),
             loadChildren,
-            PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull())
+            PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull()),
+            false
         );
         var output = listPortalNavigationItemsUseCase.execute(input);
         return Response.ok(portalNavigationItemMapper.map(output.items())).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -66,6 +66,7 @@ import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
+import io.gravitee.apim.core.api.query_service.ApiPortalSearchQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
@@ -1308,12 +1309,14 @@ public class ResourceContextConfiguration {
     public ListPortalNavigationItemsUseCase listPortalNavigationItemsUseCase(
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService,
-        PortalNavigationApiProductVisibilityDomainService portalNavigationApiProductVisibilityDomainService
+        PortalNavigationApiProductVisibilityDomainService portalNavigationApiProductVisibilityDomainService,
+        ApiPortalSearchQueryService apiPortalSearchQueryService
     ) {
         return new ListPortalNavigationItemsUseCase(
             portalNavigationItemsQueryService,
             List.of(portalNavigationApiVisibilityDomainService, portalNavigationApiProductVisibilityDomainService),
-            new PortalNavigationItemSourceDomainServiceInMemory()
+            new PortalNavigationItemSourceDomainServiceInMemory(),
+            apiPortalSearchQueryService
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCase.java
@@ -16,10 +16,13 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.query_service.ApiPortalSearchQueryService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityEvaluator;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityService;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemComparator;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
@@ -29,11 +32,15 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -43,6 +50,7 @@ public class ListPortalNavigationItemsUseCase {
     private final PortalNavigationItemsQueryService queryService;
     private final List<PortalNavigationItemVisibilityService> visibilityServices;
     private final PortalNavigationItemSourceDomainService sourceDomainService;
+    private final ApiPortalSearchQueryService apiPortalSearchQueryService;
     private static final Predicate<PortalNavigationItem> IS_CONTAINER_PREDICATE = i -> i instanceof PortalNavigationItemContainer;
 
     public Output execute(Input input) {
@@ -57,7 +65,7 @@ public class ListPortalNavigationItemsUseCase {
         if (input.parentId().isPresent()) {
             parentItem = findAndValidateParent(input, visibilityEvaluator);
             if (parentItem == null) {
-                return new Output(List.of());
+                return new Output(List.of(), Map.of());
             }
         }
 
@@ -77,7 +85,38 @@ public class ListPortalNavigationItemsUseCase {
 
         allItems.stream().map(PortalNavigationItem::getSource).filter(Objects::nonNull).forEach(sourceDomainService::removeSensitiveData);
 
-        return new Output(sortItems(allItems));
+        return new Output(sortItems(allItems), resolveApis(input, allItems));
+    }
+
+    private Map<PortalNavigationItemId, Api> resolveApis(Input input, List<PortalNavigationItem> allItems) {
+        if (!input.includeApis()) {
+            return Map.of();
+        }
+
+        List<PortalNavigationApi> apiItems = allItems
+            .stream()
+            .filter(PortalNavigationApi.class::isInstance)
+            .map(PortalNavigationApi.class::cast)
+            .toList();
+
+        if (apiItems.isEmpty()) {
+            return Map.of();
+        }
+
+        Set<String> apiIds = apiItems.stream().map(PortalNavigationApi::getApiId).collect(Collectors.toSet());
+        Map<String, Api> apisByApiId = apiPortalSearchQueryService
+            .search(input.environmentId(), input.organizationId(), apiIds)
+            .stream()
+            .collect(Collectors.toMap(Api::getId, api -> api));
+
+        Map<PortalNavigationItemId, Api> apisByNavigationItemId = new HashMap<>();
+        for (PortalNavigationApi navItem : apiItems) {
+            Api api = apisByApiId.get(navItem.getApiId());
+            if (api != null) {
+                apisByNavigationItemId.put(navItem.getId(), api);
+            }
+        }
+        return apisByNavigationItemId;
     }
 
     private PortalNavigationItem findAndValidateParent(Input input, PortalNavigationItemVisibilityEvaluator visibilityEvaluator) {
@@ -170,13 +209,15 @@ public class ListPortalNavigationItemsUseCase {
         return items.stream().sorted(PortalNavigationItemComparator.byNullableParentIdThenNullableOrder()).toList();
     }
 
-    public record Output(List<PortalNavigationItem> items) {}
+    public record Output(List<PortalNavigationItem> items, Map<PortalNavigationItemId, Api> apis) {}
 
     public record Input(
         String environmentId,
+        String organizationId,
         PortalArea portalArea,
         Optional<PortalNavigationItemId> parentId,
         boolean loadChildren,
-        PortalNavigationItemViewerContext viewerContext
+        PortalNavigationItemViewerContext viewerContext,
+        boolean includeApis
     ) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
@@ -21,7 +21,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import fixtures.core.model.ApiFixtures;
 import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.ApiPortalSearchQueryServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
@@ -48,12 +50,14 @@ import org.junit.jupiter.api.Test;
 class ListPortalNavigationItemsUseCaseTest {
 
     private static final String ENV_ID = "env-id";
+    private static final String ORG_ID = "org-id";
 
     private ListPortalNavigationItemsUseCase useCase;
     private PortalNavigationItemsQueryServiceInMemory queryService;
     private MembershipQueryServiceInMemory membershipQueryService;
     private SubscriptionQueryServiceInMemory subscriptionQueryService;
     private ApiQueryServiceInMemory apiQueryService;
+    private ApiPortalSearchQueryServiceInMemory apiPortalSearchQueryService;
     private ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService;
 
     @BeforeEach
@@ -62,6 +66,7 @@ class ListPortalNavigationItemsUseCaseTest {
         membershipQueryService = new MembershipQueryServiceInMemory();
         subscriptionQueryService = new SubscriptionQueryServiceInMemory();
         apiQueryService = new ApiQueryServiceInMemory();
+        apiPortalSearchQueryService = new ApiPortalSearchQueryServiceInMemory();
         var apiMembershipDomainService = new ApiPortalMembershipDomainService(
             membershipQueryService,
             subscriptionQueryService,
@@ -78,7 +83,8 @@ class ListPortalNavigationItemsUseCaseTest {
         useCase = new ListPortalNavigationItemsUseCase(
             queryService,
             List.of(apiVisibilityDomainService, apiProductVisibilityDomainService),
-            new PortalNavigationItemSourceDomainServiceInMemory()
+            new PortalNavigationItemSourceDomainServiceInMemory(),
+            apiPortalSearchQueryService
         );
 
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
@@ -93,10 +99,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 true,
-                PortalNavigationItemViewerContext.forConsole()
+                PortalNavigationItemViewerContext.forConsole(),
+                false
             )
         );
 
@@ -130,10 +138,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.of(PortalNavigationItemId.of(APIS_ID)),
                 false,
-                PortalNavigationItemViewerContext.forConsole()
+                PortalNavigationItemViewerContext.forConsole(),
+                false
             )
         );
 
@@ -153,10 +163,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.of(PortalNavigationItemId.of(APIS_ID)),
                 true,
-                PortalNavigationItemViewerContext.forConsole()
+                PortalNavigationItemViewerContext.forConsole(),
+                false
             )
         );
 
@@ -186,10 +198,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 true,
-                PortalNavigationItemViewerContext.forPortal(true)
+                PortalNavigationItemViewerContext.forPortal(true),
+                false
             )
         );
 
@@ -232,10 +246,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 true,
-                PortalNavigationItemViewerContext.forPortal(true)
+                PortalNavigationItemViewerContext.forPortal(true),
+                false
             )
         );
 
@@ -262,10 +278,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.of(unpublishedFolder.getId()),
                 true,
-                PortalNavigationItemViewerContext.forPortal(true)
+                PortalNavigationItemViewerContext.forPortal(true),
+                false
             )
         );
 
@@ -292,10 +310,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.of(publishedFolder.getId()),
                 true,
-                PortalNavigationItemViewerContext.forPortal(true)
+                PortalNavigationItemViewerContext.forPortal(true),
+                false
             )
         );
 
@@ -312,10 +332,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.of(PortalNavigationItemId.random()),
                 true,
-                PortalNavigationItemViewerContext.forConsole()
+                PortalNavigationItemViewerContext.forConsole(),
+                false
             )
         );
 
@@ -341,10 +363,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.of(unpublishedFolder.getId()),
                 true,
-                PortalNavigationItemViewerContext.forPortal(true)
+                PortalNavigationItemViewerContext.forPortal(true),
+                false
             )
         );
 
@@ -368,10 +392,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 false,
-                PortalNavigationItemViewerContext.forPortal(true)
+                PortalNavigationItemViewerContext.forPortal(true),
+                false
             )
         );
 
@@ -395,10 +421,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 false,
-                PortalNavigationItemViewerContext.forPortal(false)
+                PortalNavigationItemViewerContext.forPortal(false),
+                false
             )
         );
 
@@ -424,10 +452,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 true,
-                PortalNavigationItemViewerContext.forPortal("user-without-access")
+                PortalNavigationItemViewerContext.forPortal("user-without-access"),
+                false
             )
         );
 
@@ -465,10 +495,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 true,
-                PortalNavigationItemViewerContext.forPortal("user-member")
+                PortalNavigationItemViewerContext.forPortal("user-member"),
+                false
             )
         );
 
@@ -504,10 +536,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 true,
-                PortalNavigationItemViewerContext.forPortal("user-without-access")
+                PortalNavigationItemViewerContext.forPortal("user-without-access"),
+                false
             )
         );
 
@@ -536,10 +570,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.of(apiNavItem.getId()),
                 true,
-                PortalNavigationItemViewerContext.forPortal("user-without-access")
+                PortalNavigationItemViewerContext.forPortal("user-without-access"),
+                false
             )
         );
 
@@ -575,10 +611,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.of(childFolder.getId()),
                 true,
-                PortalNavigationItemViewerContext.forPortal("user-without-access")
+                PortalNavigationItemViewerContext.forPortal("user-without-access"),
+                false
             )
         );
 
@@ -605,10 +643,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 true,
-                PortalNavigationItemViewerContext.forPortal("user-without-access")
+                PortalNavigationItemViewerContext.forPortal("user-without-access"),
+                false
             )
         );
 
@@ -640,10 +680,12 @@ class ListPortalNavigationItemsUseCaseTest {
         useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 true,
-                PortalNavigationItemViewerContext.forPortal("user-without-access")
+                PortalNavigationItemViewerContext.forPortal("user-without-access"),
+                false
             )
         );
 
@@ -680,10 +722,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 true,
-                PortalNavigationItemViewerContext.forPortal("product-member")
+                PortalNavigationItemViewerContext.forPortal("product-member"),
+                false
             )
         );
 
@@ -716,10 +760,12 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 true,
-                PortalNavigationItemViewerContext.forPortal("user-without-api-access")
+                PortalNavigationItemViewerContext.forPortal("user-without-api-access"),
+                false
             )
         );
 
@@ -743,14 +789,87 @@ class ListPortalNavigationItemsUseCaseTest {
         var result = useCase.execute(
             new ListPortalNavigationItemsUseCase.Input(
                 ENV_ID,
+                ORG_ID,
                 PortalArea.TOP_NAVBAR,
                 Optional.empty(),
                 true,
-                PortalNavigationItemViewerContext.forConsole()
+                PortalNavigationItemViewerContext.forConsole(),
+                false
             )
         );
 
         // Then
         assertThat(result.items()).hasSize(1).extracting(PortalNavigationItem::getTitle).containsExactly("Nav Bar Item");
+    }
+
+    @Test
+    void should_return_empty_apis_map_when_include_apis_is_false_even_with_api_items() {
+        // Given
+        var apiNavItem = PortalNavigationItemFixtures.anApi(PortalNavigationItemId.random().toString(), "API 1", null, "api-1");
+        queryService.initWith(List.of(apiNavItem));
+        apiPortalSearchQueryService.initWith(List.of(ApiFixtures.aProxyApiV4().toBuilder().id("api-1").environmentId(ENV_ID).build()));
+
+        // When
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forConsole(),
+                false
+            )
+        );
+
+        // Then
+        assertThat(result.apis()).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_apis_map_when_include_apis_is_true_but_no_api_items() {
+        // Given
+        // Setup data for APIs, Guides, Support (no API-type items)
+
+        // When
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.of(PortalNavigationItemId.of(APIS_ID)),
+                false,
+                PortalNavigationItemViewerContext.forConsole(),
+                true
+            )
+        );
+
+        // Then
+        assertThat(result.apis()).isEmpty();
+    }
+
+    @Test
+    void should_populate_apis_map_keyed_by_navigation_item_id_when_include_apis_is_true() {
+        // Given
+        var apiNavItem = PortalNavigationItemFixtures.anApi(PortalNavigationItemId.random().toString(), "API 1", null, "api-1");
+        queryService.initWith(List.of(apiNavItem));
+        var api = ApiFixtures.aProxyApiV4().toBuilder().id("api-1").environmentId(ENV_ID).build();
+        apiPortalSearchQueryService.initWith(List.of(api));
+
+        // When
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forConsole(),
+                true
+            )
+        );
+
+        // Then
+        assertThat(result.apis()).containsExactly(java.util.Map.entry(apiNavItem.getId(), api));
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-18

## Description

Resolves review comment #1 on #19084 (the N+1 `apiService.get()` calls in the category APIs
table): `GET /portal-navigation-items` gains an opt-in `includes=apis` query parameter that
returns a `metadata.apis` sidecar map (nav-item-id → `{ id, name, apiVersion, contextPath }`)
in the same response, scoped to the same `ENVIRONMENT_DOCUMENTATION:READ` permission the
endpoint already requires — resolving the permission-mismatch concern the reviewer also raised
(`apiService.get()` needs broader API-management read access than this screen is gated on).

- `ListPortalNavigationItemsUseCase` gains `includeApis` on `Input` and an `apis` map on
  `Output`, resolved via the existing `ApiPortalSearchQueryService` port (version-agnostic,
  already used by the portal-facing `_search` endpoint — no legacy service dependency).
- `PortalNavigationItemsMapper` maps those domain APIs straight to the REST summary DTO,
  computing `contextPath` from the domain `Api`'s own listener/proxy data (mirrors the
  frontend's `getApiAccess`/`getApiContextPath` utilities) — no second network round-trip.
- `category.component.ts` drops the `forkJoin` of individual `apiService.get()` calls entirely
  and consumes `metadata.apis` from the single navigation-items request.

## Additional context

- Full backend suite for the three touched modules passes (only pre-existing, unrelated
  failures elsewhere: a locale-dependent test and two log-pagination tests, neither touched by
  this change).
- Full frontend suite for the touched files passes.
- Verified end-to-end against a local full-stack build via curl: `metadata.apis` populated with
  correct `contextPath` per API type (V2 virtual hosts, V4 HTTP/TCP listeners, V4 native Kafka
  listeners), absent when `includes` is omitted (backward compatible).