### PR TITLE
feat: support API Product subscriptions in Portal API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
@@ -18,6 +18,8 @@ package io.gravitee.rest.api.portal.rest.resource;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toSet;
 
+import io.gravitee.apim.core.portal_page.domain_service.PortalApiProductAccessDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
 import io.gravitee.apim.core.subscription.model.SubscriptionConfiguration;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
@@ -56,6 +58,7 @@ import io.gravitee.rest.api.service.v4.PlanSearchService;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -106,6 +109,9 @@ public class SubscriptionsResource extends AbstractResource {
     @Inject
     private GraviteeMapper graviteeMapper;
 
+    @Inject
+    private PortalApiProductAccessDomainService portalApiProductAccessDomainService;
+
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
@@ -114,6 +120,15 @@ public class SubscriptionsResource extends AbstractResource {
         String applicationId = subscriptionInput.getApplication();
         if (hasPermission(executionContext, RolePermission.APPLICATION_SUBSCRIPTION, applicationId, RolePermissionAction.CREATE)) {
             GenericPlanEntity plan = planSearchService.findById(executionContext, subscriptionInput.getPlan());
+            boolean isApiProductPlan = GenericPlanEntity.ReferenceType.API_PRODUCT == plan.getReferenceType();
+
+            if (isApiProductPlan) {
+                portalApiProductAccessDomainService.findAccessible(
+                    executionContext.getEnvironmentId(),
+                    plan.getReferenceId(),
+                    PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull())
+                );
+            }
 
             var auditInfo = getAuditInfo();
 
@@ -127,10 +142,10 @@ public class SubscriptionsResource extends AbstractResource {
                     .metadata(subscriptionInput.getMetadata())
                     .configuration(getSubscriptionConfiguration(subscriptionInput))
                     .apiKeyMode(getApiKeyMode(subscriptionInput))
-                    .generalConditionsAccepted(subscriptionInput.getGeneralConditionsAccepted())
-                    .generalConditionsContentRevision(getPageRevisionId(subscriptionInput))
+                    .generalConditionsAccepted(isApiProductPlan ? null : subscriptionInput.getGeneralConditionsAccepted())
+                    .generalConditionsContentRevision(isApiProductPlan ? null : getPageRevisionId(subscriptionInput))
                     .auditInfo(auditInfo)
-                    .subscriptionFormMetadataValidationRequired(true)
+                    .subscriptionFormMetadataValidationRequired(!isApiProductPlan)
                     .build()
             );
 
@@ -192,21 +207,30 @@ public class SubscriptionsResource extends AbstractResource {
         @Deprecated @QueryParam("apiId") String apiId,
         @Deprecated @QueryParam("applicationId") String applicationId,
         @QueryParam("apiIds") List<String> apiIds,
+        @QueryParam("apiProductIds") List<String> apiProductIds,
         @QueryParam("applicationIds") List<String> applicationIds,
         @QueryParam("statuses") List<SubscriptionStatus> statuses,
         @BeanParam PaginationParam paginationParam
     ) {
         List<String> effectiveApiIds = resolveApiIds(apiId, apiIds);
         List<String> effectiveApplicationIds = resolveApplicationIds(applicationId, applicationIds);
+        boolean hasApiFilter = effectiveApiIds != null && !effectiveApiIds.isEmpty();
+        boolean hasApiProductFilter = apiProductIds != null && !apiProductIds.isEmpty();
+
+        if (hasApiFilter && hasApiProductFilter) {
+            throw new BadRequestException("API and API Product filters cannot be used together.");
+        }
 
         final SubscriptionQuery query = new SubscriptionQuery();
-        if (effectiveApiIds != null && !effectiveApiIds.isEmpty()) {
-            query.setApis(effectiveApiIds);
-        }
-        query.setStatuses(statuses);
-        if (apiId == null || apiId.isEmpty()) {
+        if (hasApiProductFilter) {
+            query.setApiProducts(apiProductIds);
+        } else {
+            if (hasApiFilter) {
+                query.setApis(effectiveApiIds);
+            }
             query.setReferenceType(GenericPlanEntity.ReferenceType.API);
         }
+        query.setStatuses(statuses);
 
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (effectiveApplicationIds == null || effectiveApplicationIds.isEmpty()) {
@@ -253,6 +277,7 @@ public class SubscriptionsResource extends AbstractResource {
             subscriptions
         )
             .withApis(true)
+            .withApiProducts(true)
             .withApplications(true)
             .withPlans(true)
             .withSubscribers(true)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -2500,12 +2500,14 @@ paths:
                 - $ref: "#/components/parameters/apiIdQueryParam"
                 - $ref: "#/components/parameters/applicationIdQueryParam"
                 - $ref: "#/components/parameters/apiIdsQueryParam"
+                - $ref: "#/components/parameters/apiProductIdsQueryParam"
                 - $ref: "#/components/parameters/applicationIdsQueryParam"
                 - $ref: "#/components/parameters/subscriptionStatusesQueryParam"
                 - $ref: "#/components/parameters/pageNumberParam"
                 - $ref: "#/components/parameters/pageSizeParam"
             description: |
-                List all ACCEPTED, PAUSED & PENDING subscriptions, filtered by api and/or by application. At least an api or an application must be provided.
+                List all ACCEPTED, PAUSED & PENDING subscriptions, filtered by API, API Product and/or application.
+                API and API Product filters cannot be used together. When neither is provided, only API subscriptions are returned.
 
                 User must have the APPLICATION_SUBSCRIPTION[READ] permission to list subscription with application query param.\
                 User must have the API_SUBSCRIPTION[READ] permission to list subscription with api query param.
@@ -2519,7 +2521,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/SubscriptionsResponse"
                 400:
-                    description: At least an api or an application must be provided.
+                    description: Invalid query parameters, including combined API and API Product filters.
                     content:
                         application/json:
                             schema:
@@ -2559,6 +2561,12 @@ paths:
                                 $ref: "#/components/schemas/ErrorResponse"
                 403:
                     $ref: "#/components/responses/PermissionError"
+                404:
+                    description: Plan or API Product not found, or API Product not accessible from the Portal.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ErrorResponse"
                 500:
                     $ref: "#/components/responses/InternalServerError"
     /subscriptions/{subscriptionId}:
@@ -4302,6 +4310,15 @@ components:
             in: query
             required: false
             description: List of API IDs to filter subscriptions.
+            schema:
+                type: array
+                items:
+                    type: string
+        apiProductIdsQueryParam:
+            name: apiProductIds
+            in: query
+            required: false
+            description: List of API Product IDs to filter subscriptions.
             schema:
                 type: array
                 items:
@@ -6118,7 +6135,6 @@ components:
         Subscription:
             required:
                 - id
-                - api
                 - application
                 - plan
                 - status
@@ -6127,13 +6143,13 @@ components:
                     description: Unique identifier of a subscription.
                     type: string
                 api:
-                    description: Subscribed API (API id; same as reference_id when reference_type is API).
+                    description: Subscribed API. Present for API subscriptions and absent for API Product subscriptions.
                     type: string
                 reference_id:
-                    description: Reference id (API id or API Product id). Use with reference_type for subscription context.
+                    description: Identifier of the subscribed API or API Product. Use with reference_type as the authoritative subscription target.
                     type: string
                 reference_type:
-                    description: Reference type of the subscription (API or API_PRODUCT). Portal returns API subscriptions only.
+                    description: Type of the subscribed reference. Use with reference_id as the authoritative subscription target.
                     type: string
                     enum:
                         - API

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/SubscriptionMapperTest.java
@@ -39,6 +39,7 @@ import org.mapstruct.factory.Mappers;
 public class SubscriptionMapperTest {
 
     private static final String SUBSCRIPTION_API = "my-subscription-api";
+    private static final String SUBSCRIPTION_API_PRODUCT = "my-subscription-api-product";
     private static final String SUBSCRIPTION_APPLICATION = "my-subscription-application";
     private static final String SUBSCRIPTION_PLAN = "my-subscription-plan";
     private static final String SUBSCRIPTION_ID = "my-subscription-id";
@@ -114,6 +115,22 @@ public class SubscriptionMapperTest {
 
         assertEquals(SUBSCRIPTION_API, subscription.getApi());
         assertNull(subscription.getOrigin());
+    }
+
+    @Test
+    void should_map_api_product_reference_without_api() {
+        subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity.setApi(null);
+        subscriptionEntity.setReferenceId(SUBSCRIPTION_API_PRODUCT);
+        subscriptionEntity.setReferenceType("API_PRODUCT");
+        subscriptionEntity.setStatus(SubscriptionStatus.ACCEPTED);
+
+        Subscription subscription = subscriptionMapper.map(subscriptionEntity);
+
+        assertNotNull(subscription);
+        assertNull(subscription.getApi());
+        assertEquals(SUBSCRIPTION_API_PRODUCT, subscription.getReferenceId());
+        assertEquals(Subscription.ReferenceTypeEnum.API_PRODUCT, subscription.getReferenceType());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
@@ -25,12 +25,20 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.util.collections.Sets.newSet;
 
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormValidationException;
@@ -44,6 +52,8 @@ import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.pagedresult.Metadata;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.subscription.SubscriptionMetadataQuery;
+import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.portal.rest.model.ApiKeyModeEnum;
 import io.gravitee.rest.api.portal.rest.model.Key;
@@ -61,10 +71,12 @@ import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -75,8 +87,16 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
     private static final String SUBSCRIPTION = "my-subscription";
     private static final String ANOTHER_SUBSCRIPTION = "my-other-subscription";
     private static final String API = "my-api";
+    private static final String API_PRODUCT = "my-api-product";
+    private static final String ANOTHER_API_PRODUCT = "my-other-api-product";
     private static final String APPLICATION = "my-application";
     private static final String PLAN = "my-plan";
+
+    @Autowired
+    private ApiProductQueryServiceInMemory apiProductQueryService;
+
+    @Autowired
+    private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
 
     @Override
     protected String contextPath() {
@@ -85,6 +105,8 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
 
     @BeforeEach
     public void init() {
+        apiProductQueryService.reset();
+        portalNavigationItemsQueryService.reset();
         resetAllMocks();
 
         io.gravitee.rest.api.model.SubscriptionEntity subscriptionEntity1 = new io.gravitee.rest.api.model.SubscriptionEntity();
@@ -122,6 +144,12 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
         planEntity.setReferenceId(API);
         planEntity.setReferenceType(GenericPlanEntity.ReferenceType.API);
         doReturn(planEntity).when(planSearchService).findById(GraviteeContext.getExecutionContext(), PLAN);
+    }
+
+    @AfterEach
+    void resetApiProductData() {
+        apiProductQueryService.reset();
+        portalNavigationItemsQueryService.reset();
     }
 
     @Test
@@ -209,6 +237,7 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
         assertEquals("{\"url\":\"my-url\"}", useCaseInput.configuration().getEntrypointConfiguration());
         assertEquals(ApiKeyMode.EXCLUSIVE, useCaseInput.apiKeyMode());
         assertEquals(API, useCaseInput.referenceId());
+        assertEquals(io.gravitee.apim.core.subscription.model.SubscriptionReferenceType.API, useCaseInput.referenceType());
         assertTrue(Boolean.TRUE.equals(useCaseInput.subscriptionFormMetadataValidationRequired()));
 
         final Subscription subscriptionResponse = response.readEntity(Subscription.class);
@@ -217,6 +246,89 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
         assertNotNull(subscriptionResponse.getKeys());
         assertEquals(1, subscriptionResponse.getKeys().size());
         assertEquals(key, subscriptionResponse.getKeys().get(0));
+    }
+
+    @Test
+    void shouldCreateApiProductSubscriptionWhenProductIsAccessible() {
+        mockApiProductPlan();
+        exposeApiProductInPortal();
+
+        io.gravitee.rest.api.model.SubscriptionEntity subscriptionEntity = new io.gravitee.rest.api.model.SubscriptionEntity();
+        subscriptionEntity.setId(SUBSCRIPTION);
+        subscriptionEntity.setStatus(SubscriptionStatus.ACCEPTED);
+        subscriptionEntity.setReferenceId(API_PRODUCT);
+        subscriptionEntity.setReferenceType("API_PRODUCT");
+        subscriptionEntity.setApplication(APPLICATION);
+        doReturn(subscriptionEntity).when(subscriptionService).findById(SUBSCRIPTION);
+
+        SubscriptionInput subscriptionInput = new SubscriptionInput().application(APPLICATION).plan(PLAN).metadata(Map.of("key", "value"));
+        subscriptionInput.setGeneralConditionsAccepted(true);
+
+        Response response = target().request().post(Entity.json(subscriptionInput));
+
+        assertEquals(OK_200, response.getStatus());
+
+        ArgumentCaptor<CreateSubscriptionUseCase.Input> inputCaptor = ArgumentCaptor.forClass(CreateSubscriptionUseCase.Input.class);
+        verify(createSubscriptionUseCase).execute(inputCaptor.capture());
+        CreateSubscriptionUseCase.Input useCaseInput = inputCaptor.getValue();
+        assertEquals(API_PRODUCT, useCaseInput.referenceId());
+        assertEquals(io.gravitee.apim.core.subscription.model.SubscriptionReferenceType.API_PRODUCT, useCaseInput.referenceType());
+        assertEquals(Map.of("key", "value"), useCaseInput.metadata());
+        assertFalse(Boolean.TRUE.equals(useCaseInput.subscriptionFormMetadataValidationRequired()));
+        assertNull(useCaseInput.generalConditionsAccepted());
+        assertNull(useCaseInput.generalConditionsContentRevision());
+
+        Subscription subscription = response.readEntity(Subscription.class);
+        assertNull(subscription.getApi());
+        assertEquals(API_PRODUCT, subscription.getReferenceId());
+        assertEquals(Subscription.ReferenceTypeEnum.API_PRODUCT, subscription.getReferenceType());
+    }
+
+    @Test
+    void shouldReturnNotFoundAndNotCreateSubscriptionWhenApiProductIsNotAccessible() {
+        mockApiProductPlan();
+        initApiProduct();
+
+        Response response = target().request().post(Entity.json(new SubscriptionInput().application(APPLICATION).plan(PLAN)));
+
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+        verify(createSubscriptionUseCase, never()).execute(any());
+    }
+
+    @Test
+    void shouldFilterSubscriptionsByApiProductIdsAndIncludeApiProductMetadata() {
+        mockCurrentUserApplication();
+        Metadata metadata = new Metadata();
+        metadata.put(API_PRODUCT, "name", "My API Product");
+        doReturn(metadata).when(subscriptionService).getMetadata(eq(GraviteeContext.getExecutionContext()), any());
+
+        Response response = target().queryParam("apiProductIds", API_PRODUCT, ANOTHER_API_PRODUCT).request().get();
+
+        assertEquals(OK_200, response.getStatus());
+
+        ArgumentCaptor<SubscriptionQuery> queryCaptor = ArgumentCaptor.forClass(SubscriptionQuery.class);
+        verify(subscriptionService).search(eq(GraviteeContext.getExecutionContext()), queryCaptor.capture(), any());
+        assertEquals(List.of(API_PRODUCT, ANOTHER_API_PRODUCT), queryCaptor.getValue().getApiProducts());
+        assertNull(queryCaptor.getValue().getApis());
+        assertNull(queryCaptor.getValue().getReferenceType());
+
+        ArgumentCaptor<SubscriptionMetadataQuery> metadataQueryCaptor = ArgumentCaptor.forClass(SubscriptionMetadataQuery.class);
+        verify(subscriptionService).getMetadata(eq(GraviteeContext.getExecutionContext()), metadataQueryCaptor.capture());
+        assertTrue(metadataQueryCaptor.getValue().ifApiProducts().isPresent());
+    }
+
+    @Test
+    void shouldRejectCombinedApiAndApiProductFilters() {
+        Response response = target().queryParam("apiIds", API).queryParam("apiProductIds", API_PRODUCT).request().get();
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    void shouldRejectCombinedDeprecatedApiAndApiProductFilters() {
+        Response response = target().queryParam("apiId", API).queryParam("apiProductIds", API_PRODUCT).request().get();
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
     }
 
     @Test
@@ -385,6 +497,45 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
         assertEquals(FORBIDDEN_403, target().queryParam("applicationId", APPLICATION).request().get().getStatus());
         assertEquals(OK_200, target().queryParam("apiId", API).request().get().getStatus());
         assertEquals(FORBIDDEN_403, target().queryParam("apiId", API).queryParam("applicationId", APPLICATION).request().get().getStatus());
+    }
+
+    private void mockApiProductPlan() {
+        PlanEntity planEntity = new PlanEntity();
+        planEntity.setReferenceId(API_PRODUCT);
+        planEntity.setReferenceType(GenericPlanEntity.ReferenceType.API_PRODUCT);
+        doReturn(planEntity).when(planSearchService).findById(GraviteeContext.getExecutionContext(), PLAN);
+    }
+
+    private void exposeApiProductInPortal() {
+        initApiProduct();
+        portalNavigationItemsQueryService.initWith(
+            List.of(
+                PortalNavigationApiProduct.builder()
+                    .id(PortalNavigationItemId.random())
+                    .organizationId("organization-id")
+                    .environmentId(GraviteeContext.getCurrentEnvironment())
+                    .title("API Product")
+                    .segment("api-product")
+                    .area(PortalArea.TOP_NAVBAR)
+                    .order(0)
+                    .apiProductId(API_PRODUCT)
+                    .published(true)
+                    .visibility(PortalVisibility.PUBLIC)
+                    .build()
+            )
+        );
+    }
+
+    private void initApiProduct() {
+        apiProductQueryService.initWith(
+            List.of(ApiProduct.builder().id(API_PRODUCT).environmentId(GraviteeContext.getCurrentEnvironment()).name("API Product").build())
+        );
+    }
+
+    private void mockCurrentUserApplication() {
+        ApplicationListItem application = new ApplicationListItem();
+        application.setId(APPLICATION);
+        doReturn(newSet(application)).when(applicationService).findByUser(eq(GraviteeContext.getExecutionContext()), any());
     }
 
     @Getter


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-110

## Description

Adds Portal API support for API Product subscriptions.

## Changes

- validates API Product accessibility before creating a subscription
- creates subscriptions using the API Product reference from the selected plan
- skips subscription form and general conditions validation for API Products
- adds `apiProductIds` filtering to `GET /subscriptions`
- rejects combined API and API Product filters
- includes API Product metadata in subscription responses
- makes the `api` response field optional for API Product subscriptions
- updates the Portal OpenAPI contract and test coverage

