### PR TITLE
chore(deps): bump gravitee-reactor-llm-proxy to 3.3.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
     <gravitee-reactor-native-kafka.version>7.0.5</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.1.5</gravitee-reactor-mcp-proxy.version>
-    <gravitee-reactor-llm-proxy.version>3.3.6</gravitee-reactor-llm-proxy.version>
+    <gravitee-reactor-llm-proxy.version>3.3.8</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.1.0</gravitee-reactor-a2a-proxy.version>
     <gravitee-reactor-authz.version>1.0.0</gravitee-reactor-authz.version>
     <gravitee-reactor-edge.version>1.0.0</gravitee-reactor-edge.version>


### PR DESCRIPTION
## Summary of changes

Bumps the `gravitee-reactor-llm-proxy` dependency version from `3.3.6` to `3.3.8` in `pom.xml`.