### PR TITLE
feat(gateway): diagnose connection closures, unexpected 500s and shutdown cut-offs

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/diagnostic/UnexpectedErrorReporter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/diagnostic/UnexpectedErrorReporter.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.context.diagnostic;
+
+import io.gravitee.gateway.reactive.api.ExecutionWarn;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.reporter.api.v4.metric.Diagnostic;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import org.slf4j.Logger;
+import org.springframework.core.NestedExceptionUtils;
+
+/**
+ * Reports the last-resort failure path of an API reactor: an error that reached the end of the chain without having
+ * been turned into a proper execution failure, and which the reactor answers with a bare 500.
+ *
+ * <p>Left alone, that path is close to undiagnosable. It logs "Unexpected error while handling request" and nothing
+ * else, while overwriting whatever status the request had reached — so the reported outcome can be a 500 carrying an
+ * error key that belongs to a completely different status (a {@code GATEWAY_CLIENT_*} key normally answered with a
+ * 502, for instance), with an empty body because the error handling itself never got to write one. The combination is
+ * indistinguishable, from analytics alone, from the gateway simply returning 500.
+ *
+ * <p>This records what is needed to tell those apart, on both sides:
+ * <ul>
+ *   <li>in the gateway log, a line naming the request and transaction ids, the status being replaced, the error
+ *       already attributed, the endpoint reached and the cause — enough to conclude without correlating anything;</li>
+ *   <li>in the analytics, a key of its own when nothing was attributed, so the request stops being reported as a
+ *       success that happens to carry a 500 — and otherwise a warning carrying the exception, which would otherwise
+ *       exist nowhere but the gateway's own log file.</li>
+ * </ul>
+ */
+public final class UnexpectedErrorReporter {
+
+    /** Key recorded when the failure reached the reactor with nothing attributed to it yet. */
+    public static final String UNEXPECTED_ERROR_KEY = "GATEWAY_UNEXPECTED_ERROR";
+
+    private UnexpectedErrorReporter() {}
+
+    /**
+     * Reports the failure <em>and</em> answers it with the given status, in that order.
+     * <p>
+     * The two are done here together on purpose: every message below states the status the request is answered with,
+     * and the status the request had reached before that. Leaving the caller to apply the status separately would let
+     * the two drift apart, and the reports would then describe a response that was never sent.
+     *
+     * @param statusCode the status to answer with; the caller still decides which one, it is simply written once.
+     */
+    public static void recordAndAnswer(
+        final HttpPlainExecutionContext ctx,
+        final int statusCode,
+        final String reasonPhrase,
+        final Throwable throwable,
+        final Logger log
+    ) {
+        final Metrics metrics = ctx.metrics();
+        final Diagnostic failure = metrics != null ? metrics.getFailure() : null;
+        final String attributedKey = attributedKey(metrics, failure);
+        // Read before the answer below overwrites it.
+        final int replacedStatus = ctx.response().status();
+
+        // The contextual logger already carries apiId, apiName, envId, orgId, appId, planId and user, but neither
+        // request nor transaction id — and those are what tie this line to the analytics entry it explains. The rest
+        // is what one needs to decide whether the answered status is the real outcome or an overwrite: the status it
+        // replaces, the error already attributed, where the request had got to, and the cause spelled out for the
+        // cases where the stack trace is truncated by whatever collects these logs.
+        ctx
+            .withLogger(log)
+            .error(
+                "Unexpected error while handling request, answering {} [requestId={}, transactionId={}, " +
+                    "statusBeingReplaced={}, attributedErrorKey={}, attributedFailure={}, endpoint={}, elapsed={}ms]: {}",
+                statusCode,
+                metrics != null ? metrics.getRequestId() : null,
+                metrics != null ? metrics.getTransactionId() : null,
+                replacedStatus,
+                attributedKey,
+                failure != null,
+                metrics != null ? metrics.getEndpoint() : null,
+                elapsedMillis(metrics),
+                mostSpecificCause(throwable),
+                throwable
+            );
+
+        if (metrics != null) {
+            if (attributedKey == null) {
+                // Nothing was attributed: without a key of its own the request is reported as a success that happens
+                // to carry an error status.
+                metrics.setErrorKey(UNEXPECTED_ERROR_KEY);
+                metrics.setErrorMessage(
+                    "The request failed unexpectedly while being handled by the gateway, and was answered with a " +
+                        statusCode +
+                        " (" +
+                        mostSpecificCause(throwable) +
+                        ")"
+                );
+            } else {
+                // Something was already attributed, and it is the more precise diagnosis: it names what actually went
+                // wrong, whereas reaching this path only says the gateway could not handle the consequence. Keep it,
+                // and record the exception as a warning — otherwise it exists nowhere but the gateway's log file.
+                ctx.warnWith(
+                    new ExecutionWarn(UNEXPECTED_ERROR_KEY)
+                        .message(
+                            "The gateway could not complete the handling of this request and answered " +
+                                statusCode +
+                                ", replacing status " +
+                                replacedStatus
+                        )
+                        .cause(throwable)
+                );
+            }
+        }
+
+        ctx.response().status(statusCode);
+        ctx.response().reason(reasonPhrase);
+    }
+
+    /** How long the request had been running, so a recurring duration (a shutdown countdown) stands out. */
+    private static long elapsedMillis(final Metrics metrics) {
+        if (metrics == null || metrics.timestamp() == null) {
+            return -1L;
+        }
+        return System.currentTimeMillis() - metrics.timestamp().toEpochMilli();
+    }
+
+    /**
+     * Description of the failure to carry into analytics: the message of the most specific cause, which is the one
+     * naming the actual fault, or its type when it carries no message.
+     */
+    private static String mostSpecificCause(final Throwable throwable) {
+        final Throwable cause = NestedExceptionUtils.getMostSpecificCause(throwable);
+        return cause.getMessage() != null && !cause.getMessage().isBlank() ? cause.getMessage() : cause.getClass().getSimpleName();
+    }
+
+    /**
+     * The error already attributed to the request, wherever it was recorded: connectors set {@code errorKey} on the
+     * metrics, while {@code interruptWith} records a {@link Diagnostic} failure without touching it.
+     */
+    private static String attributedKey(final Metrics metrics, final Diagnostic failure) {
+        if (metrics == null) {
+            return null;
+        }
+        if (metrics.getErrorKey() != null) {
+            return metrics.getErrorKey();
+        }
+        if (failure != null) {
+            return failure.getKey();
+        }
+        return null;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/context/diagnostic/UnexpectedErrorReporterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/context/diagnostic/UnexpectedErrorReporterTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.context.diagnostic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.reactive.api.ExecutionWarn;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
+import io.gravitee.reporter.api.v4.metric.Diagnostic;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UnexpectedErrorReporterTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UnexpectedErrorReporterTest.class);
+
+    @Mock
+    private HttpPlainExecutionContext ctx;
+
+    @Mock
+    private HttpPlainResponse response;
+
+    private Metrics metrics;
+
+    @BeforeEach
+    void init() {
+        metrics = Metrics.builder().build();
+        lenient().when(ctx.metrics()).thenReturn(metrics);
+        lenient().when(ctx.response()).thenReturn(response);
+        lenient().when(response.status()).thenReturn(502);
+        lenient()
+            .when(ctx.withLogger(any(Logger.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void should_attribute_a_key_of_its_own_when_nothing_was_attributed_to_the_request() {
+        UnexpectedErrorReporter.recordAndAnswer(ctx, 500, "Internal Server Error", new IllegalStateException("boom"), LOG);
+
+        // Without this, the request is reported with a 500 and no error key at all, which reads as a success in any
+        // dashboard counting failures by key.
+        assertThat(metrics.getErrorKey()).isEqualTo(UnexpectedErrorReporter.UNEXPECTED_ERROR_KEY);
+        // The cause is what makes the entry actionable: "the gateway failed" alone sends operators to the pod logs.
+        assertThat(metrics.getErrorMessage()).contains("boom");
+        verify(ctx, never()).warnWith(any());
+    }
+
+    @Test
+    void should_carry_the_unexpected_exception_into_analytics_when_a_key_is_already_attributed() {
+        metrics.setErrorKey("GATEWAY_CLIENT_CONNECTION_CLOSED");
+        metrics.setErrorMessage("Connection was closed");
+
+        UnexpectedErrorReporter.recordAndAnswer(
+            ctx,
+            500,
+            "Internal Server Error",
+            new IllegalStateException("policy chain already stopped"),
+            LOG
+        );
+
+        // The failure keeps naming the original cause, so without this warning the exception that actually broke the
+        // error handling exists nowhere but the gateway's log file — invisible to whoever reads the analytics.
+        final ArgumentCaptor<ExecutionWarn> warn = ArgumentCaptor.forClass(ExecutionWarn.class);
+        verify(ctx).warnWith(warn.capture());
+        assertThat(warn.getValue().key()).isEqualTo(UnexpectedErrorReporter.UNEXPECTED_ERROR_KEY);
+        assertThat(warn.getValue().message()).contains("replacing status 502");
+        assertThat(warn.getValue().cause()).hasMessage("policy chain already stopped");
+    }
+
+    @Test
+    void should_describe_the_most_specific_cause_rather_than_the_wrapper() {
+        final Throwable wrapped = new RuntimeException("handling failed", new IllegalStateException("endpoint manager stopped"));
+
+        UnexpectedErrorReporter.recordAndAnswer(ctx, 500, "Internal Server Error", wrapped, LOG);
+
+        // Wrapper messages are generic by nature; the innermost one is the only one naming the actual fault.
+        assertThat(metrics.getErrorMessage()).contains("endpoint manager stopped").doesNotContain("handling failed");
+    }
+
+    @Test
+    void should_preserve_an_error_key_already_recorded_on_the_metrics() {
+        metrics.setErrorKey("GATEWAY_CLIENT_CONNECTION_CLOSED");
+        metrics.setErrorMessage("Connection was closed");
+
+        UnexpectedErrorReporter.recordAndAnswer(ctx, 500, "Internal Server Error", new IllegalStateException("boom"), LOG);
+
+        // The recorded key names what actually went wrong; reaching this path only says the gateway could not handle
+        // the consequence of it.
+        assertThat(metrics.getErrorKey()).isEqualTo("GATEWAY_CLIENT_CONNECTION_CLOSED");
+        assertThat(metrics.getErrorMessage()).isEqualTo("Connection was closed");
+    }
+
+    @Test
+    void should_preserve_a_failure_already_attributed_through_an_interruption() {
+        // interruptWith records a failure without touching errorKey: the diagnosis lives there, and overwriting it
+        // would replace a 502-worth of context with a generic one.
+        metrics.setFailure(new Diagnostic("GATEWAY_CLIENT_CONNECTION_CLOSED", "Connection was closed", "ENDPOINT", "https://backend"));
+
+        UnexpectedErrorReporter.recordAndAnswer(ctx, 500, "Internal Server Error", new IllegalStateException("boom"), LOG);
+
+        assertThat(metrics.getErrorKey()).isNull();
+        assertThat(metrics.getFailure().getKey()).isEqualTo("GATEWAY_CLIENT_CONNECTION_CLOSED");
+    }
+
+    @Test
+    void should_answer_with_the_status_it_reports() {
+        UnexpectedErrorReporter.recordAndAnswer(ctx, 500, "Internal Server Error", new IllegalStateException("boom"), LOG);
+
+        // Reporting and answering are done together so the two cannot drift: every message states the status the
+        // request is answered with, and would describe a response that was never sent if the caller applied its own.
+        final InOrder inOrder = inOrder(response);
+        inOrder.verify(response).status(500);
+        inOrder.verify(response).reason("Internal Server Error");
+        assertThat(metrics.getErrorMessage()).contains("answered with a 500");
+    }
+
+    @Test
+    void should_report_the_status_being_replaced_not_the_one_it_answers() {
+        metrics.setErrorKey("GATEWAY_CLIENT_CONNECTION_CLOSED");
+        metrics.setErrorMessage("Connection was closed");
+        when(response.status()).thenReturn(502);
+
+        UnexpectedErrorReporter.recordAndAnswer(ctx, 500, "Internal Server Error", new IllegalStateException("boom"), LOG);
+
+        // The 502 is what the failure called for; the 500 is what the caller gets. Both matter, and confusing them is
+        // exactly what makes this path unreadable in analytics.
+        final ArgumentCaptor<ExecutionWarn> warn = ArgumentCaptor.forClass(ExecutionWarn.class);
+        verify(ctx).warnWith(warn.capture());
+        assertThat(warn.getValue().message()).contains("answered 500").contains("replacing status 502");
+    }
+
+    @Test
+    void should_not_fail_when_the_request_carries_no_metrics() {
+        when(ctx.metrics()).thenReturn(null);
+
+        UnexpectedErrorReporter.recordAndAnswer(ctx, 500, "Internal Server Error", new IllegalStateException("boom"), LOG);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
@@ -522,6 +522,9 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
     protected void doStop() throws Exception {
         if (!node.lifecycleState().equals(Lifecycle.State.STARTED)) {
             log.debug("Current node is not started, API handler will be stopped immediately");
+            // No grace period on this path: whatever is running is cut right away, so the count is read here, before
+            // the teardown empties it.
+            warnAboutRequestsCutShort(pendingRequests.get());
             stopNow();
         } else {
             log.debug("Current node is started, API handler will wait for pending requests before stopping");
@@ -539,14 +542,53 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
         log.debug("API reactor is now stopped: {}", this);
     }
 
+    /**
+     * Warn when the reactor is torn down while requests are still running. Stopping closes the endpoint connections,
+     * the policies and the resources from under them, so those requests end with an upstream error — an outcome that
+     * looks like a runtime fault in analytics but is really the reactor going away (an API redeploy, a node shutdown,
+     * a scale down).
+     * <p>
+     * Without this line there is nothing in the logs tying the two together, and the error rate simply appears to
+     * spike for no reason at the same instant as every deployment.
+     *
+     * @param stillRunning how many requests were running when the decision to stop anyway was taken. It has to be
+     *   captured at that point and passed in: by the time the teardown actually runs, the counter no longer reflects
+     *   the requests about to be cut.
+     */
+    private void warnAboutRequestsCutShort(final int stillRunning) {
+        if (stillRunning > 0) {
+            log.warn(
+                "API reactor is stopping while {} request(s) are still being handled: they will be cut short and " +
+                    "reported as errors. Waited up to {} ms for them ({}). [{}]",
+                stillRunning,
+                pendingRequestsTimeout,
+                PENDING_REQUESTS_TIMEOUT_PROPERTY,
+                this
+            );
+        }
+    }
+
     protected Observable<Timed<Long>> stopUntil(long timeout) {
         long period = 100;
+        // Remembers what the loop last saw, because that is the only place the count is meaningful: the predicate
+        // returns false either because the requests are gone (0) or because the grace period expired while they were
+        // still running (> 0) — and only the second case is worth a warning. Reading the counter after the loop, in
+        // the teardown itself, always yields 0.
+        final AtomicInteger lastSeenPendingRequests = new AtomicInteger();
+
         return interval(period, TimeUnit.MILLISECONDS)
             .timestamp()
             .observeOn(Schedulers.io())
-            .takeWhile(t -> pendingRequests.get() > 0 && (t.value() + 1) * period < timeout)
+            .takeWhile(t -> {
+                final int stillRunning = pendingRequests.get();
+                lastSeenPendingRequests.set(stillRunning);
+                return stillRunning > 0 && (t.value() + 1) * period < timeout;
+            })
             .onErrorComplete()
-            .doFinally(this::stopNow);
+            .doFinally(() -> {
+                warnAboutRequestsCutShort(lastSeenPendingRequests.get());
+                stopNow();
+            });
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
@@ -52,6 +52,7 @@ import io.gravitee.gateway.reactive.core.context.ComponentScope;
 import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
+import io.gravitee.gateway.reactive.core.context.diagnostic.UnexpectedErrorReporter;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionHelper;
 import io.gravitee.gateway.reactive.core.hook.HookHelper;
 import io.gravitee.gateway.reactive.core.processor.ProcessorChain;
@@ -432,11 +433,15 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
 
     private Completable handleUnexpectedError(final HttpExecutionContext ctx, final Throwable throwable) {
         return Completable.fromRunnable(() -> {
-            ctx.withLogger(log).error("Unexpected error while handling request", throwable);
+            // Reports the failure and answers it, so the status the reports name is the one actually sent.
+            UnexpectedErrorReporter.recordAndAnswer(
+                ctx,
+                HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase(),
+                throwable,
+                log
+            );
             setApiResponseTimeMetric(ctx);
-
-            ctx.response().status(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
-            ctx.response().reason(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
         });
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/AbstractApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/AbstractApiReactor.java
@@ -136,14 +136,53 @@ public abstract class AbstractApiReactor extends AbstractLifecycleComponent<Reac
 
     abstract void stopNow() throws Exception;
 
+    /**
+     * Warn when the reactor is torn down while requests are still running. Stopping closes the endpoint connections,
+     * the policies and the resources from under them, so those requests end with an upstream error — an outcome that
+     * looks like a runtime fault in analytics but is really the reactor going away (an API redeploy, a node shutdown,
+     * a scale down).
+     * <p>
+     * Without this line there is nothing in the logs tying the two together, and the error rate simply appears to
+     * spike for no reason at the same instant as every deployment.
+     *
+     * @param stillRunning how many requests were running when the decision to stop anyway was taken. It has to be
+     *   captured at that point and passed in: by the time the teardown actually runs, the counter no longer reflects
+     *   the requests about to be cut.
+     */
+    protected void warnAboutRequestsCutShort(final long stillRunning) {
+        if (stillRunning > 0) {
+            log.warn(
+                "API reactor is stopping while {} request(s) are still being handled: they will be cut short and " +
+                    "reported as errors. Waited up to {} ms for them ({}). [{}]",
+                stillRunning,
+                pendingRequestsTimeout,
+                PENDING_REQUESTS_TIMEOUT_PROPERTY,
+                this
+            );
+        }
+    }
+
     protected Completable stopUntil() {
+        // Remembers what the loop last saw, because that is the only place the count is meaningful: the predicate
+        // returns false either because the requests are gone (0) or because the grace period expired while they were
+        // still running (> 0) — and only the second case is worth a warning. Reading the counter after the loop, in
+        // the teardown itself, always yields 0.
+        final AtomicLong lastSeenPendingRequests = new AtomicLong();
+
         return interval(STOP_UNTIL_INTERVAL_PERIOD_MS, TimeUnit.MILLISECONDS)
             .timestamp()
             .observeOn(Schedulers.io())
-            .takeWhile(t -> pendingRequests.get() > 0 && (t.value() + 1) * STOP_UNTIL_INTERVAL_PERIOD_MS < pendingRequestsTimeout)
+            .takeWhile(t -> {
+                final long stillRunning = pendingRequests.get();
+                lastSeenPendingRequests.set(stillRunning);
+                return stillRunning > 0 && (t.value() + 1) * STOP_UNTIL_INTERVAL_PERIOD_MS < pendingRequestsTimeout;
+            })
             .ignoreElements()
             .onErrorComplete()
-            .doFinally(this::stopNow);
+            .doFinally(() -> {
+                warnAboutRequestsCutShort(lastSeenPendingRequests.get());
+                stopNow();
+            });
     }
 
     protected void prepareCommonAttributes(MutableExecutionContext ctx) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -790,6 +790,9 @@ public class DefaultApiReactor extends AbstractApiReactor {
 
             if (!node.lifecycleState().equals(Lifecycle.State.STARTED)) {
                 log.debug("Current node is not started, API handler will be stopped immediately");
+                // No grace period on this path: whatever is running is cut right away, so the count is read here,
+                // before the teardown empties it.
+                warnAboutRequestsCutShort(pendingRequests.get());
                 stopNow();
             } else {
                 log.debug("Current node is started, API handler will wait for pending requests before stopping");

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -59,6 +59,7 @@ import io.gravitee.gateway.reactive.core.context.ComponentScope;
 import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
+import io.gravitee.gateway.reactive.core.context.diagnostic.UnexpectedErrorReporter;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionHelper;
 import io.gravitee.gateway.reactive.core.failover.FailoverInvoker;
 import io.gravitee.gateway.reactive.core.hook.HookHelper;
@@ -553,11 +554,15 @@ public class DefaultApiReactor extends AbstractApiReactor {
 
     protected Completable handleUnexpectedError(final ExecutionContext ctx, final Throwable throwable) {
         return Completable.fromRunnable(() -> {
-            ctx.withLogger(log).error("Unexpected error while handling request", throwable);
+            // Reports the failure and answers it, so the status the reports name is the one actually sent.
+            UnexpectedErrorReporter.recordAndAnswer(
+                ctx,
+                HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase(),
+                throwable,
+                log
+            );
             computeEndpointResponseTtfbMetric(ctx);
-
-            ctx.response().status(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
-            ctx.response().reason(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
         });
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
@@ -40,6 +40,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import appender.MemoryAppender;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.event.EventManager;
@@ -128,6 +132,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.NOPLogger;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -1057,6 +1062,93 @@ class DefaultApiReactorTest {
         verify(resourceLifecycleManager).stop();
         verify(policyManager).stop();
         verify(apiService).stop();
+        RxJavaPlugins.reset();
+    }
+
+    @Test
+    void should_warn_about_the_requests_it_cuts_short_when_it_stops() throws Exception {
+        final MemoryAppender memoryAppender = new MemoryAppender();
+        final Logger logger = (Logger) LoggerFactory.getLogger(AbstractApiReactor.class);
+        memoryAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+        logger.setLevel(Level.WARN);
+        logger.addAppender(memoryAppender);
+        memoryAppender.start();
+
+        RxJavaPlugins.setIoSchedulerHandler(scheduler -> testScheduler);
+        when(node.lifecycleState()).thenReturn(Lifecycle.State.STARTED);
+        ReflectionTestUtils.setField(cut, "pendingRequests", new AtomicLong(3));
+
+        cut.doStop();
+        testScheduler.advanceTimeBy(10_000L, TimeUnit.MILLISECONDS);
+        testScheduler.triggerActions();
+
+        // Stopping closes the endpoints and policies from under those 3 requests: they end as errors, and without
+        // this line nothing in the logs ties the resulting spike to the redeploy that caused it.
+        assertThat(memoryAppender.getLoggedEvents()).hasSize(1);
+        assertThat(memoryAppender.getLoggedEvents().get(0).getFormattedMessage())
+            .contains("3 request(s) are still being handled")
+            .contains("api.pending_requests_timeout");
+
+        logger.detachAppender(memoryAppender);
+        RxJavaPlugins.reset();
+    }
+
+    @Test
+    void should_still_report_the_cut_requests_when_the_counter_empties_during_teardown() throws Exception {
+        final MemoryAppender memoryAppender = new MemoryAppender();
+        final Logger logger = (Logger) LoggerFactory.getLogger(AbstractApiReactor.class);
+        memoryAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+        logger.setLevel(Level.WARN);
+        logger.addAppender(memoryAppender);
+        memoryAppender.start();
+
+        RxJavaPlugins.setIoSchedulerHandler(scheduler -> testScheduler);
+        when(node.lifecycleState()).thenReturn(Lifecycle.State.STARTED);
+        final AtomicLong pendingRequests = new AtomicLong(2);
+        ReflectionTestUtils.setField(cut, "pendingRequests", pendingRequests);
+        // The counter empties while the teardown runs. Pins the invariant the reporting depends on: what is reported
+        // is what the wait loop observed, not what the counter happens to hold once the teardown is under way. On a
+        // live gateway the counter was already back to zero by then, and nothing was reported at all even though
+        // requests were demonstrably being cut short.
+        doAnswer(invocation -> {
+            pendingRequests.set(0);
+            return null;
+        })
+            .when(endpointManager)
+            .stop();
+
+        cut.doStop();
+        testScheduler.advanceTimeBy(10_000L, TimeUnit.MILLISECONDS);
+        testScheduler.triggerActions();
+
+        verify(endpointManager).stop();
+        assertThat(memoryAppender.getLoggedEvents()).hasSize(1);
+        assertThat(memoryAppender.getLoggedEvents().get(0).getFormattedMessage()).contains("2 request(s) are still being handled");
+
+        logger.detachAppender(memoryAppender);
+        RxJavaPlugins.reset();
+    }
+
+    @Test
+    void should_not_warn_when_it_stops_with_no_request_left() throws Exception {
+        final MemoryAppender memoryAppender = new MemoryAppender();
+        final Logger logger = (Logger) LoggerFactory.getLogger(AbstractApiReactor.class);
+        memoryAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+        logger.setLevel(Level.WARN);
+        logger.addAppender(memoryAppender);
+        memoryAppender.start();
+
+        RxJavaPlugins.setIoSchedulerHandler(scheduler -> testScheduler);
+        when(node.lifecycleState()).thenReturn(Lifecycle.State.STARTED);
+
+        cut.doStop();
+        testScheduler.advanceTimeBy(10_000L, TimeUnit.MILLISECONDS);
+        testScheduler.triggerActions();
+
+        // A clean shutdown is the common case: warning there would train operators to ignore the line.
+        assertThat(memoryAppender.getLoggedEvents()).isEmpty();
+
+        logger.detachAppender(memoryAppender);
         RxJavaPlugins.reset();
     }
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -69,6 +69,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.CustomLog;
 
@@ -99,6 +101,13 @@ public class HttpConnector implements ProxyConnector {
         TRAILER,
         UPGRADE
     );
+    /**
+     * How close the upstream silence has to be to the effective idleTimeout before we attribute the closure to the
+     * gateway rather than the backend. A connection cut by the idle timer lands within a few tens of milliseconds of
+     * it; anything looser would start blaming the configuration for genuine backend failures.
+     */
+    private static final long IDLE_TIMEOUT_MATCH_TOLERANCE_MS = 250;
+
     private final String relativeTarget;
     protected final String defaultHost;
     protected final int defaultPort;
@@ -289,10 +298,17 @@ public class HttpConnector implements ProxyConnector {
         HttpResponse response,
         String absoluteUri
     ) {
+        // How long the upstream has been silent when the stream breaks is the one measurement that tells a gateway
+        // idle timeout apart from a backend hanging up: the idle timer restarts on every byte received, so only the
+        // gap since the last one can be compared to it. Starts at the response headers, which is the last thing read
+        // from the connection at that point.
+        final AtomicLong lastUpstreamActivityNs = new AtomicLong(System.nanoTime());
+
         // A backend failure while streaming the response body (after status/headers were committed) is recorded on
         // the metrics below so the truncated response is observable instead of reported as a success.
         return endpointResponse
             .toFlowable()
+            .doOnNext(chunk -> lastUpstreamActivityNs.setPlain(System.nanoTime()))
             .map(Buffer::buffer)
             .doOnComplete(() ->
                 // Write trailers when chunks are completed
@@ -303,12 +319,11 @@ public class HttpConnector implements ProxyConnector {
                     // Means that we have manually reset the stream because the downstream request has been cancelled (see doOnCancel).
                     ctx.withLogger(log).debug("Stream reset to the backend [{}]", absoluteUri);
                 } else {
-                    ctx
-                        .withLogger(log)
-                        .error("Exception occurred while handling response chunk from upstream [{}]", absoluteUri, throwable);
                     // The response status/headers are already committed to the client, so we cannot change them; record
                     // the backend failure on the metrics so the (otherwise silent) truncated response is observable.
-                    recordBackendResponseStreamFailure(ctx, throwable);
+                    // That call also logs the failure, with the timeout context needed to interpret it.
+                    final long silenceMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - lastUpstreamActivityNs.getPlain());
+                    recordBackendResponseStreamFailure(ctx, absoluteUri, silenceMs, throwable);
                 }
                 return Flowable.empty();
             })
@@ -363,18 +378,125 @@ public class HttpConnector implements ProxyConnector {
      * headers were already committed to the client. The committed response is left untouched; only the metrics are
      * enriched (and later translated to a diagnostic) so the truncated response is no longer silently reported as a
      * success. An already-recorded error (e.g. a client abort) is preserved.
+     * <p>
+     * The recorded message is meant to be read on its own, months later, by someone who has the analytics entry and
+     * not the gateway configuration: it names what happened, when, and whether the endpoint's own timeouts are the
+     * likely cause. The log line carries the same information plus the raw configuration and the stack trace, and is
+     * emitted even when the metrics already hold an error, so a truncated body is never silent.
      */
-    void recordBackendResponseStreamFailure(final HttpExecutionContext ctx, final Throwable throwable) {
+    void recordBackendResponseStreamFailure(
+        final HttpExecutionContext ctx,
+        final String absoluteUri,
+        final long silenceMs,
+        final Throwable throwable
+    ) {
         final var metrics = ctx.metrics();
-        // No metrics yet, or an earlier error (e.g. a client abort) already recorded — preserve it.
-        if (metrics == null || metrics.getErrorKey() != null) {
-            return;
+        final long elapsedMs = elapsedMillis(ctx);
+        final String detail = describeStreamFailure(throwable, elapsedMs, silenceMs);
+
+        // An earlier error (e.g. a client abort) already recorded — preserve it: it describes why the exchange ended,
+        // and the upstream failure observed here is only its consequence.
+        final String alreadyRecorded = metrics != null ? metrics.getErrorKey() : null;
+        String errorKey = alreadyRecorded;
+
+        if (metrics != null && alreadyRecorded == null) {
+            ConnectionFailureClassifier.Classification classification = ConnectionFailureClassifier.classify(throwable);
+
+            // The status and headers are already committed downstream, so the caller received a valid response with a
+            // truncated body. Reporting this as a plain connection failure reads as "the backend could not be
+            // reached", which it could — hence a dedicated key for the case where the upstream simply stopped
+            // mid-body. The generic CONNECTION_CLOSED stays in use for the phases where nothing was sent yet.
+            errorKey = ConnectionFailureClassifier.CONNECTION_CLOSED.equals(classification.key())
+                ? ConnectionFailureClassifier.STREAM_ENDED_EARLY
+                : classification.key();
+
+            // Nothing more to record: the reporter turns errorKey/errorMessage into the Diagnostic carried by the
+            // metrics, attributed to the ENDPOINT component on the GATEWAY_CLIENT_ prefix. Raising an ExecutionWarn
+            // on top would emit a second diagnostic for the same event — and a worse one, the endpoint component
+            // scope being already closed by the time the body is streamed ("Unknown component").
+            metrics.setErrorKey(errorKey);
+            metrics.setErrorMessage(detail);
         }
-        ConnectionFailureClassifier.Classification classification = ConnectionFailureClassifier.classify(throwable);
-        metrics.setErrorKey(classification.key());
-        metrics.setErrorMessage(
-            throwable.getMessage() != null ? throwable.getMessage() : "Connection error while streaming the backend response"
-        );
+
+        // Single technical log holding everything needed to tell a backend problem from a gateway misconfiguration,
+        // without having to correlate several sources afterwards. WARN, not ERROR: the caller did get a response.
+        ctx
+            .withLogger(log)
+            .warn(
+                "Upstream ended the response body early [target={}, elapsed={}ms, upstreamSilence={}ms, bytesSent={}, " +
+                    "status={}, readTimeout={}ms, idleTimeout={}ms, effectiveIdleTimeout={}ms, errorKey={}]: {}",
+                absoluteUri,
+                elapsedMs,
+                silenceMs,
+                metrics != null ? metrics.getResponseContentLength() : -1,
+                ctx.response().status(),
+                sharedConfiguration.getHttpOptions().getReadTimeout(),
+                sharedConfiguration.getHttpOptions().getIdleTimeout(),
+                effectiveIdleTimeoutMillis(),
+                errorKey,
+                detail,
+                throwable
+            );
+    }
+
+    private long elapsedMillis(final HttpExecutionContext ctx) {
+        final var metrics = ctx.metrics();
+        if (metrics == null || metrics.timestamp() == null) {
+            return -1L;
+        }
+        return System.currentTimeMillis() - metrics.timestamp().toEpochMilli();
+    }
+
+    /**
+     * Vert.x applies {@code idleTimeout} with a whole-second resolution, so the value that actually fires is the
+     * configured one truncated down to the second — 12_200 ms behaves as 12_000 ms. Comparing against the configured
+     * value alone would miss the match by a few hundred milliseconds.
+     */
+    private long effectiveIdleTimeoutMillis() {
+        return (sharedConfiguration.getHttpOptions().getIdleTimeout() / 1000) * 1000;
+    }
+
+    /**
+     * Build a message that says what happened <em>and</em>, when the evidence points that way, that the gateway's own
+     * configuration is the likely cause. A connection closed on the gateway's {@code idleTimeout} is indistinguishable
+     * from a backend hanging up unless the silence that preceded it is compared against the configured timeouts —
+     * which is exactly the comparison an operator reading the logs cannot make.
+     *
+     * @param silenceMs time since the last byte read from the upstream, the only duration comparable to
+     *   {@code idleTimeout}: the idle timer restarts on every byte, so the total elapsed time of the exchange says
+     *   nothing about it.
+     */
+    private String describeStreamFailure(final Throwable throwable, final long elapsedMs, final long silenceMs) {
+        final String cause = throwable.getMessage() != null ? throwable.getMessage() : throwable.getClass().getSimpleName();
+
+        final StringBuilder message = new StringBuilder("The backend ended the response body before it was complete (" + cause + ")");
+        if (elapsedMs >= 0) {
+            message.append(", after ").append(elapsedMs).append(" ms");
+        }
+        if (silenceMs >= 0) {
+            message.append(", having received nothing from it for the last ").append(silenceMs).append(" ms");
+        }
+
+        final long readTimeout = sharedConfiguration.getHttpOptions().getReadTimeout();
+        final long idleTimeout = sharedConfiguration.getHttpOptions().getIdleTimeout();
+        final long effectiveIdle = effectiveIdleTimeoutMillis();
+
+        if (silenceMs >= 0 && effectiveIdle > 0 && Math.abs(silenceMs - effectiveIdle) <= IDLE_TIMEOUT_MATCH_TOLERANCE_MS) {
+            message
+                .append(". This matches the endpoint idleTimeout (")
+                .append(idleTimeout)
+                .append(" ms, applied as ")
+                .append(effectiveIdle)
+                .append(" ms), so the gateway itself likely closed this connection");
+            if (readTimeout >= idleTimeout) {
+                message
+                    .append(". Note that readTimeout (")
+                    .append(readTimeout)
+                    .append(" ms) is not shorter than idleTimeout, so it can never fire: lowering readTimeout below ")
+                    .append("idleTimeout would surface this as a read timeout instead");
+            }
+        }
+        return message.toString();
     }
 
     protected HttpClientRequest customizeHttpClientRequest(final HttpClientRequest httpClientRequest) {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/failure/ConnectionFailureClassifier.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/failure/ConnectionFailureClassifier.java
@@ -53,6 +53,13 @@ public final class ConnectionFailureClassifier {
     public static final String TLS_HANDSHAKE_ERROR = "GATEWAY_CLIENT_TLS_HANDSHAKE_ERROR";
     public static final String CONNECTION_RESET = "GATEWAY_CLIENT_CONNECTION_RESET";
     public static final String CONNECTION_CLOSED = "GATEWAY_CLIENT_CONNECTION_CLOSED";
+    /**
+     * The upstream ended the response body before it was complete, <em>after</em> the status and headers had already
+     * been sent downstream. The request is not a failure — the caller received a valid response — but the body it got
+     * is truncated. Reported under its own key so that a streaming API interrupted mid-flight is not counted as a
+     * failed request, which is what {@link #CONNECTION_CLOSED} would suggest.
+     */
+    public static final String STREAM_ENDED_EARLY = "GATEWAY_CLIENT_STREAM_ENDED_EARLY";
     public static final String CONNECT_TIMEOUT = "GATEWAY_CLIENT_CONNECT_TIMEOUT";
     public static final String READ_TIMEOUT = "GATEWAY_CLIENT_READ_TIMEOUT";
     public static final String CONNECTION_POOL_EXHAUSTED = "GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED";

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
@@ -73,9 +73,12 @@ import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.rxjava3.core.Vertx;
 import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
@@ -89,6 +92,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -109,6 +113,10 @@ class HttpConnectorTest {
     /** Time already spent on the endpoint when the connector takes over, so a measured duration is provably ≥ it. */
     private static final long BACKEND_ELAPSED_NS = TimeUnit.MILLISECONDS.toNanos(100);
     private static final String ERROR_ENDPOINT = "/error";
+    /** Target URI as the connector resolved it, only ever reported in the technical log. */
+    private static final String UPSTREAM_TARGET = "http://backend:8080/team";
+    /** Silence unknown: keeps the message free of any timing claim, for the cases that do not test the timing. */
+    private static final long NO_SILENCE_MEASURED = -1;
     /** Port nothing listens on, to exercise a connection that cannot be acquired. */
     private static final int UNBOUND_PORT = 1;
     /**
@@ -168,6 +176,11 @@ class HttpConnectorTest {
         lenient().when(ctx.response()).thenReturn(response);
         lenient().when(ctx.metrics()).thenReturn(metrics);
         lenient().when(ctx.getTracer()).thenReturn(new Tracer(null, new NoOpTracer()));
+        // withLogger is a default method on the context interface returning the delegate it is given; Mockito stubs
+        // default methods to null, which would NPE any logging path under test.
+        lenient()
+            .when(ctx.withLogger(any(Logger.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
 
         requestHeaders = HttpHeaders.create();
         // request.parameters() can't be null. See https://github.com/gravitee-io/gravitee-common/blob/master/src/main/java/io/gravitee/common/util/URIUtils.java#L74
@@ -217,22 +230,121 @@ class HttpConnectorTest {
     void should_record_backend_connection_reset_on_metrics_when_response_stream_fails() {
         when(metrics.getErrorKey()).thenReturn(null);
 
-        cut.recordBackendResponseStreamFailure(ctx, new IOException("Connection reset by peer"));
+        cut.recordBackendResponseStreamFailure(ctx, UPSTREAM_TARGET, NO_SILENCE_MEASURED, new IOException("Connection reset by peer"));
 
+        // A reset is a genuine backend fault, so it keeps its own key: only a clean close mid-body is re-keyed.
         verify(metrics).setErrorKey("GATEWAY_CLIENT_CONNECTION_RESET");
-        verify(metrics).setErrorMessage("Connection reset by peer");
+        verify(metrics).setErrorMessage("The backend ended the response body before it was complete (Connection reset by peer)");
         // Status was already committed before streaming, so it must not be touched.
         verify(response, never()).status(anyInt());
+        verify(ctx, never()).warnWith(any());
     }
 
     @Test
     void should_not_overwrite_an_already_recorded_error_on_response_stream_failure() {
         when(metrics.getErrorKey()).thenReturn("CLIENT_ABORTED_DURING_RESPONSE_ERROR");
 
-        cut.recordBackendResponseStreamFailure(ctx, new IOException("Connection reset by peer"));
+        cut.recordBackendResponseStreamFailure(ctx, UPSTREAM_TARGET, NO_SILENCE_MEASURED, new IOException("Connection reset by peer"));
 
         verify(metrics, never()).setErrorKey(anyString());
         verify(metrics, never()).setErrorMessage(anyString());
+        verify(ctx, never()).warnWith(any());
+        // Preserving the recorded key must not make the upstream failure disappear from the logs: it is the only
+        // trace left of a body that was cut short.
+        verify(ctx).withLogger(any(Logger.class));
+    }
+
+    @Test
+    void should_report_a_stream_cut_short_under_its_own_key_rather_than_as_a_connection_failure() {
+        when(metrics.getErrorKey()).thenReturn(null);
+
+        cut.recordBackendResponseStreamFailure(ctx, UPSTREAM_TARGET, NO_SILENCE_MEASURED, new HttpClosedException("Connection was closed"));
+
+        // The caller already received status and headers, so this is a truncated response, not a failed request:
+        // reporting it as GATEWAY_CLIENT_CONNECTION_CLOSED is what makes streaming APIs look like they are failing.
+        verify(metrics).setErrorKey("GATEWAY_CLIENT_STREAM_ENDED_EARLY");
+        verify(response, never()).status(anyInt());
+    }
+
+    @Test
+    void should_report_a_stream_cut_short_through_metrics_only_and_not_as_a_second_diagnostic() {
+        when(metrics.getErrorKey()).thenReturn(null);
+
+        cut.recordBackendResponseStreamFailure(ctx, UPSTREAM_TARGET, NO_SILENCE_MEASURED, new HttpClosedException("Connection was closed"));
+
+        // The reporter already turns errorKey/errorMessage into the Diagnostic carried by the metrics, attributed to
+        // the ENDPOINT component. Raising an ExecutionWarn on top would emit a duplicate for the very same event —
+        // and one attributed to "Unknown component", the endpoint scope being closed by the time the body streams.
+        verify(ctx, never()).warnWith(any());
+    }
+
+    @Test
+    void should_blame_the_gateway_idle_timeout_when_the_upstream_silence_matches_it() {
+        when(metrics.getErrorKey()).thenReturn(null);
+        // Vert.x applies idleTimeout truncated to the second, so 12_200 ms actually fires at 12_000 ms.
+        sharedConfiguration.getHttpOptions().setIdleTimeout(12_200);
+        sharedConfiguration.getHttpOptions().setReadTimeout(24_000);
+
+        cut.recordBackendResponseStreamFailure(ctx, UPSTREAM_TARGET, 12_000, new HttpClosedException("Connection was closed"));
+
+        assertThat(errorMessageRecorded())
+            .contains("having received nothing from it for the last 12000 ms")
+            .contains("This matches the endpoint idleTimeout (12200 ms, applied as 12000 ms)")
+            .contains("the gateway itself likely closed this connection")
+            // readTimeout longer than idleTimeout can never fire — the misconfiguration behind the whole symptom.
+            .contains("readTimeout (24000 ms) is not shorter than idleTimeout");
+    }
+
+    @Test
+    void should_blame_the_idle_timeout_on_the_silence_even_when_the_exchange_lasted_much_longer() {
+        when(metrics.getErrorKey()).thenReturn(null);
+        sharedConfiguration.getHttpOptions().setIdleTimeout(12_200);
+        sharedConfiguration.getHttpOptions().setReadTimeout(24_000);
+        // A stream that trickled for ten minutes before going quiet: the idle timer restarts on every byte, so only
+        // the trailing silence can be compared to it. Matching on the total elapsed time would never fire here.
+        when(metrics.timestamp()).thenReturn(Instant.now().minusMillis(600_000));
+
+        cut.recordBackendResponseStreamFailure(ctx, UPSTREAM_TARGET, 12_000, new HttpClosedException("Connection was closed"));
+
+        assertThat(errorMessageRecorded()).contains("This matches the endpoint idleTimeout (12200 ms, applied as 12000 ms)");
+    }
+
+    @Test
+    void should_not_blame_the_idle_timeout_when_the_silence_is_far_from_it() {
+        when(metrics.getErrorKey()).thenReturn(null);
+        sharedConfiguration.getHttpOptions().setIdleTimeout(12_200);
+        sharedConfiguration.getHttpOptions().setReadTimeout(24_000);
+
+        cut.recordBackendResponseStreamFailure(ctx, UPSTREAM_TARGET, 3_000, new HttpClosedException("Connection was closed"));
+
+        // Scattered durations point at the backend: claiming a timeout match here would send operators the wrong way.
+        assertThat(errorMessageRecorded()).doesNotContain("idleTimeout").contains("having received nothing from it for the last 3000 ms");
+    }
+
+    @Test
+    void should_not_suggest_lowering_read_timeout_when_it_is_already_below_the_idle_timeout() {
+        when(metrics.getErrorKey()).thenReturn(null);
+        sharedConfiguration.getHttpOptions().setIdleTimeout(12_200);
+        sharedConfiguration.getHttpOptions().setReadTimeout(8_000);
+
+        cut.recordBackendResponseStreamFailure(ctx, UPSTREAM_TARGET, 12_000, new HttpClosedException("Connection was closed"));
+
+        assertThat(errorMessageRecorded()).contains("This matches the endpoint idleTimeout").doesNotContain("readTimeout");
+    }
+
+    @Test
+    void should_describe_the_failure_by_type_when_the_cause_carries_no_message() {
+        when(metrics.getErrorKey()).thenReturn(null);
+
+        cut.recordBackendResponseStreamFailure(ctx, UPSTREAM_TARGET, NO_SILENCE_MEASURED, new ClosedChannelException());
+
+        assertThat(errorMessageRecorded()).isEqualTo("The backend ended the response body before it was complete (ClosedChannelException)");
+    }
+
+    private String errorMessageRecorded() {
+        final ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
+        verify(metrics).setErrorMessage(message.capture());
+        return message.getValue();
     }
 
     @Test


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-14952

No JIRA ticket. This comes out of a customer investigation on `GATEWAY_CLIENT_CONNECTION_CLOSED`
at scale on streaming APIs, where the reporting could not distinguish three genuinely different
situations, all surfacing under the same key — or under no key at all:

1. the backend really cut the response body short;
2. **the gateway closed the connection itself**, on its own `idleTimeout`, because `readTimeout`
   was configured longer than `idleTimeout` and could therefore never fire;
3. the reactor was shutting down and cut the request short.

Reproduced 11/11 on a bench. The customer's actual root cause is (2), and nothing in the
reporting pointed at it: the failure reads as a backend disconnection.

## Description

Three commits, reviewable in order — each stands on its own.

### 1. `feat` — report a stream cut short under its own key, with timeout diagnostics

*(`gravitee-apim-plugin-endpoint-http-proxy`)*

`HttpConnector.recordBackendResponseStreamFailure` runs when the upstream fails while the
response body is being streamed, i.e. after status and headers were committed downstream.

- **New key** `GATEWAY_CLIENT_STREAM_ENDED_EARLY`, substituted for `CONNECTION_CLOSED` **in this
  phase only**. The caller received a valid response with a truncated body; keying it like a
  connection that never delivered anything is what makes streaming APIs look like they are
  failing. `CONNECTION_CLOSED` is untouched everywhere else.
- **A message meant to be read alone**, by someone holding the analytics entry and not the
  gateway configuration: elapsed time, upstream silence, and — when that silence matches the
  configured `idleTimeout` — that the gateway is the likely closer, naming the misconfiguration.
- **A single WARN log** replacing the generic ERROR at the call site, carrying target, both
  durations, bytes sent, status, the three timeouts, the key and the stack trace. Now emitted
  even when an error was already recorded, so a truncated body is never silent.

**The part deserving the most attention — what is measured.** The detection compares the
**upstream silence** to the effective `idleTimeout`, not the elapsed time of the exchange:

- `idleTimeout` is a channel-level timer that **restarts on every byte received**. On a stream
  that trickles for ten minutes then goes quiet, only the trailing silence is comparable to it.
- The elapsed time additionally includes everything upstream of the backend call (policies,
  connection acquisition, first byte), so it is systematically larger by an unknown amount.

An earlier iteration compared the elapsed time; a simulation showed the detection would
essentially never fire in production. The silence is tracked with an `AtomicLong` initialised at
the response headers and updated in `doOnNext` on the chunk flow.

`effectiveIdleTimeoutMillis()` truncates to the second, because Vert.x applies `idleTimeout` with
whole-second resolution — `12_200 ms` fires at `12_000 ms`.

### 2. `fix` — make the reactor's last-resort 500 diagnosable

*(`gateway-core` + both reactors)*

`handleUnexpectedError` answers a bare `500` for any error reaching the end of the chain
unconverted. It logged `"Unexpected error while handling request"` and nothing else, while
overwriting the status the request had reached.

The observable result: a `500` carrying an error key belonging to a different status (a
`GATEWAY_CLIENT_*` key normally answered with `502`), with an empty body because the error
handling never got to write one — indistinguishable, from analytics alone, from the gateway
simply returning `500`.

New `UnexpectedErrorReporter`, called by both reactors **before** the status is overwritten:

- **In the log**: `requestId` and `transactionId` — the contextual logger injects `apiId`,
  `apiName`, `envId`, `orgId`, `appId`, `planId` and `user`, but neither of those two, and they
  are the only link to the analytics entry the line explains — plus the status being replaced,
  the attributed error, the endpoint, the elapsed time, and the most specific cause in plain text
  (stack traces get truncated by log collectors).
- **In the analytics**, when nothing was attributed: a `GATEWAY_UNEXPECTED_ERROR` key. Such a
  request previously carried **no error key at all** — a `500` reading as a success in any
  dashboard counting failures by key.
- **In the analytics**, when something was already attributed: preserve it (it names what
  actually went wrong) and record the unexpected exception as a **warning** alongside, which
  otherwise exists nowhere but the pod log file.

### 3. `feat` — log the requests an api reactor cuts short when it stops

*(both reactors)*

`stopNow()` closes endpoint connections, policies and resources from under requests still
running. Nothing tied the resulting error spike to the redeploy that caused it, and durations
clustering on `api.pending_requests_timeout` (default 10 000 ms) read as a traffic timeout rather
than the shutdown countdown they are.

One WARN when the reactor tears down with requests in flight, naming how many are cut short and
how long they were waited for. Silent on a clean shutdown — warning there would train operators
to ignore the line.

**Where the count is read matters.** It is captured inside the wait loop, where the decision to
stop anyway is taken, and passed to the log. The first version read `pendingRequests` from the
teardown itself and, on a live gateway, reported *nothing at all* while requests were demonstrably
being cut short: the counter was already back to zero by then, even though the wait loop had just
spent the full grace period precisely because it was not. So the two stop paths capture at
different points — from the wait loop for a graceful stop, and directly in `doStop` for a node
already going down, which cuts everything without waiting. `stopNow()` no longer logs: it serves
both paths and no longer holds the information when it runs.

What decrements the counter in between was not established — the thread hop of
`observeOn(Schedulers.io())` is the plausible suspect. The fix makes the measurement immune to the
race rather than removing it.

## Additional context

### Breaking change to flag in the release notes

`GATEWAY_CLIENT_CONNECTION_CLOSED` → `GATEWAY_CLIENT_STREAM_ENDED_EARLY` for the truncated-body
case. Dashboards filtering the old key will report zero for it. No impact on response templates:
the response is already committed in this phase, so no template applies.

### Design decision worth confirming — no `ExecutionWarn` in commit 1, one in commit 2

The obvious move in commit 1 was `ctx.warnWith(...)`: a truncated body on a `200` is arguably a
warning, not a failure. It was tried and removed, because:

- `ReporterProcessor.translateErrorToDiagnosticFailure` already turns `errorKey`/`errorMessage`
  into the `Diagnostic` carried by the metrics, attributed to `ENDPOINT` via the
  `GATEWAY_CLIENT_` prefix. `warnWith` would emit a **second** diagnostic for the same event.
- That second one would be worse: the `ENDPOINT` component scope is pushed only around
  `invoker.invoke(ctx)`, which completes when the response head arrives — so anything raised
  while the body streams comes out as `Unknown component`.
- `DiagnosticReportHelper` appends the cause to the message, which our message already contains.

In commit 2 it is the right tool for the opposite reason: there is no duplicate, it is the only
trace, and it does not replace the attributed diagnosis.

### And why not a warning *instead* of a failure, for the truncated body?

The semantic argument is real: the caller received a `200` with headers and a body, so the request
did not fail, and a `failure` on a 2xx is odd. It would also match the three existing
`ExecutionWarn` uses (`BAD_REGEX_CONTENT_TYPE`, `EXPRESSION_EVALUATION_ERROR`, `INVALID_XML`) —
anomalies that do not prevent the request from completing.

It was rejected because of what `warnings` costs in visibility. The field is mapped `nested`, so
Kibana does not list it as an ordinary field: it cannot be added as a column through the field
list, filtered in KQL, or aggregated, until runtime fields are declared on the data view. Moving
this case to warnings only would not reclassify it — it would remove it from every dashboard that
watches it today, for a case operators are actively monitoring, and where the truncated body means
the consumer walked away with incomplete data without knowing.

So the failure stays, and the distinction lives in the key instead of the field:
`GATEWAY_CLIENT_STREAM_ENDED_EARLY` lets a dashboard exclude these from its error rate, which was
impossible while they were keyed `CONNECTION_CLOSED`. Moving them to `warnings` becomes the right
call once warnings are usable from analytics out of the box — a product change, not a maintenance
fix.

### Open questions for review

- **`GATEWAY_UNEXPECTED_ERROR` as a key name.** It has no parent key, and no response template
  can target it usefully since this path bypasses templates entirely.
- **Scope: both reactors, v4 and sync.** The sync one is not needed for the customer case, but
  the defect is identical and leaving it out would be arbitrary.
- **`gateway-core` on a maintenance branch** — commit 2 is the most central change of the three.
- **Duplication in commit 3** between `AbstractApiReactor` and `SyncApiReactor`, which share no
  hierarchy. Consistent with how `stopUntil`, `stopNow` and `handleUnexpectedError` are already
  duplicated across the two; extracting a helper for a log line felt like more ceremony than
  value, but happy to change it.

### Deliberately out of scope

- **`GATEWAY_CLIENT_CONNECTION_POOL_EXHAUSTED` returning 502 instead of 503.** It is the only key
  whose status differs from its parent's, and `handleTemplate` applies the template's status
  unconditionally — so a template configured on `GATEWAY_CLIENT_CONNECTION_ERROR`, or a `DEFAULT`
  one, silently downgrades a deliberate 503 into a 502. A narrow fix exists (keep the failure's
  status when the template was reached through the parent fallback rather than an explicit
  match), and it would be a no-op for every other key since they are all status-aligned with
  their parent. It is a behaviour change deserving its own decision.
- **A deployment-time warning when `readTimeout >= idleTimeout`.** That configuration can never
  fire its read timeout; catching it at deploy time would beat diagnosing it in production.
  Belongs to configuration validation.

### Building and testing

Commit 2 changes classes in `gateway-core` that `handlers-api` consumes as an installed artefact.
Run `mvn install -DskipTests -pl gravitee-apim-gateway/gravitee-apim-gateway-core` before testing
`handlers-api` alone, or the tests fail on `NoClassDefFoundError`.

Tests: 104 green on the plugin module, 1 415 on the two gateway modules. No test was weakened or
removed; two existing assertions were updated where the message they asserted changed. Unit tests
cover the two cases the detection must **not** claim (silence far from `idleTimeout`,
`readTimeout` already below `idleTimeout`) and the invariant that broke on the shutdown path.

Commits 1 and 3 were also exercised on a running gateway against a bench backend: an endpoint
sending headers then going silent on an API configured with `readTimeout > idleTimeout` (cut at
12.01 s, reported under the new key, message naming the `idleTimeout` as the likely closer); the
same failure shape with sane timeouts (reported without any claim about the configuration); and a
long-running request while its API is redeployed (`WARN` emitted, naming the single request cut
short, a little over the 10 s grace period).

Commit 2 was exercised too, by deploying an API whose response template contains an expression
that throws (`{#error.thisMethodDoesNotExist()}`). The backend is then cut on its `idleTimeout`,
the failure is classified as a `502`, the template cannot be rendered, and the error reaches the
end of the chain unconverted. Result:

```
status 500, response-content-length 0, error-key GATEWAY_CLIENT_CONNECTION_CLOSED
warnings[0].key     GATEWAY_UNEXPECTED_ERROR
warnings[0].message The gateway could not complete the handling of this request and answered
                    500, replacing status 502 (Expression: #error.thisMethodDoesNotExist()
                    failed with message EL1004E: Method call: Method thisMethodDoesNotExist()
                    cannot be found on type EvaluableExecutionFailure)
```

That is the exact signature this commit set out to make diagnosable — a bare 500, an empty body,
and a key belonging to another status — now carrying the reason. The log line reports
`statusBeingReplaced=502` alongside the request and transaction ids.

Worth knowing when reviewing the analytics side: `warnings` is mapped `nested`, so it is not
listed as an ordinary field in Kibana and needs a runtime field to be filtered or aggregated. The
data is complete; the query path differs.
