### PR TITLE
fix(mongo): enforce client_id uniqueness per environment

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApplicationRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.mongodb.management;
 
 import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.exceptions.DuplicateKeyException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.search.ApplicationCriteria;
@@ -26,6 +27,7 @@ import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.repository.mongodb.management.internal.application.ApplicationMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.ApplicationMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.applications.ClientIdUniqueIndexUpgrader;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -63,8 +65,23 @@ public class MongoApplicationRepository implements ApplicationRepository {
     @Override
     public Application create(Application application) throws TechnicalException {
         ApplicationMongo applicationMongo = mapApplication(application);
-        ApplicationMongo applicationMongoCreated = internalApplicationRepo.insert(applicationMongo);
-        return mapApplication(applicationMongoCreated);
+        try {
+            ApplicationMongo applicationMongoCreated = internalApplicationRepo.insert(applicationMongo);
+            return mapApplication(applicationMongoCreated);
+        } catch (org.springframework.dao.DuplicateKeyException e) {
+            if (isClientIdConflict(e)) {
+                throw new DuplicateKeyException(String.format("An error occurred while creating application [%s]", application.getId()), e);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Only a violation of the client_id unique index is a duplicate key the callers can act upon, any other conflict
+     * (a reused application id, typically) keeps being reported as it used to be.
+     */
+    private boolean isClientIdConflict(org.springframework.dao.DuplicateKeyException e) {
+        return e.getMessage() != null && e.getMessage().contains(ClientIdUniqueIndexUpgrader.INDEX_NAME);
     }
 
     @Override
@@ -94,8 +111,15 @@ public class MongoApplicationRepository implements ApplicationRepository {
         applicationMongo.setApiKeyMode(application.getApiKeyMode().name());
         applicationMongo.setDisableMembershipNotifications(application.isDisableMembershipNotifications());
 
-        ApplicationMongo applicationMongoUpdated = internalApplicationRepo.save(applicationMongo);
-        return mapApplication(applicationMongoUpdated);
+        try {
+            ApplicationMongo applicationMongoUpdated = internalApplicationRepo.save(applicationMongo);
+            return mapApplication(applicationMongoUpdated);
+        } catch (org.springframework.dao.DuplicateKeyException e) {
+            if (isClientIdConflict(e)) {
+                throw new DuplicateKeyException(String.format("An error occurred while updating application [%s]", application.getId()), e);
+            }
+            throw e;
+        }
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/applications/ClientIdUniqueIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/applications/ClientIdUniqueIndexUpgrader.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.applications;
+
+import static io.gravitee.repository.management.model.Application.METADATA_CLIENT_ID;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Accumulators;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import io.gravitee.repository.management.model.ApplicationStatus;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Enforces, at database level, that a client_id is used by at most one active application per environment.
+ * <p>
+ * Applications sharing a client_id cannot be arbitrated here: both may be serving traffic, and the losing one would
+ * have its subscriptions closed. They are reported instead, and the index is left out until an operator resolves them.
+ *
+ * @author GraviteeSource Team
+ */
+@Component("ApplicationsClientIdUniqueIndexUpgrader")
+public class ClientIdUniqueIndexUpgrader extends MongoUpgrader {
+
+    public static final String INDEX_NAME = "ei1mci1_unique";
+
+    private static final String CLIENT_ID_FIELD = "metadata." + METADATA_CLIENT_ID;
+
+    private static final Logger LOG = LoggerFactory.getLogger(
+        ClientIdUniqueIndexUpgrader.class
+    );
+
+    @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+
+    /**
+     * Never reports a failure: the node stops when an upgrader fails, and a missing index only means keeping the
+     * behaviour of the previous versions. Run it again by removing its record from the `upgrades` collection.
+     */
+    @Override
+    public boolean upgrade() {
+        try {
+            createIndex();
+        } catch (Exception e) {
+            LOG.error(
+                "Unexpected error while creating index {} on applications, client_id uniqueness stays unenforced",
+                INDEX_NAME,
+                e
+            );
+        }
+        return true;
+    }
+
+    private void createIndex() {
+        final var applicationsCollection = this.getCollection("applications");
+        final var duplicates = searchDuplicateClientIds(applicationsCollection);
+
+        if (!duplicates.isEmpty()) {
+            LOG.warn(
+                "Index {} has not been created on applications: {} client_id(s) are shared by several active " +
+                    "applications, and client_id uniqueness stays unenforced until they are resolved.",
+                INDEX_NAME,
+                duplicates.size()
+            );
+            duplicates.forEach(duplicate -> {
+                Document group = duplicate.get("_id", Document.class);
+                LOG.warn(
+                    "Duplicated client_id [{}] in environment [{}] used by applications {}",
+                    group.getString(METADATA_CLIENT_ID),
+                    group.getString("environmentId"),
+                    duplicate.get("applicationIds")
+                );
+            });
+            return;
+        }
+
+        applicationsCollection.createIndex(
+            Indexes.ascending("environmentId", CLIENT_ID_FIELD),
+            new IndexOptions()
+                .name(INDEX_NAME)
+                .unique(true)
+                .partialFilterExpression(activeApplicationsHavingAClientId())
+        );
+        LOG.info("Index {} has been created successfully on applications", INDEX_NAME);
+    }
+
+    private List<Document> searchDuplicateClientIds(
+        MongoCollection<Document> collection
+    ) {
+        final var duplicatesAggregated = collection.aggregate(
+            Arrays.asList(
+                Aggregates.match(activeApplicationsHavingAClientId()),
+                Aggregates.group(
+                    new Document("environmentId", "$environmentId").append(
+                        METADATA_CLIENT_ID,
+                        "$" + CLIENT_ID_FIELD
+                    ),
+                    Accumulators.push("applicationIds", "$_id"),
+                    Accumulators.sum("count", 1)
+                ),
+                Aggregates.match(Filters.gt("count", 1))
+            )
+        );
+        return StreamSupport.stream(duplicatesAggregated.spliterator(), false).toList();
+    }
+
+    private static Bson activeApplicationsHavingAClientId() {
+        return Filters.and(
+            Filters.eq("status", ApplicationStatus.ACTIVE.name()),
+            Filters.exists(CLIENT_ID_FIELD)
+        );
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/MongoApplicationClientIdUniquenessTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/MongoApplicationClientIdUniquenessTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import static io.gravitee.repository.management.model.Application.METADATA_CLIENT_ID;
+import static io.gravitee.repository.utils.DateUtils.parse;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import io.gravitee.repository.exceptions.DuplicateKeyException;
+import io.gravitee.repository.management.AbstractManagementRepositoryTest;
+import io.gravitee.repository.management.model.Application;
+import io.gravitee.repository.management.model.ApplicationStatus;
+import io.gravitee.repository.management.model.ApplicationType;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * The client_id uniqueness is enforced by a unique index only created on MongoDB, hence a MongoDB specific test
+ * instead of a shared repository test.
+ *
+ * @author GraviteeSource Team
+ */
+public class MongoApplicationClientIdUniquenessTest extends AbstractManagementRepositoryTest {
+
+    @Override
+    protected String getTestCasesPath() {
+        return "/data/application-tests/";
+    }
+
+    @Test
+    public void should_not_create_two_active_applications_with_same_client_id_in_same_environment() {
+        assertThatThrownBy(() -> applicationRepository.create(anApplicationWithClientId("duplicate", "PROD", "my-client-id"))).isInstanceOf(
+            DuplicateKeyException.class
+        );
+    }
+
+    @Test
+    public void should_create_application_with_same_client_id_in_another_environment() throws Exception {
+        applicationRepository.create(anApplicationWithClientId("other-env", "DEFAULT", "my-client-id"));
+
+        assertTrue(applicationRepository.findById("other-env").isPresent());
+    }
+
+    @Test
+    public void should_create_application_with_client_id_of_an_archived_application() throws Exception {
+        applicationRepository.create(anApplicationWithClientId("reusing-archived", "PROD", "my-client-id-old"));
+
+        assertTrue(applicationRepository.findById("reusing-archived").isPresent());
+    }
+
+    @Test
+    public void should_not_update_an_application_to_use_an_existing_client_id() throws Exception {
+        Application application = applicationRepository.create(anApplicationWithClientId("to-be-updated", "PROD", "its-own-client-id"));
+        application.getMetadata().put(METADATA_CLIENT_ID, "my-client-id");
+
+        assertThatThrownBy(() -> applicationRepository.update(application)).isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    public void should_update_an_application_keeping_its_own_client_id() throws Exception {
+        Application application = applicationRepository.create(anApplicationWithClientId("keeping-client-id", "PROD", "kept-client-id"));
+        application.setName("renamed");
+
+        Application updated = applicationRepository.update(application);
+
+        assertEquals("renamed", updated.getName());
+        assertEquals("kept-client-id", updated.getMetadata().get(METADATA_CLIENT_ID));
+    }
+
+    @Test
+    public void should_release_client_id_when_application_is_archived() throws Exception {
+        Application application = applicationRepository.findById("app-with-client-id").orElseThrow();
+        application.setStatus(ApplicationStatus.ARCHIVED);
+        applicationRepository.update(application);
+
+        applicationRepository.create(anApplicationWithClientId("taking-over", "PROD", "my-client-id"));
+
+        assertTrue(applicationRepository.findById("taking-over").isPresent());
+    }
+
+    private Application anApplicationWithClientId(String id, String environmentId, String clientId) {
+        Application application = new Application();
+        application.setId(id);
+        application.setName(id);
+        application.setEnvironmentId(environmentId);
+        application.setType(ApplicationType.SIMPLE);
+        application.setStatus(ApplicationStatus.ACTIVE);
+        application.setCreatedAt(parse("11/02/2016"));
+        application.setUpdatedAt(parse("11/02/2016"));
+        application.setMetadata(new HashMap<>(Map.of(METADATA_CLIENT_ID, clientId)));
+        return application;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/applications/ClientIdUniqueIndexUpgraderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/applications/ClientIdUniqueIndexUpgraderTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.applications;
+
+import static io.gravitee.repository.mongodb.management.upgrade.upgrader.index.applications.ClientIdUniqueIndexUpgrader.INDEX_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import io.gravitee.repository.management.AbstractManagementRepositoryTest;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.bson.Document;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.data.mongodb.core.MongoOperations;
+
+public class ClientIdUniqueIndexUpgraderTest extends AbstractManagementRepositoryTest {
+
+    private static final List<String> DUPLICATED_APPLICATION_IDS = List.of(
+        "duplicate-1",
+        "duplicate-2"
+    );
+
+    @Inject
+    private ClientIdUniqueIndexUpgrader upgrader;
+
+    @Inject
+    private MongoOperations mongoOperations;
+
+    @Inject
+    private Environment environment;
+
+    @Override
+    protected String getTestCasesPath() {
+        return null;
+    }
+
+    @Before
+    public void dropIndex() {
+        if (indexNames().contains(INDEX_NAME)) {
+            applications().dropIndex(INDEX_NAME);
+        }
+    }
+
+    /**
+     * The index is shared with the other tests running against the same database, it has to be put back in place.
+     */
+    @After
+    public void restoreIndex() {
+        applications().deleteMany(Filters.in("_id", DUPLICATED_APPLICATION_IDS));
+        upgrader.upgrade();
+    }
+
+    @Test
+    public void should_create_index_when_no_application_shares_a_client_id() {
+        assertThat(upgrader.upgrade()).isTrue();
+
+        assertThat(indexNames()).contains(INDEX_NAME);
+    }
+
+    @Test
+    public void should_not_create_index_nor_fail_when_applications_share_a_client_id() {
+        DUPLICATED_APPLICATION_IDS.forEach(id ->
+            applications().insertOne(
+                anActiveApplication(id, "DEFAULT", "shared-client-id")
+            )
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        assertThat(indexNames()).doesNotContain(INDEX_NAME);
+    }
+
+    @Test
+    public void should_ignore_a_client_id_shared_with_an_archived_application() {
+        applications().insertOne(
+            anActiveApplication("duplicate-1", "DEFAULT", "shared-client-id")
+        );
+        applications().insertOne(
+            anActiveApplication("duplicate-2", "DEFAULT", "shared-client-id").append(
+                "status",
+                "ARCHIVED"
+            )
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        assertThat(indexNames()).contains(INDEX_NAME);
+    }
+
+    private MongoCollection<Document> applications() {
+        return mongoOperations.getCollection(
+            environment.getProperty("management.mongodb.prefix", "") + "applications"
+        );
+    }
+
+    private List<String> indexNames() {
+        return StreamSupport.stream(applications().listIndexes().spliterator(), false)
+            .map(index -> index.getString("name"))
+            .toList();
+    }
+
+    private Document anActiveApplication(
+        String id,
+        String environmentId,
+        String clientId
+    ) {
+        return new Document("_id", id)
+            .append("name", id)
+            .append("environmentId", environmentId)
+            .append("status", "ACTIVE")
+            .append("metadata", new Document("client_id", clientId));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -40,6 +40,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.util.KeyStoreUtils;
 import io.gravitee.definition.model.Origin;
 import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.repository.exceptions.DuplicateKeyException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.search.ApplicationCriteria;
@@ -603,6 +604,8 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 genericNotificationConfigService.create(notificationConfigEntity);
             }
             return convert(executionContext, createdApplication, userEntity);
+        } catch (DuplicateKeyException ex) {
+            throw new ClientIdAlreadyExistsException(application.getMetadata().get(METADATA_CLIENT_ID));
         } catch (TechnicalException ex) {
             LOGGER.error(
                 "An error occurs while trying to create {} for user {} in environment {}",
@@ -784,7 +787,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             application.setOrigin(applicationToUpdate.getOrigin() != null ? applicationToUpdate.getOrigin() : Origin.MANAGEMENT);
             metadata.forEach((key, value) -> application.getMetadata().put(key, value));
 
-            Application updatedApplication = applicationRepository.update(application);
+            Application updatedApplication = updateApplication(application);
 
             // Audit
             auditService.createApplicationAuditLog(
@@ -1059,7 +1062,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             genericNotificationConfigService.deleteReference(NotificationReferenceType.APPLICATION, applicationId);
             portalNotificationConfigService.deleteReference(NotificationReferenceType.APPLICATION, applicationId);
 
-            Application restoredApplication = applicationRepository.update(application);
+            Application restoredApplication = updateApplication(application);
 
             Collection<SubscriptionEntity> subscriptions = subscriptionService.findByApplicationAndPlan(
                 executionContext,
@@ -1593,6 +1596,18 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     private void checkClientIdIsUniqueForEnv(String clientId, String environmentId) {
         if (applicationRepository.existsMetadataEntryForEnv(METADATA_CLIENT_ID, clientId, environmentId)) {
             throw new ClientIdAlreadyExistsException(clientId);
+        }
+    }
+
+    /**
+     * The checks above cannot see an application being created or updated concurrently by another node, only the
+     * repository can reject it.
+     */
+    private Application updateApplication(Application application) throws TechnicalException {
+        try {
+            return applicationRepository.update(application);
+        } catch (DuplicateKeyException ex) {
+            throw new ClientIdAlreadyExistsException(application.getMetadata().get(METADATA_CLIENT_ID));
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.repository.exceptions.DuplicateKeyException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.model.ApiKeyMode;
@@ -315,6 +316,23 @@ public class ApplicationService_CreateTest {
         when(newApplication.getSettings()).thenReturn(settings);
 
         when(applicationRepository.existsMetadataEntryForEnv(METADATA_CLIENT_ID, CLIENT_ID, "DEFAULT")).thenReturn(true);
+
+        applicationService.create(GraviteeContext.getExecutionContext(), newApplication, USER_NAME);
+    }
+
+    @Test(expected = ClientIdAlreadyExistsException.class)
+    public void shouldNotCreateBecauseClientIdWasTakenConcurrently() throws TechnicalException {
+        ApplicationSettings settings = new ApplicationSettings();
+        SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
+        clientSettings.setClientId(CLIENT_ID);
+        settings.setApp(clientSettings);
+        when(newApplication.getSettings()).thenReturn(settings);
+        when(newApplication.getName()).thenReturn(APPLICATION_NAME);
+        when(groupService.findByEvent(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(Collections.emptySet());
+        when(applicationConverter.toApplication(any(NewApplicationEntity.class))).thenCallRealMethod();
+
+        when(applicationRepository.existsMetadataEntryForEnv(METADATA_CLIENT_ID, CLIENT_ID, "DEFAULT")).thenReturn(false);
+        when(applicationRepository.create(any())).thenThrow(new DuplicateKeyException("client_id already used"));
 
         applicationService.create(GraviteeContext.getExecutionContext(), newApplication, USER_NAME);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.*;
 
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.repository.exceptions.DuplicateKeyException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.model.ApiKeyMode;
@@ -349,6 +350,25 @@ public class ApplicationService_UpdateTest {
 
         when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
         when(updateApplication.getDescription()).thenReturn("My description");
+
+        applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
+    }
+
+    @Test(expected = ClientIdAlreadyExistsException.class)
+    public void shouldNotUpdateBecauseClientIdWasTakenConcurrently() throws TechnicalException {
+        ApplicationSettings settings = new ApplicationSettings();
+        SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
+        clientSettings.setClientId(CLIENT_ID);
+        settings.setApp(clientSettings);
+
+        when(configService.getConsoleConfig(GraviteeContext.getExecutionContext())).thenReturn(getConsoleConfigEntity(false));
+        when(updateApplication.getSettings()).thenReturn(settings);
+        when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
+        when(updateApplication.getDescription()).thenReturn("My description");
+        when(existingApplication.getType()).thenReturn(ApplicationType.SIMPLE);
+        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(existingApplication));
+        when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
+        when(applicationRepository.update(any())).thenThrow(new DuplicateKeyException("client_id already used"));
 
         applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14844

## Description

Concurrent `POST /applications` with the same `settings.app.client_id` could create several ACTIVE applications sharing that client_id: the uniqueness check (`existsMetadataEntryForEnv`) and the write are two separate operations, with no transaction, no lock and no database constraint, so every replica could pass the check before any insert became visible.

Uniqueness is now enforced by MongoDB, with a partial unique index on `applications`:

- key `(environmentId, metadata.client_id)`
- `partialFilterExpression: { status: "ACTIVE", "metadata.client_id": { $exists: true } }` — archived applications keep their client_id so `restore` can still check and reuse it

`MongoApplicationRepository` turns a violation of that index (and only that one, matched by index name, so a reused application id keeps failing as before) into the existing `DuplicateKeyException`, which `ApplicationServiceImpl` maps to `ClientIdAlreadyExistsException`. Callers keep getting `400 application.clientId.exists`, whether the conflict is detected by the pre-flight check or by the database. The same protection now covers `update` and `restore`, which had the same race.

The pre-flight check is kept as the fast path, so error messages are unchanged for the sequential case.

## Additional context

**The upgrader can never prevent the node from starting.** An upgrader returning `false` or throwing makes mAPI `System.exit` at boot, so `upgrade()` catches everything and always returns `true`. A missing index only means keeping the behaviour of the previous versions.

**Applications already sharing a client_id are reported, never modified.** They cannot be arbitrated automatically: both may be serving traffic (the gateway caches subscriptions by `(api, plan, clientId)`), and archiving the loser would close its subscriptions and revoke its keys. When duplicates are found, the index is skipped and each group is logged:

```
WARN  Index ei1mci1_unique has not been created on applications: 1 client_id(s) are shared by several active applications, and client_id uniqueness stays unenforced until they are resolved.
WARN  Duplicated client_id [shared-client-id] in environment [DEFAULT] used by applications [duplicate-1, duplicate-2]
```

Once an operator has resolved them, removing the upgrader record from the `upgrades` collection re-runs it (the record id is `className + version()`).

Duplicates can be listed before upgrading with:

```js
db.applications.aggregate([
  { $match: { status: "ACTIVE", "metadata.client_id": { $exists: true } } },
  { $group: { _id: { environmentId: "$environmentId", client_id: "$metadata.client_id" },
              applicationIds: { $push: "$_id" }, count: { $sum: 1 } } },
  { $match: { count: { $gt: 1 } } }
])
```

**MongoDB only.** On JDBC the client_id lives in `application_metadata(application_id, k, v)`, which has neither `environment_id` nor `status`, so the constraint cannot be expressed there without a schema change. JDBC keeps the current pre-flight check and the existing race; it is not regressed by this PR.

## Tests

- `MongoApplicationClientIdUniquenessTest` — duplicate rejected in the same environment, allowed in another environment, allowed when the holder is archived, update onto a taken client_id rejected, update keeping its own client_id accepted, archiving releases the client_id
- `ClientIdUniqueIndexUpgraderTest` — index created when clean, skipped without failing when duplicates exist, client_id shared only with an archived application ignored
- `ApplicationService_CreateTest` / `ApplicationService_UpdateTest` — a repository duplicate key surfaces as `ClientIdAlreadyExistsException`
