### PR TITLE
feat(gamma-platform): added new two column sidebar UI

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -25,12 +25,14 @@ jest.mock('./PlatformToaster', () => ({
     PlatformToaster: () => <div data-testid="platform-toaster" />,
 }));
 
+const mockUseModuleRouting = jest.fn(() => ({
+    activeNavKey: 'applications',
+    navigateToKey: jest.fn(),
+    rootPath: '/platform',
+}));
+
 jest.mock('@gravitee/gamma-modules-sdk/routing', () => ({
-    useModuleRouting: () => ({
-        activeNavKey: 'applications',
-        navigateToKey: jest.fn(),
-        rootPath: '/platform',
-    }),
+    useModuleRouting: () => mockUseModuleRouting(),
 }));
 
 const mockUseLayoutConfig = jest.fn();
@@ -40,7 +42,8 @@ jest.mock('@gravitee/graphene-core', () => {
     return {
         ...actual,
         useLayoutConfig: (config: unknown, deps: unknown) => mockUseLayoutConfig(config, deps),
-        SidebarNavigation: () => null,
+        ContextSidebar: () => null,
+        ContextToggleButton: () => null,
         buildLinearBreadcrumbs: () => [],
     };
 });
@@ -99,23 +102,48 @@ jest.mock('../pages/ApplicationDetailSubscriptionPage', () => ({
     ApplicationDetailSubscriptionPage: () => null,
 }));
 
-function renderPlatform() {
+function renderPlatform(path = '/applications') {
     render(
-        <MemoryRouter initialEntries={['/applications']}>
+        <MemoryRouter initialEntries={[path]}>
             <AppRoutes />
         </MemoryRouter>,
     );
 }
 
+type LayoutConfig = {
+    navigation?: { props?: { items?: { key: string; title: string }[]; onItemSelect?: (key: string) => void } };
+    contextSidebar?: { props?: { groups?: { items: { key: string }[] }[]; onItemSelect?: (key: string) => void } };
+};
+
+function layoutConfigs(): LayoutConfig[] {
+    return mockUseLayoutConfig.mock.calls.map(call => call[0] as LayoutConfig);
+}
+
+function primaryNav() {
+    return layoutConfigs().findLast(config => config.navigation)?.navigation;
+}
+
+function contextSidebar() {
+    return layoutConfigs().findLast(config => config.contextSidebar)?.contextSidebar;
+}
+
 function visibleNavKeys(): string[] {
-    const config = mockUseLayoutConfig.mock.calls.at(-1)?.[0] as { navigation?: { props?: { groups?: unknown } } } | undefined;
-    const groups = (config?.navigation?.props?.groups ?? []) as { items: { key: string }[] }[];
+    const groups = contextSidebar()?.props?.groups ?? [];
     return groups.flatMap(group => group.items.map(item => item.key));
+}
+
+function primaryNavKeys(): string[] {
+    return primaryNav()?.props?.items?.map(item => item.key) ?? [];
 }
 
 describe('AppRoutes', () => {
     beforeEach(() => {
         mockUseLayoutConfig.mockClear();
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'applications',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
         mockUseHasPermission.mockReset().mockReturnValue(true);
         mockUseEnvironmentDictionaries.mockReturnValue({
             data: [],
@@ -168,16 +196,48 @@ describe('AppRoutes', () => {
         expect(screen.getByTestId('group-detail-page')).not.toBeNull();
     });
 
-    it('shows the Groups nav item when the user has read permission', () => {
+    it('shows Organization, Environment, and Team in the primary sidebar', () => {
         renderPlatform();
+
+        expect(primaryNavKeys()).toEqual(['organization', 'environment', 'team']);
+        expect(primaryNav()?.props?.items?.map(item => item.title)).toEqual(['Organization', 'Environment', 'Team']);
+    });
+
+    it('does not show a General primary nav item', () => {
+        renderPlatform();
+
+        expect(primaryNavKeys()).not.toContain('general');
+    });
+
+    it('shows Applications in the Environment context sidebar', () => {
+        renderPlatform();
+
+        expect(visibleNavKeys()).toContain('applications');
+        expect(visibleNavKeys()).toContain('metadata');
+        expect(visibleNavKeys()).toContain('dictionaries');
+        expect(visibleNavKeys()).not.toContain('users');
+    });
+
+    it('shows the User Groups nav item when the user has read permission', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'user-groups',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        renderPlatform('/user-groups');
 
         expect(visibleNavKeys()).toContain('user-groups');
     });
 
     it('hides the Groups nav item when the user lacks environment-group-r', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'user-groups',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
         mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-group-r'));
 
-        renderPlatform();
+        renderPlatform('/user-groups');
 
         expect(visibleNavKeys()).not.toContain('user-groups');
     });
@@ -246,5 +306,61 @@ describe('AppRoutes', () => {
         );
 
         expect(screen.getByTestId('user-detail-page')).not.toBeNull();
+    });
+
+    it('navigates to the first visible item when a different primary section is selected', () => {
+        const navigateToKey = jest.fn();
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'applications',
+            navigateToKey,
+            rootPath: '/platform',
+        });
+        renderPlatform();
+
+        primaryNav()?.props?.onItemSelect?.('team');
+
+        expect(navigateToKey).toHaveBeenCalledWith('users');
+    });
+
+    it('does not navigate when the already-active primary section is selected', () => {
+        const navigateToKey = jest.fn();
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'applications',
+            navigateToKey,
+            rootPath: '/platform',
+        });
+        renderPlatform();
+
+        primaryNav()?.props?.onItemSelect?.('environment');
+
+        expect(navigateToKey).not.toHaveBeenCalled();
+    });
+
+    it('navigates context sidebar items by their own keys', () => {
+        const navigateToKey = jest.fn();
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'applications',
+            navigateToKey,
+            rootPath: '/platform',
+        });
+        renderPlatform();
+
+        contextSidebar()?.props?.onItemSelect?.('metadata');
+
+        expect(navigateToKey).toHaveBeenCalledWith('metadata');
+    });
+
+    it('does not set a platform context sidebar on application detail pages', () => {
+        renderPlatform('/applications/app-1');
+
+        expect(screen.getByTestId('application-detail-layout')).not.toBeNull();
+        expect(primaryNavKeys()).toEqual(['organization', 'environment', 'team']);
+        expect(contextSidebar()).toBeUndefined();
+    });
+
+    it('routes to the register application page under the platform module', () => {
+        renderPlatform('/applications/new');
+
+        expect(screen.getByTestId('register-application-page')).not.toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -14,15 +14,33 @@
  * limitations under the License.
  */
 import { useModuleRouting } from '@gravitee/gamma-modules-sdk/routing';
-import { buildLinearBreadcrumbs, SidebarNavigation, useLayoutConfig } from '@gravitee/graphene-core';
+import {
+    buildLinearBreadcrumbs,
+    ContextSidebar,
+    ContextToggleButton,
+    type NavItem,
+    SidebarGroup,
+    SidebarGroupContent,
+    SidebarMenu,
+    SidebarMenuButton,
+    SidebarMenuItem,
+    useLayoutConfig,
+} from '@gravitee/graphene-core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { type ReactElement, useMemo } from 'react';
+import { createContext, type ReactElement, useCallback, useContext, useMemo, useState } from 'react';
 import { Navigate, Outlet, Route, Routes, useNavigate } from 'react-router-dom';
 
 import { PlatformToaster } from './PlatformToaster';
 import { APPLICATION_NAV_GROUPS, flattenApplicationDetailNavItems } from '../config/applicationDetailNavigation';
 import { applicationDetailTabElement } from '../config/applicationDetailPages';
-import { NAV_GROUPS } from '../config/navigation';
+import {
+    filterNavSections,
+    findNavSectionKey,
+    firstNavItemKey,
+    NAV_SECTIONS,
+    platformPrimaryNavItems,
+    type PlatformNavSection,
+} from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
 import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
@@ -124,10 +142,60 @@ function EntrypointsGuard() {
     return <EntrypointsAndShardingTagsPage />;
 }
 
+function PlatformPrimaryNavigation({
+    items,
+    activeItemKey,
+    onItemSelect,
+}: Readonly<{ items: NavItem[]; activeItemKey?: string; onItemSelect: (key: string) => void }>) {
+    return (
+        <SidebarGroup>
+            <SidebarGroupContent>
+                <SidebarMenu>
+                    {items.map(item => {
+                        const Icon = item.icon;
+                        return (
+                            <SidebarMenuItem key={item.key}>
+                                <SidebarMenuButton
+                                    isActive={item.key === activeItemKey}
+                                    tooltip={item.title}
+                                    onClick={() => onItemSelect(item.key)}
+                                >
+                                    {Icon ? <Icon /> : null}
+                                    <span>{item.title}</span>
+                                </SidebarMenuButton>
+                            </SidebarMenuItem>
+                        );
+                    })}
+                </SidebarMenu>
+            </SidebarGroupContent>
+        </SidebarGroup>
+    );
+}
+
+interface PlatformNavContextValue {
+    readonly activeNavKey: string;
+    readonly activeSection: PlatformNavSection | undefined;
+    readonly navigateToKey: (key: string) => void;
+    readonly contextExpanded: boolean;
+    readonly toggleContext: () => void;
+}
+
+const PlatformNavContext = createContext<PlatformNavContextValue | null>(null);
+
+function usePlatformNavContext(): PlatformNavContextValue {
+    const value = useContext(PlatformNavContext);
+    if (!value) {
+        throw new Error('PlatformSectionLayout must render inside ModuleLayout');
+    }
+    return value;
+}
+
 function ModuleLayout() {
     useEnvironmentPermissions();
 
     const permissionsReady = useEnvironmentPermissionsReady();
+    const [contextExpanded, setContextExpanded] = useState(true);
+    const toggleContext = useCallback(() => setContextExpanded(expanded => !expanded), []);
 
     // Only probe the resource once the permission map already says "yes" — that's the only case where a
     // 403 here would disagree with it. Probing unconditionally would hit both list APIs on every platform
@@ -145,29 +213,76 @@ function ModuleLayout() {
     const canReadEntrypoints = useHasPermission({ anyOf: ['environment-entrypoint-r', 'organization-entrypoint-r'] });
     const canReadGroups = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_READ_PERMISSION] });
 
-    const navigate = useNavigate();
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
 
-    const visibleNavGroups = useMemo(
+    const visibleNavSections = useMemo(
         () =>
-            NAV_GROUPS.map(group => ({
-                ...group,
-                items: group.items.filter(item =>
-                    isNavItemVisible(
-                        item.key,
-                        permissionsReady,
-                        canReadMetadata,
-                        canReadDictionaries,
-                        canAccessUsers,
-                        canReadGateways,
-                        canReadEntrypoints,
-                        canReadGroups,
-                    ),
+            filterNavSections(NAV_SECTIONS, itemKey =>
+                isNavItemVisible(
+                    itemKey,
+                    permissionsReady,
+                    canReadMetadata,
+                    canReadDictionaries,
+                    canAccessUsers,
+                    canReadGateways,
+                    canReadEntrypoints,
+                    canReadGroups,
                 ),
-            })).filter(group => group.items.length > 0),
+            ),
         [permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers, canReadGateways, canReadEntrypoints, canReadGroups],
     );
 
+    const activeSectionKey = findNavSectionKey(visibleNavSections, activeNavKey) ?? visibleNavSections[0]?.key;
+    const activeSection = visibleNavSections.find(section => section.key === activeSectionKey);
+
+    const handleSectionSelect = useCallback(
+        (key: string) => {
+            const section = visibleNavSections.find(candidate => candidate.key === key);
+            if (!section) {
+                return;
+            }
+            // Compare against the section that owns the current page, not activeSectionKey.
+            // activeSectionKey falls back to the first visible section, which would no-op a click
+            // onto that section when the current page is not in any visible section.
+            if (findNavSectionKey(visibleNavSections, activeNavKey) === section.key) {
+                return;
+            }
+            const firstKey = firstNavItemKey(section);
+            if (firstKey) {
+                navigateToKey(firstKey);
+            }
+        },
+        [activeNavKey, navigateToKey, visibleNavSections],
+    );
+
+    useLayoutConfig(
+        {
+            navigation: (
+                <PlatformPrimaryNavigation
+                    items={platformPrimaryNavItems(visibleNavSections)}
+                    activeItemKey={activeSectionKey}
+                    onItemSelect={handleSectionSelect}
+                />
+            ),
+        },
+        [activeSectionKey, handleSectionSelect, visibleNavSections],
+    );
+
+    const navContext = useMemo(
+        () => ({ activeNavKey, activeSection, navigateToKey, contextExpanded, toggleContext }),
+        [activeNavKey, activeSection, navigateToKey, contextExpanded, toggleContext],
+    );
+
+    return (
+        <PlatformNavContext.Provider value={navContext}>
+            <Outlet />
+        </PlatformNavContext.Provider>
+    );
+}
+
+function PlatformSectionLayout() {
+    const { activeNavKey, activeSection, navigateToKey, contextExpanded, toggleContext } = usePlatformNavContext();
+    const navigate = useNavigate();
     const breadcrumbs = useMemo(
         () => buildLinearBreadcrumbs(navigate, [{ label: PLATFORM_ROUTE_CONFIG.routes[activeNavKey].label }]),
         [activeNavKey, navigate],
@@ -175,10 +290,15 @@ function ModuleLayout() {
 
     useLayoutConfig(
         {
-            navigation: <SidebarNavigation groups={visibleNavGroups} activeItemKey={activeNavKey} onItemSelect={navigateToKey} />,
+            viewMode: 'context',
+            contextExpanded,
+            contextSidebar: (
+                <ContextSidebar groups={activeSection?.groups ?? []} activeItemKey={activeNavKey} onItemSelect={navigateToKey} />
+            ),
+            leading: <ContextToggleButton expanded={contextExpanded} onToggle={toggleContext} />,
             breadcrumbs,
         },
-        [activeNavKey, breadcrumbs, navigateToKey, visibleNavGroups],
+        [activeNavKey, activeSection, breadcrumbs, contextExpanded, navigateToKey, toggleContext],
     );
 
     return <Outlet />;
@@ -192,114 +312,120 @@ export function AppRoutes() {
                 <PlatformToaster />
                 <Routes>
                     <Route element={<ModuleLayout />}>
-                        <Route index element={<Navigate to="applications" replace />} />
-                        <Route path="applications">
-                            <Route index element={<ApplicationsPage />} />
-                            <Route path="new" element={<RegisterApplicationPage />} />
-                            <Route path=":applicationId" element={<ApplicationDetailLayout />}>
-                                <Route index element={<ApplicationDetailIndexRedirect />} />
-                                {APPLICATION_DETAIL_TABS.map(tab => (
-                                    <Route key={tab.path} path={tab.path} element={applicationDetailTabElement(tab.path, tab.label)} />
-                                ))}
-                                <Route path="subscriptions/:subscriptionId" element={<ApplicationDetailSubscriptionPage />} />
-                                <Route path="*" element={<ApplicationDetailIndexRedirect />} />
+                        <Route element={<PlatformSectionLayout />}>
+                            <Route index element={<Navigate to="applications" replace />} />
+                            <Route path="applications" element={<ApplicationsPage />} />
+                            <Route path="applications/new" element={<RegisterApplicationPage />} />
+                            <Route path="access-management" element={<AccessManagementPage />} />
+                            <Route path="users">
+                                <Route
+                                    index
+                                    element={
+                                        <PermissionPageGuard anyOf={ORGANIZATION_USER_ACCESS_PERMISSIONS}>
+                                            <UsersPage />
+                                        </PermissionPageGuard>
+                                    }
+                                />
+                                <Route
+                                    path=":userId"
+                                    element={
+                                        <PermissionPageGuard anyOf={ORGANIZATION_USER_ACCESS_PERMISSIONS}>
+                                            <UserDetailPage />
+                                        </PermissionPageGuard>
+                                    }
+                                />
                             </Route>
-                        </Route>
-                        <Route path="access-management" element={<AccessManagementPage />} />
-                        <Route path="users">
-                            <Route
-                                index
-                                element={
-                                    <PermissionPageGuard anyOf={ORGANIZATION_USER_ACCESS_PERMISSIONS}>
-                                        <UsersPage />
-                                    </PermissionPageGuard>
-                                }
-                            />
-                            <Route
-                                path=":userId"
-                                element={
-                                    <PermissionPageGuard anyOf={ORGANIZATION_USER_ACCESS_PERMISSIONS}>
-                                        <UserDetailPage />
-                                    </PermissionPageGuard>
-                                }
-                            />
-                        </Route>
-                        <Route path="user-groups">
-                            <Route
-                                index
-                                element={
-                                    <PermissionPageGuard permission={ENVIRONMENT_GROUP_READ_PERMISSION} unauthorizedTo="../applications">
-                                        <GroupsPage />
-                                    </PermissionPageGuard>
-                                }
-                            />
-                            <Route
-                                path=":groupId"
-                                element={
-                                    <PermissionPageGuard permission={ENVIRONMENT_GROUP_READ_PERMISSION} unauthorizedTo="../../applications">
-                                        <GroupDetailPage />
-                                    </PermissionPageGuard>
-                                }
-                            />
-                        </Route>
-                        <Route
-                            path="metadata"
-                            element={
-                                <PermissionPageGuard permission="environment-metadata-r">
-                                    <MetadataPage />
-                                </PermissionPageGuard>
-                            }
-                        />
-                        <Route path="dictionaries">
-                            <Route
-                                index
-                                element={
-                                    <PermissionPageGuard permission="environment-dictionary-r" unauthorizedTo="../applications">
-                                        <DictionariesPage />
-                                    </PermissionPageGuard>
-                                }
-                            />
-                            <Route
-                                path=":dictionaryId"
-                                element={
-                                    <PermissionPageGuard
-                                        anyOf={[
-                                            'environment-dictionary-c',
-                                            'environment-dictionary-r',
-                                            'environment-dictionary-u',
-                                            'environment-dictionary-d',
-                                        ]}
-                                        unauthorizedTo="../../applications"
-                                    >
-                                        <DictionaryDetailPage />
-                                    </PermissionPageGuard>
-                                }
-                            />
-                        </Route>
-                        <Route path="gateways">
-                            <Route
-                                index
-                                element={
-                                    <PermissionPageGuard permission="environment-instance-r" unauthorizedTo="../applications">
-                                        <GatewayInstancesPage />
-                                    </PermissionPageGuard>
-                                }
-                            />
-                            <Route
-                                path=":instanceId"
-                                element={
-                                    <PermissionPageGuard permission="environment-instance-r" unauthorizedTo="../../applications">
-                                        <GatewayInstanceDetailLayout />
-                                    </PermissionPageGuard>
-                                }
-                            >
-                                <Route index element={<Navigate to="environment" replace />} />
-                                <Route path="environment" element={<GatewayInstanceEnvironmentPage />} />
-                                <Route path="monitoring" element={<GatewayInstanceMonitoringPage />} />
+                            <Route path="user-groups">
+                                <Route
+                                    index
+                                    element={
+                                        <PermissionPageGuard
+                                            permission={ENVIRONMENT_GROUP_READ_PERMISSION}
+                                            unauthorizedTo="../applications"
+                                        >
+                                            <GroupsPage />
+                                        </PermissionPageGuard>
+                                    }
+                                />
+                                <Route
+                                    path=":groupId"
+                                    element={
+                                        <PermissionPageGuard
+                                            permission={ENVIRONMENT_GROUP_READ_PERMISSION}
+                                            unauthorizedTo="../../applications"
+                                        >
+                                            <GroupDetailPage />
+                                        </PermissionPageGuard>
+                                    }
+                                />
                             </Route>
+                            <Route
+                                path="metadata"
+                                element={
+                                    <PermissionPageGuard permission="environment-metadata-r">
+                                        <MetadataPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                            <Route path="dictionaries">
+                                <Route
+                                    index
+                                    element={
+                                        <PermissionPageGuard permission="environment-dictionary-r" unauthorizedTo="../applications">
+                                            <DictionariesPage />
+                                        </PermissionPageGuard>
+                                    }
+                                />
+                                <Route
+                                    path=":dictionaryId"
+                                    element={
+                                        <PermissionPageGuard
+                                            anyOf={[
+                                                'environment-dictionary-c',
+                                                'environment-dictionary-r',
+                                                'environment-dictionary-u',
+                                                'environment-dictionary-d',
+                                            ]}
+                                            unauthorizedTo="../../applications"
+                                        >
+                                            <DictionaryDetailPage />
+                                        </PermissionPageGuard>
+                                    }
+                                />
+                            </Route>
+                            <Route path="gateways">
+                                <Route
+                                    index
+                                    element={
+                                        <PermissionPageGuard permission="environment-instance-r" unauthorizedTo="../applications">
+                                            <GatewayInstancesPage />
+                                        </PermissionPageGuard>
+                                    }
+                                />
+                                <Route
+                                    path=":instanceId"
+                                    element={
+                                        <PermissionPageGuard permission="environment-instance-r" unauthorizedTo="../../applications">
+                                            <GatewayInstanceDetailLayout />
+                                        </PermissionPageGuard>
+                                    }
+                                >
+                                    <Route index element={<Navigate to="environment" replace />} />
+                                    <Route path="environment" element={<GatewayInstanceEnvironmentPage />} />
+                                    <Route path="monitoring" element={<GatewayInstanceMonitoringPage />} />
+                                </Route>
+                            </Route>
+                            <Route path="entrypoints-and-sharding-tags" element={<EntrypointsGuard />} />
+                            <Route path="security-plan-types" element={<SecurityPlanTypesPage />} />
                         </Route>
-                        <Route path="entrypoints-and-sharding-tags" element={<EntrypointsGuard />} />
-                        <Route path="security-plan-types" element={<SecurityPlanTypesPage />} />
+                        <Route path="applications/:applicationId" element={<ApplicationDetailLayout />}>
+                            <Route index element={<ApplicationDetailIndexRedirect />} />
+                            {APPLICATION_DETAIL_TABS.map(tab => (
+                                <Route key={tab.path} path={tab.path} element={applicationDetailTabElement(tab.path, tab.label)} />
+                            ))}
+                            <Route path="subscriptions/:subscriptionId" element={<ApplicationDetailSubscriptionPage />} />
+                            <Route path="*" element={<ApplicationDetailIndexRedirect />} />
+                        </Route>
                     </Route>
                 </Routes>
             </ConsoleSettingsProvider>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/LocalDevShell.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/LocalDevShell.tsx
@@ -27,8 +27,12 @@ export function LocalDevShell({ children }: { readonly children: ReactNode }) {
             defaultSidebarMode="hover-expand"
             defaultTheme="system"
             fullHeight
+            viewMode={slots.viewMode}
+            contextExpanded={slots.contextExpanded}
+            contextSidebar={slots.contextSidebar}
+            contentVariant={slots.contentVariant}
             sidebar={<AppSidebar onLogoClick={() => navigate('/')} renderNavigation={() => slots.navigation} />}
-            subheader={<ContentHeader breadcrumbs={slots.breadcrumbs} />}
+            subheader={<ContentHeader leading={slots.leading} breadcrumbs={slots.breadcrumbs} />}
         >
             {children}
         </AppLayout>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -13,20 +13,85 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { GroupIcon, UsersIcon } from '@gravitee/graphene-core/icons';
+import { CloudIcon, GlobeIcon, GroupIcon, UsersIcon } from '@gravitee/graphene-core/icons';
 
-import { NAV_GROUPS } from './navigation';
+import { filterNavSections, findNavSectionKey, firstNavItemKey, NAV_SECTIONS, platformPrimaryNavItems } from './navigation';
 import { PLATFORM_ROUTE_CONFIG, ROUTES } from './routes';
 
+function sectionKeys(label: string, groupLabel: string): string[] {
+    const section = NAV_SECTIONS.find(candidate => candidate.title === label);
+    const group = section?.groups.find(candidate => candidate.label === groupLabel);
+    return group?.items.map(item => item.key) ?? [];
+}
+
 describe('platform navigation config', () => {
-    it('registers Users and Groups under Identity & Access', () => {
-        const identityGroup = NAV_GROUPS.find(group => group.label === 'Identity & Access');
-        expect(identityGroup).toBeDefined();
-        expect(identityGroup?.items.map(item => item.key)).toEqual(['users', 'user-groups']);
-        expect(identityGroup?.items[0]?.title).toBe('Users');
-        expect(identityGroup?.items[0]?.icon).toBe(UsersIcon);
-        expect(identityGroup?.items[1]?.title).toBe('Groups');
-        expect(identityGroup?.items[1]?.icon).toBe(GroupIcon);
+    it('exposes Organization, Environment, and Team as the only primary sections', () => {
+        expect(NAV_SECTIONS.map(section => section.key)).toEqual(['organization', 'environment', 'team']);
+        expect(NAV_SECTIONS.map(section => section.title)).toEqual(['Organization', 'Environment', 'Team']);
+        expect(NAV_SECTIONS[0]?.icon).toBe(GlobeIcon);
+        expect(NAV_SECTIONS[1]?.icon).toBe(CloudIcon);
+        expect(NAV_SECTIONS[2]?.icon).toBe(UsersIcon);
+    });
+
+    it('does not include a General primary section', () => {
+        expect(NAV_SECTIONS.some(section => section.key === 'general' || section.title === 'General')).toBe(false);
+    });
+
+    it('places Entrypoints & Sharding Tags under Organization / Assets', () => {
+        expect(sectionKeys('Organization', 'Assets')).toEqual(['entrypoints-and-sharding-tags']);
+    });
+
+    it('places Access Management under Organization / System & Security', () => {
+        expect(sectionKeys('Organization', 'System & Security')).toEqual(['access-management']);
+    });
+
+    it('places Applications, Metadata, and Dictionaries under Environment / APIs & Assets', () => {
+        expect(sectionKeys('Environment', 'APIs & Assets')).toEqual(['applications', 'metadata', 'dictionaries']);
+    });
+
+    it('places Gateways and Security Plan Types under Environment / System & Security', () => {
+        expect(sectionKeys('Environment', 'System & Security')).toEqual(['gateways', 'security-plan-types']);
+    });
+
+    it('places Users and Groups under Team', () => {
+        const teamGroup = NAV_SECTIONS.find(section => section.key === 'team')?.groups.find(group => group.label === 'Team');
+        expect(teamGroup?.items.map(item => item.key)).toEqual(['users', 'user-groups']);
+        expect(teamGroup?.items[0]?.title).toBe('Users');
+        expect(teamGroup?.items[0]?.icon).toBe(UsersIcon);
+        expect(teamGroup?.items[1]?.title).toBe('Groups');
+        expect(teamGroup?.items[1]?.icon).toBe(GroupIcon);
+    });
+
+    it('builds unlabeled primary items from visible sections', () => {
+        const items = platformPrimaryNavItems(NAV_SECTIONS);
+        expect(items.map(item => item.key)).toEqual(['organization', 'environment', 'team']);
+        expect(items.map(item => item.title)).toEqual(['Organization', 'Environment', 'Team']);
+        expect(items.some(item => item.title === 'Platform')).toBe(false);
+    });
+
+    it('resolves the section that owns a nav item', () => {
+        expect(findNavSectionKey(NAV_SECTIONS, 'applications')).toBe('environment');
+        expect(findNavSectionKey(NAV_SECTIONS, 'users')).toBe('team');
+        expect(findNavSectionKey(NAV_SECTIONS, 'access-management')).toBe('organization');
+        expect(findNavSectionKey(NAV_SECTIONS, 'missing')).toBeUndefined();
+    });
+
+    it('returns the first visible item in a section', () => {
+        const organization = NAV_SECTIONS.find(section => section.key === 'organization');
+        expect(organization).toBeDefined();
+        expect(firstNavItemKey(organization!)).toBe('entrypoints-and-sharding-tags');
+    });
+
+    it('filters hidden items and drops empty groups and sections', () => {
+        const filtered = filterNavSections(NAV_SECTIONS, key => key === 'users');
+
+        expect(filtered.map(section => section.key)).toEqual(['team']);
+        expect(filtered[0]?.groups).toEqual([
+            expect.objectContaining({
+                label: 'Team',
+                items: [expect.objectContaining({ key: 'users' })],
+            }),
+        ]);
     });
 
     it('declares the users route in platform routing config', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { NavGroup } from '@gravitee/graphene-core';
+import type { NavGroup, NavItem } from '@gravitee/graphene-core';
 import {
     AppWindowIcon,
     BookOpenIcon,
+    CloudIcon,
     DatabaseIcon,
+    GlobeIcon,
     GroupIcon,
     KeyIcon,
     RadioIcon,
@@ -25,48 +27,107 @@ import {
     ShieldIcon,
     UsersIcon,
 } from '@gravitee/graphene-core/icons';
+import type { ElementType } from 'react';
 
 import { ROUTES } from './routes';
 
-export const NAV_GROUPS: NavGroup[] = [
+export type PlatformNavSectionKey = 'organization' | 'environment' | 'team';
+
+export interface PlatformNavSection {
+    readonly key: PlatformNavSectionKey;
+    readonly title: string;
+    readonly icon: ElementType;
+    readonly groups: NavGroup[];
+}
+
+export const NAV_SECTIONS: PlatformNavSection[] = [
     {
-        label: 'Overview',
-        items: [{ key: 'applications', title: ROUTES.applications.label, icon: AppWindowIcon }],
-    },
-    {
-        label: 'Identity & Access',
-        items: [
-            { key: 'users', title: ROUTES.users.label, icon: UsersIcon },
-            { key: 'user-groups', title: ROUTES['user-groups'].label, icon: GroupIcon },
-        ],
-    },
-    {
-        label: 'APIs & Assets',
-        items: [
-            { key: 'metadata', title: ROUTES.metadata.label, icon: DatabaseIcon },
-            { key: 'dictionaries', title: ROUTES.dictionaries.label, icon: BookOpenIcon },
-        ],
-    },
-    {
-        label: 'Gateways & Infrastructure',
-        items: [
+        key: 'organization',
+        title: 'Organization',
+        icon: GlobeIcon,
+        groups: [
             {
-                key: 'gateways',
-                title: ROUTES.gateways.label,
-                icon: ServerIcon,
+                label: 'Assets',
+                items: [
+                    {
+                        key: 'entrypoints-and-sharding-tags',
+                        title: ROUTES['entrypoints-and-sharding-tags'].label,
+                        icon: RadioIcon,
+                    },
+                ],
             },
             {
-                key: 'entrypoints-and-sharding-tags',
-                title: ROUTES['entrypoints-and-sharding-tags'].label,
-                icon: RadioIcon,
+                label: 'System & Security',
+                items: [{ key: 'access-management', title: ROUTES['access-management'].label, icon: ShieldIcon }],
             },
         ],
     },
     {
-        label: 'System & Security',
-        items: [
-            { key: 'access-management', title: ROUTES['access-management'].label, icon: ShieldIcon },
-            { key: 'security-plan-types', title: ROUTES['security-plan-types'].label, icon: KeyIcon },
+        key: 'environment',
+        title: 'Environment',
+        icon: CloudIcon,
+        groups: [
+            {
+                label: 'APIs & Assets',
+                items: [
+                    { key: 'applications', title: ROUTES.applications.label, icon: AppWindowIcon },
+                    { key: 'metadata', title: ROUTES.metadata.label, icon: DatabaseIcon },
+                    { key: 'dictionaries', title: ROUTES.dictionaries.label, icon: BookOpenIcon },
+                ],
+            },
+            {
+                label: 'System & Security',
+                items: [
+                    { key: 'gateways', title: ROUTES.gateways.label, icon: ServerIcon },
+                    { key: 'security-plan-types', title: ROUTES['security-plan-types'].label, icon: KeyIcon },
+                ],
+            },
+        ],
+    },
+    {
+        key: 'team',
+        title: 'Team',
+        icon: UsersIcon,
+        groups: [
+            {
+                label: 'Team',
+                items: [
+                    { key: 'users', title: ROUTES.users.label, icon: UsersIcon },
+                    { key: 'user-groups', title: ROUTES['user-groups'].label, icon: GroupIcon },
+                ],
+            },
         ],
     },
 ];
+
+export function platformPrimaryNavItems(sections: readonly PlatformNavSection[]): NavItem[] {
+    return sections.map(section => ({ key: section.key, title: section.title, icon: section.icon }));
+}
+
+export function findNavSectionKey(sections: readonly PlatformNavSection[], itemKey: string): PlatformNavSectionKey | undefined {
+    return sections.find(section => section.groups.some(group => group.items.some(item => item.key === itemKey)))?.key;
+}
+
+export function firstNavItemKey(section: PlatformNavSection): string | undefined {
+    for (const group of section.groups) {
+        const firstItem = group.items[0];
+        if (firstItem) {
+            return firstItem.key;
+        }
+    }
+    return undefined;
+}
+
+export function filterNavSections(sections: readonly PlatformNavSection[], isVisible: (itemKey: string) => boolean): PlatformNavSection[] {
+    return sections
+        .map(section => ({
+            ...section,
+            groups: section.groups
+                .map(group => ({
+                    ...group,
+                    items: group.items.filter(item => isVisible(item.key)),
+                }))
+                .filter(group => group.items.length > 0),
+        }))
+        .filter(section => section.groups.length > 0);
+}


### PR DESCRIPTION
## Issue

[no specific ticket, its added as common change for all]
https://gravitee.atlassian.net/browse/APIM-14934

## Description

In gamma platform module, replace the single-column Platform sidebar with a two-column Graphene layout.
- Primary column: Organization, Environment, Team (no General, no “Platform” group label)
- Secondary column: existing Gamma items only, grouped as specified
- Clicking a primary section opens that section’s first visible item
- Permission filtering still hides items and drops empty groups/sections

## Additional context
NEW UI

[image]
<img width="1727" height="930" alt="image" src="https://github.com/user-attachments/assets/7b7b897d-0e74-4fe2-88b4-c8d2407a8e87" />

[video]

https://github.com/user-attachments/assets/85be6ac8-e9e3-40db-8de1-af2231843d1a



