### PR TITLE
test(gateway): stop asserting a timestamp as the sse endpoint response time

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/logging/MetricsIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/logging/MetricsIntegrationTest.java
@@ -122,7 +122,11 @@ class MetricsIntegrationTest extends AbstractGatewayTest {
                     soft.assertThat(metrics.getTransactionId()).isEqualTo(TRANSACTION_ID);
                     soft.assertThat(metrics.isRequestEnded()).isFalse();
                     soft.assertThat(metrics.getStatus()).isEqualTo(200);
-                    soft.assertThat(metrics.getEndpointResponseTimeMs()).isPositive();
+                    // Nothing is measured yet: the endpoint response is still streaming, so its durations are no more
+                    // available than the gateway ones asserted right below. The time to first byte, which does carry a
+                    // "not measured" value, states it explicitly.
+                    soft.assertThat(metrics.getEndpointResponseTtfbMs()).isEqualTo(-1);
+                    soft.assertThat(metrics.getEndpointResponseTimeMs()).isEqualTo(0);
                     soft.assertThat(metrics.getGatewayLatencyMs()).isEqualTo(0);
                     soft.assertThat(metrics.getGatewayResponseTimeMs()).isEqualTo(0);
                 });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14903

## Description

Fixes `MetricsIntegrationTest#should_report_the_metrics_for_sse_request`, red on `4.12.x` since APIM-14903 was merged.

The test asserted that the endpoint response time of a **partial** metrics was positive. It only ever held because the field doubled as the storage for the epoch timestamp of the endpoint invocation start, until the duration was computed:

```java
// before APIM-14903
metrics.setEndpointResponseTimeMs(System.currentTimeMillis());   // an epoch timestamp
// ... later
if (metrics.getEndpointResponseTimeMs() > Integer.MAX_VALUE) {   // "not computed yet"
    metrics.setEndpointResponseTimeMs(System.currentTimeMillis() - metrics.getEndpointResponseTimeMs());
}
```

That storage now lives in a dedicated `endpointRequestStartNs`, so the response time keeps its default until it is measured, and the assertion fails.

The assertion was encoding the defect rather than the behaviour: a partial metrics is reported while the endpoint response is still streaming, so no endpoint duration is measured yet — and the value that used to reach Elasticsearch as `endpoint-response-time-ms` on every message API (SSE, WebSocket) was ~1.75e12. It is now 0, in line with `gateway-latency-ms` and `gateway-response-time-ms`, which the very next two lines already assert to be 0.

The added assertion on the time to first byte is the useful one: it is the only one of the two able to carry a "not measured" value, and `putWhenMeasured` keeps it out of the Elasticsearch document entirely.

## Additional context

Reproduced locally, then verified fixed:

```
partial : startNs=436361645314791  ttfbNs=-1         respNs=-1         respMs=0
final   : startNs=436361645314791  ttfbNs=37371375   respNs=37371375   respMs=37
```

`invokeBackend` has not completed when the partial metrics is reported — nothing is measured at that point.

The module lives behind a Maven profile that is off by default, which is why the run that validated APIM-14903 never covered it:

```bash
mvn -Dintegration-tests-modules=true -pl gravitee-apim-integration-tests test -Dtest='MetricsIntegrationTest'
```

Both tests of the class pass, `BUILD SUCCESS`. It is the only integration test reading these fields.

Left out on purpose: `endpointResponseTimeMs` still defaults to 0 rather than -1, so it reaches the document with a 0 that drags aggregations down on message APIs. Fixing that means changing the default of a historical field in `gravitee-reporter-api` — a breaking change worth its own discussion, beyond getting the pipeline green.
