### PR TITLE
chore: align helm node plugins with gravitee-node 9.6.1

### DIFF
--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-9.4.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.4.1.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-9.4.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.4.1.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-9.6.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.6.1.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-9.6.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.6.1.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -510,8 +510,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.4.1.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.4.1.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.6.1.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.6.1.zip
 
 api:
   enabled: true


### PR DESCRIPTION
## Issue

Follow-up to `chore: bump gravitee-common to 5.1.0 and gravitee-node to 9.6.1` (425718c574), which bumped `gravitee-node.version` in `pom.xml` without updating the Helm chart.

## Description

`helm/values.yaml` pins the Hazelcast node plugins by URL. They were left at 9.4.1 while the pom moved to 9.6.1, so the `gravitee-node-version-consistency` Danger rule now fails on every PR touching `pom.xml` on this branch. Aligns both plugin URLs, and the Helm test asserting them, to 9.6.1.

## Additional context

Both 9.6.1 artifacts are available on download.gravitee.io. Same drift on `master` (9.6.0 → 9.6.1), fixed in a separate PR since the previous values differ and a cherry-pick would conflict.
