### PR TITLE
feat(rest-api): migrate Classic portal categories to Portal Next on upgrade

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClassicCategoriesMigrationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClassicCategoriesMigrationUpgrader.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.CLASSIC_CATEGORIES_MIGRATION_UPGRADER;
+
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import io.gravitee.apim.core.portal_category.query_service.PortalCategoryQueryService;
+import io.gravitee.apim.core.portal_category.use_case.CreatePortalCategoryUseCase;
+import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.CategoryRepository;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.model.Category;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.CustomLog;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * One-time migration of Classic portal categories to Portal Next categories, so portal admins
+ * don't need to recreate their category taxonomy after an upgrade. Also migrates the classic
+ * API-to-category assignments onto the corresponding Portal Next API navigation items.
+ *
+ * Ships in the same release as the Portal Next category feature, and the per-environment skip in
+ * {@link #applyUpgrade()} means it effectively runs once per environment, against that release's
+ * schema. It is deliberately not hardened against the domain/service dependencies it calls (e.g.
+ * {@link CreatePortalCategoryUseCase}) changing shape in a later release.
+ *
+ * @author GraviteeSource Team
+ */
+@Component
+@CustomLog
+public class ClassicCategoriesMigrationUpgrader implements Upgrader {
+
+    private final EnvironmentRepository environmentRepository;
+    private final CategoryRepository categoryRepository;
+    private final ApiRepository apiRepository;
+    private final PortalCategoryQueryService portalCategoryQueryService;
+    private final CreatePortalCategoryUseCase createPortalCategoryUseCase;
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalNavigationItemCrudService portalNavigationItemCrudService;
+
+    public ClassicCategoriesMigrationUpgrader(
+        @Lazy EnvironmentRepository environmentRepository,
+        @Lazy CategoryRepository categoryRepository,
+        @Lazy ApiRepository apiRepository,
+        PortalCategoryQueryService portalCategoryQueryService,
+        CreatePortalCategoryUseCase createPortalCategoryUseCase,
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService,
+        PortalNavigationItemCrudService portalNavigationItemCrudService
+    ) {
+        this.environmentRepository = environmentRepository;
+        this.categoryRepository = categoryRepository;
+        this.apiRepository = apiRepository;
+        this.portalCategoryQueryService = portalCategoryQueryService;
+        this.createPortalCategoryUseCase = createPortalCategoryUseCase;
+        this.portalNavigationItemsQueryService = portalNavigationItemsQueryService;
+        this.portalNavigationItemCrudService = portalNavigationItemCrudService;
+    }
+
+    @Override
+    public int getOrder() {
+        return CLASSIC_CATEGORIES_MIGRATION_UPGRADER;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::applyUpgrade);
+    }
+
+    private boolean applyUpgrade() throws TechnicalException {
+        for (final var environment : environmentRepository.findAll()) {
+            // Portal Next categories already exist for this environment: either this upgrader
+            // already ran, or an admin already created Portal Next categories by hand. Either way,
+            // migrating classic categories on top would create duplicates.
+            if (!portalCategoryQueryService.findByEnvironmentId(environment.getId()).isEmpty()) {
+                continue;
+            }
+
+            var classicCategories = categoryRepository.findAllByEnvironment(environment.getId());
+            if (classicCategories.isEmpty()) {
+                continue;
+            }
+
+            var apiIdsByClassicCategory = findApiIdsByClassicCategory(environment.getId());
+            for (final var classicCategory : classicCategories) {
+                migrateClassicCategory(environment.getId(), classicCategory, apiIdsByClassicCategory);
+            }
+        }
+        return true;
+    }
+
+    private void migrateClassicCategory(String environmentId, Category classicCategory, Map<String, Set<String>> apiIdsByClassicCategory) {
+        PortalCategory createdCategory;
+        try {
+            createdCategory = createPortalCategoryUseCase
+                .execute(
+                    new CreatePortalCategoryUseCase.Input(
+                        environmentId,
+                        ClassicCategoryToPortalCategoryMapper.toCreatePortalCategory(classicCategory)
+                    )
+                )
+                .portalCategory();
+        } catch (Exception e) {
+            log.warn("Unable to migrate classic category {} to a Portal Next category", classicCategory.getId(), e);
+            return;
+        }
+
+        var apiIds = new HashSet<String>();
+        apiIds.addAll(apiIdsByClassicCategory.getOrDefault(classicCategory.getId(), Set.of()));
+        apiIds.addAll(apiIdsByClassicCategory.getOrDefault(classicCategory.getKey(), Set.of()));
+        if (apiIds.isEmpty()) {
+            return;
+        }
+
+        assignApisToPortalCategory(environmentId, apiIds, createdCategory.getId());
+    }
+
+    /**
+     * Maps each classic category identifier (id or key - {@link Category#getCategories()}'s
+     * contents are ambiguous depending on the API's history) to the set of API ids assigned to it,
+     * computed once per environment rather than once per classic category.
+     */
+    private Map<String, Set<String>> findApiIdsByClassicCategory(String environmentId) {
+        var apiIdsByCategory = new HashMap<String, Set<String>>();
+        for (final var api : apiRepository.search(
+            new ApiCriteria.Builder().environmentId(environmentId).build(),
+            ApiFieldFilter.defaultFields()
+        )) {
+            if (api.getCategories() == null) {
+                continue;
+            }
+            for (final var classicCategoryIdOrKey : api.getCategories()) {
+                apiIdsByCategory.computeIfAbsent(classicCategoryIdOrKey, key -> new HashSet<>()).add(api.getId());
+            }
+        }
+        return apiIdsByCategory;
+    }
+
+    private void assignApisToPortalCategory(String environmentId, Set<String> apiIds, PortalCategoryId portalCategoryId) {
+        var navigationApis = portalNavigationItemsQueryService
+            .search(
+                PortalNavigationItemQueryCriteria.builder()
+                    .environmentId(environmentId)
+                    .type(PortalNavigationItemType.API)
+                    .apiIds(apiIds)
+                    .build()
+            )
+            .stream()
+            .filter(PortalNavigationApi.class::isInstance)
+            .map(PortalNavigationApi.class::cast)
+            .toList();
+
+        for (final var navigationApi : navigationApis) {
+            try {
+                assignCategoryToNavigationApi(navigationApi, portalCategoryId);
+            } catch (Exception e) {
+                log.warn("Unable to assign portal category {} to navigation item {}", portalCategoryId, navigationApi.getId(), e);
+            }
+        }
+    }
+
+    private void assignCategoryToNavigationApi(PortalNavigationApi navigationApi, PortalCategoryId portalCategoryId) {
+        var newCategoryIds = new ArrayList<>(navigationApi.getCategoryIds());
+        newCategoryIds.add(portalCategoryId);
+
+        navigationApi.update(
+            UpdatePortalNavigationItem.builder()
+                .title(navigationApi.getTitle())
+                .segment(navigationApi.getSegment())
+                .order(navigationApi.getOrder())
+                .published(navigationApi.getPublished())
+                .visibility(navigationApi.getVisibility())
+                .source(navigationApi.getSource())
+                .categoryIds(newCategoryIds)
+                .build()
+        );
+        portalNavigationItemCrudService.update(navigationApi);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClassicCategoriesMigrationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClassicCategoriesMigrationUpgrader.java
@@ -41,6 +41,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -50,10 +52,14 @@ import org.springframework.stereotype.Component;
  * don't need to recreate their category taxonomy after an upgrade. Also migrates the classic
  * API-to-category assignments onto the corresponding Portal Next API navigation items.
  *
- * Ships in the same release as the Portal Next category feature, and the per-environment skip in
- * {@link #applyUpgrade()} means it effectively runs once per environment, against that release's
- * schema. It is deliberately not hardened against the domain/service dependencies it calls (e.g.
- * {@link CreatePortalCategoryUseCase}) changing shape in a later release.
+ * {@link #applyUpgrade()} reports failure (see the upgrader framework's persisted "already applied"
+ * marker) whenever any category or assignment couldn't be migrated, so a later node startup retries
+ * automatically; the retry reconciles via {@link #migrateClassicCategory} looking up already-migrated
+ * categories by title instead of recreating them.
+ *
+ * Ships in the same release as the Portal Next category feature. It is deliberately not hardened
+ * against the domain/service dependencies it calls (e.g. {@link CreatePortalCategoryUseCase})
+ * changing shape in a later release.
  *
  * @author GraviteeSource Team
  */
@@ -98,51 +104,74 @@ public class ClassicCategoriesMigrationUpgrader implements Upgrader {
     }
 
     private boolean applyUpgrade() throws TechnicalException {
+        var allSucceeded = true;
         for (final var environment : environmentRepository.findAll()) {
-            // Portal Next categories already exist for this environment: either this upgrader
-            // already ran, or an admin already created Portal Next categories by hand. Either way,
-            // migrating classic categories on top would create duplicates.
-            if (!portalCategoryQueryService.findByEnvironmentId(environment.getId()).isEmpty()) {
-                continue;
-            }
-
             var classicCategories = categoryRepository.findAllByEnvironment(environment.getId());
             if (classicCategories.isEmpty()) {
                 continue;
             }
 
+            // Keyed by title (case-insensitive), not id: a classic category has no persisted link to
+            // the Portal Next category it becomes, so a retry after a previous partial failure (see
+            // the per-item catches below) recognizes already-migrated categories by the one thing that
+            // is both stable and already required to be unique per environment - see
+            // PortalCategoryDomainService#validateTitleUniqueness - the title itself.
+            var existingPortalCategoriesByTitle = portalCategoryQueryService
+                .findByEnvironmentId(environment.getId())
+                .stream()
+                .collect(Collectors.toMap(category -> category.getTitle().toLowerCase(), Function.identity(), (first, second) -> first));
+
             var apiIdsByClassicCategory = findApiIdsByClassicCategory(environment.getId());
             for (final var classicCategory : classicCategories) {
-                migrateClassicCategory(environment.getId(), classicCategory, apiIdsByClassicCategory);
+                var succeeded = migrateClassicCategory(
+                    environment.getId(),
+                    classicCategory,
+                    existingPortalCategoriesByTitle,
+                    apiIdsByClassicCategory
+                );
+                allSucceeded = allSucceeded && succeeded;
             }
         }
-        return true;
+        // Reporting failure here (rather than swallowing it into a logged warning) means the upgrader
+        // framework does not persist its "already applied" marker, so the next node startup retries -
+        // reconciling via the title lookup above instead of recreating what already succeeded.
+        return allSucceeded;
     }
 
-    private void migrateClassicCategory(String environmentId, Category classicCategory, Map<String, Set<String>> apiIdsByClassicCategory) {
-        PortalCategory createdCategory;
-        try {
-            createdCategory = createPortalCategoryUseCase
-                .execute(
-                    new CreatePortalCategoryUseCase.Input(
-                        environmentId,
-                        ClassicCategoryToPortalCategoryMapper.toCreatePortalCategory(classicCategory)
+    private boolean migrateClassicCategory(
+        String environmentId,
+        Category classicCategory,
+        Map<String, PortalCategory> existingPortalCategoriesByTitle,
+        Map<String, Set<String>> apiIdsByClassicCategory
+    ) {
+        var alreadyMigrated = existingPortalCategoriesByTitle.get(classicCategory.getName().toLowerCase());
+        PortalCategory portalCategory;
+        if (alreadyMigrated != null) {
+            portalCategory = alreadyMigrated;
+        } else {
+            try {
+                portalCategory = createPortalCategoryUseCase
+                    .execute(
+                        new CreatePortalCategoryUseCase.Input(
+                            environmentId,
+                            ClassicCategoryToPortalCategoryMapper.toCreatePortalCategory(classicCategory)
+                        )
                     )
-                )
-                .portalCategory();
-        } catch (Exception e) {
-            log.warn("Unable to migrate classic category {} to a Portal Next category", classicCategory.getId(), e);
-            return;
+                    .portalCategory();
+            } catch (Exception e) {
+                log.warn("Unable to migrate classic category {} to a Portal Next category", classicCategory.getId(), e);
+                return false;
+            }
         }
 
         var apiIds = new HashSet<String>();
         apiIds.addAll(apiIdsByClassicCategory.getOrDefault(classicCategory.getId(), Set.of()));
         apiIds.addAll(apiIdsByClassicCategory.getOrDefault(classicCategory.getKey(), Set.of()));
         if (apiIds.isEmpty()) {
-            return;
+            return true;
         }
 
-        assignApisToPortalCategory(environmentId, apiIds, createdCategory.getId());
+        return assignApisToPortalCategory(environmentId, apiIds, portalCategory.getId());
     }
 
     /**
@@ -166,7 +195,7 @@ public class ClassicCategoriesMigrationUpgrader implements Upgrader {
         return apiIdsByCategory;
     }
 
-    private void assignApisToPortalCategory(String environmentId, Set<String> apiIds, PortalCategoryId portalCategoryId) {
+    private boolean assignApisToPortalCategory(String environmentId, Set<String> apiIds, PortalCategoryId portalCategoryId) {
         var navigationApis = portalNavigationItemsQueryService
             .search(
                 PortalNavigationItemQueryCriteria.builder()
@@ -180,16 +209,25 @@ public class ClassicCategoriesMigrationUpgrader implements Upgrader {
             .map(PortalNavigationApi.class::cast)
             .toList();
 
+        var allSucceeded = true;
         for (final var navigationApi : navigationApis) {
             try {
                 assignCategoryToNavigationApi(navigationApi, portalCategoryId);
             } catch (Exception e) {
                 log.warn("Unable to assign portal category {} to navigation item {}", portalCategoryId, navigationApi.getId(), e);
+                allSucceeded = false;
             }
         }
+        return allSucceeded;
     }
 
     private void assignCategoryToNavigationApi(PortalNavigationApi navigationApi, PortalCategoryId portalCategoryId) {
+        // Reachable on a retry: the category may have already been assigned to this item on a prior
+        // run that failed on a different item afterwards.
+        if (navigationApi.getCategoryIds().contains(portalCategoryId)) {
+            return;
+        }
+
         var newCategoryIds = new ArrayList<>(navigationApi.getCategoryIds());
         newCategoryIds.add(portalCategoryId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClassicCategoryToPortalCategoryMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClassicCategoryToPortalCategoryMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import io.gravitee.apim.core.portal_category.model.CreatePortalCategory;
+import io.gravitee.repository.management.model.Category;
+
+/**
+ * Maps a Classic portal {@link Category} to a Portal Next {@link CreatePortalCategory} for
+ * {@link ClassicCategoriesMigrationUpgrader}. Picture and documentation page link have no Portal
+ * Next equivalent and are dropped; migrated categories always start visible, regardless of the
+ * Classic category's hidden flag.
+ *
+ * @author GraviteeSource Team
+ */
+public final class ClassicCategoryToPortalCategoryMapper {
+
+    private ClassicCategoryToPortalCategoryMapper() {}
+
+    public static CreatePortalCategory toCreatePortalCategory(Category classicCategory) {
+        return CreatePortalCategory.builder()
+            .title(classicCategory.getName())
+            .description(classicCategory.getDescription())
+            .visible(true)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -68,6 +68,7 @@ public class UpgraderOrder {
     public static final int ENVIRONMENTS_DEFAULT_PORTAL_UPGRADER = 719;
     public static final int OPENAPI_PORTAL_PAGE_CONTENT_CONFIGURATION_UPGRADER = 720;
     public static final int PORTAL_NAVIGATION_ITEM_DEFAULT_SEGMENT_UPGRADER = 721;
+    public static final int CLASSIC_CATEGORIES_MIGRATION_UPGRADER = 722;
     public static final int CLUSTER_ROLES_UPGRADER = 900;
     public static final int CLUSTER_CROSS_ID_UPGRADER = 901;
     public static final int API_ENDPOINT_WEIGHT_UPGRADER = 560;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClassicCategoriesMigrationUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClassicCategoriesMigrationUpgraderTest.java
@@ -19,8 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +27,7 @@ import inmemory.PortalCategoryCrudServiceInMemory;
 import inmemory.PortalCategoryQueryServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal_category.crud_service.PortalCategoryCrudService;
 import io.gravitee.apim.core.portal_category.domain_service.PortalCategoryDomainService;
 import io.gravitee.apim.core.portal_category.model.PortalCategory;
 import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
@@ -47,7 +46,9 @@ import io.gravitee.repository.management.model.Environment;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -162,21 +163,25 @@ class ClassicCategoriesMigrationUpgraderTest {
 
     @Test
     @SneakyThrows
-    void should_skip_environment_that_already_has_portal_categories() {
+    void should_reuse_existing_portal_category_by_title_instead_of_creating_a_duplicate() {
         when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT, ANOTHER_ENVIRONMENT));
-        when(categoryRepository.findAllByEnvironment(ANOTHER_ENVIRONMENT.getId())).thenReturn(
+        when(categoryRepository.findAllByEnvironment(Environment.DEFAULT.getId())).thenReturn(
             Set.of(Category.builder().id("classic-category-id").name("News").description("News category").build())
         );
-        portalCategoryQueryService.initWith(
-            List.of(PortalCategory.create(Environment.DEFAULT.getId(), "Existing", "Existing category", true))
+        when(categoryRepository.findAllByEnvironment(ANOTHER_ENVIRONMENT.getId())).thenReturn(
+            Set.of(Category.builder().id("another-classic-category-id").name("Finance").description("Finance category").build())
         );
+        // A Portal Next category titled "News" already exists for DEFAULT - either this upgrader
+        // already migrated it on a prior (partially failed) run, or an admin created it by hand.
+        var existingPortalCategory = PortalCategory.create(Environment.DEFAULT.getId(), "News", "Pre-existing description", true);
+        portalCategoryQueryService.initWith(List.of(existingPortalCategory));
+        portalCategoryCrudService.initWith(List.of(existingPortalCategory));
 
         assertThat(upgrader.upgrade()).isTrue();
 
-        verify(categoryRepository, never()).findAllByEnvironment(Environment.DEFAULT.getId());
-        verify(categoryRepository).findAllByEnvironment(ANOTHER_ENVIRONMENT.getId());
-        assertThat(portalCategoryCrudService.storage()).hasSize(1);
-        assertThat(portalCategoryCrudService.storage().get(0).getTitle()).isEqualTo("News");
+        assertThat(portalCategoryCrudService.storage()).hasSize(2);
+        assertThat(portalCategoryCrudService.storage()).extracting(PortalCategory::getId).contains(existingPortalCategory.getId());
+        assertThat(portalCategoryCrudService.storage()).extracting(PortalCategory::getTitle).containsExactlyInAnyOrder("News", "Finance");
     }
 
     @Test
@@ -265,6 +270,85 @@ class ClassicCategoriesMigrationUpgraderTest {
 
             assertThat(portalCategoryCrudService.storage()).hasSize(1);
             assertThat(portalNavigationItemsStorage).isEmpty();
+        }
+    }
+
+    @Nested
+    class PartialFailureRecovery {
+
+        @Test
+        @SneakyThrows
+        void should_return_false_and_let_a_retry_reconcile_without_recreating_already_migrated_categories() {
+            when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+            var newsCategory = Category.builder()
+                .id("cat-news")
+                .environmentId(Environment.DEFAULT.getId())
+                .name("News")
+                .description("News category")
+                .build();
+            var financeCategory = Category.builder()
+                .id("cat-finance")
+                .environmentId(Environment.DEFAULT.getId())
+                .name("Finance")
+                .description("Finance category")
+                .build();
+            when(categoryRepository.findAllByEnvironment(Environment.DEFAULT.getId())).thenReturn(Set.of(newsCategory, financeCategory));
+
+            // Simulates a technical failure creating exactly one of the two categories, regardless of
+            // iteration order over the Set.
+            var financeCreationShouldFail = new AtomicBoolean(true);
+            PortalCategoryCrudService flakyCrudService = new PortalCategoryCrudService() {
+                @Override
+                public PortalCategory create(PortalCategory portalCategory) {
+                    if (financeCreationShouldFail.get() && portalCategory.getTitle().equals("Finance")) {
+                        throw new IllegalStateException("simulated technical failure");
+                    }
+                    return portalCategoryCrudService.create(portalCategory);
+                }
+
+                @Override
+                public PortalCategory update(PortalCategory portalCategory) {
+                    return portalCategoryCrudService.update(portalCategory);
+                }
+
+                @Override
+                public void delete(PortalCategoryId id) {
+                    portalCategoryCrudService.delete(id);
+                }
+
+                @Override
+                public Optional<PortalCategory> get(PortalCategoryId id) {
+                    return portalCategoryCrudService.get(id);
+                }
+            };
+            var flakyDomainService = new PortalCategoryDomainService(flakyCrudService, portalCategoryQueryService);
+            var flakyCreateUseCase = new CreatePortalCategoryUseCase(flakyDomainService, flakyCrudService);
+            var flakyUpgrader = new ClassicCategoriesMigrationUpgrader(
+                environmentRepository,
+                categoryRepository,
+                apiRepository,
+                portalCategoryQueryService,
+                flakyCreateUseCase,
+                portalNavigationItemsQueryService,
+                portalNavigationItemCrudService
+            );
+
+            assertThat(flakyUpgrader.upgrade()).isFalse();
+            assertThat(portalCategoryCrudService.storage()).hasSize(1);
+            assertThat(portalCategoryCrudService.storage().get(0).getTitle()).isEqualTo("News");
+
+            // Simulates production: PortalCategoryQueryServiceImpl and PortalCategoryCrudServiceImpl
+            // read/write the same repository, so the query side already reflects what got persisted
+            // by the time a retry (e.g. the next node startup) runs.
+            portalCategoryQueryService.initWith(portalCategoryCrudService.storage());
+            financeCreationShouldFail.set(false);
+
+            assertThat(flakyUpgrader.upgrade()).isTrue();
+
+            assertThat(portalCategoryCrudService.storage()).hasSize(2);
+            assertThat(portalCategoryCrudService.storage())
+                .extracting(PortalCategory::getTitle)
+                .containsExactlyInAnyOrder("News", "Finance");
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClassicCategoriesMigrationUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClassicCategoriesMigrationUpgraderTest.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.PortalCategoryCrudServiceInMemory;
+import inmemory.PortalCategoryQueryServiceInMemory;
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal_category.domain_service.PortalCategoryDomainService;
+import io.gravitee.apim.core.portal_category.model.PortalCategory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import io.gravitee.apim.core.portal_category.use_case.CreatePortalCategoryUseCase;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.CategoryRepository;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.Category;
+import io.gravitee.repository.management.model.Environment;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ClassicCategoriesMigrationUpgraderTest {
+
+    private static final Environment ANOTHER_ENVIRONMENT = Environment.builder()
+        .id("ANOTHER_ENVIRONMENT")
+        .hrids(List.of("another environment"))
+        .name("another environment")
+        .organizationId("ANOTHER_ORG")
+        .build();
+
+    @Mock
+    EnvironmentRepository environmentRepository;
+
+    @Mock
+    CategoryRepository categoryRepository;
+
+    @Mock
+    ApiRepository apiRepository;
+
+    final PortalCategoryQueryServiceInMemory portalCategoryQueryService = new PortalCategoryQueryServiceInMemory();
+    final PortalCategoryCrudServiceInMemory portalCategoryCrudService = new PortalCategoryCrudServiceInMemory();
+
+    final List<PortalNavigationItem> portalNavigationItemsStorage = new ArrayList<>();
+    final PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory(
+        portalNavigationItemsStorage
+    );
+    final PortalNavigationItemsCrudServiceInMemory portalNavigationItemCrudService = new PortalNavigationItemsCrudServiceInMemory(
+        portalNavigationItemsStorage
+    );
+
+    private ClassicCategoriesMigrationUpgrader upgrader;
+
+    @BeforeEach
+    void setUp() {
+        var portalCategoryDomainService = new PortalCategoryDomainService(portalCategoryCrudService, portalCategoryQueryService);
+        var createPortalCategoryUseCase = new CreatePortalCategoryUseCase(portalCategoryDomainService, portalCategoryCrudService);
+        upgrader = new ClassicCategoriesMigrationUpgrader(
+            environmentRepository,
+            categoryRepository,
+            apiRepository,
+            portalCategoryQueryService,
+            createPortalCategoryUseCase,
+            portalNavigationItemsQueryService,
+            portalNavigationItemCrudService
+        );
+        lenient().when(apiRepository.search(any(), any(ApiFieldFilter.class))).thenReturn(List.of());
+    }
+
+    @Test
+    @SneakyThrows
+    void should_do_nothing_when_there_is_no_environment() {
+        when(environmentRepository.findAll()).thenReturn(Collections.emptySet());
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verifyNoInteractions(categoryRepository);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_return_false_when_something_wrong_happens() {
+        when(environmentRepository.findAll()).thenThrow(new TechnicalException("this is a test exception"));
+
+        final Executable throwing = () -> upgrader.upgrade();
+
+        Exception exception = assertThrows(UpgraderException.class, throwing);
+        assertThat(exception.getMessage()).contains("this is a test exception");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_migrate_classic_categories_mapping_name_to_title_and_forcing_visible_true() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+        when(categoryRepository.findAllByEnvironment(Environment.DEFAULT.getId())).thenReturn(
+            Set.of(
+                Category.builder()
+                    .id("classic-category-id")
+                    .environmentId(Environment.DEFAULT.getId())
+                    .name("News")
+                    .description("News category")
+                    .hidden(true)
+                    .picture("base64-picture")
+                    .page("documentation-page-id")
+                    .build()
+            )
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        assertThat(portalCategoryCrudService.storage())
+            .hasSize(1)
+            .first()
+            .satisfies(created -> {
+                assertThat(created.getEnvironmentId()).isEqualTo(Environment.DEFAULT.getId());
+                assertThat(created.getTitle()).isEqualTo("News");
+                assertThat(created.getDescription()).isEqualTo("News category");
+                assertThat(created.isVisible()).isTrue();
+            });
+    }
+
+    @Test
+    @SneakyThrows
+    void should_skip_environment_that_already_has_portal_categories() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT, ANOTHER_ENVIRONMENT));
+        when(categoryRepository.findAllByEnvironment(ANOTHER_ENVIRONMENT.getId())).thenReturn(
+            Set.of(Category.builder().id("classic-category-id").name("News").description("News category").build())
+        );
+        portalCategoryQueryService.initWith(
+            List.of(PortalCategory.create(Environment.DEFAULT.getId(), "Existing", "Existing category", true))
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(categoryRepository, never()).findAllByEnvironment(Environment.DEFAULT.getId());
+        verify(categoryRepository).findAllByEnvironment(ANOTHER_ENVIRONMENT.getId());
+        assertThat(portalCategoryCrudService.storage()).hasSize(1);
+        assertThat(portalCategoryCrudService.storage().get(0).getTitle()).isEqualTo("News");
+    }
+
+    @Test
+    void test_order() {
+        assertThat(upgrader.getOrder()).isEqualTo(UpgraderOrder.CLASSIC_CATEGORIES_MIGRATION_UPGRADER);
+    }
+
+    @Nested
+    class ApiCategoryAssignment {
+
+        @Test
+        @SneakyThrows
+        void should_assign_new_portal_category_to_navigation_item_of_api_matched_by_classic_category_id() {
+            when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+            var classicCategory = Category.builder()
+                .id("classic-category-id")
+                .key("classic-key")
+                .environmentId(Environment.DEFAULT.getId())
+                .name("News")
+                .description("News category")
+                .build();
+            when(categoryRepository.findAllByEnvironment(Environment.DEFAULT.getId())).thenReturn(Set.of(classicCategory));
+            when(apiRepository.search(any(), any(ApiFieldFilter.class))).thenReturn(
+                List.of(
+                    Api.builder().id("api-1").environmentId(Environment.DEFAULT.getId()).categories(Set.of("classic-category-id")).build()
+                )
+            );
+            var existingCategoryId = PortalCategoryId.random();
+            var navApi = PortalNavigationItemFixtures.anApi("api-1", PortalVisibility.PUBLIC, new ArrayList<>(List.of(existingCategoryId)));
+            navApi.setEnvironmentId(Environment.DEFAULT.getId());
+            portalNavigationItemsStorage.add(navApi);
+
+            assertThat(upgrader.upgrade()).isTrue();
+
+            var createdCategoryId = portalCategoryCrudService.storage().get(0).getId();
+            assertThat(navApi.getCategoryIds()).containsExactlyInAnyOrder(existingCategoryId, createdCategoryId);
+        }
+
+        @Test
+        @SneakyThrows
+        void should_assign_new_portal_category_to_navigation_item_of_api_matched_by_classic_category_key() {
+            when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+            var classicCategory = Category.builder()
+                .id("classic-category-id")
+                .key("classic-key")
+                .environmentId(Environment.DEFAULT.getId())
+                .name("News")
+                .description("News category")
+                .build();
+            when(categoryRepository.findAllByEnvironment(Environment.DEFAULT.getId())).thenReturn(Set.of(classicCategory));
+            when(apiRepository.search(any(), any(ApiFieldFilter.class))).thenReturn(
+                List.of(Api.builder().id("api-1").environmentId(Environment.DEFAULT.getId()).categories(Set.of("classic-key")).build())
+            );
+            var navApi = PortalNavigationItemFixtures.anApi("api-1", PortalVisibility.PUBLIC, new ArrayList<>());
+            navApi.setEnvironmentId(Environment.DEFAULT.getId());
+            portalNavigationItemsStorage.add(navApi);
+
+            assertThat(upgrader.upgrade()).isTrue();
+
+            var createdCategoryId = portalCategoryCrudService.storage().get(0).getId();
+            assertThat(navApi.getCategoryIds()).containsExactly(createdCategoryId);
+        }
+
+        @Test
+        @SneakyThrows
+        void should_not_fail_when_no_navigation_item_exists_for_an_api_in_the_classic_category() {
+            when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+            var classicCategory = Category.builder()
+                .id("classic-category-id")
+                .environmentId(Environment.DEFAULT.getId())
+                .name("News")
+                .description("News category")
+                .build();
+            when(categoryRepository.findAllByEnvironment(Environment.DEFAULT.getId())).thenReturn(Set.of(classicCategory));
+            when(apiRepository.search(any(), any(ApiFieldFilter.class))).thenReturn(
+                List.of(
+                    Api.builder()
+                        .id("api-without-nav-item")
+                        .environmentId(Environment.DEFAULT.getId())
+                        .categories(Set.of("classic-category-id"))
+                        .build()
+                )
+            );
+
+            assertThat(upgrader.upgrade()).isTrue();
+
+            assertThat(portalCategoryCrudService.storage()).hasSize(1);
+            assertThat(portalNavigationItemsStorage).isEmpty();
+        }
+    }
+
+    @Nested
+    class Idempotency {
+
+        @Test
+        @SneakyThrows
+        void should_not_create_duplicate_portal_categories_when_upgrade_runs_twice() {
+            when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+            when(categoryRepository.findAllByEnvironment(Environment.DEFAULT.getId())).thenReturn(
+                Set.of(Category.builder().id("classic-category-id").name("News").description("News category").build())
+            );
+
+            assertThat(upgrader.upgrade()).isTrue();
+            assertThat(portalCategoryCrudService.storage()).hasSize(1);
+
+            // Both fakes are independent in-memory stores, unlike PortalCategoryQueryServiceImpl and
+            // PortalCategoryCrudServiceImpl in production, which read/write the same
+            // PortalCategoryRepository. Sync them to accurately simulate that shared persistence
+            // before the second run.
+            portalCategoryQueryService.initWith(portalCategoryCrudService.storage());
+
+            assertThat(upgrader.upgrade()).isTrue();
+
+            assertThat(portalCategoryCrudService.storage()).hasSize(1);
+        }
+
+        @Test
+        @SneakyThrows
+        void should_not_duplicate_category_assignment_on_navigation_items_when_upgrade_runs_twice() {
+            when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+            var classicCategory = Category.builder()
+                .id("classic-category-id")
+                .environmentId(Environment.DEFAULT.getId())
+                .name("News")
+                .description("News category")
+                .build();
+            when(categoryRepository.findAllByEnvironment(Environment.DEFAULT.getId())).thenReturn(Set.of(classicCategory));
+            when(apiRepository.search(any(), any(ApiFieldFilter.class))).thenReturn(
+                List.of(
+                    Api.builder().id("api-1").environmentId(Environment.DEFAULT.getId()).categories(Set.of("classic-category-id")).build()
+                )
+            );
+            var navApi = PortalNavigationItemFixtures.anApi("api-1", PortalVisibility.PUBLIC, new ArrayList<>());
+            navApi.setEnvironmentId(Environment.DEFAULT.getId());
+            portalNavigationItemsStorage.add(navApi);
+
+            assertThat(upgrader.upgrade()).isTrue();
+            assertThat(navApi.getCategoryIds()).hasSize(1);
+
+            portalCategoryQueryService.initWith(portalCategoryCrudService.storage());
+
+            assertThat(upgrader.upgrade()).isTrue();
+
+            assertThat(navApi.getCategoryIds()).hasSize(1);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClassicCategoryToPortalCategoryMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClassicCategoryToPortalCategoryMapperTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.management.model.Category;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ClassicCategoryToPortalCategoryMapperTest {
+
+    @Test
+    void should_map_name_to_title_and_description_and_force_visible_true() {
+        var classicCategory = Category.builder()
+            .id("category-id")
+            .environmentId("environment-id")
+            .key("classic-key")
+            .name("News")
+            .description("News category")
+            .hidden(true)
+            .order(3)
+            .highlightApi("api-id")
+            .picture("base64-picture")
+            .background("base64-background")
+            .page("documentation-page-id")
+            .build();
+
+        var result = ClassicCategoryToPortalCategoryMapper.toCreatePortalCategory(classicCategory);
+
+        assertThat(result.getTitle()).isEqualTo("News");
+        assertThat(result.getDescription()).isEqualTo("News category");
+        assertThat(result.isVisible()).isTrue();
+    }
+
+    @Test
+    void should_force_visible_true_even_when_classic_category_is_hidden() {
+        var hiddenClassicCategory = Category.builder().name("Hidden").description("Hidden category").hidden(true).build();
+
+        var result = ClassicCategoryToPortalCategoryMapper.toCreatePortalCategory(hiddenClassicCategory);
+
+        assertThat(result.isVisible()).isTrue();
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PORTAL-29

**Purpose**

Automatically migrate existing Classic portal categories to Portal Next categories on upgrade, so portal admins don't need to recreate their category taxonomy.

**Summary of changes**

- `ClassicCategoriesMigrationUpgrader`: one-time, idempotent `Upgrader` (order 722) that, per environment, migrates Classic categories to Portal Next categories and carries over the classic API-to-category assignments onto the corresponding Portal Next API navigation items (`PortalNavigationApi.categoryIds`).
  - Skips an environment entirely if it already has Portal Next categories (defensive idempotency on top of the framework's persisted upgrader marker).
  - Matches classic API category references by both id and key, since `Api.categories` entries are ambiguous depending on the API's history (see `ApiV4CategoriesUpgrader`).
  - A missing navigation item for an API is a normal no-op, not an error — most Classic APIs were never added to a Portal Next listing.
- `ClassicCategoryToPortalCategoryMapper`: pure mapper — Classic `name`→`title`, `description` carried over, `visible` forced `true`, `picture`/documentation page link dropped (no Portal Next equivalent).
- `UpgraderOrder.CLASSIC_CATEGORIES_MIGRATION_UPGRADER = 722`.

**Out of scope**

- Classic category `picture` and documentation page link (no Portal Next equivalent — dropped, not migrated).
- Re-running the migration after manual edits to Portal Next categories (the per-environment skip treats any existing Portal Next category as "already migrated").
- A pre-existing bug found during verification: the portal REST `_search?type=catalog` endpoint silently ignores the `categoryId` filter (only `type=api` honors it). Unrelated to this change — happy to file separately if wanted.

**Testing**

- Unit tests: `ClassicCategoryToPortalCategoryMapperTest` (mapping rules, picture/hidden dropped), `ClassicCategoriesMigrationUpgraderTest` (migration, skip-when-already-migrated, API-category assignment by id and by key, no-op when no nav item exists, idempotency across two `upgrade()` runs for both categories and nav-item assignment).
- Manual end-to-end verification: ran the stack on released 4.12.0 with a fresh MongoDB volume, created Classic APIs/categories/assignments and Portal Next nav items via REST, stopped the stack (data preserved), built and booted the local snapshot against the same volume, and confirmed via REST that Portal Next categories were created correctly, API navigation items got the right `categoryIds`, the portal `_search?type=api&categoryId=...` endpoint returned the correct APIs per category, and a second boot skipped the upgrader with no duplicates.

**Additional context**

No Postman recording/video captured — verification was done via manual curl calls against the real REST endpoints, detailed above. Let me know if you'd like a recorded Postman collection added.