### PR TITLE
fix(gamma-platform): address AM by the connection's organization

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkClientFactory.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkClientFactory.java
@@ -43,6 +43,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AmSdkClientFactory {
 
+    // AM addresses resources per organization. It comes from the connection — the APIM org passed to
+    // forOrg is only the lookup key — falling back to AM's well-known default when the connection
+    // has none configured yet.
+    private static final String AM_DEFAULT_ORGANIZATION = "DEFAULT";
+
     private final Vertx vertx;
     private final AmConnectionRepository amConnectionRepository;
 
@@ -81,7 +86,11 @@ public class AmSdkClientFactory {
         // domain payload (returned by findDomain/listDomains) deserialises cleanly.
         apiClient.getObjectMapper().addMixIn(ClientRegistrationSettings.class, ClientRegistrationSettingsMixin.class);
 
-        return new AmApis(apiClient, new DefaultApiImpl(apiClient), new DomainApiImpl(apiClient));
+        String amOrganizationId = connection.amOrganizationId() == null || connection.amOrganizationId().isBlank()
+            ? AM_DEFAULT_ORGANIZATION
+            : connection.amOrganizationId();
+
+        return new AmApis(apiClient, amOrganizationId, new DefaultApiImpl(apiClient), new DomainApiImpl(apiClient));
     }
 
     @SuppressWarnings("unused")
@@ -100,5 +109,7 @@ public class AmSdkClientFactory {
         abstract void setClientTemplateEnabled(Boolean value);
     }
 
-    public record AmApis(ApiClient client, DefaultApi defaults, DomainApi domains) {}
+    // amOrganizationId is the AM-side organization resolved from the connection — call sites address
+    // AM with it, never with the APIM org.
+    public record AmApis(ApiClient client, String amOrganizationId, DefaultApi defaults, DomainApi domains) {}
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkDirectoryClient.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkDirectoryClient.java
@@ -35,7 +35,7 @@ public class AmSdkDirectoryClient implements AmDirectoryClient {
         return AmSdkInvocations.await(
             apis
                 .defaults()
-                .listEnvironments(orgId)
+                .listEnvironments(apis.amOrganizationId())
                 .map(envs -> {
                     List<Environment> out = new ArrayList<>();
                     for (var e : envs) out.add(new Environment(e.getId(), e.getName()));
@@ -50,7 +50,7 @@ public class AmSdkDirectoryClient implements AmDirectoryClient {
         return AmSdkInvocations.await(
             apis
                 .domains()
-                .getDomainEntrypoints(orgId, envId, domainId)
+                .getDomainEntrypoints(apis.amOrganizationId(), envId, domainId)
                 .map(entrypoints -> {
                     List<GatewayEntrypoint> out = new ArrayList<>();
                     if (entrypoints != null) {
@@ -71,7 +71,7 @@ public class AmSdkDirectoryClient implements AmDirectoryClient {
         return AmSdkInvocations.await(
             apis
                 .domains()
-                .findDomain(orgId, envId, domainId)
+                .findDomain(apis.amOrganizationId(), envId, domainId)
                 .map(d -> new Domain(d.getId(), d.getName(), d.getHrid()))
         );
     }
@@ -85,7 +85,7 @@ public class AmSdkDirectoryClient implements AmDirectoryClient {
         return AmSdkInvocations.await(
             apis
                 .domains()
-                .listDomains(orgId, envId, null, null, search)
+                .listDomains(apis.amOrganizationId(), envId, null, null, search)
                 .map(page -> {
                     List<Domain> out = new ArrayList<>();
                     if (page != null && page.getData() != null) {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/rest/resource/am/DomainEntrypointsResource.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/rest/resource/am/DomainEntrypointsResource.java
@@ -35,12 +35,12 @@ public class DomainEntrypointsResource {
     @GET
     public List<GatewayEntrypointResponse> list(
         @PathParam("orgId") String orgId,
-        @PathParam("envId") String envId,
+        @PathParam("amEnvId") String amEnvId,
         @PathParam("domainId") String domainId
     ) {
         return AmCalls.run(() ->
             listDomainEntrypointsUseCase
-                .execute(new ListDomainEntrypointsUseCase.Input(orgId, envId, domainId))
+                .execute(new ListDomainEntrypointsUseCase.Input(orgId, amEnvId, domainId))
                 .entrypoints()
                 .stream()
                 .map(e -> new GatewayEntrypointResponse(e.id(), e.name(), e.url(), e.defaultEntrypoint()))

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/rest/resource/am/DomainResource.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/rest/resource/am/DomainResource.java
@@ -39,8 +39,14 @@ public class DomainResource {
     private ResourceContext resourceContext;
 
     @GET
-    public DomainResponse get(@PathParam("orgId") String orgId, @PathParam("envId") String envId, @PathParam("domainId") String domainId) {
-        return AmCalls.run(() -> AmDtoMapper.toDto(getDomainUseCase.execute(new GetDomainUseCase.Input(orgId, envId, domainId)).domain()));
+    public DomainResponse get(
+        @PathParam("orgId") String orgId,
+        @PathParam("amEnvId") String amEnvId,
+        @PathParam("domainId") String domainId
+    ) {
+        return AmCalls.run(() ->
+            AmDtoMapper.toDto(getDomainUseCase.execute(new GetDomainUseCase.Input(orgId, amEnvId, domainId)).domain())
+        );
     }
 
     @Path("/entrypoints")

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/rest/resource/am/DomainsResource.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/rest/resource/am/DomainsResource.java
@@ -41,9 +41,9 @@ public class DomainsResource {
     private ResourceContext resourceContext;
 
     @GET
-    public List<DomainResponse> list(@PathParam("orgId") String orgId, @PathParam("envId") String envId, @QueryParam("q") String q) {
+    public List<DomainResponse> list(@PathParam("orgId") String orgId, @PathParam("amEnvId") String amEnvId, @QueryParam("q") String q) {
         return AmCalls.run(() ->
-            listDomainsUseCase.execute(new ListDomainsUseCase.Input(orgId, envId, q)).domains().stream().map(AmDtoMapper::toDto).toList()
+            listDomainsUseCase.execute(new ListDomainsUseCase.Input(orgId, amEnvId, q)).domains().stream().map(AmDtoMapper::toDto).toList()
         );
     }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/rest/resource/am/EnvironmentsResource.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/java/io/gravitee/gamma/module/platform/rest/resource/am/EnvironmentsResource.java
@@ -51,7 +51,10 @@ public class EnvironmentsResource {
         );
     }
 
-    @Path("/{envId}/domains")
+    // amEnvId, not envId: the module is mounted under /organizations/{orgId}/environments/{envId},
+    // so an inner {envId} would declare the same template variable twice — one holding the APIM
+    // environment, one the AM environment picked from the list above.
+    @Path("/{amEnvId}/domains")
     public DomainsResource domains() {
         return resourceContext.getResource(DomainsResource.class);
     }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkClientFactoryTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkClientFactoryTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.module.platform.infra.service_provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.gravitee.apim.plugin.gamma.api.identity.AmConnection;
+import io.gravitee.apim.plugin.gamma.api.identity.AmConnectionRepository;
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AmSdkClientFactoryTest {
+
+    private Vertx vertx;
+    private AmSdkClientFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+        factory = new AmSdkClientFactory(vertx, mock(AmConnectionRepository.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        vertx.close();
+    }
+
+    @Test
+    void should_carry_the_am_organization_from_the_connection() {
+        var apis = factory.forConnection(connection("am-org-9"));
+
+        assertThat(apis.amOrganizationId()).isEqualTo("am-org-9");
+    }
+
+    @Test
+    void should_fall_back_to_the_default_organization_when_the_connection_has_none() {
+        assertThat(factory.forConnection(connection(null)).amOrganizationId()).isEqualTo("DEFAULT");
+        assertThat(factory.forConnection(connection("  ")).amOrganizationId()).isEqualTo("DEFAULT");
+    }
+
+    private static AmConnection connection(String amOrganizationId) {
+        return new AmConnection("http://am:8093", "token", amOrganizationId, "env-7", "domain-1", "domain-hrid", null);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkConnectionTesterTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkConnectionTesterTest.java
@@ -58,7 +58,7 @@ class AmSdkConnectionTesterTest {
 
     @Test
     void should_probe_the_configured_am_organization_not_the_apim_org() {
-        when(clientFactory.forConnection(any())).thenReturn(new AmApis(null, defaults, null));
+        when(clientFactory.forConnection(any())).thenReturn(new AmApis(null, "am-org", defaults, null));
         when(defaults.listEnvironments("am-org")).thenReturn(Future.succeededFuture(List.<Environment>of()));
 
         var result = tester.test(APIM_ORG, connection("am-org"));
@@ -82,7 +82,7 @@ class AmSdkConnectionTesterTest {
 
     @Test
     void should_surface_am_status_and_a_clean_message_when_organization_is_rejected() {
-        when(clientFactory.forConnection(any())).thenReturn(new AmApis(null, defaults, null));
+        when(clientFactory.forConnection(any())).thenReturn(new AmApis(null, "bogus", defaults, null));
         when(defaults.listEnvironments("bogus")).thenReturn(
             Future.failedFuture(new ApiException(403, "Forbidden", null, "{\"message\":\"Permission denied\",\"http_status\":403}"))
         );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkDirectoryClientTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/test/java/io/gravitee/gamma/module/platform/infra/service_provider/AmSdkDirectoryClientTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.module.platform.infra.service_provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.am.sdk.management.api.DefaultApi;
+import io.gravitee.am.sdk.management.api.DomainApi;
+import io.gravitee.am.sdk.management.model.Domain;
+import io.gravitee.am.sdk.management.model.DomainPage;
+import io.gravitee.am.sdk.management.model.Entrypoint;
+import io.gravitee.am.sdk.management.model.Environment;
+import io.gravitee.gamma.module.platform.infra.service_provider.AmSdkClientFactory.AmApis;
+import io.vertx.core.Future;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The APIM org is only the key the connection is stored under; AM must always be addressed with the
+ * connection's own organization. When the two differ (any cloud org) AM answers 403 to the APIM one.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AmSdkDirectoryClientTest {
+
+    private static final String APIM_ORG = "aca99aca-86ef-4cf8-a99a-ca86efacf876";
+    private static final String AM_ORG = "DEFAULT";
+    private static final String AM_ENV = "am-env";
+
+    private DefaultApi defaults;
+    private DomainApi domains;
+    private AmSdkDirectoryClient client;
+
+    @BeforeEach
+    void setUp() {
+        defaults = mock(DefaultApi.class);
+        domains = mock(DomainApi.class);
+        AmSdkClientFactory clientFactory = mock(AmSdkClientFactory.class);
+        when(clientFactory.forOrg(APIM_ORG)).thenReturn(new AmApis(null, AM_ORG, defaults, domains));
+        client = new AmSdkDirectoryClient(clientFactory);
+    }
+
+    @Test
+    void should_list_environments_from_the_am_organization() {
+        when(defaults.listEnvironments(AM_ORG)).thenReturn(Future.succeededFuture(List.of(environment("env-1", "Env one"))));
+
+        var environments = client.listEnvironments(APIM_ORG);
+
+        assertThat(environments)
+            .singleElement()
+            .satisfies(env -> assertThat(env.id()).isEqualTo("env-1"));
+    }
+
+    @Test
+    void should_list_domains_from_the_am_organization() {
+        when(domains.listDomains(AM_ORG, AM_ENV, null, null, "*gamma*")).thenReturn(
+            Future.succeededFuture(new DomainPage().data(List.of(domain())))
+        );
+
+        var found = client.listDomains(APIM_ORG, AM_ENV, "gamma");
+
+        assertThat(found)
+            .singleElement()
+            .satisfies(d -> assertThat(d.id()).isEqualTo("domain-1"));
+    }
+
+    @Test
+    void should_get_a_domain_from_the_am_organization() {
+        when(domains.findDomain(AM_ORG, AM_ENV, "domain-1")).thenReturn(Future.succeededFuture(domain()));
+
+        var found = client.getDomain(APIM_ORG, AM_ENV, "domain-1");
+
+        assertThat(found.id()).isEqualTo("domain-1");
+    }
+
+    @Test
+    void should_list_domain_entrypoints_from_the_am_organization() {
+        when(domains.getDomainEntrypoints(AM_ORG, AM_ENV, "domain-1")).thenReturn(
+            Future.succeededFuture(List.of(new Entrypoint().id("ep-1").name("Default").url("https://gw").defaultEntrypoint(true)))
+        );
+
+        var entrypoints = client.listDomainEntrypoints(APIM_ORG, AM_ENV, "domain-1");
+
+        assertThat(entrypoints)
+            .singleElement()
+            .satisfies(ep -> {
+                assertThat(ep.id()).isEqualTo("ep-1");
+                assertThat(ep.defaultEntrypoint()).isTrue();
+            });
+    }
+
+    private static Environment environment(String id, String name) {
+        return new Environment().id(id).name(name);
+    }
+
+    private static Domain domain() {
+        return new Domain().id("domain-1").name("Domain one").hrid("domain-one");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-958

## Description

The AM scope endpoints in the platform module looked up the stored connection by APIM org, then reused that same APIM org id as the AM organization in the path it sent to AM. Anywhere the two ids differ, AM answers 403 on every directory call while the connection test passes, because the test already used the connection's org. That's the split you see on a cloud org: verify and load is fine, loading environments is Permission denied.

The factory now resolves the AM organization from the connection and carries it on AmApis, so the call sites address AM with it and orgId goes back to being what it always was, the key the connection is stored under. Blank falls back to DEFAULT.

Second commit renames the AM environment path param to amEnvId. The module is mounted under /organizations/{orgId}/environments/{envId}, so the sub-resources were declaring {envId} twice, one holding the APIM environment and one the AM environment. It picked the right one only because of how Jersey orders repeated template values. The request path is unchanged.

## Additional context

This is the AIM fix from GMA-860 that didn't follow the module. AM settings were ported out of AIM two weeks before that fix landed, so the tester came across corrected and the directory client didn't. gravitee-gamma-module-aim and the authz module are unaffected, they each have their own AM client and both already resolve the org from the connection.

Straight at 4.12.x since that's where the module ships. Master has the same bug and should take this as a cherry-pick.

### How I tested it

Reproduced the reported setup locally rather than approximating it. AM only ever has one organization, DEFAULT, so the id that differs in the field is the APIM one. I inserted a second APIM organization into mongo with the same shape as the reported one (a uuid), gave it an environment, cloned the org roles and the admin memberships onto it, and saved an AM connection under that org with amOrganizationId DEFAULT. That is the customer config exactly.

Stack was rest-api from the built distribution with gravitee_gamma_enabled=true on 8083, gamma console on 4200, AM management API in docker on 8093.

Against the plugin built from 4.12.x, under the uuid org:

    _test         200  {"ok":true}
    environments  403  {"code":"am_upstream_error","message":"Permission denied","upstreamStatus":403}

Same error code and upstream status as the report. Swapping in the plugin from this branch, same org, same stored connection:

    _test         200
    environments  200  ['DEFAULT']
    domains       200  ['gamma-test']
    domain        200  gamma-test
    entrypoints   200  ['http://localhost:8092']

The DEFAULT org still returns its environments on the new plugin, so nothing regresses where the two ids already matched. I also clicked the settings screen in the console: it loads the environment and domain pickers and shows the discovered gateway, and putting an unknown org in the field surfaces "Access Management rejected the connection: Permission denied" instead of quietly loading someone else's scope.

One behaviour change worth knowing about. A stored connection with no amOrganizationId now sends DEFAULT where it used to send the APIM org. That was already broken for a non-DEFAULT org so it isn't a regression, but it is a change.
