### PR TITLE
fix: API Score evaluation fails when many custom rulesets are configured

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/SaveScoringResponseUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/SaveScoringResponseUseCase.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.async_job.crud_service.AsyncJobCrudService;
 import io.gravitee.apim.core.scoring.crud_service.ScoringReportCrudService;
 import io.gravitee.apim.core.scoring.domain_service.ScoreComputingDomainService;
 import io.gravitee.apim.core.scoring.model.ScoringReport;
+import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.common.utils.TimeProvider;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -38,6 +39,12 @@ import lombok.RequiredArgsConstructor;
 @CustomLog
 public class SaveScoringResponseUseCase {
 
+    /**
+     * Fallback used when the scoring provider reports a failure without any message, so the user is at least told the
+     * evaluation failed rather than being shown an empty error.
+     */
+    private static final String UNKNOWN_FAILURE_MESSAGE = "Scoring failed without any reported reason";
+
     private final AsyncJobCrudService asyncJobCrudService;
     private final ScoringReportCrudService scoringReportCrudService;
     private final ScoreComputingDomainService scoreComputingDomainService;
@@ -46,6 +53,15 @@ public class SaveScoringResponseUseCase {
         return Maybe.defer(() -> Maybe.fromOptional(asyncJobCrudService.findById(input.jobId)))
             .subscribeOn(Schedulers.computation())
             .flatMapCompletable(job -> {
+                if (!input.success) {
+                    // The scoring provider failed: keep the previous report and surface the failure on the job.
+                    var errorMessage = StringUtils.isEmpty(input.errorMessage) ? UNKNOWN_FAILURE_MESSAGE : input.errorMessage;
+                    return Completable.fromRunnable(() -> {
+                        log.warn("Scoring failed for API [{}]: {}", job.getSourceId(), errorMessage);
+                        asyncJobCrudService.update(job.error(errorMessage));
+                    });
+                }
+
                 String apiId = job.getSourceId();
                 String environmentId = job.getEnvironmentId();
 
@@ -116,5 +132,13 @@ public class SaveScoringResponseUseCase {
             );
     }
 
-    public record Input(String jobId, List<ScoringReport.Asset> analyzedAssets) {}
+    public record Input(String jobId, List<ScoringReport.Asset> analyzedAssets, boolean success, String errorMessage) {
+        public static Input success(String jobId, List<ScoringReport.Asset> analyzedAssets) {
+            return new Input(jobId, analyzedAssets, true, null);
+        }
+
+        public static Input failure(String jobId, String errorMessage) {
+            return new Input(jobId, List.of(), false, errorMessage);
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
@@ -56,6 +56,10 @@ import lombok.RequiredArgsConstructor;
 @UseCase
 public class ScoreApiRequestUseCase {
 
+    private static final long SECONDS_PER_RUN = 10;
+    private static final Duration MARGIN = Duration.ofSeconds(30);
+    private static final Duration MAX_TTL = Duration.ofMinutes(15);
+
     private final ApiCrudService apiCrudService;
     private final ApiDocumentationDomainService apiDocumentationDomainService;
     private final ApiExportDomainService apiExportDomainService;
@@ -196,16 +200,21 @@ public class ScoreApiRequestUseCase {
     /**
      * Compute the TTL of the scoring job.
      * <p>
-     * As simple rule, we consider that the scoring job will take 10 seconds per asset per ruleset to score (as simple ) and 30 seconds for the margin.
+     * As simple rule, we consider that the scoring job will take {@value #SECONDS_PER_RUN} seconds per asset per ruleset
+     * to score, plus a fixed margin. Environments with no custom ruleset still run against the built-in ones, hence the
+     * minimum of one ruleset.
+     * <p>
+     * The result is capped: a job kept PENDING is polled every second by the console, so an unbounded deadline would
+     * mean thousands of requests per opened tab. The cap is deliberately generous, as a value lower than the actual
+     * scoring time is what makes the evaluation silently expire.
      *
      * @param request the scoring request
      * @return the TTL of the scoring job
      */
     private Duration deadLine(ScoreRequest request) {
-        var margin = Duration.ofSeconds(30);
         int nbAssets = request.assets().size();
-        int rulesets = Math.min(1, request.customRulesets().size());
-        int numberOfRuns = nbAssets * rulesets;
-        return Duration.ofSeconds(10).multipliedBy(numberOfRuns).plus(margin);
+        int nbRulesets = Math.max(1, request.customRulesets().size());
+        long ttlInSeconds = SECONDS_PER_RUN * nbAssets * nbRulesets + MARGIN.toSeconds();
+        return Duration.ofSeconds(Math.min(ttlInSeconds, MAX_TTL.toSeconds()));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/ScoringResponseCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/ScoringResponseCommandHandler.java
@@ -47,11 +47,17 @@ public class ScoringResponseCommandHandler implements CommandHandler<ScoringResp
     @Override
     public Single<ScoringResponseReply> handle(ScoringResponseCommand command) {
         var payload = command.getPayload();
+        var result = payload.result();
 
-        log.info("received response [{}]", payload.result());
+        log.info("received response [{}]", result);
 
-        var analyzedAssets = payload
-            .result()
+        if (!result.success()) {
+            return saveScoringResponseUseCase
+                .execute(SaveScoringResponseUseCase.Input.failure(payload.correlationId(), result.error()))
+                .andThen(Single.just(new ScoringResponseReply(command.getId(), CommandStatus.SUCCEEDED)));
+        }
+
+        var analyzedAssets = result
             .assetDiagnostics()
             .stream()
             .map(a ->
@@ -88,7 +94,7 @@ public class ScoringResponseCommandHandler implements CommandHandler<ScoringResp
             .toList();
 
         return saveScoringResponseUseCase
-            .execute(new SaveScoringResponseUseCase.Input(payload.correlationId(), analyzedAssets))
+            .execute(SaveScoringResponseUseCase.Input.success(payload.correlationId(), analyzedAssets))
             .andThen(Single.just(new ScoringResponseReply(command.getId(), CommandStatus.SUCCEEDED)));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/SaveScoringResponseUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/SaveScoringResponseUseCaseTest.java
@@ -138,7 +138,7 @@ class SaveScoringResponseUseCaseTest {
         );
 
         // When
-        useCase.execute(new Input(JOB_ID, List.of(ANALYZED_ASSET_1))).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
+        useCase.execute(Input.success(JOB_ID, List.of(ANALYZED_ASSET_1))).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
 
         // Then
         assertThat(scoringReportCrudService.storage()).contains(
@@ -161,12 +161,75 @@ class SaveScoringResponseUseCaseTest {
         );
 
         // When
-        useCase.execute(new Input(JOB_ID, List.of(ANALYZED_ASSET_1))).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
+        useCase.execute(Input.success(JOB_ID, List.of(ANALYZED_ASSET_1))).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
 
         // Then
         assertThat(asyncJobCrudService.storage()).contains(
             job.toBuilder().status(AsyncJob.Status.SUCCESS).updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault())).build()
         );
+    }
+
+    @Test
+    void should_flag_job_in_error_and_keep_previous_report_when_scoring_failed() {
+        // Given a previously scored API and a failed scoring response
+        var previousReport = ScoringReportFixture.aScoringReport().toBuilder().apiId(API_ID).build();
+        givenExistingScoringReports(previousReport);
+        var job = givenAnAsyncJob(
+            aPendingScoringRequestJob().toBuilder().id(JOB_ID).sourceId(API_ID).initiatorId(USER_ID).environmentId(ENVIRONMENT_ID).build()
+        );
+
+        // When
+        useCase.execute(Input.failure(JOB_ID, "boom")).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
+
+        // Then the failure is surfaced on the job...
+        assertThat(asyncJobCrudService.storage()).contains(
+            job.toBuilder().status(AsyncJob.Status.ERROR).errorMessage("boom").updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault())).build()
+        );
+        // ...and the previous report is left untouched instead of being replaced by an empty one
+        assertThat(scoringReportCrudService.storage()).containsExactly(previousReport);
+    }
+
+    @Test
+    void should_fall_back_on_a_generic_message_when_the_failure_carries_none() {
+        // Given a provider failure without any message, as Cockpit forwards throwable.getMessage() as-is
+        givenAnAsyncJob(
+            aPendingScoringRequestJob().toBuilder().id(JOB_ID).sourceId(API_ID).initiatorId(USER_ID).environmentId(ENVIRONMENT_ID).build()
+        );
+
+        // When
+        useCase.execute(Input.failure(JOB_ID, null)).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
+
+        // Then the user is not shown an empty error
+        assertThat(asyncJobCrudService.storage())
+            .singleElement()
+            .extracting(AsyncJob::getErrorMessage)
+            .isEqualTo("Scoring failed without any reported reason");
+    }
+
+    @Test
+    void should_override_the_timeout_verdict_when_the_response_finally_arrives() {
+        // Given a job already marked TIMEOUT, as AsyncJobCrudServiceImpl#findById does when the deadline has passed
+        givenAnAsyncJob(
+            aPendingScoringRequestJob()
+                .toBuilder()
+                .id(JOB_ID)
+                .sourceId(API_ID)
+                .initiatorId(USER_ID)
+                .environmentId(ENVIRONMENT_ID)
+                .status(AsyncJob.Status.TIMEOUT)
+                .build()
+        );
+
+        // When a late response eventually arrives
+        useCase.execute(Input.failure(JOB_ID, "boom")).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
+
+        // Then the real outcome wins over the deadline guess: the response did arrive, so it is what the user is told
+        assertThat(asyncJobCrudService.storage())
+            .singleElement()
+            .satisfies(job -> {
+                assertThat(job.getStatus()).isEqualTo(AsyncJob.Status.ERROR);
+                assertThat(job.getErrorMessage()).isEqualTo("boom");
+            });
     }
 
     @Test
@@ -178,7 +241,7 @@ class SaveScoringResponseUseCaseTest {
         );
 
         // When
-        useCase.execute(new Input(JOB_ID, List.of(ANALYZED_ASSET_1))).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
+        useCase.execute(Input.success(JOB_ID, List.of(ANALYZED_ASSET_1))).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
 
         // Then
         assertThat(scoringReportCrudService.storage())
@@ -204,7 +267,7 @@ class SaveScoringResponseUseCaseTest {
 
         // When
         useCase
-            .execute(new Input(JOB_ID, List.of(ANALYZED_ASSET_1, ANALYZED_ASSET_2, ANALYZED_ASSET_3, ANALYZED_ASSET_4)))
+            .execute(Input.success(JOB_ID, List.of(ANALYZED_ASSET_1, ANALYZED_ASSET_2, ANALYZED_ASSET_3, ANALYZED_ASSET_4)))
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertComplete();
@@ -223,7 +286,7 @@ class SaveScoringResponseUseCaseTest {
         );
 
         // When
-        useCase.execute(new Input(JOB_ID, List.of(ANALYZED_ASSET_4))).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
+        useCase.execute(Input.success(JOB_ID, List.of(ANALYZED_ASSET_4))).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
 
         // Then
         assertThat(scoringReportCrudService.storage())
@@ -236,7 +299,7 @@ class SaveScoringResponseUseCaseTest {
         // Given
 
         // When
-        useCase.execute(new Input(JOB_ID, List.of(ANALYZED_ASSET_1))).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
+        useCase.execute(Input.success(JOB_ID, List.of(ANALYZED_ASSET_1))).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
 
         // Then
         assertThat(scoringReportCrudService.storage()).isEmpty();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCaseTest.java
@@ -58,6 +58,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.assertj.core.api.Condition;
 import org.assertj.core.data.Index;
@@ -187,7 +188,7 @@ class ScoreApiRequestUseCaseTest {
                 .upperLimit(1L)
                 .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
                 .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
-                .deadLine(INSTANT_NOW.atZone(ZoneId.systemDefault()).plus(Duration.ofSeconds(30)))
+                .deadLine(INSTANT_NOW.atZone(ZoneId.systemDefault()).plus(Duration.ofSeconds(1 * 1 * 10 + 30)))
                 .build()
         );
     }
@@ -234,7 +235,7 @@ class ScoreApiRequestUseCaseTest {
                 .upperLimit(1L)
                 .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
                 .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
-                .deadLine(INSTANT_NOW.atZone(ZoneId.systemDefault()).plus(Duration.ofSeconds(30)))
+                .deadLine(INSTANT_NOW.atZone(ZoneId.systemDefault()).plus(Duration.ofSeconds(2 * 1 * 10 + 30)))
                 .build()
         );
     }
@@ -281,7 +282,7 @@ class ScoreApiRequestUseCaseTest {
                 .upperLimit(1L)
                 .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
                 .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
-                .deadLine(INSTANT_NOW.atZone(ZoneId.systemDefault()).plus(Duration.ofSeconds(30)))
+                .deadLine(INSTANT_NOW.atZone(ZoneId.systemDefault()).plus(Duration.ofSeconds(2 * 1 * 10 + 30)))
                 .build()
         );
     }
@@ -312,6 +313,54 @@ class ScoreApiRequestUseCaseTest {
                     new ScoreRequest.CustomRuleset(CUSTOM_RULESET_3.payload())
                 );
         });
+    }
+
+    @Test
+    public void should_scale_scoring_job_deadline_with_the_number_of_custom_rulesets() {
+        // Given an API with a single scorable asset, scored against 9 custom rulesets
+        var api = givenExistingApi(ApiFixtures.aFederatedApi());
+        givenExistingRulesets(
+            IntStream.rangeClosed(1, 9)
+                .mapToObj(i -> ScoringRulesetFixture.aRuleset("ruleset" + i).withReferenceId(ENVIRONMENT_ID))
+                .toArray(ScoringRuleset[]::new)
+        );
+
+        // When
+        scoreApiRequestUseCase
+            .execute(new ScoreApiRequestUseCase.Input(api.getId(), AUDIT_INFO))
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertComplete();
+
+        // Then the deadline accounts for every ruleset: 10s per asset per ruleset, plus a 30s margin
+        assertThat(asyncJobCrudService.storage())
+            .singleElement()
+            .extracting(AsyncJob::getDeadLine)
+            .isEqualTo(INSTANT_NOW.atZone(ZoneId.systemDefault()).plus(Duration.ofSeconds(1 * 9 * 10 + 30)));
+    }
+
+    @Test
+    public void should_cap_the_scoring_job_deadline() {
+        // Given an API scored against far more rulesets than the cap allows for
+        var api = givenExistingApi(ApiFixtures.aFederatedApi());
+        givenExistingRulesets(
+            IntStream.rangeClosed(1, 200)
+                .mapToObj(i -> ScoringRulesetFixture.aRuleset("ruleset" + i).withReferenceId(ENVIRONMENT_ID))
+                .toArray(ScoringRuleset[]::new)
+        );
+
+        // When
+        scoreApiRequestUseCase
+            .execute(new ScoreApiRequestUseCase.Input(api.getId(), AUDIT_INFO))
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertComplete();
+
+        // Then the deadline is capped instead of growing to 1 * 200 * 10 + 30 seconds
+        assertThat(asyncJobCrudService.storage())
+            .singleElement()
+            .extracting(AsyncJob::getDeadLine)
+            .isEqualTo(INSTANT_NOW.atZone(ZoneId.systemDefault()).plus(Duration.ofMinutes(15)));
     }
 
     @Test
@@ -416,7 +465,7 @@ class ScoreApiRequestUseCaseTest {
                 .upperLimit(1L)
                 .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
                 .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
-                .deadLine(INSTANT_NOW.atZone(ZoneId.systemDefault()).plus(Duration.ofSeconds(30)))
+                .deadLine(INSTANT_NOW.atZone(ZoneId.systemDefault()).plus(Duration.ofSeconds(1 * 1 * 10 + 30)))
                 .build()
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/ScoringResponseCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/ScoringResponseCommandHandlerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.cockpit.command.handler;
+
+import static fixtures.core.model.AsyncJobFixture.aPendingScoringRequestJob;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.ScoringReportFixture;
+import inmemory.AsyncJobCrudServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.ScoringReportCrudServiceInMemory;
+import io.gravitee.apim.core.async_job.model.AsyncJob;
+import io.gravitee.apim.core.scoring.domain_service.ScoreComputingDomainService;
+import io.gravitee.apim.core.scoring.model.ScoringReport;
+import io.gravitee.apim.core.scoring.use_case.SaveScoringResponseUseCase;
+import io.gravitee.cockpit.api.command.v1.scoring.response.ScoringResponseCommand;
+import io.gravitee.cockpit.api.command.v1.scoring.response.ScoringResponseCommandPayload;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.scoring.api.model.ScoringResult;
+import io.gravitee.scoring.api.model.asset.AssetAnalyzed;
+import io.gravitee.scoring.api.model.asset.AssetType;
+import io.gravitee.scoring.api.model.asset.ContentType;
+import io.gravitee.scoring.api.model.diagnostic.AssetDiagnostic;
+import io.gravitee.scoring.api.model.diagnostic.Diagnostic;
+import io.gravitee.scoring.api.model.diagnostic.Position;
+import io.gravitee.scoring.api.model.diagnostic.Range;
+import io.gravitee.scoring.api.model.diagnostic.Severity;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ScoringResponseCommandHandlerTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    private static final String JOB_ID = "job-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String API_ID = "api-id";
+    private static final String USER_ID = "user-id";
+
+    ScoringReportCrudServiceInMemory scoringReportCrudService = new ScoringReportCrudServiceInMemory();
+    AsyncJobCrudServiceInMemory asyncJobCrudService = new AsyncJobCrudServiceInMemory();
+
+    ScoringResponseCommandHandler handler;
+
+    @BeforeAll
+    static void beforeAll() {
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void setUp() {
+        handler = new ScoringResponseCommandHandler(
+            new SaveScoringResponseUseCase(asyncJobCrudService, scoringReportCrudService, new ScoreComputingDomainService())
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(asyncJobCrudService, scoringReportCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_store_the_report_and_complete_the_job_when_scoring_succeeded() {
+        // Given
+        givenAPendingJob();
+
+        // When
+        handler.handle(aCommand(new ScoringResult(List.of(anAssetDiagnostic())))).test().awaitDone(5, TimeUnit.SECONDS).assertComplete();
+
+        // Then
+        assertThat(asyncJobCrudService.storage()).singleElement().extracting(AsyncJob::getStatus).isEqualTo(AsyncJob.Status.SUCCESS);
+        assertThat(scoringReportCrudService.storage()).singleElement().extracting(ScoringReport::apiId).isEqualTo(API_ID);
+    }
+
+    @Test
+    void should_flag_the_job_in_error_and_keep_the_previous_report_when_scoring_failed() {
+        // Given a previously scored API, and a provider failure reported by Cockpit
+        var previousReport = ScoringReportFixture.aScoringReport().toBuilder().apiId(API_ID).build();
+        scoringReportCrudService.initWith(List.of(previousReport));
+        givenAPendingJob();
+
+        // When
+        handler
+            .handle(aCommand(new ScoringResult(List.of(), false, "Error while scoring with provider spectral")))
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertComplete();
+
+        // Then the failure is surfaced on the job instead of being recorded as an empty successful report
+        assertThat(asyncJobCrudService.storage())
+            .singleElement()
+            .satisfies(job -> {
+                assertThat(job.getStatus()).isEqualTo(AsyncJob.Status.ERROR);
+                assertThat(job.getErrorMessage()).isEqualTo("Error while scoring with provider spectral");
+            });
+        assertThat(scoringReportCrudService.storage()).containsExactly(previousReport);
+    }
+
+    private void givenAPendingJob() {
+        asyncJobCrudService.initWith(
+            List.of(
+                aPendingScoringRequestJob()
+                    .toBuilder()
+                    .id(JOB_ID)
+                    .sourceId(API_ID)
+                    .initiatorId(USER_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .build()
+            )
+        );
+    }
+
+    private static ScoringResponseCommand aCommand(ScoringResult result) {
+        return new ScoringResponseCommand(new ScoringResponseCommandPayload(JOB_ID, ORGANIZATION_ID, ENVIRONMENT_ID, result));
+    }
+
+    private static AssetDiagnostic anAssetDiagnostic() {
+        return new AssetDiagnostic(
+            new AssetAnalyzed("page-id", AssetType.OPEN_API, "swagger.json", ContentType.JSON),
+            List.of(
+                new Diagnostic(
+                    new Range(new Position(1, 0), new Position(1, 5)),
+                    Severity.WARN,
+                    "operation-operationId",
+                    "Operation must have \"operationId\".",
+                    "swagger.json",
+                    "paths./echo.options"
+                )
+            ),
+            List.of()
+        );
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-107

## Description

Two defects surfaced by the ticket. Neither is the root cause, which is fixed separately in `spectral-scoring-service`. This PR makes APIM behave correctly when the provider fails.

### 1. The job deadline ignored the number of rulesets

`ScoreApiRequestUseCase#deadLine` computed `Math.min(1, nbRulesets)`, always `1`. The TTL stayed at `10s x nbAssets + 30s` whatever the ruleset count, while the javadoc above it stated "10 seconds per asset **per ruleset**". Past that TTL the job is flipped to `TIMEOUT` on read and the console stops polling.

`min` -> `max`, capped at 15 min so a PENDING job cannot be polled indefinitely. Note this is not what the reporter hit: the provider fails after ~10s, well within even the old 40s deadline.

### 2. Provider failures were stored as successful empty reports

Cockpit reports a failure as `ScoringResult(assetDiagnostics=[], success=false, error=...)`.
`ScoringResponseCommandHandler` never read `success` nor `error`: it was processed as a successful run with zero assets, which **deleted the existing report** and replaced it with an empty one (`score = -1` -> `summary = null` -> "No scorable assets"), job left in `SUCCESS`.

Failures now short-circuit before `deleteByApi`: the job goes to `ERROR` carrying the provider message, and the previous report is left untouched. **This is the path the reporter is on.**

### Root cause

`spectral-scoring-service` spawns one Deno subprocess per (asset x ruleset) with unbounded concurrency. Under its Helm limits (`cpu: 500m`), past ~7 rulesets they starve each other, cross the 10s SIGKILL, and return truncated output — measured: 5 rulesets pass in 7s, 7 fail, 11 crash the service. Bounding the concurrency makes 15 rulesets pass. Fixed in that repo.