### PR TITLE
feat(gateway): resolve dot segments before routing, behind handlers.request.pathHandling

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestConfiguration.java
@@ -51,4 +51,24 @@ public class RequestConfiguration {
     ) {
         return new RequestClientAuthConfiguration(headerName);
     }
+
+    @Bean
+    public RequestPathConfiguration httpRequestPathConfiguration(@Value("${handlers.request.pathHandling:RAW}") String pathHandling) {
+        RequestPathHandling handling;
+        try {
+            handling = RequestPathHandling.valueOf(pathHandling.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn(
+                "Unknown value [{}] for handlers.request.pathHandling, falling back to {}. Expected one of {}.",
+                pathHandling,
+                RequestPathHandling.RAW,
+                java.util.Arrays.toString(RequestPathHandling.values())
+            );
+            handling = RequestPathHandling.RAW;
+        }
+        if (handling != RequestPathHandling.RAW) {
+            log.info("Request path handling is set to {}: dot segments are resolved before the listener is resolved.", handling);
+        }
+        return new RequestPathConfiguration(handling);
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestPathConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestPathConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.env;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@RequiredArgsConstructor
+public class RequestPathConfiguration {
+
+    private final RequestPathHandling handling;
+
+    public boolean isEnabled() {
+        return handling != RequestPathHandling.RAW;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestPathHandling.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestPathHandling.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.env;
+
+/**
+ * How the gateway treats dot segments in an incoming request path, before the listener context path
+ * is resolved and therefore before any plan is enforced.
+ *
+ * <p>The distinction matters because the gateway both decides on that path and forwards it upstream.
+ * Left untouched, a request can be authorized as one API and, once a conforming upstream applies
+ * RFC 3986 §5.2.4, delivered to another one's backend.
+ *
+ * @author GraviteeSource Team
+ */
+public enum RequestPathHandling {
+    /**
+     * Byte-preserving pass-through: the path is used, and forwarded, exactly as it arrived. This is
+     * the historical behaviour and remains the default, so that request signing and encoded slashes
+     * keep working without any change.
+     */
+    RAW,
+
+    /**
+     * Answers {@code 400} when the normalized path differs from the one received. Nothing is
+     * rewritten and no routing decision changes, which makes it the safest way to close the gap on
+     * an existing platform.
+     */
+    REJECT,
+
+    /**
+     * Resolves the dot segments and uses the result for listener resolution, plan enforcement, flow
+     * selection and the upstream URI. The request is not blocked, it is simply read for what it
+     * means: {@code /alpha/api/../../beta/api} is a call to {@code beta}, so {@code beta}'s plan
+     * applies.
+     */
+    NORMALIZE,
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -20,6 +20,7 @@ import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ERROR;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN;
 
+import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.ExecutionMode;
@@ -28,6 +29,8 @@ import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
+import io.gravitee.gateway.env.RequestPathConfiguration;
+import io.gravitee.gateway.env.RequestPathHandling;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.http.utils.RequestUtils;
 import io.gravitee.gateway.http.vertx.VertxHttp2ServerRequest;
@@ -47,6 +50,7 @@ import io.gravitee.gateway.reactive.core.tracing.TracingHook;
 import io.gravitee.gateway.reactive.http.vertx.ClientCloseClassifier;
 import io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest;
 import io.gravitee.gateway.reactive.reactor.handler.HttpAcceptorResolver;
+import io.gravitee.gateway.reactive.reactor.path.RequestPathNormalizer;
 import io.gravitee.gateway.reactive.reactor.processor.DefaultPlatformProcessorChainFactory;
 import io.gravitee.gateway.reactive.reactor.processor.NotFoundProcessorChainFactory;
 import io.gravitee.gateway.reactor.handler.HttpAcceptor;
@@ -95,6 +99,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
     private final TracingContext gatewayTracingContext;
     private final RequestTimeoutConfiguration requestTimeoutConfiguration;
     private final RequestClientAuthConfiguration requestClientAuthConfiguration;
+    private final RequestPathConfiguration requestPathConfiguration;
     private final Vertx vertx;
     private final ComponentProvider globalComponentProvider;
     private final TracingHook tracingHook;
@@ -112,6 +117,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         TracingContext gatewayTracingContext,
         RequestTimeoutConfiguration requestTimeoutConfiguration,
         RequestClientAuthConfiguration requestClientAuthConfiguration,
+        RequestPathConfiguration requestPathConfiguration,
         Vertx vertx,
         boolean warningsEnabled
     ) {
@@ -126,6 +132,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         this.gatewayTracingContext = gatewayTracingContext;
         this.requestTimeoutConfiguration = requestTimeoutConfiguration;
         this.requestClientAuthConfiguration = requestClientAuthConfiguration;
+        this.requestPathConfiguration = requestPathConfiguration;
         this.vertx = vertx;
         this.tracingHook = new TracingHook("Processor chain");
         this.warningsEnabled = warningsEnabled;
@@ -144,7 +151,33 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
     public Completable dispatch(HttpServerRequest httpServerRequest, String serverId) {
         log.debug("Dispatching request on host {} and path {}", httpServerRequest.host(), httpServerRequest.path());
 
-        final HttpAcceptor httpAcceptor = httpAcceptorResolver.resolve(httpServerRequest.host(), httpServerRequest.path(), serverId);
+        final String rawPath = httpServerRequest.path();
+        String candidatePath = rawPath;
+
+        if (requestPathConfiguration.isEnabled()) {
+            final String normalized = RequestPathNormalizer.normalize(rawPath);
+            if (normalized != rawPath) {
+                if (requestPathConfiguration.getHandling() == RequestPathHandling.REJECT) {
+                    log.debug("Rejecting request on host {}: path [{}] carries dot segments", httpServerRequest.host(), rawPath);
+                    return httpServerRequest.response().setStatusCode(HttpStatusCode.BAD_REQUEST_400).rxEnd();
+                }
+                candidatePath = normalized;
+            }
+        }
+
+        HttpAcceptor resolvedAcceptor = httpAcceptorResolver.resolve(httpServerRequest.host(), candidatePath, serverId);
+
+        if (candidatePath != rawPath && resolvedAcceptor != null && !(resolvedAcceptor.reactor() instanceof ApiReactor<?>)) {
+            // V3 is out of scope. Its request wrapper exposes the native path and cannot be
+            // rewritten, so a normalized resolution would leave pathInfo derived from the raw path
+            // at the wrong offset. Resolving again on the raw path keeps V3 exactly as it was.
+            log.debug("Path normalization skipped for the V3 handler on host {}", httpServerRequest.host());
+            resolvedAcceptor = httpAcceptorResolver.resolve(httpServerRequest.host(), rawPath, serverId);
+            candidatePath = rawPath;
+        }
+
+        final HttpAcceptor httpAcceptor = resolvedAcceptor;
+        final String resolutionPath = candidatePath;
         Context vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
         if (httpAcceptor == null || httpAcceptor.reactor() == null) {
             log.debug(
@@ -191,6 +224,12 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         } else if (httpAcceptor.reactor() instanceof ApiReactor<?> apiReactor) {
             log.debug("Request routed to API reactor on path [{}]", httpAcceptor.path());
             MutableExecutionContext mutableCtx = prepareExecutionContext(httpServerRequest, serverId);
+            if (resolutionPath != rawPath) {
+                // Seed the lazily initialized path so that pathInfo, the flow selectors and the
+                // upstream URI are all derived from the value the acceptor actually matched.
+                // uri() and parameters() keep reading the untouched native request.
+                mutableCtx.request().path(resolutionPath);
+            }
             mutableCtx.request().contextPath(httpAcceptor.path());
             TracingContext tracingContext = apiReactor.tracingContext();
             mutableCtx.tracer(new io.gravitee.gateway.reactive.api.tracing.Tracer(vertxContext, tracingContext.opentelemetryTracer()));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizer.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.path;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Resolves the dot segments of a request path, following RFC 3986 §5.2.4.
+ *
+ * <p>Two deliberate boundaries:
+ *
+ * <ul>
+ *   <li><b>Percent-encoding is decoded only where it spells a dot segment.</b> RFC 3986 §6.2.2.2
+ *       allows decoding every unreserved character, but doing so would rewrite paths that have
+ *       nothing to do with traversal. A segment is decoded only when it resolves to {@code .} or
+ *       {@code ..}, which is exactly what {@code %2e%2e} is used for. Any other segment is carried
+ *       over untouched, encoding included.
+ *   <li><b>Encoded slashes are left alone.</b> Turning {@code %2F} into a separator is a separate
+ *       decision with its own breakage profile, and it belongs to its own option rather than being
+ *       folded in here.
+ * </ul>
+ *
+ * <p>Duplicate slashes are preserved for the same reason: an empty segment is a valid segment, and
+ * merging them is a distinct behaviour change.
+ *
+ * @author GraviteeSource Team
+ */
+public final class RequestPathNormalizer {
+
+    private static final char SEGMENT_SEPARATOR = '/';
+    private static final String CURRENT = ".";
+    private static final String PARENT = "..";
+
+    private RequestPathNormalizer() {}
+
+    /**
+     * @return the path with its dot segments resolved, or the very same instance when there is
+     *     nothing to resolve, so callers can rely on {@code ==} for the common case.
+     */
+    public static String normalize(final String path) {
+        if (path == null || path.isEmpty() || !mayContainDotSegments(path)) {
+            return path;
+        }
+
+        final boolean absolute = path.charAt(0) == SEGMENT_SEPARATOR;
+        final String[] segments = path.split("/", -1);
+        final Deque<String> resolved = new ArrayDeque<>(segments.length);
+        boolean lastWasDotSegment = false;
+
+        for (int i = absolute ? 1 : 0; i < segments.length; i++) {
+            final String segment = segments[i];
+            final String dotSegment = asDotSegment(segment);
+
+            if (CURRENT.equals(dotSegment)) {
+                lastWasDotSegment = true;
+            } else if (PARENT.equals(dotSegment)) {
+                // Popping past the root is not an error: RFC 3986 §5.2.4 discards the extra step.
+                resolved.pollLast();
+                lastWasDotSegment = true;
+            } else {
+                resolved.addLast(segment);
+                lastWasDotSegment = false;
+            }
+        }
+
+        final StringBuilder normalized = new StringBuilder(path.length());
+        if (absolute) {
+            normalized.append(SEGMENT_SEPARATOR);
+        }
+        normalized.append(String.join("/", resolved));
+        // "/a/b/.." resolves to "/a/", not "/a": a dot segment always leaves a directory behind.
+        if (lastWasDotSegment && (normalized.length() == 0 || normalized.charAt(normalized.length() - 1) != SEGMENT_SEPARATOR)) {
+            normalized.append(SEGMENT_SEPARATOR);
+        }
+
+        final String result = normalized.toString();
+        return result.equals(path) ? path : result;
+    }
+
+    /**
+     * A dot segment can be spelled several ways in the same request: {@code ..}, {@code %2e%2e},
+     * {@code .%2E}. All of them mean the parent directory to a conforming receiver.
+     *
+     * @return {@code "."}, {@code ".."}, or {@code null} when the segment is an ordinary one.
+     */
+    private static String asDotSegment(final String segment) {
+        if (segment.isEmpty() || segment.length() > 6) {
+            return null;
+        }
+        final String decoded = segment.indexOf('%') < 0 ? segment : replaceEncodedDots(segment);
+        return CURRENT.equals(decoded) || PARENT.equals(decoded) ? decoded : null;
+    }
+
+    private static String replaceEncodedDots(final String segment) {
+        final StringBuilder decoded = new StringBuilder(segment.length());
+        for (int i = 0; i < segment.length(); i++) {
+            final char c = segment.charAt(i);
+            if (c == '%' && i + 2 < segment.length() && segment.charAt(i + 1) == '2' && (segment.charAt(i + 2) | 0x20) == 'e') {
+                decoded.append('.');
+                i += 2;
+            } else {
+                decoded.append(c);
+            }
+        }
+        return decoded.toString();
+    }
+
+    private static boolean mayContainDotSegments(final String path) {
+        return path.indexOf('.') >= 0 || path.indexOf('%') >= 0;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -25,6 +25,7 @@ import io.gravitee.common.utils.UUID;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
+import io.gravitee.gateway.env.RequestPathConfiguration;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.reactive.core.connection.ConnectionDrainManager;
@@ -164,6 +165,7 @@ public class ReactorConfiguration {
         NotFoundProcessorChainFactory notFoundProcessorChainFactory,
         RequestTimeoutConfiguration requestTimeoutConfiguration,
         RequestClientAuthConfiguration requestClientAuthConfiguration,
+        RequestPathConfiguration requestPathConfiguration,
         Vertx vertx,
         TracingContext tracingContext,
         @Value("${reporters.warnings.enabled:true}") boolean warningsEnabled
@@ -180,6 +182,7 @@ public class ReactorConfiguration {
             tracingContext,
             requestTimeoutConfiguration,
             requestClientAuthConfiguration,
+            requestPathConfiguration,
             vertx,
             warningsEnabled
         );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
@@ -41,6 +41,8 @@ import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.core.processor.provider.ProcessorProviderChain;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
+import io.gravitee.gateway.env.RequestPathConfiguration;
+import io.gravitee.gateway.env.RequestPathHandling;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
@@ -216,6 +218,7 @@ class DefaultHttpRequestDispatcherTest {
             tracingContext,
             requestTimeoutConfiguration,
             requestClientAuthConfiguration,
+            new RequestPathConfiguration(RequestPathHandling.RAW),
             vertx,
             true
         );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RequestPathNormalizerTest {
+
+    @Nested
+    class Resolving_dot_segments {
+
+        @ParameterizedTest
+        @CsvSource(
+            {
+                "/alpha/api/../../beta/api/echo, /beta/api/echo",
+                "/alpha/api/../beta, /alpha/beta",
+                "/a/./b, /a/b",
+                "/a/b/./, /a/b/",
+                "/./a, /a",
+            }
+        )
+        void should_resolve_plain_dot_segments(String path, String expected) {
+            assertThat(RequestPathNormalizer.normalize(path)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            {
+                "/alpha/api/%2e%2e/%2e%2e/beta/api/echo, /beta/api/echo",
+                "/alpha/api/%2E%2E/%2E%2E/beta/api/echo, /beta/api/echo",
+                "/alpha/api/.%2e/%2e./beta/api/echo, /beta/api/echo",
+                "/a/%2e/b, /a/b",
+            }
+        )
+        void should_resolve_percent_encoded_dot_segments(String path, String expected) {
+            assertThat(RequestPathNormalizer.normalize(path)).isEqualTo(expected);
+        }
+
+        @Test
+        void should_leave_a_directory_behind_when_the_path_ends_on_a_dot_segment() {
+            assertThat(RequestPathNormalizer.normalize("/a/b/..")).isEqualTo("/a/");
+        }
+
+        @Test
+        void should_discard_the_steps_that_would_climb_above_the_root() {
+            // RFC 3986 §5.2.4 drops them rather than failing.
+            assertThat(RequestPathNormalizer.normalize("/../../x")).isEqualTo("/x");
+        }
+    }
+
+    @Nested
+    class Leaving_the_rest_untouched {
+
+        @ParameterizedTest
+        @ValueSource(
+            strings = {
+                "/alpha/api/echo",
+                "/file.txt",
+                "/a/b.c/d",
+                // An empty segment is a valid segment: merging slashes is a separate decision.
+                "/a//b",
+                // Encoded slashes belong to their own option, not to dot segment resolution.
+                "/a/b%2Fc",
+                // Encoded dots that do not spell a dot segment stay encoded.
+                "/a/x%2ey/b",
+            }
+        )
+        void should_return_the_very_same_instance_when_there_is_nothing_to_resolve(String path) {
+            assertThat(RequestPathNormalizer.normalize(path)).isSameAs(path);
+        }
+
+        @Test
+        void should_tolerate_a_null_path() {
+            assertThat(RequestPathNormalizer.normalize(null)).isNull();
+        }
+
+        @Test
+        void should_tolerate_an_empty_path() {
+            assertThat(RequestPathNormalizer.normalize("")).isEmpty();
+        }
+
+        @Test
+        void should_keep_the_query_string_out_of_its_business() {
+            // normalize() only ever sees a path: the query is carried by uri(), untouched.
+            assertThat(RequestPathNormalizer.normalize("/a/../b")).isEqualTo("/b");
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -741,6 +741,15 @@ services:
 
 #handlers:
 #  request:
+#    # How dot segments in the request path are treated, before the listener context path is
+#    # resolved and therefore before any plan is enforced. V4 APIs only.
+#    #   RAW       (default) the path is used, and forwarded, exactly as received.
+#    #   REJECT    answers 400 when the normalized path differs from the one received.
+#    #   NORMALIZE resolves the dot segments and routes, enforces and forwards on the result,
+#    #             so /alpha/api/../../beta/api is read as the call to beta that it is.
+#    # RAW is kept as the default for backward compatibility: switching changes which API a
+#    # request carrying "../" or "%2e%2e" is routed to, and what is sent upstream.
+#    pathHandling: RAW
 #    # manage traceparent header defined by W3C trace-context specification
 #    trace-context:
 #      enabled: false

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingV4IntegrationTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.pathtraversal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the three values of {@code handlers.request.pathHandling} against the same pair of APIs:
+ * {@code alpha} on {@code /alpha/api/} with no plan, {@code beta} on {@code /beta/api/} behind an
+ * api-key plan, both pointing at the same upstream host.
+ *
+ * <p>The request under test, {@code /alpha/api/../../beta/api/echo}, means one thing to the gateway
+ * when it reads the path as it arrived, and another to any receiver applying RFC 3986 §5.2.4. Each
+ * mode below is one answer to that disagreement.
+ *
+ * <p>V4 APIs only. The V3 handler keeps its historical behaviour whatever the setting, because its
+ * request wrapper exposes the native path and cannot be rewritten.
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PathHandlingV4IntegrationTest {
+
+    private static final String TRAVERSAL = "/alpha/api/../../beta/api/echo";
+    private static final String ENCODED_TRAVERSAL = "/alpha/api/%2e%2e/%2e%2e/beta/api/echo";
+    private static final String REGULAR = "/alpha/api/echo";
+
+    /**
+     * Base wiring shared by the three modes. Only {@link #configureGateway} differs between them,
+     * which is the whole point of the comparison.
+     */
+    abstract static class PathHandlingTest extends AbstractGatewayTest {
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.put(
+                "api-key",
+                PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
+            );
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            if (isV4Api(definitionClass) && "beta".equals(api.getId())) {
+                configurePlans((Api) api.getDefinition(), Set.of("api-key"));
+            }
+        }
+
+        protected void assertStatus(final HttpClient httpClient, final String rawPath, final int expectedStatus)
+            throws InterruptedException {
+            httpClient
+                .rxRequest(HttpMethod.GET, rawPath)
+                .flatMap(HttpClientRequest::rxSend)
+                .test()
+                .await()
+                .assertComplete()
+                .assertValue(response -> {
+                    assertThat(response.statusCode()).isEqualTo(expectedStatus);
+                    return true;
+                })
+                .assertNoErrors();
+        }
+
+        protected String singleUpstreamRequestUrl() {
+            final List<LoggedRequest> upstreamRequests = wiremock.findAll(getRequestedFor(anyUrl()));
+            assertThat(upstreamRequests).hasSize(1);
+            return upstreamRequests.get(0).getUrl();
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi({ "/apis/v4/http/pathtraversal/api-alpha.json", "/apis/v4/http/pathtraversal/api-beta.json" })
+    class With_raw_handling extends PathHandlingTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("handlers.request.pathHandling", "RAW");
+        }
+
+        @Test
+        void should_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, REGULAR, 200);
+        }
+
+        @Test
+        void should_keep_the_bypass_because_nothing_is_resolved(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // The historical behaviour, kept as the default so no deployment changes on upgrade.
+            assertStatus(httpClient, TRAVERSAL, 200);
+
+            assertThat(singleUpstreamRequestUrl()).isEqualTo(TRAVERSAL);
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi({ "/apis/v4/http/pathtraversal/api-alpha.json", "/apis/v4/http/pathtraversal/api-beta.json" })
+    class With_reject_handling extends PathHandlingTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("handlers.request.pathHandling", "REJECT");
+        }
+
+        @Test
+        void should_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, REGULAR, 200);
+
+            assertThat(singleUpstreamRequestUrl()).isEqualTo(REGULAR);
+        }
+
+        @Test
+        void should_reject_dot_segments_before_any_api_is_selected(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, TRAVERSAL, 400);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_reject_encoded_dot_segments(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, ENCODED_TRAVERSAL, 400);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi({ "/apis/v4/http/pathtraversal/api-alpha.json", "/apis/v4/http/pathtraversal/api-beta.json" })
+    class With_normalize_handling extends PathHandlingTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("handlers.request.pathHandling", "NORMALIZE");
+        }
+
+        @Test
+        void should_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, REGULAR, 200);
+
+            assertThat(singleUpstreamRequestUrl()).isEqualTo(REGULAR);
+        }
+
+        @Test
+        void should_enforce_the_plan_of_the_api_the_resolved_path_designates(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // Resolved, the request is a call to beta, so beta's api-key plan applies and answers
+            // 401 for want of a key. The request is not blocked as malformed, it is simply read
+            // for what it means.
+            assertStatus(httpClient, TRAVERSAL, 401);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_enforce_that_plan_on_encoded_dot_segments_too(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, ENCODED_TRAVERSAL, 401);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_answer_not_found_when_the_resolved_path_matches_no_api(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // The other half of the defect: escaping the configured endpoint target no longer
+            // reaches a neighbour of that target, because the gateway now reads where the request
+            // actually points and finds no listener there.
+            assertStatus(httpClient, "/alpha/api/../../elsewhere/resource", 404);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathTraversalOrganizationGuardV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathTraversalOrganizationGuardV4IntegrationTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.pathtraversal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployOrganization;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.gravitee.policy.groovy.GroovyInitializer;
+import io.gravitee.policy.groovy.GroovyPolicy;
+import io.gravitee.policy.groovy.configuration.GroovyPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the mitigation available without a gateway change: a Groovy policy on an organization flow
+ * that rejects any request whose path carries dot segments.
+ *
+ * <p>An organization flow runs inside the API reactor but ahead of the security chain and of the
+ * backend call, so it closes the traversal for every API on the gateway at once, including APIs
+ * published later, and without touching a single API definition.
+ *
+ * <p>Its limit is worth stating precisely, and the last test pins it: the API has already been
+ * selected by the time the policy runs, so the guard can only <em>reject</em> the request. It cannot
+ * route it to the API the resolved path actually designates. Reaching that behaviour requires
+ * normalizing before listener resolution, which is a gateway-level change.
+ *
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DeployOrganization(
+    organization = "/organizations/organization-reject-dot-segments.json",
+    apis = { "/apis/v4/http/pathtraversal/api-alpha.json", "/apis/v4/http/pathtraversal/api-beta.json" }
+)
+class PathTraversalOrganizationGuardV4IntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put("groovy", PolicyBuilder.build("groovy", GroovyPolicy.class, GroovyPolicyConfiguration.class, GroovyInitializer.class));
+        policies.put(
+            "api-key",
+            PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
+        );
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        if (isV4Api(definitionClass) && "beta".equals(api.getId())) {
+            configurePlans((Api) api.getDefinition(), Set.of("api-key"));
+        }
+    }
+
+    @Test
+    void should_still_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        assertStatus(httpClient, "/alpha/api/echo", 200);
+    }
+
+    @Test
+    void should_reject_dot_segments_before_the_backend_is_called(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        assertStatus(httpClient, "/alpha/api/../../beta/api/echo", 400);
+
+        assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+    }
+
+    @Test
+    void should_reject_encoded_dot_segments_before_the_backend_is_called(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        assertStatus(httpClient, "/alpha/api/%2e%2e/%2e%2e/beta/api/echo", 400);
+
+        assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+    }
+
+    @Test
+    void should_reject_rather_than_route_to_the_api_the_resolved_path_designates(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        // Once resolved the path designates beta, whose plan would answer 401 without an api key.
+        // The guard answers 400 instead: it interrupts, it does not re-route. This is the gap that
+        // only front-door normalization closes.
+        assertStatus(httpClient, "/alpha/api/../../beta/api/echo", 400);
+
+        assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+    }
+
+    private void assertStatus(final HttpClient httpClient, final String rawPath, final int expectedStatus) throws InterruptedException {
+        httpClient
+            .rxRequest(HttpMethod.GET, rawPath)
+            .flatMap(HttpClientRequest::rxSend)
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(expectedStatus);
+                return true;
+            })
+            .assertNoErrors();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathTraversalV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathTraversalV4IntegrationTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.pathtraversal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the gateway's current handling of dot segments in a request path.
+ *
+ * <p>Two v4 HTTP proxy APIs share one upstream host, each on its own path prefix: {@code alpha} on
+ * {@code /alpha/api/} with no plan, so it is reachable without any credential, and {@code beta} on
+ * {@code /beta/api/} behind an api-key plan, so it must never be reached without a key.
+ *
+ * <p>The gateway resolves the listener context path against the request path exactly as it arrived,
+ * enforces the matched API's plan, then appends the remaining path to the endpoint target without
+ * resolving it. A conforming upstream applies RFC 3986 §5.2.4 and serves a different resource than
+ * the one the gateway authorized.
+ *
+ * <p><strong>These assertions describe the behaviour as it stands, not the behaviour we want.</strong>
+ * They exist so the change is visible the day the gateway starts normalizing: this class is expected
+ * to go red, and the expectations below then become 401 or 404 rather than 200.
+ *
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DeployApi({ "/apis/v4/http/pathtraversal/api-alpha.json", "/apis/v4/http/pathtraversal/api-beta.json" })
+class PathTraversalV4IntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put(
+            "api-key",
+            PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
+        );
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    /** Only beta carries a plan, so any bypass below is obtained with no credential at all. */
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        if (isV4Api(definitionClass) && "beta".equals(api.getId())) {
+            configurePlans((Api) api.getDefinition(), Set.of("api-key"));
+        }
+    }
+
+    @Test
+    void should_serve_alpha_on_a_regular_path(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        assertStatus(httpClient, "/alpha/api/echo", 200);
+
+        assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/echo");
+    }
+
+    @Test
+    void should_reject_a_direct_call_to_beta_without_its_api_key(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        assertStatus(httpClient, "/beta/api/echo", 401);
+
+        assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+    }
+
+    @Test
+    void should_reach_beta_backend_through_dot_segments_without_any_credential(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        // Same resource as the call above, spelled so that the raw path still starts with alpha's
+        // context path. Alpha is selected, alpha's absent plan lets it through, and the upstream
+        // resolves the segments back to beta.
+        assertStatus(httpClient, "/alpha/api/../../beta/api/echo", 200);
+
+        // The gateway resolved nothing: it emitted its own target's base path followed by the
+        // client-controlled remainder, which lands outside that base path once resolved.
+        assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/../../beta/api/echo");
+    }
+
+    @Test
+    void should_reach_beta_backend_through_encoded_dot_segments(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        // Percent-encoded dots. Removing dot segments without first decoding the unreserved
+        // characters, as RFC 3986 §6.2.2.2 requires, would leave this variant open.
+        assertStatus(httpClient, "/alpha/api/%2e%2e/%2e%2e/beta/api/echo", 200);
+
+        assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/%2e%2e/%2e%2e/beta/api/echo");
+    }
+
+    @Test
+    void should_forward_a_path_that_escapes_the_configured_endpoint_target(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        // Nothing to do with a second API: the emitted URI simply leaves the subtree of the target
+        // configured on alpha's endpoint, which is enough to reach any neighbour of that target.
+        assertStatus(httpClient, "/alpha/api/../../elsewhere/resource", 200);
+
+        assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/../../elsewhere/resource");
+    }
+
+    private void assertStatus(final HttpClient httpClient, final String rawPath, final int expectedStatus) throws InterruptedException {
+        httpClient
+            .rxRequest(HttpMethod.GET, rawPath)
+            .flatMap(HttpClientRequest::rxSend)
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(expectedStatus);
+                return true;
+            })
+            .assertNoErrors();
+    }
+
+    /** The request line the gateway emitted upstream, verbatim. */
+    private String singleUpstreamRequestUrl() {
+        final List<LoggedRequest> upstreamRequests = wiremock.findAll(getRequestedFor(anyUrl()));
+        assertThat(upstreamRequests).hasSize(1);
+        return upstreamRequests.get(0).getUrl();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-alpha.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-alpha.json
@@ -1,0 +1,48 @@
+{
+  "id": "alpha",
+  "name": "alpha",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/alpha/api/"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/alpha/api"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-beta.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-beta.json
@@ -1,0 +1,48 @@
+{
+  "id": "beta",
+  "name": "beta",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/beta/api/"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/beta/api"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/organizations/organization-reject-dot-segments.json
+++ b/gravitee-apim-integration-tests/src/test/resources/organizations/organization-reject-dot-segments.json
@@ -1,0 +1,30 @@
+{
+  "id": "DEFAULT",
+  "hrids": ["default"],
+  "name": "Reject dot segments",
+  "description": "Platform flow rejecting any request whose path carries dot segments, encoded or not.",
+  "flowMode": "DEFAULT",
+  "flows": [
+    {
+      "name": "reject-dot-segments",
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "pre": [
+        {
+          "name": "Reject dot segments",
+          "description": "Interrupts the request before its plan is enforced and before the backend is invoked.",
+          "enabled": true,
+          "policy": "groovy",
+          "configuration": {
+            "script": "import io.gravitee.policy.groovy.PolicyResult.State\nString path = request.path.toLowerCase()\nif (path.contains('..') || path.contains('%2e')) {\n    result.state = State.FAILURE\n    result.code = 400\n    result.error = 'Request path contains dot segments'\n}\n"
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
**Description**

Reported on 4.11.6 (Zendesk 17952). The gateway resolves the listener context path against the request path exactly as it arrived, enforces the matched API's plan, then appends the remaining path to the endpoint target without resolving it. A conforming upstream applies RFC 3986 §5.2.4 and serves a different resource than the one the gateway authorized.

Reproduced on a clean stack: with `alpha` on `/alpha/api/` carrying no plan and `beta` on `/beta/api/` behind an api-key plan, both pointing at the same upstream host, `GET /alpha/api/../../beta/api/echo` reaches beta's backend with **no credential at all**, while `GET /beta/api/echo` correctly answers 401. The same holds for `%2e%2e`, and `/alpha/api/../../elsewhere/resource` escapes the subtree of the configured endpoint target entirely — no second API needed.

### What this adds

A single gateway-level setting, `handlers.request.pathHandling`, applied **before** the listener is resolved and therefore before any plan is enforced:

| Mode | Behaviour |
|---|---|
| `RAW` | **Default.** The path is used, and forwarded, exactly as received. Today's behaviour. |
| `REJECT` | Answers 400 when the normalized path differs from the one received. Nothing is rewritten, no routing decision changes. |
| `NORMALIZE` | Resolves the dot segments and uses the result for listener resolution, plan enforcement, flow selection and the upstream URI. |

`NORMALIZE` does not block the request, it makes the gateway read it for what it means: `/alpha/api/../../beta/api` is a call to beta, so beta's plan applies and answers 401 for want of a key. Where the resolved path matches no listener, 404.

State of the art, checked rather than assumed: nginx normalizes before location matching, but Envoy documents `normalize_path` as **false** by default ("will default to true in the future"), HAProxy makes it an explicit `http-request normalize-uri` action, and Apache ships `AllowEncodedSlashes Off`. Normalization is not universally on by default — what is universal is that the behaviour is configurable, which is what the gateway was missing.

Normalization decodes percent-encoding **only** in segments that spell a dot segment, so `%2e%2e` is covered while unrelated encoded characters are carried over untouched. Encoded slashes are deliberately left alone: turning `%2F` into a separator has its own breakage profile and belongs to its own option, as Envoy separates it into `path_with_escaped_slashes_action`. Duplicate slashes are preserved for the same reason.

### Scope of this increment

`REJECT` applies to every definition version: it answers before the acceptor is resolved, so it never reaches the code that distinguishes V4 from V3. Only established at code level here — the integration tests cover V4 APIs.

`NORMALIZE` is **V4 only in this increment**. The V3 handler exposes the native request path through a wrapper that cannot be rewritten, so a normalized resolution would leave `pathInfo` derived from the raw path at the wrong offset; when a normalized path resolves to a V3 handler, the dispatcher resolves again on the raw path and V3 keeps its historical behaviour. Extending `NORMALIZE` to the earlier definition versions belongs to the fix, it is simply not in this first step — as does the identical concatenation in `DefaultProxyEndpoint`.

### Coverage

- `PathHandlingV4IntegrationTest` — the three modes against the same pair of APIs, one nested class per mode.
- `PathTraversalV4IntegrationTest` — pins the `RAW` behaviour, including the exact unresolved request line emitted upstream.
- `PathTraversalOrganizationGuardV4IntegrationTest` — the mitigation deployable without upgrading: a Groovy policy on an organization flow. It runs ahead of the security chain, so it closes the traversal for every API at once, but the last test pins its limit — the API is already selected when it runs, so it can only reject, never route to the API the resolved path designates.
- `RequestPathNormalizerTest` — dot segment resolution, encoded variants, above-root climbs, and everything deliberately left untouched.

The 257 existing unit tests of the reactor module still pass.

**Additional context**

**Open question — the default.** `RAW` is kept so that nothing changes on upgrade, which also means the gap stays open unless an operator opts in. The argument for flipping the default to `NORMALIZE` on `master`, while leaving `RAW` on the maintenance branches, is that a security fix shipped off by default protects nobody; the argument against is that switching changes which API a request carrying `../` is routed to, and what is sent upstream. Worth settling before this leaves draft.

Also worth knowing for anyone writing the Groovy guard: `PolicyResult.State` exposes `SUCCESS` and `FAILURE` only. Using a non-existent constant surfaces as `SecurityException: Failed to resolve getter method or field` from the sandbox, which reads like a sandbox denial rather than a typo.
