### PR TITLE
feat: add API Product subscription flow to Portal Next

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api-product/subscribe-to-api-product/subscribe-to-api-product.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api-product/subscribe-to-api-product/subscribe-to-api-product.component.harness.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ContentContainerComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+import { PlanCardHarness } from '../../../components/subscribe/plan-card/plan-card.harness';
+
+export class SubscribeToApiProductHarness extends ContentContainerComponentHarness {
+  static readonly hostSelector = 'app-subscribe-to-api-product';
+
+  private readonly locateNextButton = this.locatorForOptional(MatButtonHarness.with({ text: 'Next' }));
+  private readonly locateSubscribeButton = this.locatorForOptional(MatButtonHarness.with({ text: /Subscribe|Subscribing/ }));
+  private readonly locateConfirmation = this.locatorForOptional('[data-testid="subscription-confirmation"]');
+  private readonly locateError = this.locatorForOptional('[role="alert"]');
+
+  async getText(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  async selectPlan(planId: string): Promise<void> {
+    const plan = await this.locatorForOptional(PlanCardHarness.with({ selector: `#${planId}` }))();
+    if (!plan) {
+      throw new Error(`Plan ${planId} not found`);
+    }
+    await plan.select();
+  }
+
+  async goToNextStep(): Promise<void> {
+    const button = await this.locateNextButton();
+    if (!button) {
+      throw new Error('Next button not found');
+    }
+    await button.click();
+  }
+
+  async subscribe(): Promise<void> {
+    const button = await this.locateSubscribeButton();
+    if (!button) {
+      throw new Error('Subscribe button not found');
+    }
+    await button.click();
+  }
+
+  async hasSubscribeAction(): Promise<boolean> {
+    return (await this.locateSubscribeButton()) !== null;
+  }
+
+  async hasConfirmation(): Promise<boolean> {
+    return (await this.locateConfirmation()) !== null;
+  }
+
+  async hasError(): Promise<boolean> {
+    return (await this.locateError()) !== null;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/api-product/subscribe-to-api-product/subscribe-to-api-product.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api-product/subscribe-to-api-product/subscribe-to-api-product.component.html
@@ -1,0 +1,185 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@if (createdSubscription(); as subscription) {
+  <app-banner class="subscribe-to-api-product__confirmation" aria-live="polite" data-testid="subscription-confirmation">
+    <div class="next-gen-h5" i18n="@@subscribeToApiProductConfirmationTitle">Subscription created</div>
+    @if (subscription.status === 'PENDING') {
+      <p class="next-gen-body" i18n="@@subscribeToApiProductPendingConfirmation">
+        Your subscription request has been sent and is awaiting approval.
+      </p>
+    } @else {
+      <p class="next-gen-body" i18n="@@subscribeToApiProductAcceptedConfirmation">
+        Your application is now subscribed to this API Product.
+      </p>
+    }
+  </app-banner>
+  @if (cancelFn()) {
+    <div class="subscribe-to-api-product__confirmation-actions">
+      <button mat-flat-button color="primary" (click)="cancelFn()!()" i18n="@@subscribeToApiProductReturnToDocumentation">
+        Return to documentation
+      </button>
+    </div>
+  }
+} @else {
+  <mat-card class="subscribe-to-api-product" appearance="outlined">
+    @if (currentStep() === SubscribeStep.PLAN_SELECTION) {
+      <app-subscribe-to-api-step-header [stepNumber]="stepNumberOf(SubscribeStep.PLAN_SELECTION)">
+        <div class="next-gen-h5" i18n="@@subscribeToApiProductChoosePlan">Choose a plan</div>
+        <div class="next-gen-body" i18n="@@subscribeToApiProductChoosePlanDescription">
+          Choose how your application will access the APIs in this product.
+        </div>
+      </app-subscribe-to-api-step-header>
+      <mat-card-content>
+        @if (plansResource.isLoading()) {
+          <app-loader />
+        } @else if (plansResource.error()) {
+          <app-banner type="error" role="alert" data-testid="plans-error">
+            <p class="next-gen-body" i18n="@@subscribeToApiProductPlansError">The available plans could not be loaded.</p>
+            <button mat-stroked-button color="primary" (click)="retryPlans()" i18n="@@subscribeToApiProductRetryPlans">Try again</button>
+          </app-banner>
+        } @else if (plans().length) {
+          <div
+            class="subscribe-to-api-product__plan-list"
+            [appIsNarrow]="'subscribe-to-api-product__plan-list--narrow'"
+            [appIsMobile]="'subscribe-to-api-product__plan-list--mobile'"
+          >
+            @for (plan of plans(); track plan.id) {
+              <app-plan-card [id]="plan.id" [plan]="plan" [selected]="currentPlan()?.id === plan.id" (selectPlan)="selectPlan($event)" />
+            }
+          </div>
+        } @else {
+          <app-banner data-testid="no-plans">
+            <p class="next-gen-body" i18n="@@subscribeToApiProductNoPlans">No subscription plan is currently available.</p>
+          </app-banner>
+        }
+      </mat-card-content>
+    } @else if (currentStep() === SubscribeStep.APP_SELECTION) {
+      <app-subscribe-to-api-step-header [stepNumber]="stepNumberOf(SubscribeStep.APP_SELECTION)">
+        <div class="next-gen-h5" i18n="@@subscribeToApiProductChooseApplication">Choose an application</div>
+        <div class="next-gen-body" i18n="@@subscribeToApiProductChooseApplicationDescription">
+          Select the application that will use this API Product.
+        </div>
+      </app-subscribe-to-api-step-header>
+      <mat-card-content>
+        @if (isApplicationStepLoading()) {
+          <app-loader />
+        } @else if (hasApplicationStepError()) {
+          <app-banner type="error" role="alert" data-testid="applications-error">
+            <p class="next-gen-body" i18n="@@subscribeToApiProductApplicationsError">Eligible applications could not be loaded.</p>
+            <button mat-stroked-button color="primary" (click)="retryApplications()" i18n="@@subscribeToApiProductRetryApplications">
+              Try again
+            </button>
+          </app-banner>
+        } @else {
+          <app-subscribe-to-api-choose-application
+            [applications]="applicationsData().applications"
+            [selectedApplication]="currentApplication()"
+            [pagination]="applicationsData().pagination"
+            (selectApplication)="selectApplication($event)"
+            (pageChange)="onApplicationPageChange($event)"
+            (pageSizeChange)="onApplicationPageSizeChange($event)"
+          />
+        }
+      </mat-card-content>
+    } @else if (currentStep() === SubscribeStep.PUSH_DETAILS) {
+      <app-subscribe-to-api-step-header [stepNumber]="stepNumberOf(SubscribeStep.PUSH_DETAILS)">
+        <div class="next-gen-h5" i18n="@@subscribeToApiProductConfigureConsumer">Configure consumer</div>
+      </app-subscribe-to-api-step-header>
+      <mat-card-content>
+        <app-consumer-configuration
+          [consumerConfigurationFormValues]="consumerConfigurationFormData().value"
+          (consumerConfigurationFormDataChange)="consumerConfigurationFormChanges($event)"
+        />
+      </mat-card-content>
+    } @else if (currentStep() === SubscribeStep.REVIEW) {
+      <app-subscribe-to-api-step-header [stepNumber]="stepNumberOf(SubscribeStep.REVIEW)">
+        <div class="next-gen-h5" i18n="@@subscribeToApiProductReview">Review</div>
+        @if (currentPlan()?.security === 'KEY_LESS') {
+          <div class="next-gen-body" i18n="@@subscribeToApiProductKeylessDescription">
+            This plan does not require a subscription to consume the API Product.
+          </div>
+        }
+      </app-subscribe-to-api-step-header>
+      <mat-card-content class="subscribe-to-api-product__review">
+        <dl class="subscribe-to-api-product__summary next-gen-body">
+          <dt class="next-gen-body-strong" i18n="@@subscribeToApiProductProductLabel">API Product</dt>
+          <dd>{{ apiProduct().name }}</dd>
+          <dt class="next-gen-body-strong" i18n="@@subscribeToApiProductPlanLabel">Plan</dt>
+          <dd>{{ currentPlan()?.name }}</dd>
+          @if (currentApplication(); as application) {
+            <dt class="next-gen-body-strong" i18n="@@subscribeToApiProductApplicationLabel">Application</dt>
+            <dd>{{ application.name }}</dd>
+          }
+        </dl>
+        @if (hasSubscriptionError()) {
+          <app-banner type="error" role="alert" data-testid="subscription-error">
+            <p class="next-gen-body" i18n="@@subscribeToApiProductSubmissionError">
+              The subscription could not be created. Try again, and if the issue persists, contact your Portal administrator.
+            </p>
+          </app-banner>
+        }
+      </mat-card-content>
+    }
+  </mat-card>
+
+  <mat-card-actions class="subscribe-to-api-product__actions">
+    <div>
+      @if (activeSteps().indexOf(currentStep()) > 0) {
+        <button
+          mat-stroked-button
+          color="primary"
+          (click)="goToPreviousStep()"
+          [disabled]="isSubmitting()"
+          i18n="@@subscribeToApiProductPrevious"
+        >
+          Previous
+        </button>
+      } @else if (cancelFn()) {
+        <button mat-stroked-button color="primary" (click)="cancelFn()!()" i18n="@@subscribeToApiProductCancel">Cancel</button>
+      }
+    </div>
+    <div>
+      @if (currentStep() !== SubscribeStep.REVIEW) {
+        <div class="subscribe-to-api-product__next-actions">
+          @if (currentApplication(); as application) {
+            <div class="next-gen-body subscribe-to-api-product__selected-application">
+              <span i18n="@@subscribeToApiProductSelectedApplication">Selected application:</span>
+              <mat-chip (removed)="currentApplication.set(undefined)">
+                {{ application.name }}
+                <button matChipRemove i18n-aria-label="@@subscribeToApiProductClearApplication" aria-label="Clear selected application">
+                  <mat-icon aria-hidden="true">cancel</mat-icon>
+                </button>
+              </mat-chip>
+            </div>
+          }
+          <button mat-flat-button color="primary" (click)="goToNextStep()" [disabled]="stepIsInvalid()" i18n="@@subscribeToApiProductNext">
+            Next
+          </button>
+        </div>
+      } @else if (currentPlan()?.security !== 'KEY_LESS') {
+        <button mat-flat-button color="primary" (click)="subscribe()" [disabled]="stepIsInvalid() || isSubmitting()">
+          @if (isSubmitting()) {
+            <span i18n="@@subscribeToApiProductSubscribing">Subscribing...</span>
+          } @else {
+            <span i18n="@@subscribeToApiProductSubscribe">Subscribe</span>
+          }
+        </button>
+      }
+    </div>
+  </mat-card-actions>
+}

--- a/gravitee-apim-portal-webui-next/src/app/api-product/subscribe-to-api-product/subscribe-to-api-product.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api-product/subscribe-to-api-product/subscribe-to-api-product.component.scss
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../scss/layout' as layout;
+@use '../../../scss/theme' as app-theme;
+
+.subscribe-to-api-product {
+  &__plan-list {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: layout.$container-padding-horizontal;
+
+    &--narrow {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    &--mobile {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &__review {
+    display: flex;
+    flex-direction: column;
+    gap: layout.$container-padding-horizontal;
+  }
+
+  &__summary {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 2fr;
+    gap: layout.$container-padding-horizontal;
+    margin: 0;
+
+    dd {
+      margin: 0;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    padding: layout.$container-padding-horizontal 0;
+  }
+
+  &__next-actions,
+  &__selected-application,
+  &__confirmation-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: layout.$container-padding-horizontal;
+  }
+
+  &__selected-application {
+    --mat-chip-elevated-container-color: #{app-theme.$chip-background};
+    --mat-chip-container-shape-radius: #{app-theme.$chip-shape};
+    --mat-chip-outline-width: 0;
+  }
+
+  &__confirmation-actions {
+    justify-content: flex-end;
+    padding-top: layout.$container-padding-horizontal;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/api-product/subscribe-to-api-product/subscribe-to-api-product.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api-product/subscribe-to-api-product/subscribe-to-api-product.component.spec.ts
@@ -1,0 +1,340 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import { SubscribeToApiProductComponent } from './subscribe-to-api-product.component';
+import { SubscribeToApiProductHarness } from './subscribe-to-api-product.component.harness';
+import { RadioCardHarness } from '../../../components/radio-card/radio-card.harness';
+import { fakeApiProduct } from '../../../entities/api-product/api-product.fixture';
+import { fakeApplication, fakeApplicationsResponse } from '../../../entities/application/application.fixture';
+import { fakePlan } from '../../../entities/plan/plan.fixture';
+import { fakeSubscription, fakeSubscriptionResponse, Subscription } from '../../../entities/subscription';
+import { ApiProductsService } from '../../../services/api-products.service';
+import { ApplicationService } from '../../../services/application.service';
+import { SubscriptionService } from '../../../services/subscription.service';
+
+describe('SubscribeToApiProductComponent', () => {
+  let fixture: ComponentFixture<SubscribeToApiProductComponent>;
+  let harness: SubscribeToApiProductHarness;
+  let harnessLoader: HarnessLoader;
+  let apiProductsService: { listPlans: jest.Mock };
+  let applicationService: { list: jest.Mock };
+  let subscriptionService: { list: jest.Mock; subscribe: jest.Mock };
+  let matDialog: { open: jest.Mock };
+
+  const apiProduct = fakeApiProduct({ id: 'api-product-id', name: 'Developer Product' });
+  const apiKeyPlan = fakePlan({ id: 'api-key-plan', name: 'API Key', security: 'API_KEY', mode: 'STANDARD' });
+  const application = fakeApplication({ id: 'application-id', name: 'Developer App', api_key_mode: 'EXCLUSIVE' });
+
+  const init = async ({
+    plans = [apiKeyPlan],
+    plansError = undefined as Error | undefined,
+    subscriptions = fakeSubscriptionResponse({ data: [], metadata: {} }),
+    applications = fakeApplicationsResponse({ data: [application] }),
+    applicationsError = undefined as Error | undefined,
+  } = {}) => {
+    apiProductsService = {
+      listPlans: jest.fn().mockReturnValue(plansError ? throwError(() => plansError) : of({ data: plans })),
+    };
+    applicationService = {
+      list: jest.fn().mockReturnValue(applicationsError ? throwError(() => applicationsError) : of(applications)),
+    };
+    subscriptionService = {
+      list: jest.fn().mockReturnValue(of(subscriptions)),
+      subscribe: jest.fn(),
+    };
+    matDialog = { open: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [SubscribeToApiProductComponent, MatIconTestingModule],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ApiProductsService, useValue: apiProductsService },
+        { provide: ApplicationService, useValue: applicationService },
+        { provide: SubscriptionService, useValue: subscriptionService },
+        { provide: MatDialog, useValue: matDialog },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SubscribeToApiProductComponent);
+    fixture.componentRef.setInput('apiProduct', apiProduct);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SubscribeToApiProductHarness);
+  };
+
+  it('should load and display only plans returned for the API Product', async () => {
+    await init({ plans: [apiKeyPlan, fakePlan({ id: 'jwt-plan', name: 'JWT', security: 'JWT' })] });
+
+    expect(apiProductsService.listPlans).toHaveBeenCalledWith(apiProduct.id);
+    expect(await harness.getText()).toContain('API Key');
+    expect(await harness.getText()).toContain('JWT');
+  });
+
+  it('should display an empty state when no plan is available', async () => {
+    await init({ plans: [] });
+
+    expect(await harness.getText()).toContain('No subscription plan is currently available');
+  });
+
+  it('should preserve keyless behavior without creating a subscription', async () => {
+    const keylessPlan = fakePlan({ id: 'keyless-plan', security: 'KEY_LESS' });
+    await init({ plans: [keylessPlan] });
+
+    await harness.selectPlan(keylessPlan.id);
+    await harness.goToNextStep();
+
+    expect(await harness.getText()).toContain('does not require a subscription');
+    expect(await harness.hasSubscribeAction()).toBe(false);
+    expect(applicationService.list).not.toHaveBeenCalled();
+
+    fixture.componentInstance.subscribe();
+
+    expect(subscriptionService.subscribe).not.toHaveBeenCalled();
+  });
+
+  it('should keep standalone API subscriptions independent from API Product eligibility', async () => {
+    const duplicateProductApplication = fakeApplication({ id: 'duplicate-app', name: 'Duplicate Product App', api_key_mode: 'EXCLUSIVE' });
+    const subscriptions = fakeSubscriptionResponse({
+      data: [
+        fakeSubscription({
+          application: application.id,
+          plan: apiKeyPlan.id,
+          status: 'ACCEPTED',
+          reference_id: 'included-api-id',
+          reference_type: 'API',
+        }),
+        fakeSubscription({
+          api: undefined,
+          application: duplicateProductApplication.id,
+          plan: apiKeyPlan.id,
+          status: 'PENDING',
+          reference_id: apiProduct.id,
+          reference_type: 'API_PRODUCT',
+        }),
+      ],
+      metadata: { [apiKeyPlan.id]: { securityType: 'API_KEY', planMode: 'STANDARD' } },
+    });
+    await init({
+      subscriptions,
+      applications: fakeApplicationsResponse({ data: [application, duplicateProductApplication] }),
+    });
+
+    await harness.selectPlan(apiKeyPlan.id);
+    await harness.goToNextStep();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const standaloneApplication = await harnessLoader.getHarness(RadioCardHarness.with({ title: application.name }));
+    const duplicateApplication = await harnessLoader.getHarness(RadioCardHarness.with({ title: duplicateProductApplication.name }));
+    expect(await standaloneApplication.isDisabled()).toBe(false);
+    expect(await duplicateApplication.isDisabled()).toBe(true);
+  });
+
+  it('should disable an application missing credentials required by the selected plan', async () => {
+    const oauthPlan = fakePlan({ id: 'oauth-plan', security: 'OAUTH2' });
+    const applicationWithoutClientId = fakeApplication({ id: 'no-client-id', name: 'No Client ID', hasClientId: false });
+    await init({ plans: [oauthPlan], applications: fakeApplicationsResponse({ data: [applicationWithoutClientId] }) });
+
+    await harness.selectPlan(oauthPlan.id);
+    await harness.goToNextStep();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const applicationCard = await harnessLoader.getHarness(RadioCardHarness.with({ title: applicationWithoutClientId.name }));
+    expect(await applicationCard.isDisabled()).toBe(true);
+  });
+
+  it.each([
+    ['PENDING', 'awaiting approval'],
+    ['ACCEPTED', 'now subscribed'],
+  ] as const)('should submit the existing payload and show an inline %s confirmation', async (status, expectedText) => {
+    await init();
+    subscriptionService.subscribe.mockReturnValue(
+      of(
+        fakeSubscription({
+          api: undefined,
+          application: application.id,
+          plan: apiKeyPlan.id,
+          reference_id: apiProduct.id,
+          reference_type: 'API_PRODUCT',
+          status,
+        }),
+      ),
+    );
+
+    await selectPlanAndApplication();
+    await harness.subscribe();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(subscriptionService.subscribe).toHaveBeenCalledWith({ application: application.id, plan: apiKeyPlan.id });
+    expect(subscriptionService.subscribe.mock.calls[0][0]).not.toHaveProperty('apiProductId');
+    expect(await harness.hasConfirmation()).toBe(true);
+    expect(await harness.getText()).toContain(expectedText);
+  });
+
+  it('should capture a plan request comment', async () => {
+    const commentPlan = fakePlan({ ...apiKeyPlan, comment_required: true, comment_question: 'Why do you need access?' });
+    await init({ plans: [commentPlan] });
+    matDialog.open.mockReturnValue({ afterClosed: () => of('Business integration') });
+    subscriptionService.subscribe.mockReturnValue(of(createdSubscription('PENDING', commentPlan.id)));
+
+    await selectPlanAndApplication(commentPlan.id);
+    await harness.subscribe();
+
+    expect(matDialog.open).toHaveBeenCalled();
+    expect(subscriptionService.subscribe).toHaveBeenCalledWith({
+      application: application.id,
+      plan: commentPlan.id,
+      request: 'Business integration',
+    });
+  });
+
+  it('should submit PUSH consumer configuration', async () => {
+    const pushPlan = fakePlan({ id: 'push-plan', mode: 'PUSH', security: 'API_KEY' });
+    await init({ plans: [pushPlan] });
+    subscriptionService.subscribe.mockReturnValue(of(createdSubscription('ACCEPTED', pushPlan.id)));
+
+    await harness.selectPlan(pushPlan.id);
+    await harness.goToNextStep();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await (await harnessLoader.getHarness(RadioCardHarness.with({ title: application.name }))).select();
+    await harness.goToNextStep();
+    fixture.componentInstance.consumerConfigurationFormChanges({
+      isValid: true,
+      value: {
+        channel: 'orders',
+        consumerConfiguration: {
+          callbackUrl: 'https://example.com/callback',
+          headers: [],
+          retry: { retryOption: 'No Retry' },
+          ssl: { hostnameVerifier: false, trustAll: false },
+          auth: { type: 'none' },
+        },
+      },
+    });
+    await harness.goToNextStep();
+    await harness.subscribe();
+
+    expect(subscriptionService.subscribe).toHaveBeenCalledWith({
+      application: application.id,
+      plan: pushPlan.id,
+      configuration: {
+        entrypointId: 'webhook',
+        channel: 'orders',
+        entrypointConfiguration: {
+          callbackUrl: 'https://example.com/callback',
+          headers: [],
+          retry: { retryOption: 'No Retry' },
+          ssl: { hostnameVerifier: false, trustAll: false },
+          auth: { type: 'none' },
+        },
+      },
+    });
+  });
+
+  it('should expose plan loading errors and retry', async () => {
+    await init({ plansError: new Error('plans unavailable') });
+
+    expect(await harness.hasError()).toBe(true);
+
+    apiProductsService.listPlans.mockReturnValue(of({ data: [apiKeyPlan] }));
+    fixture.componentInstance.retryPlans();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(apiProductsService.listPlans).toHaveBeenCalledTimes(2);
+    expect(await harness.getText()).toContain(apiKeyPlan.name);
+  });
+
+  it('should fail closed when eligibility cannot be loaded and allow retry', async () => {
+    await init({ applicationsError: new Error('applications unavailable') });
+
+    await harness.selectPlan(apiKeyPlan.id);
+    await harness.goToNextStep();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.hasError()).toBe(true);
+
+    applicationService.list.mockReturnValue(of(fakeApplicationsResponse({ data: [application] })));
+    fixture.componentInstance.retryApplications();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harnessLoader.getHarness(RadioCardHarness.with({ title: application.name }))).toBeDefined();
+  });
+
+  it('should display a submission error and allow retry', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    await init();
+    subscriptionService.subscribe
+      .mockReturnValueOnce(throwError(() => new Error('subscription unavailable')))
+      .mockReturnValueOnce(of(createdSubscription('ACCEPTED', apiKeyPlan.id)));
+    await selectPlanAndApplication();
+
+    await harness.subscribe();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(await harness.hasError()).toBe(true);
+
+    await harness.subscribe();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(await harness.hasConfirmation()).toBe(true);
+
+    consoleError.mockRestore();
+  });
+
+  async function selectPlanAndApplication(planId = apiKeyPlan.id): Promise<void> {
+    await harness.selectPlan(planId);
+    await harness.goToNextStep();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await (await harnessLoader.getHarness(RadioCardHarness.with({ title: application.name }))).select();
+    await harness.goToNextStep();
+    fixture.detectChanges();
+  }
+
+  function createdSubscription(status: Subscription['status'], planId: string): Subscription {
+    return fakeSubscription({
+      api: undefined,
+      application: application.id,
+      plan: planId,
+      reference_id: apiProduct.id,
+      reference_type: 'API_PRODUCT',
+      status,
+    });
+  }
+});

--- a/gravitee-apim-portal-webui-next/src/app/api-product/subscribe-to-api-product/subscribe-to-api-product.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api-product/subscribe-to-api-product/subscribe-to-api-product.component.ts
@@ -1,0 +1,409 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, DestroyRef, inject, input, signal } from '@angular/core';
+import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatButton } from '@angular/material/button';
+import { MatCard, MatCardActions, MatCardContent } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIcon } from '@angular/material/icon';
+import { filter, finalize, Observable, of, switchMap, tap } from 'rxjs';
+
+import { BannerComponent } from '../../../components/banner/banner.component';
+import { LoaderComponent } from '../../../components/loader/loader.component';
+import { PlanCardComponent } from '../../../components/subscribe/plan-card/plan-card.component';
+import {
+  SubscriptionCommentDialogComponent,
+  SubscriptionCommentDialogData,
+} from '../../../components/subscription/subscription-comment-dialog/subscription-comment-dialog.component';
+import { ConsumerConfigurationComponent } from '../../../components/subscription/webhook/consumer-configuration/consumer-configuration.component';
+import { ConsumerConfigurationFormData } from '../../../components/subscription/webhook/consumer-configuration/consumer-configuration.models';
+import { MobileClassDirective } from '../../../directives/mobile-class.directive';
+import { NarrowClassDirective } from '../../../directives/narrow-class.directive';
+import { ApiProduct } from '../../../entities/api-product/api-product';
+import { Application, ApplicationsResponse } from '../../../entities/application/application';
+import { Plan } from '../../../entities/plan/plan';
+import { PlansResponse } from '../../../entities/plan/plans-response';
+import { CreateSubscription, Subscription } from '../../../entities/subscription';
+import { SubscriptionsResponse } from '../../../entities/subscription/subscriptions-response';
+import { ApiProductsService } from '../../../services/api-products.service';
+import { ApplicationService } from '../../../services/application.service';
+import { SubscriptionService } from '../../../services/subscription.service';
+import { SubscribeToApiStepHeaderComponent } from '../../api/subscribe-to-api/components/subscribe-to-api-step-header/subscribe-to-api-step-header.component';
+import {
+  ApplicationsPagination,
+  ApplicationVM,
+  DEFAULT_APPLICATIONS_PAGE_SIZE,
+  SubscribeToApiChooseApplicationComponent,
+} from '../../api/subscribe-to-api/subscribe-to-api-choose-application/subscribe-to-api-choose-application.component';
+
+export enum SubscribeToApiProductStep {
+  PLAN_SELECTION = 'PLAN_SELECTION',
+  APP_SELECTION = 'APP_SELECTION',
+  PUSH_DETAILS = 'PUSH_DETAILS',
+  REVIEW = 'REVIEW',
+}
+
+interface ApplicationsData {
+  applications: ApplicationVM[];
+  pagination: ApplicationsPagination;
+}
+
+interface ApplicationsParams {
+  page: number;
+  pageSize: number;
+  planId: string;
+}
+
+@Component({
+  selector: 'app-subscribe-to-api-product',
+  imports: [
+    BannerComponent,
+    ConsumerConfigurationComponent,
+    LoaderComponent,
+    MatButton,
+    MatCard,
+    MatCardActions,
+    MatCardContent,
+    MatChipsModule,
+    MatIcon,
+    MobileClassDirective,
+    NarrowClassDirective,
+    PlanCardComponent,
+    SubscribeToApiChooseApplicationComponent,
+    SubscribeToApiStepHeaderComponent,
+  ],
+  templateUrl: './subscribe-to-api-product.component.html',
+  styleUrl: './subscribe-to-api-product.component.scss',
+})
+export class SubscribeToApiProductComponent {
+  private readonly apiProductsService = inject(ApiProductsService);
+  private readonly applicationService = inject(ApplicationService);
+  private readonly subscriptionService = inject(SubscriptionService);
+  private readonly matDialog = inject(MatDialog);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly apiProduct = input.required<ApiProduct>();
+  readonly cancelFn = input<() => void>();
+
+  readonly SubscribeStep = SubscribeToApiProductStep;
+  readonly currentStep = signal(SubscribeToApiProductStep.PLAN_SELECTION);
+  readonly currentPlan = signal<Plan | undefined>(undefined);
+  readonly currentApplication = signal<Application | undefined>(undefined);
+  readonly currentApplicationsPage = signal(1);
+  readonly currentApplicationsPageSize = signal(DEFAULT_APPLICATIONS_PAGE_SIZE);
+  readonly consumerConfigurationFormData = signal<ConsumerConfigurationFormData>({ value: undefined, isValid: false });
+  readonly isSubmitting = signal(false);
+  readonly hasSubscriptionError = signal(false);
+  readonly createdSubscription = signal<Subscription | undefined>(undefined);
+
+  readonly activeSteps = computed(() => {
+    const steps = [SubscribeToApiProductStep.PLAN_SELECTION];
+    const plan = this.currentPlan();
+
+    if (plan?.security !== 'KEY_LESS') {
+      steps.push(SubscribeToApiProductStep.APP_SELECTION);
+      if (plan?.mode === 'PUSH') {
+        steps.push(SubscribeToApiProductStep.PUSH_DETAILS);
+      }
+    }
+
+    steps.push(SubscribeToApiProductStep.REVIEW);
+    return steps;
+  });
+
+  readonly plansResource = rxResource<PlansResponse, string>({
+    params: () => this.apiProduct().id,
+    stream: ({ params }) => this.apiProductsService.listPlans(params),
+  });
+
+  readonly subscriptionsResource = rxResource<SubscriptionsResponse, string>({
+    params: () => this.apiProduct().id,
+    stream: ({ params }) =>
+      this.subscriptionService.list({
+        apiProductIds: [params],
+        statuses: ['PENDING', 'ACCEPTED', 'PAUSED'],
+        size: -1,
+      }),
+  });
+
+  readonly applicationsResource = rxResource<ApplicationsResponse | undefined, ApplicationsParams | null>({
+    params: () => {
+      const plan = this.currentPlan();
+      return plan && plan.security !== 'KEY_LESS'
+        ? {
+            page: this.currentApplicationsPage(),
+            pageSize: this.currentApplicationsPageSize(),
+            planId: plan.id,
+          }
+        : null;
+    },
+    stream: ({ params }) =>
+      params ? this.applicationService.list(params.page, params.pageSize, true) : of<ApplicationsResponse | undefined>(undefined),
+  });
+
+  readonly plans = computed(() => this.plansResource.value()?.data ?? []);
+  readonly applicationsData = computed<ApplicationsData>(() => {
+    const response = this.applicationsResource.value();
+    const subscriptions = this.subscriptionsResource.value();
+
+    return {
+      applications: response && subscriptions ? this.addApplicationDisabledState(response, subscriptions) : [],
+      pagination: {
+        currentPage: response?.metadata?.pagination?.current_page ?? 1,
+        totalApplications: response?.metadata?.pagination?.total ?? 0,
+        pageSize: this.currentApplicationsPageSize(),
+      },
+    };
+  });
+  readonly isApplicationStepLoading = computed(() => this.applicationsResource.isLoading() || this.subscriptionsResource.isLoading());
+  readonly hasApplicationStepError = computed(() => !!this.applicationsResource.error() || !!this.subscriptionsResource.error());
+  readonly stepIsInvalid = computed(() => {
+    switch (this.currentStep()) {
+      case SubscribeToApiProductStep.PLAN_SELECTION:
+        return !this.currentPlan();
+      case SubscribeToApiProductStep.APP_SELECTION:
+        return !this.currentApplication() || this.hasApplicationStepError();
+      case SubscribeToApiProductStep.PUSH_DETAILS:
+        return !this.consumerConfigurationFormData().isValid;
+      default:
+        return false;
+    }
+  });
+
+  selectPlan(plan: Plan): void {
+    if (this.currentPlan()?.id !== plan.id) {
+      this.currentApplication.set(undefined);
+      this.currentApplicationsPage.set(1);
+      this.consumerConfigurationFormData.set({ value: undefined, isValid: false });
+    }
+    this.currentPlan.set(plan);
+  }
+
+  selectApplication(application: Application): void {
+    this.currentApplication.set(application);
+  }
+
+  consumerConfigurationFormChanges(data: ConsumerConfigurationFormData): void {
+    this.consumerConfigurationFormData.set(data);
+  }
+
+  stepNumberOf(step: SubscribeToApiProductStep): number {
+    return this.activeSteps().indexOf(step) + 1;
+  }
+
+  goToNextStep(): void {
+    const steps = this.activeSteps();
+    const currentIndex = steps.indexOf(this.currentStep());
+    if (currentIndex < steps.length - 1) {
+      this.currentStep.set(steps[currentIndex + 1]);
+    }
+  }
+
+  goToPreviousStep(): void {
+    const steps = this.activeSteps();
+    const currentIndex = steps.indexOf(this.currentStep());
+    if (currentIndex > 0) {
+      this.currentStep.set(steps[currentIndex - 1]);
+    }
+  }
+
+  onApplicationPageChange(page: number): void {
+    this.currentApplicationsPage.set(page);
+  }
+
+  onApplicationPageSizeChange(pageSize: number): void {
+    this.currentApplicationsPageSize.set(pageSize);
+    this.currentApplicationsPage.set(1);
+  }
+
+  retryPlans(): void {
+    this.plansResource.reload();
+  }
+
+  retryApplications(): void {
+    this.subscriptionsResource.reload();
+    this.applicationsResource.reload();
+  }
+
+  subscribe(): void {
+    const application = this.currentApplication()?.id;
+    const plan = this.currentPlan();
+    if (!plan || plan.security === 'KEY_LESS' || !application || this.isSubmitting()) {
+      return;
+    }
+
+    this.requestComment$(plan)
+      .pipe(
+        filter((request): request is string | null => request !== undefined),
+        tap(() => {
+          this.hasSubscriptionError.set(false);
+          this.isSubmitting.set(true);
+        }),
+        switchMap(request => {
+          const createSubscription: CreateSubscription = {
+            application,
+            plan: plan.id,
+            ...this.toConsumerConfiguration(plan),
+            ...(request?.trim() ? { request: request.trim() } : {}),
+          };
+          return this.subscriptionService.subscribe(createSubscription);
+        }),
+        finalize(() => this.isSubmitting.set(false)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: subscription => this.createdSubscription.set(subscription),
+        error: error => {
+          console.error(error);
+          this.hasSubscriptionError.set(true);
+        },
+      });
+  }
+
+  private requestComment$(plan: Plan): Observable<string | null | undefined> {
+    if (!plan.comment_required && !plan.comment_question) {
+      return of(null);
+    }
+
+    return this.matDialog
+      .open<SubscriptionCommentDialogComponent, SubscriptionCommentDialogData, string>(SubscriptionCommentDialogComponent, {
+        data: { plan },
+        width: '500px',
+      })
+      .afterClosed();
+  }
+
+  private toConsumerConfiguration(plan: Plan): Pick<CreateSubscription, 'configuration'> {
+    const formValue = this.consumerConfigurationFormData().value;
+    if (plan.mode !== 'PUSH' || !formValue) {
+      return {};
+    }
+
+    return {
+      configuration: {
+        entrypointId: 'webhook',
+        channel: formValue.channel,
+        entrypointConfiguration: {
+          ...formValue.consumerConfiguration,
+          headers: formValue.consumerConfiguration.headers ?? [],
+        },
+      },
+    };
+  }
+
+  private addApplicationDisabledState(
+    applicationsResponse: ApplicationsResponse,
+    subscriptionsResponse: SubscriptionsResponse,
+  ): ApplicationVM[] {
+    const activeProductSubscriptions = subscriptionsResponse.data.filter(
+      subscription =>
+        subscription.reference_type === 'API_PRODUCT' &&
+        subscription.reference_id === this.apiProduct().id &&
+        ['PENDING', 'ACCEPTED', 'PAUSED'].includes(subscription.status),
+    );
+
+    return applicationsResponse.data.map(application => {
+      if (
+        activeProductSubscriptions.some(
+          subscription => subscription.plan === this.currentPlan()?.id && subscription.application === application.id,
+        )
+      ) {
+        return {
+          ...application,
+          disabled: true,
+          disabledMessage: $localize`:@@subscribeToApiProductExistingPlanSubscription:A subscription already exists for this plan`,
+        };
+      }
+
+      if (this.hasIncompatibleSecuritySubscription(application, activeProductSubscriptions, subscriptionsResponse)) {
+        return this.toDisabledApplication(application);
+      }
+
+      if (this.isClientIdMissing(application)) {
+        return {
+          ...application,
+          disabled: true,
+          disabledMessage: $localize`:@@subscribeToApiProductMissingClientId:Missing Client ID`,
+        };
+      }
+
+      if (this.isClientCertificateMissing(application)) {
+        return {
+          ...application,
+          disabled: true,
+          disabledMessage: $localize`:@@subscribeToApiProductMissingCertificate:Missing TLS Client Certificate`,
+        };
+      }
+
+      return application;
+    });
+  }
+
+  private hasIncompatibleSecuritySubscription(
+    application: Application,
+    subscriptions: Subscription[],
+    response: SubscriptionsResponse,
+  ): boolean {
+    const security = this.currentPlan()?.security;
+    return subscriptions.some(subscription => {
+      if (subscription.application !== application.id) {
+        return false;
+      }
+
+      const existingSecurity = response.metadata[subscription.plan]?.securityType;
+      if (security === 'API_KEY' && application.api_key_mode === 'SHARED') {
+        return existingSecurity === 'API_KEY';
+      }
+      if (security === 'JWT' || security === 'OAUTH2') {
+        return existingSecurity === 'JWT' || existingSecurity === 'OAUTH2';
+      }
+      return security === 'MTLS' && existingSecurity === 'MTLS';
+    });
+  }
+
+  private toDisabledApplication(application: Application): ApplicationVM {
+    const security = this.currentPlan()?.security;
+    if (security === 'API_KEY') {
+      return {
+        ...application,
+        disabled: true,
+        disabledMessage: $localize`:@@subscribeToApiProductExistingSharedApiKeySubscription:This application uses shared API keys and already has an active API Key subscription`,
+      };
+    }
+    if (security === 'MTLS') {
+      return {
+        ...application,
+        disabled: true,
+        disabledMessage: $localize`:@@subscribeToApiProductExistingMtlsSubscription:Already subscribed to an mTLS plan for this API Product`,
+      };
+    }
+    return {
+      ...application,
+      disabled: true,
+      disabledMessage: $localize`:@@subscribeToApiProductExistingOAuthJwtSubscription:Already subscribed to an OAuth2 or JWT plan for this API Product`,
+    };
+  }
+
+  private isClientIdMissing(application: Application): boolean {
+    const security = this.currentPlan()?.security;
+    return (security === 'OAUTH2' || security === 'JWT') && application.hasClientId !== true;
+  }
+
+  private isClientCertificateMissing(application: Application): boolean {
+    return this.currentPlan()?.security === 'MTLS' && !application.settings?.tls?.client_certificate;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-application/subscribe-to-api-choose-application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-application/subscribe-to-api-choose-application.component.ts
@@ -20,7 +20,11 @@ import { RadioCardComponent } from '../../../../components/radio-card/radio-card
 import { MobileClassDirective } from '../../../../directives/mobile-class.directive';
 import { NarrowClassDirective } from '../../../../directives/narrow-class.directive';
 import { Application } from '../../../../entities/application/application';
-import { ApplicationVM } from '../subscribe-to-api.component';
+
+export interface ApplicationVM extends Application {
+  disabled?: boolean;
+  disabledMessage?: string;
+}
 
 export const APPLICATIONS_PAGE_SIZE_OPTIONS: number[] = [6, 12, 24, 48, 96];
 export const DEFAULT_APPLICATIONS_PAGE_SIZE = 6;

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
@@ -34,6 +34,7 @@ import {
 } from './components/terms-and-conditions-dialog/terms-and-conditions-dialog.component';
 import { SubscribeToApiCheckoutComponent } from './subscribe-to-api-checkout/subscribe-to-api-checkout.component';
 import {
+  ApplicationVM,
   ApplicationsPagination,
   DEFAULT_APPLICATIONS_PAGE_SIZE,
   SubscribeToApiChooseApplicationComponent,
@@ -62,11 +63,6 @@ export enum SubscribeStep {
   APP_SELECTION = 'APP_SELECTION',
   PUSH_DETAILS = 'PUSH_DETAILS',
   REVIEW = 'REVIEW',
-}
-
-export interface ApplicationVM extends Application {
-  disabled?: boolean;
-  disabledMessage?: string;
 }
 
 interface ApplicationsData {

--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -38,6 +38,7 @@ import { ApplicationTabLogsComponent } from './dashboard/application-details/app
 import { ApplicationTabMembersComponent } from './dashboard/application-details/application-tab-members/application-tab-members.component';
 import { ApplicationTabSettingsComponent } from './dashboard/application-details/application-tab-settings/application-tab-settings.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
+import { DocumentationApiProductSubscribeComponent } from './documentation/components/documentation-api-product-subscribe/documentation-api-product-subscribe.component';
 import { DocumentationSubscribeComponent } from './documentation/components/documentation-subscribe/documentation-subscribe.component';
 import { InvitationConfirmationComponent } from './registration/invitation-confirmation/invitation-confirmation.component';
 import { RegistrationConfirmationComponent } from './registration/registration-confirmation/registration-confirmation.component';
@@ -46,6 +47,7 @@ import { NavigationPageFullWidthComponent } from '../components/navigation-page-
 import { analyticsEnabledGuard } from '../guards/analytics-enabled.guard';
 import { applicationInvitationsEnabledGuard, applicationMembershipEnabledGuard } from '../guards/application-membership-enabled.guard';
 import { redirectGuard } from '../guards/redirect.guard';
+import { apiProductResolver } from '../resolvers/api-product.resolver';
 import { apiResolver } from '../resolvers/api.resolver';
 import { applicationPermissionResolver, applicationResolver, applicationTypeResolver } from '../resolvers/application.resolver';
 import { homepageContentResolver } from '../resolvers/homepage-content.resolver';
@@ -270,6 +272,11 @@ export const routes: Routes = [
             path: 'api/:apiId/subscribe',
             resolve: { api: apiResolver },
             component: DocumentationSubscribeComponent,
+          },
+          {
+            path: 'api-product/:apiProductId/subscribe',
+            resolve: { apiProduct: apiProductResolver },
+            component: DocumentationApiProductSubscribeComponent,
           },
         ],
       },

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-logs/application-log-table/application-log-table.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-logs/application-log-table/application-log-table.component.ts
@@ -207,7 +207,7 @@ export class ApplicationLogTableComponent implements OnInit {
       .list({ applicationIds: [this.application.id], size: -1, statuses: ['ACCEPTED', 'PAUSED'] })
       .pipe(
         map(response => {
-          const apiIds = [...new Set(response.data.map(s => s.api))];
+          const apiIds = [...new Set(response.data.map(s => s.api).filter((apiId): apiId is string => apiId !== undefined))];
           return apiIds.map(apiId => ({
             id: apiId,
             name: response.metadata[apiId]?.name ?? '',

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.ts
@@ -136,7 +136,7 @@ export default class SubscriptionsComponent {
 
     return response.data.map(sub => ({
       id: sub.id,
-      api: this.retrieveMetadataName(sub.api, response.metadata),
+      api: sub.api ? this.retrieveMetadataName(sub.api, response.metadata) : '',
       plan: this.retrieveMetadataName(sub.plan, response.metadata),
       application: this.retrieveMetadataName(sub.application, response.metadata),
       created_at: sub.created_at ?? '',

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-api-product-subscribe/documentation-api-product-subscribe.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-api-product-subscribe/documentation-api-product-subscribe.component.html
@@ -1,0 +1,31 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="container">
+  <a
+    [routerLink]="['/documentation', navId()]"
+    [queryParams]="{ selectedId: selectedId() }"
+    class="documentation-api-product-subscribe__back-link internal-link"
+  >
+    <mat-icon aria-hidden="true">arrow_backward</mat-icon>
+    <span i18n="@@documentationApiProductSubscribeBack">Back to API Product</span>
+  </a>
+  <h1 class="next-gen-h3">
+    <span i18n="@@documentationApiProductSubscribeTitle">Subscribe to the API Product:</span> {{ apiProduct().name }}
+  </h1>
+  <app-subscribe-to-api-product [apiProduct]="apiProduct()" [cancelFn]="cancel" />
+</div>

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-api-product-subscribe/documentation-api-product-subscribe.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-api-product-subscribe/documentation-api-product-subscribe.component.scss
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../scss/layout' as layout;
+@use '../../../../scss/theme' as app-theme;
+
+:host {
+  @include layout.medium-container();
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: layout.$container-content-padding-horizontal;
+  padding: layout.$container-content-padding-vertical layout.$container-content-padding-horizontal;
+  max-width: app-theme.$inner-content-width;
+  margin: 0 auto;
+}
+
+.documentation-api-product-subscribe__back-link {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: layout.$container-padding-horizontal;
+}

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-api-product-subscribe/documentation-api-product-subscribe.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-api-product-subscribe/documentation-api-product-subscribe.component.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { Router } from '@angular/router';
+
+import { DocumentationApiProductSubscribeComponent } from './documentation-api-product-subscribe.component';
+import { fakeApiProduct } from '../../../../entities/api-product/api-product.fixture';
+import { AppTestingModule } from '../../../../testing/app-testing.module';
+
+describe('DocumentationApiProductSubscribeComponent', () => {
+  let fixture: ComponentFixture<DocumentationApiProductSubscribeComponent>;
+  let router: jest.Mocked<Router>;
+
+  beforeEach(async () => {
+    router = { navigate: jest.fn().mockResolvedValue(true) } as unknown as jest.Mocked<Router>;
+
+    await TestBed.configureTestingModule({
+      imports: [DocumentationApiProductSubscribeComponent, MatIconTestingModule, AppTestingModule],
+      providers: [{ provide: Router, useValue: router }],
+      schemas: [NO_ERRORS_SCHEMA],
+    })
+      .overrideComponent(DocumentationApiProductSubscribeComponent, {
+        set: { imports: [MatIconTestingModule], schemas: [NO_ERRORS_SCHEMA] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(DocumentationApiProductSubscribeComponent);
+    fixture.componentRef.setInput('apiProduct', fakeApiProduct({ name: 'Developer Product' }));
+    fixture.componentRef.setInput('navId', 'nav-id');
+    fixture.componentRef.setInput('selectedId', 'selected-id');
+    fixture.detectChanges();
+  });
+
+  it('should display the API Product name', () => {
+    expect(fixture.nativeElement.textContent).toContain('Subscribe to the API Product: Developer Product');
+  });
+
+  it('should return to documentation and preserve the selected item', () => {
+    fixture.componentInstance.cancel();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/documentation', 'nav-id'], {
+      queryParams: { selectedId: 'selected-id' },
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-api-product-subscribe/documentation-api-product-subscribe.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-api-product-subscribe/documentation-api-product-subscribe.component.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, inject, input } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+import { Router, RouterLink } from '@angular/router';
+
+import { ApiProduct } from '../../../../entities/api-product/api-product';
+import { SubscribeToApiProductComponent } from '../../../api-product/subscribe-to-api-product/subscribe-to-api-product.component';
+
+@Component({
+  selector: 'app-documentation-api-product-subscribe',
+  imports: [MatIcon, RouterLink, SubscribeToApiProductComponent],
+  templateUrl: './documentation-api-product-subscribe.component.html',
+  styleUrl: './documentation-api-product-subscribe.component.scss',
+})
+export class DocumentationApiProductSubscribeComponent {
+  private readonly router = inject(Router);
+
+  readonly apiProduct = input.required<ApiProduct>();
+  readonly navId = input.required<string>();
+  readonly selectedId = input<string>();
+
+  readonly cancel = () => this.router.navigate(['/documentation', this.navId()], { queryParams: { selectedId: this.selectedId() } });
+}

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/configure-consumer/configure-consumer.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/configure-consumer/configure-consumer.component.spec.ts
@@ -107,6 +107,21 @@ describe('ConfigureConsumerComponent', () => {
       initComponent(subscription);
     });
 
+    it('should reject consumer configuration for an API Product subscription', async () => {
+      const subscription = fakeSubscription({
+        api: undefined,
+        reference_id: 'api-product-id',
+        reference_type: 'API_PRODUCT',
+        consumerConfiguration: fakeSubscriptionConsumerConfiguration(),
+      });
+
+      expectSubscription(subscription);
+      fixture.detectChanges();
+
+      httpTestingController.expectNone(request => request.url.includes('/apis/'));
+      expect(fixture.nativeElement.textContent).toContain('The consumer configuration update has failed');
+    });
+
     it('should reset the form', async () => {
       const consumerConfiguration = fakeSubscriptionConsumerConfiguration();
       const subscription = fakeSubscription({ status: 'ACCEPTED', api: API_ID, plan: PLAN_ID, consumerConfiguration });

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/configure-consumer/configure-consumer.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/configure-consumer/configure-consumer.component.ts
@@ -58,12 +58,17 @@ export class ConfigureConsumerComponent implements OnInit {
     this.subscriptionService
       .get(this.subscriptionId)
       .pipe(
-        switchMap(subscription => combineLatest([this.planService.list(subscription.api), of(subscription)])),
+        switchMap(subscription => this.loadPlansWithSubscription(subscription)),
         tap(([plans, subscription]) => {
           this.subscription = subscription;
           this.consumerConfigurationFormValues = this.toConsumerConfigurationFormValues();
           this.plan = plans.data?.find(p => p.id === subscription.plan);
           this.isLoadingSubscription = false;
+        }),
+        catchError(() => {
+          this.error = true;
+          this.isLoadingSubscription = false;
+          return of(null);
         }),
         takeUntilDestroyed(this.destroyRef),
       )
@@ -93,7 +98,7 @@ export class ConfigureConsumerComponent implements OnInit {
         switchMap(() => {
           return this.subscriptionService.get(this.subscriptionId);
         }),
-        switchMap(subscription => combineLatest([this.planService.list(subscription.api), of(subscription)])),
+        switchMap(subscription => this.loadPlansWithSubscription(subscription)),
         tap(([plans, subscription]) => {
           this.subscription = subscription;
           this.consumerConfigurationFormValues = this.toConsumerConfigurationFormValues();
@@ -102,11 +107,20 @@ export class ConfigureConsumerComponent implements OnInit {
         }),
         catchError(() => {
           this.error = true;
+          this.isLoadingSubscription = false;
           return of(null);
         }),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
+  }
+
+  private loadPlansWithSubscription(subscription: Subscription) {
+    if (!subscription.api) {
+      throw new Error('Consumer configuration is only supported for API subscriptions');
+    }
+
+    return combineLatest([this.planService.list(subscription.api), of(subscription)]);
   }
 
   private toUpdateSubscription(updatedValues: ConsumerConfigurationValues): UpdateSubscription {

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.fixture.ts
@@ -31,6 +31,8 @@ export function fakeSubscription(modifier?: Partial<Subscription> | ((baseSubscr
     status: 'REJECTED',
     consumerStatus: SubscriptionConsumerStatusEnum.STARTED,
     api: 'api-id',
+    reference_id: 'api-id',
+    reference_type: 'API',
     keys: [
       {
         id: '12f73b0a-59e6-4d23-b73b-0a59e62d2369',

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
@@ -17,7 +17,9 @@ import { SubscriptionConsumerConfiguration } from './subscription-consumer-confi
 
 export interface Subscription {
   id: string;
-  api: string;
+  api?: string;
+  reference_id?: string;
+  reference_type?: SubscriptionReferenceType;
   application: string;
   closed_at?: string;
   created_at?: string;
@@ -32,6 +34,8 @@ export interface Subscription {
   keys?: SubscriptionDataKeys[];
   consumerConfiguration?: SubscriptionConsumerConfiguration;
 }
+
+export type SubscriptionReferenceType = 'API' | 'API_PRODUCT';
 
 export type SubscriptionStatusEnum = 'PENDING' | 'ACCEPTED' | 'CLOSED' | 'REJECTED' | 'PAUSED';
 

--- a/gravitee-apim-portal-webui-next/src/resolvers/api-product.resolver.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/resolvers/api-product.resolver.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpErrorResponse } from '@angular/common/http';
+import { ApplicationRef, Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { NavigationEnd, provideRouter, Router } from '@angular/router';
+import { filter, firstValueFrom, of, take, throwError } from 'rxjs';
+
+import { apiProductResolver } from './api-product.resolver';
+import { fakeApiProduct } from '../entities/api-product/api-product.fixture';
+import { ApiProductsService } from '../services/api-products.service';
+
+describe('apiProductResolver', () => {
+  @Component({ template: '' })
+  class StubComponent {}
+
+  let router: Router;
+  let apiProductsService: { getById: jest.Mock };
+
+  beforeEach(async () => {
+    apiProductsService = { getById: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: 'api-product/:apiProductId', component: StubComponent, resolve: { apiProduct: apiProductResolver } },
+          { path: '404', component: StubComponent },
+        ]),
+        { provide: ApiProductsService, useValue: apiProductsService },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+  });
+
+  it('should resolve API Product details', async () => {
+    const apiProduct = fakeApiProduct();
+    apiProductsService.getById.mockReturnValue(of(apiProduct));
+
+    await router.navigateByUrl(`/api-product/${apiProduct.id}`);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(apiProductsService.getById).toHaveBeenCalledWith(apiProduct.id);
+    expect(router.routerState.snapshot.root.firstChild?.data['apiProduct']).toEqual(apiProduct);
+  });
+
+  it('should end navigation on /404 when API Product details return 404', async () => {
+    apiProductsService.getById.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' })));
+    const navigatedTo404 = firstValueFrom(
+      router.events.pipe(
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        filter(event => event.urlAfterRedirects === '/404'),
+        take(1),
+      ),
+    );
+
+    void router.navigateByUrl('/api-product/unknown');
+
+    await navigatedTo404;
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(router.url).toBe('/404');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/resolvers/api-product.resolver.ts
+++ b/gravitee-apim-portal-webui-next/src/resolvers/api-product.resolver.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpErrorResponse } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, ResolveFn, Router, RouterStateSnapshot } from '@angular/router';
+import { catchError, EMPTY, Observable } from 'rxjs';
+
+import { ApiProduct } from '../entities/api-product/api-product';
+import { ApiProductsService } from '../services/api-products.service';
+
+export const apiProductResolver = ((
+  route: ActivatedRouteSnapshot,
+  _: RouterStateSnapshot,
+  apiProductsService: ApiProductsService = inject(ApiProductsService),
+  router: Router = inject(Router),
+): Observable<ApiProduct> =>
+  apiProductsService.getById(route.params['apiProductId']).pipe(
+    catchError((error: unknown) => {
+      if (error instanceof HttpErrorResponse && error.status === 404) {
+        void router.navigate(['/404']);
+        return EMPTY;
+      }
+      throw error;
+    }),
+  )) satisfies ResolveFn<ApiProduct>;

--- a/gravitee-apim-portal-webui-next/src/services/api-products.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/api-products.service.spec.ts
@@ -18,6 +18,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { ApiProductsService } from './api-products.service';
 import { fakeApiProduct } from '../entities/api-product/api-product.fixture';
+import { fakePlan } from '../entities/plan/plan.fixture';
 import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
 
 describe('ApiProductsService', () => {
@@ -78,6 +79,22 @@ describe('ApiProductsService', () => {
 
       const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/api-products/${apiProductId}`);
       req.flush({ message: 'API Product not found' }, { status: 404, statusText: 'Not Found' });
+    });
+  });
+
+  describe('listPlans', () => {
+    it('should list all available API Product plans', done => {
+      const apiProductId = '4f6597ca-74b8-4e68-a597-ca74b83e6824';
+      const plansResponse = { data: [fakePlan()] };
+
+      service.listPlans(apiProductId).subscribe(response => {
+        expect(response).toEqual(plansResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/api-products/${apiProductId}/plans?size=-1`);
+      expect(req.request.method).toEqual('GET');
+      req.flush(plansResponse);
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/api-products.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/api-products.service.ts
@@ -19,6 +19,7 @@ import { Observable } from 'rxjs';
 
 import { ConfigService } from './config.service';
 import { ApiProduct } from '../entities/api-product/api-product';
+import { PlansResponse } from '../entities/plan/plans-response';
 
 @Injectable({
   providedIn: 'root',
@@ -29,5 +30,9 @@ export class ApiProductsService {
 
   getById(apiProductId: string): Observable<ApiProduct> {
     return this.http.get<ApiProduct>(`${this.configService.baseURL}/api-products/${apiProductId}`);
+  }
+
+  listPlans(apiProductId: string): Observable<PlansResponse> {
+    return this.http.get<PlansResponse>(`${this.configService.baseURL}/api-products/${apiProductId}/plans?size=-1`);
   }
 }

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.spec.ts
@@ -51,6 +51,21 @@ describe('SubscriptionService', () => {
     req.flush(subscriptionResponse);
   });
 
+  it('should filter subscriptions by API Product IDs', done => {
+    const subscriptionResponse: SubscriptionsResponse = fakeSubscriptionResponse();
+
+    service.list({ apiProductIds: ['api-product-id'], statuses: ['PENDING', 'ACCEPTED', 'PAUSED'], size: -1 }).subscribe(response => {
+      expect(response).toEqual(subscriptionResponse);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(
+      `${TESTING_BASE_URL}/subscriptions?apiProductIds=api-product-id&statuses=PENDING&statuses=ACCEPTED&statuses=PAUSED&size=-1`,
+    );
+    expect(req.request.method).toEqual('GET');
+    req.flush(subscriptionResponse);
+  });
+
   it('should close subscription', done => {
     service.close('subscriptionId').subscribe(() => {
       done();

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
@@ -37,6 +37,7 @@ export class SubscriptionService {
 
   list(queryParams: {
     apiIds?: string[];
+    apiProductIds?: string[];
     applicationIds?: string[];
     statuses: SubscriptionStatusEnum[] | null;
     size?: number;
@@ -44,6 +45,7 @@ export class SubscriptionService {
   }): Observable<SubscriptionsResponse> {
     const params = {
       ...(queryParams.apiIds?.length ? { apiIds: queryParams.apiIds } : {}),
+      ...(queryParams.apiProductIds?.length ? { apiProductIds: queryParams.apiProductIds } : {}),
       ...(queryParams.applicationIds?.length ? { applicationIds: queryParams.applicationIds } : {}),
       ...(queryParams.statuses?.length ? { statuses: queryParams.statuses } : {}),
       ...(queryParams.size != null ? { size: queryParams.size } : {}),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-117

## Description

Adds a dedicated API Product subscription flow to Portal Next.

## Changes

- add the API Product subscription route under the documentation context
- load API Product details and available plans
- support plan and application selection
- validate subscription eligibility and application credentials
- support PUSH plan consumer configuration
- collect a subscription request comment when required by the plan
- create subscriptions through the existing `/subscriptions` endpoint
- display inline confirmation for accepted and pending subscriptions
- preserve the documentation navigation context when cancelling the flow
- handle loading, empty, error, and retry states
- update subscription models and services to support API Product references

## Scope

Subscription forms and general conditions are not supported for API Products and are not in scope for API products

https://github.com/user-attachments/assets/ce9f7cf9-9b53-445b-99d4-7f79bcc3cb5c

