### PR TITLE
feat(gamma): added env alert educational UX

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -102,6 +102,10 @@ jest.mock('../pages/ApplicationDetailSubscriptionPage', () => ({
     ApplicationDetailSubscriptionPage: () => null,
 }));
 
+jest.mock('../pages/AlertsPage', () => ({
+    AlertsPage: () => <div data-testid="alerts-page" />,
+}));
+
 function renderPlatform(path = '/applications') {
     render(
         <MemoryRouter initialEntries={[path]}>
@@ -362,5 +366,29 @@ describe('AppRoutes', () => {
         renderPlatform('/applications/new');
 
         expect(screen.getByTestId('register-application-page')).not.toBeNull();
+    });
+
+    it('routes to the Alerts page under the platform module', () => {
+        render(
+            <MemoryRouter initialEntries={['/alerts']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('alerts-page')).not.toBeNull();
+    });
+
+    it('shows the Alerts nav item when the user has read permission', () => {
+        renderPlatform();
+
+        expect(visibleNavKeys()).toContain('alerts');
+    });
+
+    it('hides the Alerts nav item when the user lacks environment-alert-r', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-alert-r'));
+
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('alerts');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -42,6 +42,7 @@ import {
     type PlatformNavSection,
 } from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
+import { ENVIRONMENT_ALERT_READ_PERMISSION } from '../features/alerts/utils/alertPermissions';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
 import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
 import { GatewayInstanceDetailLayout } from '../features/gateway-instances/components/GatewayInstanceDetailLayout';
@@ -50,6 +51,7 @@ import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmen
 import { SecurityPlanTypesPage } from '../features/security-plan-types/SecurityPlanTypesPage';
 import { ORGANIZATION_USER_ACCESS_PERMISSIONS } from '../features/users/utils/userPermissions';
 import { AccessManagementPage } from '../pages/AccessManagementPage';
+import { AlertsPage } from '../pages/AlertsPage';
 import { ApplicationDetailSubscriptionPage } from '../pages/ApplicationDetailSubscriptionPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { DictionariesPage } from '../pages/DictionariesPage';
@@ -112,6 +114,7 @@ function isNavItemVisible(
     canReadGateways: boolean,
     canReadEntrypoints: boolean,
     canReadGroups: boolean,
+    canReadAlerts: boolean,
 ): boolean {
     if (itemKey === 'users') {
         return !permissionsReady || canAccessUsers;
@@ -130,6 +133,9 @@ function isNavItemVisible(
     }
     if (itemKey === 'entrypoints-and-sharding-tags') {
         return !permissionsReady || canReadEntrypoints;
+    }
+    if (itemKey === 'alerts') {
+        return !permissionsReady || canReadAlerts;
     }
     return true;
 }
@@ -212,6 +218,7 @@ function ModuleLayout() {
     const canReadGateways = useHasPermission({ anyOf: ['environment-instance-r'] });
     const canReadEntrypoints = useHasPermission({ anyOf: ['environment-entrypoint-r', 'organization-entrypoint-r'] });
     const canReadGroups = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_READ_PERMISSION] });
+    const canReadAlerts = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_READ_PERMISSION] });
 
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
 
@@ -227,9 +234,19 @@ function ModuleLayout() {
                     canReadGateways,
                     canReadEntrypoints,
                     canReadGroups,
+                    canReadAlerts,
                 ),
             ),
-        [permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers, canReadGateways, canReadEntrypoints, canReadGroups],
+        [
+            permissionsReady,
+            canReadMetadata,
+            canReadDictionaries,
+            canAccessUsers,
+            canReadGateways,
+            canReadEntrypoints,
+            canReadGroups,
+            canReadAlerts,
+        ],
     );
 
     const activeSectionKey = findNavSectionKey(visibleNavSections, activeNavKey) ?? visibleNavSections[0]?.key;
@@ -417,6 +434,14 @@ export function AppRoutes() {
                             </Route>
                             <Route path="entrypoints-and-sharding-tags" element={<EntrypointsGuard />} />
                             <Route path="security-plan-types" element={<SecurityPlanTypesPage />} />
+                            <Route
+                                path="alerts"
+                                element={
+                                    <PermissionPageGuard permission={ENVIRONMENT_ALERT_READ_PERMISSION} unauthorizedTo="../applications">
+                                        <AlertsPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
                         </Route>
                         <Route path="applications/:applicationId" element={<ApplicationDetailLayout />}>
                             <Route index element={<ApplicationDetailIndexRedirect />} />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -49,8 +49,8 @@ describe('platform navigation config', () => {
         expect(sectionKeys('Environment', 'APIs & Assets')).toEqual(['applications', 'metadata', 'dictionaries']);
     });
 
-    it('places Gateways and Security Plan Types under Environment / System & Security', () => {
-        expect(sectionKeys('Environment', 'System & Security')).toEqual(['gateways', 'security-plan-types']);
+    it('places Gateways, Alerts, and Security Plan Types under Environment / System & Security', () => {
+        expect(sectionKeys('Environment', 'System & Security')).toEqual(['gateways', 'alerts', 'security-plan-types']);
     });
 
     it('places Users and Groups under Team', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -16,6 +16,7 @@
 import type { NavGroup, NavItem } from '@gravitee/graphene-core';
 import {
     AppWindowIcon,
+    BellIcon,
     BookOpenIcon,
     CloudIcon,
     DatabaseIcon,
@@ -79,6 +80,7 @@ export const NAV_SECTIONS: PlatformNavSection[] = [
                 label: 'System & Security',
                 items: [
                     { key: 'gateways', title: ROUTES.gateways.label, icon: ServerIcon },
+                    { key: 'alerts', title: ROUTES.alerts.label, icon: BellIcon },
                     { key: 'security-plan-types', title: ROUTES['security-plan-types'].label, icon: KeyIcon },
                 ],
             },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -25,6 +25,7 @@ export const ROUTE_KEYS: readonly string[] = [
     'security-plan-types',
     'gateways',
     'entrypoints-and-sharding-tags',
+    'alerts',
 ];
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
@@ -40,6 +41,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     dictionaries: { path: 'dictionaries', label: 'Dictionaries' },
     gateways: { path: 'gateways', label: 'Gateways' },
     'entrypoints-and-sharding-tags': { path: 'entrypoints-and-sharding-tags', label: 'Entrypoints & Sharding Tags' },
+    alerts: { path: 'alerts', label: 'Alerts' },
 };
 
 export const PLATFORM_ROUTE_CONFIG: ModuleRouteConfig<RouteKey> = {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsEducationalEmptyState.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsEducationalEmptyState.spec.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { AlertsEducationalEmptyState } from './AlertsEducationalEmptyState';
+
+describe('AlertsEducationalEmptyState', () => {
+    it('renders the why/how-it-works/capabilities content', () => {
+        render(<AlertsEducationalEmptyState />);
+
+        expect(screen.getByText('Why configure alerts?')).not.toBeNull();
+        expect(screen.getByText('How it works')).not.toBeNull();
+        expect(screen.getByText('Alert rule')).not.toBeNull();
+        expect(screen.getByText('Email · Slack · Webhook')).not.toBeNull();
+        expect(screen.getByText('What you can alert on')).not.toBeNull();
+        expect(screen.getByText('Key capabilities')).not.toBeNull();
+        expect(screen.getByText(/Node lifecycle/)).not.toBeNull();
+        expect(screen.getByText('Send notifications via email, Slack, or webhook')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsEducationalEmptyState.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsEducationalEmptyState.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, cn } from '@gravitee/graphene-core';
+import {
+    ActivityIcon,
+    ArrowRightIcon,
+    BellIcon,
+    CircleCheckIcon,
+    MailIcon,
+    MessageSquareIcon,
+    WebhookIcon,
+} from '@gravitee/graphene-core/icons';
+import type { ComponentType } from 'react';
+
+const RULE_CATEGORIES = [
+    'Node lifecycle — when a gateway node starts, stops, or its health status changes',
+    'Node heartbeat metrics — CPU, memory, and other node metrics rising above a threshold',
+    'Health-check status — when an endpoint health check transitions between UP and DOWN',
+] as const;
+
+const CAPABILITIES = [
+    'Send notifications via email, Slack, or webhook',
+    'Set severity levels: info, warning, or critical',
+    'Configure timeframes for notification windows',
+    'Apply dampening rules to avoid alert fatigue',
+] as const;
+
+function FlowNode({
+    icon: Icon,
+    label,
+    active = false,
+}: Readonly<{ icon: ComponentType<{ className?: string }>; label: string; active?: boolean }>) {
+    return (
+        <div className={cn('flex flex-col items-center gap-1.5', active && 'rounded-lg border border-border bg-card px-3 py-2')}>
+            <div className={cn('rounded-lg p-2', active ? 'bg-primary/10' : 'bg-muted')}>
+                <Icon className={cn('size-4', active ? 'text-primary' : 'text-muted-foreground')} />
+            </div>
+            <p className={cn('text-center text-xs', active ? 'font-semibold' : 'text-muted-foreground')}>{label}</p>
+        </div>
+    );
+}
+
+export function AlertsEducationalEmptyState() {
+    return (
+        <Card className="space-y-6 p-6">
+            <div className="space-y-1">
+                <p className="text-sm font-semibold">Why configure alerts?</p>
+                <p className="text-sm text-muted-foreground">
+                    Get notified automatically when a gateway node or the platform needs attention — health status changes, heartbeat
+                    anomalies, health-check failures — without constantly monitoring dashboards.
+                </p>
+            </div>
+
+            <div className="rounded-xl p-5 bg-primary/10" style={{ border: '2px solid hsl(var(--primary))' }}>
+                <p className="mb-4 text-xs font-semibold text-primary">How it works</p>
+                <div className="flex items-center justify-center gap-3">
+                    <FlowNode icon={ActivityIcon} label="Platform events" />
+                    <ArrowRightIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    <FlowNode icon={BellIcon} label="Alert rule" active />
+                    <ArrowRightIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    <div className="flex flex-col items-center gap-1.5">
+                        <div className="flex gap-1">
+                            <div className="rounded-lg bg-muted p-1.5">
+                                <MailIcon className="size-3 text-muted-foreground" />
+                            </div>
+                            <div className="rounded-lg bg-muted p-1.5">
+                                <MessageSquareIcon className="size-3 text-muted-foreground" />
+                            </div>
+                            <div className="rounded-lg bg-muted p-1.5">
+                                <WebhookIcon className="size-3 text-muted-foreground" />
+                            </div>
+                        </div>
+                        <p className="text-xs text-muted-foreground">Email · Slack · Webhook</p>
+                    </div>
+                </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <div className="space-y-3">
+                    <p className="text-xs font-semibold">What you can alert on</p>
+                    <ul className="space-y-2.5">
+                        {RULE_CATEGORIES.map(category => (
+                            <li key={category} className="flex items-start gap-2">
+                                <BellIcon className="mt-0.5 size-3.5 shrink-0 text-primary" aria-hidden="true" />
+                                <span className="text-xs text-muted-foreground">{category}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+
+                <div className="space-y-3">
+                    <p className="text-xs font-semibold">Key capabilities</p>
+                    <ul className="space-y-2.5">
+                        {CAPABILITIES.map(cap => (
+                            <li key={cap} className="flex items-start gap-2">
+                                <CircleCheckIcon className="mt-0.5 size-3.5 shrink-0 text-success" aria-hidden="true" />
+                                <span className="text-xs text-muted-foreground">{cap}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertPermissions.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Mirrors classic Console's environment alerts route guard (management-routing.module.ts / gio-side-nav). */
+export const ENVIRONMENT_ALERT_READ_PERMISSION = 'environment-alert-r' as const;
+export const ENVIRONMENT_ALERT_CREATE_PERMISSION = 'environment-alert-c' as const;
+export const ENVIRONMENT_ALERT_UPDATE_PERMISSION = 'environment-alert-u' as const;
+export const ENVIRONMENT_ALERT_DELETE_PERMISSION = 'environment-alert-d' as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.spec.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
+
+import { AlertsPage } from './AlertsPage';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: jest.fn(),
+}));
+
+jest.mock('../features/alerts/components/AlertsEducationalEmptyState', () => ({
+    AlertsEducationalEmptyState: () => <div data-testid="alerts-educational-empty-state" />,
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseNavigate = jest.mocked(useNavigate);
+const mockNavigate = jest.fn();
+
+function renderPage() {
+    return render(
+        <MemoryRouter>
+            <AlertsPage />
+        </MemoryRouter>,
+    );
+}
+
+describe('AlertsPage', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseNavigate.mockReturnValue(mockNavigate);
+        mockUseHasPermission.mockReturnValue(true);
+    });
+
+    it('renders the page header and the educational empty state', () => {
+        renderPage();
+
+        expect(screen.getByText('Alerts')).not.toBeNull();
+        expect(screen.getByText('Get notified when your gateways or platform need attention.')).not.toBeNull();
+        expect(screen.getByTestId('alerts-educational-empty-state')).not.toBeNull();
+    });
+
+    it('shows Add alert when the user has create permission', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => anyOf.includes('environment-alert-c'));
+        renderPage();
+
+        expect(screen.getByRole('button', { name: /Add alert/i })).not.toBeNull();
+        expect(screen.getByTestId('alerts-educational-empty-state')).not.toBeNull();
+    });
+
+    it('hides Add alert when the user lacks create permission', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-alert-c'));
+        renderPage();
+
+        expect(screen.queryByRole('button', { name: /Add alert/i })).toBeNull();
+        expect(screen.getByTestId('alerts-educational-empty-state')).not.toBeNull();
+    });
+
+    it('navigates to new when Add alert is clicked', async () => {
+        const user = userEvent.setup();
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => anyOf.includes('environment-alert-c'));
+        renderPage();
+
+        await user.click(screen.getByRole('button', { name: /Add alert/i }));
+        expect(mockNavigate).toHaveBeenCalledWith('new');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Button } from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useNavigate } from 'react-router-dom';
+
+import { AlertsEducationalEmptyState } from '../features/alerts/components/AlertsEducationalEmptyState';
+import { ENVIRONMENT_ALERT_CREATE_PERMISSION } from '../features/alerts/utils/alertPermissions';
+
+/**
+ * Environment-level Alerts landing page.
+ *
+ * Skeleton for APIM-14910 (educational UX): the alert list and activity views land in
+ * follow-up tickets (APIM-14911 and beyond), so this page currently always renders the
+ * educational content that introduces the feature. Create is gated here so users with
+ * environment-alert-c see Add alert (same as API Alerts empty state); the form route
+ * lands in a follow-up ticket.
+ */
+export function AlertsPage() {
+    const navigate = useNavigate();
+    const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_CREATE_PERMISSION] });
+
+    return (
+        <div className="space-y-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Alerts</h1>
+                    <p className="text-sm text-muted-foreground">Get notified when your gateways or platform need attention.</p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                    {canCreate && (
+                        <Button type="button" size="sm" onClick={() => navigate('new')}>
+                            <PlusIcon className="size-4" aria-hidden="true" />
+                            Add alert
+                        </Button>
+                    )}
+                </div>
+            </div>
+
+            <AlertsEducationalEmptyState />
+        </div>
+    );
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14910

## Description

Adds the environment-level Alerts entry in the Gamma platform module: Monitoring nav item, /alerts route guarded by environment-alert-r, and an educational empty-state page that introduces why/how alerts work. List, create, and activity flows are deferred to follow-up stack PRs

## Additional context

<img width="1915" height="994" alt="image" src="https://github.com/user-attachments/assets/68ae6a22-63a8-43bb-82e7-37a1d32020d2" />

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>