### PR TITLE
fix(repository-mongodb): backfill null segment on portal navigation items before guard query

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portalnavigationindex/PortalNavigationItemSegmentIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portalnavigationindex/PortalNavigationItemSegmentIndexUpgrader.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.portalnavigationindex;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PortalNavigationItemSegmentIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("portal_navigation_items")
+            .key("segment", ascending())
+            .name("s1")
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/portalnavigationitem/PortalNavigationItemDefaultSegmentMongoUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/portalnavigationitem/PortalNavigationItemDefaultSegmentMongoUpgrader.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.portalnavigationitem;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Sets a placeholder {@code segment} on portal navigation items that have a null or missing value,
+ * so that Spring Data MongoDB can deserialize them without a NullPointerException.
+ * The subsequent {@code PortalNavigationItemDefaultSegmentUpgrader} then replaces this placeholder
+ * with the correct path segment.
+ *
+ * Must run before {@code EnvironmentsDefaultPortalNavigationItemsUpgrader} (order 712), whose guard
+ * query fully deserializes existing items into the {@code @Nonnull}-annotated core domain model.
+ */
+@Component
+public class PortalNavigationItemDefaultSegmentMongoUpgrader extends MongoUpgrader {
+
+    public static final int PORTAL_NAVIGATION_ITEM_DEFAULT_SEGMENT_MONGO_UPGRADER_ORDER =
+        PortalNavigationItemDefaultRootIdMongoUpgrader.PORTAL_NAVIGATION_ITEM_DEFAULT_ROOT_ID_MONGO_UPGRADER_ORDER + 1;
+
+    public static final String SEGMENT = "segment";
+    public static final String DEFAULT_SEGMENT = "__CHANGE_ME__";
+
+    @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
+    public boolean upgrade() {
+        var result = this.getCollection("portal_navigation_items").updateMany(
+            Filters.or(Filters.eq(SEGMENT, null), Filters.eq(SEGMENT, "")),
+            Updates.set(SEGMENT, DEFAULT_SEGMENT)
+        );
+        return result.wasAcknowledged();
+    }
+
+    @Override
+    public int getOrder() {
+        return PORTAL_NAVIGATION_ITEM_DEFAULT_SEGMENT_MONGO_UPGRADER_ORDER;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/portalnavigationitem/PortalNavigationItemDefaultSegmentMongoUpgraderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/portalnavigationitem/PortalNavigationItemDefaultSegmentMongoUpgraderTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.portalnavigationitem;
+
+import static io.gravitee.repository.mongodb.management.upgrade.upgrader.portalnavigationitem.PortalNavigationItemDefaultSegmentMongoUpgrader.DEFAULT_SEGMENT;
+import static io.gravitee.repository.mongodb.management.upgrade.upgrader.portalnavigationitem.PortalNavigationItemDefaultSegmentMongoUpgrader.SEGMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.management.AbstractManagementRepositoryTest;
+import jakarta.inject.Inject;
+import org.bson.Document;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+public class PortalNavigationItemDefaultSegmentMongoUpgraderTest extends AbstractManagementRepositoryTest {
+
+    private static final String COLLECTION_NAME = "portal_navigation_items";
+
+    @Inject
+    private MongoTemplate mongoTemplate;
+
+    @Inject
+    private Environment environment;
+
+    private PortalNavigationItemDefaultSegmentMongoUpgrader upgrader;
+    private String targetCollectionName;
+
+    @Override
+    protected String getTestCasesPath() {
+        // No fixtures: the upgrader manipulates the collection directly.
+        return null;
+    }
+
+    @Before
+    public void initUpgrader() {
+        upgrader = new PortalNavigationItemDefaultSegmentMongoUpgrader();
+        upgrader.setMongoTemplate(mongoTemplate);
+        upgrader.setEnvironment(environment);
+        targetCollectionName = environment.getProperty("management.mongodb.prefix", "") + COLLECTION_NAME;
+        // deleteMany, not drop: drop() also removes the collection's indexes created once at context
+        // bootstrap, which would then make the notablescan-guarded updateMany fail with no index.
+        mongoTemplate.getCollection(targetCollectionName).deleteMany(new Document());
+    }
+
+    @After
+    public void cleanUp() {
+        mongoTemplate.getCollection(targetCollectionName).deleteMany(new Document());
+    }
+
+    private Document findById(String id) {
+        return mongoTemplate.getCollection(targetCollectionName).find(new Document("_id", id)).first();
+    }
+
+    @Test
+    public void upgrade_should_backfill_segment_when_field_is_missing() throws Exception {
+        // Given
+        mongoTemplate.getCollection(targetCollectionName).insertOne(new Document("_id", "item-missing"));
+
+        // When
+        boolean result = upgrader.upgrade();
+
+        // Then
+        assertThat(result).isTrue();
+        assertThat(findById("item-missing").getString(SEGMENT)).isEqualTo(DEFAULT_SEGMENT);
+    }
+
+    @Test
+    public void upgrade_should_backfill_segment_when_field_is_null() throws Exception {
+        // Given
+        mongoTemplate.getCollection(targetCollectionName).insertOne(new Document("_id", "item-null").append(SEGMENT, null));
+
+        // When
+        boolean result = upgrader.upgrade();
+
+        // Then
+        assertThat(result).isTrue();
+        assertThat(findById("item-null").getString(SEGMENT)).isEqualTo(DEFAULT_SEGMENT);
+    }
+
+    @Test
+    public void upgrade_should_backfill_segment_when_field_is_empty() throws Exception {
+        // Given
+        mongoTemplate.getCollection(targetCollectionName).insertOne(new Document("_id", "item-empty").append(SEGMENT, ""));
+
+        // When
+        boolean result = upgrader.upgrade();
+
+        // Then
+        assertThat(result).isTrue();
+        assertThat(findById("item-empty").getString(SEGMENT)).isEqualTo(DEFAULT_SEGMENT);
+    }
+
+    @Test
+    public void upgrade_should_leave_existing_segment_untouched() throws Exception {
+        // Given
+        mongoTemplate.getCollection(targetCollectionName).insertOne(new Document("_id", "item-set").append(SEGMENT, "my-page"));
+
+        // When
+        boolean result = upgrader.upgrade();
+
+        // Then
+        assertThat(result).isTrue();
+        assertThat(findById("item-set").getString(SEGMENT)).isEqualTo("my-page");
+    }
+
+    @Test
+    public void upgrade_should_be_idempotent() throws Exception {
+        // Given
+        mongoTemplate.getCollection(targetCollectionName).insertOne(new Document("_id", "item-missing"));
+
+        // When
+        boolean first = upgrader.upgrade();
+        boolean second = upgrader.upgrade();
+
+        // Then
+        assertThat(first).isTrue();
+        assertThat(second).isTrue();
+        assertThat(findById("item-missing").getString(SEGMENT)).isEqualTo(DEFAULT_SEGMENT);
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PORTAL-116

**Purpose**

Fix a MongoDB-only upgrade failure where `EnvironmentsDefaultPortalNavigationItemsUpgrader` throws a NullPointerException on legacy `portal_navigation_items` documents with a null `segment`, blocking `apim-api` startup on 4.12.x upgrades.

**Summary of changes**

- Added `PortalNavigationItemDefaultSegmentMongoUpgrader`, a raw-driver Mongo pre-upgrader that backfills null/empty `segment` with `__CHANGE_ME__` (same placeholder the JDBC Liquibase changelog already uses), ordered right after the existing `rootId` pre-upgrader and well before the guard query that was failing.
- Added `PortalNavigationItemSegmentIndexUpgrader`, mirroring the existing `rootId` index, so the backfill query isn't an unindexed collection scan (this Mongo test suite runs with `notablescan=true`).
- Added `PortalNavigationItemDefaultSegmentMongoUpgraderTest` covering missing/null/empty/already-set/idempotent cases.

**Out of scope**

- JDBC is unaffected (already backfills `segment` via Liquibase) — no changes there.
- Not replacing `EnvironmentsDefaultPortalNavigationItemsUpgrader`'s guard query with a lighter `.exists()`-style check, as suggested as a longer-term follow-up in the ticket.

**Testing**

- Added `PortalNavigationItemDefaultSegmentMongoUpgraderTest`, run against a real Testcontainers MongoDB instance (`mvn test -Dtest=PortalNavigationItemDefaultSegmentMongoUpgraderTest -pl gravitee-apim-repository/gravitee-apim-repository-mongodb`) — all 5 cases pass.
- Verified end to end: started a 4.11.24 install (Docker Compose, MongoDB), confirmed 7 default navigation items seeded with no `segment` field at all (legacy pre-`segment` state). Built this branch's management-api image from source and swapped it in against the same Mongo data (in-place upgrade). Result: clean startup, no exception, all 7 items preserved, 0 with null/empty `segment`, all correctly backfilled to real slugs by the existing ORM-based upgrader.
- No REST endpoint or UI is touched, so no Postman recording/screenshot applies.