### PR TITLE
feat(observability): filter v4 runtime logs by tenant

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/connection/MetricsQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/connection/MetricsQuery.java
@@ -59,6 +59,7 @@ public class MetricsQuery {
         private Set<String> mcpProxyTools;
         private Set<String> mcpProxyResources;
         private Set<String> mcpProxyPrompts;
+        private Set<String> tenants;
 
         @Data
         @Builder

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/RequestV2MetricsV4Fields.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/RequestV2MetricsV4Fields.java
@@ -44,6 +44,7 @@ public class RequestV2MetricsV4Fields {
     public static final String REMOTE_ADDRESS = "remote-address";
     public static final String LOCAL_ADDRESS = "local-address";
     public static final String HOST = "host";
+    public static final String TENANT = "tenant";
 
     // Fields with different names in each index
     public static final Field MESSAGE = new Field("message", "error-message");

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapter.java
@@ -90,6 +90,8 @@ public class SearchMetricsQueryAdapter {
 
         addMcpProxyPromptsFilter(filter, mustFilterList);
 
+        addTenantsFilter(filter, mustFilterList);
+
         if (!mustFilterList.isEmpty()) {
             return JsonObject.of("bool", JsonObject.of("must", JsonArray.of(mustFilterList.toArray())));
         }
@@ -137,6 +139,16 @@ public class SearchMetricsQueryAdapter {
     private static void addErrorKeysFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
         if (!CollectionUtils.isEmpty(filter.getErrorKeys())) {
             mustFilterList.add(JsonObject.of("terms", JsonObject.of(RequestV2MetricsV4Fields.ERROR_KEY, filter.getErrorKeys().toArray())));
+        }
+    }
+
+    /**
+     * The gateway reports the tenant under the same {@code tenant} keyword in both the v2 request and the v4
+     * metrics index, so a single terms clause covers them — no v2/v4 should needed.
+     */
+    private static void addTenantsFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
+        if (!CollectionUtils.isEmpty(filter.getTenants())) {
+            mustFilterList.add(JsonObject.of("terms", JsonObject.of(RequestV2MetricsV4Fields.TENANT, filter.getTenants().toArray())));
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapterTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.repository.log.v4.model.connection.MetricsQuery;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.util.List;
 import java.util.Set;
@@ -1013,6 +1014,54 @@ class SearchMetricsQueryAdapterTest {
             var query = MetricsQuery.builder().filter(MetricsQuery.Filter.builder().llmProxyModels(Set.of()).build()).build();
 
             assertThat(hasTermsOn(query, RequestV2MetricsV4Fields.LLM_PROXY_MODEL.v4Metrics())).isFalse();
+        }
+    }
+
+    @Nested
+    class TenantsFilter {
+
+        @Test
+        void should_add_tenants_terms_filter_when_provided() {
+            var query = MetricsQuery.builder()
+                .filter(MetricsQuery.Filter.builder().apiIds(Set.of("api-1")).tenants(Set.of("tenant-a", "tenant-b")).build())
+                .build();
+
+            assertThat(hasTermsOn(query, RequestV2MetricsV4Fields.TENANT)).isTrue();
+        }
+
+        /**
+         * The gateway writes {@code tenant} under the same name in both indexes, so — unlike the api or plan
+         * ids — the clause must not be split into a v2/v4 should.
+         */
+        @Test
+        void should_query_the_tenant_field_directly_for_both_indexes() {
+            var query = MetricsQuery.builder().filter(MetricsQuery.Filter.builder().tenants(Set.of("tenant-a")).build()).build();
+
+            var mustClauses = new JsonObject(SearchMetricsQueryAdapter.adapt(query))
+                .getJsonObject("query")
+                .getJsonObject("bool")
+                .getJsonArray("must");
+
+            assertThat(mustClauses).hasSize(1);
+            assertThat(mustClauses.getJsonObject(0)).isEqualTo(
+                JsonObject.of("terms", JsonObject.of(RequestV2MetricsV4Fields.TENANT, JsonArray.of("tenant-a")))
+            );
+        }
+
+        @Test
+        void should_not_add_tenants_filter_when_null() {
+            var query = MetricsQuery.builder().filter(MetricsQuery.Filter.builder().apiIds(Set.of("api-1")).tenants(null).build()).build();
+
+            assertThat(hasTermsOn(query, RequestV2MetricsV4Fields.TENANT)).isFalse();
+        }
+
+        @Test
+        void should_not_add_tenants_filter_when_empty() {
+            var query = MetricsQuery.builder()
+                .filter(MetricsQuery.Filter.builder().apiIds(Set.of("api-1")).tenants(Set.of()).build())
+                .build();
+
+            assertThat(hasTermsOn(query, RequestV2MetricsV4Fields.TENANT)).isFalse();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
@@ -457,6 +457,7 @@ components:
         - API_PRODUCT
         - API_TYPE
         - PAYLOAD
+        - TENANT
         - MCP_METHOD
         - URI
         - RESPONSE_TIME

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
@@ -195,7 +195,8 @@ class ObservabilityFiltersDefinitionResourceTest extends AbstractResourceTest {
                     "ERROR_KEY",
                     "REQUEST_ID",
                     "TRANSACTION_ID",
-                    "PAYLOAD"
+                    "PAYLOAD",
+                    "TENANT"
                 );
                 // The filters APIM-14817 reported as offered-but-ignored on the logs screen.
                 assertThat(names(filters)).doesNotContain("GATEWAY", "HTTP_ENDPOINT_RESPONSE_TIME", "GEO_IP_COUNTRY");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/SearchLogsFilters.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/SearchLogsFilters.java
@@ -44,7 +44,8 @@ public record SearchLogsFilters(
     Set<String> llmProxyProviders,
     Set<String> mcpProxyTools,
     Set<String> mcpProxyResources,
-    Set<String> mcpProxyPrompts
+    Set<String> mcpProxyPrompts,
+    Set<String> tenants
 ) {
     /**
      * An inclusive HTTP status code range bound for {@code HTTP_STATUS GTE/LTE}.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/domain_service/FilterContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/domain_service/FilterContext.java
@@ -41,6 +41,7 @@ public final class FilterContext {
     private Long responseTimeTo;
     private Set<String> errorKeys;
     private Set<String> apiProductIds;
+    private Set<String> tenants;
     private String bodyText;
 
     private <T> Set<T> limitBy(Set<T> current, Set<T> incoming) {
@@ -114,6 +115,10 @@ public final class FilterContext {
 
     public void limitByApiProductIds(Set<String> apiProductIds) {
         this.apiProductIds = limitBy(this.apiProductIds, apiProductIds);
+    }
+
+    public void limitByTenants(Set<String> tenants) {
+        this.tenants = limitBy(this.tenants, tenants);
     }
 
     public void limitByUri(String uri) {
@@ -210,6 +215,10 @@ public final class FilterContext {
 
     public Optional<Set<String>> apiProductIds() {
         return Optional.ofNullable(apiProductIds);
+    }
+
+    public Optional<Set<String>> tenants() {
+        return Optional.ofNullable(tenants);
     }
 
     public Optional<String> bodyText() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/FilterName.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/FilterName.java
@@ -32,4 +32,5 @@ public enum FilterName {
     API_PRODUCT,
     API_TYPE,
     PAYLOAD,
+    TENANT,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
@@ -248,6 +248,7 @@ public class SearchEnvironmentLogsUseCase {
         builder.responseTimeRanges(buildResponseTimeRanges(filterContext));
         builder.errorKeys(filterContext.errorKeys().orElseGet(Collections::emptySet));
         builder.apiProductIds(filterContext.apiProductIds().orElseGet(Collections::emptySet));
+        builder.tenants(filterContext.tenants().orElseGet(Collections::emptySet));
         builder.bodyText(filterContext.bodyText().orElse(null));
 
         if (request.timeRange() != null) {
@@ -394,6 +395,7 @@ public class SearchEnvironmentLogsUseCase {
             case REQUEST_ID -> filterContext.limitByRequestIds(ids);
             case ERROR_KEY -> filterContext.limitByErrorKeys(ids);
             case API_PRODUCT -> filterContext.limitByApiProductIds(ids);
+            case TENANT -> filterContext.limitByTenants(ids);
             case HTTP_STATUS_CODE_GROUP -> filterContext.limitByStatusCodeGroups(validateStatusCodeGroups(ids));
             case URI -> {
                 if (!ids.isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
@@ -227,7 +227,8 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
             .llmProxyProviders(searchLogsFilters.llmProxyProviders())
             .mcpProxyTools(searchLogsFilters.mcpProxyTools())
             .mcpProxyResources(searchLogsFilters.mcpProxyResources())
-            .mcpProxyPrompts(searchLogsFilters.mcpProxyPrompts());
+            .mcpProxyPrompts(searchLogsFilters.mcpProxyPrompts())
+            .tenants(searchLogsFilters.tenants());
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
@@ -1190,6 +1190,9 @@ spec:
 
         - name: TENANT
           label: Tenant
+          signals:
+              - LOGS
+              - ANALYTICS
           type: KEYWORD
           operators:
               - EQ

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/ObservabilityLogsFilterCoverageTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/ObservabilityLogsFilterCoverageTest.java
@@ -193,7 +193,8 @@ class ObservabilityLogsFilterCoverageTest {
 
     @Test
     void analytics_only_filters_should_not_be_advertised_on_the_logs_signal() {
-        // The exact set APIM-14817 reported as offered-but-ignored on the logs screen.
+        // The set APIM-14817 reported as offered-but-ignored on the logs screen, less TENANT: OBS-37 wired it
+        // through to the search rather than dropping it from the screen.
         assertThat(
             catalog
                 .getFilters(Set.of(Signal.LOGS))
@@ -201,7 +202,6 @@ class ObservabilityLogsFilterCoverageTest {
                 .map(spec -> spec.name().name())
         ).doesNotContain(
             "GATEWAY",
-            "TENANT",
             "ZONE",
             "HOST",
             "HTTP_ENDPOINT_RESPONSE_TIME",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
@@ -491,6 +491,56 @@ class SearchEnvironmentLogsUseCaseTest {
         }
 
         @ParameterizedTest
+        @MethodSource("tenantFiltersProvider")
+        void should_intersect_tenant_filters(List<Filter> filters, String[] expectedTenants) {
+            var request = new SearchLogsRequest(null, filters, 1, 10);
+
+            when_searching(request);
+
+            var filtersCaptor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+            verify(connectionLogsCrudService).searchApiConnectionLogs(any(), filtersCaptor.capture(), any(), any());
+
+            assertThat(filtersCaptor.getValue().tenants()).containsExactlyInAnyOrder(expectedTenants);
+        }
+
+        static Stream<Arguments> tenantFiltersProvider() {
+            return Stream.of(
+                Arguments.of(
+                    List.of(new Filter(new StringFilter(FilterName.TENANT, Operator.EQ, "tenant-1"))),
+                    new String[] { "tenant-1" }
+                ),
+                Arguments.of(
+                    List.of(new Filter(new ArrayFilter(FilterName.TENANT, Operator.IN, List.of("tenant-1", "tenant-2")))),
+                    new String[] { "tenant-1", "tenant-2" }
+                ),
+                Arguments.of(
+                    List.of(
+                        new Filter(new StringFilter(FilterName.TENANT, Operator.EQ, "tenant-1")),
+                        new Filter(new ArrayFilter(FilterName.TENANT, Operator.IN, List.of("tenant-1", "tenant-2")))
+                    ),
+                    new String[] { "tenant-1" }
+                ),
+                Arguments.of(
+                    List.of(
+                        new Filter(new StringFilter(FilterName.TENANT, Operator.EQ, "tenant-1")),
+                        new Filter(new StringFilter(FilterName.TENANT, Operator.EQ, "tenant-2"))
+                    ),
+                    new String[] {}
+                )
+            );
+        }
+
+        @Test
+        void should_leave_tenants_empty_when_no_tenant_filter_is_sent() {
+            when_searching(new SearchLogsRequest(null, List.of(), 1, 10));
+
+            var filtersCaptor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+            verify(connectionLogsCrudService).searchApiConnectionLogs(any(), filtersCaptor.capture(), any(), any());
+
+            assertThat(filtersCaptor.getValue().tenants()).isEmpty();
+        }
+
+        @ParameterizedTest
         @MethodSource("httpStatusFiltersProvider")
         void should_intersect_http_status_filters(List<Filter> filters, Integer[] expectedStatuses) {
             var request = new SearchLogsRequest(null, filters, 1, 10);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImplTest.java
@@ -487,6 +487,7 @@ class ConnectionLogsCrudServiceImplTest {
                     .methods(Set.of(HttpMethod.GET))
                     .statuses(Set.of(3))
                     .errorKeys(Set.of("GATEWAY_OAUTH2_ACCESS_DENIED"))
+                    .tenants(Set.of("tenant-1"))
                     .build(),
                 new PageableImpl(1, 20)
             );
@@ -516,6 +517,7 @@ class ConnectionLogsCrudServiceImplTest {
                             .methods(Set.of(HttpMethod.GET))
                             .statuses(Set.of(3))
                             .errorKeys(Set.of("GATEWAY_OAUTH2_ACCESS_DENIED"))
+                            .tenants(Set.of("tenant-1"))
                             .build()
                     )
                     .build()

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
@@ -60,7 +60,7 @@ public enum StaticFilters {
     PLAN("Plan", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS_ANALYTICS, Defs.APP_TYPES),
     API_PRODUCT("API Product", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS_ANALYTICS, Set.of(ApiType.HTTP_PROXY)),
     GATEWAY("Gateway", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.ANALYTICS, Defs.GATEWAY_TYPES),
-    TENANT("Tenant", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.ANALYTICS, Defs.GATEWAY_TYPES),
+    TENANT("Tenant", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS_ANALYTICS, Defs.GATEWAY_TYPES),
     ZONE("Zone", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.ANALYTICS, Defs.GATEWAY_TYPES),
 
     ENTRYPOINT("Entrypoint", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS_ANALYTICS, ApiType.ALL),

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
@@ -285,6 +285,7 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
         Set<String> mcpProxyTools = new HashSet<>();
         Set<String> mcpProxyResources = new HashSet<>();
         Set<String> mcpProxyPrompts = new HashSet<>();
+        Set<String> tenants = new HashSet<>();
         String uri = null;
         List<Range> responseTimeRanges = new ArrayList<>();
         var responseTimeAccumulator = new NumericRangeAccumulator<Long>("HTTP_GATEWAY_RESPONSE_TIME");
@@ -324,6 +325,7 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
                 case "TRANSACTION_ID" -> transactionIds.addAll(values);
                 case "ERROR_KEY" -> errorKeys.addAll(values);
                 case "API_PRODUCT" -> apiProductIds.addAll(values);
+                case "TENANT" -> tenants.addAll(values);
                 case "PAYLOAD" -> {
                     if (values.isEmpty() || values.stream().allMatch(value -> value == null || value.isBlank())) {
                         throw UnsupportedObservabilityFilterException.blankValue("PAYLOAD");
@@ -365,6 +367,7 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
         builder.mcpProxyTools(mcpProxyTools);
         builder.mcpProxyResources(mcpProxyResources);
         builder.mcpProxyPrompts(mcpProxyPrompts);
+        builder.tenants(tenants);
         builder.uri(uri);
         builder.bodyText(bodyText);
         builder.responseTimeRanges(responseTimeRanges);

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
@@ -323,6 +323,29 @@ class ObservabilityLogsDataPortAdapterTest {
     }
 
     @Nested
+    class TenantFilter {
+
+        @Test
+        void should_translate_tenant() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("TENANT", FilterOperator.IN, List.of("tenant-a", "tenant-b")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().tenants()).containsExactlyInAnyOrder("tenant-a", "tenant-b");
+        }
+
+        @Test
+        void should_leave_tenants_empty_when_not_requested() {
+            stubEmptySearchResult();
+
+            adapter.searchLogs(ORG, ENV, queryWith());
+
+            assertThat(captureSearchFilters().tenants()).isEmpty();
+        }
+    }
+
+    @Nested
     class ResponseTimeFilter {
 
         @Test


### PR DESCRIPTION
## Summary

Multi-tenant operators cannot scope an **Observability → Logs** search to a tenant. Before 4.12.14 the console offered the chip and the engine silently ignored it; APIM-14817 resolved that disagreement by dropping `TENANT` from the `LOGS` signal instead of wiring it. This PR wires it, bringing the logs screen to parity with analytics, where Tenant has always worked.

The gateway already reports `tenant` as a keyword on both the v2 `request` and the v4 `metrics` index — the very field the analytics engine reads — so this adds a search clause, not a new metric. No reporter, mapping, or index change is required, and existing data is immediately filterable.

Closes [OBS-37](https://gravitee.atlassian.net/browse/OBS-37).

## Changes

- **Filter catalog** (`analytics-definition.yaml`): `TENANT` declares `signals: [LOGS, ANALYTICS]`, so `GET /observability/filters/definition?signal=LOGS` advertises it. Value suggestions need no work — `FilterValuesQueryServiceImpl` already resolves `TENANT → tenant`, which is why the console populates the dropdown on its own.
- **Logs engine** (`SearchEnvironmentLogsUseCase`, `FilterContext`, `FilterName`): a `TENANT` condition reaches `SearchLogsFilters.tenants()` and intersects across conditions exactly like `APPLICATION` or `API_PRODUCT` (two conflicting `EQ` → empty scope; `EQ` ∩ `IN` → the common value).
- **Repository** (`MetricsQuery.Filter.tenants`, `SearchMetricsQueryAdapter`): one `terms` clause on `tenant`. Unlike api/plan ids, the field is spelled identically in both indexes, so the clause is *not* split into a v2/v4 `should`.
- **Management API v2** (`openapi-logs.yaml`): `TENANT` added to the `FilterName` enum. No alias needed — catalog and engine already agree on the spelling.
- **Gamma observability**: its own catalog (`StaticFilters`) and logs adapter learn the same filter, so the two surfaces cannot drift apart the way APIM-14817 described.
- **Tests**: `ObservabilityLogsFilterCoverageTest` — which pins the real catalog against the engine — now covers `TENANT` for both advertised operators, so a future regression fails here rather than in production.

## Known gap (pre-existing, not introduced here)

Two **contradictory** conditions on the same filter (`TENANT EQ a` AND `TENANT EQ b`) return *every* row instead of none. `FilterContext` does distinguish "filter absent" from "filter present, intersection empty", but `buildFilters` flattens both with `.orElseGet(Collections::emptySet)` and the repository reads an empty set as "no clause".

This is **not specific to tenant** — verified on the running 4.12.15 build, `APPLICATION EQ app-x AND EQ app-y` and `API_PRODUCT EQ p-1 AND EQ p-2` behave the same way. A single unknown value filters correctly (0 rows); only the empty intersection collapses. Access scoping is unaffected, since `apiIds` is intersected separately and always present.

`TENANT` deliberately behaves like its siblings here rather than growing a special case. Fixing it means giving every `FilterContext`-backed filter a "matches nothing" short-circuit — worth doing, but a behaviour change across the whole logs filter set, tracked separately.

## Endpoint summary

| Endpoint | Method | Change | Request example | Response example |
| --- | --- | --- | --- | --- |
| `/environments/{envId}/logs/_search` | POST | Accepts `TENANT` in `filters[].name` (`EQ`, `IN`) | `{"filters":[{"name":"TENANT","operator":"IN","value":["tenant-a","tenant-b"]}]}` | Unchanged shape; `data` restricted to the selected tenants |
| `/environments/{envId}/observability/filters/definition?signal=LOGS` | GET | Now includes the `TENANT` spec | — | `{"name":"TENANT","label":"Tenant","type":"KEYWORD","operators":["EQ","IN"],"signals":["LOGS","ANALYTICS"]}` |
| `/environments/{envId}/observability/filters/TENANT/values` | GET | Unchanged — already worked | — | Tenants observed in the window |

## Test plan

- [x] **UI** — Observability → Logs: `Tenant` appears in *Add filter*, its dropdown lists the tenants seen in the window, and selecting one narrows the table. *(Screenshots/recording to attach.)*
- [x] Pick a tenant from a log row, filter on it, and confirm every remaining row carries that tenant.
- [x] Two tenants with `IN` → union, and rows without a tenant stay out.
- [x] Combine `TENANT` with `HTTP_STATUS` / `APPLICATION` and confirm the clauses AND together.
- [x] No tenant filter → result set identical to before this PR.
- [x] Analytics dashboards still filter by Tenant, and the dashboard filter bar is unchanged.
- [x] Gamma Observability → Logs offers Tenant and filters with it.

<img width="490" height="833" alt="Screenshot 2026-08-12 at 12 30 59" src="https://github.com/user-attachments/assets/75a9b9f9-0f50-47f6-bf83-89349d90d163" />


https://github.com/user-attachments/assets/46e8250c-801d-4096-8228-806cdcb2bdfb




## Reviewer notes

- `SearchMetricsQueryAdapter#addTenantsFilter` is the one place worth a close read: it deliberately emits a bare `terms` rather than the `buildV2AndV4Terms` `should` used by fields whose name differs per index.
- The removal of `"TENANT"` from the `doesNotContain` list in `ObservabilityLogsFilterCoverageTest` is the point where this reverses the APIM-14817 decision — intentional, and now backed by the coverage assertion in the same class.


[OBS-37]: https://gravitee.atlassian.net/browse/OBS-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ