### PR TITLE
feat: integrate API Product subscription entry point

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
@@ -16,12 +16,14 @@
 
 -->
 <app-sidenav-layout [breadcrumbs]="breadcrumbs()" [breadcrumbsLoading]="folderLoading()">
-  @if (apiId()) {
+  @if (subscriptionTarget()) {
     <div breadcrumbActions class="documentation-folder__breadcrumb-actions">
-      @if (apiHasMcp()) {
-        <button mat-stroked-button type="button" (click)="this.mcpDrawerOpen.set(true)" data-testid="mcp-button">
-          <span i18n="@@documentationMcpButton">MCP</span>
-        </button>
+      @if (apiId()) {
+        @if (apiHasMcp()) {
+          <button mat-stroked-button type="button" (click)="this.mcpDrawerOpen.set(true)" data-testid="mcp-button">
+            <span i18n="@@documentationMcpButton">MCP</span>
+          </button>
+        }
       }
       <button mat-stroked-button (click)="onSubscribe()" [disabled]="!currentUser()" data-testid="subscribe-button">
         @if (currentUser()) {

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
@@ -24,6 +24,7 @@ import { of } from 'rxjs/internal/observable/of';
 import { DocumentationFolderComponent } from './documentation-folder.component';
 import { DocumentationFolderComponentHarness } from './documentation-folder.component.harness';
 import { PortalNavigationItem } from '../../../../entities/portal-navigation/portal-navigation-item';
+import { fakePortalNavigationApiProduct } from '../../../../entities/portal-navigation/portal-navigation-item.fixture';
 import { makeItem, MOCK_ITEMS } from '../../../../mocks/portal-navigation-item.mocks';
 import { ApiService } from '../../../../services/api.service';
 import { CurrentUserService } from '../../../../services/current-user.service';
@@ -34,6 +35,7 @@ describe('DocumentationFolderComponent', () => {
   let fixture: ComponentFixture<DocumentationFolderComponent>;
   let harness: DocumentationFolderComponentHarness;
   let navigationServiceSpy: PortalNavigationItemsService;
+  let apiServiceSpy: { details: jest.Mock };
   let routerSpy: jest.Mocked<Router>;
   let queryParamsSubject: BehaviorSubject<{ selectedId?: string }>;
 
@@ -79,7 +81,7 @@ describe('DocumentationFolderComponent', () => {
     } as unknown as PortalNavigationItemsService;
 
     const apiHasMcp = params.apiHasMcp === true;
-    const apiServiceSpy = {
+    apiServiceSpy = {
       details: jest.fn().mockImplementation((id: string) =>
         of({
           ...baseApiDetails,
@@ -87,7 +89,7 @@ describe('DocumentationFolderComponent', () => {
           ...(apiHasMcp ? { mcp: { mcpPath: '/mcp', tools: [] as { toolDefinition: Record<string, unknown> }[] } } : {}),
         }),
       ),
-    } as unknown as ApiService;
+    };
 
     await TestBed.configureTestingModule({
       animationsEnabled: true,
@@ -418,6 +420,61 @@ describe('DocumentationFolderComponent', () => {
       expect(await contentEmptyState?.getText()).toEqual('No content to show');
     });
 
+    it('should show a subscription action for product documentation and navigate to the product flow', async () => {
+      const apiProduct = fakePortalNavigationApiProduct({
+        id: 'product1',
+        apiProductId: 'api-product-1',
+        title: 'API Product 1',
+        rootId: 'root1',
+      });
+      const productPage = makeItem('product-overview1', 'PAGE', 'Product Overview', 0, 'product1', 'root1');
+
+      await init({ items: [apiProduct, productPage], queryParams: { selectedId: 'product-overview1' }, content: MOCK_CONTENT });
+
+      const subscribeButton = await harness.getSubscribeButton();
+      expect(subscribeButton).not.toBeNull();
+      expect(await subscribeButton!.getText()).toEqual('Subscribe');
+
+      await subscribeButton!.click();
+
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['api-product', 'api-product-1', 'subscribe'], {
+        relativeTo: expect.anything(),
+        queryParamsHandling: 'preserve',
+      });
+    });
+
+    it('should keep the product subscription action disabled for an unauthenticated user', async () => {
+      const apiProduct = fakePortalNavigationApiProduct({ id: 'product1', apiProductId: 'api-product-1', rootId: 'root1' });
+      const productPage = makeItem('product-overview1', 'PAGE', 'Product Overview', 0, 'product1', 'root1');
+
+      await init({
+        items: [apiProduct, productPage],
+        queryParams: { selectedId: 'product-overview1' },
+        content: MOCK_CONTENT,
+        isAuthenticated: false,
+      });
+
+      const subscribeButton = await harness.getSubscribeButton();
+      expect(subscribeButton).not.toBeNull();
+      expect(await subscribeButton!.getText()).toEqual('Sign in to subscribe');
+      expect(await subscribeButton!.isDisabled()).toBe(true);
+    });
+
+    it('should not load API details or show MCP actions for product documentation', async () => {
+      const apiProduct = fakePortalNavigationApiProduct({ id: 'product1', apiProductId: 'api-product-1', rootId: 'root1' });
+      const productPage = makeItem('product-overview1', 'PAGE', 'Product Overview', 0, 'product1', 'root1');
+
+      await init({
+        items: [apiProduct, productPage],
+        queryParams: { selectedId: 'product-overview1' },
+        content: MOCK_CONTENT,
+        apiHasMcp: true,
+      });
+
+      expect(apiServiceSpy.details).not.toHaveBeenCalled();
+      expect(await harness.getMcpButton()).toBeNull();
+    });
+
     it('should preserve API behavior for documentation nested under an API Product', async () => {
       const apiProduct = makeItem('product1', 'API_PRODUCT', 'API Product 1', 0, undefined, 'root1');
       const apiItem = makeItem('api1', 'API', 'API 1', 0, 'product1', 'root1');
@@ -426,10 +483,49 @@ describe('DocumentationFolderComponent', () => {
       await init({ items: [apiProduct, apiItem, apiPage], queryParams: { selectedId: 'p-api1' }, content: MOCK_CONTENT });
 
       expect(routerSpy.navigate).not.toHaveBeenCalled();
-      expect(await harness.getSubscribeButton()).not.toBeNull();
+      const subscribeButton = await harness.getSubscribeButton();
+      expect(subscribeButton).not.toBeNull();
+
+      await subscribeButton!.click();
+
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['api', 'api-api1', 'subscribe'], {
+        relativeTo: expect.anything(),
+        queryParamsHandling: 'preserve',
+      });
 
       const breadcrumbs = await harness.getBreadcrumbs();
       expect(await breadcrumbs?.getText()).toEqual('Test item/API Product 1/API 1/API 1 Documentation');
+    });
+
+    it('should hide the previous API action while product documentation is loading', async () => {
+      const apiProduct = fakePortalNavigationApiProduct({
+        id: 'product1',
+        apiProductId: 'api-product-1',
+        title: 'API Product 1',
+        rootId: 'root1',
+      });
+      const productPage = makeItem('product-overview1', 'PAGE', 'Product Overview', 0, 'product1', 'root1');
+      const apiItem = makeItem('api1', 'API', 'API 1', 1, 'product1', 'root1');
+      const apiPage = makeItem('p-api1', 'PAGE', 'API 1 Documentation', 0, 'api1', 'root1');
+
+      await init({ items: [apiProduct, productPage, apiItem, apiPage], queryParams: { selectedId: 'p-api1' }, content: MOCK_CONTENT });
+      expect(await harness.getSubscribeButton()).not.toBeNull();
+
+      const contentSubject = new Subject<{ content: string; type: string }>();
+      navigationServiceSpy.getNavigationItemContent = jest.fn().mockReturnValue(contentSubject.asObservable());
+
+      const tree = await harness.getTreeHarness();
+      await tree!.clickItemByTitle('Product Overview');
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+      expect(await harness.getSubscribeButton()).toBeNull();
+
+      contentSubject.next({ content: MOCK_CONTENT, type: 'GRAVITEE_MARKDOWN' });
+      contentSubject.complete();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(await harness.getSubscribeButton()).not.toBeNull();
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
@@ -39,7 +39,7 @@ import { ApiService } from '../../../../services/api.service';
 import { CurrentUserService } from '../../../../services/current-user.service';
 import { PortalNavigationItemsService } from '../../../../services/portal-navigation-items.service';
 import { ApiTabToolsComponent } from '../../../api/api-details/api-tab-tools/api-tab-tools.component';
-import { TreeNode, TreeService } from '../../services/tree.service';
+import { DocumentationSubscriptionTarget, TreeNode, TreeService } from '../../services/tree.service';
 
 interface FolderData {
   children: PortalNavigationItem[];
@@ -85,7 +85,11 @@ export class DocumentationFolderComponent {
   tree = signal<TreeNode[]>([]);
   breadcrumbs = signal<Breadcrumb[]>([]);
 
-  apiId = signal<string | null>(null);
+  subscriptionTarget = signal<DocumentationSubscriptionTarget | null>(null);
+  apiId = computed(() => {
+    const target = this.subscriptionTarget();
+    return target?.type === 'API' ? target.apiId : null;
+  });
   api = rxResource<Api | null, string | null>({
     params: this.apiId,
     stream: ({ params }) => (params ? this.apiService.details(params) : of(null)),
@@ -105,13 +109,16 @@ export class DocumentationFolderComponent {
   }
 
   onSubscribe() {
-    const apiId = this.apiId();
-    if (apiId) {
-      this.router.navigate(['api', apiId, 'subscribe'], {
-        relativeTo: this.activatedRoute,
-        queryParamsHandling: 'preserve',
-      });
+    const target = this.subscriptionTarget();
+    if (!target) {
+      return;
     }
+
+    const route = target.type === 'API' ? ['api', target.apiId, 'subscribe'] : ['api-product', target.apiProductId, 'subscribe'];
+    this.router.navigate(route, {
+      relativeTo: this.activatedRoute,
+      queryParamsHandling: 'preserve',
+    });
   }
 
   private loadFolderData(): Observable<FolderData | undefined> {
@@ -149,10 +156,11 @@ export class DocumentationFolderComponent {
   }
 
   private loadContentOrRedirect(selectedId: string, children = this.folderData()?.children ?? []): Observable<FolderData> {
+    this.subscriptionTarget.set(null);
+
     if (!selectedId) {
       return of({ children, selectedPageContent: null }).pipe(
         tap(() => this.breadcrumbs.set(this.treeService.getBreadcrumbsByDefault())),
-        tap(() => this.apiId.set(null)),
         tap(() => this.navigateToFirstPage()),
       );
     }
@@ -168,9 +176,10 @@ export class DocumentationFolderComponent {
       return of({ children, selectedPageContent: null }).pipe(tap(() => firstPageId && this.navigateToPage(firstPageId)));
     }
 
+    const subscriptionTarget = this.treeService.getSubscriptionTarget(selectedId);
     return this.itemsService.getNavigationItemContent(selectedId).pipe(
       tap(() => this.breadcrumbs.set(this.treeService.getBreadcrumbsByNodeId(selectedId))),
-      tap(() => this.apiId.set(this.treeService.getAncestorApiId(selectedId))),
+      tap(() => this.subscriptionTarget.set(subscriptionTarget)),
       map(selectedPageContent => ({ children, selectedPageContent })),
     );
   }

--- a/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.spec.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 import { TreeService } from './tree.service';
-import { fakePortalNavigationFolder } from '../../../entities/portal-navigation/portal-navigation-item.fixture';
+import {
+  fakePortalNavigationApiProduct,
+  fakePortalNavigationFolder,
+} from '../../../entities/portal-navigation/portal-navigation-item.fixture';
 import { makeItem, MOCK_ITEMS } from '../../../mocks/portal-navigation-item.mocks';
 
 const parentItem = fakePortalNavigationFolder();
@@ -116,16 +119,38 @@ describe('DocumentationTreeService', () => {
     });
   });
 
-  describe('getAncestorApiId', () => {
-    it('should return apiId when page is under API', () => {
+  describe('getSubscriptionTarget', () => {
+    it('should return an API target when page is under a standalone API', () => {
       const items = [makeItem('api1', 'API', 'API 1', 0), makeItem('p-api1', 'PAGE', 'API doc', 0, 'api1')];
       service.init(parentItem, items);
-      expect(service.getAncestorApiId('p-api1')).toEqual('api-api1');
+      expect(service.getSubscriptionTarget('p-api1')).toEqual({ type: 'API', apiId: 'api-api1' });
     });
 
-    it('should return null when page has no API ancestor', () => {
-      expect(service.getAncestorApiId('p1')).toBeNull();
-      expect(service.getAncestorApiId('p3')).toBeNull();
+    it('should return an API Product target when page is under an API Product folder', () => {
+      const items = [
+        fakePortalNavigationApiProduct({ id: 'product1', apiProductId: 'api-product-1', rootId: 'product1' }),
+        makeItem('product-folder1', 'FOLDER', 'Product documentation', 0, 'product1', 'product1'),
+        makeItem('product-page1', 'PAGE', 'Product overview', 0, 'product-folder1', 'product1'),
+      ];
+      service.init(parentItem, items);
+
+      expect(service.getSubscriptionTarget('product-page1')).toEqual({ type: 'API_PRODUCT', apiProductId: 'api-product-1' });
+    });
+
+    it('should prefer a nested API over its enclosing API Product', () => {
+      const items = [
+        fakePortalNavigationApiProduct({ id: 'product1', apiProductId: 'api-product-1', rootId: 'product1' }),
+        makeItem('api1', 'API', 'API 1', 0, 'product1', 'product1'),
+        makeItem('p-api1', 'PAGE', 'API doc', 0, 'api1', 'product1'),
+      ];
+      service.init(parentItem, items);
+
+      expect(service.getSubscriptionTarget('p-api1')).toEqual({ type: 'API', apiId: 'api-api1' });
+    });
+
+    it('should return null when page has no subscribable ancestor', () => {
+      expect(service.getSubscriptionTarget('p1')).toBeNull();
+      expect(service.getSubscriptionTarget('p3')).toBeNull();
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.ts
@@ -27,6 +27,8 @@ export interface TreeNode {
   breadcrumbs?: Breadcrumb[];
 }
 
+export type DocumentationSubscriptionTarget = { type: 'API'; apiId: string } | { type: 'API_PRODUCT'; apiProductId: string };
+
 type ProcessingNode = TreeNode & {
   __order: number;
   __parentId: string | null;
@@ -59,11 +61,14 @@ export class TreeService {
     return this.parentItemBreadcrumb ? [this.parentItemBreadcrumb] : [];
   }
 
-  getAncestorApiId(nodeId: string): string | null {
+  getSubscriptionTarget(nodeId: string): DocumentationSubscriptionTarget | null {
     let node = this.treeNodesById.get(nodeId);
     while (node) {
-      if (node.type === 'API' && node.data?.type === 'API') {
-        return node.data.apiId;
+      if (node.data?.type === 'API') {
+        return { type: 'API', apiId: node.data.apiId };
+      }
+      if (node.data?.type === 'API_PRODUCT') {
+        return { type: 'API_PRODUCT', apiProductId: node.data.apiProductId };
       }
       node = node.__parentId ? this.treeNodesById.get(node.__parentId) : undefined;
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-118

## Summary

- Resolve the nearest subscribable target from the selected documentation page.
- Route API Product documentation to the API Product subscription flow.
- Keep nested and standalone API documentation using the existing API subscription flow.
- Display a single Subscribe action for either an API or API Product.
- Preserve `selectedId` when opening and leaving the subscription flow.
- Keep API details and MCP actions restricted to API targets.


## Dependency

This PR is stacked on PORTAL-117, which provides the API Product subscription flow and route.

## Compatibility

This changes documentation CTA routing. The existing API subscription route, authentication behavior, copy, and standalone API behavior remain unchanged.



https://github.com/user-attachments/assets/aee789fe-9bac-4b70-b275-577f4f2f4a7a



