### PR TITLE
fix(gamma): declare the observability cascade layer first (FOUND-166)

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/main.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/main.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// Must stay first: fixes the cascade layer order for the whole app (FOUND-166).
+import './styles/layer-order.css';
 import '@gravitee/graphene-core/fonts';
 import '@gravitee/graphene-core/styles';
 import('./bootstrap').catch(err => console.error(err));

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/styles/layer-order.css
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/styles/layer-order.css
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * App-wide cascade layer order (FOUND-166).
+ *
+ * Must stay the first stylesheet the shell loads. Layer order is fixed by each layer's
+ * FIRST declaration, and a layer discovered later sorts after the earlier ones — which
+ * means it wins against them. Only the host can set that order; a library loaded later
+ * cannot place itself ahead of layers the host has already declared.
+ *
+ * `@gravitee/gamma-lib-observability` emits its utilities into an `observability` layer.
+ * It re-emits utilities graphene also ships (it scans graphene's dist so the design-system
+ * components it renders keep their classes), so without this line its copy would sort last
+ * and win — silently cancelling overrides written on graphene components in our own code.
+ *
+ * Declaring it here, ahead of everything else, makes it the lowest-priority layer.
+ * Add any other library that ships its own Tailwind utilities to this list.
+ */
+@layer observability;

--- a/gravitee-gamma/gravitee-gamma-module-apim/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/package.json
@@ -2,7 +2,7 @@
     "name": "gravitee-gamma-module-apim",
     "private": true,
     "dependencies": {
-        "@gravitee/gamma-lib-observability": "1.39.1",
+        "@gravitee/gamma-lib-observability": "1.39.2",
         "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/graphene-charts": "3.8.0",
         "@gravitee/graphene-core": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@fontsource/material-icons-two-tone": "5.2.5",
         "@fontsource/montserrat": "5.2.5",
         "@fontsource/roboto": "5.2.5",
-        "@gravitee/gamma-lib-observability": "1.39.1",
+        "@gravitee/gamma-lib-observability": "1.39.2",
         "@gravitee/graphene-charts": "3.8.0",
         "@gravitee/graphene-core": "3.8.0",
         "@gravitee/graphene-policy-studio": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4567,9 +4567,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/gamma-lib-observability@npm:1.39.1":
-  version: 1.39.1
-  resolution: "@gravitee/gamma-lib-observability@npm:1.39.1"
+"@gravitee/gamma-lib-observability@npm:1.39.2":
+  version: 1.39.2
+  resolution: "@gravitee/gamma-lib-observability@npm:1.39.2"
   peerDependencies:
     "@gravitee/graphene-charts": ^3.7.0
     "@gravitee/graphene-core": ^3.7.0
@@ -4585,7 +4585,7 @@ __metadata:
       optional: true
     tailwindcss:
       optional: true
-  checksum: 10c0/5f6d444168ff7824a5f3b44af14e6476e8e8729e44e46e1c7e60a3d4d60dac18f042807eb44b5d0c7fca977e1385deff4f84188b3a709873cc1e6849c641ea49
+  checksum: 10c0/7211182f355a57d35772e30f36d06b689153ec9efe85b19148c144965c347d2c444fd6dcfd83dbc77e3a75fbb15a7a021a2544eabbbd928e967938927e6a8732
   languageName: node
   linkType: hard
 
@@ -21519,7 +21519,7 @@ __metadata:
     "@fontsource/material-icons-two-tone": "npm:5.2.5"
     "@fontsource/montserrat": "npm:5.2.5"
     "@fontsource/roboto": "npm:5.2.5"
-    "@gravitee/gamma-lib-observability": "npm:1.39.1"
+    "@gravitee/gamma-lib-observability": "npm:1.39.2"
     "@gravitee/gamma-modules-sdk": "npm:1.2.0"
     "@gravitee/graphene-charts": "npm:3.8.0"
     "@gravitee/graphene-core": "npm:3.8.0"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-166

## Problem

Utility classes written in a Gamma module could silently have no effect on graphene components.

Concrete symptom on **API Proxies**: the search input renders `pl-9` to clear the search icon, but the computed `padding-left` stayed at `10px` instead of `36px`, so the icon overlapped the placeholder text.

Before
<img width="1627" height="290" alt="image" src="https://github.com/user-attachments/assets/9f37a718-2780-4f13-83d8-1cb30a2cd2d4" />

After
<img width="1686" height="298" alt="image" src="https://github.com/user-attachments/assets/34c7ae66-f1ae-4314-968e-83c825128ed9" />


## Root cause

Not a graphene bug, and not a bug in the calling code — both were correct in isolation.

`@gravitee/gamma-lib-observability` scans graphene's compiled dist so the design-system components it renders keep their classes (deliberate, documented on their side). As a side effect its stylesheet re-emits utilities graphene already ships — `px-2.5`, `Input`'s base padding, among ~1200 others.

Until now those duplicates landed in `@layer utilities`, the same layer graphene uses. Inside a single layer CSS arbitrates by declaration order alone, and the observability sheet loads last — so its `px-2.5` beat graphene's `pl-9`, and the override was cancelled.

The asymmetry that makes it a bug rather than a wash: that sheet ships `px-2.5` (visible in graphene's dist) but not `pl-9` (only referenced in a graphene story, absent from the published dist, so their `@source` scans cannot see it).

Worth noting for future debugging: this class of defect **cannot** be reproduced in Storybook or in component tests. It only exists once both stylesheets are loaded in the same page.

## Change

`gamma-lib-observability` now emits its utilities into a private `observability` layer. That alone is not enough: CSS layer order is fixed by each layer's *first* declaration, and a library loaded later cannot place itself ahead of layers the host already declared. **Only the host can set the order.**

Hence two lines here:

- `control-plane-webui/src/styles/layer-order.css` (new) — `@layer observability;`
- `control-plane-webui/src/main.ts` — imports it as the very first stylesheet

That makes `observability` the lowest-priority layer, so it can no longer arbitrate an override written anywhere in our own code. Any future library shipping its own Tailwind utilities gets added to the same list.

The fix lives in the shell on purpose: every federated module inherits it, and nothing has to be repeated per module.

## Dependency

Requires `@gravitee/gamma-lib-observability` >= the release carrying the layer change (https://github.com/gravitee-io/gamma-lib-observability/pull/70). Against an older version this PR is inert — the declared layer simply stays empty, no regression either way.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

